### PR TITLE
fix(conversation): rune-based token estimation and system message ordering

### DIFF
--- a/conversation/message.go
+++ b/conversation/message.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"time"
+	"unicode/utf8"
 )
 
 // ErrNotFound is returned by Load when the conversation ID does not exist.
@@ -23,10 +24,11 @@ type TokenEstimator func(text string) int
 // multilingual/code models.
 func CharRatioEstimator(charsPerToken float64) TokenEstimator {
 	return func(text string) int {
-		if len(text) == 0 {
+		n := utf8.RuneCountInString(text)
+		if n == 0 {
 			return 0
 		}
-		return int(math.Ceil(float64(len(text)) / charsPerToken))
+		return int(math.Ceil(float64(n) / charsPerToken))
 	}
 }
 

--- a/conversation/trim.go
+++ b/conversation/trim.go
@@ -174,22 +174,15 @@ func TrimMessages(msgs []Message, maxTokens int, estimator TokenEstimator) TrimR
 		}
 	}
 
-	// Build result.
-	var result []Message
-	result = append(result, systemMsgs...)
-	trimmedCount := 0
-	keptCost := systemCost
-	for i, m := range nonSystem {
-		if keep[i] {
-			result = append(result, m)
-			keptCost += messageCost(m, estimator)
-		} else {
-			trimmedCount++
+	// Ensure at least one non-system message if any existed.
+	hasKeptNonSystem := false
+	for _, kept := range keep {
+		if kept {
+			hasKeptNonSystem = true
+			break
 		}
 	}
-
-	// Ensure at least one non-system message if any existed.
-	if len(result) == len(systemMsgs) && len(nonSystem) > 0 {
+	if !hasKeptNonSystem && len(nonSystem) > 0 {
 		fallback := len(nonSystem) - 1
 		for j := len(nonSystem) - 1; j >= 0; j-- {
 			if nonSystem[j].Role == "user" {
@@ -197,9 +190,26 @@ func TrimMessages(msgs []Message, maxTokens int, estimator TokenEstimator) TrimR
 				break
 			}
 		}
-		result = append(result, nonSystem[fallback])
-		keptCost += messageCost(nonSystem[fallback], estimator)
-		trimmedCount--
+		keep[fallback] = true
+	}
+
+	// Build result preserving original message order.
+	var result []Message
+	trimmedCount := 0
+	keptCost := systemCost
+	nsIdx := 0
+	for _, m := range msgs {
+		if m.Role == "system" {
+			result = append(result, m)
+		} else {
+			if keep[nsIdx] {
+				result = append(result, m)
+				keptCost += messageCost(m, estimator)
+			} else {
+				trimmedCount++
+			}
+			nsIdx++
+		}
 	}
 
 	return TrimResult{
@@ -304,14 +314,20 @@ func TrimByExchanges(msgs []Message, maxExchanges int) TrimResult {
 		}
 	}
 
+	// Build result preserving original message order.
 	var result []Message
-	result = append(result, systemMsgs...)
 	trimmedCount := 0
-	for i, m := range nonSystem {
-		if keep[i] {
+	nsIdx := 0
+	for _, m := range msgs {
+		if m.Role == "system" {
 			result = append(result, m)
 		} else {
-			trimmedCount++
+			if keep[nsIdx] {
+				result = append(result, m)
+			} else {
+				trimmedCount++
+			}
+			nsIdx++
 		}
 	}
 

--- a/conversation/trim_test.go
+++ b/conversation/trim_test.go
@@ -3,6 +3,7 @@ package conversation
 import (
 	"encoding/json"
 	"testing"
+	"unicode/utf8"
 )
 
 // lenEstimator counts characters as tokens (1:1) for deterministic tests.
@@ -322,5 +323,90 @@ func TestTrimByExchanges_ZeroExchanges(t *testing.T) {
 	}
 	if result.Messages[0].Role != "system" {
 		t.Error("expected system message only")
+	}
+}
+
+// --- Regression tests for review findings ---
+
+func TestCharRatioEstimator_CountsRunesNotBytes(t *testing.T) {
+	est := CharRatioEstimator(4)
+	// "éééé" is 4 runes but 8 UTF-8 bytes.
+	text := "éééé"
+	if utf8.RuneCountInString(text) != 4 {
+		t.Fatal("test precondition: expected 4 runes")
+	}
+	got := est(text)
+	// 4 runes / 4 chars-per-token = 1 token
+	if got != 1 {
+		t.Errorf("CharRatioEstimator(4)(%q) = %d, want 1 (rune-based)", text, got)
+	}
+}
+
+func TestCharRatioEstimator_EmptyAndASCII(t *testing.T) {
+	est := CharRatioEstimator(4)
+	if got := est(""); got != 0 {
+		t.Errorf("empty string: got %d, want 0", got)
+	}
+	// "hello" = 5 runes, ceil(5/4) = 2
+	if got := est("hello"); got != 2 {
+		t.Errorf("\"hello\": got %d, want 2", got)
+	}
+}
+
+func TestTrimMessages_MidThreadSystemOrderPreserved(t *testing.T) {
+	msgs := []Message{
+		makeMsg("user", "q1"),
+		makeMsg("system", "mid-thread instruction"),
+		makeMsg("assistant", "a1"),
+	}
+	result := TrimMessages(msgs, 1000, lenEstimator)
+
+	// Order must be: user, system, assistant — not system, user, assistant.
+	if len(result.Messages) != 3 {
+		t.Fatalf("Messages len = %d, want 3", len(result.Messages))
+	}
+	expected := []string{"user", "system", "assistant"}
+	for i, want := range expected {
+		if result.Messages[i].Role != want {
+			t.Errorf("Messages[%d].Role = %q, want %q", i, result.Messages[i].Role, want)
+		}
+	}
+}
+
+func TestTrimMessages_FallbackPreservesMidThreadSystemOrder(t *testing.T) {
+	msgs := []Message{
+		makeMsg("user", "q1"),
+		makeMsg("system", "mid-thread instruction"),
+		makeMsg("assistant", "a1"),
+	}
+	result := TrimMessages(msgs, 0, lenEstimator)
+
+	if len(result.Messages) != 2 {
+		t.Fatalf("Messages len = %d, want 2", len(result.Messages))
+	}
+	expected := []string{"user", "system"}
+	for i, want := range expected {
+		if result.Messages[i].Role != want {
+			t.Errorf("Messages[%d].Role = %q, want %q", i, result.Messages[i].Role, want)
+		}
+	}
+}
+
+func TestTrimByExchanges_MidThreadSystemOrderPreserved(t *testing.T) {
+	msgs := []Message{
+		makeMsg("user", "q1"),
+		makeMsg("system", "mid-thread instruction"),
+		makeMsg("assistant", "a1"),
+	}
+	result := TrimByExchanges(msgs, 10)
+
+	if len(result.Messages) != 3 {
+		t.Fatalf("Messages len = %d, want 3", len(result.Messages))
+	}
+	expected := []string{"user", "system", "assistant"}
+	for i, want := range expected {
+		if result.Messages[i].Role != want {
+			t.Errorf("Messages[%d].Role = %q, want %q", i, result.Messages[i].Role, want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- **CharRatioEstimator** used `len(text)` (byte count) instead of `utf8.RuneCountInString`, causing non-ASCII text to be overcounted and trimmed too aggressively. For example, `CharRatioEstimator(4)("éééé")` returned `2` instead of `1`.
- **TrimMessages** and **TrimByExchanges** separated system messages into a slice and prepended them to the result, reordering mid-thread system messages even when no trimming was necessary. Input like `user -> system -> assistant` came back as `system -> user -> assistant`.
- Both assembly loops now iterate the original `msgs` slice with a secondary index into the `keep` array, preserving insertion order.
- The fallback "ensure at least one non-system message" logic in `TrimMessages` was moved before assembly so the `keep` array is authoritative and the single-pass build loop handles it correctly.

## Test plan

- [x] `TestCharRatioEstimator_CountsRunesNotBytes` -- verifies rune-based counting with multi-byte characters
- [x] `TestCharRatioEstimator_EmptyAndASCII` -- sanity check that ASCII and empty strings still work
- [x] `TestTrimMessages_MidThreadSystemOrderPreserved` -- `user -> system -> assistant` stays in that order (no trim needed)
- [x] `TestTrimMessages_FallbackPreservesMidThreadSystemOrder` -- zero-budget fallback preserves `user -> system` order
- [x] `TestTrimByExchanges_MidThreadSystemOrderPreserved` -- same ordering guarantee for exchange-based trimming
- [x] All 36 existing tests pass unchanged

Generated with [Claude Code](https://claude.com/claude-code)