### PR TITLE
feat(fingerprint): add fingerprint foundation with backend-scoped profiles (issue #29)

### DIFF
--- a/fingerprint/backend.go
+++ b/fingerprint/backend.go
@@ -1,0 +1,77 @@
+package fingerprint
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// localHosts maps hostnames that resolve to the local machine to "localhost".
+// 0.0.0.0 (INADDR_ANY) is included because Ollama binds to it by default;
+// while not technically a loopback address, connections to it reach localhost.
+var localHosts = map[string]bool{
+	"localhost": true,
+	"127.0.0.1": true,
+	"::1":       true,
+	"0.0.0.0":   true,
+}
+
+// NormalizeBackendID produces a canonical backend ID from a raw URL.
+// It lowercases scheme and host, canonicalizes loopback addresses to "localhost",
+// strips trailing slashes, userinfo, query, and fragment.
+func NormalizeBackendID(rawURL string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("fingerprint: invalid backend URL %q: %w", rawURL, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("fingerprint: invalid backend URL %q: missing scheme or host", rawURL)
+	}
+
+	// Lowercase scheme
+	u.Scheme = strings.ToLower(u.Scheme)
+
+	// Split host and port
+	host := u.Hostname()
+	port := u.Port()
+
+	// Lowercase and canonicalize host
+	host = strings.ToLower(host)
+	if localHosts[host] {
+		host = "localhost"
+	}
+
+	// Rebuild host with port, handling IPv6 bracket insertion correctly
+	if port != "" {
+		u.Host = net.JoinHostPort(host, port)
+	} else {
+		if strings.Contains(host, ":") {
+			u.Host = "[" + host + "]"
+		} else {
+			u.Host = host
+		}
+	}
+
+	// Strip trailing slashes from path
+	u.Path = strings.TrimRight(u.Path, "/")
+	u.RawPath = "" // Force String() to derive from cleaned Path
+
+	// Strip userinfo, query, fragment
+	u.User = nil
+	u.RawQuery = ""
+	u.Fragment = ""
+
+	return u.String(), nil
+}
+
+// IsLocalBackend reports whether the given backend URL points to the local machine.
+// Checks for localhost, 127.0.0.1, [::1], and 0.0.0.0.
+func IsLocalBackend(backendURL string) bool {
+	u, err := url.Parse(backendURL)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	return localHosts[host]
+}

--- a/fingerprint/backend_test.go
+++ b/fingerprint/backend_test.go
@@ -1,0 +1,70 @@
+package fingerprint
+
+import "testing"
+
+func TestNormalizeBackendID(t *testing.T) {
+	tests := []struct {
+		name    string
+		rawURL  string
+		want    string
+		wantErr bool
+	}{
+		{"standard", "http://localhost:11434", "http://localhost:11434", false},
+		{"trailing slash", "http://localhost:11434/", "http://localhost:11434", false},
+		{"uppercase host", "HTTP://LocalHost:11434", "http://localhost:11434", false},
+		{"loopback ipv4", "http://127.0.0.1:11434", "http://localhost:11434", false},
+		{"loopback ipv6", "http://[::1]:11434", "http://localhost:11434", false},
+		{"zero addr", "http://0.0.0.0:11434", "http://localhost:11434", false},
+		{"non-default port", "http://localhost:8080", "http://localhost:8080", false},
+		{"remote host", "http://gpu-server:11434", "http://gpu-server:11434", false},
+		{"reverse proxy path", "http://host:8080/ollama/", "http://host:8080/ollama", false},
+		{"strip query and fragment", "http://localhost:11434?foo=bar#baz", "http://localhost:11434", false},
+		{"strip userinfo", "http://user:pass@localhost:11434", "http://localhost:11434", false},
+		{"empty string", "", "", true},
+		{"no scheme", "localhost:11434", "", true},
+		{"invalid url", "://bad", "", true},
+		{"https scheme", "HTTPS://gpu-server:11434", "https://gpu-server:11434", false},
+		{"ipv6 remote", "http://[fe80::1]:11434", "http://[fe80::1]:11434", false},
+		{"multiple trailing slashes", "http://localhost:11434///", "http://localhost:11434", false},
+		{"deep path with trailing slash", "http://host:8080/v1/ollama/", "http://host:8080/v1/ollama", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeBackendID(tt.rawURL)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NormalizeBackendID(%q) error = %v, wantErr %v", tt.rawURL, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("NormalizeBackendID(%q) = %q, want %q", tt.rawURL, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsLocalBackend(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"localhost", "http://localhost:11434", true},
+		{"127.0.0.1", "http://127.0.0.1:11434", true},
+		{"ipv6 loopback", "http://[::1]:11434", true},
+		{"0.0.0.0", "http://0.0.0.0:11434", true},
+		{"remote host", "http://gpu-server:11434", false},
+		{"remote ip", "http://192.168.1.100:11434", false},
+		{"empty string", "", false},
+		{"no scheme", "localhost:11434", false},
+		{"invalid url", "://bad", false},
+		{"ipv6 remote", "http://[fe80::1]:11434", false},
+		{"schemeless with host", "//localhost:11434", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsLocalBackend(tt.url)
+			if got != tt.want {
+				t.Errorf("IsLocalBackend(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}

--- a/fingerprint/fingerprint.go
+++ b/fingerprint/fingerprint.go
@@ -1,0 +1,108 @@
+// Package fingerprint profiles Ollama models with latency benchmarks,
+// detects model kind (chat vs embedding), and persists backend-scoped
+// profiles in SQLite for intelligent model selection.
+package fingerprint
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// CurrentProfileVersion is the benchmark suite version written by this build.
+// Increment when new benchmarks are added (e.g., Phase 2 full suite).
+const CurrentProfileVersion = 1
+
+// ErrNotFound is returned by Store.Get when no profile exists for the given key.
+var ErrNotFound = errors.New("fingerprint: not found")
+
+// ModelKind classifies a model's primary function.
+type ModelKind string
+
+const (
+	ModelKindChat      ModelKind = "chat"
+	ModelKindEmbedding ModelKind = "embedding"
+	ModelKindUnknown   ModelKind = "unknown"
+)
+
+// KindDetection holds the result of model kind detection, including
+// all detected capabilities and metadata from /api/show.
+type KindDetection struct {
+	Kind         ModelKind
+	Capabilities []string // all detected capabilities (e.g. ["completion","tools","embedding"])
+	Family       string   // /api/show family; passed through for think-mode gating
+	Source       string   // "capabilities", "heuristic", or "probe"
+}
+
+// Profile holds a complete model fingerprint, including identity,
+// capabilities, performance metrics, and resource observations.
+//
+// Capabilities is the authoritative field for what a model can do.
+// ModelKind exists for backward compatibility and simple single-purpose
+// routing; it does not reflect all model abilities. Callers that need
+// full capability info must use Capabilities, not ModelKind.
+type Profile struct {
+	// Identity (composite key: backend_id + model_name)
+	ModelName              string
+	ModelDigest            string    // content-addressed version hash from /api/show
+	BackendID              string    // normalized Ollama base URL
+	ModelKind              ModelKind // primary kind for backward compat routing
+	Capabilities           []string  // all model capabilities (e.g. ["completion","embedding"])
+	IncompleteCapabilities []string  // capabilities still missing metrics; empty = complete
+	KindSource             string    // how kind was determined: "capabilities", "heuristic", or "probe"
+	ProfileVersion         int       // benchmark suite version (1 = latency-only, 2 = full suite)
+	TestedAt               time.Time
+
+	// Chat capabilities (-1 = not tested)
+	EffectiveContext int     // 0 = not tested
+	ToolCallingRate  float64 // 0.0-1.0, -1 = not tested
+	InstructionScore float64 // 0.0-1.0, -1 = not tested
+
+	// Chat performance (-1 / 0 = not tested)
+	GenerationTokensPerSecond float64       // -1 = not tested
+	PromptLatency             time.Duration // prompt_eval_duration; 0 = not tested
+	ColdStartLatency          time.Duration // first-run latency including model load; 0 = model was warm
+
+	// Embedding (-1 / 0 = not tested)
+	EmbeddingDim       int           // 0 = not tested
+	EmbeddingCoherence float64       // -1 = not tested
+	EmbeddingLatency   time.Duration // 0 = not tested
+
+	// Resource observations
+	PeakMemoryMB  int64 // 0 = not measured (Phase 1)
+	GPULayersUsed int   // 0 = not measured (Phase 1)
+}
+
+// ChatMetrics holds the output of a chat probe benchmark.
+type ChatMetrics struct {
+	TokensPerSecond  float64
+	PromptLatency    time.Duration // prompt_eval_duration (warm model)
+	ColdStartLatency time.Duration // total latency of cold-loaded first run; 0 if warm
+}
+
+// EmbeddingMetrics holds the output of an embedding probe benchmark.
+type EmbeddingMetrics struct {
+	Latency          time.Duration
+	ColdStartLatency time.Duration // 0 if warm
+	Dim              int           // embedding dimensions, captured from embed response
+}
+
+// FailureInfo records a failed fingerprint attempt for backoff tracking.
+type FailureInfo struct {
+	ModelDigest  string
+	LastError    string
+	AttemptedAt  time.Time
+	AttemptCount int
+	RetryAfter   time.Time
+}
+
+// BackoffError indicates that a model is in a fingerprint backoff window
+// and should not be retried yet.
+type BackoffError struct {
+	RetryAfter time.Time
+	LastError  string
+}
+
+func (e *BackoffError) Error() string {
+	return fmt.Sprintf("fingerprint: in backoff until %s: %s", e.RetryAfter.Format(time.RFC3339), e.LastError)
+}

--- a/fingerprint/kind.go
+++ b/fingerprint/kind.go
@@ -1,0 +1,44 @@
+package fingerprint
+
+// InferKindFromCapabilities classifies using the explicit capabilities array
+// from /api/show (available in Ollama 0.5.x+). This is the strongest signal.
+//
+// Detection order: embedding wins over completion for dual-capability models,
+// since embedding models are rarer and more specific.
+func InferKindFromCapabilities(capabilities []string) ModelKind {
+	hasEmbedding := false
+	hasCompletion := false
+	for _, c := range capabilities {
+		switch c {
+		case "embedding":
+			hasEmbedding = true
+		case "completion":
+			hasCompletion = true
+		}
+	}
+	if hasEmbedding {
+		return ModelKindEmbedding
+	}
+	if hasCompletion {
+		return ModelKindChat
+	}
+	return ModelKindUnknown
+}
+
+// embeddingFamilies maps model families known to be embedding-only.
+var embeddingFamilies = map[string]bool{
+	"bert":       true,
+	"nomic-bert": true,
+}
+
+// InferKind classifies using family/template heuristics as a fallback
+// for older Ollama versions that don't expose capabilities.
+func InferKind(family, template string) ModelKind {
+	if embeddingFamilies[family] {
+		return ModelKindEmbedding
+	}
+	if template != "" {
+		return ModelKindChat
+	}
+	return ModelKindUnknown
+}

--- a/fingerprint/kind_test.go
+++ b/fingerprint/kind_test.go
@@ -1,0 +1,51 @@
+package fingerprint
+
+import "testing"
+
+func TestInferKindFromCapabilities(t *testing.T) {
+	tests := []struct {
+		name         string
+		capabilities []string
+		want         ModelKind
+	}{
+		{"completion capability", []string{"completion", "tools"}, ModelKindChat},
+		{"embedding capability", []string{"embedding"}, ModelKindEmbedding},
+		{"dual capability returns embedding kind", []string{"completion", "embedding"}, ModelKindEmbedding},
+		{"empty capabilities", []string{}, ModelKindUnknown},
+		{"nil capabilities", nil, ModelKindUnknown},
+		{"unrecognized capabilities", []string{"vision"}, ModelKindUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := InferKindFromCapabilities(tt.capabilities)
+			if got != tt.want {
+				t.Errorf("InferKindFromCapabilities(%v) = %q, want %q", tt.capabilities, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInferKind(t *testing.T) {
+	tests := []struct {
+		name     string
+		family   string
+		template string
+		want     ModelKind
+	}{
+		{"bert family", "bert", "", ModelKindEmbedding},
+		{"nomic-bert family", "nomic-bert", "", ModelKindEmbedding},
+		{"qwen2 with template", "qwen2", "{{ .System }}", ModelKindChat},
+		{"llama with template", "llama", "{{ .Prompt }}", ModelKindChat},
+		{"embedding family with template still embedding", "bert", "{{ .Prompt }}", ModelKindEmbedding},
+		{"unknown family no template", "custom", "", ModelKindUnknown},
+		{"empty everything", "", "", ModelKindUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := InferKind(tt.family, tt.template)
+			if got != tt.want {
+				t.Errorf("InferKind(%q, %q) = %q, want %q", tt.family, tt.template, got, tt.want)
+			}
+		})
+	}
+}

--- a/fingerprint/migration.go
+++ b/fingerprint/migration.go
@@ -1,0 +1,119 @@
+package fingerprint
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+type migration struct {
+	version     int
+	description string
+	fn          func(tx *sql.Tx) error
+}
+
+var migrations = []migration{
+	{
+		version:     1,
+		description: "baseline fingerprint profiles and failures tables",
+		fn:          migrateV1,
+	},
+}
+
+func migrateV1(tx *sql.Tx) error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS fingerprint_profiles (
+			backend_id                  TEXT NOT NULL,
+			model_name                  TEXT NOT NULL,
+			model_digest                TEXT NOT NULL,
+			model_kind                  TEXT NOT NULL,
+			capabilities                TEXT NOT NULL DEFAULT '[]',
+			incomplete_capabilities     TEXT NOT NULL DEFAULT '[]',
+			kind_source                 TEXT NOT NULL DEFAULT '',
+			profile_version             INTEGER NOT NULL DEFAULT 1,
+			tested_at                   INTEGER NOT NULL,
+			effective_context           INTEGER NOT NULL DEFAULT 0,
+			tool_calling_rate           REAL NOT NULL DEFAULT -1,
+			instruction_score           REAL NOT NULL DEFAULT -1,
+			generation_tokens_per_sec   REAL NOT NULL DEFAULT -1,
+			prompt_latency_ns           INTEGER NOT NULL DEFAULT 0,
+			cold_start_latency_ns       INTEGER NOT NULL DEFAULT 0,
+			embedding_dim               INTEGER NOT NULL DEFAULT 0,
+			embedding_coherence         REAL NOT NULL DEFAULT -1,
+			embedding_latency_ns        INTEGER NOT NULL DEFAULT 0,
+			peak_memory_mb              INTEGER NOT NULL DEFAULT 0,
+			gpu_layers_used             INTEGER NOT NULL DEFAULT 0,
+			PRIMARY KEY (backend_id, model_name)
+		)`,
+		`CREATE TABLE IF NOT EXISTS fingerprint_failures (
+			backend_id      TEXT NOT NULL,
+			model_name      TEXT NOT NULL,
+			model_digest    TEXT NOT NULL,
+			last_error      TEXT NOT NULL,
+			attempted_at    INTEGER NOT NULL,
+			attempt_count   INTEGER NOT NULL DEFAULT 1,
+			PRIMARY KEY (backend_id, model_name)
+		)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := tx.Exec(stmt); err != nil {
+			return fmt.Errorf("fingerprint: migrate v1: %w", err)
+		}
+	}
+	return nil
+}
+
+func runMigrations(db *sql.DB) error {
+	const createVersionTable = `CREATE TABLE IF NOT EXISTS fingerprint_schema_version (
+		version     INTEGER PRIMARY KEY,
+		description TEXT NOT NULL,
+		applied_at  INTEGER NOT NULL
+	)`
+	if _, err := db.Exec(createVersionTable); err != nil {
+		return fmt.Errorf("fingerprint: create version table: %w", err)
+	}
+
+	currentVersion, err := currentSchemaVersion(db)
+	if err != nil {
+		return err
+	}
+
+	for _, m := range migrations {
+		if m.version <= currentVersion {
+			continue
+		}
+
+		tx, err := db.Begin()
+		if err != nil {
+			return fmt.Errorf("fingerprint: begin migration v%d: %w", m.version, err)
+		}
+
+		if err := m.fn(tx); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("fingerprint: migration v%d (%s): %w", m.version, m.description, err)
+		}
+
+		if _, err := tx.Exec(
+			`INSERT INTO fingerprint_schema_version (version, description, applied_at) VALUES (?, ?, ?)`,
+			m.version, m.description, time.Now().UnixMilli(),
+		); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("fingerprint: record version %d: %w", m.version, err)
+		}
+
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("fingerprint: commit migration v%d: %w", m.version, err)
+		}
+	}
+
+	return nil
+}
+
+func currentSchemaVersion(db *sql.DB) (int, error) {
+	var version int
+	err := db.QueryRow(`SELECT COALESCE(MAX(version), 0) FROM fingerprint_schema_version`).Scan(&version)
+	if err != nil {
+		return 0, fmt.Errorf("fingerprint: query schema version: %w", err)
+	}
+	return version, nil
+}

--- a/fingerprint/migration_test.go
+++ b/fingerprint/migration_test.go
@@ -1,0 +1,42 @@
+package fingerprint
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestMigrations_FreshDB(t *testing.T) {
+	db := openTestDB(t)
+	if err := runMigrations(db); err != nil {
+		t.Fatalf("runMigrations() error: %v", err)
+	}
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM fingerprint_profiles").Scan(&count); err != nil {
+		t.Fatalf("query profiles table: %v", err)
+	}
+	if err := db.QueryRow("SELECT COUNT(*) FROM fingerprint_failures").Scan(&count); err != nil {
+		t.Fatalf("query failures table: %v", err)
+	}
+}
+
+func TestMigrations_Idempotent(t *testing.T) {
+	db := openTestDB(t)
+	if err := runMigrations(db); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	if err := runMigrations(db); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+}
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}

--- a/fingerprint/probe.go
+++ b/fingerprint/probe.go
@@ -102,19 +102,30 @@ func (p *OllamaProber) probeKind(ctx context.Context, model string, info *ollama
 	}, nil
 }
 
+// Compile-time interface check.
+var _ ModelProber = (*OllamaProber)(nil)
+
 // ProbeChat sends a minimal chat request and extracts performance metrics
-// from Ollama's timing fields. The options parameter allows callers to
-// control context size and token limits; pass nil for defaults.
-func (p *OllamaProber) ProbeChat(ctx context.Context, model string, opts *ollama.ModelOptions) (*ChatMetrics, error) {
-	if opts == nil {
-		opts = &ollama.ModelOptions{NumPredict: 16}
+// from Ollama's timing fields. The opts parameter accepts *ollama.ModelOptions
+// or nil for defaults.
+func (p *OllamaProber) ProbeChat(ctx context.Context, model string, opts interface{}) (*ChatMetrics, error) {
+	var modelOpts *ollama.ModelOptions
+	if opts != nil {
+		var ok bool
+		modelOpts, ok = opts.(*ollama.ModelOptions)
+		if !ok {
+			return nil, fmt.Errorf("fingerprint: probe chat %q: opts must be *ollama.ModelOptions, got %T", model, opts)
+		}
+	}
+	if modelOpts == nil {
+		modelOpts = &ollama.ModelOptions{NumPredict: 16}
 	}
 
 	start := time.Now()
 	resp, err := p.client.Chat(ctx, ollama.ChatRequest{
 		Model:    model,
 		Messages: []ollama.ChatMessage{{Role: "user", Content: "Say hello."}},
-		Options:  opts,
+		Options:  modelOpts,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("fingerprint: probe chat %q: %w", model, err)

--- a/fingerprint/probe.go
+++ b/fingerprint/probe.go
@@ -1,0 +1,162 @@
+package fingerprint
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+// OllamaProber queries an Ollama backend to detect model kind and
+// collect performance metrics for building a fingerprint Profile.
+type OllamaProber struct {
+	client *ollama.Client
+}
+
+// NewProber creates an OllamaProber using the given Ollama client.
+func NewProber(client *ollama.Client) *OllamaProber {
+	return &OllamaProber{client: client}
+}
+
+// DetectKind determines the model's kind using a three-tier strategy:
+//  1. Capabilities array from /api/show (Ollama 0.5.x+)
+//  2. Family/template heuristics (older Ollama versions)
+//  3. Live probe: try chat, then embedding
+//
+// Returns a KindDetection describing the result and how it was determined.
+func (p *OllamaProber) DetectKind(ctx context.Context, model string) (*KindDetection, error) {
+	info, err := p.client.ShowModel(ctx, model)
+	if err != nil {
+		return nil, fmt.Errorf("fingerprint: detect kind %q: %w", model, err)
+	}
+
+	// Tier 1: explicit capabilities
+	if len(info.Capabilities) > 0 {
+		kind := InferKindFromCapabilities(info.Capabilities)
+		if kind != ModelKindUnknown {
+			return &KindDetection{
+				Kind:         kind,
+				Capabilities: info.Capabilities,
+				Family:       info.Family,
+				Source:       "capabilities",
+			}, nil
+		}
+	}
+
+	// Tier 2: family/template heuristic
+	kind := InferKind(info.Family, info.Template)
+	if kind != ModelKindUnknown {
+		return &KindDetection{
+			Kind:         kind,
+			Capabilities: info.Capabilities,
+			Family:       info.Family,
+			Source:       "heuristic",
+		}, nil
+	}
+
+	// Tier 3: live probe — try chat first, then embedding
+	det, err := p.probeKind(ctx, model, info)
+	if err != nil {
+		return nil, fmt.Errorf("fingerprint: detect kind %q: %w", model, err)
+	}
+	return det, nil
+}
+
+// probeKind attempts to classify an unknown model by making live API calls.
+func (p *OllamaProber) probeKind(ctx context.Context, model string, info *ollama.ModelInfo) (*KindDetection, error) {
+	// Try chat
+	_, chatErr := p.client.Chat(ctx, ollama.ChatRequest{
+		Model:    model,
+		Messages: []ollama.ChatMessage{{Role: "user", Content: "hi"}},
+		Options:  &ollama.ModelOptions{NumPredict: 1},
+	})
+	if chatErr == nil {
+		return &KindDetection{
+			Kind:         ModelKindChat,
+			Capabilities: info.Capabilities,
+			Family:       info.Family,
+			Source:       "probe",
+		}, nil
+	}
+
+	// Try embedding
+	_, embedErr := p.client.Embed(ctx, model, "test")
+	if embedErr == nil {
+		return &KindDetection{
+			Kind:         ModelKindEmbedding,
+			Capabilities: info.Capabilities,
+			Family:       info.Family,
+			Source:       "probe",
+		}, nil
+	}
+
+	// Both failed — return unknown rather than an error, since the model
+	// exists but we can't classify it.
+	return &KindDetection{
+		Kind:         ModelKindUnknown,
+		Capabilities: info.Capabilities,
+		Family:       info.Family,
+		Source:       "probe",
+	}, nil
+}
+
+// ProbeChat sends a minimal chat request and extracts performance metrics
+// from Ollama's timing fields. The options parameter allows callers to
+// control context size and token limits; pass nil for defaults.
+func (p *OllamaProber) ProbeChat(ctx context.Context, model string, opts *ollama.ModelOptions) (*ChatMetrics, error) {
+	if opts == nil {
+		opts = &ollama.ModelOptions{NumPredict: 16}
+	}
+
+	start := time.Now()
+	resp, err := p.client.Chat(ctx, ollama.ChatRequest{
+		Model:    model,
+		Messages: []ollama.ChatMessage{{Role: "user", Content: "Say hello."}},
+		Options:  opts,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("fingerprint: probe chat %q: %w", model, err)
+	}
+
+	metrics := &ChatMetrics{}
+
+	// Token throughput from eval_count / eval_duration
+	if resp.EvalDuration > 0 && resp.EvalCount > 0 {
+		evalSecs := float64(resp.EvalDuration) / 1e9
+		metrics.TokensPerSecond = float64(resp.EvalCount) / evalSecs
+	}
+
+	// Prompt eval latency
+	if resp.PromptEvalDuration > 0 {
+		metrics.PromptLatency = time.Duration(resp.PromptEvalDuration)
+	}
+
+	// Cold start: if load_duration is significant (>100ms), the model
+	// was loaded from disk for this request.
+	if resp.LoadDuration > 100_000_000 { // 100ms in nanoseconds
+		metrics.ColdStartLatency = time.Since(start)
+	}
+
+	return metrics, nil
+}
+
+// ProbeEmbedding sends a minimal embedding request and captures dimension
+// and latency metrics.
+func (p *OllamaProber) ProbeEmbedding(ctx context.Context, model string) (*EmbeddingMetrics, error) {
+	start := time.Now()
+	vec, err := p.client.Embed(ctx, model, "The quick brown fox jumps over the lazy dog.")
+	if err != nil {
+		var apiErr *ollama.APIError
+		if errors.As(err, &apiErr) {
+			return nil, fmt.Errorf("fingerprint: probe embedding %q: %w", model, apiErr)
+		}
+		return nil, fmt.Errorf("fingerprint: probe embedding %q: %w", model, err)
+	}
+
+	return &EmbeddingMetrics{
+		Latency: time.Since(start),
+		Dim:     len(vec),
+	}, nil
+}

--- a/fingerprint/probe_test.go
+++ b/fingerprint/probe_test.go
@@ -225,13 +225,13 @@ func TestProbeChat(t *testing.T) {
 	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{
 			"model":                "test-model",
-			"message":             map[string]any{"role": "assistant", "content": "Hello!"},
-			"done":                true,
-			"eval_count":          10,
-			"eval_duration":       500_000_000, // 500ms → 20 tok/s
+			"message":              map[string]any{"role": "assistant", "content": "Hello!"},
+			"done":                 true,
+			"eval_count":           10,
+			"eval_duration":        500_000_000, // 500ms → 20 tok/s
 			"prompt_eval_duration": 200_000_000, // 200ms
-			"load_duration":       50_000_000,  // 50ms (warm — below threshold)
-			"total_duration":      800_000_000,
+			"load_duration":        50_000_000,  // 50ms (warm — below threshold)
+			"total_duration":       800_000_000,
 		})
 	}))
 	defer srv.Close()

--- a/fingerprint/probe_test.go
+++ b/fingerprint/probe_test.go
@@ -1,0 +1,332 @@
+package fingerprint
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+// newTestProber creates a prober backed by a test server.
+func newTestProber(handler http.Handler) (*OllamaProber, *httptest.Server) {
+	srv := httptest.NewServer(handler)
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	return NewProber(client), srv
+}
+
+// TestDetectKind_Capabilities verifies Tier 1: capabilities array.
+func TestDetectKind_Capabilities(t *testing.T) {
+	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"details":      map[string]any{"family": "qwen2"},
+			"template":     "{{ .System }}\n{{ .Prompt }}",
+			"capabilities": []string{"completion", "tools"},
+		})
+	}))
+	defer srv.Close()
+
+	det, err := prober.DetectKind(context.Background(), "qwen2.5:72b")
+	if err != nil {
+		t.Fatalf("DetectKind() error: %v", err)
+	}
+	if det.Kind != ModelKindChat {
+		t.Errorf("Kind = %q, want %q", det.Kind, ModelKindChat)
+	}
+	if det.Source != "capabilities" {
+		t.Errorf("Source = %q, want %q", det.Source, "capabilities")
+	}
+	if det.Family != "qwen2" {
+		t.Errorf("Family = %q, want %q", det.Family, "qwen2")
+	}
+}
+
+// TestDetectKind_Embedding verifies embedding detection from capabilities.
+func TestDetectKind_Embedding(t *testing.T) {
+	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"details":      map[string]any{"family": "nomic-bert"},
+			"capabilities": []string{"embedding"},
+		})
+	}))
+	defer srv.Close()
+
+	det, err := prober.DetectKind(context.Background(), "nomic-embed-text")
+	if err != nil {
+		t.Fatalf("DetectKind() error: %v", err)
+	}
+	if det.Kind != ModelKindEmbedding {
+		t.Errorf("Kind = %q, want %q", det.Kind, ModelKindEmbedding)
+	}
+	if det.Source != "capabilities" {
+		t.Errorf("Source = %q, want %q", det.Source, "capabilities")
+	}
+}
+
+// TestDetectKind_Heuristic verifies Tier 2: family/template fallback.
+func TestDetectKind_Heuristic(t *testing.T) {
+	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// No capabilities, but has template (chat model).
+		json.NewEncoder(w).Encode(map[string]any{
+			"details":  map[string]any{"family": "llama"},
+			"template": "{{ .System }}\n{{ .Prompt }}",
+		})
+	}))
+	defer srv.Close()
+
+	det, err := prober.DetectKind(context.Background(), "llama3:8b")
+	if err != nil {
+		t.Fatalf("DetectKind() error: %v", err)
+	}
+	if det.Kind != ModelKindChat {
+		t.Errorf("Kind = %q, want %q", det.Kind, ModelKindChat)
+	}
+	if det.Source != "heuristic" {
+		t.Errorf("Source = %q, want %q", det.Source, "heuristic")
+	}
+}
+
+// TestDetectKind_HeuristicEmbedding verifies heuristic for known embedding families.
+func TestDetectKind_HeuristicEmbedding(t *testing.T) {
+	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Known embedding family, no capabilities.
+		json.NewEncoder(w).Encode(map[string]any{
+			"details": map[string]any{"family": "bert"},
+		})
+	}))
+	defer srv.Close()
+
+	det, err := prober.DetectKind(context.Background(), "bert-base")
+	if err != nil {
+		t.Fatalf("DetectKind() error: %v", err)
+	}
+	if det.Kind != ModelKindEmbedding {
+		t.Errorf("Kind = %q, want %q", det.Kind, ModelKindEmbedding)
+	}
+	if det.Source != "heuristic" {
+		t.Errorf("Source = %q, want %q", det.Source, "heuristic")
+	}
+}
+
+// TestDetectKind_Probe verifies Tier 3: live probe when heuristics fail.
+func TestDetectKind_Probe(t *testing.T) {
+	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/show":
+			// No capabilities, no template, unknown family
+			json.NewEncoder(w).Encode(map[string]any{
+				"details": map[string]any{"family": "custom"},
+			})
+		case "/api/chat":
+			// Chat succeeds — this model is a chat model
+			json.NewEncoder(w).Encode(map[string]any{
+				"model":   "custom-model",
+				"message": map[string]any{"role": "assistant", "content": "hi"},
+				"done":    true,
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	det, err := prober.DetectKind(context.Background(), "custom-model")
+	if err != nil {
+		t.Fatalf("DetectKind() error: %v", err)
+	}
+	if det.Kind != ModelKindChat {
+		t.Errorf("Kind = %q, want %q", det.Kind, ModelKindChat)
+	}
+	if det.Source != "probe" {
+		t.Errorf("Source = %q, want %q", det.Source, "probe")
+	}
+}
+
+// TestDetectKind_ProbeEmbedding verifies probe falls through to embedding.
+func TestDetectKind_ProbeEmbedding(t *testing.T) {
+	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/show":
+			json.NewEncoder(w).Encode(map[string]any{
+				"details": map[string]any{"family": "custom"},
+			})
+		case "/api/chat":
+			// Chat fails
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"error":"not a chat model"}`))
+		case "/api/embed":
+			// Embedding succeeds
+			json.NewEncoder(w).Encode(map[string]any{
+				"embeddings": [][]float64{{0.1, 0.2, 0.3}},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	det, err := prober.DetectKind(context.Background(), "custom-embed")
+	if err != nil {
+		t.Fatalf("DetectKind() error: %v", err)
+	}
+	if det.Kind != ModelKindEmbedding {
+		t.Errorf("Kind = %q, want %q", det.Kind, ModelKindEmbedding)
+	}
+	if det.Source != "probe" {
+		t.Errorf("Source = %q, want %q", det.Source, "probe")
+	}
+}
+
+// TestDetectKind_ProbeUnknown verifies probe returns unknown when both fail.
+func TestDetectKind_ProbeUnknown(t *testing.T) {
+	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/show":
+			json.NewEncoder(w).Encode(map[string]any{
+				"details": map[string]any{"family": "custom"},
+			})
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"error":"not supported"}`))
+		}
+	}))
+	defer srv.Close()
+
+	det, err := prober.DetectKind(context.Background(), "mystery-model")
+	if err != nil {
+		t.Fatalf("DetectKind() error: %v", err)
+	}
+	if det.Kind != ModelKindUnknown {
+		t.Errorf("Kind = %q, want %q", det.Kind, ModelKindUnknown)
+	}
+	if det.Source != "probe" {
+		t.Errorf("Source = %q, want %q", det.Source, "probe")
+	}
+}
+
+// TestDetectKind_ShowError verifies error propagation from ShowModel.
+func TestDetectKind_ShowError(t *testing.T) {
+	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"error":"model not found"}`))
+	}))
+	defer srv.Close()
+
+	_, err := prober.DetectKind(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error from ShowModel failure")
+	}
+}
+
+// TestProbeChat verifies chat metric extraction.
+func TestProbeChat(t *testing.T) {
+	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"model":                "test-model",
+			"message":             map[string]any{"role": "assistant", "content": "Hello!"},
+			"done":                true,
+			"eval_count":          10,
+			"eval_duration":       500_000_000, // 500ms → 20 tok/s
+			"prompt_eval_duration": 200_000_000, // 200ms
+			"load_duration":       50_000_000,  // 50ms (warm — below threshold)
+			"total_duration":      800_000_000,
+		})
+	}))
+	defer srv.Close()
+
+	metrics, err := prober.ProbeChat(context.Background(), "test-model", nil)
+	if err != nil {
+		t.Fatalf("ProbeChat() error: %v", err)
+	}
+
+	// 10 tokens / 0.5s = 20 tok/s
+	if metrics.TokensPerSecond < 19.9 || metrics.TokensPerSecond > 20.1 {
+		t.Errorf("TokensPerSecond = %f, want ~20.0", metrics.TokensPerSecond)
+	}
+	if metrics.PromptLatency != 200_000_000 {
+		t.Errorf("PromptLatency = %v, want 200ms", metrics.PromptLatency)
+	}
+	if metrics.ColdStartLatency != 0 {
+		t.Errorf("ColdStartLatency = %v, want 0 (warm model)", metrics.ColdStartLatency)
+	}
+}
+
+// TestProbeChat_ColdStart verifies cold start detection.
+func TestProbeChat_ColdStart(t *testing.T) {
+	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"model":          "test-model",
+			"message":        map[string]any{"role": "assistant", "content": "Hi"},
+			"done":           true,
+			"eval_count":     5,
+			"eval_duration":  250_000_000,
+			"load_duration":  3_000_000_000, // 3 seconds — cold load
+			"total_duration": 3_500_000_000,
+		})
+	}))
+	defer srv.Close()
+
+	metrics, err := prober.ProbeChat(context.Background(), "test-model", nil)
+	if err != nil {
+		t.Fatalf("ProbeChat() error: %v", err)
+	}
+	if metrics.ColdStartLatency == 0 {
+		t.Error("ColdStartLatency = 0, want non-zero for cold model load")
+	}
+}
+
+// TestProbeChat_Error verifies error propagation.
+func TestProbeChat_Error(t *testing.T) {
+	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":"model unavailable"}`))
+	}))
+	defer srv.Close()
+
+	_, err := prober.ProbeChat(context.Background(), "bad-model", nil)
+	if err == nil {
+		t.Fatal("expected error from chat failure")
+	}
+}
+
+// TestProbeEmbedding verifies embedding metric extraction.
+func TestProbeEmbedding(t *testing.T) {
+	vec := make([]float64, 768)
+	for i := range vec {
+		vec[i] = float64(i) * 0.001
+	}
+
+	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"embeddings": [][]float64{vec},
+		})
+	}))
+	defer srv.Close()
+
+	metrics, err := prober.ProbeEmbedding(context.Background(), "nomic-embed-text")
+	if err != nil {
+		t.Fatalf("ProbeEmbedding() error: %v", err)
+	}
+	if metrics.Dim != 768 {
+		t.Errorf("Dim = %d, want 768", metrics.Dim)
+	}
+	if metrics.Latency <= 0 {
+		t.Errorf("Latency = %v, want > 0", metrics.Latency)
+	}
+}
+
+// TestProbeEmbedding_Error verifies error propagation.
+func TestProbeEmbedding_Error(t *testing.T) {
+	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":"not an embedding model"}`))
+	}))
+	defer srv.Close()
+
+	_, err := prober.ProbeEmbedding(context.Background(), "chat-only-model")
+	if err == nil {
+		t.Fatal("expected error from embedding failure")
+	}
+}

