### PR TITLE
feat: Phase 2 Wave 1 -- stable chunks, feedback collector, prefetch engine (#30, #31, #32)

### DIFF
--- a/feedback/collector.go
+++ b/feedback/collector.go
@@ -148,9 +148,11 @@ func (c *Collector) Record(ctx context.Context, signal Signal) error {
 		}
 	}
 
+	oldCount := c.signalCount.Load()
 	newCount := c.signalCount.Add(int64(len(keys)))
-	if newCount%recomputeInterval == 0 {
-		// Trigger async recomputation (best effort).
+	// Trigger when the counter crosses an interval boundary, not just on
+	// exact multiples. This handles batched signals that skip exact hits.
+	if newCount/recomputeInterval > oldCount/recomputeInterval {
 		go func() {
 			_ = c.store.RecomputeAggregates(context.Background(), c.config.DecayLambda)
 		}()

--- a/prefetch/cache.go
+++ b/prefetch/cache.go
@@ -119,10 +119,14 @@ func (c *WarmCache) Put(key string, results []rag.ScoredResult) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	// Defensive copy so callers cannot mutate cached state.
+	stored := make([]rag.ScoredResult, len(results))
+	copy(stored, results)
+
 	// Update existing entry in-place.
 	if elem, ok := c.items[key]; ok {
 		entry := elem.Value.(*cacheEntry)
-		entry.results = results
+		entry.results = stored
 		entry.expiresAt = c.now().Add(c.ttl)
 		c.order.MoveToFront(elem)
 		return
@@ -140,7 +144,7 @@ func (c *WarmCache) Put(key string, results []rag.ScoredResult) {
 
 	entry := &cacheEntry{
 		key:       key,
-		results:   results,
+		results:   stored,
 		expiresAt: c.now().Add(c.ttl),
 	}
 	elem := c.order.PushFront(entry)

--- a/prefetch/cache.go
+++ b/prefetch/cache.go
@@ -2,11 +2,60 @@ package prefetch
 
 import (
 	"container/list"
+	"sort"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/kstruzzieri/go-llm/rag"
 )
+
+// cacheKey combines query text, result count, and context-sensitive fields
+// so that different (query, k, context) combinations get independent entries.
+type cacheKey struct {
+	query         string
+	k             int
+	currentFile   string
+	workspaceRoot string
+	openFiles     []string
+	timestampUnix int64
+}
+
+func newCacheKey(query string, k int, qCtx rag.QueryContext) cacheKey {
+	openFiles := append([]string(nil), qCtx.OpenFiles...)
+	sort.Strings(openFiles)
+
+	var ts int64
+	if !qCtx.Timestamp.IsZero() {
+		ts = qCtx.Timestamp.Unix()
+	}
+
+	return cacheKey{
+		query:         query,
+		k:             k,
+		currentFile:   qCtx.CurrentFile,
+		workspaceRoot: qCtx.WorkspaceRoot,
+		openFiles:     openFiles,
+		timestampUnix: ts,
+	}
+}
+
+func (ck cacheKey) String() string {
+	var b strings.Builder
+	b.WriteString(ck.query)
+	b.WriteString("\x00")
+	b.WriteString(strconv.Itoa(ck.k))
+	b.WriteString("\x00")
+	b.WriteString(ck.currentFile)
+	b.WriteString("\x00")
+	b.WriteString(ck.workspaceRoot)
+	b.WriteString("\x00")
+	b.WriteString(strings.Join(ck.openFiles, "\x1f"))
+	b.WriteString("\x00")
+	b.WriteString(strconv.FormatInt(ck.timestampUnix, 10))
+	return b.String()
+}
 
 // cacheEntry holds a cached set of scored results with an expiration time.
 type cacheEntry struct {
@@ -58,7 +107,10 @@ func (c *WarmCache) Get(key string) ([]rag.ScoredResult, bool) {
 
 	// Move to front (most recently used).
 	c.order.MoveToFront(elem)
-	return entry.results, true
+	// Return a copy so callers cannot mutate the cached slice.
+	cp := make([]rag.ScoredResult, len(entry.results))
+	copy(cp, entry.results)
+	return cp, true
 }
 
 // Put stores results for the given query key, evicting the least recently

--- a/prefetch/engine.go
+++ b/prefetch/engine.go
@@ -130,14 +130,10 @@ func (e *Engine) Retrieve(ctx context.Context, query string, k int,
 	// Cancel any in-flight prefetch so the cold retriever is not contended.
 	e.cancelPrefetch()
 
-	cacheKey := buildCacheKey(query, k, qCtx)
+	key := newCacheKey(query, k, qCtx).String()
 
 	if !opts.SkipCache && e.cache != nil {
-		if results, ok := e.cache.Get(cacheKey); ok {
-			// Trim to requested k if cache has more.
-			if k > 0 && len(results) > k {
-				results = results[:k]
-			}
+		if results, ok := e.cache.Get(key); ok {
 			return &RetrieveResult{
 				Chunks:   results,
 				CacheHit: true,
@@ -152,7 +148,7 @@ func (e *Engine) Retrieve(ctx context.Context, query string, k int,
 
 	// Warm the cache with this result for future hits.
 	if e.cache != nil {
-		e.cache.Put(cacheKey, result.Chunks)
+		e.cache.Put(key, result.Chunks)
 	}
 
 	return result, nil
@@ -230,7 +226,7 @@ func (e *Engine) prefetchForState(parentCtx context.Context, activeFile string, 
 			continue
 		}
 		if e.cache != nil {
-			e.cache.Put(buildCacheKey(q, prefetchK, qCtx), result.Chunks)
+			e.cache.Put(newCacheKey(q, prefetchK, qCtx).String(), result.Chunks)
 		}
 	}
 }
@@ -390,14 +386,9 @@ func commonPathPrefix(path string) string {
 	return parent + "/"
 }
 
-// buildCacheKey constructs a composite cache key that includes the query
-// context dimensions affecting multi-signal scoring, so that different editor
-// contexts do not share cached results.
-func buildCacheKey(query string, k int, qCtx rag.QueryContext) string {
-	return fmt.Sprintf("%s|k=%d|file=%s", query, k, qCtx.CurrentFile)
-}
-
 // stateChanged returns true if the active file or open files set has changed.
+// Open files are compared as sets (order-insensitive) because StateProvider
+// does not guarantee ordering.
 func stateChanged(activeFile string, openFiles []string, lastActive string, lastOpen []string) bool {
 	if activeFile != lastActive {
 		return true
@@ -405,8 +396,12 @@ func stateChanged(activeFile string, openFiles []string, lastActive string, last
 	if len(openFiles) != len(lastOpen) {
 		return true
 	}
-	for i := range openFiles {
-		if openFiles[i] != lastOpen[i] {
+	set := make(map[string]struct{}, len(lastOpen))
+	for _, f := range lastOpen {
+		set[f] = struct{}{}
+	}
+	for _, f := range openFiles {
+		if _, ok := set[f]; !ok {
 			return true
 		}
 	}

--- a/prefetch/engine.go
+++ b/prefetch/engine.go
@@ -217,7 +217,6 @@ func (e *Engine) prefetchForState(parentCtx context.Context, activeFile string, 
 		qCtx := rag.QueryContext{
 			CurrentFile: activeFile,
 			OpenFiles:   openFiles,
-			Timestamp:   time.Now(),
 		}
 		const prefetchK = 10
 		result, err := e.retriever.Retrieve(ctx, q, prefetchK, qCtx, RetrieveOptions{})

--- a/rag/stable_key.go
+++ b/rag/stable_key.go
@@ -122,7 +122,7 @@ func anchorHash(content string) string {
 // same boundary patterns used in chunker_code.go, extracting the identifier
 // that follows the keyword.
 var symbolExtractors = map[string]*regexp.Regexp{
-	"go":         regexp.MustCompile(`^func\s+(?:\(\s*\w+\s+\*?\w+\)\s+)?(\w+)`),
+	"go":         regexp.MustCompile(`^func\s+(?:\(\s*\w+\s+(\*?\w+(?:\[[\w,\s]+\])?)\)\s+)?(\w+)`),
 	"python":     regexp.MustCompile(`^(?:def|class)\s+(\w+)`),
 	"typescript": regexp.MustCompile(`^(?:export\s+)?(?:function|class|const|interface|type)\s+(\w+)`),
 	"javascript": regexp.MustCompile(`^(?:export\s+)?(?:function|class|const)\s+(\w+)`),
@@ -132,7 +132,10 @@ var symbolExtractors = map[string]*regexp.Regexp{
 }
 
 // extractSymbolName scans the chunk content for the first recognizable symbol
-// declaration and returns its name. Returns "" if no symbol is found.
+// declaration and returns its name. For Go methods, the result includes the
+// receiver type (e.g. "Server.Start") to disambiguate same-named methods on
+// different types. Generic type params are stripped (Server[T] -> Server).
+// Returns "" if no symbol is found.
 func extractSymbolName(content string, lang string) string {
 	pattern, ok := symbolExtractors[lang]
 	if !ok {
@@ -141,6 +144,19 @@ func extractSymbolName(content string, lang string) string {
 	for _, line := range strings.Split(content, "\n") {
 		trimmed := strings.TrimSpace(line)
 		if m := pattern.FindStringSubmatch(trimmed); m != nil {
+			// Go regex has 2 capture groups: receiver type (may be empty) and func name.
+			if lang == "go" && len(m) >= 3 {
+				receiver := m[1]
+				funcName := m[2]
+				if receiver != "" {
+					receiver = strings.TrimPrefix(receiver, "*")
+					if idx := strings.IndexByte(receiver, '['); idx >= 0 {
+						receiver = receiver[:idx]
+					}
+					return receiver + "." + funcName
+				}
+				return funcName
+			}
 			return m[1]
 		}
 	}

--- a/rag/stable_key_test.go
+++ b/rag/stable_key_test.go
@@ -266,7 +266,10 @@ func TestExtractSymbolName(t *testing.T) {
 		want    string
 	}{
 		{"go func", "func Hello() {}", "go", "Hello"},
-		{"go method", "func (s *Server) Start() error {}", "go", "Start"},
+		{"go method", "func (s *Server) Start() error {}", "go", "Server.Start"},
+		{"go method value receiver", "func (s Server) Stop() error {}", "go", "Server.Stop"},
+		{"go generic receiver", "func (s *Server[T]) Start() error {}", "go", "Server.Start"},
+		{"go generic multi-param", "func (s *Cache[K, V]) Get() {}", "go", "Cache.Get"},
 		{"python def", "def process_data():", "python", "process_data"},
 		{"python class", "class MyModel:", "python", "MyModel"},
 		{"ts function", "export function render() {}", "typescript", "render"},


### PR DESCRIPTION
## Summary

Phase 2 Wave 1 of the Adaptive Intelligence Layer epic (#35). Three packages built in parallel, reviewed, and fixed.

- **rag/ StableKey** (#30): Adds `Chunk.StableKey` -- a logical identity that survives re-indexing and benign line shifts. Deterministic key from workspace-relative path + symbol/section/anchor metadata. v3 schema migration. Go methods include receiver type (e.g. `Server.Start`). Persisted through Store/Search/SearchMulti round-trips.

- **feedback/** (#31): New package for implicit behavioral learning. 8 signal types, three-layer SQLite storage (retrieval log, signal events, materialized aggregates), Collector with attribution windows, cold-start thresholds, time-decay aggregation. Signal.Timestamp and Source are persisted for correct decay. Sweep accounting and stale aggregate cleanup included.

- **prefetch/** (#32): New package for predictive cache warming. Retriever interface (consumed by future #33 orchestrate), ScoredRetriever adapter, WarmCache (LRU+TTL), Engine with resource-aware sizing and Watch loop. Cache key includes full QueryContext (query, k, currentFile, workspaceRoot, openFiles, timestamp).

27 files changed, 4,894 insertions. All 11 packages pass.

Closes #30, closes #31, closes #32

## Test plan

- [x] `go test ./... -count=1` -- all 11 packages pass
- [x] `go vet ./...` -- clean
- [x] StableKey deterministic key tests, line-shift stability, path normalization
- [x] StableKey Store/Search/SearchMulti round-trip tests
- [x] Go method receiver-qualified symbol extraction
- [x] IndexDirectory does not leak workspace root to later IndexFile calls
- [x] Feedback attribution window lifecycle, cold start, warmup thresholds
- [x] Signal time-decay with persisted event timestamps
- [x] Sweep weak-negative accounting and stale aggregate cleanup
- [x] Cache miss on different k, different QueryContext
- [x] Cache key includes all context-sensitive fields
- [x] Resource adaptation (3-tier table-driven)
- [x] Watch loop cancellation and state change
- [x] Verify on Linux: `GOOS=linux GOARCH=amd64 go build ./rag/ ./feedback/ ./prefetch/`

Generated with [Claude Code](https://claude.com/claude-code)