### PR TITLE
feat: wire context window management into FIM completion (Issue #1)

### DIFF
--- a/completion/context.go
+++ b/completion/context.go
@@ -25,3 +25,17 @@ func TruncateToTokens(text string, maxTokens int) string {
 	}
 	return text[len(text)-maxChars:]
 }
+
+// TruncateSuffixToTokens truncates text to fit within the given token budget,
+// keeping the first (nearest to cursor) content. This is useful for suffix
+// context where the code immediately after the cursor is most relevant.
+func TruncateSuffixToTokens(text string, maxTokens int) string {
+	if maxTokens <= 0 {
+		return ""
+	}
+	maxChars := maxTokens * 4
+	if len(text) <= maxChars {
+		return text
+	}
+	return text[:maxChars]
+}

--- a/completion/context.go
+++ b/completion/context.go
@@ -2,6 +2,8 @@
 // prompting with Ollama models.
 package completion
 
+import "unicode/utf8"
+
 // EstimateTokens returns a rough token count for the given text.
 // It uses a simple heuristic of ~4 characters per token, which is
 // a reasonable approximation for code across most tokenizers.
@@ -15,6 +17,7 @@ func EstimateTokens(text string) int {
 // TruncateToTokens truncates text to fit within the given token budget,
 // keeping the last (most recent) content. This is useful for prefix context
 // where the code nearest to the cursor is most relevant.
+// The cut point is adjusted to avoid splitting multi-byte UTF-8 runes.
 func TruncateToTokens(text string, maxTokens int) string {
 	if maxTokens <= 0 {
 		return ""
@@ -23,12 +26,18 @@ func TruncateToTokens(text string, maxTokens int) string {
 	if len(text) <= maxChars {
 		return text
 	}
-	return text[len(text)-maxChars:]
+	start := len(text) - maxChars
+	// Advance past any continuation bytes to the next rune boundary
+	for start < len(text) && !utf8.RuneStart(text[start]) {
+		start++
+	}
+	return text[start:]
 }
 
 // TruncateSuffixToTokens truncates text to fit within the given token budget,
 // keeping the first (nearest to cursor) content. This is useful for suffix
 // context where the code immediately after the cursor is most relevant.
+// The cut point is adjusted to avoid splitting multi-byte UTF-8 runes.
 func TruncateSuffixToTokens(text string, maxTokens int) string {
 	if maxTokens <= 0 {
 		return ""
@@ -37,5 +46,10 @@ func TruncateSuffixToTokens(text string, maxTokens int) string {
 	if len(text) <= maxChars {
 		return text
 	}
-	return text[:maxChars]
+	// Walk back from the cut point to avoid splitting a multi-byte rune
+	end := maxChars
+	for end > 0 && !utf8.RuneStart(text[end]) {
+		end--
+	}
+	return text[:end]
 }

--- a/completion/context_test.go
+++ b/completion/context_test.go
@@ -41,6 +41,9 @@ func TestTruncateToTokens(t *testing.T) {
 		{name: "exact fit", input: "abcdefgh", maxTokens: 2, want: "abcdefgh"},
 		{name: "truncates to last chars", input: "0123456789abcd", maxTokens: 2, want: "6789abcd"},
 		{name: "single token budget", input: "hello world", maxTokens: 1, want: "orld"},
+		// "ab" + "世" (3 bytes) + "界" (3 bytes) = 8 bytes. Budget=1 token=4 bytes.
+		// Cut at byte 4 lands mid-rune in "界", so advance to byte 5 → keep "界".
+		{name: "utf8 rune boundary", input: "ab世界", maxTokens: 1, want: "界"},
 	}
 
 	for _, tt := range tests {
@@ -67,6 +70,9 @@ func TestTruncateSuffixToTokens(t *testing.T) {
 		{name: "exact fit", input: "abcdefgh", maxTokens: 2, want: "abcdefgh"},
 		{name: "truncates to first chars", input: "0123456789abcd", maxTokens: 2, want: "01234567"},
 		{name: "single token budget", input: "hello world", maxTokens: 1, want: "hell"},
+		// "世界abc" = 6+3 = 9 bytes. Budget=1 token=4 bytes.
+		// Cut at byte 4 would split "界" (bytes 3-5), so walk back to byte 3 → keep "世".
+		{name: "utf8 rune boundary", input: "世界abc", maxTokens: 1, want: "世"},
 	}
 
 	for _, tt := range tests {

--- a/completion/context_test.go
+++ b/completion/context_test.go
@@ -52,3 +52,29 @@ func TestTruncateToTokens(t *testing.T) {
 		})
 	}
 }
+
+func TestTruncateSuffixToTokens(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		maxTokens int
+		want      string
+	}{
+		{name: "empty string", input: "", maxTokens: 10, want: ""},
+		{name: "zero tokens", input: "hello", maxTokens: 0, want: ""},
+		{name: "negative tokens", input: "hello", maxTokens: -1, want: ""},
+		{name: "within budget", input: "abcd", maxTokens: 1, want: "abcd"},
+		{name: "exact fit", input: "abcdefgh", maxTokens: 2, want: "abcdefgh"},
+		{name: "truncates to first chars", input: "0123456789abcd", maxTokens: 2, want: "01234567"},
+		{name: "single token budget", input: "hello world", maxTokens: 1, want: "hell"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TruncateSuffixToTokens(tt.input, tt.maxTokens)
+			if got != tt.want {
+				t.Errorf("TruncateSuffixToTokens(%q, %d) = %q, want %q", tt.input, tt.maxTokens, got, tt.want)
+			}
+		})
+	}
+}

--- a/completion/inline.go
+++ b/completion/inline.go
@@ -16,6 +16,11 @@ const (
 	defaultMaxTokens   = 128
 	defaultNumCtx      = 2048
 	defaultTemperature = 0.2
+
+	// fimTokenOverhead accounts for the 3 FIM special tokens in the context budget.
+	fimTokenOverhead = 3
+	// prefixBudgetPercent is the percentage of available context allocated to prefix.
+	prefixBudgetPercent = 75
 )
 
 // FIMRequest represents a Fill-in-the-Middle completion request.
@@ -98,13 +103,26 @@ func (p *Provider) CompleteStream(ctx context.Context, req FIMRequest, fn func(t
 }
 
 // buildRequest constructs an Ollama GenerateRequest with FIM prompt format.
+// It enforces the context window budget by truncating prefix and suffix to fit
+// within num_ctx, reserving space for generation tokens and FIM special tokens.
 func (p *Provider) buildRequest(req FIMRequest) ollama.GenerateRequest {
 	maxTokens := req.MaxTokens
 	if maxTokens <= 0 {
 		maxTokens = defaultMaxTokens
 	}
 
-	prompt := fimPrefix + req.Prefix + fimSuffix + req.Suffix + fimMiddle
+	// Budget the context window: total - generation - FIM overhead
+	availableCtx := defaultNumCtx - maxTokens - fimTokenOverhead
+	if availableCtx < 0 {
+		availableCtx = 0
+	}
+	prefixBudget := availableCtx * prefixBudgetPercent / 100
+	suffixBudget := availableCtx - prefixBudget
+
+	prefix := TruncateToTokens(req.Prefix, prefixBudget)
+	suffix := TruncateSuffixToTokens(req.Suffix, suffixBudget)
+
+	prompt := fimPrefix + prefix + fimSuffix + suffix + fimMiddle
 
 	return ollama.GenerateRequest{
 		Model:  p.model,

--- a/completion/inline.go
+++ b/completion/inline.go
@@ -119,6 +119,17 @@ func (p *Provider) buildRequest(req FIMRequest) ollama.GenerateRequest {
 	prefixBudget := availableCtx * prefixBudgetPercent / 100
 	suffixBudget := availableCtx - prefixBudget
 
+	// Reallocate unused budget: if one side is short, give its spare to the other
+	prefixTokens := EstimateTokens(req.Prefix)
+	suffixTokens := EstimateTokens(req.Suffix)
+	if prefixTokens < prefixBudget {
+		suffixBudget += prefixBudget - prefixTokens
+		prefixBudget = prefixTokens
+	} else if suffixTokens < suffixBudget {
+		prefixBudget += suffixBudget - suffixTokens
+		suffixBudget = suffixTokens
+	}
+
 	prefix := TruncateToTokens(req.Prefix, prefixBudget)
 	suffix := TruncateSuffixToTokens(req.Suffix, suffixBudget)
 

--- a/completion/inline_test.go
+++ b/completion/inline_test.go
@@ -230,32 +230,46 @@ func TestCompleteModelOptions(t *testing.T) {
 }
 
 func TestCompleteContextTruncation(t *testing.T) {
-	// Create prefix and suffix that far exceed the context window budget.
-	// With num_ctx=2048, num_predict=128, FIM overhead=3, available=1917 tokens.
-	// At ~4 chars/token, that's ~7668 chars total (5748 prefix + 1920 suffix).
-	longPrefix := strings.Repeat("a", 30000) // way over budget
-	longSuffix := strings.Repeat("z", 10000) // way over budget
+	// Build distinguishable prefix and suffix that far exceed the context budget.
+	// Prefix: "P00000...P29999" — each segment is 6 chars, so we can verify
+	// that truncation keeps the END of the prefix (high-numbered segments).
+	// Suffix: "S00000...S09999" — verify truncation keeps the BEGINNING (low-numbered).
+	var prefixBuilder, suffixBuilder strings.Builder
+	for i := 0; i < 5000; i++ {
+		fmt.Fprintf(&prefixBuilder, "P%05d", i) // 6 chars each = 30000 total
+	}
+	for i := 0; i < 1667; i++ {
+		fmt.Fprintf(&suffixBuilder, "S%05d", i) // 6 chars each = 10002 total
+	}
+	longPrefix := prefixBuilder.String()
+	longSuffix := suffixBuilder.String()
 
 	var capturedPrompt string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req ollama.GenerateRequest
-		json.NewDecoder(r.Body).Decode(&req)
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("failed to decode generate request: %v", err)
+		}
 		capturedPrompt = req.Prompt
 
 		resp := ollama.GenerateResponse{Model: "test-model", Response: "x", Done: true}
-		json.NewEncoder(w).Encode(resp)
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("failed to encode generate response: %v", err)
+		}
 	}))
 	defer srv.Close()
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	provider := NewProvider(client, "test-model")
-	provider.Complete(context.Background(), FIMRequest{
+	_, err := provider.Complete(context.Background(), FIMRequest{
 		Prefix: longPrefix,
 		Suffix: longSuffix,
 	})
+	if err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
 
 	// The prompt should be much shorter than the raw inputs.
-	// Raw would be 40000+ chars; truncated should fit within budget.
 	// Available = 2048 - 128 - 3 = 1917 tokens * 4 chars = 7668 chars max for prefix+suffix.
 	// Plus FIM tokens themselves (~42 chars for the 3 token strings).
 	maxExpectedLen := 7668 + len("<|fim_prefix|>") + len("<|fim_suffix|>") + len("<|fim_middle|>")
@@ -263,27 +277,34 @@ func TestCompleteContextTruncation(t *testing.T) {
 		t.Errorf("prompt length %d exceeds budget %d", len(capturedPrompt), maxExpectedLen)
 	}
 
-	// Verify prefix was truncated to keep the END (most recent code)
-	if !strings.HasSuffix(capturedPrompt, "<|fim_middle|>") {
-		t.Error("prompt should end with FIM middle token")
-	}
-	// The prefix portion should end with 'a's (kept from the end of longPrefix)
-	prefixStart := len("<|fim_prefix|>")
+	// Extract prefix and suffix portions from the prompt
 	suffixTokenIdx := strings.Index(capturedPrompt, "<|fim_suffix|>")
-	truncatedPrefix := capturedPrompt[prefixStart:suffixTokenIdx]
+	middleTokenIdx := strings.Index(capturedPrompt, "<|fim_middle|>")
+	if suffixTokenIdx == -1 || middleTokenIdx == -1 {
+		t.Fatal("prompt missing FIM tokens")
+	}
+	truncatedPrefix := capturedPrompt[len("<|fim_prefix|>"):suffixTokenIdx]
+	truncatedSuffix := capturedPrompt[suffixTokenIdx+len("<|fim_suffix|>") : middleTokenIdx]
+
+	// Verify prefix was truncated and keeps the END (high-numbered segments)
 	if len(truncatedPrefix) >= len(longPrefix) {
 		t.Error("prefix should have been truncated")
 	}
+	if !strings.HasSuffix(truncatedPrefix, "P04999") {
+		t.Errorf("prefix should end with last segment P04999, got suffix %q",
+			truncatedPrefix[max(0, len(truncatedPrefix)-6):])
+	}
+	if strings.HasPrefix(truncatedPrefix, "P00000") {
+		t.Error("prefix should NOT start with P00000 (beginning should be trimmed)")
+	}
 
-	// Verify suffix was truncated to keep the BEGINNING (nearest to cursor)
-	middleTokenIdx := strings.Index(capturedPrompt, "<|fim_middle|>")
-	truncatedSuffix := capturedPrompt[suffixTokenIdx+len("<|fim_suffix|>") : middleTokenIdx]
+	// Verify suffix was truncated and keeps the BEGINNING (low-numbered segments)
 	if len(truncatedSuffix) >= len(longSuffix) {
 		t.Error("suffix should have been truncated")
 	}
-	// Suffix should start with 'z's (kept from the beginning of longSuffix)
-	if len(truncatedSuffix) > 0 && truncatedSuffix[0] != 'z' {
-		t.Errorf("truncated suffix should start with 'z', got %q", truncatedSuffix[0:1])
+	if !strings.HasPrefix(truncatedSuffix, "S00000") {
+		t.Errorf("suffix should start with first segment S00000, got prefix %q",
+			truncatedSuffix[:min(6, len(truncatedSuffix))])
 	}
 }
 

--- a/completion/inline_test.go
+++ b/completion/inline_test.go
@@ -229,6 +229,64 @@ func TestCompleteModelOptions(t *testing.T) {
 	provider.Complete(context.Background(), FIMRequest{Prefix: "code"})
 }
 
+func TestCompleteContextTruncation(t *testing.T) {
+	// Create prefix and suffix that far exceed the context window budget.
+	// With num_ctx=2048, num_predict=128, FIM overhead=3, available=1917 tokens.
+	// At ~4 chars/token, that's ~7668 chars total (5748 prefix + 1920 suffix).
+	longPrefix := strings.Repeat("a", 30000) // way over budget
+	longSuffix := strings.Repeat("z", 10000) // way over budget
+
+	var capturedPrompt string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollama.GenerateRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		capturedPrompt = req.Prompt
+
+		resp := ollama.GenerateResponse{Model: "test-model", Response: "x", Done: true}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	provider := NewProvider(client, "test-model")
+	provider.Complete(context.Background(), FIMRequest{
+		Prefix: longPrefix,
+		Suffix: longSuffix,
+	})
+
+	// The prompt should be much shorter than the raw inputs.
+	// Raw would be 40000+ chars; truncated should fit within budget.
+	// Available = 2048 - 128 - 3 = 1917 tokens * 4 chars = 7668 chars max for prefix+suffix.
+	// Plus FIM tokens themselves (~42 chars for the 3 token strings).
+	maxExpectedLen := 7668 + len("<|fim_prefix|>") + len("<|fim_suffix|>") + len("<|fim_middle|>")
+	if len(capturedPrompt) > maxExpectedLen {
+		t.Errorf("prompt length %d exceeds budget %d", len(capturedPrompt), maxExpectedLen)
+	}
+
+	// Verify prefix was truncated to keep the END (most recent code)
+	if !strings.HasSuffix(capturedPrompt, "<|fim_middle|>") {
+		t.Error("prompt should end with FIM middle token")
+	}
+	// The prefix portion should end with 'a's (kept from the end of longPrefix)
+	prefixStart := len("<|fim_prefix|>")
+	suffixTokenIdx := strings.Index(capturedPrompt, "<|fim_suffix|>")
+	truncatedPrefix := capturedPrompt[prefixStart:suffixTokenIdx]
+	if len(truncatedPrefix) >= len(longPrefix) {
+		t.Error("prefix should have been truncated")
+	}
+
+	// Verify suffix was truncated to keep the BEGINNING (nearest to cursor)
+	middleTokenIdx := strings.Index(capturedPrompt, "<|fim_middle|>")
+	truncatedSuffix := capturedPrompt[suffixTokenIdx+len("<|fim_suffix|>") : middleTokenIdx]
+	if len(truncatedSuffix) >= len(longSuffix) {
+		t.Error("suffix should have been truncated")
+	}
+	// Suffix should start with 'z's (kept from the beginning of longSuffix)
+	if len(truncatedSuffix) > 0 && truncatedSuffix[0] != 'z' {
+		t.Errorf("truncated suffix should start with 'z', got %q", truncatedSuffix[0:1])
+	}
+}
+
 func TestCompleteCustomMaxTokens(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req ollama.GenerateRequest


### PR DESCRIPTION
## Summary

- Added `TruncateSuffixToTokens()` to `context.go` — keeps the beginning of text (nearest to cursor), complementing the existing `TruncateToTokens()` which keeps the end
- Wired context budget enforcement into `buildRequest()` in `inline.go` — prefix and suffix are now truncated to fit within `num_ctx` (2048), reserving space for `num_predict` (128) and FIM special tokens (3), with a 75/25 prefix/suffix budget split
- Added table-driven tests for suffix truncation and an integration-style test verifying oversized inputs get truncated correctly

Closes #1

## Test plan

- [x] `go test ./completion/ -v -count=1` — 9 tests, 21 subtests, all pass
- [x] `go test ./... -count=1` — full suite green (ollama, completion, rag, analysis)

Generated with Claude Code