### PR TITLE
feat: conversation store with shape-preserving tool-call persistence (issue #27)

### DIFF
--- a/conversation/convert.go
+++ b/conversation/convert.go
@@ -1,0 +1,52 @@
+package conversation
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+// FromChatMessages converts Ollama messages to provider-agnostic Messages.
+// ToolCalls are marshaled to json.RawMessage for shape-preserving storage.
+func FromChatMessages(msgs []ollama.ChatMessage) ([]Message, error) {
+	result := make([]Message, len(msgs))
+	for i, cm := range msgs {
+		m := Message{
+			Role:       cm.Role,
+			Content:    cm.Content,
+			ToolName:   cm.ToolName,
+			ToolCallID: cm.ToolCallID,
+		}
+		if len(cm.ToolCalls) > 0 {
+			raw, err := json.Marshal(cm.ToolCalls)
+			if err != nil {
+				return nil, fmt.Errorf("conversation: marshal tool calls at index %d: %w", i, err)
+			}
+			m.ToolCalls = raw
+		}
+		result[i] = m
+	}
+	return result, nil
+}
+
+// ToChatMessages converts stored Messages back to Ollama messages.
+// ToolCalls are unmarshaled from json.RawMessage back to []ollama.ToolCall.
+func ToChatMessages(msgs []Message) ([]ollama.ChatMessage, error) {
+	result := make([]ollama.ChatMessage, len(msgs))
+	for i, m := range msgs {
+		cm := ollama.ChatMessage{
+			Role:       m.Role,
+			Content:    m.Content,
+			ToolName:   m.ToolName,
+			ToolCallID: m.ToolCallID,
+		}
+		if len(m.ToolCalls) > 0 {
+			if err := json.Unmarshal(m.ToolCalls, &cm.ToolCalls); err != nil {
+				return nil, fmt.Errorf("conversation: unmarshal tool calls at index %d: %w", i, err)
+			}
+		}
+		result[i] = cm
+	}
+	return result, nil
+}

--- a/conversation/convert_test.go
+++ b/conversation/convert_test.go
@@ -1,0 +1,142 @@
+package conversation
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+func TestFromChatMessages_SimpleRoundTrip(t *testing.T) {
+	original := []ollama.ChatMessage{
+		{Role: "system", Content: "You are helpful."},
+		{Role: "user", Content: "What is 2+2?"},
+		{Role: "assistant", Content: "4"},
+	}
+
+	converted, err := FromChatMessages(original)
+	if err != nil {
+		t.Fatalf("FromChatMessages() error: %v", err)
+	}
+	if len(converted) != 3 {
+		t.Fatalf("len = %d, want 3", len(converted))
+	}
+
+	restored, err := ToChatMessages(converted)
+	if err != nil {
+		t.Fatalf("ToChatMessages() error: %v", err)
+	}
+	if len(restored) != 3 {
+		t.Fatalf("restored len = %d, want 3", len(restored))
+	}
+
+	for i, msg := range restored {
+		if msg.Role != original[i].Role || msg.Content != original[i].Content {
+			t.Errorf("[%d] = {%s, %q}, want {%s, %q}",
+				i, msg.Role, msg.Content, original[i].Role, original[i].Content)
+		}
+	}
+}
+
+func TestFromChatMessages_ToolCallRoundTrip(t *testing.T) {
+	original := []ollama.ChatMessage{
+		{Role: "user", Content: "Search for Go tutorials"},
+		{
+			Role: "assistant",
+			ToolCalls: []ollama.ToolCall{
+				{
+					ID:   "call_1",
+					Type: "function",
+					Function: ollama.ToolCallFunction{
+						Index: 0,
+						Name:  "search",
+						Arguments: map[string]any{
+							"query":  "Go tutorials",
+							"limit":  float64(10),
+							"nested": map[string]any{"key": "value"},
+							"tags":   []any{"go", "tutorial"},
+						},
+					},
+				},
+			},
+		},
+		{
+			Role:       "tool",
+			Content:    `{"results": ["result1", "result2"]}`,
+			ToolName:   "search",
+			ToolCallID: "call_1",
+		},
+		{Role: "assistant", Content: "I found some tutorials."},
+	}
+
+	converted, err := FromChatMessages(original)
+	if err != nil {
+		t.Fatalf("FromChatMessages() error: %v", err)
+	}
+
+	if converted[1].ToolCalls == nil {
+		t.Fatal("converted[1].ToolCalls is nil")
+	}
+
+	if converted[2].ToolName != "search" {
+		t.Errorf("ToolName = %q, want %q", converted[2].ToolName, "search")
+	}
+	if converted[2].ToolCallID != "call_1" {
+		t.Errorf("ToolCallID = %q, want %q", converted[2].ToolCallID, "call_1")
+	}
+
+	restored, err := ToChatMessages(converted)
+	if err != nil {
+		t.Fatalf("ToChatMessages() error: %v", err)
+	}
+
+	if len(restored[1].ToolCalls) != 1 {
+		t.Fatalf("restored[1].ToolCalls len = %d, want 1", len(restored[1].ToolCalls))
+	}
+	tc := restored[1].ToolCalls[0]
+	if tc.ID != "call_1" {
+		t.Errorf("ToolCall.ID = %q, want %q", tc.ID, "call_1")
+	}
+	if tc.Function.Name != "search" {
+		t.Errorf("ToolCall.Function.Name = %q, want %q", tc.Function.Name, "search")
+	}
+	if tc.Function.Arguments["query"] != "Go tutorials" {
+		t.Errorf("Arguments[query] = %v, want %q", tc.Function.Arguments["query"], "Go tutorials")
+	}
+
+	if restored[2].ToolCallID != "call_1" {
+		t.Errorf("restored ToolCallID = %q, want %q", restored[2].ToolCallID, "call_1")
+	}
+}
+
+func TestFromChatMessages_NilToolCalls(t *testing.T) {
+	original := []ollama.ChatMessage{
+		{Role: "user", Content: "hello"},
+	}
+
+	converted, err := FromChatMessages(original)
+	if err != nil {
+		t.Fatalf("FromChatMessages() error: %v", err)
+	}
+	if converted[0].ToolCalls != nil {
+		t.Error("ToolCalls should be nil for non-tool message")
+	}
+
+	restored, err := ToChatMessages(converted)
+	if err != nil {
+		t.Fatalf("ToChatMessages() error: %v", err)
+	}
+	if restored[0].ToolCalls != nil {
+		t.Error("restored ToolCalls should be nil")
+	}
+}
+
+func TestToChatMessages_CorruptedJSON(t *testing.T) {
+	msgs := []Message{
+		{Role: "assistant", ToolCalls: json.RawMessage(`{broken json`)},
+	}
+	_, err := ToChatMessages(msgs)
+	if err == nil {
+		t.Fatal("ToChatMessages() should return error for corrupted JSON")
+	}
+}

--- a/conversation/message.go
+++ b/conversation/message.go
@@ -1,0 +1,78 @@
+// Package conversation provides persistent conversation storage with
+// shape-preserving tool-call persistence and context-window trimming.
+package conversation
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"time"
+)
+
+// ErrNotFound is returned by Load when the conversation ID does not exist.
+var ErrNotFound = errors.New("conversation: not found")
+
+// TokenEstimator computes an approximate token count for a string.
+type TokenEstimator func(text string) int
+
+// CharRatioEstimator returns a TokenEstimator that divides character count
+// by the given chars-per-token ratio. Different model families tokenize
+// differently — e.g., ~3.5 for English-heavy models, ~4.5 for
+// multilingual/code models.
+func CharRatioEstimator(charsPerToken float64) TokenEstimator {
+	return func(text string) int {
+		if len(text) == 0 {
+			return 0
+		}
+		return int(math.Ceil(float64(len(text)) / charsPerToken))
+	}
+}
+
+// NewID returns a new conversation identifier (UUID v4).
+func NewID() string {
+	var uuid [16]byte
+	if _, err := rand.Read(uuid[:]); err != nil {
+		panic(fmt.Sprintf("conversation: crypto/rand failed: %v", err))
+	}
+	uuid[6] = (uuid[6] & 0x0f) | 0x40 // version 4
+	uuid[8] = (uuid[8] & 0x3f) | 0x80 // variant 2
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		uuid[0:4], uuid[4:6], uuid[6:8], uuid[8:10], uuid[10:16])
+}
+
+// Message is a provider-agnostic chat message with shape-preserving
+// tool-call support.
+type Message struct {
+	Role       string          `json:"role"`
+	Content    string          `json:"content"`
+	ToolCalls  json.RawMessage `json:"tool_calls,omitempty"`
+	ToolName   string          `json:"tool_name,omitempty"`
+	ToolCallID string          `json:"tool_call_id,omitempty"`
+}
+
+// Conversation is the unit of persistence.
+type Conversation struct {
+	ID        string
+	Title     string
+	Messages  []Message
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// Summary is the lightweight listing type returned by List (no messages loaded).
+type Summary struct {
+	ID           string
+	Title        string
+	MessageCount int
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+// TrimResult holds the trimmed message slice and metadata about the trim.
+type TrimResult struct {
+	Messages        []Message
+	TrimmedCount    int
+	EstimatedTokens int
+}

--- a/conversation/message_test.go
+++ b/conversation/message_test.go
@@ -1,0 +1,53 @@
+package conversation
+
+import (
+	"testing"
+)
+
+func TestNewID_Unique(t *testing.T) {
+	seen := make(map[string]bool, 100)
+	for i := 0; i < 100; i++ {
+		id := NewID()
+		if id == "" {
+			t.Fatal("NewID() returned empty string")
+		}
+		if seen[id] {
+			t.Fatalf("NewID() returned duplicate: %s", id)
+		}
+		seen[id] = true
+	}
+}
+
+func TestNewID_Format(t *testing.T) {
+	id := NewID()
+	if len(id) != 36 {
+		t.Fatalf("NewID() length = %d, want 36", len(id))
+	}
+	if id[8] != '-' || id[13] != '-' || id[18] != '-' || id[23] != '-' {
+		t.Fatalf("NewID() invalid format: %s", id)
+	}
+}
+
+func TestCharRatioEstimator(t *testing.T) {
+	tests := []struct {
+		name  string
+		ratio float64
+		input string
+		want  int
+	}{
+		{"empty string", 4.0, "", 0},
+		{"exact division", 4.0, "abcd", 1},
+		{"rounds up", 4.0, "abcde", 2},
+		{"short ratio", 3.5, "1234567", 2},
+		{"single char", 4.0, "a", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			est := CharRatioEstimator(tt.ratio)
+			got := est(tt.input)
+			if got != tt.want {
+				t.Errorf("CharRatioEstimator(%v)(%q) = %d, want %d", tt.ratio, tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/conversation/migration.go
+++ b/conversation/migration.go
@@ -1,0 +1,96 @@
+package conversation
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+type migration struct {
+	version     int
+	description string
+	fn          func(tx *sql.Tx) error
+}
+
+var migrations = []migration{
+	{
+		version:     1,
+		description: "baseline conversations table",
+		fn:          migrateV1,
+	},
+}
+
+func migrateV1(tx *sql.Tx) error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS conversations (
+			id         TEXT PRIMARY KEY,
+			title      TEXT NOT NULL DEFAULT '',
+			messages   TEXT NOT NULL,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_conversations_updated_id
+			ON conversations(updated_at DESC, id ASC)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := tx.Exec(stmt); err != nil {
+			return fmt.Errorf("conversation: migrate v1: %w", err)
+		}
+	}
+	return nil
+}
+
+func runMigrations(db *sql.DB) error {
+	const createVersionTable = `CREATE TABLE IF NOT EXISTS conversation_schema_version (
+		version     INTEGER PRIMARY KEY,
+		description TEXT NOT NULL,
+		applied_at  INTEGER NOT NULL
+	)`
+	if _, err := db.Exec(createVersionTable); err != nil {
+		return fmt.Errorf("conversation: create version table: %w", err)
+	}
+
+	currentVersion, err := currentSchemaVersion(db)
+	if err != nil {
+		return err
+	}
+
+	for _, m := range migrations {
+		if m.version <= currentVersion {
+			continue
+		}
+
+		tx, err := db.Begin()
+		if err != nil {
+			return fmt.Errorf("conversation: begin migration v%d: %w", m.version, err)
+		}
+
+		if err := m.fn(tx); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("conversation: migration v%d (%s): %w", m.version, m.description, err)
+		}
+
+		if _, err := tx.Exec(
+			`INSERT INTO conversation_schema_version (version, description, applied_at) VALUES (?, ?, ?)`,
+			m.version, m.description, time.Now().UnixMilli(),
+		); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("conversation: record version %d: %w", m.version, err)
+		}
+
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("conversation: commit migration v%d: %w", m.version, err)
+		}
+	}
+
+	return nil
+}
+
+func currentSchemaVersion(db *sql.DB) (int, error) {
+	var version int
+	err := db.QueryRow(`SELECT COALESCE(MAX(version), 0) FROM conversation_schema_version`).Scan(&version)
+	if err != nil {
+		return 0, fmt.Errorf("conversation: query schema version: %w", err)
+	}
+	return version, nil
+}

--- a/conversation/migration_test.go
+++ b/conversation/migration_test.go
@@ -1,0 +1,75 @@
+package conversation
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open :memory: db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func TestRunMigrations_FreshDB(t *testing.T) {
+	db := openTestDB(t)
+	if err := runMigrations(db); err != nil {
+		t.Fatalf("runMigrations() error: %v", err)
+	}
+
+	var count int
+	err := db.QueryRow(`SELECT COUNT(*) FROM conversations`).Scan(&count)
+	if err != nil {
+		t.Fatalf("conversations table missing: %v", err)
+	}
+
+	var version int
+	err = db.QueryRow(`SELECT MAX(version) FROM conversation_schema_version`).Scan(&version)
+	if err != nil {
+		t.Fatalf("version query failed: %v", err)
+	}
+	if version != 1 {
+		t.Fatalf("schema version = %d, want 1", version)
+	}
+}
+
+func TestRunMigrations_Idempotent(t *testing.T) {
+	db := openTestDB(t)
+	if err := runMigrations(db); err != nil {
+		t.Fatalf("first runMigrations() error: %v", err)
+	}
+	if err := runMigrations(db); err != nil {
+		t.Fatalf("second runMigrations() error: %v", err)
+	}
+
+	var version int
+	err := db.QueryRow(`SELECT MAX(version) FROM conversation_schema_version`).Scan(&version)
+	if err != nil {
+		t.Fatalf("version query failed: %v", err)
+	}
+	if version != 1 {
+		t.Fatalf("schema version = %d, want 1", version)
+	}
+}
+
+func TestRunMigrations_IndexExists(t *testing.T) {
+	db := openTestDB(t)
+	if err := runMigrations(db); err != nil {
+		t.Fatalf("runMigrations() error: %v", err)
+	}
+
+	var count int
+	err := db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_conversations_updated_id'`,
+	).Scan(&count)
+	if err != nil || count != 1 {
+		t.Fatalf("expected idx_conversations_updated_id index, count=%d err=%v", count, err)
+	}
+}

--- a/conversation/store.go
+++ b/conversation/store.go
@@ -1,0 +1,133 @@
+package conversation
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Store defines conversation persistence operations.
+type Store interface {
+	Save(ctx context.Context, conv Conversation) error
+	Load(ctx context.Context, id string) (*Conversation, error)
+	List(ctx context.Context) ([]Summary, error)
+	Delete(ctx context.Context, id string) error
+}
+
+// SQLiteStore is a conversation Store backed by SQLite.
+type SQLiteStore struct {
+	db *sql.DB
+}
+
+// NewStore creates a conversation store on the given database, running
+// migrations if needed.
+func NewStore(ctx context.Context, db *sql.DB) (*SQLiteStore, error) {
+	if err := runMigrations(db); err != nil {
+		return nil, fmt.Errorf("conversation: init store: %w", err)
+	}
+	return &SQLiteStore{db: db}, nil
+}
+
+// Save persists a conversation using upsert semantics.
+func (s *SQLiteStore) Save(ctx context.Context, conv Conversation) error {
+	if conv.ID == "" {
+		return fmt.Errorf("conversation: save: id is required")
+	}
+
+	msgs := conv.Messages
+	if msgs == nil {
+		msgs = []Message{}
+	}
+
+	messagesJSON, err := json.Marshal(msgs)
+	if err != nil {
+		return fmt.Errorf("conversation: save: marshal messages: %w", err)
+	}
+
+	now := time.Now().UnixMilli()
+
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO conversations (id, title, messages, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?)
+		 ON CONFLICT(id) DO UPDATE SET
+			title      = excluded.title,
+			messages   = excluded.messages,
+			updated_at = excluded.updated_at`,
+		conv.ID, conv.Title, string(messagesJSON), now, now,
+	)
+	if err != nil {
+		return fmt.Errorf("conversation: save %q: %w", conv.ID, err)
+	}
+	return nil
+}
+
+// Load retrieves a conversation by ID. Returns ErrNotFound if not found.
+func (s *SQLiteStore) Load(ctx context.Context, id string) (*Conversation, error) {
+	var conv Conversation
+	var messagesJSON string
+	var createdMs, updatedMs int64
+
+	err := s.db.QueryRowContext(ctx,
+		`SELECT id, title, messages, created_at, updated_at FROM conversations WHERE id = ?`,
+		id,
+	).Scan(&conv.ID, &conv.Title, &messagesJSON, &createdMs, &updatedMs)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("conversation: load %q: %w", id, ErrNotFound)
+		}
+		return nil, fmt.Errorf("conversation: load %q: %w", id, err)
+	}
+
+	if err := json.Unmarshal([]byte(messagesJSON), &conv.Messages); err != nil {
+		return nil, fmt.Errorf("conversation: load %q: unmarshal messages: %w", id, err)
+	}
+
+	conv.CreatedAt = time.UnixMilli(createdMs)
+	conv.UpdatedAt = time.UnixMilli(updatedMs)
+
+	return &conv, nil
+}
+
+// List returns summaries ordered by most recently updated first.
+func (s *SQLiteStore) List(ctx context.Context) ([]Summary, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, title, json_array_length(messages), created_at, updated_at
+		 FROM conversations
+		 ORDER BY updated_at DESC, id ASC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("conversation: list: %w", err)
+	}
+	defer rows.Close()
+
+	var summaries []Summary
+	for rows.Next() {
+		var s Summary
+		var createdMs, updatedMs int64
+		if err := rows.Scan(&s.ID, &s.Title, &s.MessageCount, &createdMs, &updatedMs); err != nil {
+			return nil, fmt.Errorf("conversation: list: scan: %w", err)
+		}
+		s.CreatedAt = time.UnixMilli(createdMs)
+		s.UpdatedAt = time.UnixMilli(updatedMs)
+		summaries = append(summaries, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("conversation: list: iterate: %w", err)
+	}
+
+	if summaries == nil {
+		summaries = []Summary{}
+	}
+	return summaries, nil
+}
+
+// Delete removes a conversation by ID. Returns nil if not found (idempotent).
+func (s *SQLiteStore) Delete(ctx context.Context, id string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM conversations WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("conversation: delete %q: %w", id, err)
+	}
+	return nil
+}

--- a/conversation/store_test.go
+++ b/conversation/store_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/kstruzzieri/go-llm/ollama"
 )
 
 func newTestStore(t *testing.T) *SQLiteStore {
@@ -210,5 +212,80 @@ func TestDelete_Idempotent(t *testing.T) {
 	_, err := store.Load(ctx, id)
 	if !errors.Is(err, ErrNotFound) {
 		t.Errorf("Load after Delete: error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSave_And_Load_WithToolCalls(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	original := []ollama.ChatMessage{
+		{Role: "user", Content: "Find files"},
+		{
+			Role: "assistant",
+			ToolCalls: []ollama.ToolCall{
+				{
+					ID:   "call_1",
+					Type: "function",
+					Function: ollama.ToolCallFunction{
+						Index: 0,
+						Name:  "find",
+						Arguments: map[string]any{
+							"pattern": "*.go",
+							"depth":   float64(3),
+						},
+					},
+				},
+			},
+		},
+		{
+			Role:       "tool",
+			Content:    `["main.go", "util.go"]`,
+			ToolName:   "find",
+			ToolCallID: "call_1",
+		},
+		{Role: "assistant", Content: "Found 2 Go files."},
+	}
+
+	msgs, err := FromChatMessages(original)
+	if err != nil {
+		t.Fatalf("FromChatMessages() error: %v", err)
+	}
+
+	conv := Conversation{
+		ID:       NewID(),
+		Title:    "tool call test",
+		Messages: msgs,
+	}
+	if err := store.Save(ctx, conv); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	loaded, err := store.Load(ctx, conv.ID)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	restored, err := ToChatMessages(loaded.Messages)
+	if err != nil {
+		t.Fatalf("ToChatMessages() error: %v", err)
+	}
+
+	if len(restored[1].ToolCalls) != 1 {
+		t.Fatalf("ToolCalls len = %d, want 1", len(restored[1].ToolCalls))
+	}
+	tc := restored[1].ToolCalls[0]
+	if tc.Function.Name != "find" {
+		t.Errorf("Function.Name = %q, want %q", tc.Function.Name, "find")
+	}
+	args := tc.Function.Arguments
+	if args["pattern"] != "*.go" {
+		t.Errorf("Arguments[pattern] = %v, want %q", args["pattern"], "*.go")
+	}
+	if args["depth"] != float64(3) {
+		t.Errorf("Arguments[depth] = %v, want %v", args["depth"], float64(3))
+	}
+	if restored[2].ToolCallID != "call_1" {
+		t.Errorf("ToolCallID = %q, want %q", restored[2].ToolCallID, "call_1")
 	}
 }

--- a/conversation/store_test.go
+++ b/conversation/store_test.go
@@ -1,0 +1,214 @@
+package conversation
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func newTestStore(t *testing.T) *SQLiteStore {
+	t.Helper()
+	db := openTestDB(t)
+	store, err := NewStore(context.Background(), db)
+	if err != nil {
+		t.Fatalf("NewStore() error: %v", err)
+	}
+	return store
+}
+
+func TestSave_And_Load_RoundTrip(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	conv := Conversation{
+		ID:    NewID(),
+		Title: "test conversation",
+		Messages: []Message{
+			{Role: "system", Content: "You are helpful."},
+			{Role: "user", Content: "Hello"},
+			{Role: "assistant", Content: "Hi there!"},
+		},
+	}
+
+	if err := store.Save(ctx, conv); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	loaded, err := store.Load(ctx, conv.ID)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if loaded.ID != conv.ID {
+		t.Errorf("ID = %q, want %q", loaded.ID, conv.ID)
+	}
+	if loaded.Title != conv.Title {
+		t.Errorf("Title = %q, want %q", loaded.Title, conv.Title)
+	}
+	if len(loaded.Messages) != len(conv.Messages) {
+		t.Fatalf("Messages len = %d, want %d", len(loaded.Messages), len(conv.Messages))
+	}
+	for i, msg := range loaded.Messages {
+		if msg.Role != conv.Messages[i].Role || msg.Content != conv.Messages[i].Content {
+			t.Errorf("Messages[%d] = {%s, %q}, want {%s, %q}",
+				i, msg.Role, msg.Content, conv.Messages[i].Role, conv.Messages[i].Content)
+		}
+	}
+	if loaded.CreatedAt.IsZero() {
+		t.Error("CreatedAt is zero")
+	}
+	if loaded.UpdatedAt.IsZero() {
+		t.Error("UpdatedAt is zero")
+	}
+}
+
+func TestSave_EmptyID_ReturnsError(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	err := store.Save(ctx, Conversation{ID: "", Title: "no id"})
+	if err == nil {
+		t.Fatal("Save() with empty ID should return error")
+	}
+}
+
+func TestSave_NilMessages_NormalizesToEmptyArray(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	conv := Conversation{ID: NewID(), Title: "empty"}
+	if err := store.Save(ctx, conv); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	loaded, err := store.Load(ctx, conv.ID)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if loaded.Messages == nil {
+		t.Error("Messages is nil, want empty slice")
+	}
+	if len(loaded.Messages) != 0 {
+		t.Errorf("Messages len = %d, want 0", len(loaded.Messages))
+	}
+}
+
+func TestSave_Upsert_PreservesCreatedAt(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	id := NewID()
+	conv := Conversation{
+		ID:       id,
+		Title:    "original",
+		Messages: []Message{{Role: "user", Content: "v1"}},
+	}
+	if err := store.Save(ctx, conv); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	first, err := store.Load(ctx, id)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+
+	conv.Title = "updated"
+	conv.Messages = append(conv.Messages, Message{Role: "assistant", Content: "v2"})
+	if err := store.Save(ctx, conv); err != nil {
+		t.Fatalf("Save() update error: %v", err)
+	}
+
+	second, err := store.Load(ctx, id)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if !second.CreatedAt.Equal(first.CreatedAt) {
+		t.Errorf("CreatedAt changed: %v -> %v", first.CreatedAt, second.CreatedAt)
+	}
+	if !second.UpdatedAt.After(first.UpdatedAt) {
+		t.Errorf("UpdatedAt did not advance: %v -> %v", first.UpdatedAt, second.UpdatedAt)
+	}
+	if second.Title != "updated" {
+		t.Errorf("Title = %q, want %q", second.Title, "updated")
+	}
+	if len(second.Messages) != 2 {
+		t.Errorf("Messages len = %d, want 2", len(second.Messages))
+	}
+}
+
+func TestLoad_NotFound(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := store.Load(ctx, "nonexistent-id")
+	if err == nil {
+		t.Fatal("Load() should return error for nonexistent ID")
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestList_OrderedByUpdatedAtDesc(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	ids := make([]string, 3)
+	for i := range ids {
+		ids[i] = NewID()
+		err := store.Save(ctx, Conversation{
+			ID:       ids[i],
+			Title:    string(rune('A' + i)),
+			Messages: []Message{{Role: "user", Content: "msg"}},
+		})
+		if err != nil {
+			t.Fatalf("Save() error: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	summaries, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+	if len(summaries) != 3 {
+		t.Fatalf("List() len = %d, want 3", len(summaries))
+	}
+
+	if summaries[0].ID != ids[2] {
+		t.Errorf("summaries[0].ID = %q, want %q", summaries[0].ID, ids[2])
+	}
+	if summaries[2].ID != ids[0] {
+		t.Errorf("summaries[2].ID = %q, want %q", summaries[2].ID, ids[0])
+	}
+
+	for _, s := range summaries {
+		if s.MessageCount != 1 {
+			t.Errorf("summary %q MessageCount = %d, want 1", s.ID, s.MessageCount)
+		}
+	}
+}
+
+func TestDelete_Idempotent(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	id := NewID()
+	if err := store.Save(ctx, Conversation{ID: id, Title: "delete me"}); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+	if err := store.Delete(ctx, id); err != nil {
+		t.Fatalf("Delete() error: %v", err)
+	}
+	if err := store.Delete(ctx, id); err != nil {
+		t.Fatalf("Delete() second call error: %v", err)
+	}
+	_, err := store.Load(ctx, id)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("Load after Delete: error = %v, want ErrNotFound", err)
+	}
+}

--- a/conversation/trim.go
+++ b/conversation/trim.go
@@ -1,0 +1,323 @@
+package conversation
+
+// messageCost computes the estimated token cost of a message using all
+// prompt-visible fields.
+func messageCost(m Message, estimator TokenEstimator) int {
+	cost := estimator(m.Content)
+	if len(m.ToolCalls) > 0 {
+		cost += estimator(string(m.ToolCalls))
+	}
+	if m.ToolName != "" {
+		cost += estimator(m.ToolName)
+	}
+	if m.ToolCallID != "" {
+		cost += estimator(m.ToolCallID)
+	}
+	return cost
+}
+
+// toolChain represents a contiguous tool-call sequence in the message slice.
+type toolChain struct {
+	start     int
+	end       int
+	completed bool
+	cost      int
+}
+
+// identifyToolChains scans messages and returns all tool-call chains.
+func identifyToolChains(msgs []Message, estimator TokenEstimator) []toolChain {
+	var chains []toolChain
+	i := 0
+	for i < len(msgs) {
+		m := msgs[i]
+		if m.Role == "assistant" && len(m.ToolCalls) > 0 {
+			chain := toolChain{start: i, end: i}
+			cost := 0
+			if estimator != nil {
+				cost = messageCost(m, estimator)
+			}
+			j := i + 1
+			for j < len(msgs) && msgs[j].Role == "tool" {
+				chain.end = j
+				if estimator != nil {
+					cost += messageCost(msgs[j], estimator)
+				}
+				j++
+			}
+			chain.cost = cost
+			if j < len(msgs) && msgs[j].Role == "assistant" && len(msgs[j].ToolCalls) == 0 {
+				chain.completed = true
+			}
+			chains = append(chains, chain)
+			i = j
+		} else {
+			i++
+		}
+	}
+	return chains
+}
+
+// TrimMessages returns the most recent messages that fit within maxTokens.
+// Safety invariants are enforced unconditionally, even when all messages fit.
+// Panics if estimator is nil.
+func TrimMessages(msgs []Message, maxTokens int, estimator TokenEstimator) TrimResult {
+	if estimator == nil {
+		panic("conversation: TrimMessages requires non-nil TokenEstimator")
+	}
+	if len(msgs) == 0 {
+		return TrimResult{Messages: []Message{}}
+	}
+
+	var systemMsgs []Message
+	var nonSystem []Message
+	systemCost := 0
+	for _, m := range msgs {
+		if m.Role == "system" {
+			systemMsgs = append(systemMsgs, m)
+			systemCost += messageCost(m, estimator)
+		} else {
+			nonSystem = append(nonSystem, m)
+		}
+	}
+
+	if len(nonSystem) == 0 {
+		return TrimResult{
+			Messages:        systemMsgs,
+			TrimmedCount:    0,
+			EstimatedTokens: systemCost,
+		}
+	}
+
+	budget := maxTokens - systemCost
+	if budget < 0 {
+		budget = 0
+	}
+
+	keep := make([]bool, len(nonSystem))
+	for i := range keep {
+		keep[i] = true
+	}
+
+	currentCost := 0
+	for _, m := range nonSystem {
+		currentCost += messageCost(m, estimator)
+	}
+
+	chains := identifyToolChains(nonSystem, estimator)
+
+	// Determine the unresolved tail boundary including preceding user message.
+	unresolvedProtectFrom := -1
+	if len(chains) > 0 {
+		lastChain := chains[len(chains)-1]
+		if !lastChain.completed {
+			unresolvedProtectFrom = lastChain.start
+			for t := lastChain.start - 1; t >= 0; t-- {
+				if nonSystem[t].Role == "user" {
+					unresolvedProtectFrom = t
+					break
+				}
+			}
+		}
+	}
+
+	needsTrimming := currentCost > budget
+
+	if needsTrimming {
+		// Tier 1: Remove completed tool chains, oldest first.
+		for _, chain := range chains {
+			if currentCost <= budget {
+				break
+			}
+			if !chain.completed {
+				continue
+			}
+			for k := chain.start; k <= chain.end; k++ {
+				keep[k] = false
+			}
+			currentCost -= chain.cost
+		}
+
+		// Tier 2: Remove remaining messages oldest first, protecting unresolved tail.
+		for i := 0; i < len(nonSystem) && currentCost > budget; i++ {
+			if !keep[i] {
+				continue
+			}
+			if unresolvedProtectFrom >= 0 && i >= unresolvedProtectFrom {
+				continue
+			}
+			keep[i] = false
+			currentCost -= messageCost(nonSystem[i], estimator)
+		}
+	}
+
+	// Enforce first-non-system-is-user rule unconditionally.
+	// Do NOT remove messages in the unresolved tail.
+	for i := 0; i < len(nonSystem); i++ {
+		if !keep[i] {
+			continue
+		}
+		if nonSystem[i].Role == "user" {
+			break
+		}
+		if unresolvedProtectFrom >= 0 && i >= unresolvedProtectFrom {
+			break
+		}
+		keep[i] = false
+		currentCost -= messageCost(nonSystem[i], estimator)
+	}
+
+	// Enforce tool-pair atomicity.
+	for _, chain := range chains {
+		assistantKept := keep[chain.start]
+		for k := chain.start; k <= chain.end; k++ {
+			keep[k] = assistantKept
+		}
+	}
+
+	// Build result.
+	var result []Message
+	result = append(result, systemMsgs...)
+	trimmedCount := 0
+	keptCost := systemCost
+	for i, m := range nonSystem {
+		if keep[i] {
+			result = append(result, m)
+			keptCost += messageCost(m, estimator)
+		} else {
+			trimmedCount++
+		}
+	}
+
+	// Ensure at least one non-system message if any existed.
+	if len(result) == len(systemMsgs) && len(nonSystem) > 0 {
+		fallback := len(nonSystem) - 1
+		for j := len(nonSystem) - 1; j >= 0; j-- {
+			if nonSystem[j].Role == "user" {
+				fallback = j
+				break
+			}
+		}
+		result = append(result, nonSystem[fallback])
+		keptCost += messageCost(nonSystem[fallback], estimator)
+		trimmedCount--
+	}
+
+	return TrimResult{
+		Messages:        result,
+		TrimmedCount:    trimmedCount,
+		EstimatedTokens: keptCost,
+	}
+}
+
+// TrimByExchanges keeps the most recent maxExchanges user-assistant exchanges.
+// System messages are always preserved. Unresolved tool-call tails are preserved.
+// EstimatedTokens is 0 since no estimator is used.
+func TrimByExchanges(msgs []Message, maxExchanges int) TrimResult {
+	if len(msgs) == 0 {
+		return TrimResult{Messages: []Message{}}
+	}
+
+	var systemMsgs []Message
+	var nonSystem []Message
+	for _, m := range msgs {
+		if m.Role == "system" {
+			systemMsgs = append(systemMsgs, m)
+		} else {
+			nonSystem = append(nonSystem, m)
+		}
+	}
+
+	if len(nonSystem) == 0 {
+		return TrimResult{Messages: systemMsgs, TrimmedCount: 0}
+	}
+
+	type exchange struct {
+		start int
+		end   int
+	}
+
+	unresolvedStart := -1
+	chains := identifyToolChains(nonSystem, nil)
+	if len(chains) > 0 {
+		lastChain := chains[len(chains)-1]
+		if !lastChain.completed {
+			unresolvedStart = lastChain.start
+		}
+	}
+
+	resolvedEnd := len(nonSystem)
+	if unresolvedStart >= 0 {
+		resolvedEnd = unresolvedStart
+		for resolvedEnd > 0 && nonSystem[resolvedEnd-1].Role != "user" {
+			resolvedEnd--
+		}
+		if resolvedEnd > 0 {
+			resolvedEnd--
+		}
+	}
+
+	var exchanges []exchange
+	i := 0
+	for i < resolvedEnd {
+		if nonSystem[i].Role == "user" {
+			ex := exchange{start: i}
+			j := i + 1
+			for j < resolvedEnd {
+				if nonSystem[j].Role == "assistant" && len(nonSystem[j].ToolCalls) == 0 {
+					ex.end = j
+					exchanges = append(exchanges, ex)
+					j++
+					break
+				}
+				j++
+			}
+			i = j
+		} else {
+			i++
+		}
+	}
+
+	keepFrom := 0
+	if maxExchanges >= 0 && maxExchanges < len(exchanges) {
+		keepFrom = len(exchanges) - maxExchanges
+	}
+
+	keep := make([]bool, len(nonSystem))
+
+	for idx := keepFrom; idx < len(exchanges); idx++ {
+		ex := exchanges[idx]
+		for k := ex.start; k <= ex.end; k++ {
+			keep[k] = true
+		}
+	}
+
+	if unresolvedStart >= 0 {
+		tailStart := unresolvedStart
+		for t := unresolvedStart - 1; t >= 0; t-- {
+			if nonSystem[t].Role == "user" {
+				tailStart = t
+				break
+			}
+		}
+		for k := tailStart; k < len(nonSystem); k++ {
+			keep[k] = true
+		}
+	}
+
+	var result []Message
+	result = append(result, systemMsgs...)
+	trimmedCount := 0
+	for i, m := range nonSystem {
+		if keep[i] {
+			result = append(result, m)
+		} else {
+			trimmedCount++
+		}
+	}
+
+	return TrimResult{
+		Messages:        result,
+		TrimmedCount:    trimmedCount,
+		EstimatedTokens: 0,
+	}
+}

--- a/conversation/trim_test.go
+++ b/conversation/trim_test.go
@@ -1,0 +1,326 @@
+package conversation
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// lenEstimator counts characters as tokens (1:1) for deterministic tests.
+func lenEstimator(s string) int { return len(s) }
+
+// makeMsg is a test helper for building messages.
+func makeMsg(role, content string) Message {
+	return Message{Role: role, Content: content}
+}
+
+// makeToolCallMsg builds an assistant message with tool calls.
+func makeToolCallMsg(content string, toolCallsJSON string) Message {
+	return Message{
+		Role:      "assistant",
+		Content:   content,
+		ToolCalls: json.RawMessage(toolCallsJSON),
+	}
+}
+
+// makeToolResult builds a tool result message.
+func makeToolResult(content, toolName, callID string) Message {
+	return Message{
+		Role:       "tool",
+		Content:    content,
+		ToolName:   toolName,
+		ToolCallID: callID,
+	}
+}
+
+func TestTrimMessages_AllFit(t *testing.T) {
+	msgs := []Message{
+		makeMsg("user", "hi"),
+		makeMsg("assistant", "hello"),
+	}
+	result := TrimMessages(msgs, 1000, lenEstimator)
+	if result.TrimmedCount != 0 {
+		t.Errorf("TrimmedCount = %d, want 0", result.TrimmedCount)
+	}
+	if len(result.Messages) != 2 {
+		t.Errorf("Messages len = %d, want 2", len(result.Messages))
+	}
+}
+
+func TestTrimMessages_Empty(t *testing.T) {
+	result := TrimMessages(nil, 100, lenEstimator)
+	if len(result.Messages) != 0 {
+		t.Errorf("Messages len = %d, want 0", len(result.Messages))
+	}
+	if result.TrimmedCount != 0 {
+		t.Errorf("TrimmedCount = %d, want 0", result.TrimmedCount)
+	}
+}
+
+func TestTrimMessages_SystemAlwaysPreserved(t *testing.T) {
+	msgs := []Message{
+		makeMsg("system", "You are helpful."),
+		makeMsg("user", "hello"),
+		makeMsg("assistant", "hi there how are you doing today"),
+		makeMsg("user", "fine"),
+		makeMsg("assistant", "great"),
+	}
+	result := TrimMessages(msgs, 30, lenEstimator)
+	if result.Messages[0].Role != "system" {
+		t.Error("system message missing")
+	}
+	for _, m := range result.Messages {
+		if m.Role == "system" {
+			return
+		}
+	}
+	t.Error("system message not found in result")
+}
+
+func TestTrimMessages_ToolPairsAtomic(t *testing.T) {
+	msgs := []Message{
+		makeMsg("user", "search"),
+		makeToolCallMsg("", `[{"id":"c1","type":"function","function":{"name":"search","arguments":{}}}]`),
+		makeToolResult("result data here", "search", "c1"),
+		makeMsg("assistant", "found it"),
+		makeMsg("user", "thanks"),
+		makeMsg("assistant", "welcome"),
+	}
+	result := TrimMessages(msgs, 40, lenEstimator)
+
+	for i, m := range result.Messages {
+		if m.Role == "tool" {
+			found := false
+			for j := i - 1; j >= 0; j-- {
+				if result.Messages[j].Role == "assistant" && result.Messages[j].ToolCalls != nil {
+					found = true
+					break
+				}
+				if result.Messages[j].Role != "tool" {
+					break
+				}
+			}
+			if !found {
+				t.Errorf("orphaned tool result at index %d", i)
+			}
+		}
+	}
+}
+
+func TestTrimMessages_FirstNonSystemMustBeUser(t *testing.T) {
+	msgs := []Message{
+		makeMsg("system", "sys"),
+		makeMsg("assistant", "summary"),
+		makeMsg("user", "hello"),
+		makeMsg("assistant", "hi"),
+	}
+	result := TrimMessages(msgs, 13, lenEstimator)
+	for _, m := range result.Messages {
+		if m.Role == "system" {
+			continue
+		}
+		if m.Role != "user" {
+			t.Errorf("first non-system message role = %q, want user", m.Role)
+		}
+		break
+	}
+}
+
+func TestTrimMessages_FirstNonSystemMustBeUser_NoTrimNeeded(t *testing.T) {
+	msgs := []Message{
+		makeMsg("system", "sys"),
+		makeMsg("assistant", "summary"),
+		makeMsg("user", "hello"),
+		makeMsg("assistant", "hi"),
+	}
+	result := TrimMessages(msgs, 1000, lenEstimator)
+	for _, m := range result.Messages {
+		if m.Role == "system" {
+			continue
+		}
+		if m.Role != "user" {
+			t.Errorf("first non-system message role = %q, want user (even without budget pressure)", m.Role)
+		}
+		break
+	}
+}
+
+func TestTrimMessages_TieredStrategy_ToolChainsFirst(t *testing.T) {
+	msgs := []Message{
+		makeMsg("user", "aaa"),
+		makeToolCallMsg("", `[{"id":"c1","type":"function","function":{"name":"f","arguments":{"x":"long-argument-value-here"}}}]`),
+		makeToolResult("long tool result content here!!!", "f", "c1"),
+		makeMsg("assistant", "synthesized"),
+		makeMsg("user", "bbb"),
+		makeMsg("assistant", "short"),
+	}
+
+	totalCost := 0
+	for _, m := range msgs {
+		totalCost += messageCost(m, lenEstimator)
+	}
+	chainCost := messageCost(msgs[1], lenEstimator) +
+		messageCost(msgs[2], lenEstimator)
+
+	budget := totalCost - chainCost + 5
+	result := TrimMessages(msgs, budget, lenEstimator)
+
+	if result.Messages[0].Content != "aaa" {
+		t.Errorf("expected first user msg preserved, got %q", result.Messages[0].Content)
+	}
+	for _, m := range result.Messages {
+		if m.Role == "tool" {
+			t.Error("tool message should have been trimmed by tiered strategy")
+		}
+	}
+	if result.TrimmedCount < 2 {
+		t.Errorf("TrimmedCount = %d, want >= 2", result.TrimmedCount)
+	}
+}
+
+func TestTrimMessages_UnresolvedTailPreserved(t *testing.T) {
+	msgs := []Message{
+		makeMsg("user", "old question"),
+		makeMsg("assistant", "old answer that is rather long to push budget"),
+		makeMsg("user", "do something"),
+		makeToolCallMsg("", `[{"id":"c1","type":"function","function":{"name":"act","arguments":{}}}]`),
+		makeToolResult("pending result", "act", "c1"),
+	}
+
+	result := TrimMessages(msgs, 60, lenEstimator)
+
+	lastTwo := result.Messages[len(result.Messages)-2:]
+	if lastTwo[0].ToolCalls == nil {
+		t.Error("unresolved assistant tool-call message was trimmed")
+	}
+	if lastTwo[1].Role != "tool" {
+		t.Error("unresolved tool result was trimmed")
+	}
+}
+
+func TestTrimMessages_SingleUserExceedsBudget(t *testing.T) {
+	msgs := []Message{
+		makeMsg("user", "this message is way longer than the budget allows"),
+	}
+	result := TrimMessages(msgs, 5, lenEstimator)
+	if len(result.Messages) != 1 {
+		t.Errorf("Messages len = %d, want 1 (preserve at least one)", len(result.Messages))
+	}
+}
+
+func TestTrimMessages_OnlySystemFits(t *testing.T) {
+	msgs := []Message{
+		makeMsg("system", "short"),
+		makeMsg("user", "this is a long user message that exceeds budget"),
+		makeMsg("assistant", "this is a long assistant message that exceeds budget"),
+	}
+	result := TrimMessages(msgs, 6, lenEstimator)
+	if len(result.Messages) < 1 || result.Messages[0].Role != "system" {
+		t.Error("system message should be preserved even when nothing else fits")
+	}
+}
+
+func TestTrimMessages_AllSystem(t *testing.T) {
+	msgs := []Message{
+		makeMsg("system", "sys1"),
+		makeMsg("system", "sys2"),
+	}
+	result := TrimMessages(msgs, 100, lenEstimator)
+	if len(result.Messages) != 2 {
+		t.Errorf("Messages len = %d, want 2", len(result.Messages))
+	}
+	if result.TrimmedCount != 0 {
+		t.Errorf("TrimmedCount = %d, want 0", result.TrimmedCount)
+	}
+}
+
+func TestTrimMessages_ZeroBudget(t *testing.T) {
+	msgs := []Message{
+		makeMsg("system", "sys"),
+		makeMsg("user", "hello"),
+		makeMsg("assistant", "hi"),
+	}
+	result := TrimMessages(msgs, 0, lenEstimator)
+	if result.Messages[0].Role != "system" {
+		t.Error("system message missing")
+	}
+}
+
+func TestTrimByExchanges_Basic(t *testing.T) {
+	msgs := []Message{
+		makeMsg("system", "sys"),
+		makeMsg("user", "q1"),
+		makeMsg("assistant", "a1"),
+		makeMsg("user", "q2"),
+		makeMsg("assistant", "a2"),
+		makeMsg("user", "q3"),
+		makeMsg("assistant", "a3"),
+	}
+	result := TrimByExchanges(msgs, 2)
+	if result.Messages[0].Role != "system" {
+		t.Error("system missing")
+	}
+	if len(result.Messages) != 5 {
+		t.Errorf("Messages len = %d, want 5", len(result.Messages))
+	}
+	if result.Messages[1].Content != "q2" {
+		t.Errorf("expected q2, got %q", result.Messages[1].Content)
+	}
+	if result.EstimatedTokens != 0 {
+		t.Errorf("EstimatedTokens = %d, want 0 for TrimByExchanges", result.EstimatedTokens)
+	}
+}
+
+func TestTrimByExchanges_WithToolChain(t *testing.T) {
+	msgs := []Message{
+		makeMsg("user", "q1"),
+		makeMsg("assistant", "a1"),
+		makeMsg("user", "search"),
+		makeToolCallMsg("", `[{"id":"c1","type":"function","function":{"name":"s","arguments":{}}}]`),
+		makeToolResult("data", "s", "c1"),
+		makeMsg("assistant", "found it"),
+		makeMsg("user", "q3"),
+		makeMsg("assistant", "a3"),
+	}
+	result := TrimByExchanges(msgs, 1)
+	if len(result.Messages) != 2 {
+		t.Errorf("Messages len = %d, want 2", len(result.Messages))
+	}
+	if result.Messages[0].Content != "q3" {
+		t.Errorf("expected q3, got %q", result.Messages[0].Content)
+	}
+}
+
+func TestTrimByExchanges_UnresolvedTail(t *testing.T) {
+	msgs := []Message{
+		makeMsg("user", "q1"),
+		makeMsg("assistant", "a1"),
+		makeMsg("user", "do it"),
+		makeToolCallMsg("", `[{"id":"c1","type":"function","function":{"name":"act","arguments":{}}}]`),
+		makeToolResult("pending", "act", "c1"),
+	}
+	result := TrimByExchanges(msgs, 0)
+	found := false
+	for _, m := range result.Messages {
+		if m.ToolCalls != nil {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("unresolved tail should be preserved even with 0 exchanges")
+	}
+}
+
+func TestTrimByExchanges_ZeroExchanges(t *testing.T) {
+	msgs := []Message{
+		makeMsg("system", "sys"),
+		makeMsg("user", "q1"),
+		makeMsg("assistant", "a1"),
+	}
+	result := TrimByExchanges(msgs, 0)
+	if len(result.Messages) != 1 {
+		t.Errorf("Messages len = %d, want 1 (system only)", len(result.Messages))
+	}
+	if result.Messages[0].Role != "system" {
+		t.Error("expected system message only")
+	}
+}


### PR DESCRIPTION
## Summary
- New `conversation/` package with SQLiteStore for persistent conversation storage
- Shape-preserving tool-call persistence via `json.RawMessage` -- preserves full structure across store/load cycles
- Tiered trimming strategy: completed tool chains removed before conversational messages
- Two trim modes: `TrimMessages` (token budget) and `TrimByExchanges` (sliding window)
- Safety invariants: system messages preserved, tool pairs atomic, first non-system is user, unresolved tails protected
- Conversion helpers: `FromChatMessages`/`ToChatMessages` for Ollama round-trips
- Own migration system (`conversation_schema_version`) on shared workspace DB

Closes #27

## Test plan
- [x] `go test ./conversation/ -v` -- 35 conversation package tests pass
- [x] `go test ./... -count=1` -- full repo suite passes (7/7 packages), no regressions
- [x] `go vet ./...` -- no issues

Generated with [Claude Code](https://claude.com/claude-code)