### PR TITLE
feat(rag): add StableKey for feedback-safe chunk identity (issue #30)

### DIFF
--- a/rag/chunker.go
+++ b/rag/chunker.go
@@ -8,16 +8,16 @@ import (
 	"strings"
 )
 
-
 // Chunk represents a segment of text suitable for embedding.
 type Chunk struct {
-	ID        string            // deterministic hash of content + source
-	Content   string            // the text
-	Source    string            // file path
-	StartLine int              // line number in source (1-indexed)
+	ID        string // deterministic hash of content + source
+	Content   string // the text
+	Source    string // file path
+	StartLine int    // line number in source (1-indexed)
 	EndLine   int
 	Language  string            // "go", "python", "typescript", etc.
 	Metadata  map[string]string // arbitrary k/v (function name, class, etc.)
+	StableKey string            // logical identity surviving re-indexes (see stable_key.go)
 }
 
 // Chunker splits text into chunks suitable for embedding.
@@ -118,6 +118,7 @@ func (sw *SlidingWindowChunker) Chunk(source string, content string) ([]Chunk, e
 		chunks = append(chunks, makeChunk(source, buf.String(), startLine, len(lines), ""))
 	}
 
+	populateSlidingWindowMetadata(chunks)
 	return chunks, nil
 }
 

--- a/rag/chunker_code.go
+++ b/rag/chunker_code.go
@@ -46,7 +46,12 @@ func (c *codeChunker) Chunk(source string, content string) ([]Chunk, error) {
 		if err != nil {
 			return nil, fmt.Errorf("rag: create fallback chunker for %q: %w", source, err)
 		}
-		return sw.Chunk(source, content)
+		swChunks, err := sw.Chunk(source, content)
+		if err != nil {
+			return nil, err
+		}
+		populateSlidingWindowMetadata(swChunks)
+		return swChunks, nil
 	}
 
 	chunks := c.splitByBoundaries(source, content, lang)
@@ -56,9 +61,15 @@ func (c *codeChunker) Chunk(source string, content string) ([]Chunk, error) {
 		if err != nil {
 			return nil, fmt.Errorf("rag: create fallback chunker for %q: %w", source, err)
 		}
-		return sw.Chunk(source, content)
+		swChunks, err := sw.Chunk(source, content)
+		if err != nil {
+			return nil, err
+		}
+		populateSlidingWindowMetadata(swChunks)
+		return swChunks, nil
 	}
 
+	populateCodeChunkMetadata(chunks, lang)
 	return chunks, nil
 }
 

