### PR TITLE
feat: add analysis package for domain-specific LLM analysis

### DIFF
--- a/analysis/code_review.go
+++ b/analysis/code_review.go
@@ -1,0 +1,118 @@
+// Package analysis provides domain-specific LLM analysis helpers for code review,
+// code explanation, ML training metrics, and trading strategy analysis.
+package analysis
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+	"github.com/kstruzzieri/go-llm/rag"
+)
+
+// reviewConfig holds optional configuration for a code review request.
+type reviewConfig struct {
+	language string
+	focus    string
+}
+
+// ReviewOption configures a code review request.
+type ReviewOption func(*reviewConfig)
+
+// WithLanguage sets the programming language for more targeted review feedback.
+func WithLanguage(lang string) ReviewOption {
+	return func(cfg *reviewConfig) {
+		cfg.language = lang
+	}
+}
+
+// WithFocus narrows the review to a specific area such as "security", "performance",
+// or "error handling".
+func WithFocus(focus string) ReviewOption {
+	return func(cfg *reviewConfig) {
+		cfg.focus = focus
+	}
+}
+
+// CodeReviewer generates code reviews using an LLM with optional RAG context.
+type CodeReviewer struct {
+	client    *ollama.Client
+	retriever *rag.Retriever
+	model     string
+}
+
+// NewCodeReviewer creates a CodeReviewer. The retriever may be nil if RAG context
+// is not needed. The client and model are required.
+func NewCodeReviewer(client *ollama.Client, retriever *rag.Retriever, model string) (*CodeReviewer, error) {
+	if client == nil {
+		return nil, fmt.Errorf("analysis: new code reviewer: client is required")
+	}
+	if model == "" {
+		return nil, fmt.Errorf("analysis: new code reviewer: model is required")
+	}
+	return &CodeReviewer{
+		client:    client,
+		retriever: retriever,
+		model:     model,
+	}, nil
+}
+
+// Review performs a code review on the provided code and returns the review as text.
+// Options can specify language and focus area. If a retriever is configured, relevant
+// codebase context is included in the prompt.
+func (cr *CodeReviewer) Review(ctx context.Context, code string, opts ...ReviewOption) (string, error) {
+	if code == "" {
+		return "", fmt.Errorf("analysis: review code: code is required")
+	}
+
+	cfg := &reviewConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	prompt := cr.buildReviewPrompt(ctx, code, cfg)
+
+	resp, err := cr.client.Chat(ctx, ollama.ChatRequest{
+		Model: cr.model,
+		Messages: []ollama.ChatMessage{
+			{Role: "system", Content: "You are an expert code reviewer. Provide clear, actionable feedback."},
+			{Role: "user", Content: prompt},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("analysis: review code: %w", err)
+	}
+
+	return resp.Message.Content, nil
+}
+
+// buildReviewPrompt constructs the review prompt with optional language, focus, and RAG context.
+func (cr *CodeReviewer) buildReviewPrompt(ctx context.Context, code string, cfg *reviewConfig) string {
+	var b strings.Builder
+
+	// Include RAG context if available
+	if cr.retriever != nil {
+		results, err := cr.retriever.Retrieve(ctx, code, 5)
+		if err == nil && len(results) > 0 {
+			ragContext := cr.retriever.BuildContext(results, 2048)
+			if ragContext != "" {
+				b.WriteString(ragContext)
+				b.WriteString("\n")
+			}
+		}
+	}
+
+	b.WriteString("Please review the following code")
+	if cfg.language != "" {
+		b.WriteString(fmt.Sprintf(" (language: %s)", cfg.language))
+	}
+	if cfg.focus != "" {
+		b.WriteString(fmt.Sprintf(" with a focus on %s", cfg.focus))
+	}
+	b.WriteString(":\n\n```\n")
+	b.WriteString(code)
+	b.WriteString("\n```\n\nProvide:\n1. Issues found (bugs, style, potential problems)\n2. Suggestions for improvement\n3. Positive aspects of the code")
+
+	return b.String()
+}

--- a/analysis/code_review_test.go
+++ b/analysis/code_review_test.go
@@ -1,0 +1,214 @@
+package analysis
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+func newMockChatServer(t *testing.T, wantContent string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		var req ollama.ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		resp := ollama.ChatResponse{
+			Model:   req.Model,
+			Message: ollama.ChatMessage{Role: "assistant", Content: wantContent},
+			Done:    true,
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func TestNewCodeReviewer(t *testing.T) {
+	client := ollama.NewClient()
+
+	tests := []struct {
+		name      string
+		client    *ollama.Client
+		model     string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:    "valid",
+			client:  client,
+			model:   "test-model",
+			wantErr: false,
+		},
+		{
+			name:      "nil client",
+			client:    nil,
+			model:     "test-model",
+			wantErr:   true,
+			errSubstr: "client is required",
+		},
+		{
+			name:      "empty model",
+			client:    client,
+			model:     "",
+			wantErr:   true,
+			errSubstr: "model is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cr, err := NewCodeReviewer(tt.client, nil, tt.model)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("error %q should contain %q", err.Error(), tt.errSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cr == nil {
+				t.Fatal("expected non-nil CodeReviewer")
+			}
+		})
+	}
+}
+
+func TestReview(t *testing.T) {
+	const reviewResponse = "Code looks good. Consider adding error handling."
+	srv := newMockChatServer(t, reviewResponse)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	cr, err := NewCodeReviewer(client, nil, "test-model")
+	if err != nil {
+		t.Fatalf("NewCodeReviewer() error: %v", err)
+	}
+
+	result, err := cr.Review(context.Background(), "func main() { fmt.Println(\"hello\") }")
+	if err != nil {
+		t.Fatalf("Review() error: %v", err)
+	}
+	if result != reviewResponse {
+		t.Errorf("expected %q, got %q", reviewResponse, result)
+	}
+}
+
+func TestReviewWithOptions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollama.ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+
+		// Verify the prompt includes language and focus
+		userMsg := req.Messages[len(req.Messages)-1].Content
+		if !strings.Contains(userMsg, "language: Go") {
+			t.Error("expected prompt to contain language: Go")
+		}
+		if !strings.Contains(userMsg, "focus on security") {
+			t.Error("expected prompt to contain focus on security")
+		}
+
+		resp := ollama.ChatResponse{
+			Model:   req.Model,
+			Message: ollama.ChatMessage{Role: "assistant", Content: "Security review complete."},
+			Done:    true,
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	cr, err := NewCodeReviewer(client, nil, "test-model")
+	if err != nil {
+		t.Fatalf("NewCodeReviewer() error: %v", err)
+	}
+
+	result, err := cr.Review(context.Background(), "func main() {}",
+		WithLanguage("Go"),
+		WithFocus("security"),
+	)
+	if err != nil {
+		t.Fatalf("Review() error: %v", err)
+	}
+	if result != "Security review complete." {
+		t.Errorf("unexpected result: %q", result)
+	}
+}
+
+func TestReviewEmptyCode(t *testing.T) {
+	client := ollama.NewClient()
+	cr, err := NewCodeReviewer(client, nil, "test-model")
+	if err != nil {
+		t.Fatalf("NewCodeReviewer() error: %v", err)
+	}
+
+	_, err = cr.Review(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error for empty code")
+	}
+	if !strings.Contains(err.Error(), "code is required") {
+		t.Errorf("error %q should mention code is required", err.Error())
+	}
+}
+
+func TestReviewServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	cr, err := NewCodeReviewer(client, nil, "test-model")
+	if err != nil {
+		t.Fatalf("NewCodeReviewer() error: %v", err)
+	}
+
+	_, err = cr.Review(context.Background(), "some code")
+	if err == nil {
+		t.Fatal("expected error for server error")
+	}
+	if !strings.Contains(err.Error(), "analysis: review code:") {
+		t.Errorf("error %q should have analysis: prefix", err.Error())
+	}
+}
+
+func TestReviewContextCanceled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := ollama.ChatResponse{
+			Model:   "test-model",
+			Message: ollama.ChatMessage{Role: "assistant", Content: "ok"},
+			Done:    true,
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	cr, err := NewCodeReviewer(client, nil, "test-model")
+	if err != nil {
+		t.Fatalf("NewCodeReviewer() error: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = cr.Review(ctx, "some code")
+	if err == nil {
+		t.Fatal("expected error for canceled context")
+	}
+}

--- a/analysis/explain.go
+++ b/analysis/explain.go
@@ -1,0 +1,39 @@
+package analysis
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+// Explain generates a natural-language explanation of the provided code snippet
+// using the specified LLM model.
+func Explain(ctx context.Context, client *ollama.Client, model string, code string) (string, error) {
+	if client == nil {
+		return "", fmt.Errorf("analysis: explain: client is required")
+	}
+	if model == "" {
+		return "", fmt.Errorf("analysis: explain: model is required")
+	}
+	if code == "" {
+		return "", fmt.Errorf("analysis: explain: code is required")
+	}
+
+	prompt := "Explain the following code clearly and concisely. " +
+		"Describe what it does, how it works, and any notable patterns or techniques used:\n\n```\n" +
+		code + "\n```"
+
+	resp, err := client.Chat(ctx, ollama.ChatRequest{
+		Model: model,
+		Messages: []ollama.ChatMessage{
+			{Role: "system", Content: "You are an expert programmer. Explain code clearly for developers of all skill levels."},
+			{Role: "user", Content: prompt},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("analysis: explain: %w", err)
+	}
+
+	return resp.Message.Content, nil
+}

--- a/analysis/explain_test.go
+++ b/analysis/explain_test.go
@@ -1,0 +1,131 @@
+package analysis
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+func TestExplain(t *testing.T) {
+	const explanation = "This function prints hello world to stdout."
+	srv := newMockChatServer(t, explanation)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	result, err := Explain(context.Background(), client, "test-model", "fmt.Println(\"hello\")")
+	if err != nil {
+		t.Fatalf("Explain() error: %v", err)
+	}
+	if result != explanation {
+		t.Errorf("expected %q, got %q", explanation, result)
+	}
+}
+
+func TestExplainValidation(t *testing.T) {
+	client := ollama.NewClient()
+
+	tests := []struct {
+		name      string
+		client    *ollama.Client
+		model     string
+		code      string
+		errSubstr string
+	}{
+		{
+			name:      "nil client",
+			client:    nil,
+			model:     "test-model",
+			code:      "some code",
+			errSubstr: "client is required",
+		},
+		{
+			name:      "empty model",
+			client:    client,
+			model:     "",
+			code:      "some code",
+			errSubstr: "model is required",
+		},
+		{
+			name:      "empty code",
+			client:    client,
+			model:     "test-model",
+			code:      "",
+			errSubstr: "code is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Explain(context.Background(), tt.client, tt.model, tt.code)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.errSubstr) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.errSubstr)
+			}
+			if !strings.Contains(err.Error(), "analysis: explain:") {
+				t.Errorf("error %q should have analysis: explain: prefix", err.Error())
+			}
+		})
+	}
+}
+
+func TestExplainPromptContent(t *testing.T) {
+	const code = "func add(a, b int) int { return a + b }"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollama.ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+
+		// Verify system message
+		if req.Messages[0].Role != "system" {
+			t.Errorf("first message should be system, got %q", req.Messages[0].Role)
+		}
+
+		// Verify code is in user prompt
+		userMsg := req.Messages[1].Content
+		if !strings.Contains(userMsg, code) {
+			t.Error("expected user prompt to contain the code")
+		}
+
+		resp := ollama.ChatResponse{
+			Model:   req.Model,
+			Message: ollama.ChatMessage{Role: "assistant", Content: "Adds two integers."},
+			Done:    true,
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	result, err := Explain(context.Background(), client, "test-model", code)
+	if err != nil {
+		t.Fatalf("Explain() error: %v", err)
+	}
+	if result != "Adds two integers." {
+		t.Errorf("unexpected result: %q", result)
+	}
+}
+
+func TestExplainServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	_, err := Explain(context.Background(), client, "test-model", "some code")
+	if err == nil {
+		t.Fatal("expected error for server error")
+	}
+	if !strings.Contains(err.Error(), "analysis: explain:") {
+		t.Errorf("error %q should have analysis: explain: prefix", err.Error())
+	}
+}

--- a/analysis/metrics.go
+++ b/analysis/metrics.go
@@ -1,0 +1,144 @@
+package analysis
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+// TrainingMetrics holds ML training metrics for a single epoch or checkpoint.
+type TrainingMetrics struct {
+	Epoch         int
+	Loss          float64
+	LossHistory   []float64
+	RewardMean    float64
+	RewardHistory []float64
+	KLDivergence  float64
+	LearningRate  float64
+	CustomMetrics map[string]float64
+}
+
+// AnomalyInfo describes a detected anomaly in training metrics.
+type AnomalyInfo struct {
+	Type        string             // e.g. "reward_hack", "kl_drift", "loss_spike"
+	Severity    string             // "warning" or "critical"
+	Description string
+	Metrics     map[string]float64
+}
+
+// MetricsAnalyzer generates natural-language analysis of ML training metrics.
+type MetricsAnalyzer struct {
+	client *ollama.Client
+	model  string
+}
+
+// NewMetricsAnalyzer creates a MetricsAnalyzer with the given client and model.
+func NewMetricsAnalyzer(client *ollama.Client, model string) (*MetricsAnalyzer, error) {
+	if client == nil {
+		return nil, fmt.Errorf("analysis: new metrics analyzer: client is required")
+	}
+	if model == "" {
+		return nil, fmt.Errorf("analysis: new metrics analyzer: model is required")
+	}
+	return &MetricsAnalyzer{
+		client: client,
+		model:  model,
+	}, nil
+}
+
+// AnalyzeTraining generates a natural-language analysis of training metrics,
+// including trend detection and recommendations.
+func (ma *MetricsAnalyzer) AnalyzeTraining(ctx context.Context, metrics TrainingMetrics) (string, error) {
+	if metrics.Epoch < 0 {
+		return "", fmt.Errorf("analysis: analyze training: epoch must be non-negative, got %d", metrics.Epoch)
+	}
+	if metrics.LearningRate < 0 {
+		return "", fmt.Errorf("analysis: analyze training: learning rate must be non-negative, got %f", metrics.LearningRate)
+	}
+
+	prompt := buildTrainingPrompt(metrics)
+
+	resp, err := ma.client.Chat(ctx, ollama.ChatRequest{
+		Model: ma.model,
+		Messages: []ollama.ChatMessage{
+			{Role: "system", Content: "You are an ML training expert. Analyze training metrics and provide actionable insights about convergence, stability, and potential issues."},
+			{Role: "user", Content: prompt},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("analysis: analyze training: %w", err)
+	}
+
+	return resp.Message.Content, nil
+}
+
+// ExplainAnomaly generates a natural-language explanation and remediation advice
+// for a detected training anomaly.
+func (ma *MetricsAnalyzer) ExplainAnomaly(ctx context.Context, anomaly AnomalyInfo) (string, error) {
+	if anomaly.Type == "" {
+		return "", fmt.Errorf("analysis: explain anomaly: type is required")
+	}
+	if anomaly.Severity == "" {
+		return "", fmt.Errorf("analysis: explain anomaly: severity is required")
+	}
+
+	prompt := buildAnomalyPrompt(anomaly)
+
+	resp, err := ma.client.Chat(ctx, ollama.ChatRequest{
+		Model: ma.model,
+		Messages: []ollama.ChatMessage{
+			{Role: "system", Content: "You are an ML training expert. Explain training anomalies clearly and suggest concrete remediation steps."},
+			{Role: "user", Content: prompt},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("analysis: explain anomaly: %w", err)
+	}
+
+	return resp.Message.Content, nil
+}
+
+func buildTrainingPrompt(m TrainingMetrics) string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("Analyze the following ML training metrics at epoch %d:\n\n", m.Epoch))
+	b.WriteString(fmt.Sprintf("- Current Loss: %.6f\n", m.Loss))
+	b.WriteString(fmt.Sprintf("- Learning Rate: %g\n", m.LearningRate))
+	b.WriteString(fmt.Sprintf("- KL Divergence: %.6f\n", m.KLDivergence))
+	b.WriteString(fmt.Sprintf("- Mean Reward: %.6f\n", m.RewardMean))
+
+	if len(m.LossHistory) > 0 {
+		b.WriteString(fmt.Sprintf("- Loss History (last %d): %v\n", len(m.LossHistory), m.LossHistory))
+	}
+	if len(m.RewardHistory) > 0 {
+		b.WriteString(fmt.Sprintf("- Reward History (last %d): %v\n", len(m.RewardHistory), m.RewardHistory))
+	}
+	if len(m.CustomMetrics) > 0 {
+		b.WriteString("- Custom Metrics:\n")
+		for k, v := range m.CustomMetrics {
+			b.WriteString(fmt.Sprintf("  - %s: %.6f\n", k, v))
+		}
+	}
+
+	b.WriteString("\nProvide:\n1. Overall training health assessment\n2. Trend analysis\n3. Potential issues or concerns\n4. Recommendations for next steps")
+	return b.String()
+}
+
+func buildAnomalyPrompt(a AnomalyInfo) string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("Explain the following training anomaly:\n\n"))
+	b.WriteString(fmt.Sprintf("- Type: %s\n", a.Type))
+	b.WriteString(fmt.Sprintf("- Severity: %s\n", a.Severity))
+	b.WriteString(fmt.Sprintf("- Description: %s\n", a.Description))
+
+	if len(a.Metrics) > 0 {
+		b.WriteString("- Associated Metrics:\n")
+		for k, v := range a.Metrics {
+			b.WriteString(fmt.Sprintf("  - %s: %.6f\n", k, v))
+		}
+	}
+
+	b.WriteString("\nProvide:\n1. What this anomaly means\n2. Likely causes\n3. Impact on training\n4. Recommended remediation steps")
+	return b.String()
+}

--- a/analysis/metrics_test.go
+++ b/analysis/metrics_test.go
@@ -1,0 +1,268 @@
+package analysis
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+func TestNewMetricsAnalyzer(t *testing.T) {
+	client := ollama.NewClient()
+
+	tests := []struct {
+		name      string
+		client    *ollama.Client
+		model     string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:    "valid",
+			client:  client,
+			model:   "test-model",
+			wantErr: false,
+		},
+		{
+			name:      "nil client",
+			client:    nil,
+			model:     "test-model",
+			wantErr:   true,
+			errSubstr: "client is required",
+		},
+		{
+			name:      "empty model",
+			client:    client,
+			model:     "",
+			wantErr:   true,
+			errSubstr: "model is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ma, err := NewMetricsAnalyzer(tt.client, tt.model)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("error %q should contain %q", err.Error(), tt.errSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ma == nil {
+				t.Fatal("expected non-nil MetricsAnalyzer")
+			}
+		})
+	}
+}
+
+func TestAnalyzeTraining(t *testing.T) {
+	const analysisResult = "Training is progressing well. Loss is decreasing steadily."
+	srv := newMockChatServer(t, analysisResult)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	ma, err := NewMetricsAnalyzer(client, "test-model")
+	if err != nil {
+		t.Fatalf("NewMetricsAnalyzer() error: %v", err)
+	}
+
+	metrics := TrainingMetrics{
+		Epoch:         10,
+		Loss:          0.05,
+		LossHistory:   []float64{0.5, 0.3, 0.1, 0.05},
+		RewardMean:    0.85,
+		RewardHistory: []float64{0.1, 0.5, 0.7, 0.85},
+		KLDivergence:  0.02,
+		LearningRate:  0.001,
+		CustomMetrics: map[string]float64{"accuracy": 0.95},
+	}
+
+	result, err := ma.AnalyzeTraining(context.Background(), metrics)
+	if err != nil {
+		t.Fatalf("AnalyzeTraining() error: %v", err)
+	}
+	if result != analysisResult {
+		t.Errorf("expected %q, got %q", analysisResult, result)
+	}
+}
+
+func TestAnalyzeTrainingPromptContent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollama.ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+
+		userMsg := req.Messages[1].Content
+		if !strings.Contains(userMsg, "epoch 5") {
+			t.Error("expected prompt to mention epoch")
+		}
+		if !strings.Contains(userMsg, "Current Loss") {
+			t.Error("expected prompt to contain loss")
+		}
+		if !strings.Contains(userMsg, "Learning Rate") {
+			t.Error("expected prompt to contain learning rate")
+		}
+
+		resp := ollama.ChatResponse{
+			Model:   req.Model,
+			Message: ollama.ChatMessage{Role: "assistant", Content: "analysis"},
+			Done:    true,
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	ma, err := NewMetricsAnalyzer(client, "test-model")
+	if err != nil {
+		t.Fatalf("NewMetricsAnalyzer() error: %v", err)
+	}
+
+	_, err = ma.AnalyzeTraining(context.Background(), TrainingMetrics{
+		Epoch:        5,
+		Loss:         0.1,
+		LearningRate: 0.001,
+	})
+	if err != nil {
+		t.Fatalf("AnalyzeTraining() error: %v", err)
+	}
+}
+
+func TestAnalyzeTrainingValidation(t *testing.T) {
+	client := ollama.NewClient()
+	ma, err := NewMetricsAnalyzer(client, "test-model")
+	if err != nil {
+		t.Fatalf("NewMetricsAnalyzer() error: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		metrics   TrainingMetrics
+		errSubstr string
+	}{
+		{
+			name:      "negative epoch",
+			metrics:   TrainingMetrics{Epoch: -1, LearningRate: 0.001},
+			errSubstr: "epoch must be non-negative",
+		},
+		{
+			name:      "negative learning rate",
+			metrics:   TrainingMetrics{Epoch: 0, LearningRate: -0.001},
+			errSubstr: "learning rate must be non-negative",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ma.AnalyzeTraining(context.Background(), tt.metrics)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.errSubstr) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.errSubstr)
+			}
+			if !strings.Contains(err.Error(), "analysis: analyze training:") {
+				t.Errorf("error %q should have analysis: prefix", err.Error())
+			}
+		})
+	}
+}
+
+func TestExplainAnomaly(t *testing.T) {
+	const explanation = "KL drift indicates policy divergence. Reduce learning rate."
+	srv := newMockChatServer(t, explanation)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	ma, err := NewMetricsAnalyzer(client, "test-model")
+	if err != nil {
+		t.Fatalf("NewMetricsAnalyzer() error: %v", err)
+	}
+
+	anomaly := AnomalyInfo{
+		Type:        "kl_drift",
+		Severity:    "warning",
+		Description: "KL divergence exceeded threshold",
+		Metrics:     map[string]float64{"kl_divergence": 0.15},
+	}
+
+	result, err := ma.ExplainAnomaly(context.Background(), anomaly)
+	if err != nil {
+		t.Fatalf("ExplainAnomaly() error: %v", err)
+	}
+	if result != explanation {
+		t.Errorf("expected %q, got %q", explanation, result)
+	}
+}
+
+func TestExplainAnomalyValidation(t *testing.T) {
+	client := ollama.NewClient()
+	ma, err := NewMetricsAnalyzer(client, "test-model")
+	if err != nil {
+		t.Fatalf("NewMetricsAnalyzer() error: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		anomaly   AnomalyInfo
+		errSubstr string
+	}{
+		{
+			name:      "empty type",
+			anomaly:   AnomalyInfo{Type: "", Severity: "warning"},
+			errSubstr: "type is required",
+		},
+		{
+			name:      "empty severity",
+			anomaly:   AnomalyInfo{Type: "loss_spike", Severity: ""},
+			errSubstr: "severity is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ma.ExplainAnomaly(context.Background(), tt.anomaly)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.errSubstr) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.errSubstr)
+			}
+			if !strings.Contains(err.Error(), "analysis: explain anomaly:") {
+				t.Errorf("error %q should have analysis: prefix", err.Error())
+			}
+		})
+	}
+}
+
+func TestAnalyzeTrainingServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	ma, err := NewMetricsAnalyzer(client, "test-model")
+	if err != nil {
+		t.Fatalf("NewMetricsAnalyzer() error: %v", err)
+	}
+
+	_, err = ma.AnalyzeTraining(context.Background(), TrainingMetrics{Epoch: 1, LearningRate: 0.001})
+	if err == nil {
+		t.Fatal("expected error for server error")
+	}
+	if !strings.Contains(err.Error(), "analysis: analyze training:") {
+		t.Errorf("error %q should have analysis: prefix", err.Error())
+	}
+}

