### PR TITLE
feat(feedback): add behavioral feedback collector (issue #31)

### DIFF
--- a/feedback/collector.go
+++ b/feedback/collector.go
@@ -229,6 +229,9 @@ func (c *Collector) sweepLoop() {
 }
 
 // sweepExpired checks all open windows and expires those past maxWindowAge.
+// Weak-negative signals are written for non-interacted chunks, the signal
+// counter is bumped, and aggregates are recomputed so the penalties take
+// effect immediately.
 func (c *Collector) sweepExpired() {
 	now := time.Now()
 	c.mu.Lock()
@@ -242,12 +245,19 @@ func (c *Collector) sweepExpired() {
 	c.mu.Unlock()
 
 	ctx := context.Background()
+	var written int
 	for _, w := range expired {
 		for _, key := range w.chunkKeys {
 			if !w.interacted[key] {
 				_ = c.store.InsertSignal(ctx, w.retrievalID, key, "window_expired", weakNegative)
+				written++
 			}
 		}
+	}
+
+	if written > 0 {
+		c.signalCount.Add(int64(written))
+		_ = c.store.RecomputeAggregates(ctx, c.config.DecayLambda)
 	}
 }
 

--- a/feedback/collector.go
+++ b/feedback/collector.go
@@ -1,0 +1,261 @@
+package feedback
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	// maxWindowAge is the maximum duration an attribution window stays open.
+	maxWindowAge = 300 * time.Second
+
+	// sweepInterval is how often the background goroutine checks for
+	// expired attribution windows.
+	sweepInterval = 60 * time.Second
+
+	// recomputeInterval is the number of signals between automatic
+	// aggregate recomputation.
+	recomputeInterval = 100
+
+	// weakNegative is the strength applied to chunks in an expired window
+	// that received no interaction.
+	weakNegative = -0.1
+)
+
+// attributionWindow tracks an open retrieval for signal attribution.
+type attributionWindow struct {
+	retrievalID string
+	chunkKeys   []string
+	interacted  map[string]bool
+	createdAt   time.Time
+}
+
+// Collector orchestrates behavioral feedback collection. It manages
+// attribution windows, delegates persistence to a SignalStore, and
+// runs background maintenance.
+type Collector struct {
+	store  SignalStore
+	config CollectorConfig
+
+	mu      sync.Mutex
+	windows map[string]*attributionWindow
+
+	signalCount atomic.Int64
+	closeOnce   sync.Once
+	done        chan struct{}
+	wg          sync.WaitGroup
+}
+
+// NewCollector creates a Collector backed by the given store and config.
+// A background goroutine is started to sweep expired attribution windows;
+// call Close to stop it.
+func NewCollector(store SignalStore, config CollectorConfig) *Collector {
+	cfg := config.withDefaults()
+	c := &Collector{
+		store:   store,
+		config:  cfg,
+		windows: make(map[string]*attributionWindow),
+		done:    make(chan struct{}),
+	}
+	c.wg.Add(1)
+	go c.sweepLoop()
+	return c
+}
+
+// Close stops the background goroutine and waits for it to finish.
+// Close is safe to call multiple times.
+func (c *Collector) Close() {
+	c.closeOnce.Do(func() {
+		close(c.done)
+	})
+	c.wg.Wait()
+}
+
+// RegisterRetrieval opens an attribution window for the given query and
+// chunk keys. It returns a unique retrieval ID.
+func (c *Collector) RegisterRetrieval(ctx context.Context, query string, chunkKeys []string) (string, error) {
+	id, err := generateID()
+	if err != nil {
+		return "", fmt.Errorf("feedback: generate retrieval id: %w", err)
+	}
+
+	if err := c.store.InsertRetrieval(ctx, id, query, chunkKeys); err != nil {
+		return "", err
+	}
+
+	if err := c.store.IncrementRetrievalCount(ctx, chunkKeys); err != nil {
+		return "", err
+	}
+
+	c.mu.Lock()
+	c.windows[id] = &attributionWindow{
+		retrievalID: id,
+		chunkKeys:   chunkKeys,
+		interacted:  make(map[string]bool),
+		createdAt:   time.Now(),
+	}
+	c.mu.Unlock()
+
+	return id, nil
+}
+
+// Record persists a signal against an open attribution window.
+func (c *Collector) Record(ctx context.Context, signal Signal) error {
+	if signal.RetrievalID == "" {
+		return fmt.Errorf("feedback: record: retrieval id is required")
+	}
+
+	c.mu.Lock()
+	w, ok := c.windows[signal.RetrievalID]
+	if ok {
+		// Mark interacted chunk keys.
+		for _, k := range signal.ChunkKeys {
+			w.interacted[k] = true
+		}
+		// If no explicit chunk keys, mark all.
+		if len(signal.ChunkKeys) == 0 {
+			for _, k := range w.chunkKeys {
+				w.interacted[k] = true
+			}
+		}
+	}
+	c.mu.Unlock()
+
+	if !ok {
+		return fmt.Errorf("feedback: record: unknown retrieval id %q", signal.RetrievalID)
+	}
+
+	strength := signal.effectiveStrength()
+
+	// Determine which chunk keys to record against.
+	keys := signal.ChunkKeys
+	if len(keys) == 0 {
+		keys = w.chunkKeys
+	}
+
+	for _, key := range keys {
+		if err := c.store.InsertSignal(ctx, signal.RetrievalID, key, signal.Kind, strength); err != nil {
+			return err
+		}
+	}
+
+	newCount := c.signalCount.Add(int64(len(keys)))
+	if newCount%recomputeInterval == 0 {
+		// Trigger async recomputation (best effort).
+		go func() {
+			_ = c.store.RecomputeAggregates(context.Background(), c.config.DecayLambda)
+		}()
+	}
+
+	return nil
+}
+
+// Weights returns the behavioral weight for a single chunk key.
+// Returns 0.0 if the system is in cold-start or the chunk is below
+// MinRetrievals.
+func (c *Collector) Weights(ctx context.Context, chunkKey string) (float64, error) {
+	totalSignals, err := c.store.SignalCount(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if totalSignals < c.config.WarmupSignals {
+		return 0, nil
+	}
+
+	agg, err := c.store.GetAggregate(ctx, chunkKey)
+	if err != nil {
+		return 0, err
+	}
+	if agg.RetrievalCount < c.config.MinRetrievals {
+		return 0, nil
+	}
+
+	return agg.WeightedScore, nil
+}
+
+// WeightsBatch returns behavioral weights for multiple chunk keys in one
+// query. Keys that are below MinRetrievals or that have no aggregate return
+// 0.0.
+func (c *Collector) WeightsBatch(ctx context.Context, chunkKeys []string) (map[string]float64, error) {
+	result := make(map[string]float64, len(chunkKeys))
+	for _, k := range chunkKeys {
+		result[k] = 0
+	}
+
+	totalSignals, err := c.store.SignalCount(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if totalSignals < c.config.WarmupSignals {
+		return result, nil
+	}
+
+	aggs, err := c.store.GetAggregatesBatch(ctx, chunkKeys)
+	if err != nil {
+		return nil, err
+	}
+
+	for k, agg := range aggs {
+		if agg.RetrievalCount >= c.config.MinRetrievals {
+			result[k] = agg.WeightedScore
+		}
+	}
+
+	return result, nil
+}
+
+// sweepLoop runs in a goroutine, expiring attribution windows and applying
+// weak negatives for non-interacted chunks.
+func (c *Collector) sweepLoop() {
+	defer c.wg.Done()
+	ticker := time.NewTicker(sweepInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.done:
+			// Final sweep on shutdown.
+			c.sweepExpired()
+			return
+		case <-ticker.C:
+			c.sweepExpired()
+		}
+	}
+}
+
+// sweepExpired checks all open windows and expires those past maxWindowAge.
+func (c *Collector) sweepExpired() {
+	now := time.Now()
+	c.mu.Lock()
+	var expired []*attributionWindow
+	for id, w := range c.windows {
+		if now.Sub(w.createdAt) >= maxWindowAge {
+			expired = append(expired, w)
+			delete(c.windows, id)
+		}
+	}
+	c.mu.Unlock()
+
+	ctx := context.Background()
+	for _, w := range expired {
+		for _, key := range w.chunkKeys {
+			if !w.interacted[key] {
+				_ = c.store.InsertSignal(ctx, w.retrievalID, key, "window_expired", weakNegative)
+			}
+		}
+	}
+}
+
+// generateID returns a random 16-byte hex string.
+func generateID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("feedback: read random bytes: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/feedback/collector.go
+++ b/feedback/collector.go
@@ -92,10 +92,14 @@ func (c *Collector) RegisterRetrieval(ctx context.Context, query string, chunkKe
 		return "", err
 	}
 
+	// Defensive copy so callers cannot mutate the window's key set.
+	keysCopy := make([]string, len(chunkKeys))
+	copy(keysCopy, chunkKeys)
+
 	c.mu.Lock()
 	c.windows[id] = &attributionWindow{
 		retrievalID: id,
-		chunkKeys:   chunkKeys,
+		chunkKeys:   keysCopy,
 		interacted:  make(map[string]bool),
 		createdAt:   time.Now(),
 	}
@@ -139,7 +143,7 @@ func (c *Collector) Record(ctx context.Context, signal Signal) error {
 	}
 
 	for _, key := range keys {
-		if err := c.store.InsertSignal(ctx, signal.RetrievalID, key, signal.Kind, strength); err != nil {
+		if err := c.store.InsertSignal(ctx, signal.RetrievalID, key, signal.Kind, strength, signal.Timestamp); err != nil {
 			return err
 		}
 	}
@@ -249,7 +253,7 @@ func (c *Collector) sweepExpired() {
 	for _, w := range expired {
 		for _, key := range w.chunkKeys {
 			if !w.interacted[key] {
-				_ = c.store.InsertSignal(ctx, w.retrievalID, key, "window_expired", weakNegative)
+				_ = c.store.InsertSignal(ctx, w.retrievalID, key, "window_expired", weakNegative, time.Time{})
 				written++
 			}
 		}

--- a/feedback/collector_config.go
+++ b/feedback/collector_config.go
@@ -1,0 +1,51 @@
+package feedback
+
+// CollectorConfig tunes the behavioral feedback collector.
+//
+// A zero-valued config is valid: MinRetrievals=0 means no minimum,
+// WarmupSignals=0 means no warmup phase, DecayLambda=0 means no decay.
+// Use DefaultConfig() when you want the recommended defaults, or set
+// MinRetrievals/WarmupSignals/DecayLambda to -1 to request the default
+// for individual fields while leaving others at zero.
+type CollectorConfig struct {
+	// MinRetrievals is the minimum number of retrievals a chunk must appear
+	// in before its weight is considered meaningful. Chunks below this
+	// threshold return a weight of 0.0.
+	MinRetrievals int
+
+	// WarmupSignals is the total signal count below which the system is
+	// considered to be in a cold-start phase. During warmup, all chunk
+	// weights return 0.0.
+	WarmupSignals int
+
+	// DecayLambda controls the exponential time-decay applied when
+	// recomputing aggregate scores. Higher values cause older signals to
+	// lose influence faster.
+	DecayLambda float64
+}
+
+// DefaultConfig returns a CollectorConfig populated with sensible defaults.
+func DefaultConfig() CollectorConfig {
+	return CollectorConfig{
+		MinRetrievals: 5,
+		WarmupSignals: 100,
+		DecayLambda:   0.1,
+	}
+}
+
+// withDefaults returns a copy of cfg where any negative field has been
+// replaced with the corresponding default. Zero values are left as-is
+// since they carry meaning (e.g. no warmup, no minimum).
+func (cfg CollectorConfig) withDefaults() CollectorConfig {
+	d := DefaultConfig()
+	if cfg.MinRetrievals < 0 {
+		cfg.MinRetrievals = d.MinRetrievals
+	}
+	if cfg.WarmupSignals < 0 {
+		cfg.WarmupSignals = d.WarmupSignals
+	}
+	if cfg.DecayLambda < 0 {
+		cfg.DecayLambda = d.DecayLambda
+	}
+	return cfg
+}

--- a/feedback/collector_config_test.go
+++ b/feedback/collector_config_test.go
@@ -1,0 +1,59 @@
+package feedback
+
+import "testing"
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.MinRetrievals != 5 {
+		t.Errorf("MinRetrievals = %d, want 5", cfg.MinRetrievals)
+	}
+	if cfg.WarmupSignals != 100 {
+		t.Errorf("WarmupSignals = %d, want 100", cfg.WarmupSignals)
+	}
+	if cfg.DecayLambda != 0.1 {
+		t.Errorf("DecayLambda = %f, want 0.1", cfg.DecayLambda)
+	}
+}
+
+func TestWithDefaults(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  CollectorConfig
+		expect CollectorConfig
+	}{
+		{
+			name:   "all zeros preserved",
+			input:  CollectorConfig{},
+			expect: CollectorConfig{},
+		},
+		{
+			name:   "negative values replaced with defaults",
+			input:  CollectorConfig{MinRetrievals: -1, WarmupSignals: -1, DecayLambda: -1},
+			expect: DefaultConfig(),
+		},
+		{
+			name:   "partial negative replaced",
+			input:  CollectorConfig{MinRetrievals: -1, WarmupSignals: 50},
+			expect: CollectorConfig{MinRetrievals: 5, WarmupSignals: 50, DecayLambda: 0},
+		},
+		{
+			name:   "positive values preserved",
+			input:  CollectorConfig{MinRetrievals: 3, WarmupSignals: 50, DecayLambda: 0.05},
+			expect: CollectorConfig{MinRetrievals: 3, WarmupSignals: 50, DecayLambda: 0.05},
+		},
+		{
+			name:   "zero values are intentional",
+			input:  CollectorConfig{MinRetrievals: 0, WarmupSignals: 0, DecayLambda: 0},
+			expect: CollectorConfig{MinRetrievals: 0, WarmupSignals: 0, DecayLambda: 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.input.withDefaults()
+			if got != tt.expect {
+				t.Errorf("withDefaults() = %+v, want %+v", got, tt.expect)
+			}
+		})
+	}
+}

--- a/feedback/collector_test.go
+++ b/feedback/collector_test.go
@@ -3,6 +3,7 @@ package feedback
 import (
 	"context"
 	"testing"
+	"time"
 
 	_ "modernc.org/sqlite"
 )
@@ -330,6 +331,37 @@ func TestMultipleSignalsSameChunk(t *testing.T) {
 	// With decay=0, score = 0.8 + 0.6 + 0.3 = 1.7 exactly.
 	if w < 1.6 || w > 1.8 {
 		t.Errorf("Weights = %f, expected ~1.7", w)
+	}
+}
+
+func TestSweepExpiredTriggersRecompute(t *testing.T) {
+	// Verify that weak-negative signals written by sweepExpired are reflected
+	// in materialized aggregates immediately (not deferred to later Record).
+	store := newTestStore(t)
+	cfg := CollectorConfig{WarmupSignals: 0, MinRetrievals: 1, DecayLambda: 0.0}
+	c := NewCollector(store, cfg)
+	t.Cleanup(func() { c.Close() })
+	ctx := context.Background()
+
+	id, err := c.RegisterRetrieval(ctx, "q", []string{"chunk-1"})
+	if err != nil {
+		t.Fatalf("RegisterRetrieval: %v", err)
+	}
+
+	// Manually expire the window so sweepExpired writes weak negatives.
+	c.mu.Lock()
+	c.windows[id].createdAt = time.Now().Add(-2 * maxWindowAge)
+	c.mu.Unlock()
+
+	c.sweepExpired()
+
+	// The weak-negative should already be materialized in aggregates.
+	agg, err := store.GetAggregate(ctx, "chunk-1")
+	if err != nil {
+		t.Fatalf("GetAggregate: %v", err)
+	}
+	if agg.WeightedScore >= 0 {
+		t.Errorf("weighted_score = %f, expected negative after expiry sweep", agg.WeightedScore)
 	}
 }
 

--- a/feedback/collector_test.go
+++ b/feedback/collector_test.go
@@ -1,0 +1,347 @@
+package feedback
+
+import (
+	"context"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// newTestCollector creates a Collector backed by an in-memory SQLite store
+// with the given config. The collector is automatically closed on test
+// cleanup.
+func newTestCollector(t *testing.T, cfg CollectorConfig) *Collector {
+	t.Helper()
+	store := newTestStore(t)
+	c := NewCollector(store, cfg)
+	t.Cleanup(func() { c.Close() })
+	return c
+}
+
+func TestRegisterRetrievalReturnsID(t *testing.T) {
+	c := newTestCollector(t, CollectorConfig{})
+	ctx := context.Background()
+
+	id, err := c.RegisterRetrieval(ctx, "test query", []string{"chunk-1", "chunk-2"})
+	if err != nil {
+		t.Fatalf("RegisterRetrieval: %v", err)
+	}
+	if id == "" {
+		t.Error("expected non-empty retrieval ID")
+	}
+	if len(id) != 32 { // 16 bytes = 32 hex chars
+		t.Errorf("id length = %d, want 32", len(id))
+	}
+}
+
+func TestRegisterRetrievalUniqueIDs(t *testing.T) {
+	c := newTestCollector(t, CollectorConfig{})
+	ctx := context.Background()
+
+	id1, err := c.RegisterRetrieval(ctx, "q1", []string{"chunk-1"})
+	if err != nil {
+		t.Fatalf("RegisterRetrieval 1: %v", err)
+	}
+	id2, err := c.RegisterRetrieval(ctx, "q2", []string{"chunk-2"})
+	if err != nil {
+		t.Fatalf("RegisterRetrieval 2: %v", err)
+	}
+	if id1 == id2 {
+		t.Error("expected unique retrieval IDs")
+	}
+}
+
+func TestRecordAgainstOpenWindow(t *testing.T) {
+	c := newTestCollector(t, CollectorConfig{})
+	ctx := context.Background()
+
+	id, err := c.RegisterRetrieval(ctx, "q", []string{"chunk-1", "chunk-2"})
+	if err != nil {
+		t.Fatalf("RegisterRetrieval: %v", err)
+	}
+
+	err = c.Record(ctx, Signal{
+		Kind:        SignalCompletionAccepted,
+		RetrievalID: id,
+		ChunkKeys:   []string{"chunk-1"},
+	})
+	if err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+}
+
+func TestRecordUnknownWindow(t *testing.T) {
+	c := newTestCollector(t, CollectorConfig{})
+	ctx := context.Background()
+
+	err := c.Record(ctx, Signal{
+		Kind:        SignalCompletionAccepted,
+		RetrievalID: "nonexistent",
+		ChunkKeys:   []string{"chunk-1"},
+	})
+	if err == nil {
+		t.Error("expected error for unknown retrieval ID")
+	}
+}
+
+func TestRecordMissingRetrievalID(t *testing.T) {
+	c := newTestCollector(t, CollectorConfig{})
+	ctx := context.Background()
+
+	err := c.Record(ctx, Signal{
+		Kind:      SignalCompletionAccepted,
+		ChunkKeys: []string{"chunk-1"},
+	})
+	if err == nil {
+		t.Error("expected error for empty retrieval ID")
+	}
+}
+
+func TestRecordBroadcastsToAllChunks(t *testing.T) {
+	c := newTestCollector(t, CollectorConfig{})
+	ctx := context.Background()
+
+	id, err := c.RegisterRetrieval(ctx, "q", []string{"chunk-1", "chunk-2", "chunk-3"})
+	if err != nil {
+		t.Fatalf("RegisterRetrieval: %v", err)
+	}
+
+	// Record with empty ChunkKeys should broadcast to all chunks.
+	err = c.Record(ctx, Signal{
+		Kind:        SignalCompletionAccepted,
+		RetrievalID: id,
+	})
+	if err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	// Verify signal count: 3 signals (one per chunk).
+	count, err := c.store.SignalCount(ctx)
+	if err != nil {
+		t.Fatalf("SignalCount: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("SignalCount = %d, want 3", count)
+	}
+}
+
+func TestWeightsColdStart(t *testing.T) {
+	// WarmupSignals=100 means we need at least 100 signals before weights
+	// are non-zero.
+	c := newTestCollector(t, CollectorConfig{WarmupSignals: 100, MinRetrievals: 1})
+	ctx := context.Background()
+
+	id, err := c.RegisterRetrieval(ctx, "q", []string{"chunk-1"})
+	if err != nil {
+		t.Fatalf("RegisterRetrieval: %v", err)
+	}
+	if err := c.Record(ctx, Signal{Kind: SignalCompletionAccepted, RetrievalID: id, ChunkKeys: []string{"chunk-1"}}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	w, err := c.Weights(ctx, "chunk-1")
+	if err != nil {
+		t.Fatalf("Weights: %v", err)
+	}
+	if w != 0 {
+		t.Errorf("Weights during warmup = %f, want 0", w)
+	}
+}
+
+func TestWeightsBelowMinRetrievals(t *testing.T) {
+	// Set warmup to 0 so cold-start does not interfere, but require 5
+	// retrievals.
+	c := newTestCollector(t, CollectorConfig{WarmupSignals: 0, MinRetrievals: 5})
+	ctx := context.Background()
+
+	// Register only 1 retrieval (below MinRetrievals=5).
+	id, err := c.RegisterRetrieval(ctx, "q", []string{"chunk-1"})
+	if err != nil {
+		t.Fatalf("RegisterRetrieval: %v", err)
+	}
+	if err := c.Record(ctx, Signal{Kind: SignalCompletionAccepted, RetrievalID: id, ChunkKeys: []string{"chunk-1"}}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	// Force recompute so weighted_score is populated.
+	if err := c.store.RecomputeAggregates(ctx, c.config.DecayLambda); err != nil {
+		t.Fatalf("RecomputeAggregates: %v", err)
+	}
+
+	w, err := c.Weights(ctx, "chunk-1")
+	if err != nil {
+		t.Fatalf("Weights: %v", err)
+	}
+	if w != 0 {
+		t.Errorf("Weights below MinRetrievals = %f, want 0", w)
+	}
+}
+
+func TestWeightsAboveThresholds(t *testing.T) {
+	// Warmup=0 and MinRetrievals=1 so a single retrieval+signal suffices.
+	c := newTestCollector(t, CollectorConfig{WarmupSignals: 0, MinRetrievals: 1, DecayLambda: 0.1})
+	ctx := context.Background()
+
+	id, err := c.RegisterRetrieval(ctx, "q", []string{"chunk-1"})
+	if err != nil {
+		t.Fatalf("RegisterRetrieval: %v", err)
+	}
+	if err := c.Record(ctx, Signal{Kind: SignalCompletionAccepted, RetrievalID: id, ChunkKeys: []string{"chunk-1"}}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	// Force recompute.
+	if err := c.store.RecomputeAggregates(ctx, c.config.DecayLambda); err != nil {
+		t.Fatalf("RecomputeAggregates: %v", err)
+	}
+
+	w, err := c.Weights(ctx, "chunk-1")
+	if err != nil {
+		t.Fatalf("Weights: %v", err)
+	}
+	// Single recent signal of strength 0.8, decay negligible.
+	if w < 0.7 || w > 0.9 {
+		t.Errorf("Weights = %f, expected ~0.8", w)
+	}
+}
+
+func TestWeightsBatch(t *testing.T) {
+	c := newTestCollector(t, CollectorConfig{WarmupSignals: 0, MinRetrievals: 1, DecayLambda: 0.1})
+	ctx := context.Background()
+
+	id, err := c.RegisterRetrieval(ctx, "q", []string{"chunk-1", "chunk-2"})
+	if err != nil {
+		t.Fatalf("RegisterRetrieval: %v", err)
+	}
+	if err := c.Record(ctx, Signal{Kind: SignalCompletionAccepted, RetrievalID: id, ChunkKeys: []string{"chunk-1"}}); err != nil {
+		t.Fatalf("Record chunk-1: %v", err)
+	}
+	if err := c.Record(ctx, Signal{Kind: SignalCompletionRejected, RetrievalID: id, ChunkKeys: []string{"chunk-2"}}); err != nil {
+		t.Fatalf("Record chunk-2: %v", err)
+	}
+
+	// Force recompute.
+	if err := c.store.RecomputeAggregates(ctx, c.config.DecayLambda); err != nil {
+		t.Fatalf("RecomputeAggregates: %v", err)
+	}
+
+	weights, err := c.WeightsBatch(ctx, []string{"chunk-1", "chunk-2", "chunk-3"})
+	if err != nil {
+		t.Fatalf("WeightsBatch: %v", err)
+	}
+
+	if len(weights) != 3 {
+		t.Fatalf("WeightsBatch returned %d entries, want 3", len(weights))
+	}
+
+	if weights["chunk-1"] < 0.7 || weights["chunk-1"] > 0.9 {
+		t.Errorf("chunk-1 weight = %f, expected ~0.8", weights["chunk-1"])
+	}
+	if weights["chunk-2"] > -0.7 || weights["chunk-2"] < -0.9 {
+		t.Errorf("chunk-2 weight = %f, expected ~-0.8", weights["chunk-2"])
+	}
+	if weights["chunk-3"] != 0 {
+		t.Errorf("chunk-3 weight = %f, expected 0", weights["chunk-3"])
+	}
+}
+
+func TestWeightsBatchColdStart(t *testing.T) {
+	c := newTestCollector(t, CollectorConfig{WarmupSignals: 100, MinRetrievals: 1})
+	ctx := context.Background()
+
+	weights, err := c.WeightsBatch(ctx, []string{"chunk-1", "chunk-2"})
+	if err != nil {
+		t.Fatalf("WeightsBatch: %v", err)
+	}
+	for k, w := range weights {
+		if w != 0 {
+			t.Errorf("chunk %q weight = %f during warmup, want 0", k, w)
+		}
+	}
+}
+
+func TestCollectorClose(t *testing.T) {
+	c := newTestCollector(t, CollectorConfig{})
+	// Close should not panic or hang.
+	c.Close()
+}
+
+func TestRecordCustomStrength(t *testing.T) {
+	c := newTestCollector(t, CollectorConfig{WarmupSignals: 0, MinRetrievals: 1, DecayLambda: 0.1})
+	ctx := context.Background()
+
+	id, err := c.RegisterRetrieval(ctx, "q", []string{"chunk-1"})
+	if err != nil {
+		t.Fatalf("RegisterRetrieval: %v", err)
+	}
+
+	// Use a custom strength instead of the default.
+	if err := c.Record(ctx, Signal{
+		Kind:        SignalCompletionAccepted,
+		RetrievalID: id,
+		ChunkKeys:   []string{"chunk-1"},
+		Strength:    0.5,
+	}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	if err := c.store.RecomputeAggregates(ctx, c.config.DecayLambda); err != nil {
+		t.Fatalf("RecomputeAggregates: %v", err)
+	}
+
+	w, err := c.Weights(ctx, "chunk-1")
+	if err != nil {
+		t.Fatalf("Weights: %v", err)
+	}
+	// Custom strength of 0.5 should be used.
+	if w < 0.4 || w > 0.6 {
+		t.Errorf("Weights = %f, expected ~0.5", w)
+	}
+}
+
+func TestMultipleSignalsSameChunk(t *testing.T) {
+	c := newTestCollector(t, CollectorConfig{WarmupSignals: 0, MinRetrievals: 1, DecayLambda: 0.0})
+	ctx := context.Background()
+
+	id, err := c.RegisterRetrieval(ctx, "q", []string{"chunk-1"})
+	if err != nil {
+		t.Fatalf("RegisterRetrieval: %v", err)
+	}
+
+	signals := []Signal{
+		{Kind: SignalCompletionAccepted, RetrievalID: id, ChunkKeys: []string{"chunk-1"}}, // +0.8
+		{Kind: SignalCodeKept, RetrievalID: id, ChunkKeys: []string{"chunk-1"}},           // +0.6
+		{Kind: SignalFileOpened, RetrievalID: id, ChunkKeys: []string{"chunk-1"}},         // +0.3
+	}
+	for _, sig := range signals {
+		if err := c.Record(ctx, sig); err != nil {
+			t.Fatalf("Record: %v", err)
+		}
+	}
+
+	if err := c.store.RecomputeAggregates(ctx, 0.0); err != nil {
+		t.Fatalf("RecomputeAggregates: %v", err)
+	}
+
+	w, err := c.Weights(ctx, "chunk-1")
+	if err != nil {
+		t.Fatalf("Weights: %v", err)
+	}
+	// With decay=0, score = 0.8 + 0.6 + 0.3 = 1.7 exactly.
+	if w < 1.6 || w > 1.8 {
+		t.Errorf("Weights = %f, expected ~1.7", w)
+	}
+}
+
+func TestWeightsNonExistentChunk(t *testing.T) {
+	c := newTestCollector(t, CollectorConfig{WarmupSignals: 0, MinRetrievals: 1})
+	ctx := context.Background()
+
+	w, err := c.Weights(ctx, "nonexistent")
+	if err != nil {
+		t.Fatalf("Weights: %v", err)
+	}
+	if w != 0 {
+		t.Errorf("Weights = %f, want 0 for nonexistent chunk", w)
+	}
+}

--- a/feedback/migration.go
+++ b/feedback/migration.go
@@ -1,0 +1,116 @@
+package feedback
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+type migration struct {
+	version     int
+	description string
+	fn          func(tx *sql.Tx) error
+}
+
+var migrations = []migration{
+	{
+		version:     1,
+		description: "baseline feedback tables",
+		fn:          migrateV1,
+	},
+}
+
+func migrateV1(tx *sql.Tx) error {
+	stmts := []string{
+		// Layer 1 -- Retrieval Log
+		`CREATE TABLE IF NOT EXISTS feedback_retrievals (
+			retrieval_id TEXT PRIMARY KEY,
+			query        TEXT NOT NULL,
+			chunk_keys   TEXT NOT NULL,
+			created_at   INTEGER NOT NULL
+		)`,
+
+		// Layer 2 -- Signal Events
+		`CREATE TABLE IF NOT EXISTS feedback_signals (
+			id           INTEGER PRIMARY KEY AUTOINCREMENT,
+			retrieval_id TEXT NOT NULL,
+			chunk_key    TEXT NOT NULL,
+			signal_kind  TEXT NOT NULL,
+			strength     REAL NOT NULL,
+			created_at   INTEGER NOT NULL,
+			FOREIGN KEY (retrieval_id) REFERENCES feedback_retrievals(retrieval_id)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_signals_chunk
+			ON feedback_signals(chunk_key, created_at)`,
+
+		// Layer 3 -- Materialized Aggregates
+		`CREATE TABLE IF NOT EXISTS feedback_aggregates (
+			chunk_key       TEXT PRIMARY KEY,
+			retrieval_count INTEGER NOT NULL DEFAULT 0,
+			weighted_score  REAL NOT NULL DEFAULT 0.0,
+			last_signal_at  INTEGER NOT NULL DEFAULT 0,
+			recomputed_at   INTEGER NOT NULL DEFAULT 0
+		)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := tx.Exec(stmt); err != nil {
+			return fmt.Errorf("feedback: migrate v1: %w", err)
+		}
+	}
+	return nil
+}
+
+func runMigrations(db *sql.DB) error {
+	const createVersionTable = `CREATE TABLE IF NOT EXISTS feedback_schema_version (
+		version     INTEGER PRIMARY KEY,
+		description TEXT NOT NULL,
+		applied_at  INTEGER NOT NULL
+	)`
+	if _, err := db.Exec(createVersionTable); err != nil {
+		return fmt.Errorf("feedback: create version table: %w", err)
+	}
+
+	currentVersion, err := currentSchemaVersion(db)
+	if err != nil {
+		return err
+	}
+
+	for _, m := range migrations {
+		if m.version <= currentVersion {
+			continue
+		}
+
+		tx, err := db.Begin()
+		if err != nil {
+			return fmt.Errorf("feedback: begin migration v%d: %w", m.version, err)
+		}
+
+		if err := m.fn(tx); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("feedback: migration v%d (%s): %w", m.version, m.description, err)
+		}
+
+		if _, err := tx.Exec(
+			`INSERT INTO feedback_schema_version (version, description, applied_at) VALUES (?, ?, ?)`,
+			m.version, m.description, time.Now().UnixMilli(),
+		); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("feedback: record version %d: %w", m.version, err)
+		}
+
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("feedback: commit migration v%d: %w", m.version, err)
+		}
+	}
+
+	return nil
+}
+
+func currentSchemaVersion(db *sql.DB) (int, error) {
+	var version int
+	err := db.QueryRow(`SELECT COALESCE(MAX(version), 0) FROM feedback_schema_version`).Scan(&version)
+	if err != nil {
+		return 0, fmt.Errorf("feedback: query schema version: %w", err)
+	}
+	return version, nil
+}

--- a/feedback/migration_test.go
+++ b/feedback/migration_test.go
@@ -1,0 +1,72 @@
+package feedback
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func TestRunMigrations(t *testing.T) {
+	db := openTestDB(t)
+
+	if err := runMigrations(db); err != nil {
+		t.Fatalf("runMigrations: %v", err)
+	}
+
+	// Verify schema version was recorded.
+	ver, err := currentSchemaVersion(db)
+	if err != nil {
+		t.Fatalf("currentSchemaVersion: %v", err)
+	}
+	if ver != 1 {
+		t.Errorf("schema version = %d, want 1", ver)
+	}
+
+	// Verify tables exist by inserting a row into each.
+	if _, err := db.Exec(
+		`INSERT INTO feedback_retrievals (retrieval_id, query, chunk_keys, created_at)
+		 VALUES ('r1', 'test query', 'c1', 1000)`,
+	); err != nil {
+		t.Errorf("insert into feedback_retrievals: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO feedback_signals (retrieval_id, chunk_key, signal_kind, strength, created_at)
+		 VALUES ('r1', 'c1', 'completion_accepted', 0.8, 1000)`,
+	); err != nil {
+		t.Errorf("insert into feedback_signals: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO feedback_aggregates (chunk_key) VALUES ('c1')`,
+	); err != nil {
+		t.Errorf("insert into feedback_aggregates: %v", err)
+	}
+}
+
+func TestRunMigrationsIdempotent(t *testing.T) {
+	db := openTestDB(t)
+
+	for i := 0; i < 3; i++ {
+		if err := runMigrations(db); err != nil {
+			t.Fatalf("runMigrations (pass %d): %v", i+1, err)
+		}
+	}
+
+	ver, err := currentSchemaVersion(db)
+	if err != nil {
+		t.Fatalf("currentSchemaVersion: %v", err)
+	}
+	if ver != 1 {
+		t.Errorf("schema version = %d, want 1", ver)
+	}
+}

--- a/feedback/signal.go
+++ b/feedback/signal.go
@@ -1,0 +1,96 @@
+// Package feedback collects implicit user behavioral signals (completion
+// accepted, code kept, file opened, etc.) and aggregates them so that
+// retrieval quality can be improved over time.
+//
+// The package stores and queries opaque chunk-key strings and does not
+// import or depend on the rag package.
+package feedback
+
+import "time"
+
+// SignalKind identifies the type of behavioral event.
+type SignalKind string
+
+const (
+	// SignalCompletionAccepted indicates the user accepted a code completion.
+	SignalCompletionAccepted SignalKind = "completion_accepted"
+
+	// SignalCompletionRejected indicates the user rejected a code completion.
+	SignalCompletionRejected SignalKind = "completion_rejected"
+
+	// SignalCodeKept indicates the generated code was retained after review.
+	SignalCodeKept SignalKind = "code_kept"
+
+	// SignalCodeUndone indicates the generated code was undone or reverted.
+	SignalCodeUndone SignalKind = "code_undone"
+
+	// SignalFileOpened indicates the user opened a file that was referenced
+	// in retrieved context.
+	SignalFileOpened SignalKind = "file_opened"
+
+	// SignalQueryRepeated indicates the user repeated or rephrased a query,
+	// suggesting the first retrieval was unsatisfactory.
+	SignalQueryRepeated SignalKind = "query_repeated"
+
+	// SignalInsightActedOn indicates the user acted on an analysis insight.
+	SignalInsightActedOn SignalKind = "insight_acted_on"
+
+	// SignalInsightDismissed indicates the user dismissed an analysis insight.
+	SignalInsightDismissed SignalKind = "insight_dismissed"
+)
+
+// defaultStrength maps each signal kind to its default weight contribution.
+var defaultStrength = map[SignalKind]float64{
+	SignalCompletionAccepted: +0.8,
+	SignalCompletionRejected: -0.8,
+	SignalCodeKept:           +0.6,
+	SignalCodeUndone:         -0.7,
+	SignalFileOpened:         +0.3,
+	SignalQueryRepeated:      -0.5,
+	SignalInsightActedOn:     +0.5,
+	SignalInsightDismissed:   -0.5,
+}
+
+// DefaultStrength returns the built-in strength for the given signal kind,
+// or 0 if the kind is unrecognised.
+func DefaultStrength(kind SignalKind) float64 {
+	return defaultStrength[kind]
+}
+
+// Signal represents a single behavioral event recorded against an
+// attribution window.
+type Signal struct {
+	// Kind identifies the type of behavioral event.
+	Kind SignalKind
+
+	// RetrievalID links this signal to an open attribution window.
+	RetrievalID string
+
+	// ChunkKeys identifies the chunks this signal applies to. When empty,
+	// the signal applies to all chunks in the attribution window.
+	ChunkKeys []string
+
+	// Source identifies the originating subsystem (e.g. "completion",
+	// "analysis").
+	Source string
+
+	// Strength is the weight contribution for this signal. When zero, the
+	// default strength for the signal kind is used.
+	Strength float64
+
+	// Metadata carries optional key-value pairs for signal context.
+	Metadata map[string]string
+
+	// Timestamp is the wall-clock time the event occurred. When zero, the
+	// current time is used at recording time.
+	Timestamp time.Time
+}
+
+// effectiveStrength returns the signal's strength, falling back to the
+// default for its kind if Strength is zero.
+func (s Signal) effectiveStrength() float64 {
+	if s.Strength != 0 {
+		return s.Strength
+	}
+	return DefaultStrength(s.Kind)
+}

--- a/feedback/signal_test.go
+++ b/feedback/signal_test.go
@@ -1,0 +1,68 @@
+package feedback
+
+import "testing"
+
+func TestDefaultStrength(t *testing.T) {
+	tests := []struct {
+		name     string
+		kind     SignalKind
+		expected float64
+	}{
+		{"completion accepted", SignalCompletionAccepted, 0.8},
+		{"completion rejected", SignalCompletionRejected, -0.8},
+		{"code kept", SignalCodeKept, 0.6},
+		{"code undone", SignalCodeUndone, -0.7},
+		{"file opened", SignalFileOpened, 0.3},
+		{"query repeated", SignalQueryRepeated, -0.5},
+		{"insight acted on", SignalInsightActedOn, 0.5},
+		{"insight dismissed", SignalInsightDismissed, -0.5},
+		{"unknown kind", SignalKind("unknown"), 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DefaultStrength(tt.kind)
+			if got != tt.expected {
+				t.Errorf("DefaultStrength(%q) = %v, want %v", tt.kind, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSignalEffectiveStrength(t *testing.T) {
+	tests := []struct {
+		name     string
+		signal   Signal
+		expected float64
+	}{
+		{
+			name:     "explicit strength used",
+			signal:   Signal{Kind: SignalCompletionAccepted, Strength: 0.5},
+			expected: 0.5,
+		},
+		{
+			name:     "zero strength uses default",
+			signal:   Signal{Kind: SignalCompletionAccepted},
+			expected: 0.8,
+		},
+		{
+			name:     "negative explicit strength used",
+			signal:   Signal{Kind: SignalFileOpened, Strength: -0.2},
+			expected: -0.2,
+		},
+		{
+			name:     "unknown kind zero strength returns zero",
+			signal:   Signal{Kind: SignalKind("bogus")},
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.signal.effectiveStrength()
+			if got != tt.expected {
+				t.Errorf("effectiveStrength() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/feedback/store.go
+++ b/feedback/store.go
@@ -214,6 +214,16 @@ func (s *SQLiteSignalStore) RecomputeAggregates(ctx context.Context, lambda floa
 		return fmt.Errorf("feedback: recompute begin: %w", err)
 	}
 
+	// Zero out all weighted_scores so that chunks whose signals were fully
+	// pruned don't retain stale non-zero scores.
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE feedback_aggregates SET weighted_score = 0, recomputed_at = ?`,
+		nowMs,
+	); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("feedback: recompute zero scores: %w", err)
+	}
+
 	for key, score := range scores {
 		if _, err := tx.ExecContext(ctx,
 			`INSERT INTO feedback_aggregates (chunk_key, weighted_score, recomputed_at)

--- a/feedback/store.go
+++ b/feedback/store.go
@@ -1,0 +1,298 @@
+package feedback
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+)
+
+// Aggregate holds the materialized score for a single chunk key.
+type Aggregate struct {
+	WeightedScore  float64
+	RetrievalCount int
+}
+
+// SignalStore defines the persistence operations for behavioral feedback.
+type SignalStore interface {
+	// InsertRetrieval records a retrieval event with its associated chunk keys.
+	InsertRetrieval(ctx context.Context, id, query string, chunkKeys []string) error
+
+	// InsertSignal persists a signal event.
+	InsertSignal(ctx context.Context, retrievalID, chunkKey string, kind SignalKind, strength float64) error
+
+	// SignalCount returns the total number of recorded signals.
+	SignalCount(ctx context.Context) (int, error)
+
+	// GetAggregate returns the aggregate for a single chunk key.
+	GetAggregate(ctx context.Context, chunkKey string) (Aggregate, error)
+
+	// GetAggregatesBatch returns aggregates for multiple chunk keys.
+	GetAggregatesBatch(ctx context.Context, chunkKeys []string) (map[string]Aggregate, error)
+
+	// RecomputeAggregates recalculates weighted_score for all chunks using
+	// the provided decay lambda.
+	RecomputeAggregates(ctx context.Context, lambda float64) error
+
+	// IncrementRetrievalCount bumps retrieval_count for each chunk key.
+	IncrementRetrievalCount(ctx context.Context, chunkKeys []string) error
+
+	// PruneSignals deletes signal events older than the given time and
+	// returns the number of deleted rows.
+	PruneSignals(ctx context.Context, olderThan time.Time) (int, error)
+
+	// PruneRetrievals deletes retrieval rows that have no remaining signal
+	// events referencing them. Returns the number of deleted rows.
+	PruneRetrievals(ctx context.Context) (int, error)
+}
+
+// SQLiteSignalStore implements SignalStore using a SQLite database.
+type SQLiteSignalStore struct {
+	db *sql.DB
+}
+
+// NewSignalStore creates a SQLiteSignalStore, running migrations on the
+// provided database if needed.
+func NewSignalStore(ctx context.Context, db *sql.DB) (*SQLiteSignalStore, error) {
+	if err := runMigrations(db); err != nil {
+		return nil, fmt.Errorf("feedback: init store: %w", err)
+	}
+	return &SQLiteSignalStore{db: db}, nil
+}
+
+// InsertRetrieval records a retrieval event.
+func (s *SQLiteSignalStore) InsertRetrieval(ctx context.Context, id, query string, chunkKeys []string) error {
+	keys := strings.Join(chunkKeys, "\n")
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO feedback_retrievals (retrieval_id, query, chunk_keys, created_at) VALUES (?, ?, ?, ?)`,
+		id, query, keys, time.Now().UnixMilli(),
+	)
+	if err != nil {
+		return fmt.Errorf("feedback: insert retrieval %q: %w", id, err)
+	}
+	return nil
+}
+
+// InsertSignal persists a signal event and updates the last_signal_at
+// aggregate timestamp.
+func (s *SQLiteSignalStore) InsertSignal(ctx context.Context, retrievalID, chunkKey string, kind SignalKind, strength float64) error {
+	now := time.Now().UnixMilli()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("feedback: insert signal begin: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO feedback_signals (retrieval_id, chunk_key, signal_kind, strength, created_at)
+		 VALUES (?, ?, ?, ?, ?)`,
+		retrievalID, chunkKey, string(kind), strength, now,
+	); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("feedback: insert signal: %w", err)
+	}
+
+	// Upsert aggregate row to track last_signal_at.
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO feedback_aggregates (chunk_key, last_signal_at)
+		 VALUES (?, ?)
+		 ON CONFLICT(chunk_key) DO UPDATE SET last_signal_at = excluded.last_signal_at`,
+		chunkKey, now,
+	); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("feedback: upsert aggregate last_signal_at: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("feedback: insert signal commit: %w", err)
+	}
+	return nil
+}
+
+// SignalCount returns the total number of recorded signals.
+func (s *SQLiteSignalStore) SignalCount(ctx context.Context) (int, error) {
+	var count int
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM feedback_signals`).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("feedback: signal count: %w", err)
+	}
+	return count, nil
+}
+
+// GetAggregate returns the materialized aggregate for a single chunk key.
+func (s *SQLiteSignalStore) GetAggregate(ctx context.Context, chunkKey string) (Aggregate, error) {
+	var agg Aggregate
+	err := s.db.QueryRowContext(ctx,
+		`SELECT weighted_score, retrieval_count FROM feedback_aggregates WHERE chunk_key = ?`,
+		chunkKey,
+	).Scan(&agg.WeightedScore, &agg.RetrievalCount)
+	if err == sql.ErrNoRows {
+		return Aggregate{}, nil
+	}
+	if err != nil {
+		return Aggregate{}, fmt.Errorf("feedback: get aggregate %q: %w", chunkKey, err)
+	}
+	return agg, nil
+}
+
+// GetAggregatesBatch returns aggregates for multiple chunk keys in a single
+// query.
+func (s *SQLiteSignalStore) GetAggregatesBatch(ctx context.Context, chunkKeys []string) (map[string]Aggregate, error) {
+	if len(chunkKeys) == 0 {
+		return map[string]Aggregate{}, nil
+	}
+
+	placeholders := make([]string, len(chunkKeys))
+	args := make([]any, len(chunkKeys))
+	for i, k := range chunkKeys {
+		placeholders[i] = "?"
+		args[i] = k
+	}
+
+	query := fmt.Sprintf(
+		`SELECT chunk_key, weighted_score, retrieval_count FROM feedback_aggregates WHERE chunk_key IN (%s)`,
+		strings.Join(placeholders, ","),
+	)
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("feedback: get aggregates batch: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[string]Aggregate, len(chunkKeys))
+	for rows.Next() {
+		var key string
+		var agg Aggregate
+		if err := rows.Scan(&key, &agg.WeightedScore, &agg.RetrievalCount); err != nil {
+			return nil, fmt.Errorf("feedback: get aggregates batch scan: %w", err)
+		}
+		result[key] = agg
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("feedback: get aggregates batch iterate: %w", err)
+	}
+	return result, nil
+}
+
+// RecomputeAggregates recalculates the weighted_score for every chunk key
+// from raw signal events, applying exponential time-decay.
+//
+// Formula: SUM(strength * exp(-lambda * days_since_signal))
+func (s *SQLiteSignalStore) RecomputeAggregates(ctx context.Context, lambda float64) error {
+	nowMs := time.Now().UnixMilli()
+
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT chunk_key, strength, created_at FROM feedback_signals ORDER BY chunk_key`)
+	if err != nil {
+		return fmt.Errorf("feedback: recompute query signals: %w", err)
+	}
+	defer rows.Close()
+
+	scores := make(map[string]float64)
+	for rows.Next() {
+		var key string
+		var strength float64
+		var createdMs int64
+		if err := rows.Scan(&key, &strength, &createdMs); err != nil {
+			return fmt.Errorf("feedback: recompute scan: %w", err)
+		}
+		daysSince := float64(nowMs-createdMs) / (24 * 60 * 60 * 1000)
+		if daysSince < 0 {
+			daysSince = 0
+		}
+		scores[key] += strength * math.Exp(-lambda*daysSince)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("feedback: recompute iterate: %w", err)
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("feedback: recompute begin: %w", err)
+	}
+
+	for key, score := range scores {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO feedback_aggregates (chunk_key, weighted_score, recomputed_at)
+			 VALUES (?, ?, ?)
+			 ON CONFLICT(chunk_key) DO UPDATE SET
+				weighted_score = excluded.weighted_score,
+				recomputed_at  = excluded.recomputed_at`,
+			key, score, nowMs,
+		); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("feedback: recompute upsert %q: %w", key, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("feedback: recompute commit: %w", err)
+	}
+	return nil
+}
+
+// IncrementRetrievalCount bumps retrieval_count for each provided chunk key.
+func (s *SQLiteSignalStore) IncrementRetrievalCount(ctx context.Context, chunkKeys []string) error {
+	if len(chunkKeys) == 0 {
+		return nil
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("feedback: increment retrieval count begin: %w", err)
+	}
+
+	for _, key := range chunkKeys {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO feedback_aggregates (chunk_key, retrieval_count)
+			 VALUES (?, 1)
+			 ON CONFLICT(chunk_key) DO UPDATE SET
+				retrieval_count = feedback_aggregates.retrieval_count + 1`,
+			key,
+		); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("feedback: increment retrieval count %q: %w", key, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("feedback: increment retrieval count commit: %w", err)
+	}
+	return nil
+}
+
+// PruneSignals deletes signals older than olderThan and returns the number
+// of deleted rows.
+func (s *SQLiteSignalStore) PruneSignals(ctx context.Context, olderThan time.Time) (int, error) {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM feedback_signals WHERE created_at < ?`,
+		olderThan.UnixMilli(),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("feedback: prune signals: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("feedback: prune signals rows affected: %w", err)
+	}
+	return int(n), nil
+}
+
+// PruneRetrievals deletes retrieval rows with no remaining signal events.
+func (s *SQLiteSignalStore) PruneRetrievals(ctx context.Context) (int, error) {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM feedback_retrievals
+		 WHERE retrieval_id NOT IN (SELECT DISTINCT retrieval_id FROM feedback_signals)`,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("feedback: prune retrievals: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("feedback: prune retrievals rows affected: %w", err)
+	}
+	return int(n), nil
+}

--- a/feedback/store.go
+++ b/feedback/store.go
@@ -20,8 +20,9 @@ type SignalStore interface {
 	// InsertRetrieval records a retrieval event with its associated chunk keys.
 	InsertRetrieval(ctx context.Context, id, query string, chunkKeys []string) error
 
-	// InsertSignal persists a signal event.
-	InsertSignal(ctx context.Context, retrievalID, chunkKey string, kind SignalKind, strength float64) error
+	// InsertSignal persists a signal event. When createdAt is zero the
+	// current time is used.
+	InsertSignal(ctx context.Context, retrievalID, chunkKey string, kind SignalKind, strength float64, createdAt time.Time) error
 
 	// SignalCount returns the total number of recorded signals.
 	SignalCount(ctx context.Context) (int, error)
@@ -76,9 +77,12 @@ func (s *SQLiteSignalStore) InsertRetrieval(ctx context.Context, id, query strin
 }
 
 // InsertSignal persists a signal event and updates the last_signal_at
-// aggregate timestamp.
-func (s *SQLiteSignalStore) InsertSignal(ctx context.Context, retrievalID, chunkKey string, kind SignalKind, strength float64) error {
-	now := time.Now().UnixMilli()
+// aggregate timestamp. When createdAt is zero the current time is used.
+func (s *SQLiteSignalStore) InsertSignal(ctx context.Context, retrievalID, chunkKey string, kind SignalKind, strength float64, createdAt time.Time) error {
+	if createdAt.IsZero() {
+		createdAt = time.Now()
+	}
+	now := createdAt.UnixMilli()
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/feedback/store_test.go
+++ b/feedback/store_test.go
@@ -191,6 +191,49 @@ func TestRecomputeAggregatesEmpty(t *testing.T) {
 	}
 }
 
+func TestRecomputeAggregatesZerosStaleScores(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	// Insert a signal and recompute to set a non-zero weighted_score.
+	if err := store.InsertRetrieval(ctx, "r1", "q", []string{"chunk-1"}); err != nil {
+		t.Fatalf("InsertRetrieval: %v", err)
+	}
+	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCompletionAccepted, 0.8); err != nil {
+		t.Fatalf("InsertSignal: %v", err)
+	}
+	if err := store.RecomputeAggregates(ctx, 0.0); err != nil {
+		t.Fatalf("RecomputeAggregates: %v", err)
+	}
+
+	agg, err := store.GetAggregate(ctx, "chunk-1")
+	if err != nil {
+		t.Fatalf("GetAggregate before prune: %v", err)
+	}
+	if agg.WeightedScore < 0.7 {
+		t.Fatalf("expected non-zero score before prune, got %f", agg.WeightedScore)
+	}
+
+	// Prune ALL signals for this chunk.
+	cutoff := time.Now().Add(time.Hour)
+	if _, err := store.PruneSignals(ctx, cutoff); err != nil {
+		t.Fatalf("PruneSignals: %v", err)
+	}
+
+	// Recompute -- chunk-1 has no signals left, score should be zeroed.
+	if err := store.RecomputeAggregates(ctx, 0.0); err != nil {
+		t.Fatalf("RecomputeAggregates after prune: %v", err)
+	}
+
+	agg, err = store.GetAggregate(ctx, "chunk-1")
+	if err != nil {
+		t.Fatalf("GetAggregate after prune+recompute: %v", err)
+	}
+	if agg.WeightedScore != 0 {
+		t.Errorf("weighted_score after prune+recompute = %f, want 0", agg.WeightedScore)
+	}
+}
+
 func TestPruneSignals(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore(t)

--- a/feedback/store_test.go
+++ b/feedback/store_test.go
@@ -26,7 +26,7 @@ func TestInsertRetrievalAndSignal(t *testing.T) {
 		t.Fatalf("InsertRetrieval: %v", err)
 	}
 
-	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCompletionAccepted, 0.8); err != nil {
+	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCompletionAccepted, 0.8, time.Time{}); err != nil {
 		t.Fatalf("InsertSignal: %v", err)
 	}
 
@@ -69,7 +69,7 @@ func TestGetAggregate(t *testing.T) {
 	if err := store.InsertRetrieval(ctx, "r1", "q", []string{"chunk-1"}); err != nil {
 		t.Fatalf("InsertRetrieval: %v", err)
 	}
-	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCompletionAccepted, 0.8); err != nil {
+	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCompletionAccepted, 0.8, time.Time{}); err != nil {
 		t.Fatalf("InsertSignal: %v", err)
 	}
 
@@ -102,10 +102,10 @@ func TestGetAggregatesBatch(t *testing.T) {
 	if err := store.InsertRetrieval(ctx, "r1", "q", []string{"chunk-1", "chunk-2"}); err != nil {
 		t.Fatalf("InsertRetrieval: %v", err)
 	}
-	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCodeKept, 0.6); err != nil {
+	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCodeKept, 0.6, time.Time{}); err != nil {
 		t.Fatalf("InsertSignal: %v", err)
 	}
-	if err := store.InsertSignal(ctx, "r1", "chunk-2", SignalCodeUndone, -0.7); err != nil {
+	if err := store.InsertSignal(ctx, "r1", "chunk-2", SignalCodeUndone, -0.7, time.Time{}); err != nil {
 		t.Fatalf("InsertSignal: %v", err)
 	}
 
@@ -159,10 +159,10 @@ func TestRecomputeAggregates(t *testing.T) {
 	if err := store.InsertRetrieval(ctx, "r1", "q", []string{"chunk-1"}); err != nil {
 		t.Fatalf("InsertRetrieval: %v", err)
 	}
-	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCompletionAccepted, 0.8); err != nil {
+	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCompletionAccepted, 0.8, time.Time{}); err != nil {
 		t.Fatalf("InsertSignal: %v", err)
 	}
-	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCodeKept, 0.6); err != nil {
+	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCodeKept, 0.6, time.Time{}); err != nil {
 		t.Fatalf("InsertSignal (2nd): %v", err)
 	}
 
@@ -199,7 +199,7 @@ func TestRecomputeAggregatesZerosStaleScores(t *testing.T) {
 	if err := store.InsertRetrieval(ctx, "r1", "q", []string{"chunk-1"}); err != nil {
 		t.Fatalf("InsertRetrieval: %v", err)
 	}
-	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCompletionAccepted, 0.8); err != nil {
+	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCompletionAccepted, 0.8, time.Time{}); err != nil {
 		t.Fatalf("InsertSignal: %v", err)
 	}
 	if err := store.RecomputeAggregates(ctx, 0.0); err != nil {
@@ -241,7 +241,7 @@ func TestPruneSignals(t *testing.T) {
 	if err := store.InsertRetrieval(ctx, "r1", "q", []string{"chunk-1"}); err != nil {
 		t.Fatalf("InsertRetrieval: %v", err)
 	}
-	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCompletionAccepted, 0.8); err != nil {
+	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCompletionAccepted, 0.8, time.Time{}); err != nil {
 		t.Fatalf("InsertSignal: %v", err)
 	}
 
@@ -271,7 +271,7 @@ func TestPruneSignalsNone(t *testing.T) {
 	if err := store.InsertRetrieval(ctx, "r1", "q", []string{"chunk-1"}); err != nil {
 		t.Fatalf("InsertRetrieval: %v", err)
 	}
-	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCompletionAccepted, 0.8); err != nil {
+	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCompletionAccepted, 0.8, time.Time{}); err != nil {
 		t.Fatalf("InsertSignal: %v", err)
 	}
 
@@ -297,7 +297,7 @@ func TestPruneRetrievals(t *testing.T) {
 	if err := store.InsertRetrieval(ctx, "r2", "q2", []string{"chunk-2"}); err != nil {
 		t.Fatalf("InsertRetrieval r2: %v", err)
 	}
-	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCompletionAccepted, 0.8); err != nil {
+	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCompletionAccepted, 0.8, time.Time{}); err != nil {
 		t.Fatalf("InsertSignal: %v", err)
 	}
 

--- a/feedback/store_test.go
+++ b/feedback/store_test.go
@@ -1,0 +1,268 @@
+package feedback
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func newTestStore(t *testing.T) *SQLiteSignalStore {
+	t.Helper()
+	db := openTestDB(t)
+	store, err := NewSignalStore(context.Background(), db)
+	if err != nil {
+		t.Fatalf("NewSignalStore: %v", err)
+	}
+	return store
+}
+
+func TestInsertRetrievalAndSignal(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	if err := store.InsertRetrieval(ctx, "r1", "test query", []string{"chunk-1", "chunk-2"}); err != nil {
+		t.Fatalf("InsertRetrieval: %v", err)
+	}
+
+	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCompletionAccepted, 0.8); err != nil {
+		t.Fatalf("InsertSignal: %v", err)
+	}
+
+	count, err := store.SignalCount(ctx)
+	if err != nil {
+		t.Fatalf("SignalCount: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("SignalCount = %d, want 1", count)
+	}
+}
+
+func TestSignalCountEmpty(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	count, err := store.SignalCount(ctx)
+	if err != nil {
+		t.Fatalf("SignalCount: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("SignalCount = %d, want 0", count)
+	}
+}
+
+func TestGetAggregate(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	// Non-existent chunk returns zero aggregate.
+	agg, err := store.GetAggregate(ctx, "nonexistent")
+	if err != nil {
+		t.Fatalf("GetAggregate: %v", err)
+	}
+	if agg.WeightedScore != 0 || agg.RetrievalCount != 0 {
+		t.Errorf("expected zero aggregate, got %+v", agg)
+	}
+
+	// Insert a signal to create an aggregate row.
+	if err := store.InsertRetrieval(ctx, "r1", "q", []string{"chunk-1"}); err != nil {
+		t.Fatalf("InsertRetrieval: %v", err)
+	}
+	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCompletionAccepted, 0.8); err != nil {
+		t.Fatalf("InsertSignal: %v", err)
+	}
+
+	agg, err = store.GetAggregate(ctx, "chunk-1")
+	if err != nil {
+		t.Fatalf("GetAggregate: %v", err)
+	}
+	// Signal creates an aggregate with last_signal_at set, but weighted_score
+	// is only updated by RecomputeAggregates. retrieval_count is 0 until
+	// IncrementRetrievalCount is called.
+	if agg.RetrievalCount != 0 {
+		t.Errorf("retrieval_count = %d, want 0", agg.RetrievalCount)
+	}
+}
+
+func TestGetAggregatesBatch(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	// Empty batch returns empty map.
+	result, err := store.GetAggregatesBatch(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetAggregatesBatch empty: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty map, got %d entries", len(result))
+	}
+
+	// Set up some data.
+	if err := store.InsertRetrieval(ctx, "r1", "q", []string{"chunk-1", "chunk-2"}); err != nil {
+		t.Fatalf("InsertRetrieval: %v", err)
+	}
+	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCodeKept, 0.6); err != nil {
+		t.Fatalf("InsertSignal: %v", err)
+	}
+	if err := store.InsertSignal(ctx, "r1", "chunk-2", SignalCodeUndone, -0.7); err != nil {
+		t.Fatalf("InsertSignal: %v", err)
+	}
+
+	result, err = store.GetAggregatesBatch(ctx, []string{"chunk-1", "chunk-2", "chunk-3"})
+	if err != nil {
+		t.Fatalf("GetAggregatesBatch: %v", err)
+	}
+
+	// chunk-1 and chunk-2 exist, chunk-3 does not.
+	if len(result) != 2 {
+		t.Errorf("expected 2 results, got %d", len(result))
+	}
+	if _, ok := result["chunk-1"]; !ok {
+		t.Error("chunk-1 not in results")
+	}
+	if _, ok := result["chunk-2"]; !ok {
+		t.Error("chunk-2 not in results")
+	}
+}
+
+func TestIncrementRetrievalCount(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	keys := []string{"chunk-1", "chunk-2"}
+	if err := store.IncrementRetrievalCount(ctx, keys); err != nil {
+		t.Fatalf("IncrementRetrievalCount: %v", err)
+	}
+	if err := store.IncrementRetrievalCount(ctx, keys); err != nil {
+		t.Fatalf("IncrementRetrievalCount (2nd): %v", err)
+	}
+
+	agg, err := store.GetAggregate(ctx, "chunk-1")
+	if err != nil {
+		t.Fatalf("GetAggregate: %v", err)
+	}
+	if agg.RetrievalCount != 2 {
+		t.Errorf("retrieval_count = %d, want 2", agg.RetrievalCount)
+	}
+
+	// Empty slice is a no-op.
+	if err := store.IncrementRetrievalCount(ctx, nil); err != nil {
+		t.Fatalf("IncrementRetrievalCount nil: %v", err)
+	}
+}
+
+func TestRecomputeAggregates(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	if err := store.InsertRetrieval(ctx, "r1", "q", []string{"chunk-1"}); err != nil {
+		t.Fatalf("InsertRetrieval: %v", err)
+	}
+	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCompletionAccepted, 0.8); err != nil {
+		t.Fatalf("InsertSignal: %v", err)
+	}
+	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCodeKept, 0.6); err != nil {
+		t.Fatalf("InsertSignal (2nd): %v", err)
+	}
+
+	if err := store.RecomputeAggregates(ctx, 0.1); err != nil {
+		t.Fatalf("RecomputeAggregates: %v", err)
+	}
+
+	agg, err := store.GetAggregate(ctx, "chunk-1")
+	if err != nil {
+		t.Fatalf("GetAggregate: %v", err)
+	}
+	// Both signals are very recent so decay is negligible.
+	// Score should be approximately 0.8 + 0.6 = 1.4.
+	if agg.WeightedScore < 1.3 || agg.WeightedScore > 1.5 {
+		t.Errorf("weighted_score = %f, expected ~1.4", agg.WeightedScore)
+	}
+}
+
+func TestRecomputeAggregatesEmpty(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	// Recompute with no signals should be a no-op.
+	if err := store.RecomputeAggregates(ctx, 0.1); err != nil {
+		t.Fatalf("RecomputeAggregates (empty): %v", err)
+	}
+}
+
+func TestPruneSignals(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	if err := store.InsertRetrieval(ctx, "r1", "q", []string{"chunk-1"}); err != nil {
+		t.Fatalf("InsertRetrieval: %v", err)
+	}
+	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCompletionAccepted, 0.8); err != nil {
+		t.Fatalf("InsertSignal: %v", err)
+	}
+
+	// Prune with a future cutoff should delete the signal.
+	cutoff := time.Now().Add(time.Hour)
+	n, err := store.PruneSignals(ctx, cutoff)
+	if err != nil {
+		t.Fatalf("PruneSignals: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("PruneSignals deleted %d, want 1", n)
+	}
+
+	count, err := store.SignalCount(ctx)
+	if err != nil {
+		t.Fatalf("SignalCount: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("SignalCount = %d, want 0 after prune", count)
+	}
+}
+
+func TestPruneSignalsNone(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	if err := store.InsertRetrieval(ctx, "r1", "q", []string{"chunk-1"}); err != nil {
+		t.Fatalf("InsertRetrieval: %v", err)
+	}
+	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCompletionAccepted, 0.8); err != nil {
+		t.Fatalf("InsertSignal: %v", err)
+	}
+
+	// Prune with a past cutoff should delete nothing.
+	cutoff := time.Now().Add(-time.Hour)
+	n, err := store.PruneSignals(ctx, cutoff)
+	if err != nil {
+		t.Fatalf("PruneSignals: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("PruneSignals deleted %d, want 0", n)
+	}
+}
+
+func TestPruneRetrievals(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	// Insert two retrievals, only one with signals.
+	if err := store.InsertRetrieval(ctx, "r1", "q1", []string{"chunk-1"}); err != nil {
+		t.Fatalf("InsertRetrieval r1: %v", err)
+	}
+	if err := store.InsertRetrieval(ctx, "r2", "q2", []string{"chunk-2"}); err != nil {
+		t.Fatalf("InsertRetrieval r2: %v", err)
+	}
+	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCompletionAccepted, 0.8); err != nil {
+		t.Fatalf("InsertSignal: %v", err)
+	}
+
+	n, err := store.PruneRetrievals(ctx)
+	if err != nil {
+		t.Fatalf("PruneRetrievals: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("PruneRetrievals deleted %d, want 1", n)
+	}
+}


### PR DESCRIPTION
## Summary

- New `feedback/` package for implicit user behavioral learning
- 8 signal types: completion accepted/rejected, code kept/undone, file opened, query repeated, insight acted on/dismissed
- Three-layer SQLite storage: retrieval log, signal events (append-only), materialized aggregates
- `Collector` with attribution window lifecycle: register retrieval, record signals, auto-expire with weak negatives
- Cold-start safety: `MinRetrievals` (5) and `WarmupSignals` (100) thresholds before weights activate
- Time-decay aggregation: `SUM(strength * exp(-lambda * days_since))` with lambda=0.1
- Background sweep goroutine for expired windows (60s interval, 300s max window)
- `Weights`/`WeightsBatch` for chunk-level behavioral scores (consumed by future #33 orchestrate)
- Chunk keys are opaque strings -- no dependency on rag/ package

Closes #31

## Test plan

- [x] `go test ./feedback/... -count=1` -- 31 tests pass
- [x] `go test ./... -count=1` -- no regressions
- [x] `go vet ./feedback/...` -- clean
- [x] Attribution window lifecycle tests
- [x] Cold start and warmup threshold tests
- [x] Signal aggregation with time decay tests

Generated with [Claude Code](https://claude.com/claude-code)