### PR TITLE
feat(config): add ordered candidate resolution API (issue #28)

### DIFF
--- a/config/candidates.go
+++ b/config/candidates.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"context"
+	"fmt"
+)
+
+// CandidateModel represents an available model discovered during fallback
+// chain traversal. Unlike ResolvedModel (which returns the first match),
+// CandidateModel is one entry in a fully enumerated list of all available
+// models for a use-case, ordered by config preference.
+type CandidateModel struct {
+	Name       string // the model name (e.g. "qwen3.5:27b")
+	Role       string // the config role this model belongs to (e.g. "general")
+	IsFallback bool   // true if reached via fallback chain, not the primary role
+}
+
+// ResolveCandidates returns all available models for a use-case, ordered by
+// config preference (primary first, then fallback chain traversal order).
+// Unlike Resolve (which returns the first available model), this enumerates
+// every reachable model that is currently available, giving orchestration
+// layers the full candidate set for enrichment and scoring.
+//
+// Returns an empty slice (not an error) when no candidates are available.
+// Errors are reserved for operational failures, unknown use-cases, and invalid
+// role references encountered during traversal.
+func (c *Config) ResolveCandidates(ctx context.Context, checker ModelChecker, useCase string) ([]CandidateModel, error) {
+	if checker == nil {
+		return nil, fmt.Errorf("config: model checker is required")
+	}
+	role, ok := c.Defaults[useCase]
+	if !ok {
+		return nil, fmt.Errorf("config: unknown use-case %q", useCase)
+	}
+
+	models, err := checker.AvailableModels(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("config: checking available models: %w", err)
+	}
+
+	available := toSet(models)
+	visited := make(map[string]bool)
+	candidates := make([]CandidateModel, 0)
+	if err := c.collectCandidates(role, available, visited, false, &candidates); err != nil {
+		return nil, err
+	}
+	return candidates, nil
+}
+
+// collectCandidates walks the fallback chain from the given role, appending
+// every available model to candidates. It continues walking after finding
+// matches (unlike resolveRole which short-circuits). The visited set prevents
+// both circular fallbacks and duplicate entries in diamond-shaped graphs
+// (e.g. a→b→d, a→c→d — d appears once, from whichever branch reaches it first).
+func (c *Config) collectCandidates(role string, available, visited map[string]bool, isFallback bool, candidates *[]CandidateModel) error {
+	if visited[role] {
+		return nil // already visited (cycle or diamond) — skip
+	}
+
+	m, ok := c.Models[role]
+	if !ok {
+		return fmt.Errorf("config: unknown role %q", role)
+	}
+	visited[role] = true
+
+	if available[m.Name] {
+		*candidates = append(*candidates, CandidateModel{
+			Name:       m.Name,
+			Role:       role,
+			IsFallback: isFallback,
+		})
+	}
+
+	for _, fbRole := range m.Fallbacks {
+		if err := c.collectCandidates(fbRole, available, visited, true, candidates); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/config/candidates_test.go
+++ b/config/candidates_test.go
@@ -1,0 +1,372 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestResolveCandidates_PrimaryOnly(t *testing.T) {
+	cfg := loadTestConfig(t)
+	// Only the primary model for "embedding" is available (no fallbacks defined).
+	checker := &mockChecker{models: []string{"qwen3-embedding:8b"}}
+
+	got, err := cfg.ResolveCandidates(context.Background(), checker, "embedding")
+	if err != nil {
+		t.Fatalf("ResolveCandidates() error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(candidates) = %d, want 1", len(got))
+	}
+	if got[0].Name != "qwen3-embedding:8b" {
+		t.Errorf("Name = %q, want %q", got[0].Name, "qwen3-embedding:8b")
+	}
+	if got[0].Role != "embedding" {
+		t.Errorf("Role = %q, want %q", got[0].Role, "embedding")
+	}
+	if got[0].IsFallback {
+		t.Error("IsFallback = true, want false")
+	}
+}
+
+func TestResolveCandidates_PrimaryAndFallback(t *testing.T) {
+	cfg := loadTestConfig(t)
+	// Both primary (general=qwen3.5:27b) and fallback (lightweight=qwen3:8b) available.
+	// chat -> general -> lightweight
+	checker := &mockChecker{models: []string{"qwen3.5:27b", "qwen3:8b"}}
+
+	got, err := cfg.ResolveCandidates(context.Background(), checker, "chat")
+	if err != nil {
+		t.Fatalf("ResolveCandidates() error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(candidates) = %d, want 2", len(got))
+	}
+
+	// First candidate: primary model.
+	if got[0].Name != "qwen3.5:27b" {
+		t.Errorf("[0].Name = %q, want %q", got[0].Name, "qwen3.5:27b")
+	}
+	if got[0].IsFallback {
+		t.Error("[0].IsFallback = true, want false")
+	}
+
+	// Second candidate: fallback model.
+	if got[1].Name != "qwen3:8b" {
+		t.Errorf("[1].Name = %q, want %q", got[1].Name, "qwen3:8b")
+	}
+	if !got[1].IsFallback {
+		t.Error("[1].IsFallback = false, want true")
+	}
+}
+
+func TestResolveCandidates_FallbackOnlyAvailable(t *testing.T) {
+	cfg := loadTestConfig(t)
+	// Primary not available, only fallback.
+	// chat -> general (unavailable) -> lightweight (available)
+	checker := &mockChecker{models: []string{"qwen3:8b"}}
+
+	got, err := cfg.ResolveCandidates(context.Background(), checker, "chat")
+	if err != nil {
+		t.Fatalf("ResolveCandidates() error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(candidates) = %d, want 1", len(got))
+	}
+	if got[0].Name != "qwen3:8b" {
+		t.Errorf("Name = %q, want %q", got[0].Name, "qwen3:8b")
+	}
+	if got[0].Role != "lightweight" {
+		t.Errorf("Role = %q, want %q", got[0].Role, "lightweight")
+	}
+	if !got[0].IsFallback {
+		t.Error("IsFallback = false, want true")
+	}
+}
+
+func TestResolveCandidates_DeepChainOrdering(t *testing.T) {
+	cfg := loadTestConfig(t)
+	// completion -> coding -> general -> lightweight
+	// All three models available — verify traversal order.
+	checker := &mockChecker{models: []string{
+		"qwen3-coder-next:latest",
+		"qwen3.5:27b",
+		"qwen3:8b",
+	}}
+
+	got, err := cfg.ResolveCandidates(context.Background(), checker, "completion")
+	if err != nil {
+		t.Fatalf("ResolveCandidates() error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len(candidates) = %d, want 3", len(got))
+	}
+
+	// DFS order: coding (primary), then general (first fallback), then lightweight (general's fallback).
+	// Note: coding also lists lightweight as a direct fallback, but general's subtree
+	// is walked first (DFS), so lightweight appears via general before coding's
+	// direct lightweight fallback. The visited set prevents revisiting.
+	wantOrder := []struct {
+		name       string
+		role       string
+		isFallback bool
+	}{
+		{"qwen3-coder-next:latest", "coding", false},
+		{"qwen3.5:27b", "general", true},
+		{"qwen3:8b", "lightweight", true},
+	}
+
+	for i, want := range wantOrder {
+		if got[i].Name != want.name {
+			t.Errorf("[%d].Name = %q, want %q", i, got[i].Name, want.name)
+		}
+		if got[i].Role != want.role {
+			t.Errorf("[%d].Role = %q, want %q", i, got[i].Role, want.role)
+		}
+		if got[i].IsFallback != want.isFallback {
+			t.Errorf("[%d].IsFallback = %v, want %v", i, got[i].IsFallback, want.isFallback)
+		}
+	}
+}
+
+func TestResolveCandidates_NoneAvailable(t *testing.T) {
+	cfg := loadTestConfig(t)
+	checker := &mockChecker{models: []string{}}
+
+	got, err := cfg.ResolveCandidates(context.Background(), checker, "chat")
+	if err != nil {
+		t.Fatalf("ResolveCandidates() error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("len(candidates) = %d, want 0", len(got))
+	}
+}
+
+func TestResolveCandidates_UnknownUseCase(t *testing.T) {
+	cfg := loadTestConfig(t)
+	checker := &mockChecker{models: []string{"qwen3.5:27b"}}
+
+	_, err := cfg.ResolveCandidates(context.Background(), checker, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for unknown use-case")
+	}
+}
+
+func TestResolveCandidates_UnknownDefaultRole(t *testing.T) {
+	cfg := &Config{
+		Models: map[string]ModelConfig{
+			"a": {Name: "model-a"},
+		},
+		Defaults: map[string]string{
+			"test": "missing",
+		},
+	}
+	checker := &mockChecker{models: []string{"model-a"}}
+
+	_, err := cfg.ResolveCandidates(context.Background(), checker, "test")
+	if err == nil {
+		t.Fatal("expected error for unknown default role")
+	}
+	if !contains(err.Error(), `unknown role "missing"`) {
+		t.Errorf("error = %q, want substring %q", err.Error(), `unknown role "missing"`)
+	}
+}
+
+func TestResolveCandidates_UnknownFallbackRole(t *testing.T) {
+	cfg := &Config{
+		Models: map[string]ModelConfig{
+			"a": {Name: "model-a", Fallbacks: []string{"missing"}},
+		},
+		Defaults: map[string]string{
+			"test": "a",
+		},
+	}
+	checker := &mockChecker{models: []string{"model-a"}}
+
+	_, err := cfg.ResolveCandidates(context.Background(), checker, "test")
+	if err == nil {
+		t.Fatal("expected error for unknown fallback role")
+	}
+	if !contains(err.Error(), `unknown role "missing"`) {
+		t.Errorf("error = %q, want substring %q", err.Error(), `unknown role "missing"`)
+	}
+}
+
+func TestResolveCandidates_NilChecker(t *testing.T) {
+	cfg := loadTestConfig(t)
+	_, err := cfg.ResolveCandidates(context.Background(), nil, "chat")
+	if err == nil {
+		t.Fatal("expected error for nil checker")
+	}
+}
+
+func TestResolveCandidates_CheckerError(t *testing.T) {
+	cfg := loadTestConfig(t)
+	checker := &mockChecker{err: fmt.Errorf("connection refused")}
+
+	_, err := cfg.ResolveCandidates(context.Background(), checker, "chat")
+	if err == nil {
+		t.Fatal("expected error when checker fails")
+	}
+	if !contains(err.Error(), "connection refused") {
+		t.Errorf("error = %q, want substring %q", err.Error(), "connection refused")
+	}
+}
+
+func TestResolveCandidates_CircularFallback(t *testing.T) {
+	cfg := &Config{
+		Models: map[string]ModelConfig{
+			"a": {Name: "model-a", Fallbacks: []string{"b"}},
+			"b": {Name: "model-b", Fallbacks: []string{"a"}}, // cycle: a → b → a
+		},
+		Defaults: map[string]string{
+			"test": "a",
+		},
+	}
+	// Both available — the cycle must not cause infinite recursion or duplicates.
+	checker := &mockChecker{models: []string{"model-a", "model-b"}}
+
+	got, err := cfg.ResolveCandidates(context.Background(), checker, "test")
+	if err != nil {
+		t.Fatalf("ResolveCandidates() error: %v", err)
+	}
+	// Should get both models: a (primary), b (fallback). No infinite loop.
+	if len(got) != 2 {
+		t.Fatalf("len(candidates) = %d, want 2", len(got))
+	}
+	if got[0].Name != "model-a" {
+		t.Errorf("[0].Name = %q, want %q", got[0].Name, "model-a")
+	}
+	if got[0].IsFallback {
+		t.Error("[0].IsFallback = true, want false")
+	}
+	if got[1].Name != "model-b" {
+		t.Errorf("[1].Name = %q, want %q", got[1].Name, "model-b")
+	}
+	if !got[1].IsFallback {
+		t.Error("[1].IsFallback = false, want true")
+	}
+}
+
+func TestResolveCandidates_DiamondNoDuplicates(t *testing.T) {
+	// Diamond: a → {b, c}, both b and c fall back to d.
+	// d should appear only once in candidates.
+	cfg := &Config{
+		Models: map[string]ModelConfig{
+			"a": {Name: "model-a", Fallbacks: []string{"b", "c"}},
+			"b": {Name: "model-b", Fallbacks: []string{"d"}},
+			"c": {Name: "model-c", Fallbacks: []string{"d"}},
+			"d": {Name: "model-d"},
+		},
+		Defaults: map[string]string{
+			"test": "a",
+		},
+	}
+	checker := &mockChecker{models: []string{"model-a", "model-b", "model-c", "model-d"}}
+
+	got, err := cfg.ResolveCandidates(context.Background(), checker, "test")
+	if err != nil {
+		t.Fatalf("ResolveCandidates() error: %v", err)
+	}
+
+	// DFS order: a (primary), b (first fallback of a), d (fallback of b),
+	// c (second fallback of a). d is NOT revisited via c's fallback because
+	// the visited set marks it done after b's subtree.
+	wantNames := []string{"model-a", "model-b", "model-d", "model-c"}
+	if len(got) != len(wantNames) {
+		t.Fatalf("len(candidates) = %d, want %d; got: %v", len(got), len(wantNames), candidateNames(got))
+	}
+	for i, want := range wantNames {
+		if got[i].Name != want {
+			t.Errorf("[%d].Name = %q, want %q", i, got[i].Name, want)
+		}
+	}
+}
+
+func TestResolveCandidates_ConsistentWithResolve(t *testing.T) {
+	cfg := loadTestConfig(t)
+
+	tests := []struct {
+		name    string
+		models  []string
+		useCase string
+	}{
+		{"primary available", []string{"qwen3.5:27b", "qwen3:8b"}, "chat"},
+		{"fallback only", []string{"qwen3:8b"}, "chat"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checker := &mockChecker{models: tt.models}
+
+			resolved, err := cfg.Resolve(context.Background(), checker, tt.useCase)
+			if err != nil {
+				t.Fatalf("Resolve() error: %v", err)
+			}
+
+			candidates, err := cfg.ResolveCandidates(context.Background(), checker, tt.useCase)
+			if err != nil {
+				t.Fatalf("ResolveCandidates() error: %v", err)
+			}
+			if len(candidates) == 0 {
+				t.Fatal("expected at least one candidate")
+			}
+
+			// The first candidate must match what Resolve returns.
+			if candidates[0].Name != resolved.Name {
+				t.Errorf("first candidate Name = %q, Resolve Name = %q", candidates[0].Name, resolved.Name)
+			}
+			if candidates[0].Role != resolved.Role {
+				t.Errorf("first candidate Role = %q, Resolve Role = %q", candidates[0].Role, resolved.Role)
+			}
+			if candidates[0].IsFallback != resolved.IsFallback {
+				t.Errorf("first candidate IsFallback = %v, Resolve IsFallback = %v", candidates[0].IsFallback, resolved.IsFallback)
+			}
+		})
+	}
+}
+
+func TestResolveCandidates_DuplicateModelNames(t *testing.T) {
+	// Two roles map to the same model name. Both should appear as candidates
+	// since the orchestration layer cares about roles, not just model names.
+	cfg := &Config{
+		Models: map[string]ModelConfig{
+			"primary": {Name: "shared-model", Fallbacks: []string{"backup"}},
+			"backup":  {Name: "shared-model"},
+		},
+		Defaults: map[string]string{
+			"test": "primary",
+		},
+	}
+	checker := &mockChecker{models: []string{"shared-model"}}
+
+	got, err := cfg.ResolveCandidates(context.Background(), checker, "test")
+	if err != nil {
+		t.Fatalf("ResolveCandidates() error: %v", err)
+	}
+	// Both roles should appear — tracked by role, not model name.
+	if len(got) != 2 {
+		t.Fatalf("len(candidates) = %d, want 2", len(got))
+	}
+	if got[0].Role != "primary" {
+		t.Errorf("[0].Role = %q, want %q", got[0].Role, "primary")
+	}
+	if got[0].IsFallback {
+		t.Error("[0].IsFallback = true, want false")
+	}
+	if got[1].Role != "backup" {
+		t.Errorf("[1].Role = %q, want %q", got[1].Role, "backup")
+	}
+	if !got[1].IsFallback {
+		t.Error("[1].IsFallback = false, want true")
+	}
+}
+
+// candidateNames extracts names from a candidate slice for debug output.
+func candidateNames(candidates []CandidateModel) []string {
+	names := make([]string, len(candidates))
+	for i, c := range candidates {
+		names[i] = c.Name
+	}
+	return names
+}


### PR DESCRIPTION
## Summary

- Add `CandidateModel` type and `ResolveCandidates()` method to `config/` package
- Enumerates **all** available models for a use-case in config preference order (primary first, then DFS fallback traversal), unlike `Resolve()` which returns only the first match
- Uses a `visited` set (not path-tracking) to handle both circular fallbacks and diamond-shaped deduplication
- Unknown roles encountered during traversal are surfaced as errors, not silently skipped
- `Resolve()` and `ResolveAll()` remain completely unchanged

This is the API that `orchestrate/` will consume to build `EnrichedModel` candidates with fingerprint data (Phase 2, issue #33).

## Test plan

- [x] Primary-only resolution (embedding, no fallbacks)
- [x] Primary + fallback both available (chat -> general -> lightweight)
- [x] Fallback-only available (primary unavailable)
- [x] Deep chain ordering (completion -> coding -> general -> lightweight, DFS order verified)
- [x] No candidates available (empty slice, no error)
- [x] Unknown use-case (error)
- [x] Unknown default role (error with role name)
- [x] Unknown fallback role (error with role name)
- [x] Nil checker (error)
- [x] Checker error propagation
- [x] Circular fallback (a -> b -> a, terminates without infinite loop)
- [x] Diamond graph deduplication (a -> {b,c} -> d, d appears once)
- [x] Consistency with Resolve (first candidate matches Resolve result, both primary and fallback scenarios)
- [x] Duplicate model names across roles (both roles appear, tracked by role not name)
- [x] Full existing test suite passes (40 config tests, all packages green)

Closes #28

Generated with [Claude Code](https://claude.com/claude-code)