--- a/rag/indexer.go
+++ b/rag/indexer.go
@@ -17,11 +17,12 @@ import (
 // may call IndexFile concurrently provided the injected Chunker and
 // VectorStore implementations are themselves safe for concurrent use.
 type Indexer struct {
-	client  *ollama.Client
-	model   string
-	store   VectorStore
-	chunker Chunker
-	storeMu sync.Mutex
+	client        *ollama.Client
+	model         string
+	store         VectorStore
+	chunker       Chunker
+	storeMu       sync.Mutex
+	workspaceRoot string // canonicalized absolute path; used for StableKey computation
 }
 
 // atomicSourceReplacer is an optional store capability for transactional
@@ -44,6 +45,19 @@ func WithEmbeddingModel(model string) IndexerOption {
 func WithChunker(c Chunker) IndexerOption {
 	return func(idx *Indexer) {
 		idx.chunker = c
+	}
+}
+
+// WithWorkspaceRoot sets the workspace root directory used for StableKey
+// computation. The path is canonicalized with filepath.Abs + filepath.Clean.
+// This is required when using IndexFile directly; IndexDirectory sets it
+// automatically from the directory argument.
+func WithWorkspaceRoot(root string) IndexerOption {
+	return func(idx *Indexer) {
+		abs, err := filepath.Abs(root)
+		if err == nil {
+			idx.workspaceRoot = filepath.Clean(abs)
+		}
 	}
 }
 
@@ -112,6 +126,18 @@ func (idx *Indexer) IndexFile(ctx context.Context, path string) error {
 			return fmt.Errorf("rag: clear chunks for %q with no chunk output: %w", path, err)
 		}
 		return nil
+	}
+
+	// Step 1.5: Compute stable keys if workspace root is set.
+	if idx.workspaceRoot != "" {
+		for i := range chunks {
+			key, err := ComputeStableKey(chunks[i], idx.workspaceRoot)
+			if err != nil {
+				// Non-fatal: leave StableKey empty rather than failing the entire index.
+				continue
+			}
+			chunks[i].StableKey = key
+		}
 	}
 
 	// Step 2: Generate embeddings (most likely to fail — network/model errors)
@@ -183,7 +209,16 @@ type IndexStatus struct {
 // IndexDirectory indexes all supported files in a directory tree.
 // Files are processed concurrently (default: 4 workers).
 // It respects .gitignore patterns and can be cancelled via context.
+// The cleaned absolute path of dir is used as the workspace root for
+// StableKey computation during this indexing run.
 func (idx *Indexer) IndexDirectory(ctx context.Context, dir string, opts ...IndexDirOption) error {
+	// Set workspace root for StableKey computation.
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return fmt.Errorf("rag: resolve directory %q: %w", dir, err)
+	}
+	idx.workspaceRoot = filepath.Clean(absDir)
+
 	cfg := &indexDirConfig{
 		extensions: map[string]bool{
 			".go": true, ".py": true, ".ts": true, ".tsx": true,

--- a/rag/migration.go
+++ b/rag/migration.go
@@ -27,6 +27,11 @@ var migrations = []migration{
 		description: "add indexed_at, FTS5 index, and sync triggers",
 		fn:          migrateV2,
 	},
+	{
+		version:     3,
+		description: "add stable_key column for chunk identity",
+		fn:          migrateV3,
+	},
 }
 
 // migrateV1 creates the baseline chunks table and indexes.
@@ -96,6 +101,21 @@ func migrateV2(tx *sql.Tx) error {
 	for _, stmt := range stmts {
 		if _, err := tx.Exec(stmt); err != nil {
 			return fmt.Errorf("rag: migrate v2: %w", err)
+		}
+	}
+	return nil
+}
+
+// migrateV3 adds the stable_key column for logical chunk identity.
+// Existing rows get an empty default that will be populated on re-index.
+func migrateV3(tx *sql.Tx) error {
+	stmts := []string{
+		`ALTER TABLE chunks ADD COLUMN stable_key TEXT NOT NULL DEFAULT ''`,
+		`CREATE INDEX IF NOT EXISTS idx_chunks_stable_key ON chunks(stable_key)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := tx.Exec(stmt); err != nil {
+			return fmt.Errorf("rag: migrate v3: %w", err)
 		}
 	}
 	return nil

--- a/rag/migration_test.go
+++ b/rag/migration_test.go
@@ -12,14 +12,14 @@ import (
 func TestMigrationFreshDB(t *testing.T) {
 	store := newTestStore(t)
 
-	// Verify rag_schema_version exists with version 2.
+	// Verify rag_schema_version exists with version 3.
 	var maxVersion int
 	err := store.db.QueryRow(`SELECT MAX(version) FROM rag_schema_version`).Scan(&maxVersion)
 	if err != nil {
 		t.Fatalf("query rag_schema_version: %v", err)
 	}
-	if maxVersion != 2 {
-		t.Errorf("max schema version = %d, want 2", maxVersion)
+	if maxVersion != 3 {
+		t.Errorf("max schema version = %d, want 3", maxVersion)
 	}
 
 	// Verify chunks_fts virtual table exists.
@@ -102,14 +102,14 @@ func TestMigrationExistingDB(t *testing.T) {
 		t.Fatalf("runMigrations() error: %v", err)
 	}
 
-	// Verify version upgraded to 2.
+	// Verify version upgraded to 3.
 	var maxVersion int
 	err = db.QueryRow(`SELECT MAX(version) FROM rag_schema_version`).Scan(&maxVersion)
 	if err != nil {
 		t.Fatalf("query schema version: %v", err)
 	}
-	if maxVersion != 2 {
-		t.Errorf("max schema version = %d, want 2", maxVersion)
+	if maxVersion != 3 {
+		t.Errorf("max schema version = %d, want 3", maxVersion)
 	}
 
 	// Verify indexed_at was backfilled (should be non-zero).
@@ -393,13 +393,13 @@ func TestMigrationIdempotency(t *testing.T) {
 		t.Fatalf("second runMigrations() error: %v", err)
 	}
 
-	// Verify version is still 2 (not duplicated).
+	// Verify version is still 3 (not duplicated).
 	var count int
 	if err := db.QueryRow(`SELECT COUNT(*) FROM rag_schema_version`).Scan(&count); err != nil {
 		t.Fatalf("count versions: %v", err)
 	}
-	if count != 2 {
-		t.Errorf("expected 2 version records (v1, v2), got %d", count)
+	if count != 3 {
+		t.Errorf("expected 3 version records (v1, v2, v3), got %d", count)
 	}
 }
 
@@ -530,13 +530,13 @@ func TestMigrationHalfAppliedV2(t *testing.T) {
 		t.Fatalf("runMigrations() on half-applied v2: %v", err)
 	}
 
-	// Verify version recorded as 2.
+	// Verify version recorded as 3 (v2 detected, then v3 applied).
 	var maxVersion int
 	if err := db.QueryRow(`SELECT MAX(version) FROM rag_schema_version`).Scan(&maxVersion); err != nil {
 		t.Fatalf("query version: %v", err)
 	}
-	if maxVersion != 2 {
-		t.Errorf("max version = %d, want 2", maxVersion)
+	if maxVersion != 3 {
+		t.Errorf("max version = %d, want 3", maxVersion)
 	}
 }
 
@@ -602,12 +602,12 @@ func TestMigrationHalfAppliedV2WithV1Recorded(t *testing.T) {
 		t.Fatalf("runMigrations() on v2 schema with v1 recorded: %v", err)
 	}
 
-	// Verify version is now 2.
+	// Verify version is now 3 (v2 detected, then v3 applied).
 	var maxVersion int
 	if err := db.QueryRow(`SELECT MAX(version) FROM rag_schema_version`).Scan(&maxVersion); err != nil {
 		t.Fatalf("query version: %v", err)
 	}
-	if maxVersion != 2 {
-		t.Errorf("max version = %d, want 2", maxVersion)
+	if maxVersion != 3 {
+		t.Errorf("max version = %d, want 3", maxVersion)
 	}
 }

--- a/rag/search_multi.go
+++ b/rag/search_multi.go
@@ -123,7 +123,7 @@ func (s *SQLiteStore) SearchMulti(ctx context.Context, queryEmbedding []float64,
 // loadChunksWithEmbeddings loads all chunks and their embeddings from the database.
 func (s *SQLiteStore) loadChunksWithEmbeddings(ctx context.Context) ([]Chunk, [][]float64, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, content, source, start_line, end_line, language, metadata, embedding FROM chunks`)
+		`SELECT id, content, source, start_line, end_line, language, metadata, embedding, stable_key FROM chunks`)
 	if err != nil {
 		return nil, nil, fmt.Errorf("rag: query chunks: %w", err)
 	}
@@ -135,7 +135,7 @@ func (s *SQLiteStore) loadChunksWithEmbeddings(ctx context.Context) ([]Chunk, []
 		var chunk Chunk
 		var metaJSON, embJSON string
 		if err := rows.Scan(&chunk.ID, &chunk.Content, &chunk.Source,
-			&chunk.StartLine, &chunk.EndLine, &chunk.Language, &metaJSON, &embJSON); err != nil {
+			&chunk.StartLine, &chunk.EndLine, &chunk.Language, &metaJSON, &embJSON, &chunk.StableKey); err != nil {
 			return nil, nil, fmt.Errorf("rag: scan chunk: %w", err)
 		}
 

--- a/rag/sqlite_store.go
+++ b/rag/sqlite_store.go
@@ -91,8 +91,8 @@ func (s *SQLiteStore) insertChunksTx(ctx context.Context, tx *sql.Tx, chunks []C
 	// modifies the row in place (preserving its rowid) and fires the
 	// AFTER UPDATE trigger, which correctly maintains FTS5.
 	stmt, err := tx.PrepareContext(ctx,
-		`INSERT INTO chunks (id, content, source, start_line, end_line, language, metadata, embedding, indexed_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`INSERT INTO chunks (id, content, source, start_line, end_line, language, metadata, embedding, indexed_at, stable_key)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			 ON CONFLICT(id) DO UPDATE SET
 				content = excluded.content,
 				source = excluded.source,
@@ -101,7 +101,8 @@ func (s *SQLiteStore) insertChunksTx(ctx context.Context, tx *sql.Tx, chunks []C
 				language = excluded.language,
 				metadata = excluded.metadata,
 				embedding = excluded.embedding,
-				indexed_at = excluded.indexed_at`)
+				indexed_at = excluded.indexed_at,
+				stable_key = excluded.stable_key`)
 	if err != nil {
 		return fmt.Errorf("rag: prepare insert: %w", err)
 	}
@@ -118,7 +119,7 @@ func (s *SQLiteStore) insertChunksTx(ctx context.Context, tx *sql.Tx, chunks []C
 			return fmt.Errorf("rag: marshal embedding: %w", err)
 		}
 		if _, err := stmt.ExecContext(ctx, chunk.ID, chunk.Content, chunk.Source,
-			chunk.StartLine, chunk.EndLine, chunk.Language, string(metaJSON), string(embJSON), now); err != nil {
+			chunk.StartLine, chunk.EndLine, chunk.Language, string(metaJSON), string(embJSON), now, chunk.StableKey); err != nil {
 			return fmt.Errorf("rag: insert chunk %q: %w", chunk.ID, err)
 		}
 	}
@@ -187,7 +188,7 @@ func (s *SQLiteStore) ReplaceSource(ctx context.Context, source string, chunks [
 // Search finds the top-k most similar chunks using brute-force cosine similarity.
 func (s *SQLiteStore) Search(ctx context.Context, queryEmbedding []float64, k int) ([]SearchResult, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, content, source, start_line, end_line, language, metadata, embedding FROM chunks`)
+		`SELECT id, content, source, start_line, end_line, language, metadata, embedding, stable_key FROM chunks`)
 	if err != nil {
 		return nil, fmt.Errorf("rag: query chunks: %w", err)
 	}
@@ -198,7 +199,7 @@ func (s *SQLiteStore) Search(ctx context.Context, queryEmbedding []float64, k in
 		var chunk Chunk
 		var metaJSON, embJSON string
 		if err := rows.Scan(&chunk.ID, &chunk.Content, &chunk.Source,
-			&chunk.StartLine, &chunk.EndLine, &chunk.Language, &metaJSON, &embJSON); err != nil {
+			&chunk.StartLine, &chunk.EndLine, &chunk.Language, &metaJSON, &embJSON, &chunk.StableKey); err != nil {
 			return nil, fmt.Errorf("rag: scan chunk: %w", err)
 		}
 
@@ -336,7 +337,7 @@ func (s *SQLiteStore) ExportChunks(ctx context.Context, filter *ExportFilter) (i
 
 // buildExportQuery constructs the SELECT with optional WHERE clauses for export filtering.
 func buildExportQuery(filter *ExportFilter) (string, []any) {
-	base := `SELECT id, content, source, start_line, end_line, language, embedding FROM chunks`
+	base := `SELECT id, content, source, start_line, end_line, language, embedding, stable_key FROM chunks`
 	var conditions []string
 	var args []any
 
@@ -364,7 +365,7 @@ func scanExportRow(rows *sql.Rows) (Chunk, []float64, error) {
 	var chunk Chunk
 	var embJSON string
 	if err := rows.Scan(&chunk.ID, &chunk.Content, &chunk.Source,
-		&chunk.StartLine, &chunk.EndLine, &chunk.Language, &embJSON); err != nil {
+		&chunk.StartLine, &chunk.EndLine, &chunk.Language, &embJSON, &chunk.StableKey); err != nil {
 		return Chunk{}, nil, fmt.Errorf("rag: scan export row: %w", err)
 	}
 

--- a/rag/stable_key.go
+++ b/rag/stable_key.go
@@ -1,0 +1,148 @@
+package rag
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// ComputeStableKey derives a logical identity key for a chunk that survives
+// re-indexes and benign line shifts. The key format depends on the metadata
+// available on the chunk:
+//
+//	code:     {rel_path}::{symbol_path}#{ordinal}
+//	text:     {rel_path}::{section_path}#{ordinal}
+//	fallback: {rel_path}::{anchor_hash}#{ordinal}
+//
+// workspaceRoot must be an absolute, cleaned path. The chunk's Source must
+// also be an absolute path so that filepath.Rel can produce a deterministic
+// relative path.
+func ComputeStableKey(chunk Chunk, workspaceRoot string) (string, error) {
+	if workspaceRoot == "" {
+		return "", fmt.Errorf("rag: ComputeStableKey: workspaceRoot must not be empty")
+	}
+
+	absRoot, err := filepath.Abs(workspaceRoot)
+	if err != nil {
+		return "", fmt.Errorf("rag: ComputeStableKey: resolve workspaceRoot: %w", err)
+	}
+	absRoot = filepath.Clean(absRoot)
+
+	absSource, err := filepath.Abs(chunk.Source)
+	if err != nil {
+		return "", fmt.Errorf("rag: ComputeStableKey: resolve source %q: %w", chunk.Source, err)
+	}
+	absSource = filepath.Clean(absSource)
+
+	relPath, err := filepath.Rel(absRoot, absSource)
+	if err != nil {
+		return "", fmt.Errorf("rag: ComputeStableKey: compute relative path: %w", err)
+	}
+	// Normalize to forward slashes and strip leading "./"
+	relPath = filepath.ToSlash(relPath)
+	relPath = strings.TrimPrefix(relPath, "./")
+
+	ordinal := chunk.Metadata["chunk_ordinal"]
+	if ordinal == "" {
+		ordinal = "0"
+	}
+
+	// Determine key type based on available metadata.
+	if symbolPath := chunk.Metadata["symbol_path"]; symbolPath != "" {
+		return fmt.Sprintf("%s::%s#%s", relPath, symbolPath, ordinal), nil
+	}
+	if sectionPath := chunk.Metadata["section_path"]; sectionPath != "" {
+		return fmt.Sprintf("%s::%s#%s", relPath, sectionPath, ordinal), nil
+	}
+	if anchorHash := chunk.Metadata["anchor_hash"]; anchorHash != "" {
+		return fmt.Sprintf("%s::%s#%s", relPath, anchorHash, ordinal), nil
+	}
+
+	return "", fmt.Errorf("rag: ComputeStableKey: chunk has no symbol_path, section_path, or anchor_hash metadata")
+}
+
+// populateCodeChunkMetadata sets the metadata fields required for stable key
+// computation on code chunks produced by the boundary-based code chunker.
+// It extracts the symbol name from the first significant line of the chunk.
+func populateCodeChunkMetadata(chunks []Chunk, lang string) {
+	// Track ordinals per symbol_path for disambiguation.
+	ordinals := make(map[string]int)
+	for i := range chunks {
+		symbol := extractSymbolName(chunks[i].Content, lang)
+		if symbol == "" {
+			symbol = "unknown"
+		}
+		chunks[i].Metadata["symbol"] = symbol
+		chunks[i].Metadata["symbol_path"] = symbol
+
+		ord := ordinals[symbol]
+		ordinals[symbol] = ord + 1
+		chunks[i].Metadata["chunk_ordinal"] = fmt.Sprintf("%d", ord)
+	}
+}
+
+// populateSlidingWindowMetadata sets the metadata fields required for stable
+// key computation on sliding-window (fallback) chunks. These chunks have no
+// structural symbols, so we use a content-based anchor hash.
+func populateSlidingWindowMetadata(chunks []Chunk) {
+	for i := range chunks {
+		chunks[i].Metadata["anchor_hash"] = anchorHash(chunks[i].Content)
+		chunks[i].Metadata["chunk_ordinal"] = fmt.Sprintf("%d", i)
+	}
+}
+
+// anchorHash produces a short hex digest of the normalized content. The
+// normalization strips leading/trailing whitespace from each line and
+// collapses runs of blank lines, making the hash resilient to minor
+// formatting changes while still distinguishing meaningfully different content.
+func anchorHash(content string) string {
+	lines := strings.Split(content, "\n")
+	var normalized []string
+	prevBlank := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			if !prevBlank {
+				normalized = append(normalized, "")
+			}
+			prevBlank = true
+		} else {
+			normalized = append(normalized, trimmed)
+			prevBlank = false
+		}
+	}
+	joined := strings.Join(normalized, "\n")
+	h := sha256.Sum256([]byte(joined))
+	return fmt.Sprintf("%x", h[:8])
+}
+
+// Symbol extraction patterns by language. These intentionally match the
+// same boundary patterns used in chunker_code.go, extracting the identifier
+// that follows the keyword.
+var symbolExtractors = map[string]*regexp.Regexp{
+	"go":         regexp.MustCompile(`^func\s+(?:\(\s*\w+\s+\*?\w+\)\s+)?(\w+)`),
+	"python":     regexp.MustCompile(`^(?:def|class)\s+(\w+)`),
+	"typescript": regexp.MustCompile(`^(?:export\s+)?(?:function|class|const|interface|type)\s+(\w+)`),
+	"javascript": regexp.MustCompile(`^(?:export\s+)?(?:function|class|const)\s+(\w+)`),
+	"rust":       regexp.MustCompile(`^(?:pub\s+)?(?:fn|struct|impl|enum|trait)\s+(\w+)`),
+	"java":       regexp.MustCompile(`(?:public|private|protected|static)?\s*(?:class|interface|void|int|String|boolean|static)\s+(\w+)`),
+	"ruby":       regexp.MustCompile(`^(?:def|class|module)\s+(\w+)`),
+}
+
+// extractSymbolName scans the chunk content for the first recognizable symbol
+// declaration and returns its name. Returns "" if no symbol is found.
+func extractSymbolName(content string, lang string) string {
+	pattern, ok := symbolExtractors[lang]
+	if !ok {
+		return ""
+	}
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if m := pattern.FindStringSubmatch(trimmed); m != nil {
+			return m[1]
+		}
+	}
+	return ""
+}

--- a/rag/stable_key_test.go
+++ b/rag/stable_key_test.go
@@ -1,0 +1,887 @@
+package rag
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+func TestComputeStableKeyCodeChunk(t *testing.T) {
+	chunk := Chunk{
+		ID:      "abc",
+		Content: "func Hello() {}",
+		Source:  "/workspace/src/main.go",
+		Metadata: map[string]string{
+			"symbol":        "Hello",
+			"symbol_path":   "Hello",
+			"chunk_ordinal": "0",
+		},
+	}
+
+	key, err := ComputeStableKey(chunk, "/workspace")
+	if err != nil {
+		t.Fatalf("ComputeStableKey() error: %v", err)
+	}
+	if key != "src/main.go::Hello#0" {
+		t.Errorf("key = %q, want %q", key, "src/main.go::Hello#0")
+	}
+}
+
+func TestComputeStableKeySectionChunk(t *testing.T) {
+	chunk := Chunk{
+		ID:      "abc",
+		Content: "## Getting Started\nSome text...",
+		Source:  "/workspace/docs/README.md",
+		Metadata: map[string]string{
+			"section":       "Getting Started",
+			"section_path":  "Getting Started",
+			"chunk_ordinal": "0",
+		},
+	}
+
+	key, err := ComputeStableKey(chunk, "/workspace")
+	if err != nil {
+		t.Fatalf("ComputeStableKey() error: %v", err)
+	}
+	if key != "docs/README.md::Getting Started#0" {
+		t.Errorf("key = %q, want %q", key, "docs/README.md::Getting Started#0")
+	}
+}
+
+func TestComputeStableKeyFallbackChunk(t *testing.T) {
+	chunk := Chunk{
+		ID:      "abc",
+		Content: "some random text",
+		Source:  "/workspace/data/notes.txt",
+		Metadata: map[string]string{
+			"anchor_hash":   "deadbeef01234567",
+			"chunk_ordinal": "2",
+		},
+	}
+
+	key, err := ComputeStableKey(chunk, "/workspace")
+	if err != nil {
+		t.Fatalf("ComputeStableKey() error: %v", err)
+	}
+	if key != "data/notes.txt::deadbeef01234567#2" {
+		t.Errorf("key = %q, want %q", key, "data/notes.txt::deadbeef01234567#2")
+	}
+}
+
+func TestComputeStableKeyEmptyWorkspaceRoot(t *testing.T) {
+	chunk := Chunk{
+		ID:       "abc",
+		Content:  "test",
+		Source:   "/workspace/test.go",
+		Metadata: map[string]string{"symbol_path": "Foo", "chunk_ordinal": "0"},
+	}
+
+	_, err := ComputeStableKey(chunk, "")
+	if err == nil {
+		t.Fatal("expected error for empty workspaceRoot")
+	}
+}
+
+func TestComputeStableKeyNoMetadata(t *testing.T) {
+	chunk := Chunk{
+		ID:       "abc",
+		Content:  "test",
+		Source:   "/workspace/test.go",
+		Metadata: map[string]string{},
+	}
+
+	_, err := ComputeStableKey(chunk, "/workspace")
+	if err == nil {
+		t.Fatal("expected error for chunk with no stable key metadata")
+	}
+}
+
+func TestComputeStableKeyDeterministic(t *testing.T) {
+	chunk := Chunk{
+		ID:      "abc",
+		Content: "func Foo() {}",
+		Source:  "/workspace/main.go",
+		Metadata: map[string]string{
+			"symbol_path":   "Foo",
+			"chunk_ordinal": "0",
+		},
+	}
+
+	key1, err := ComputeStableKey(chunk, "/workspace")
+	if err != nil {
+		t.Fatalf("first call error: %v", err)
+	}
+	key2, err := ComputeStableKey(chunk, "/workspace")
+	if err != nil {
+		t.Fatalf("second call error: %v", err)
+	}
+	if key1 != key2 {
+		t.Errorf("not deterministic: %q != %q", key1, key2)
+	}
+}
+
+func TestComputeStableKeyPathNormalization(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  string
+		root    string
+		wantKey string
+	}{
+		{
+			name:    "trailing slash on root",
+			source:  "/workspace/src/main.go",
+			root:    "/workspace/",
+			wantKey: "src/main.go::Foo#0",
+		},
+		{
+			name:    "double slash in root",
+			source:  "/workspace/src/main.go",
+			root:    "/workspace//",
+			wantKey: "src/main.go::Foo#0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chunk := Chunk{
+				ID:      "abc",
+				Content: "func Foo() {}",
+				Source:  tt.source,
+				Metadata: map[string]string{
+					"symbol_path":   "Foo",
+					"chunk_ordinal": "0",
+				},
+			}
+			key, err := ComputeStableKey(chunk, tt.root)
+			if err != nil {
+				t.Fatalf("error: %v", err)
+			}
+			if key != tt.wantKey {
+				t.Errorf("key = %q, want %q", key, tt.wantKey)
+			}
+		})
+	}
+}
+
+func TestComputeStableKeyDefaultOrdinal(t *testing.T) {
+	// When chunk_ordinal is missing, default to "0".
+	chunk := Chunk{
+		ID:      "abc",
+		Content: "func Bar() {}",
+		Source:  "/workspace/bar.go",
+		Metadata: map[string]string{
+			"symbol_path": "Bar",
+		},
+	}
+
+	key, err := ComputeStableKey(chunk, "/workspace")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if key != "bar.go::Bar#0" {
+		t.Errorf("key = %q, want %q", key, "bar.go::Bar#0")
+	}
+}
+
+func TestComputeStableKeySymbolPrecedence(t *testing.T) {
+	// When both symbol_path and section_path are present, symbol_path wins.
+	chunk := Chunk{
+		ID:      "abc",
+		Content: "func Baz() {}",
+		Source:  "/workspace/baz.go",
+		Metadata: map[string]string{
+			"symbol_path":   "Baz",
+			"section_path":  "Section",
+			"anchor_hash":   "deadbeef",
+			"chunk_ordinal": "0",
+		},
+	}
+
+	key, err := ComputeStableKey(chunk, "/workspace")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if !strings.HasPrefix(key, "baz.go::Baz#") {
+		t.Errorf("expected symbol_path to take precedence, got key = %q", key)
+	}
+}
+
+func TestLineShiftStability(t *testing.T) {
+	// Adding blank lines before a function should not change its StableKey.
+	// The key depends on the symbol name, not the line number.
+	root := "/workspace"
+
+	chunkBefore := Chunk{
+		ID:        "v1",
+		Content:   "func Stable() { return nil }",
+		Source:    filepath.Join(root, "file.go"),
+		StartLine: 10,
+		EndLine:   12,
+		Metadata: map[string]string{
+			"symbol":        "Stable",
+			"symbol_path":   "Stable",
+			"chunk_ordinal": "0",
+		},
+	}
+
+	chunkAfter := Chunk{
+		ID:        "v2",
+		Content:   "func Stable() { return nil }",
+		Source:    filepath.Join(root, "file.go"),
+		StartLine: 15, // shifted 5 lines
+		EndLine:   17,
+		Metadata: map[string]string{
+			"symbol":        "Stable",
+			"symbol_path":   "Stable",
+			"chunk_ordinal": "0",
+		},
+	}
+
+	keyBefore, err := ComputeStableKey(chunkBefore, root)
+	if err != nil {
+		t.Fatalf("before error: %v", err)
+	}
+	keyAfter, err := ComputeStableKey(chunkAfter, root)
+	if err != nil {
+		t.Fatalf("after error: %v", err)
+	}
+	if keyBefore != keyAfter {
+		t.Errorf("StableKey changed after line shift: %q != %q", keyBefore, keyAfter)
+	}
+}
+
+func TestExtractSymbolName(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		lang    string
+		want    string
+	}{
+		{"go func", "func Hello() {}", "go", "Hello"},
+		{"go method", "func (s *Server) Start() error {}", "go", "Start"},
+		{"python def", "def process_data():", "python", "process_data"},
+		{"python class", "class MyModel:", "python", "MyModel"},
+		{"ts function", "export function render() {}", "typescript", "render"},
+		{"ts class", "class Widget {}", "typescript", "Widget"},
+		{"ts const", "const config = {}", "typescript", "config"},
+		{"ts interface", "interface Props {}", "typescript", "Props"},
+		{"js function", "function init() {}", "javascript", "init"},
+		{"rust fn", "fn calculate() {}", "rust", "calculate"},
+		{"rust pub fn", "pub fn serve() {}", "rust", "serve"},
+		{"rust struct", "struct Config {}", "rust", "Config"},
+		{"ruby def", "def process\nend", "ruby", "process"},
+		{"ruby class", "class Worker\nend", "ruby", "Worker"},
+		{"unknown lang", "func Hello() {}", "unknown", ""},
+		{"no match", "// just a comment", "go", ""},
+		{"multiline finds first", "// comment\nfunc First() {}\nfunc Second() {}", "go", "First"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractSymbolName(tt.content, tt.lang)
+			if got != tt.want {
+				t.Errorf("extractSymbolName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAnchorHashDeterministic(t *testing.T) {
+	h1 := anchorHash("hello world\nfoo bar")
+	h2 := anchorHash("hello world\nfoo bar")
+	if h1 != h2 {
+		t.Errorf("anchorHash not deterministic: %q != %q", h1, h2)
+	}
+}
+
+func TestAnchorHashWhitespaceResilience(t *testing.T) {
+	// Same content with extra leading/trailing whitespace per line.
+	h1 := anchorHash("hello\n  world\n")
+	h2 := anchorHash("  hello  \n  world  \n")
+	if h1 != h2 {
+		t.Errorf("anchorHash changed with whitespace: %q != %q", h1, h2)
+	}
+}
+
+func TestAnchorHashBlankLineCollapse(t *testing.T) {
+	h1 := anchorHash("a\n\nb")
+	h2 := anchorHash("a\n\n\n\nb")
+	if h1 != h2 {
+		t.Errorf("anchorHash changed with extra blank lines: %q != %q", h1, h2)
+	}
+}
+
+func TestAnchorHashDifferentContent(t *testing.T) {
+	h1 := anchorHash("hello world")
+	h2 := anchorHash("goodbye world")
+	if h1 == h2 {
+		t.Error("anchorHash should differ for different content")
+	}
+}
+
+func TestPopulateCodeChunkMetadata(t *testing.T) {
+	chunks := []Chunk{
+		{Content: "func Alpha() {}", Metadata: make(map[string]string)},
+		{Content: "func Beta() {}", Metadata: make(map[string]string)},
+		{Content: "// just a comment", Metadata: make(map[string]string)},
+		{Content: "func Alpha() { return 2 }", Metadata: make(map[string]string)}, // duplicate symbol
+	}
+
+	populateCodeChunkMetadata(chunks, "go")
+
+	// Alpha, Beta, unknown, Alpha
+	expected := []struct {
+		symbol  string
+		ordinal string
+	}{
+		{"Alpha", "0"},
+		{"Beta", "0"},
+		{"unknown", "0"},
+		{"Alpha", "1"}, // second Alpha gets ordinal 1
+	}
+
+	for i, exp := range expected {
+		if chunks[i].Metadata["symbol"] != exp.symbol {
+			t.Errorf("chunk %d symbol = %q, want %q", i, chunks[i].Metadata["symbol"], exp.symbol)
+		}
+		if chunks[i].Metadata["symbol_path"] != exp.symbol {
+			t.Errorf("chunk %d symbol_path = %q, want %q", i, chunks[i].Metadata["symbol_path"], exp.symbol)
+		}
+		if chunks[i].Metadata["chunk_ordinal"] != exp.ordinal {
+			t.Errorf("chunk %d chunk_ordinal = %q, want %q", i, chunks[i].Metadata["chunk_ordinal"], exp.ordinal)
+		}
+	}
+}
+
+func TestPopulateSlidingWindowMetadata(t *testing.T) {
+	chunks := []Chunk{
+		{Content: "first chunk content", Metadata: make(map[string]string)},
+		{Content: "second chunk content", Metadata: make(map[string]string)},
+		{Content: "third chunk content", Metadata: make(map[string]string)},
+	}
+
+	populateSlidingWindowMetadata(chunks)
+
+	for i, chunk := range chunks {
+		if chunk.Metadata["anchor_hash"] == "" {
+			t.Errorf("chunk %d missing anchor_hash", i)
+		}
+		expected := fmt.Sprintf("%d", i)
+		if chunk.Metadata["chunk_ordinal"] != expected {
+			t.Errorf("chunk %d chunk_ordinal = %q, want %q", i, chunk.Metadata["chunk_ordinal"], expected)
+		}
+	}
+
+	// Anchor hashes should differ for different content.
+	if chunks[0].Metadata["anchor_hash"] == chunks[1].Metadata["anchor_hash"] {
+		t.Error("different chunks should have different anchor hashes")
+	}
+}
+
+func TestCodeChunkerPopulatesMetadata(t *testing.T) {
+	content := "func Alpha() {\n\treturn 1\n}\n\nfunc Beta() {\n\treturn 2\n}\n"
+	chunker := NewCodeChunker(WithMaxChunkSize(500))
+	chunks, err := chunker.Chunk("/workspace/funcs.go", content)
+	if err != nil {
+		t.Fatalf("Chunk() error: %v", err)
+	}
+
+	if len(chunks) == 0 {
+		t.Fatal("expected at least one chunk")
+	}
+
+	for i, chunk := range chunks {
+		if chunk.Metadata["symbol"] == "" {
+			t.Errorf("chunk %d missing symbol metadata", i)
+		}
+		if chunk.Metadata["symbol_path"] == "" {
+			t.Errorf("chunk %d missing symbol_path metadata", i)
+		}
+		if chunk.Metadata["chunk_ordinal"] == "" {
+			t.Errorf("chunk %d missing chunk_ordinal metadata", i)
+		}
+	}
+}
+
+func TestSlidingWindowChunkerPopulatesMetadata(t *testing.T) {
+	content := strings.Repeat("line of text\n", 20)
+	sw, err := NewSlidingWindowChunker(100, 20)
+	if err != nil {
+		t.Fatalf("NewSlidingWindowChunker() error: %v", err)
+	}
+
+	chunks, err := sw.Chunk("test.txt", content)
+	if err != nil {
+		t.Fatalf("Chunk() error: %v", err)
+	}
+
+	if len(chunks) == 0 {
+		t.Fatal("expected at least one chunk")
+	}
+
+	for i, chunk := range chunks {
+		if chunk.Metadata["anchor_hash"] == "" {
+			t.Errorf("chunk %d missing anchor_hash metadata", i)
+		}
+		if chunk.Metadata["chunk_ordinal"] == "" {
+			t.Errorf("chunk %d missing chunk_ordinal metadata", i)
+		}
+	}
+}
+
+func TestStableKeyStoreRoundTrip(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	chunks := []Chunk{
+		{
+			ID:        "c1",
+			Content:   "func Hello() {}",
+			Source:    "/workspace/main.go",
+			StartLine: 1,
+			EndLine:   1,
+			Language:  "go",
+			Metadata:  map[string]string{"symbol_path": "Hello", "chunk_ordinal": "0"},
+			StableKey: "main.go::Hello#0",
+		},
+		{
+			ID:        "c2",
+			Content:   "func World() {}",
+			Source:    "/workspace/main.go",
+			StartLine: 3,
+			EndLine:   3,
+			Language:  "go",
+			Metadata:  map[string]string{"symbol_path": "World", "chunk_ordinal": "0"},
+			StableKey: "main.go::World#0",
+		},
+	}
+	embeddings := [][]float64{
+		{1.0, 0.0, 0.0},
+		{0.0, 1.0, 0.0},
+	}
+
+	if err := store.Store(ctx, chunks, embeddings); err != nil {
+		t.Fatalf("Store() error: %v", err)
+	}
+
+	// Verify StableKey survives Search round-trip.
+	results, err := store.Search(ctx, []float64{1.0, 0.0, 0.0}, 10)
+	if err != nil {
+		t.Fatalf("Search() error: %v", err)
+	}
+
+	keyMap := make(map[string]string)
+	for _, r := range results {
+		keyMap[r.Chunk.ID] = r.Chunk.StableKey
+	}
+
+	if keyMap["c1"] != "main.go::Hello#0" {
+		t.Errorf("c1 StableKey = %q, want %q", keyMap["c1"], "main.go::Hello#0")
+	}
+	if keyMap["c2"] != "main.go::World#0" {
+		t.Errorf("c2 StableKey = %q, want %q", keyMap["c2"], "main.go::World#0")
+	}
+}
+
+func TestStableKeySearchMultiRoundTrip(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	chunks := []Chunk{
+		{
+			ID:        "c1",
+			Content:   "func Alpha() {}",
+			Source:    "/workspace/alpha.go",
+			StartLine: 1,
+			EndLine:   1,
+			Language:  "go",
+			Metadata:  map[string]string{"symbol_path": "Alpha", "chunk_ordinal": "0"},
+			StableKey: "alpha.go::Alpha#0",
+		},
+	}
+	embeddings := [][]float64{{1.0, 0.0, 0.0}}
+
+	if err := store.Store(ctx, chunks, embeddings); err != nil {
+		t.Fatalf("Store() error: %v", err)
+	}
+
+	// SearchMulti should also return StableKey.
+	results, err := store.SearchMulti(ctx, []float64{1.0, 0.0, 0.0}, "alpha", 10, QueryContext{})
+	if err != nil {
+		t.Fatalf("SearchMulti() error: %v", err)
+	}
+
+	if len(results) == 0 {
+		t.Fatal("expected at least one result")
+	}
+	if results[0].Chunk.StableKey != "alpha.go::Alpha#0" {
+		t.Errorf("SearchMulti StableKey = %q, want %q", results[0].Chunk.StableKey, "alpha.go::Alpha#0")
+	}
+}
+
+func TestStableKeyExportRoundTrip(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	chunks := []Chunk{
+		{
+			ID:        "c1",
+			Content:   "func Export() {}",
+			Source:    "/workspace/export.go",
+			StartLine: 1,
+			EndLine:   1,
+			Language:  "go",
+			Metadata:  map[string]string{"symbol_path": "Export", "chunk_ordinal": "0"},
+			StableKey: "export.go::Export#0",
+		},
+	}
+	embeddings := [][]float64{{1.0, 0.0, 0.0}}
+
+	if err := store.Store(ctx, chunks, embeddings); err != nil {
+		t.Fatalf("Store() error: %v", err)
+	}
+
+	seq, err := store.ExportChunks(ctx, nil)
+	if err != nil {
+		t.Fatalf("ExportChunks() error: %v", err)
+	}
+
+	var exported []ExportedChunk
+	for ec, iterErr := range seq {
+		if iterErr != nil {
+			t.Fatalf("iteration error: %v", iterErr)
+		}
+		exported = append(exported, ec)
+	}
+
+	if len(exported) != 1 {
+		t.Fatalf("expected 1 exported chunk, got %d", len(exported))
+	}
+	if exported[0].Chunk.StableKey != "export.go::Export#0" {
+		t.Errorf("exported StableKey = %q, want %q", exported[0].Chunk.StableKey, "export.go::Export#0")
+	}
+}
+
+func TestStableKeyReplaceSourcePreservesKey(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	chunks := []Chunk{
+		{
+			ID:        "c1",
+			Content:   "func Replace() {}",
+			Source:    "replace.go",
+			StartLine: 1,
+			EndLine:   1,
+			Language:  "go",
+			Metadata:  map[string]string{},
+			StableKey: "replace.go::Replace#0",
+		},
+	}
+	if err := store.Store(ctx, chunks, [][]float64{{1.0, 0.0}}); err != nil {
+		t.Fatalf("Store() error: %v", err)
+	}
+
+	// Replace with updated content but same StableKey.
+	replacement := []Chunk{
+		{
+			ID:        "c1-v2",
+			Content:   "func Replace() { return 42 }",
+			Source:    "replace.go",
+			StartLine: 1,
+			EndLine:   1,
+			Language:  "go",
+			Metadata:  map[string]string{},
+			StableKey: "replace.go::Replace#0",
+		},
+	}
+	if err := store.ReplaceSource(ctx, "replace.go", replacement, [][]float64{{0.5, 0.5}}); err != nil {
+		t.Fatalf("ReplaceSource() error: %v", err)
+	}
+
+	results, err := store.Search(ctx, []float64{0.5, 0.5}, 1)
+	if err != nil {
+		t.Fatalf("Search() error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Chunk.StableKey != "replace.go::Replace#0" {
+		t.Errorf("StableKey = %q, want %q", results[0].Chunk.StableKey, "replace.go::Replace#0")
+	}
+}
+
+func TestIndexerStableKeyWithWorkspaceRoot(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/embed" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		emb := make([]float64, 4)
+		emb[0] = 0.5
+		resp := ollama.EmbedResponse{Embeddings: [][]float64{emb}}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	store, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("NewSQLiteStore() error: %v", err)
+	}
+	defer store.Close()
+
+	tmpDir := t.TempDir()
+	goFile := filepath.Join(tmpDir, "main.go")
+	os.WriteFile(goFile, []byte("package main\n\nfunc Hello() {\n\treturn\n}\n"), 0644)
+
+	idx := NewIndexer(client, store,
+		WithEmbeddingModel("test-embed"),
+		WithWorkspaceRoot(tmpDir),
+	)
+
+	if err := idx.IndexFile(context.Background(), goFile); err != nil {
+		t.Fatalf("IndexFile() error: %v", err)
+	}
+
+	results, err := store.Search(context.Background(), []float64{1, 0, 0, 0}, 10)
+	if err != nil {
+		t.Fatalf("Search() error: %v", err)
+	}
+
+	if len(results) == 0 {
+		t.Fatal("expected at least one result")
+	}
+
+	// At least one chunk should have a StableKey.
+	hasKey := false
+	for _, r := range results {
+		if r.Chunk.StableKey != "" {
+			hasKey = true
+			// Should start with "main.go::"
+			if !strings.HasPrefix(r.Chunk.StableKey, "main.go::") {
+				t.Errorf("StableKey = %q, expected prefix 'main.go::'", r.Chunk.StableKey)
+			}
+		}
+	}
+	if !hasKey {
+		t.Error("no chunks have StableKey set after indexing with workspace root")
+	}
+}
+
+func TestIndexerStableKeyWithoutWorkspaceRoot(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/embed" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		emb := make([]float64, 4)
+		emb[0] = 0.5
+		resp := ollama.EmbedResponse{Embeddings: [][]float64{emb}}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	store, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("NewSQLiteStore() error: %v", err)
+	}
+	defer store.Close()
+
+	tmpDir := t.TempDir()
+	goFile := filepath.Join(tmpDir, "main.go")
+	os.WriteFile(goFile, []byte("package main\n\nfunc Hello() {\n\treturn\n}\n"), 0644)
+
+	// No WithWorkspaceRoot -- StableKey should be empty.
+	idx := NewIndexer(client, store, WithEmbeddingModel("test-embed"))
+
+	if err := idx.IndexFile(context.Background(), goFile); err != nil {
+		t.Fatalf("IndexFile() error: %v", err)
+	}
+
+	results, err := store.Search(context.Background(), []float64{1, 0, 0, 0}, 10)
+	if err != nil {
+		t.Fatalf("Search() error: %v", err)
+	}
+
+	for _, r := range results {
+		if r.Chunk.StableKey != "" {
+			t.Errorf("expected empty StableKey without workspace root, got %q", r.Chunk.StableKey)
+		}
+	}
+}
+
+func TestIndexDirectoryStableKeyConsistency(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/embed" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		emb := make([]float64, 4)
+		emb[0] = 0.5
+		resp := ollama.EmbedResponse{Embeddings: [][]float64{emb}}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	store, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("NewSQLiteStore() error: %v", err)
+	}
+	defer store.Close()
+
+	tmpDir := t.TempDir()
+	subDir := filepath.Join(tmpDir, "pkg")
+	os.MkdirAll(subDir, 0755)
+	os.WriteFile(filepath.Join(subDir, "util.go"), []byte("package pkg\n\nfunc Helper() {\n\treturn\n}\n"), 0644)
+
+	idx := NewIndexer(client, store, WithEmbeddingModel("test-embed"))
+
+	if err := idx.IndexDirectory(context.Background(), tmpDir); err != nil {
+		t.Fatalf("IndexDirectory() error: %v", err)
+	}
+
+	results, err := store.Search(context.Background(), []float64{1, 0, 0, 0}, 10)
+	if err != nil {
+		t.Fatalf("Search() error: %v", err)
+	}
+
+	// All chunks should have StableKeys with "pkg/util.go" prefix.
+	for _, r := range results {
+		if r.Chunk.StableKey == "" {
+			t.Error("chunk has empty StableKey after IndexDirectory")
+			continue
+		}
+		if !strings.HasPrefix(r.Chunk.StableKey, "pkg/util.go::") {
+			t.Errorf("StableKey = %q, expected prefix 'pkg/util.go::'", r.Chunk.StableKey)
+		}
+	}
+}
+
+func TestIndexFileAndIndexDirectoryProduceSameKey(t *testing.T) {
+	// IndexFile with explicit workspace root should produce the same key
+	// as IndexDirectory using that directory as root.
+	content := "package main\n\nfunc Consistent() {\n\treturn\n}\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/embed" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		emb := make([]float64, 4)
+		emb[0] = 0.5
+		resp := ollama.EmbedResponse{Embeddings: [][]float64{emb}}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+
+	tmpDir := t.TempDir()
+	goFile := filepath.Join(tmpDir, "consistent.go")
+	os.WriteFile(goFile, []byte(content), 0644)
+
+	// Method 1: IndexFile with explicit workspace root.
+	store1, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("store1 error: %v", err)
+	}
+	defer store1.Close()
+
+	idx1 := NewIndexer(client, store1,
+		WithEmbeddingModel("test-embed"),
+		WithWorkspaceRoot(tmpDir),
+	)
+	if err := idx1.IndexFile(context.Background(), goFile); err != nil {
+		t.Fatalf("IndexFile() error: %v", err)
+	}
+
+	// Method 2: IndexDirectory with the same directory.
+	store2, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("store2 error: %v", err)
+	}
+	defer store2.Close()
+
+	idx2 := NewIndexer(client, store2, WithEmbeddingModel("test-embed"))
+	if err := idx2.IndexDirectory(context.Background(), tmpDir); err != nil {
+		t.Fatalf("IndexDirectory() error: %v", err)
+	}
+
+	results1, _ := store1.Search(context.Background(), []float64{1, 0, 0, 0}, 10)
+	results2, _ := store2.Search(context.Background(), []float64{1, 0, 0, 0}, 10)
+
+	if len(results1) == 0 || len(results2) == 0 {
+		t.Fatal("expected results from both methods")
+	}
+
+	// Collect stable keys from each.
+	keys1 := make(map[string]bool)
+	for _, r := range results1 {
+		if r.Chunk.StableKey != "" {
+			keys1[r.Chunk.StableKey] = true
+		}
+	}
+	keys2 := make(map[string]bool)
+	for _, r := range results2 {
+		if r.Chunk.StableKey != "" {
+			keys2[r.Chunk.StableKey] = true
+		}
+	}
+
+	// At least one key should match between the two methods.
+	matched := false
+	for k := range keys1 {
+		if keys2[k] {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		t.Errorf("no matching StableKeys between IndexFile and IndexDirectory\nIndexFile keys: %v\nIndexDirectory keys: %v", keys1, keys2)
+	}
+}
+
+func TestMigrationV3StableKeyColumn(t *testing.T) {
+	store := newTestStore(t)
+
+	// Verify stable_key column exists.
+	_, err := store.db.Exec(
+		`INSERT INTO chunks (id, content, source, start_line, end_line, language, metadata, embedding, indexed_at, stable_key)
+		 VALUES ('test', 'content', 'src.go', 1, 1, 'go', '{}', '[]', 12345, 'src.go::Test#0')`,
+	)
+	if err != nil {
+		t.Fatalf("insert with stable_key: %v", err)
+	}
+
+	var stableKey string
+	err = store.db.QueryRow(`SELECT stable_key FROM chunks WHERE id = 'test'`).Scan(&stableKey)
+	if err != nil {
+		t.Fatalf("query stable_key: %v", err)
+	}
+	if stableKey != "src.go::Test#0" {
+		t.Errorf("stable_key = %q, want %q", stableKey, "src.go::Test#0")
+	}
+
+	// Verify the index exists.
+	var indexCount int
+	err = store.db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_chunks_stable_key'`,
+	).Scan(&indexCount)
+	if err != nil {
+		t.Fatalf("query index: %v", err)
+	}
+	if indexCount != 1 {
+		t.Error("idx_chunks_stable_key index does not exist")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `StableKey` field to `rag.Chunk` -- a logical identity that survives re-indexing and benign line shifts
- `ComputeStableKey()` derives keys from workspace-relative path + symbol/section/anchor metadata
- Code chunks: `{rel_path}::{symbol_path}#{ordinal}`, text: `{rel_path}::{section_path}#{ordinal}`, fallback: `{rel_path}::{anchor_hash}#{ordinal}`
- Path normalization: `filepath.Abs` + `filepath.Clean`, forward-slash separators, no leading `./`
- v3 schema migration adds `stable_key` column with index
- StableKey persisted through Store/Search/SearchMulti/Export round-trips
- Chunkers now populate required metadata: `symbol`, `symbol_path`, `section`, `anchor_hash`, `chunk_ordinal`
- `IndexDirectory` auto-sets workspace root; `IndexFile` uses explicit `WithWorkspaceRoot()` option

Closes #30

## Test plan

- [x] `go test ./rag/... -count=1` -- all tests pass
- [x] `go test ./... -count=1` -- no regressions
- [x] `go vet ./rag/...` -- clean
- [x] Deterministic key tests, line-shift stability, path normalization
- [x] Store/Search/SearchMulti round-trip tests

Generated with [Claude Code](https://claude.com/claude-code)