--- a/analysis/trading.go
+++ b/analysis/trading.go
@@ -1,0 +1,112 @@
+package analysis
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+// StrategyReport holds the results of a trading strategy analysis.
+type StrategyReport struct {
+	StrategyName string
+	Analysis     string
+}
+
+// StrategyAnalyzer generates natural-language analysis of trading strategies.
+type StrategyAnalyzer struct {
+	client *ollama.Client
+	model  string
+}
+
+// NewStrategyAnalyzer creates a StrategyAnalyzer with the given client and model.
+func NewStrategyAnalyzer(client *ollama.Client, model string) (*StrategyAnalyzer, error) {
+	if client == nil {
+		return nil, fmt.Errorf("analysis: new strategy analyzer: client is required")
+	}
+	if model == "" {
+		return nil, fmt.Errorf("analysis: new strategy analyzer: model is required")
+	}
+	return &StrategyAnalyzer{
+		client: client,
+		model:  model,
+	}, nil
+}
+
+// AnalyzeStrategy generates a natural-language analysis of a trading strategy
+// based on its name and performance metrics.
+func (sa *StrategyAnalyzer) AnalyzeStrategy(ctx context.Context, name string, metrics map[string]float64) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("analysis: analyze strategy: name is required")
+	}
+	if len(metrics) == 0 {
+		return "", fmt.Errorf("analysis: analyze strategy: metrics are required")
+	}
+
+	prompt := buildStrategyPrompt(name, metrics)
+
+	resp, err := sa.client.Chat(ctx, ollama.ChatRequest{
+		Model: sa.model,
+		Messages: []ollama.ChatMessage{
+			{Role: "system", Content: "You are a quantitative finance expert. Analyze trading strategy performance and provide actionable insights about risk, returns, and potential improvements."},
+			{Role: "user", Content: prompt},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("analysis: analyze strategy: %w", err)
+	}
+
+	return resp.Message.Content, nil
+}
+
+// CompareStrategies generates a comparative analysis of multiple trading strategies.
+// Each entry in the map is a strategy name to its performance metrics.
+func (sa *StrategyAnalyzer) CompareStrategies(ctx context.Context, strategies map[string]map[string]float64) (string, error) {
+	if len(strategies) < 2 {
+		return "", fmt.Errorf("analysis: compare strategies: at least 2 strategies are required, got %d", len(strategies))
+	}
+
+	prompt := buildComparisonPrompt(strategies)
+
+	resp, err := sa.client.Chat(ctx, ollama.ChatRequest{
+		Model: sa.model,
+		Messages: []ollama.ChatMessage{
+			{Role: "system", Content: "You are a quantitative finance expert. Compare trading strategies objectively, highlighting relative strengths, weaknesses, and risk-adjusted performance."},
+			{Role: "user", Content: prompt},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("analysis: compare strategies: %w", err)
+	}
+
+	return resp.Message.Content, nil
+}
+
+func buildStrategyPrompt(name string, metrics map[string]float64) string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("Analyze the trading strategy %q with the following performance metrics:\n\n", name))
+
+	for k, v := range metrics {
+		b.WriteString(fmt.Sprintf("- %s: %.6f\n", k, v))
+	}
+
+	b.WriteString("\nProvide:\n1. Overall performance assessment\n2. Risk analysis\n3. Strengths and weaknesses\n4. Recommendations for improvement")
+	return b.String()
+}
+
+func buildComparisonPrompt(strategies map[string]map[string]float64) string {
+	var b strings.Builder
+	b.WriteString("Compare the following trading strategies:\n\n")
+
+	for name, metrics := range strategies {
+		b.WriteString(fmt.Sprintf("Strategy: %s\n", name))
+		for k, v := range metrics {
+			b.WriteString(fmt.Sprintf("  - %s: %.6f\n", k, v))
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("Provide:\n1. Side-by-side comparison\n2. Risk-adjusted performance ranking\n3. Best strategy for different market conditions\n4. Overall recommendation")
+	return b.String()
+}

--- a/analysis/trading_test.go
+++ b/analysis/trading_test.go
@@ -1,0 +1,273 @@
+package analysis
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+func TestNewStrategyAnalyzer(t *testing.T) {
+	client := ollama.NewClient()
+
+	tests := []struct {
+		name      string
+		client    *ollama.Client
+		model     string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:    "valid",
+			client:  client,
+			model:   "test-model",
+			wantErr: false,
+		},
+		{
+			name:      "nil client",
+			client:    nil,
+			model:     "test-model",
+			wantErr:   true,
+			errSubstr: "client is required",
+		},
+		{
+			name:      "empty model",
+			client:    client,
+			model:     "",
+			wantErr:   true,
+			errSubstr: "model is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sa, err := NewStrategyAnalyzer(tt.client, tt.model)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("error %q should contain %q", err.Error(), tt.errSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if sa == nil {
+				t.Fatal("expected non-nil StrategyAnalyzer")
+			}
+		})
+	}
+}
+
+func TestAnalyzeStrategy(t *testing.T) {
+	const analysisResult = "Strong risk-adjusted returns with moderate drawdown."
+	srv := newMockChatServer(t, analysisResult)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	sa, err := NewStrategyAnalyzer(client, "test-model")
+	if err != nil {
+		t.Fatalf("NewStrategyAnalyzer() error: %v", err)
+	}
+
+	metrics := map[string]float64{
+		"sharpe_ratio":  1.85,
+		"max_drawdown":  0.12,
+		"annual_return": 0.24,
+		"win_rate":      0.62,
+	}
+
+	result, err := sa.AnalyzeStrategy(context.Background(), "momentum_v2", metrics)
+	if err != nil {
+		t.Fatalf("AnalyzeStrategy() error: %v", err)
+	}
+	if result != analysisResult {
+		t.Errorf("expected %q, got %q", analysisResult, result)
+	}
+}
+
+func TestAnalyzeStrategyValidation(t *testing.T) {
+	client := ollama.NewClient()
+	sa, err := NewStrategyAnalyzer(client, "test-model")
+	if err != nil {
+		t.Fatalf("NewStrategyAnalyzer() error: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		strategy  string
+		metrics   map[string]float64
+		errSubstr string
+	}{
+		{
+			name:      "empty name",
+			strategy:  "",
+			metrics:   map[string]float64{"sharpe": 1.0},
+			errSubstr: "name is required",
+		},
+		{
+			name:      "nil metrics",
+			strategy:  "test",
+			metrics:   nil,
+			errSubstr: "metrics are required",
+		},
+		{
+			name:      "empty metrics",
+			strategy:  "test",
+			metrics:   map[string]float64{},
+			errSubstr: "metrics are required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := sa.AnalyzeStrategy(context.Background(), tt.strategy, tt.metrics)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.errSubstr) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.errSubstr)
+			}
+			if !strings.Contains(err.Error(), "analysis: analyze strategy:") {
+				t.Errorf("error %q should have analysis: prefix", err.Error())
+			}
+		})
+	}
+}
+
+func TestAnalyzeStrategyPromptContent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollama.ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+
+		userMsg := req.Messages[1].Content
+		if !strings.Contains(userMsg, "mean_revert") {
+			t.Error("expected prompt to contain strategy name")
+		}
+		if !strings.Contains(userMsg, "sharpe_ratio") {
+			t.Error("expected prompt to contain metric name")
+		}
+
+		resp := ollama.ChatResponse{
+			Model:   req.Model,
+			Message: ollama.ChatMessage{Role: "assistant", Content: "analysis"},
+			Done:    true,
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	sa, err := NewStrategyAnalyzer(client, "test-model")
+	if err != nil {
+		t.Fatalf("NewStrategyAnalyzer() error: %v", err)
+	}
+
+	_, err = sa.AnalyzeStrategy(context.Background(), "mean_revert", map[string]float64{
+		"sharpe_ratio": 1.5,
+	})
+	if err != nil {
+		t.Fatalf("AnalyzeStrategy() error: %v", err)
+	}
+}
+
+func TestCompareStrategies(t *testing.T) {
+	const comparison = "Strategy A outperforms on risk-adjusted basis."
+	srv := newMockChatServer(t, comparison)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	sa, err := NewStrategyAnalyzer(client, "test-model")
+	if err != nil {
+		t.Fatalf("NewStrategyAnalyzer() error: %v", err)
+	}
+
+	strategies := map[string]map[string]float64{
+		"momentum": {"sharpe_ratio": 1.85, "max_drawdown": 0.12},
+		"mean_rev": {"sharpe_ratio": 1.20, "max_drawdown": 0.08},
+	}
+
+	result, err := sa.CompareStrategies(context.Background(), strategies)
+	if err != nil {
+		t.Fatalf("CompareStrategies() error: %v", err)
+	}
+	if result != comparison {
+		t.Errorf("expected %q, got %q", comparison, result)
+	}
+}
+
+func TestCompareStrategiesValidation(t *testing.T) {
+	client := ollama.NewClient()
+	sa, err := NewStrategyAnalyzer(client, "test-model")
+	if err != nil {
+		t.Fatalf("NewStrategyAnalyzer() error: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		strategies map[string]map[string]float64
+		errSubstr  string
+	}{
+		{
+			name:       "nil strategies",
+			strategies: nil,
+			errSubstr:  "at least 2 strategies are required",
+		},
+		{
+			name: "single strategy",
+			strategies: map[string]map[string]float64{
+				"only_one": {"sharpe": 1.0},
+			},
+			errSubstr: "at least 2 strategies are required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := sa.CompareStrategies(context.Background(), tt.strategies)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.errSubstr) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.errSubstr)
+			}
+			if !strings.Contains(err.Error(), "analysis: compare strategies:") {
+				t.Errorf("error %q should have analysis: prefix", err.Error())
+			}
+		})
+	}
+}
+
+func TestCompareStrategiesServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	sa, err := NewStrategyAnalyzer(client, "test-model")
+	if err != nil {
+		t.Fatalf("NewStrategyAnalyzer() error: %v", err)
+	}
+
+	strategies := map[string]map[string]float64{
+		"a": {"sharpe": 1.0},
+		"b": {"sharpe": 2.0},
+	}
+
+	_, err = sa.CompareStrategies(context.Background(), strategies)
+	if err == nil {
+		t.Fatal("expected error for server error")
+	}
+	if !strings.Contains(err.Error(), "analysis: compare strategies:") {
+		t.Errorf("error %q should have analysis: prefix", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `analysis/` package with domain-specific LLM analysis helpers built on chat + RAG
- `code_review.go` -- `CodeReviewer` for generating code reviews using LLM + RAG context
- `explain.go` -- Code explanation generation
- `metrics.go` -- `MetricsAnalyzer` for ML training analysis (Flux ML integration)
- `trading.go` -- Trading strategy analysis (Quantum Trader integration)
- Full test coverage with mock HTTP servers (8 files, 1299 lines)

## Test plan
- [x] `go test ./analysis/` passes
- [ ] Verify integration with Flux ML's Wails bindings (future)
- [ ] Verify integration with Quantum Trader Go API (future)

Generated with [Claude Code](https://claude.com/claude-code)