--- a/fingerprint/profiler.go
+++ b/fingerprint/profiler.go
@@ -101,7 +101,12 @@ func (p *Profiler) ensureProfileInner(ctx context.Context, backendID, modelName,
 			// In backoff but have partial profile — return partial.
 			return existing, nil
 		}
-		base = existing
+		// Only use as a merge base if the profile version is current.
+		// A stale-version partial needs a full re-probe, not a
+		// selective retry that would stamp old metrics as current.
+		if existing.ProfileVersion >= CurrentProfileVersion {
+			base = existing
+		}
 	}
 
 	// Detect model kind.
@@ -205,8 +210,11 @@ func (p *Profiler) ensureProfileInner(ctx context.Context, backendID, modelName,
 // selectProbes determines which probes to run based on detection and any
 // existing base profile.
 func (p *Profiler) selectProbes(det *KindDetection, base *Profile) (chat, embed bool) {
-	if base != nil && len(base.IncompleteCapabilities) > 0 {
-		// Only retry incomplete capabilities.
+	if base != nil && len(base.IncompleteCapabilities) > 0 &&
+		base.ProfileVersion >= CurrentProfileVersion {
+		// Only retry incomplete capabilities when the profile version is
+		// current. If the version is stale, re-run all probes so that the
+		// new version's metrics are collected for every capability.
 		for _, cap := range base.IncompleteCapabilities {
 			switch cap {
 			case "completion":

--- a/fingerprint/profiler.go
+++ b/fingerprint/profiler.go
@@ -1,0 +1,315 @@
+package fingerprint
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// ModelProber abstracts model kind detection and performance probing.
+type ModelProber interface {
+	DetectKind(ctx context.Context, model string) (*KindDetection, error)
+	ProbeChat(ctx context.Context, model string, opts interface{}) (*ChatMetrics, error)
+	ProbeEmbedding(ctx context.Context, model string) (*EmbeddingMetrics, error)
+}
+
+// Profiler orchestrates model fingerprinting: detection, probing, caching,
+// failure tracking, and version upgrades. Concurrent requests for the same
+// model+digest are deduplicated via singleflight.
+type Profiler struct {
+	store  Store
+	prober ModelProber
+	sfg    singleflight.Group
+}
+
+// NewProfiler creates a Profiler backed by the given store and prober.
+func NewProfiler(store Store, prober ModelProber) *Profiler {
+	return &Profiler{
+		store:  store,
+		prober: prober,
+	}
+}
+
+// EnsureProfile returns a fingerprint profile for the given model,
+// using a cached profile if valid or running probes if needed.
+//
+// The modelDigest should come from /api/show and is used to detect
+// when a model has been updated and needs re-profiling.
+//
+// Returns a partial profile (with IncompleteCapabilities set) if some
+// probes succeed and others fail. Returns an error only if all probes
+// fail or detection fails entirely.
+func (p *Profiler) EnsureProfile(ctx context.Context, backendID, modelName, modelDigest string) (*Profile, error) {
+	key := backendID + "\x00" + modelName + "\x00" + modelDigest
+
+	v, err, _ := p.sfg.Do(key, func() (interface{}, error) {
+		return p.ensureProfileInner(ctx, backendID, modelName, modelDigest)
+	})
+	if err != nil {
+		return nil, err
+	}
+	profile := v.(*Profile)
+	return profile, nil
+}
+
+func (p *Profiler) ensureProfileInner(ctx context.Context, backendID, modelName, modelDigest string) (*Profile, error) {
+	needs, err := p.store.NeedsFingerprint(ctx, backendID, modelName, modelDigest)
+	if err != nil {
+		return nil, fmt.Errorf("fingerprint: check needs: %w", err)
+	}
+
+	if !needs {
+		// Try to return cached profile.
+		profile, err := p.store.Get(ctx, backendID, modelName)
+		if err == nil {
+			// Verify digest matches — don't return stale profiles.
+			if profile.ModelDigest == modelDigest {
+				return profile, nil
+			}
+			// Stale digest — check if in backoff for the current digest.
+			return nil, p.checkBackoff(ctx, backendID, modelName)
+		}
+		if !errors.Is(err, ErrNotFound) {
+			return nil, fmt.Errorf("fingerprint: get cached: %w", err)
+		}
+		// Not found — check failure backoff.
+		failure, fErr := p.store.GetFailure(ctx, backendID, modelName)
+		if fErr == nil && failure != nil {
+			if time.Now().Before(failure.RetryAfter) {
+				return nil, &BackoffError{
+					RetryAfter: failure.RetryAfter,
+					LastError:  failure.LastError,
+				}
+			}
+		} else if fErr != nil && !errors.Is(fErr, ErrNotFound) {
+			return nil, fmt.Errorf("fingerprint: get failure: %w", fErr)
+		}
+		// Fall through to profiling (race condition path: NeedsFingerprint
+		// returned false but Get returned not-found).
+	}
+
+	// Check for existing partial profile we can build on.
+	var base *Profile
+	existing, err := p.store.Get(ctx, backendID, modelName)
+	if err == nil && existing.ModelDigest == modelDigest && len(existing.IncompleteCapabilities) > 0 {
+		// Check backoff for partial retry.
+		failure, fErr := p.store.GetFailure(ctx, backendID, modelName)
+		if fErr == nil && failure != nil && time.Now().Before(failure.RetryAfter) {
+			// In backoff but have partial profile — return partial.
+			return existing, nil
+		}
+		base = existing
+	}
+
+	// Detect model kind.
+	detection, err := p.prober.DetectKind(ctx, modelName)
+	if err != nil {
+		_ = p.store.SaveFailure(ctx, backendID, modelName, modelDigest, err.Error())
+		return nil, fmt.Errorf("fingerprint: detect kind: %w", err)
+	}
+
+	// Determine which probes to run.
+	probeChat, probeEmbed := p.selectProbes(detection, base)
+
+	profile := p.buildBaseProfile(backendID, modelName, modelDigest, detection)
+	if base != nil {
+		// Carry forward successful metrics from base.
+		p.mergeBase(profile, base)
+	}
+
+	var chatErr, embedErr error
+
+	// Run probes in fixed order: chat first, then embedding.
+	if probeChat {
+		metrics, err := p.prober.ProbeChat(ctx, modelName, nil)
+		if err != nil {
+			chatErr = err
+		} else {
+			profile.GenerationTokensPerSecond = metrics.TokensPerSecond
+			profile.PromptLatency = metrics.PromptLatency
+			if metrics.ColdStartLatency > 0 {
+				profile.ColdStartLatency = metrics.ColdStartLatency
+			}
+		}
+	}
+
+	if probeEmbed {
+		metrics, err := p.prober.ProbeEmbedding(ctx, modelName)
+		if err != nil {
+			embedErr = err
+		} else {
+			profile.EmbeddingDim = metrics.Dim
+			profile.EmbeddingLatency = metrics.Latency
+			if metrics.ColdStartLatency > 0 && profile.ColdStartLatency == 0 {
+				profile.ColdStartLatency = metrics.ColdStartLatency
+			}
+		}
+	}
+
+	// Handle results.
+	bothFailed := (probeChat && chatErr != nil) && (probeEmbed && embedErr != nil)
+	onlyChat := probeChat && !probeEmbed
+	onlyEmbed := probeEmbed && !probeChat
+	singleFailed := (onlyChat && chatErr != nil) || (onlyEmbed && embedErr != nil)
+
+	if bothFailed || singleFailed {
+		errMsg := p.firstError(chatErr, embedErr)
+		_ = p.store.SaveFailure(ctx, backendID, modelName, modelDigest, errMsg)
+		return nil, fmt.Errorf("fingerprint: probe %q: %s", modelName, errMsg)
+	}
+
+	// Determine incomplete capabilities.
+	var incomplete []string
+	if probeChat && chatErr != nil {
+		incomplete = append(incomplete, "completion")
+	}
+	if probeEmbed && embedErr != nil {
+		incomplete = append(incomplete, "embedding")
+	}
+	profile.IncompleteCapabilities = incomplete
+
+	// Set sentinel values for untested fields.
+	if !probeChat || chatErr != nil {
+		if profile.GenerationTokensPerSecond == 0 {
+			profile.GenerationTokensPerSecond = -1
+		}
+		if profile.ToolCallingRate == 0 {
+			profile.ToolCallingRate = -1
+		}
+		if profile.InstructionScore == 0 {
+			profile.InstructionScore = -1
+		}
+	}
+	if !probeEmbed || embedErr != nil {
+		if profile.EmbeddingCoherence == 0 {
+			profile.EmbeddingCoherence = -1
+		}
+	}
+
+	if err := p.store.Save(ctx, *profile); err != nil {
+		return nil, fmt.Errorf("fingerprint: save profile: %w", err)
+	}
+
+	// If partial, also record failure for the incomplete part.
+	if len(incomplete) > 0 {
+		errMsg := p.firstError(chatErr, embedErr)
+		_ = p.store.SaveFailure(ctx, backendID, modelName, modelDigest, errMsg)
+	}
+
+	return profile, nil
+}
+
+// selectProbes determines which probes to run based on detection and any
+// existing base profile.
+func (p *Profiler) selectProbes(det *KindDetection, base *Profile) (chat, embed bool) {
+	if base != nil && len(base.IncompleteCapabilities) > 0 {
+		// Only retry incomplete capabilities.
+		for _, cap := range base.IncompleteCapabilities {
+			switch cap {
+			case "completion":
+				chat = true
+			case "embedding":
+				embed = true
+			}
+		}
+		return chat, embed
+	}
+
+	// Dual-capability only when capabilities were explicitly detected.
+	if det.Source == "capabilities" {
+		hasCap := make(map[string]bool)
+		for _, c := range det.Capabilities {
+			hasCap[c] = true
+		}
+		chat = hasCap["completion"] || hasCap["tools"]
+		embed = hasCap["embedding"]
+		return chat, embed
+	}
+
+	// Heuristic or probe: single-capability only.
+	switch det.Kind {
+	case ModelKindChat:
+		return true, false
+	case ModelKindEmbedding:
+		return false, true
+	default:
+		return true, false // default to chat probe for unknown
+	}
+}
+
+// buildBaseProfile creates a new profile with identity and detection info.
+func (p *Profiler) buildBaseProfile(backendID, modelName, modelDigest string, det *KindDetection) *Profile {
+	return &Profile{
+		BackendID:                 backendID,
+		ModelName:                 modelName,
+		ModelDigest:               modelDigest,
+		ModelKind:                 det.Kind,
+		Capabilities:              det.Capabilities,
+		KindSource:                det.Source,
+		ProfileVersion:            CurrentProfileVersion,
+		TestedAt:                  time.Now(),
+		GenerationTokensPerSecond: -1,
+		ToolCallingRate:           -1,
+		InstructionScore:          -1,
+		EmbeddingCoherence:        -1,
+	}
+}
+
+// mergeBase carries forward successful metrics from a partial base profile.
+func (p *Profiler) mergeBase(dst, src *Profile) {
+	if src.GenerationTokensPerSecond > 0 {
+		dst.GenerationTokensPerSecond = src.GenerationTokensPerSecond
+	}
+	if src.PromptLatency > 0 {
+		dst.PromptLatency = src.PromptLatency
+	}
+	if src.ColdStartLatency > 0 {
+		dst.ColdStartLatency = src.ColdStartLatency
+	}
+	if src.EmbeddingDim > 0 {
+		dst.EmbeddingDim = src.EmbeddingDim
+	}
+	if src.EmbeddingLatency > 0 {
+		dst.EmbeddingLatency = src.EmbeddingLatency
+	}
+	if src.EmbeddingCoherence > 0 {
+		dst.EmbeddingCoherence = src.EmbeddingCoherence
+	}
+	if src.ToolCallingRate >= 0 {
+		dst.ToolCallingRate = src.ToolCallingRate
+	}
+	if src.InstructionScore >= 0 {
+		dst.InstructionScore = src.InstructionScore
+	}
+}
+
+// checkBackoff returns a BackoffError if the model is in an active backoff window.
+func (p *Profiler) checkBackoff(ctx context.Context, backendID, modelName string) error {
+	failure, err := p.store.GetFailure(ctx, backendID, modelName)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return fmt.Errorf("fingerprint: stale profile with no failure record")
+		}
+		return fmt.Errorf("fingerprint: get failure: %w", err)
+	}
+	if time.Now().Before(failure.RetryAfter) {
+		return &BackoffError{
+			RetryAfter: failure.RetryAfter,
+			LastError:  failure.LastError,
+		}
+	}
+	return fmt.Errorf("fingerprint: stale profile, backoff expired")
+}
+
+// firstError returns the error message from the first non-nil error.
+func (p *Profiler) firstError(errs ...error) string {
+	for _, e := range errs {
+		if e != nil {
+			return e.Error()
+		}
+	}
+	return "unknown error"
+}

--- a/fingerprint/profiler_test.go
+++ b/fingerprint/profiler_test.go
@@ -292,6 +292,55 @@ func TestProfiler_EnsureProfile_VersionUpgrade(t *testing.T) {
 	}
 }
 
+func TestProfiler_EnsureProfile_VersionUpgrade_PartialRerunsAllProbes(t *testing.T) {
+	// Regression test for P2: a stale-version partial profile must re-run
+	// ALL probes, not just incomplete capabilities. Otherwise the merged
+	// result gets stamped as CurrentProfileVersion without collecting the
+	// new version's metrics for the already-complete capability.
+	store := newMockStore()
+	k := store.key(testBackend, "dual-model")
+	store.profiles[k] = &Profile{
+		BackendID:                 testBackend,
+		ModelName:                 "dual-model",
+		ModelDigest:               testDigest,
+		ModelKind:                 ModelKindChat,
+		ProfileVersion:            0, // Old version
+		IncompleteCapabilities:    []string{"embedding"},
+		GenerationTokensPerSecond: 10.0, // Old chat metrics
+	}
+	store.needsResult[k] = true // Version upgrade triggers
+
+	prober := &mockProber{
+		detectKindFn: func(_ context.Context, _ string) (*KindDetection, error) {
+			return &KindDetection{
+				Kind:         ModelKindChat,
+				Source:       "capabilities",
+				Capabilities: []string{"completion", "embedding"},
+			}, nil
+		},
+	}
+	profiler := NewProfiler(store, prober)
+
+	profile, err := profiler.EnsureProfile(context.Background(), testBackend, "dual-model", testDigest)
+	if err != nil {
+		t.Fatalf("EnsureProfile() error: %v", err)
+	}
+	// Both probes must run for version upgrade.
+	if prober.probeChatCalls.Load() != 1 {
+		t.Errorf("ProbeChat called %d times, want 1 (version upgrade re-runs all)", prober.probeChatCalls.Load())
+	}
+	if prober.probeEmbedCalls.Load() != 1 {
+		t.Errorf("ProbeEmbedding called %d times, want 1 (version upgrade re-runs all)", prober.probeEmbedCalls.Load())
+	}
+	// Chat metrics should be fresh (20.0 from mock), not carried forward (10.0).
+	if profile.GenerationTokensPerSecond != 20.0 {
+		t.Errorf("GenerationTokensPerSecond = %f, want 20.0 (fresh probe, not carried forward)", profile.GenerationTokensPerSecond)
+	}
+	if profile.ProfileVersion != CurrentProfileVersion {
+		t.Errorf("ProfileVersion = %d, want %d", profile.ProfileVersion, CurrentProfileVersion)
+	}
+}
+
 func TestProfiler_EnsureProfile_RaceCondition(t *testing.T) {
 	// NeedsFingerprint returns false, Get returns ErrNotFound,
 	// GetFailure returns ErrNotFound → falls through to profiling.
@@ -490,6 +539,7 @@ func TestProfiler_EnsureProfile_IncompleteProfile_RetryAfterBackoff(t *testing.T
 		ModelName:                 "partial-model",
 		ModelDigest:               testDigest,
 		ModelKind:                 ModelKindChat,
+		ProfileVersion:            CurrentProfileVersion, // Current version — only incomplete retried
 		IncompleteCapabilities:    []string{"embedding"},
 		GenerationTokensPerSecond: 20.0,
 		PromptLatency:             200 * time.Millisecond,

--- a/fingerprint/profiler_test.go
+++ b/fingerprint/profiler_test.go
@@ -1,0 +1,673 @@
+package fingerprint
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// --- Mock Store ---
+
+type mockStore struct {
+	mu           sync.Mutex
+	profiles     map[string]*Profile
+	failures     map[string]*FailureInfo
+	needsResult  map[string]bool
+	saveCalled   int
+	saveFailed   int
+	saveErr      error
+}
+
+func newMockStore() *mockStore {
+	return &mockStore{
+		profiles:    make(map[string]*Profile),
+		failures:    make(map[string]*FailureInfo),
+		needsResult: make(map[string]bool),
+	}
+}
+
+func (s *mockStore) key(backendID, modelName string) string {
+	return backendID + "\x00" + modelName
+}
+
+func (s *mockStore) Get(_ context.Context, backendID, modelName string) (*Profile, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, ok := s.profiles[s.key(backendID, modelName)]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return p, nil
+}
+
+func (s *mockStore) GetFailure(_ context.Context, backendID, modelName string) (*FailureInfo, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	f, ok := s.failures[s.key(backendID, modelName)]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return f, nil
+}
+
+func (s *mockStore) Save(_ context.Context, profile Profile) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.saveCalled++
+	if s.saveErr != nil {
+		return s.saveErr
+	}
+	p := profile // copy
+	s.profiles[s.key(profile.BackendID, profile.ModelName)] = &p
+	return nil
+}
+
+func (s *mockStore) NeedsFingerprint(_ context.Context, backendID, modelName, _ string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	k := s.key(backendID, modelName)
+	needs, ok := s.needsResult[k]
+	if ok {
+		return needs, nil
+	}
+	// Default: needs fingerprint if no profile exists.
+	_, exists := s.profiles[k]
+	return !exists, nil
+}
+
+func (s *mockStore) SaveFailure(_ context.Context, backendID, modelName, modelDigest, errMsg string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.saveFailed++
+	k := s.key(backendID, modelName)
+	existing, ok := s.failures[k]
+	count := 1
+	if ok {
+		count = existing.AttemptCount + 1
+	}
+	s.failures[k] = &FailureInfo{
+		ModelDigest:  modelDigest,
+		LastError:    errMsg,
+		AttemptedAt:  time.Now(),
+		AttemptCount: count,
+		RetryAfter:   time.Now().Add(time.Hour),
+	}
+	return nil
+}
+
+// --- Mock Prober ---
+
+type mockProber struct {
+	detectKindFn    func(ctx context.Context, model string) (*KindDetection, error)
+	probeChatFn     func(ctx context.Context, model string, opts interface{}) (*ChatMetrics, error)
+	probeEmbedFn    func(ctx context.Context, model string) (*EmbeddingMetrics, error)
+	detectCalls     atomic.Int32
+	probeChatCalls  atomic.Int32
+	probeEmbedCalls atomic.Int32
+}
+
+func (m *mockProber) DetectKind(ctx context.Context, model string) (*KindDetection, error) {
+	m.detectCalls.Add(1)
+	if m.detectKindFn != nil {
+		return m.detectKindFn(ctx, model)
+	}
+	return &KindDetection{Kind: ModelKindChat, Source: "capabilities", Capabilities: []string{"completion"}}, nil
+}
+
+func (m *mockProber) ProbeChat(ctx context.Context, model string, opts interface{}) (*ChatMetrics, error) {
+	m.probeChatCalls.Add(1)
+	if m.probeChatFn != nil {
+		return m.probeChatFn(ctx, model, opts)
+	}
+	return &ChatMetrics{TokensPerSecond: 20.0, PromptLatency: 200 * time.Millisecond}, nil
+}
+
+func (m *mockProber) ProbeEmbedding(ctx context.Context, model string) (*EmbeddingMetrics, error) {
+	m.probeEmbedCalls.Add(1)
+	if m.probeEmbedFn != nil {
+		return m.probeEmbedFn(ctx, model)
+	}
+	return &EmbeddingMetrics{Dim: 768, Latency: 50 * time.Millisecond}, nil
+}
+
+// --- Tests ---
+
+const (
+	testBackend = "http://localhost:11434"
+	testModel   = "qwen2.5:72b"
+	testDigest  = "sha256:abc123"
+)
+
+func TestProfiler_EnsureProfile_Cached(t *testing.T) {
+	store := newMockStore()
+	store.profiles[store.key(testBackend, testModel)] = &Profile{
+		BackendID:   testBackend,
+		ModelName:   testModel,
+		ModelDigest: testDigest,
+		ModelKind:   ModelKindChat,
+	}
+	store.needsResult[store.key(testBackend, testModel)] = false
+
+	prober := &mockProber{}
+	profiler := NewProfiler(store, prober)
+
+	profile, err := profiler.EnsureProfile(context.Background(), testBackend, testModel, testDigest)
+	if err != nil {
+		t.Fatalf("EnsureProfile() error: %v", err)
+	}
+	if profile.ModelName != testModel {
+		t.Errorf("ModelName = %q, want %q", profile.ModelName, testModel)
+	}
+	if prober.detectCalls.Load() != 0 {
+		t.Errorf("DetectKind called %d times, want 0 (cached)", prober.detectCalls.Load())
+	}
+}
+
+func TestProfiler_EnsureProfile_Fresh_Chat(t *testing.T) {
+	store := newMockStore()
+	prober := &mockProber{
+		detectKindFn: func(_ context.Context, _ string) (*KindDetection, error) {
+			return &KindDetection{
+				Kind:         ModelKindChat,
+				Source:       "capabilities",
+				Capabilities: []string{"completion"},
+			}, nil
+		},
+	}
+	profiler := NewProfiler(store, prober)
+
+	profile, err := profiler.EnsureProfile(context.Background(), testBackend, testModel, testDigest)
+	if err != nil {
+		t.Fatalf("EnsureProfile() error: %v", err)
+	}
+	if profile.ModelKind != ModelKindChat {
+		t.Errorf("ModelKind = %q, want %q", profile.ModelKind, ModelKindChat)
+	}
+	if profile.GenerationTokensPerSecond <= 0 {
+		t.Errorf("GenerationTokensPerSecond = %f, want > 0", profile.GenerationTokensPerSecond)
+	}
+	if store.saveCalled != 1 {
+		t.Errorf("Save called %d times, want 1", store.saveCalled)
+	}
+}
+
+func TestProfiler_EnsureProfile_Fresh_Embedding(t *testing.T) {
+	store := newMockStore()
+	prober := &mockProber{
+		detectKindFn: func(_ context.Context, _ string) (*KindDetection, error) {
+			return &KindDetection{
+				Kind:         ModelKindEmbedding,
+				Source:       "capabilities",
+				Capabilities: []string{"embedding"},
+			}, nil
+		},
+	}
+	profiler := NewProfiler(store, prober)
+
+	profile, err := profiler.EnsureProfile(context.Background(), testBackend, "nomic-embed", testDigest)
+	if err != nil {
+		t.Fatalf("EnsureProfile() error: %v", err)
+	}
+	if profile.ModelKind != ModelKindEmbedding {
+		t.Errorf("ModelKind = %q, want %q", profile.ModelKind, ModelKindEmbedding)
+	}
+	if profile.EmbeddingDim != 768 {
+		t.Errorf("EmbeddingDim = %d, want 768", profile.EmbeddingDim)
+	}
+}
+
+func TestProfiler_EnsureProfile_ProbeFails_SavesFailure(t *testing.T) {
+	store := newMockStore()
+	prober := &mockProber{
+		detectKindFn: func(_ context.Context, _ string) (*KindDetection, error) {
+			return &KindDetection{Kind: ModelKindChat, Source: "capabilities", Capabilities: []string{"completion"}}, nil
+		},
+		probeChatFn: func(_ context.Context, _ string, _ interface{}) (*ChatMetrics, error) {
+			return nil, errors.New("connection refused")
+		},
+	}
+	profiler := NewProfiler(store, prober)
+
+	_, err := profiler.EnsureProfile(context.Background(), testBackend, testModel, testDigest)
+	if err == nil {
+		t.Fatal("expected error from failed probe")
+	}
+	if store.saveFailed != 1 {
+		t.Errorf("SaveFailure called %d times, want 1", store.saveFailed)
+	}
+}
+
+func TestProfiler_EnsureProfile_InBackoff(t *testing.T) {
+	store := newMockStore()
+	store.needsResult[store.key(testBackend, testModel)] = false
+	store.failures[store.key(testBackend, testModel)] = &FailureInfo{
+		ModelDigest:  testDigest,
+		LastError:    "connection refused",
+		RetryAfter:   time.Now().Add(time.Hour),
+		AttemptCount: 1,
+	}
+
+	prober := &mockProber{}
+	profiler := NewProfiler(store, prober)
+
+	_, err := profiler.EnsureProfile(context.Background(), testBackend, testModel, testDigest)
+	if err == nil {
+		t.Fatal("expected BackoffError")
+	}
+	var backoffErr *BackoffError
+	if !errors.As(err, &backoffErr) {
+		t.Fatalf("expected *BackoffError, got %T: %v", err, err)
+	}
+}
+
+func TestProfiler_EnsureProfile_VersionUpgrade(t *testing.T) {
+	store := newMockStore()
+	// Old profile with version 0.
+	store.profiles[store.key(testBackend, testModel)] = &Profile{
+		BackendID:      testBackend,
+		ModelName:      testModel,
+		ModelDigest:    testDigest,
+		ModelKind:      ModelKindChat,
+		ProfileVersion: 0,
+	}
+	// NeedsFingerprint returns true because version mismatch.
+	store.needsResult[store.key(testBackend, testModel)] = true
+
+	prober := &mockProber{
+		detectKindFn: func(_ context.Context, _ string) (*KindDetection, error) {
+			return &KindDetection{Kind: ModelKindChat, Source: "capabilities", Capabilities: []string{"completion"}}, nil
+		},
+	}
+	profiler := NewProfiler(store, prober)
+
+	profile, err := profiler.EnsureProfile(context.Background(), testBackend, testModel, testDigest)
+	if err != nil {
+		t.Fatalf("EnsureProfile() error: %v", err)
+	}
+	if profile.ProfileVersion != CurrentProfileVersion {
+		t.Errorf("ProfileVersion = %d, want %d", profile.ProfileVersion, CurrentProfileVersion)
+	}
+}
+
+func TestProfiler_EnsureProfile_RaceCondition(t *testing.T) {
+	// NeedsFingerprint returns false, Get returns ErrNotFound,
+	// GetFailure returns ErrNotFound → falls through to profiling.
+	store := newMockStore()
+	store.needsResult[store.key(testBackend, testModel)] = false
+	// No profile, no failure — race condition path.
+
+	prober := &mockProber{
+		detectKindFn: func(_ context.Context, _ string) (*KindDetection, error) {
+			return &KindDetection{Kind: ModelKindChat, Source: "capabilities", Capabilities: []string{"completion"}}, nil
+		},
+	}
+	profiler := NewProfiler(store, prober)
+
+	profile, err := profiler.EnsureProfile(context.Background(), testBackend, testModel, testDigest)
+	if err != nil {
+		t.Fatalf("EnsureProfile() error: %v", err)
+	}
+	if profile.ModelKind != ModelKindChat {
+		t.Errorf("ModelKind = %q, want %q", profile.ModelKind, ModelKindChat)
+	}
+}
+
+func TestProfiler_EnsureProfile_DetectKindFails(t *testing.T) {
+	store := newMockStore()
+	prober := &mockProber{
+		detectKindFn: func(_ context.Context, _ string) (*KindDetection, error) {
+			return nil, errors.New("model not found")
+		},
+	}
+	profiler := NewProfiler(store, prober)
+
+	_, err := profiler.EnsureProfile(context.Background(), testBackend, testModel, testDigest)
+	if err == nil {
+		t.Fatal("expected error from DetectKind failure")
+	}
+	if store.saveFailed != 1 {
+		t.Errorf("SaveFailure called %d times, want 1", store.saveFailed)
+	}
+}
+
+func TestProfiler_EnsureProfile_BackoffError_ExtractableWithErrorsAs(t *testing.T) {
+	store := newMockStore()
+	store.needsResult[store.key(testBackend, testModel)] = false
+	store.failures[store.key(testBackend, testModel)] = &FailureInfo{
+		ModelDigest: testDigest,
+		LastError:   "timeout",
+		RetryAfter:  time.Now().Add(time.Hour),
+	}
+
+	profiler := NewProfiler(store, &mockProber{})
+
+	_, err := profiler.EnsureProfile(context.Background(), testBackend, testModel, testDigest)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var backoffErr *BackoffError
+	if !errors.As(err, &backoffErr) {
+		t.Fatalf("errors.As failed: got %T: %v", err, err)
+	}
+	if backoffErr.LastError != "timeout" {
+		t.Errorf("LastError = %q, want %q", backoffErr.LastError, "timeout")
+	}
+}
+
+func TestProfiler_EnsureProfile_DualCapability(t *testing.T) {
+	store := newMockStore()
+	prober := &mockProber{
+		detectKindFn: func(_ context.Context, _ string) (*KindDetection, error) {
+			return &KindDetection{
+				Kind:         ModelKindChat,
+				Source:       "capabilities",
+				Capabilities: []string{"completion", "embedding"},
+			}, nil
+		},
+	}
+	profiler := NewProfiler(store, prober)
+
+	profile, err := profiler.EnsureProfile(context.Background(), testBackend, "dual-model", testDigest)
+	if err != nil {
+		t.Fatalf("EnsureProfile() error: %v", err)
+	}
+	if prober.probeChatCalls.Load() != 1 {
+		t.Errorf("ProbeChat called %d times, want 1", prober.probeChatCalls.Load())
+	}
+	if prober.probeEmbedCalls.Load() != 1 {
+		t.Errorf("ProbeEmbedding called %d times, want 1", prober.probeEmbedCalls.Load())
+	}
+	if profile.GenerationTokensPerSecond <= 0 {
+		t.Error("expected chat metrics populated")
+	}
+	if profile.EmbeddingDim != 768 {
+		t.Errorf("EmbeddingDim = %d, want 768", profile.EmbeddingDim)
+	}
+}
+
+func TestProfiler_EnsureProfile_HeuristicSingleCapability(t *testing.T) {
+	store := newMockStore()
+	prober := &mockProber{
+		detectKindFn: func(_ context.Context, _ string) (*KindDetection, error) {
+			return &KindDetection{
+				Kind:   ModelKindChat,
+				Source: "heuristic",
+			}, nil
+		},
+	}
+	profiler := NewProfiler(store, prober)
+
+	_, err := profiler.EnsureProfile(context.Background(), testBackend, testModel, testDigest)
+	if err != nil {
+		t.Fatalf("EnsureProfile() error: %v", err)
+	}
+	if prober.probeChatCalls.Load() != 1 {
+		t.Errorf("ProbeChat called %d times, want 1", prober.probeChatCalls.Load())
+	}
+	if prober.probeEmbedCalls.Load() != 0 {
+		t.Errorf("ProbeEmbedding called %d times, want 0 (heuristic = single)", prober.probeEmbedCalls.Load())
+	}
+}
+
+func TestProfiler_EnsureProfile_PartialFailure(t *testing.T) {
+	store := newMockStore()
+	prober := &mockProber{
+		detectKindFn: func(_ context.Context, _ string) (*KindDetection, error) {
+			return &KindDetection{
+				Kind:         ModelKindChat,
+				Source:       "capabilities",
+				Capabilities: []string{"completion", "embedding"},
+			}, nil
+		},
+		probeEmbedFn: func(_ context.Context, _ string) (*EmbeddingMetrics, error) {
+			return nil, errors.New("embedding not supported")
+		},
+	}
+	profiler := NewProfiler(store, prober)
+
+	profile, err := profiler.EnsureProfile(context.Background(), testBackend, "partial-model", testDigest)
+	if err != nil {
+		t.Fatalf("EnsureProfile() error: %v (partial should return profile, not error)", err)
+	}
+	// Chat metrics should be populated.
+	if profile.GenerationTokensPerSecond <= 0 {
+		t.Error("expected chat metrics populated in partial profile")
+	}
+	// Embedding sentinel values.
+	if profile.EmbeddingCoherence != -1 {
+		t.Errorf("EmbeddingCoherence = %f, want -1 (sentinel)", profile.EmbeddingCoherence)
+	}
+	// IncompleteCapabilities should record the failed capability.
+	if len(profile.IncompleteCapabilities) != 1 || profile.IncompleteCapabilities[0] != "embedding" {
+		t.Errorf("IncompleteCapabilities = %v, want [embedding]", profile.IncompleteCapabilities)
+	}
+	// SaveFailure should have been called for backoff.
+	if store.saveFailed != 1 {
+		t.Errorf("SaveFailure called %d times, want 1", store.saveFailed)
+	}
+}
+
+func TestProfiler_EnsureProfile_IncompleteProfile_ActiveBackoff(t *testing.T) {
+	store := newMockStore()
+	k := store.key(testBackend, "partial-model")
+	store.profiles[k] = &Profile{
+		BackendID:              testBackend,
+		ModelName:              "partial-model",
+		ModelDigest:            testDigest,
+		ModelKind:              ModelKindChat,
+		IncompleteCapabilities: []string{"embedding"},
+		GenerationTokensPerSecond: 20.0,
+	}
+	store.failures[k] = &FailureInfo{
+		ModelDigest:  testDigest,
+		LastError:    "embedding failed",
+		RetryAfter:   time.Now().Add(time.Hour),
+		AttemptCount: 1,
+	}
+	store.needsResult[k] = true // Version upgrade or digest change triggers re-check
+
+	prober := &mockProber{}
+	profiler := NewProfiler(store, prober)
+
+	// Should return partial profile, NOT BackoffError.
+	profile, err := profiler.EnsureProfile(context.Background(), testBackend, "partial-model", testDigest)
+	if err != nil {
+		t.Fatalf("EnsureProfile() error: %v, want partial profile returned", err)
+	}
+	if profile.GenerationTokensPerSecond <= 0 {
+		t.Error("expected chat metrics preserved from partial profile")
+	}
+}
+
+func TestProfiler_EnsureProfile_IncompleteProfile_RetryAfterBackoff(t *testing.T) {
+	store := newMockStore()
+	k := store.key(testBackend, "partial-model")
+	store.profiles[k] = &Profile{
+		BackendID:              testBackend,
+		ModelName:              "partial-model",
+		ModelDigest:            testDigest,
+		ModelKind:              ModelKindChat,
+		IncompleteCapabilities: []string{"embedding"},
+		GenerationTokensPerSecond: 20.0,
+		PromptLatency:          200 * time.Millisecond,
+	}
+	store.failures[k] = &FailureInfo{
+		ModelDigest:  testDigest,
+		LastError:    "embedding failed",
+		RetryAfter:   time.Now().Add(-time.Minute), // Expired backoff
+		AttemptCount: 1,
+	}
+	store.needsResult[k] = true
+
+	prober := &mockProber{
+		detectKindFn: func(_ context.Context, _ string) (*KindDetection, error) {
+			return &KindDetection{
+				Kind:         ModelKindChat,
+				Source:       "capabilities",
+				Capabilities: []string{"completion", "embedding"},
+			}, nil
+		},
+	}
+	profiler := NewProfiler(store, prober)
+
+	profile, err := profiler.EnsureProfile(context.Background(), testBackend, "partial-model", testDigest)
+	if err != nil {
+		t.Fatalf("EnsureProfile() error: %v", err)
+	}
+	// Only embedding probe should have run (chat already has metrics).
+	if prober.probeChatCalls.Load() != 0 {
+		t.Errorf("ProbeChat called %d times, want 0 (already has chat metrics)", prober.probeChatCalls.Load())
+	}
+	if prober.probeEmbedCalls.Load() != 1 {
+		t.Errorf("ProbeEmbedding called %d times, want 1 (retry incomplete)", prober.probeEmbedCalls.Load())
+	}
+	// Verify existing chat metrics preserved.
+	if profile.GenerationTokensPerSecond != 20.0 {
+		t.Errorf("GenerationTokensPerSecond = %f, want 20.0 (preserved)", profile.GenerationTokensPerSecond)
+	}
+	// Verify embedding metrics now populated.
+	if profile.EmbeddingDim != 768 {
+		t.Errorf("EmbeddingDim = %d, want 768", profile.EmbeddingDim)
+	}
+}
+
+func TestProfiler_EnsureProfile_StaleProfileDuringBackoff(t *testing.T) {
+	store := newMockStore()
+	k := store.key(testBackend, testModel)
+	oldDigest := "sha256:old"
+	store.profiles[k] = &Profile{
+		BackendID:   testBackend,
+		ModelName:   testModel,
+		ModelDigest: oldDigest,
+		ModelKind:   ModelKindChat,
+	}
+	store.failures[k] = &FailureInfo{
+		ModelDigest:  testDigest, // New digest
+		LastError:    "timeout",
+		RetryAfter:   time.Now().Add(time.Hour),
+		AttemptCount: 1,
+	}
+	store.needsResult[k] = false
+
+	profiler := NewProfiler(store, &mockProber{})
+
+	// Profile has old digest, request is for new digest → stale.
+	// Backoff is active → should return BackoffError.
+	_, err := profiler.EnsureProfile(context.Background(), testBackend, testModel, testDigest)
+	if err == nil {
+		t.Fatal("expected BackoffError for stale profile during backoff")
+	}
+	var backoffErr *BackoffError
+	if !errors.As(err, &backoffErr) {
+		t.Fatalf("expected *BackoffError, got %T: %v", err, err)
+	}
+}
+
+func TestProfiler_EnsureProfile_Singleflight_SameDigest(t *testing.T) {
+	store := newMockStore()
+	prober := &mockProber{
+		detectKindFn: func(_ context.Context, _ string) (*KindDetection, error) {
+			return &KindDetection{Kind: ModelKindChat, Source: "capabilities", Capabilities: []string{"completion"}}, nil
+		},
+		probeChatFn: func(_ context.Context, _ string, _ interface{}) (*ChatMetrics, error) {
+			time.Sleep(50 * time.Millisecond) // Simulate work
+			return &ChatMetrics{TokensPerSecond: 20.0, PromptLatency: 200 * time.Millisecond}, nil
+		},
+	}
+	profiler := NewProfiler(store, prober)
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	profiles := make([]*Profile, 2)
+
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			profiles[idx], errs[idx] = profiler.EnsureProfile(context.Background(), testBackend, testModel, testDigest)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("goroutine %d error: %v", i, err)
+		}
+	}
+	// Singleflight should deduplicate — prober called once, not twice.
+	if prober.detectCalls.Load() != 1 {
+		t.Errorf("DetectKind called %d times, want 1 (singleflight)", prober.detectCalls.Load())
+	}
+}
+
+func TestProfiler_EnsureProfile_Singleflight_DifferentDigest(t *testing.T) {
+	store := newMockStore()
+	prober := &mockProber{
+		detectKindFn: func(_ context.Context, _ string) (*KindDetection, error) {
+			return &KindDetection{Kind: ModelKindChat, Source: "capabilities", Capabilities: []string{"completion"}}, nil
+		},
+		probeChatFn: func(_ context.Context, _ string, _ interface{}) (*ChatMetrics, error) {
+			time.Sleep(50 * time.Millisecond)
+			return &ChatMetrics{TokensPerSecond: 20.0}, nil
+		},
+	}
+	profiler := NewProfiler(store, prober)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		profiler.EnsureProfile(context.Background(), testBackend, testModel, "sha256:digest1")
+	}()
+	go func() {
+		defer wg.Done()
+		profiler.EnsureProfile(context.Background(), testBackend, testModel, "sha256:digest2")
+	}()
+	wg.Wait()
+
+	// Different digests → different singleflight keys → both run.
+	if prober.detectCalls.Load() != 2 {
+		t.Errorf("DetectKind called %d times, want 2 (different digests)", prober.detectCalls.Load())
+	}
+}
+
+func TestProfiler_EnsureProfile_DualCapability_Order(t *testing.T) {
+	store := newMockStore()
+	var order []string
+	var mu sync.Mutex
+
+	prober := &mockProber{
+		detectKindFn: func(_ context.Context, _ string) (*KindDetection, error) {
+			return &KindDetection{
+				Kind:         ModelKindChat,
+				Source:       "capabilities",
+				Capabilities: []string{"completion", "embedding"},
+			}, nil
+		},
+		probeChatFn: func(_ context.Context, _ string, _ interface{}) (*ChatMetrics, error) {
+			mu.Lock()
+			order = append(order, "chat")
+			mu.Unlock()
+			return &ChatMetrics{TokensPerSecond: 20.0}, nil
+		},
+		probeEmbedFn: func(_ context.Context, _ string) (*EmbeddingMetrics, error) {
+			mu.Lock()
+			order = append(order, "embedding")
+			mu.Unlock()
+			return &EmbeddingMetrics{Dim: 768, Latency: 50 * time.Millisecond}, nil
+		},
+	}
+	profiler := NewProfiler(store, prober)
+
+	_, err := profiler.EnsureProfile(context.Background(), testBackend, "dual-model", testDigest)
+	if err != nil {
+		t.Fatalf("EnsureProfile() error: %v", err)
+	}
+	if len(order) != 2 || order[0] != "chat" || order[1] != "embedding" {
+		t.Errorf("probe order = %v, want [chat embedding]", order)
+	}
+}

--- a/fingerprint/profiler_test.go
+++ b/fingerprint/profiler_test.go
@@ -12,13 +12,13 @@ import (
 // --- Mock Store ---
 
 type mockStore struct {
-	mu           sync.Mutex
-	profiles     map[string]*Profile
-	failures     map[string]*FailureInfo
-	needsResult  map[string]bool
-	saveCalled   int
-	saveFailed   int
-	saveErr      error
+	mu          sync.Mutex
+	profiles    map[string]*Profile
+	failures    map[string]*FailureInfo
+	needsResult map[string]bool
+	saveCalled  int
+	saveFailed  int
+	saveErr     error
 }
 
 func newMockStore() *mockStore {
@@ -454,11 +454,11 @@ func TestProfiler_EnsureProfile_IncompleteProfile_ActiveBackoff(t *testing.T) {
 	store := newMockStore()
 	k := store.key(testBackend, "partial-model")
 	store.profiles[k] = &Profile{
-		BackendID:              testBackend,
-		ModelName:              "partial-model",
-		ModelDigest:            testDigest,
-		ModelKind:              ModelKindChat,
-		IncompleteCapabilities: []string{"embedding"},
+		BackendID:                 testBackend,
+		ModelName:                 "partial-model",
+		ModelDigest:               testDigest,
+		ModelKind:                 ModelKindChat,
+		IncompleteCapabilities:    []string{"embedding"},
 		GenerationTokensPerSecond: 20.0,
 	}
 	store.failures[k] = &FailureInfo{
@@ -486,13 +486,13 @@ func TestProfiler_EnsureProfile_IncompleteProfile_RetryAfterBackoff(t *testing.T
 	store := newMockStore()
 	k := store.key(testBackend, "partial-model")
 	store.profiles[k] = &Profile{
-		BackendID:              testBackend,
-		ModelName:              "partial-model",
-		ModelDigest:            testDigest,
-		ModelKind:              ModelKindChat,
-		IncompleteCapabilities: []string{"embedding"},
+		BackendID:                 testBackend,
+		ModelName:                 "partial-model",
+		ModelDigest:               testDigest,
+		ModelKind:                 ModelKindChat,
+		IncompleteCapabilities:    []string{"embedding"},
 		GenerationTokensPerSecond: 20.0,
-		PromptLatency:          200 * time.Millisecond,
+		PromptLatency:             200 * time.Millisecond,
 	}
 	store.failures[k] = &FailureInfo{
 		ModelDigest:  testDigest,

--- a/fingerprint/resource.go
+++ b/fingerprint/resource.go
@@ -1,0 +1,48 @@
+package fingerprint
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ResourceProfile describes the system resources available for model inference.
+type ResourceProfile struct {
+	TotalMemoryMB     int64
+	AvailableMemoryMB int64
+	CPUCores          int
+	GPUAvailable      bool
+	GPUMemoryMB       int64
+}
+
+// parseMeminfoValue parses a value like "MemTotal:       32768000 kB" and
+// returns the value in megabytes. Used by the Linux implementation.
+func parseMeminfoValue(line string) (int64, error) {
+	parts := strings.Fields(line)
+	if len(parts) < 2 {
+		return 0, fmt.Errorf("fingerprint: invalid meminfo line: %q", line)
+	}
+	kb, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("fingerprint: parse meminfo value: %w", err)
+	}
+	return kb / 1024, nil
+}
+
+// parseNvidiaSmiOutput parses the output of nvidia-smi --query-gpu=memory.total
+// and returns GPU memory in MB. Returns 0 for empty or unparseable output.
+func parseNvidiaSmiOutput(output string) int64 {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return 0
+	}
+	// nvidia-smi outputs one line per GPU; take the first.
+	line := strings.SplitN(output, "\n", 2)[0]
+	line = strings.TrimSpace(line)
+	// Output is in MiB by default
+	mb, err := strconv.ParseInt(line, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return mb
+}

--- a/fingerprint/resource_darwin.go
+++ b/fingerprint/resource_darwin.go
@@ -1,0 +1,38 @@
+//go:build darwin
+
+package fingerprint
+
+import (
+	"encoding/binary"
+	"fmt"
+	"runtime"
+	"syscall"
+)
+
+// Detect returns the resource profile for macOS.
+func Detect() (ResourceProfile, error) {
+	rp := ResourceProfile{
+		CPUCores: runtime.NumCPU(),
+	}
+
+	// Total memory via sysctl hw.memsize.
+	// hw.memsize returns a binary-encoded uint64. syscall.Sysctl strips
+	// trailing NUL bytes, so we pad back to 8 bytes before decoding.
+	memstr, err := syscall.Sysctl("hw.memsize")
+	if err != nil {
+		return rp, fmt.Errorf("fingerprint: sysctl hw.memsize: %w", err)
+	}
+	raw := make([]byte, 8)
+	copy(raw, []byte(memstr))
+	rp.TotalMemoryMB = int64(binary.LittleEndian.Uint64(raw)) / (1024 * 1024)
+
+	// GPU detection based on architecture
+	if runtime.GOARCH == "arm64" {
+		// Apple Silicon: unified memory, GPU always available
+		rp.GPUAvailable = true
+		rp.GPUMemoryMB = rp.TotalMemoryMB
+	}
+	// Intel Macs: GPUAvailable stays false (discrete AMD GPUs not usable by Ollama)
+
+	return rp, nil
+}

--- a/fingerprint/resource_linux.go
+++ b/fingerprint/resource_linux.go
@@ -1,0 +1,52 @@
+//go:build linux
+
+package fingerprint
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// Detect returns the resource profile for Linux.
+func Detect() (ResourceProfile, error) {
+	rp := ResourceProfile{
+		CPUCores: runtime.NumCPU(),
+	}
+
+	// Parse /proc/meminfo
+	f, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return rp, fmt.Errorf("fingerprint: open /proc/meminfo: %w", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "MemTotal:") {
+			if v, err := parseMeminfoValue(line); err == nil {
+				rp.TotalMemoryMB = v
+			}
+		} else if strings.HasPrefix(line, "MemAvailable:") {
+			if v, err := parseMeminfoValue(line); err == nil {
+				rp.AvailableMemoryMB = v
+			}
+		}
+	}
+
+	// GPU detection via nvidia-smi
+	out, err := exec.Command("nvidia-smi", "--query-gpu=memory.total", "--format=csv,noheader,nounits").Output()
+	if err == nil {
+		gpuMem := parseNvidiaSmiOutput(string(out))
+		if gpuMem > 0 {
+			rp.GPUAvailable = true
+			rp.GPUMemoryMB = gpuMem
+		}
+	}
+
+	return rp, nil
+}

--- a/fingerprint/resource_other.go
+++ b/fingerprint/resource_other.go
@@ -1,0 +1,12 @@
+//go:build !darwin && !linux
+
+package fingerprint
+
+import "runtime"
+
+// Detect returns a minimal resource profile for unsupported platforms.
+func Detect() (ResourceProfile, error) {
+	return ResourceProfile{
+		CPUCores: runtime.NumCPU(),
+	}, nil
+}

--- a/fingerprint/resource_test.go
+++ b/fingerprint/resource_test.go
@@ -1,6 +1,7 @@
 package fingerprint
 
 import (
+	"runtime"
 	"testing"
 )
 
@@ -67,8 +68,17 @@ func TestDetect_ReturnsNonZeroMemory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Detect() error: %v", err)
 	}
-	// On any real machine, total memory should be at least 1 GB
-	if rp.TotalMemoryMB < 1024 {
-		t.Errorf("TotalMemoryMB = %d, want >= 1024", rp.TotalMemoryMB)
+	switch runtime.GOOS {
+	case "darwin", "linux":
+		// On supported platforms, total memory should be at least 1 GB.
+		if rp.TotalMemoryMB < 1024 {
+			t.Errorf("TotalMemoryMB = %d, want >= 1024", rp.TotalMemoryMB)
+		}
+	default:
+		// Fallback platform: memory detection is not implemented,
+		// so TotalMemoryMB is expected to be zero.
+		if rp.TotalMemoryMB != 0 {
+			t.Errorf("TotalMemoryMB = %d, want 0 on %s (unsupported platform)", rp.TotalMemoryMB, runtime.GOOS)
+		}
 	}
 }

--- a/fingerprint/resource_test.go
+++ b/fingerprint/resource_test.go
@@ -1,0 +1,74 @@
+package fingerprint
+
+import (
+	"testing"
+)
+
+func TestParseMeminfoValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		line    string
+		want    int64
+		wantErr bool
+	}{
+		{"MemTotal", "MemTotal:       32768000 kB", 32000, false},
+		{"MemAvailable", "MemAvailable:   16384000 kB", 16000, false},
+		{"small value", "MemTotal:       1024 kB", 1, false},
+		{"invalid", "MemTotal:", 0, true},
+		{"non-numeric", "MemTotal:       abc kB", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseMeminfoValue(tt.line)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseMeminfoValue(%q) error = %v, wantErr %v", tt.line, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("parseMeminfoValue(%q) = %d, want %d", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseNvidiaSmiOutput(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   int64
+	}{
+		{"single GPU", "24576", 24576},
+		{"multi GPU first line", "24576\n16384", 24576},
+		{"with whitespace", "  24576  \n", 24576},
+		{"empty", "", 0},
+		{"non-numeric", "error: not found", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseNvidiaSmiOutput(tt.output)
+			if got != tt.want {
+				t.Errorf("parseNvidiaSmiOutput(%q) = %d, want %d", tt.output, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetect_ReturnsNonZeroCPU(t *testing.T) {
+	rp, err := Detect()
+	if err != nil {
+		t.Fatalf("Detect() error: %v", err)
+	}
+	if rp.CPUCores < 1 {
+		t.Errorf("CPUCores = %d, want >= 1", rp.CPUCores)
+	}
+}
+
+func TestDetect_ReturnsNonZeroMemory(t *testing.T) {
+	rp, err := Detect()
+	if err != nil {
+		t.Fatalf("Detect() error: %v", err)
+	}
+	// On any real machine, total memory should be at least 1 GB
+	if rp.TotalMemoryMB < 1024 {
+		t.Errorf("TotalMemoryMB = %d, want >= 1024", rp.TotalMemoryMB)
+	}
+}

--- a/fingerprint/store.go
+++ b/fingerprint/store.go
@@ -115,6 +115,11 @@ func (s *SQLiteStore) GetFailure(ctx context.Context, backendID, modelName strin
 
 // Save persists a profile using upsert semantics. For complete profiles
 // (empty IncompleteCapabilities), any failure record for the same model is deleted.
+//
+// The upsert only overwrites an existing row when the incoming profile is
+// at least as recent (by tested_at). This prevents a slow-finishing probe
+// for an old digest from overwriting a newer profile during concurrent
+// mixed-digest profiling.
 func (s *SQLiteStore) Save(ctx context.Context, profile Profile) error {
 	capsJSON, err := json.Marshal(profile.Capabilities)
 	if err != nil {
@@ -158,7 +163,8 @@ func (s *SQLiteStore) Save(ctx context.Context, profile Profile) error {
 			embedding_coherence       = excluded.embedding_coherence,
 			embedding_latency_ns      = excluded.embedding_latency_ns,
 			peak_memory_mb            = excluded.peak_memory_mb,
-			gpu_layers_used           = excluded.gpu_layers_used`,
+			gpu_layers_used           = excluded.gpu_layers_used
+		WHERE excluded.tested_at >= fingerprint_profiles.tested_at`,
 		profile.BackendID, profile.ModelName, profile.ModelDigest, string(profile.ModelKind),
 		string(capsJSON), string(incompleteJSON), profile.KindSource,
 		profile.ProfileVersion, profile.TestedAt.UnixMilli(),
@@ -293,6 +299,8 @@ func (s *SQLiteStore) NeedsFingerprint(ctx context.Context, backendID, modelName
 }
 
 // SaveFailure records or increments a fingerprint failure for backoff tracking.
+// When the digest changes, attempt_count resets to 1 so a new model version
+// starts with a fresh backoff window instead of inheriting stale retry history.
 func (s *SQLiteStore) SaveFailure(ctx context.Context, backendID, modelName, modelDigest, errMsg string) error {
 	now := time.Now().UnixMilli()
 	_, err := s.db.ExecContext(ctx,
@@ -302,7 +310,11 @@ func (s *SQLiteStore) SaveFailure(ctx context.Context, backendID, modelName, mod
 			model_digest  = excluded.model_digest,
 			last_error    = excluded.last_error,
 			attempted_at  = excluded.attempted_at,
-			attempt_count = attempt_count + 1`,
+			attempt_count = CASE
+				WHEN fingerprint_failures.model_digest = excluded.model_digest
+				THEN attempt_count + 1
+				ELSE 1
+			END`,
 		backendID, modelName, modelDigest, errMsg, now,
 	)
 	if err != nil {

--- a/fingerprint/store.go
+++ b/fingerprint/store.go
@@ -1,0 +1,326 @@
+package fingerprint
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// maxBackoff is the ceiling for exponential failure backoff.
+const maxBackoff = 24 * time.Hour
+
+// baseBackoff is the initial backoff duration after the first failure.
+const baseBackoff = 1 * time.Hour
+
+// Store defines fingerprint persistence operations.
+type Store interface {
+	Get(ctx context.Context, backendID, modelName string) (*Profile, error)
+	GetFailure(ctx context.Context, backendID, modelName string) (*FailureInfo, error)
+	Save(ctx context.Context, profile Profile) error
+	NeedsFingerprint(ctx context.Context, backendID, modelName, currentDigest string) (bool, error)
+	SaveFailure(ctx context.Context, backendID, modelName, modelDigest, errMsg string) error
+}
+
+// SQLiteStore is a fingerprint Store backed by SQLite.
+type SQLiteStore struct {
+	db *sql.DB
+}
+
+// NewStore creates a fingerprint store on the given database, running
+// migrations if needed.
+func NewStore(ctx context.Context, db *sql.DB) (*SQLiteStore, error) {
+	if err := runMigrations(db); err != nil {
+		return nil, fmt.Errorf("fingerprint: initialize store: %w", err)
+	}
+	return &SQLiteStore{db: db}, nil
+}
+
+// Get retrieves a profile by backend ID and model name.
+// Returns ErrNotFound if no profile exists.
+func (s *SQLiteStore) Get(ctx context.Context, backendID, modelName string) (*Profile, error) {
+	var p Profile
+	var capsJSON, incompleteJSON string
+	var testedAtMs int64
+	var promptNs, coldStartNs, embLatNs int64
+
+	err := s.db.QueryRowContext(ctx,
+		`SELECT backend_id, model_name, model_digest, model_kind,
+			capabilities, incomplete_capabilities, kind_source,
+			profile_version, tested_at,
+			effective_context, tool_calling_rate, instruction_score,
+			generation_tokens_per_sec, prompt_latency_ns, cold_start_latency_ns,
+			embedding_dim, embedding_coherence, embedding_latency_ns,
+			peak_memory_mb, gpu_layers_used
+		FROM fingerprint_profiles
+		WHERE backend_id = ? AND model_name = ?`,
+		backendID, modelName,
+	).Scan(
+		&p.BackendID, &p.ModelName, &p.ModelDigest, &p.ModelKind,
+		&capsJSON, &incompleteJSON, &p.KindSource,
+		&p.ProfileVersion, &testedAtMs,
+		&p.EffectiveContext, &p.ToolCallingRate, &p.InstructionScore,
+		&p.GenerationTokensPerSecond, &promptNs, &coldStartNs,
+		&p.EmbeddingDim, &p.EmbeddingCoherence, &embLatNs,
+		&p.PeakMemoryMB, &p.GPULayersUsed,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("fingerprint: get %q/%q: %w", backendID, modelName, err)
+	}
+
+	if err := json.Unmarshal([]byte(capsJSON), &p.Capabilities); err != nil {
+		return nil, fmt.Errorf("fingerprint: get %q/%q: unmarshal capabilities: %w", backendID, modelName, err)
+	}
+	if err := json.Unmarshal([]byte(incompleteJSON), &p.IncompleteCapabilities); err != nil {
+		return nil, fmt.Errorf("fingerprint: get %q/%q: unmarshal incomplete_capabilities: %w", backendID, modelName, err)
+	}
+
+	p.TestedAt = time.UnixMilli(testedAtMs)
+	p.PromptLatency = time.Duration(promptNs)
+	p.ColdStartLatency = time.Duration(coldStartNs)
+	p.EmbeddingLatency = time.Duration(embLatNs)
+
+	return &p, nil
+}
+
+// GetFailure retrieves a failure record by backend ID and model name.
+// The returned FailureInfo includes a computed RetryAfter timestamp.
+// Returns ErrNotFound if no failure exists.
+func (s *SQLiteStore) GetFailure(ctx context.Context, backendID, modelName string) (*FailureInfo, error) {
+	var fi FailureInfo
+	var attemptedAtMs int64
+
+	err := s.db.QueryRowContext(ctx,
+		`SELECT model_digest, last_error, attempted_at, attempt_count
+		FROM fingerprint_failures
+		WHERE backend_id = ? AND model_name = ?`,
+		backendID, modelName,
+	).Scan(&fi.ModelDigest, &fi.LastError, &attemptedAtMs, &fi.AttemptCount)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("fingerprint: get failure %q/%q: %w", backendID, modelName, err)
+	}
+
+	fi.AttemptedAt = time.UnixMilli(attemptedAtMs)
+	fi.RetryAfter = computeRetryAfter(fi.AttemptedAt, fi.AttemptCount)
+
+	return &fi, nil
+}
+
+// Save persists a profile using upsert semantics. For complete profiles
+// (empty IncompleteCapabilities), any failure record for the same model is deleted.
+func (s *SQLiteStore) Save(ctx context.Context, profile Profile) error {
+	capsJSON, err := json.Marshal(profile.Capabilities)
+	if err != nil {
+		return fmt.Errorf("fingerprint: save: marshal capabilities: %w", err)
+	}
+	incompleteJSON, err := json.Marshal(profile.IncompleteCapabilities)
+	if err != nil {
+		return fmt.Errorf("fingerprint: save: marshal incomplete_capabilities: %w", err)
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("fingerprint: save: begin tx: %w", err)
+	}
+
+	_, err = tx.ExecContext(ctx,
+		`INSERT INTO fingerprint_profiles (
+			backend_id, model_name, model_digest, model_kind,
+			capabilities, incomplete_capabilities, kind_source,
+			profile_version, tested_at,
+			effective_context, tool_calling_rate, instruction_score,
+			generation_tokens_per_sec, prompt_latency_ns, cold_start_latency_ns,
+			embedding_dim, embedding_coherence, embedding_latency_ns,
+			peak_memory_mb, gpu_layers_used
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(backend_id, model_name) DO UPDATE SET
+			model_digest              = excluded.model_digest,
+			model_kind                = excluded.model_kind,
+			capabilities              = excluded.capabilities,
+			incomplete_capabilities   = excluded.incomplete_capabilities,
+			kind_source               = excluded.kind_source,
+			profile_version           = excluded.profile_version,
+			tested_at                 = excluded.tested_at,
+			effective_context         = excluded.effective_context,
+			tool_calling_rate         = excluded.tool_calling_rate,
+			instruction_score         = excluded.instruction_score,
+			generation_tokens_per_sec = excluded.generation_tokens_per_sec,
+			prompt_latency_ns         = excluded.prompt_latency_ns,
+			cold_start_latency_ns     = excluded.cold_start_latency_ns,
+			embedding_dim             = excluded.embedding_dim,
+			embedding_coherence       = excluded.embedding_coherence,
+			embedding_latency_ns      = excluded.embedding_latency_ns,
+			peak_memory_mb            = excluded.peak_memory_mb,
+			gpu_layers_used           = excluded.gpu_layers_used`,
+		profile.BackendID, profile.ModelName, profile.ModelDigest, string(profile.ModelKind),
+		string(capsJSON), string(incompleteJSON), profile.KindSource,
+		profile.ProfileVersion, profile.TestedAt.UnixMilli(),
+		profile.EffectiveContext, profile.ToolCallingRate, profile.InstructionScore,
+		profile.GenerationTokensPerSecond, int64(profile.PromptLatency), int64(profile.ColdStartLatency),
+		profile.EmbeddingDim, profile.EmbeddingCoherence, int64(profile.EmbeddingLatency),
+		profile.PeakMemoryMB, profile.GPULayersUsed,
+	)
+	if err != nil {
+		tx.Rollback()
+		return fmt.Errorf("fingerprint: save %q/%q: %w", profile.BackendID, profile.ModelName, err)
+	}
+
+	// Complete profiles clear any associated failure row.
+	if len(profile.IncompleteCapabilities) == 0 {
+		if _, err := tx.ExecContext(ctx,
+			`DELETE FROM fingerprint_failures WHERE backend_id = ? AND model_name = ?`,
+			profile.BackendID, profile.ModelName,
+		); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("fingerprint: save: clear failure %q/%q: %w", profile.BackendID, profile.ModelName, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("fingerprint: save: commit %q/%q: %w", profile.BackendID, profile.ModelName, err)
+	}
+
+	return nil
+}
+
+// NeedsFingerprint determines whether a model requires (re-)fingerprinting.
+//
+// Returns true when:
+//   - no profile exists
+//   - model digest has changed
+//   - profile version is below CurrentProfileVersion
+//   - profile has incomplete capabilities with no active backoff
+//
+// Returns false when the model is in a backoff window after a recent failure.
+func (s *SQLiteStore) NeedsFingerprint(ctx context.Context, backendID, modelName, currentDigest string) (bool, error) {
+	// Check for recent failure.
+	var failDigest string
+	var failAttemptedMs int64
+	var failCount int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT model_digest, attempted_at, attempt_count
+		FROM fingerprint_failures
+		WHERE backend_id = ? AND model_name = ?`,
+		backendID, modelName,
+	).Scan(&failDigest, &failAttemptedMs, &failCount)
+
+	hasFailure := err == nil
+	if err != nil && err != sql.ErrNoRows {
+		return false, fmt.Errorf("fingerprint: needs fingerprint: query failure %q/%q: %w", backendID, modelName, err)
+	}
+
+	if hasFailure {
+		if failDigest != currentDigest {
+			// Stale failure — digest changed, delete it and proceed.
+			if _, err := s.db.ExecContext(ctx,
+				`DELETE FROM fingerprint_failures WHERE backend_id = ? AND model_name = ?`,
+				backendID, modelName,
+			); err != nil {
+				return false, fmt.Errorf("fingerprint: needs fingerprint: delete stale failure %q/%q: %w", backendID, modelName, err)
+			}
+			hasFailure = false
+		} else {
+			// Same digest — check if still in backoff window.
+			retryAfter := computeRetryAfter(time.UnixMilli(failAttemptedMs), failCount)
+			if time.Now().Before(retryAfter) {
+				return false, nil
+			}
+			// Backoff expired — fall through to check profile.
+		}
+	}
+
+	// Check for existing profile.
+	var profileDigest string
+	var profileVersion int
+	var incompleteJSON string
+	err = s.db.QueryRowContext(ctx,
+		`SELECT model_digest, profile_version, incomplete_capabilities
+		FROM fingerprint_profiles
+		WHERE backend_id = ? AND model_name = ?`,
+		backendID, modelName,
+	).Scan(&profileDigest, &profileVersion, &incompleteJSON)
+
+	if err == sql.ErrNoRows {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("fingerprint: needs fingerprint: query profile %q/%q: %w", backendID, modelName, err)
+	}
+
+	// Digest changed — needs re-fingerprint.
+	if profileDigest != currentDigest {
+		// Also delete any stale failure for the old digest.
+		if _, err := s.db.ExecContext(ctx,
+			`DELETE FROM fingerprint_failures WHERE backend_id = ? AND model_name = ?`,
+			backendID, modelName,
+		); err != nil {
+			return false, fmt.Errorf("fingerprint: needs fingerprint: delete stale failure %q/%q: %w", backendID, modelName, err)
+		}
+		return true, nil
+	}
+
+	// Version upgrade needed.
+	if profileVersion < CurrentProfileVersion {
+		return true, nil
+	}
+
+	// Check incomplete capabilities.
+	var incomplete []string
+	if err := json.Unmarshal([]byte(incompleteJSON), &incomplete); err != nil {
+		return false, fmt.Errorf("fingerprint: needs fingerprint: unmarshal incomplete %q/%q: %w", backendID, modelName, err)
+	}
+	if len(incomplete) > 0 {
+		// Incomplete profile — need fingerprint only if not in active backoff.
+		if hasFailure {
+			// We already checked above: if we're here, backoff has expired
+			// or digest didn't match. But let's be explicit.
+			retryAfter := computeRetryAfter(time.UnixMilli(failAttemptedMs), failCount)
+			if time.Now().Before(retryAfter) {
+				return false, nil
+			}
+		}
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// SaveFailure records or increments a fingerprint failure for backoff tracking.
+func (s *SQLiteStore) SaveFailure(ctx context.Context, backendID, modelName, modelDigest, errMsg string) error {
+	now := time.Now().UnixMilli()
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO fingerprint_failures (backend_id, model_name, model_digest, last_error, attempted_at, attempt_count)
+		VALUES (?, ?, ?, ?, ?, 1)
+		ON CONFLICT(backend_id, model_name) DO UPDATE SET
+			model_digest  = excluded.model_digest,
+			last_error    = excluded.last_error,
+			attempted_at  = excluded.attempted_at,
+			attempt_count = attempt_count + 1`,
+		backendID, modelName, modelDigest, errMsg, now,
+	)
+	if err != nil {
+		return fmt.Errorf("fingerprint: save failure %q/%q: %w", backendID, modelName, err)
+	}
+	return nil
+}
+
+// computeRetryAfter calculates the retry timestamp using exponential backoff:
+// min(1h * 2^(count-1), 24h) from the attempted_at time.
+func computeRetryAfter(attemptedAt time.Time, attemptCount int) time.Time {
+	backoff := baseBackoff
+	for i := 1; i < attemptCount; i++ {
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+			break
+		}
+	}
+	return attemptedAt.Add(backoff)
+}

--- a/fingerprint/store_test.go
+++ b/fingerprint/store_test.go
@@ -527,3 +527,80 @@ func TestStore_BackendScoping(t *testing.T) {
 		t.Errorf("GetFailure p2 error = %v, want ErrNotFound", err)
 	}
 }
+
+func TestStore_SaveFailure_DigestChangeResetsCount(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	backendID := "http://localhost:11434"
+	modelName := "qwen2.5:7b"
+
+	// Build up retry count with old digest.
+	for i := 0; i < 3; i++ {
+		if err := store.SaveFailure(ctx, backendID, modelName, "old-digest", "old error"); err != nil {
+			t.Fatalf("SaveFailure() error: %v", err)
+		}
+	}
+
+	fi, err := store.GetFailure(ctx, backendID, modelName)
+	if err != nil {
+		t.Fatalf("GetFailure() error: %v", err)
+	}
+	if fi.AttemptCount != 3 {
+		t.Fatalf("AttemptCount = %d, want 3 before digest change", fi.AttemptCount)
+	}
+
+	// Save failure with new digest -- count should reset to 1.
+	if err := store.SaveFailure(ctx, backendID, modelName, "new-digest", "new error"); err != nil {
+		t.Fatalf("SaveFailure() error: %v", err)
+	}
+
+	fi, err = store.GetFailure(ctx, backendID, modelName)
+	if err != nil {
+		t.Fatalf("GetFailure() error: %v", err)
+	}
+	if fi.AttemptCount != 1 {
+		t.Errorf("AttemptCount = %d, want 1 (reset on digest change)", fi.AttemptCount)
+	}
+	if fi.ModelDigest != "new-digest" {
+		t.Errorf("ModelDigest = %q, want %q", fi.ModelDigest, "new-digest")
+	}
+	if fi.LastError != "new error" {
+		t.Errorf("LastError = %q, want %q", fi.LastError, "new error")
+	}
+}
+
+func TestStore_Save_StaleWriteGuard(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Save a newer profile first.
+	newer := testProfile()
+	newer.ModelDigest = "digest-v2"
+	newer.TestedAt = time.Now()
+	newer.GenerationTokensPerSecond = 30.0
+	if err := store.Save(ctx, newer); err != nil {
+		t.Fatalf("Save newer error: %v", err)
+	}
+
+	// Try to save an older profile for the same key.
+	older := testProfile()
+	older.ModelDigest = "digest-v1"
+	older.TestedAt = newer.TestedAt.Add(-time.Hour) // 1 hour older
+	older.GenerationTokensPerSecond = 10.0
+	if err := store.Save(ctx, older); err != nil {
+		t.Fatalf("Save older error: %v", err)
+	}
+
+	// The newer profile should still be stored.
+	got, err := store.Get(ctx, newer.BackendID, newer.ModelName)
+	if err != nil {
+		t.Fatalf("Get error: %v", err)
+	}
+	if got.ModelDigest != "digest-v2" {
+		t.Errorf("ModelDigest = %q, want %q (stale write should not overwrite)", got.ModelDigest, "digest-v2")
+	}
+	if got.GenerationTokensPerSecond != 30.0 {
+		t.Errorf("GenerationTokensPerSecond = %f, want 30.0", got.GenerationTokensPerSecond)
+	}
+}

--- a/fingerprint/store_test.go
+++ b/fingerprint/store_test.go
@@ -1,0 +1,529 @@
+package fingerprint
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func newTestStore(t *testing.T) *SQLiteStore {
+	t.Helper()
+	db := openTestDB(t)
+	ctx := context.Background()
+	store, err := NewStore(ctx, db)
+	if err != nil {
+		t.Fatalf("NewStore() error: %v", err)
+	}
+	return store
+}
+
+func testProfile() Profile {
+	return Profile{
+		BackendID:                 "http://localhost:11434",
+		ModelName:                 "qwen2.5:7b",
+		ModelDigest:               "abc123",
+		ModelKind:                 ModelKindChat,
+		Capabilities:              []string{"completion", "tools"},
+		IncompleteCapabilities:    []string{},
+		KindSource:                "capabilities",
+		ProfileVersion:            CurrentProfileVersion,
+		TestedAt:                  time.Now().Truncate(time.Millisecond),
+		EffectiveContext:          4096,
+		ToolCallingRate:           0.85,
+		InstructionScore:          0.92,
+		GenerationTokensPerSecond: 42.5,
+		PromptLatency:             150 * time.Millisecond,
+		ColdStartLatency:          3 * time.Second,
+		EmbeddingDim:              0,
+		EmbeddingCoherence:        -1,
+		EmbeddingLatency:          0,
+		PeakMemoryMB:              4096,
+		GPULayersUsed:             33,
+	}
+}
+
+func TestStore_SaveAndGet(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	want := testProfile()
+	if err := store.Save(ctx, want); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	got, err := store.Get(ctx, want.BackendID, want.ModelName)
+	if err != nil {
+		t.Fatalf("Get() error: %v", err)
+	}
+
+	// Compare all fields.
+	if got.BackendID != want.BackendID {
+		t.Errorf("BackendID = %q, want %q", got.BackendID, want.BackendID)
+	}
+	if got.ModelName != want.ModelName {
+		t.Errorf("ModelName = %q, want %q", got.ModelName, want.ModelName)
+	}
+	if got.ModelDigest != want.ModelDigest {
+		t.Errorf("ModelDigest = %q, want %q", got.ModelDigest, want.ModelDigest)
+	}
+	if got.ModelKind != want.ModelKind {
+		t.Errorf("ModelKind = %q, want %q", got.ModelKind, want.ModelKind)
+	}
+	if len(got.Capabilities) != len(want.Capabilities) {
+		t.Errorf("Capabilities len = %d, want %d", len(got.Capabilities), len(want.Capabilities))
+	} else {
+		for i := range want.Capabilities {
+			if got.Capabilities[i] != want.Capabilities[i] {
+				t.Errorf("Capabilities[%d] = %q, want %q", i, got.Capabilities[i], want.Capabilities[i])
+			}
+		}
+	}
+	if len(got.IncompleteCapabilities) != 0 {
+		t.Errorf("IncompleteCapabilities len = %d, want 0", len(got.IncompleteCapabilities))
+	}
+	if got.KindSource != want.KindSource {
+		t.Errorf("KindSource = %q, want %q", got.KindSource, want.KindSource)
+	}
+	if got.ProfileVersion != want.ProfileVersion {
+		t.Errorf("ProfileVersion = %d, want %d", got.ProfileVersion, want.ProfileVersion)
+	}
+	if !got.TestedAt.Equal(want.TestedAt) {
+		t.Errorf("TestedAt = %v, want %v", got.TestedAt, want.TestedAt)
+	}
+	if got.EffectiveContext != want.EffectiveContext {
+		t.Errorf("EffectiveContext = %d, want %d", got.EffectiveContext, want.EffectiveContext)
+	}
+	if got.ToolCallingRate != want.ToolCallingRate {
+		t.Errorf("ToolCallingRate = %f, want %f", got.ToolCallingRate, want.ToolCallingRate)
+	}
+	if got.InstructionScore != want.InstructionScore {
+		t.Errorf("InstructionScore = %f, want %f", got.InstructionScore, want.InstructionScore)
+	}
+	if got.GenerationTokensPerSecond != want.GenerationTokensPerSecond {
+		t.Errorf("GenerationTokensPerSecond = %f, want %f", got.GenerationTokensPerSecond, want.GenerationTokensPerSecond)
+	}
+	if got.PromptLatency != want.PromptLatency {
+		t.Errorf("PromptLatency = %v, want %v", got.PromptLatency, want.PromptLatency)
+	}
+	if got.ColdStartLatency != want.ColdStartLatency {
+		t.Errorf("ColdStartLatency = %v, want %v", got.ColdStartLatency, want.ColdStartLatency)
+	}
+	if got.EmbeddingDim != want.EmbeddingDim {
+		t.Errorf("EmbeddingDim = %d, want %d", got.EmbeddingDim, want.EmbeddingDim)
+	}
+	if got.EmbeddingCoherence != want.EmbeddingCoherence {
+		t.Errorf("EmbeddingCoherence = %f, want %f", got.EmbeddingCoherence, want.EmbeddingCoherence)
+	}
+	if got.EmbeddingLatency != want.EmbeddingLatency {
+		t.Errorf("EmbeddingLatency = %v, want %v", got.EmbeddingLatency, want.EmbeddingLatency)
+	}
+	if got.PeakMemoryMB != want.PeakMemoryMB {
+		t.Errorf("PeakMemoryMB = %d, want %d", got.PeakMemoryMB, want.PeakMemoryMB)
+	}
+	if got.GPULayersUsed != want.GPULayersUsed {
+		t.Errorf("GPULayersUsed = %d, want %d", got.GPULayersUsed, want.GPULayersUsed)
+	}
+}
+
+func TestStore_Get_NotFound(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := store.Get(ctx, "http://localhost:11434", "nonexistent")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get() error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestStore_Save_Upsert(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	p := testProfile()
+	if err := store.Save(ctx, p); err != nil {
+		t.Fatalf("first Save() error: %v", err)
+	}
+
+	// Update fields and save again.
+	p.ModelDigest = "def456"
+	p.GenerationTokensPerSecond = 55.0
+	p.ToolCallingRate = 0.95
+	if err := store.Save(ctx, p); err != nil {
+		t.Fatalf("second Save() error: %v", err)
+	}
+
+	got, err := store.Get(ctx, p.BackendID, p.ModelName)
+	if err != nil {
+		t.Fatalf("Get() error: %v", err)
+	}
+	if got.ModelDigest != "def456" {
+		t.Errorf("ModelDigest = %q, want %q", got.ModelDigest, "def456")
+	}
+	if got.GenerationTokensPerSecond != 55.0 {
+		t.Errorf("GenerationTokensPerSecond = %f, want 55.0", got.GenerationTokensPerSecond)
+	}
+	if got.ToolCallingRate != 0.95 {
+		t.Errorf("ToolCallingRate = %f, want 0.95", got.ToolCallingRate)
+	}
+}
+
+func TestStore_NeedsFingerprint_NoRow(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	needs, err := store.NeedsFingerprint(ctx, "http://localhost:11434", "qwen2.5:7b", "abc123")
+	if err != nil {
+		t.Fatalf("NeedsFingerprint() error: %v", err)
+	}
+	if !needs {
+		t.Error("NeedsFingerprint() = false, want true (no existing profile)")
+	}
+}
+
+func TestStore_NeedsFingerprint_MatchingDigest(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	p := testProfile()
+	if err := store.Save(ctx, p); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	needs, err := store.NeedsFingerprint(ctx, p.BackendID, p.ModelName, p.ModelDigest)
+	if err != nil {
+		t.Fatalf("NeedsFingerprint() error: %v", err)
+	}
+	if needs {
+		t.Error("NeedsFingerprint() = true, want false (matching digest, current version)")
+	}
+}
+
+func TestStore_NeedsFingerprint_ChangedDigest(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	p := testProfile()
+	if err := store.Save(ctx, p); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	needs, err := store.NeedsFingerprint(ctx, p.BackendID, p.ModelName, "new-digest-xyz")
+	if err != nil {
+		t.Fatalf("NeedsFingerprint() error: %v", err)
+	}
+	if !needs {
+		t.Error("NeedsFingerprint() = false, want true (digest changed)")
+	}
+}
+
+func TestStore_NeedsFingerprint_VersionUpgrade(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	p := testProfile()
+	p.ProfileVersion = CurrentProfileVersion - 1
+	if CurrentProfileVersion <= 1 {
+		// For testing: manually insert a row with version 0 to simulate old version.
+		p.ProfileVersion = 0
+	}
+	if err := store.Save(ctx, p); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	needs, err := store.NeedsFingerprint(ctx, p.BackendID, p.ModelName, p.ModelDigest)
+	if err != nil {
+		t.Fatalf("NeedsFingerprint() error: %v", err)
+	}
+	if !needs {
+		t.Error("NeedsFingerprint() = false, want true (profile version below current)")
+	}
+}
+
+func TestStore_SaveFailure_BackoffRespected(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	backendID := "http://localhost:11434"
+	modelName := "qwen2.5:7b"
+	digest := "abc123"
+
+	if err := store.SaveFailure(ctx, backendID, modelName, digest, "connection refused"); err != nil {
+		t.Fatalf("SaveFailure() error: %v", err)
+	}
+
+	needs, err := store.NeedsFingerprint(ctx, backendID, modelName, digest)
+	if err != nil {
+		t.Fatalf("NeedsFingerprint() error: %v", err)
+	}
+	if needs {
+		t.Error("NeedsFingerprint() = true, want false (in backoff window)")
+	}
+}
+
+func TestStore_SaveFailure_StaleDigestCleared(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	backendID := "http://localhost:11434"
+	modelName := "qwen2.5:7b"
+
+	// Save failure with old digest.
+	if err := store.SaveFailure(ctx, backendID, modelName, "old-digest", "model not found"); err != nil {
+		t.Fatalf("SaveFailure() error: %v", err)
+	}
+
+	// Check with new digest — stale failure should be cleared.
+	needs, err := store.NeedsFingerprint(ctx, backendID, modelName, "new-digest")
+	if err != nil {
+		t.Fatalf("NeedsFingerprint() error: %v", err)
+	}
+	if !needs {
+		t.Error("NeedsFingerprint() = false, want true (stale failure with different digest)")
+	}
+
+	// Verify failure row was actually deleted.
+	_, err = store.GetFailure(ctx, backendID, modelName)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("GetFailure() error = %v, want ErrNotFound (stale failure should be deleted)", err)
+	}
+}
+
+func TestStore_SaveFailure_IncrementCount(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	backendID := "http://localhost:11434"
+	modelName := "qwen2.5:7b"
+	digest := "abc123"
+
+	if err := store.SaveFailure(ctx, backendID, modelName, digest, "error 1"); err != nil {
+		t.Fatalf("first SaveFailure() error: %v", err)
+	}
+	if err := store.SaveFailure(ctx, backendID, modelName, digest, "error 2"); err != nil {
+		t.Fatalf("second SaveFailure() error: %v", err)
+	}
+	if err := store.SaveFailure(ctx, backendID, modelName, digest, "error 3"); err != nil {
+		t.Fatalf("third SaveFailure() error: %v", err)
+	}
+
+	fi, err := store.GetFailure(ctx, backendID, modelName)
+	if err != nil {
+		t.Fatalf("GetFailure() error: %v", err)
+	}
+	if fi.AttemptCount != 3 {
+		t.Errorf("AttemptCount = %d, want 3", fi.AttemptCount)
+	}
+	if fi.LastError != "error 3" {
+		t.Errorf("LastError = %q, want %q", fi.LastError, "error 3")
+	}
+}
+
+func TestStore_GetFailure_NotFound(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := store.GetFailure(ctx, "http://localhost:11434", "nonexistent")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetFailure() error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestStore_GetFailure_Active(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	backendID := "http://localhost:11434"
+	modelName := "qwen2.5:7b"
+	digest := "abc123"
+
+	if err := store.SaveFailure(ctx, backendID, modelName, digest, "timeout"); err != nil {
+		t.Fatalf("SaveFailure() error: %v", err)
+	}
+
+	fi, err := store.GetFailure(ctx, backendID, modelName)
+	if err != nil {
+		t.Fatalf("GetFailure() error: %v", err)
+	}
+
+	if fi.ModelDigest != digest {
+		t.Errorf("ModelDigest = %q, want %q", fi.ModelDigest, digest)
+	}
+	if fi.LastError != "timeout" {
+		t.Errorf("LastError = %q, want %q", fi.LastError, "timeout")
+	}
+	if fi.AttemptCount != 1 {
+		t.Errorf("AttemptCount = %d, want 1", fi.AttemptCount)
+	}
+
+	// RetryAfter should be ~1 hour from now (first attempt: 1h * 2^0 = 1h).
+	expectedRetry := fi.AttemptedAt.Add(1 * time.Hour)
+	if !fi.RetryAfter.Equal(expectedRetry) {
+		t.Errorf("RetryAfter = %v, want %v", fi.RetryAfter, expectedRetry)
+	}
+
+	// RetryAfter should be in the future.
+	if fi.RetryAfter.Before(time.Now()) {
+		t.Error("RetryAfter is in the past, expected it to be in the future")
+	}
+}
+
+func TestStore_NeedsFingerprint_IncompleteProfile_NoBackoff(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	p := testProfile()
+	p.IncompleteCapabilities = []string{"embedding"}
+	if err := store.Save(ctx, p); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	needs, err := store.NeedsFingerprint(ctx, p.BackendID, p.ModelName, p.ModelDigest)
+	if err != nil {
+		t.Fatalf("NeedsFingerprint() error: %v", err)
+	}
+	if !needs {
+		t.Error("NeedsFingerprint() = false, want true (incomplete profile with no backoff)")
+	}
+}
+
+func TestStore_NeedsFingerprint_IncompleteProfile_ActiveBackoff(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	p := testProfile()
+	p.IncompleteCapabilities = []string{"embedding"}
+	if err := store.Save(ctx, p); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	// Also record a failure with matching digest — creates active backoff.
+	if err := store.SaveFailure(ctx, p.BackendID, p.ModelName, p.ModelDigest, "embed failed"); err != nil {
+		t.Fatalf("SaveFailure() error: %v", err)
+	}
+
+	needs, err := store.NeedsFingerprint(ctx, p.BackendID, p.ModelName, p.ModelDigest)
+	if err != nil {
+		t.Fatalf("NeedsFingerprint() error: %v", err)
+	}
+	if needs {
+		t.Error("NeedsFingerprint() = true, want false (incomplete profile with active backoff)")
+	}
+}
+
+func TestStore_Save_Incomplete_PreservesFailure(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	backendID := "http://localhost:11434"
+	modelName := "qwen2.5:7b"
+	digest := "abc123"
+
+	// Record a failure first.
+	if err := store.SaveFailure(ctx, backendID, modelName, digest, "embed timeout"); err != nil {
+		t.Fatalf("SaveFailure() error: %v", err)
+	}
+
+	// Save an incomplete profile.
+	p := testProfile()
+	p.IncompleteCapabilities = []string{"embedding"}
+	if err := store.Save(ctx, p); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	// Failure should still be present.
+	fi, err := store.GetFailure(ctx, backendID, modelName)
+	if err != nil {
+		t.Fatalf("GetFailure() error: %v (expected failure to be preserved)", err)
+	}
+	if fi.LastError != "embed timeout" {
+		t.Errorf("LastError = %q, want %q", fi.LastError, "embed timeout")
+	}
+}
+
+func TestStore_Save_ClearsFailure(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	backendID := "http://localhost:11434"
+	modelName := "qwen2.5:7b"
+	digest := "abc123"
+
+	// Record a failure first.
+	if err := store.SaveFailure(ctx, backendID, modelName, digest, "transient error"); err != nil {
+		t.Fatalf("SaveFailure() error: %v", err)
+	}
+
+	// Save a complete profile (empty IncompleteCapabilities).
+	p := testProfile()
+	p.IncompleteCapabilities = []string{} // explicitly complete
+	if err := store.Save(ctx, p); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	// Failure should be gone.
+	_, err := store.GetFailure(ctx, backendID, modelName)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("GetFailure() error = %v, want ErrNotFound (failure should be cleared)", err)
+	}
+}
+
+func TestStore_BackendScoping(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Save same model name on two different backends.
+	p1 := testProfile()
+	p1.BackendID = "http://localhost:11434"
+	p1.ModelName = "qwen2.5:7b"
+	p1.GenerationTokensPerSecond = 42.0
+
+	p2 := testProfile()
+	p2.BackendID = "http://gpu-server:11434"
+	p2.ModelName = "qwen2.5:7b"
+	p2.GenerationTokensPerSecond = 85.0
+
+	if err := store.Save(ctx, p1); err != nil {
+		t.Fatalf("Save p1 error: %v", err)
+	}
+	if err := store.Save(ctx, p2); err != nil {
+		t.Fatalf("Save p2 error: %v", err)
+	}
+
+	got1, err := store.Get(ctx, p1.BackendID, p1.ModelName)
+	if err != nil {
+		t.Fatalf("Get p1 error: %v", err)
+	}
+	got2, err := store.Get(ctx, p2.BackendID, p2.ModelName)
+	if err != nil {
+		t.Fatalf("Get p2 error: %v", err)
+	}
+
+	if got1.GenerationTokensPerSecond != 42.0 {
+		t.Errorf("backend1 GenerationTokensPerSecond = %f, want 42.0", got1.GenerationTokensPerSecond)
+	}
+	if got2.GenerationTokensPerSecond != 85.0 {
+		t.Errorf("backend2 GenerationTokensPerSecond = %f, want 85.0", got2.GenerationTokensPerSecond)
+	}
+
+	// Failures are also scoped independently.
+	if err := store.SaveFailure(ctx, p1.BackendID, p1.ModelName, p1.ModelDigest, "local error"); err != nil {
+		t.Fatalf("SaveFailure p1 error: %v", err)
+	}
+
+	fi1, err := store.GetFailure(ctx, p1.BackendID, p1.ModelName)
+	if err != nil {
+		t.Fatalf("GetFailure p1 error: %v", err)
+	}
+	if fi1.LastError != "local error" {
+		t.Errorf("backend1 LastError = %q, want %q", fi1.LastError, "local error")
+	}
+
+	// Backend 2 should have no failure.
+	_, err = store.GetFailure(ctx, p2.BackendID, p2.ModelName)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("GetFailure p2 error = %v, want ErrNotFound", err)
+	}
+}

--- a/ollama/client.go
+++ b/ollama/client.go
@@ -100,8 +100,7 @@ func (c *Client) doJSON(ctx context.Context, method, path string, body any, dst 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("ollama: unexpected status %d: %s", resp.StatusCode, string(respBody))
+		return newAPIError(resp.StatusCode, resp.Body)
 	}
 
 	if dst != nil {
@@ -132,8 +131,7 @@ func (c *Client) doStream(ctx context.Context, path string, body any, fn func(js
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("ollama: unexpected status %d: %s", resp.StatusCode, string(respBody))
+		return newAPIError(resp.StatusCode, resp.Body)
 	}
 
 	scanner := bufio.NewScanner(resp.Body)
@@ -154,4 +152,20 @@ func (c *Client) doStream(ctx context.Context, path string, body any, fn func(js
 		return fmt.Errorf("ollama: read stream: %w", err)
 	}
 	return nil
+}
+
+// newAPIError constructs an APIError from a non-2xx response body.
+// It attempts to parse the Ollama JSON error format {"error":"..."} and
+// falls back to the raw body text. Reads at most 4KB to prevent memory
+// exhaustion from misbehaving upstreams.
+func newAPIError(statusCode int, body io.Reader) *APIError {
+	respBody, _ := io.ReadAll(io.LimitReader(body, 4096))
+	msg := string(respBody)
+	var errResp struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal(respBody, &errResp) == nil && errResp.Error != "" {
+		msg = errResp.Error
+	}
+	return &APIError{StatusCode: statusCode, Message: msg}
 }

--- a/ollama/models.go
+++ b/ollama/models.go
@@ -39,6 +39,9 @@ func (c *Client) AvailableModels(ctx context.Context) ([]string, error) {
 
 // ShowModel returns detailed information about a specific model.
 func (c *Client) ShowModel(ctx context.Context, name string) (*ModelInfo, error) {
+	if name == "" {
+		return nil, fmt.Errorf("ollama: show model: model name is required")
+	}
 	body := struct {
 		Name string `json:"name"`
 	}{Name: name}
@@ -49,10 +52,13 @@ func (c *Client) ShowModel(ctx context.Context, name string) (*ModelInfo, error)
 	}
 
 	return &ModelInfo{
-		Name:       name,
-		ParamSize:  resp.Details.ParamSize,
-		QuantLevel: resp.Details.QuantLevel,
-		Digest:     resp.Digest,
+		Name:         name,
+		ParamSize:    resp.Details.ParamSize,
+		QuantLevel:   resp.Details.QuantLevel,
+		Digest:       resp.Digest,
+		Family:       resp.Details.Family,
+		Template:     resp.Template,
+		Capabilities: resp.Capabilities,
 	}, nil
 }
 

--- a/ollama/models_test.go
+++ b/ollama/models_test.go
@@ -3,6 +3,7 @@ package ollama
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -72,6 +73,16 @@ func TestShowModel(t *testing.T) {
 	}
 	if info.Digest != "sha256:abc123def456" {
 		t.Errorf("expected digest %q, got %q", "sha256:abc123def456", info.Digest)
+	}
+	// Verify new fields are zero-valued when not present (older Ollama versions)
+	if info.Family != "" {
+		t.Errorf("expected empty Family, got %q", info.Family)
+	}
+	if info.Template != "" {
+		t.Errorf("expected empty Template, got %q", info.Template)
+	}
+	if info.Capabilities != nil {
+		t.Errorf("expected nil Capabilities, got %v", info.Capabilities)
 	}
 }
 
@@ -166,5 +177,88 @@ func TestListModelsServerError(t *testing.T) {
 	_, err := c.ListModels(context.Background())
 	if err == nil {
 		t.Fatal("expected error for 503 response")
+	}
+}
+
+func TestShowModel_NewFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"details": map[string]any{
+				"parameter_size":     "27B",
+				"quantization_level": "Q4_K_M",
+				"family":             "qwen2",
+			},
+			"digest":       "sha256:abc123",
+			"template":     "{{ .System }}\n{{ .Prompt }}",
+			"capabilities": []string{"completion", "tools"},
+		})
+	}))
+	defer srv.Close()
+
+	client := NewClient(WithBaseURL(srv.URL))
+	info, err := client.ShowModel(context.Background(), "test-model")
+	if err != nil {
+		t.Fatalf("ShowModel() error: %v", err)
+	}
+	if info.Family != "qwen2" {
+		t.Errorf("Family = %q, want %q", info.Family, "qwen2")
+	}
+	wantTemplate := "{{ .System }}\n{{ .Prompt }}"
+	if info.Template != wantTemplate {
+		t.Errorf("Template = %q, want %q", info.Template, wantTemplate)
+	}
+	if len(info.Capabilities) != 2 || info.Capabilities[0] != "completion" {
+		t.Errorf("Capabilities = %v, want [completion tools]", info.Capabilities)
+	}
+}
+
+func TestAPIError_ErrorsAs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":"model not found"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	_, err := c.ShowModel(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != http.StatusBadRequest {
+		t.Errorf("StatusCode = %d, want %d", apiErr.StatusCode, http.StatusBadRequest)
+	}
+	if apiErr.Message != "model not found" {
+		t.Errorf("Message = %q, want %q", apiErr.Message, "model not found")
+	}
+}
+
+func TestChatStream_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":"bad request"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	err := c.ChatStream(context.Background(), ChatRequest{
+		Model:    "test-model",
+		Messages: []ChatMessage{{Role: "user", Content: "Hi"}},
+	}, func(resp ChatResponse) error { return nil })
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError from streaming path, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != http.StatusBadRequest {
+		t.Errorf("StatusCode = %d, want %d", apiErr.StatusCode, http.StatusBadRequest)
+	}
+	if apiErr.Message != "bad request" {
+		t.Errorf("Message = %q, want %q", apiErr.Message, "bad request")
 	}
 }

--- a/ollama/types.go
+++ b/ollama/types.go
@@ -2,7 +2,10 @@
 // supporting chat completions, text generation, embeddings, and model management.
 package ollama
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // Tool defines a tool the model may call during chat.
 type Tool struct {
@@ -54,12 +57,15 @@ type ChatRequest struct {
 // ChatResponse is the response from the /api/chat endpoint.
 // During streaming, each chunk has Done=false until the final response.
 type ChatResponse struct {
-	Model         string      `json:"model"`
-	Message       ChatMessage `json:"message"`
-	Done          bool        `json:"done"`
-	TotalDuration int64       `json:"total_duration,omitempty"` // nanoseconds
-	EvalCount     int         `json:"eval_count,omitempty"`     // tokens generated
-	EvalDuration  int64       `json:"eval_duration,omitempty"`  // nanoseconds for generation
+	Model              string      `json:"model"`
+	Message            ChatMessage `json:"message"`
+	Done               bool        `json:"done"`
+	TotalDuration      int64       `json:"total_duration,omitempty"`       // nanoseconds
+	EvalCount          int         `json:"eval_count,omitempty"`           // tokens generated
+	EvalDuration       int64       `json:"eval_duration,omitempty"`        // nanoseconds for generation
+	LoadDuration       int64       `json:"load_duration,omitempty"`        // nanoseconds to load model
+	PromptEvalCount    int         `json:"prompt_eval_count,omitempty"`    // tokens in prompt
+	PromptEvalDuration int64       `json:"prompt_eval_duration,omitempty"` // nanoseconds for prompt eval
 }
 
 // ModelOptions controls generation parameters sent to Ollama.
@@ -104,18 +110,23 @@ type GenerateResponse struct {
 }
 
 // ModelInfo holds metadata about an Ollama model.
+// Capabilities may be nil when the model or Ollama version does not report capabilities.
 type ModelInfo struct {
-	Name       string `json:"name"`
-	Size       int64  `json:"size"`
-	ParamSize  string `json:"parameter_size"`
-	QuantLevel string `json:"quantization_level"`
-	Digest     string `json:"digest"` // model version hash from /api/show
+	Name         string   `json:"name"`
+	Size         int64    `json:"size"`
+	ParamSize    string   `json:"parameter_size"`
+	QuantLevel   string   `json:"quantization_level"`
+	Digest       string   `json:"digest"`       // model version hash from /api/show
+	Family       string   `json:"family"`        // model family (e.g. "qwen2", "llama")
+	Template     string   `json:"template"`      // prompt template; non-empty for chat models
+	Capabilities []string `json:"capabilities"`  // e.g. ["completion","tools"]; nil if not reported
 }
 
 // modelDetails is used when parsing /api/show responses.
 type modelDetails struct {
 	ParamSize  string `json:"parameter_size"`
 	QuantLevel string `json:"quantization_level"`
+	Family     string `json:"family"`
 }
 
 // listModelsResponse wraps the /api/tags response.
@@ -131,8 +142,10 @@ type listModelEntry struct {
 
 // showModelResponse wraps the /api/show response.
 type showModelResponse struct {
-	Details modelDetails `json:"details"`
-	Digest  string       `json:"digest"`
+	Details      modelDetails `json:"details"`
+	Digest       string       `json:"digest"`
+	Template     string       `json:"template"`
+	Capabilities []string     `json:"capabilities"`
 }
 
 // pullModelRequest is the request body for /api/pull.
@@ -147,4 +160,18 @@ type pullModelResponse struct {
 	Completed int64  `json:"completed,omitempty"`
 	Total     int64  `json:"total,omitempty"`
 	Done      bool   `json:"-"` // derived from status
+}
+
+// APIError represents a non-2xx response from the Ollama API.
+// Callers can use errors.As to extract status codes for decision logic.
+type APIError struct {
+	// StatusCode is the HTTP status code from the Ollama API response.
+	StatusCode int
+	// Message is the parsed error message from the Ollama JSON response,
+	// or the raw response body if JSON parsing fails.
+	Message string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("ollama: HTTP %d: %s", e.StatusCode, e.Message)
 }


### PR DESCRIPTION
## Summary

- Adds `fingerprint/` package implementing model profiling for intelligent model selection
- Three-tier kind detection: capabilities array (Ollama 0.5.x+), family/template heuristic, live probe fallback
- OllamaProber extracts chat throughput, prompt latency, cold start detection, and embedding dimension/latency
- SQLite-backed profile store with migration system, upsert, failure backoff (exponential `min(1h*2^(n-1), 24h)`)
- Profiler orchestrator with `singleflight` deduplication, dual-capability probing, partial profile persistence
- Cross-platform resource detection (darwin sysctl, linux /proc, fallback)
- Additive `ollama/` changes: `Family`, `Template`, `Capabilities` fields on `ModelInfo`; `APIError` type; timing fields on `ChatResponse`

Key design decisions:
- Store PK: `(backend_id, model_name)` with loopback canonicalization to `localhost`
- Partial profiles are first-class: if one probe succeeds and another fails, save what we have with `IncompleteCapabilities` tracking
- Profile version gating: `NeedsFingerprint` triggers re-profiling on version bump; version upgrades re-run all probes (not just incomplete)
- `ModelProber` interface keeps `fingerprint/` decoupled from `ollama/` concrete types

22 files changed, 3314 insertions. 83.8% test coverage on `fingerprint/`. All `go test ./...`, `go vet`, `gofmt` clean.

Closes #29

## Test plan

- [x] `go test ./fingerprint/ -v -count=1` -- all 56 tests pass
- [x] `go test ./... -count=1` -- no regressions across all packages
- [x] `go vet ./fingerprint/` -- clean
- [x] `gofmt -l ./fingerprint/` -- clean
- [x] `go test ./fingerprint/ -cover` -- 83.8% statement coverage
- [ ] Verify on Linux: `GOOS=linux GOARCH=amd64 go build ./fingerprint/`

Generated with [Claude Code](https://claude.com/claude-code)