### PR TITLE
ci: add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop, main]
+
+# Cancel stale PR runs on new pushes; let push builds on develop/main complete
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    name: Lint & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.11.4
+
+      - name: Test
+        run: go test -race ./...
+
+  darwin-smoke:
+    name: macOS Compile Smoke
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Compile smoke
+        run: go test -run '^$' ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Designed for embedding into Go applications that need LLM capabilities: chat, to
 
 ## Requirements
 
-- Go 1.24+
+- Go 1.25+
 - [Ollama](https://ollama.com) running locally (default: `http://localhost:11434`)
 
 ## Installation

--- a/analysis/code_review.go
+++ b/analysis/code_review.go
@@ -105,10 +105,10 @@ func (cr *CodeReviewer) buildReviewPrompt(ctx context.Context, code string, cfg 
 
 	b.WriteString("Please review the following code")
 	if cfg.language != "" {
-		b.WriteString(fmt.Sprintf(" (language: %s)", cfg.language))
+		fmt.Fprintf(&b, " (language: %s)", cfg.language)
 	}
 	if cfg.focus != "" {
-		b.WriteString(fmt.Sprintf(" with a focus on %s", cfg.focus))
+		fmt.Fprintf(&b, " with a focus on %s", cfg.focus)
 	}
 	b.WriteString(":\n\n```\n")
 	b.WriteString(code)

--- a/analysis/code_review_test.go
+++ b/analysis/code_review_test.go
@@ -28,7 +28,7 @@ func newMockChatServer(t *testing.T, wantContent string) *httptest.Server {
 			Message: ollama.ChatMessage{Role: "assistant", Content: wantContent},
 			Done:    true,
 		}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 }
 
@@ -127,7 +127,7 @@ func TestReviewWithOptions(t *testing.T) {
 			Message: ollama.ChatMessage{Role: "assistant", Content: "Security review complete."},
 			Done:    true,
 		}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer srv.Close()
 
@@ -168,7 +168,7 @@ func TestReviewEmptyCode(t *testing.T) {
 func TestReviewServerError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("internal error"))
+		_, _ = w.Write([]byte("internal error"))
 	}))
 	defer srv.Close()
 
@@ -194,7 +194,7 @@ func TestReviewContextCanceled(t *testing.T) {
 			Message: ollama.ChatMessage{Role: "assistant", Content: "ok"},
 			Done:    true,
 		}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer srv.Close()
 

--- a/analysis/explain_test.go
+++ b/analysis/explain_test.go
@@ -100,7 +100,7 @@ func TestExplainPromptContent(t *testing.T) {
 			Message: ollama.ChatMessage{Role: "assistant", Content: "Adds two integers."},
 			Done:    true,
 		}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer srv.Close()
 

--- a/analysis/metrics.go
+++ b/analysis/metrics.go
@@ -102,22 +102,22 @@ func (ma *MetricsAnalyzer) ExplainAnomaly(ctx context.Context, anomaly AnomalyIn
 
 func buildTrainingPrompt(m TrainingMetrics) string {
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("Analyze the following ML training metrics at epoch %d:\n\n", m.Epoch))
-	b.WriteString(fmt.Sprintf("- Current Loss: %.6f\n", m.Loss))
-	b.WriteString(fmt.Sprintf("- Learning Rate: %g\n", m.LearningRate))
-	b.WriteString(fmt.Sprintf("- KL Divergence: %.6f\n", m.KLDivergence))
-	b.WriteString(fmt.Sprintf("- Mean Reward: %.6f\n", m.RewardMean))
+	fmt.Fprintf(&b, "Analyze the following ML training metrics at epoch %d:\n\n", m.Epoch)
+	fmt.Fprintf(&b, "- Current Loss: %.6f\n", m.Loss)
+	fmt.Fprintf(&b, "- Learning Rate: %g\n", m.LearningRate)
+	fmt.Fprintf(&b, "- KL Divergence: %.6f\n", m.KLDivergence)
+	fmt.Fprintf(&b, "- Mean Reward: %.6f\n", m.RewardMean)
 
 	if len(m.LossHistory) > 0 {
-		b.WriteString(fmt.Sprintf("- Loss History (last %d): %v\n", len(m.LossHistory), m.LossHistory))
+		fmt.Fprintf(&b, "- Loss History (last %d): %v\n", len(m.LossHistory), m.LossHistory)
 	}
 	if len(m.RewardHistory) > 0 {
-		b.WriteString(fmt.Sprintf("- Reward History (last %d): %v\n", len(m.RewardHistory), m.RewardHistory))
+		fmt.Fprintf(&b, "- Reward History (last %d): %v\n", len(m.RewardHistory), m.RewardHistory)
 	}
 	if len(m.CustomMetrics) > 0 {
 		b.WriteString("- Custom Metrics:\n")
 		for k, v := range m.CustomMetrics {
-			b.WriteString(fmt.Sprintf("  - %s: %.6f\n", k, v))
+			fmt.Fprintf(&b, "  - %s: %.6f\n", k, v)
 		}
 	}
 
@@ -127,15 +127,15 @@ func buildTrainingPrompt(m TrainingMetrics) string {
 
 func buildAnomalyPrompt(a AnomalyInfo) string {
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("Explain the following training anomaly:\n\n"))
-	b.WriteString(fmt.Sprintf("- Type: %s\n", a.Type))
-	b.WriteString(fmt.Sprintf("- Severity: %s\n", a.Severity))
-	b.WriteString(fmt.Sprintf("- Description: %s\n", a.Description))
+	b.WriteString("Explain the following training anomaly:\n\n")
+	fmt.Fprintf(&b, "- Type: %s\n", a.Type)
+	fmt.Fprintf(&b, "- Severity: %s\n", a.Severity)
+	fmt.Fprintf(&b, "- Description: %s\n", a.Description)
 
 	if len(a.Metrics) > 0 {
 		b.WriteString("- Associated Metrics:\n")
 		for k, v := range a.Metrics {
-			b.WriteString(fmt.Sprintf("  - %s: %.6f\n", k, v))
+			fmt.Fprintf(&b, "  - %s: %.6f\n", k, v)
 		}
 	}
 

--- a/analysis/metrics_test.go
+++ b/analysis/metrics_test.go
@@ -119,7 +119,7 @@ func TestAnalyzeTrainingPromptContent(t *testing.T) {
 			Message: ollama.ChatMessage{Role: "assistant", Content: "analysis"},
 			Done:    true,
 		}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer srv.Close()
 

--- a/analysis/trading.go
+++ b/analysis/trading.go
@@ -85,10 +85,10 @@ func (sa *StrategyAnalyzer) CompareStrategies(ctx context.Context, strategies ma
 
 func buildStrategyPrompt(name string, metrics map[string]float64) string {
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("Analyze the trading strategy %q with the following performance metrics:\n\n", name))
+	fmt.Fprintf(&b, "Analyze the trading strategy %q with the following performance metrics:\n\n", name)
 
 	for k, v := range metrics {
-		b.WriteString(fmt.Sprintf("- %s: %.6f\n", k, v))
+		fmt.Fprintf(&b, "- %s: %.6f\n", k, v)
 	}
 
 	b.WriteString("\nProvide:\n1. Overall performance assessment\n2. Risk analysis\n3. Strengths and weaknesses\n4. Recommendations for improvement")
@@ -100,9 +100,9 @@ func buildComparisonPrompt(strategies map[string]map[string]float64) string {
 	b.WriteString("Compare the following trading strategies:\n\n")
 
 	for name, metrics := range strategies {
-		b.WriteString(fmt.Sprintf("Strategy: %s\n", name))
+		fmt.Fprintf(&b, "Strategy: %s\n", name)
 		for k, v := range metrics {
-			b.WriteString(fmt.Sprintf("  - %s: %.6f\n", k, v))
+			fmt.Fprintf(&b, "  - %s: %.6f\n", k, v)
 		}
 		b.WriteString("\n")
 	}

--- a/analysis/trading_test.go
+++ b/analysis/trading_test.go
@@ -161,7 +161,7 @@ func TestAnalyzeStrategyPromptContent(t *testing.T) {
 			Message: ollama.ChatMessage{Role: "assistant", Content: "analysis"},
 			Done:    true,
 		}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer srv.Close()
 

--- a/completion/inline_test.go
+++ b/completion/inline_test.go
@@ -41,7 +41,7 @@ func TestComplete(t *testing.T) {
 			Done:      true,
 			EvalCount: 5,
 		}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer srv.Close()
 
@@ -76,14 +76,14 @@ func TestCompleteStream(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req ollama.GenerateRequest
-		json.NewDecoder(r.Body).Decode(&req)
+		_ = json.NewDecoder(r.Body).Decode(&req)
 		if !req.Stream {
 			t.Error("expected stream=true for streaming complete")
 		}
 
 		for _, chunk := range chunks {
 			data, _ := json.Marshal(chunk)
-			fmt.Fprintf(w, "%s\n", data)
+			_, _ = fmt.Fprintf(w, "%s\n", data)
 		}
 	}))
 	defer srv.Close()
@@ -119,7 +119,7 @@ func TestCompleteStreamCallbackError(t *testing.T) {
 			Done:     false,
 		}
 		data, _ := json.Marshal(chunk)
-		fmt.Fprintf(w, "%s\n", data)
+		_, _ = fmt.Fprintf(w, "%s\n", data)
 	}))
 	defer srv.Close()
 
@@ -166,7 +166,7 @@ func TestCompleteValidation(t *testing.T) {
 	t.Run("empty prefix is valid for FIM", func(t *testing.T) {
 		// Empty prefix is valid — represents cursor at the start of a file or new buffer.
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			json.NewEncoder(w).Encode(map[string]any{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"response":   "generated",
 				"done":       true,
 				"eval_count": 1,
@@ -200,7 +200,7 @@ func TestCompleteFIMPromptFormat(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req ollama.GenerateRequest
-		json.NewDecoder(r.Body).Decode(&req)
+		_ = json.NewDecoder(r.Body).Decode(&req)
 		capturedPrompt = req.Prompt
 
 		resp := ollama.GenerateResponse{
@@ -208,14 +208,14 @@ func TestCompleteFIMPromptFormat(t *testing.T) {
 			Response: "result",
 			Done:     true,
 		}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer srv.Close()
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	provider := NewProvider(client, "test-model")
 
-	provider.Complete(context.Background(), FIMRequest{
+	_, _ = provider.Complete(context.Background(), FIMRequest{
 		Prefix: "BEFORE",
 		Suffix: "AFTER",
 	})
@@ -229,7 +229,7 @@ func TestCompleteFIMPromptFormat(t *testing.T) {
 func TestCompleteModelOptions(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req ollama.GenerateRequest
-		json.NewDecoder(r.Body).Decode(&req)
+		_ = json.NewDecoder(r.Body).Decode(&req)
 
 		if req.Options == nil {
 			t.Fatal("expected model options")
@@ -245,13 +245,13 @@ func TestCompleteModelOptions(t *testing.T) {
 		}
 
 		resp := ollama.GenerateResponse{Model: "test-model", Response: "x", Done: true}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer srv.Close()
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	provider := NewProvider(client, "test-model")
-	provider.Complete(context.Background(), FIMRequest{Prefix: "code"})
+	_, _ = provider.Complete(context.Background(), FIMRequest{Prefix: "code"})
 }
 
 func TestCompleteContextTruncation(t *testing.T) {
@@ -336,20 +336,20 @@ func TestCompleteContextTruncation(t *testing.T) {
 func TestCompleteCustomMaxTokens(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req ollama.GenerateRequest
-		json.NewDecoder(r.Body).Decode(&req)
+		_ = json.NewDecoder(r.Body).Decode(&req)
 
 		if req.Options.NumPredict != 256 {
 			t.Errorf("NumPredict = %d, want 256", req.Options.NumPredict)
 		}
 
 		resp := ollama.GenerateResponse{Model: "test-model", Response: "x", Done: true}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer srv.Close()
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	provider := NewProvider(client, "test-model")
-	provider.Complete(context.Background(), FIMRequest{
+	_, _ = provider.Complete(context.Background(), FIMRequest{
 		Prefix:    "code",
 		MaxTokens: 256,
 	})
@@ -374,7 +374,7 @@ func TestCompleteMaxTokensClamped(t *testing.T) {
 		}
 
 		resp := ollama.GenerateResponse{Model: "test-model", Response: "x", Done: true}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer srv.Close()
 

--- a/config/config.go
+++ b/config/config.go
@@ -42,7 +42,7 @@ func (d *Duration) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON returns the duration as a quoted string (e.g. "5m0s").
 func (d Duration) MarshalJSON() ([]byte, error) {
-	return json.Marshal(d.Duration.String())
+	return json.Marshal(d.String())
 }
 
 // ProviderConfig holds connection settings for an LLM provider (e.g. Ollama, vLLM).

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -466,7 +466,7 @@ func TestDefault_WorkingDir(t *testing.T) {
 	}
 
 	// Unset env var so it doesn't take precedence.
-	os.Unsetenv("GO_LLM_CONFIG")
+	_ = os.Unsetenv("GO_LLM_CONFIG")
 
 	// Chdir into the temp dir.
 	origDir, err := os.Getwd()
@@ -476,7 +476,7 @@ func TestDefault_WorkingDir(t *testing.T) {
 	if err := os.Chdir(tmpDir); err != nil {
 		t.Fatalf("failed to chdir: %v", err)
 	}
-	t.Cleanup(func() { os.Chdir(origDir) })
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
 
 	cfg, err := Default()
 	if err != nil {
@@ -491,7 +491,7 @@ func TestDefault_NotFound(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Unset env var.
-	os.Unsetenv("GO_LLM_CONFIG")
+	_ = os.Unsetenv("GO_LLM_CONFIG")
 	// Set HOME to empty temp dir so ~/.config/go-llm/models.json won't be found.
 	t.Setenv("HOME", tmpDir)
 
@@ -503,7 +503,7 @@ func TestDefault_NotFound(t *testing.T) {
 	if err := os.Chdir(tmpDir); err != nil {
 		t.Fatalf("failed to chdir: %v", err)
 	}
-	t.Cleanup(func() { os.Chdir(origDir) })
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
 
 	_, err = Default()
 	if err == nil {

--- a/conversation/migration.go
+++ b/conversation/migration.go
@@ -66,7 +66,7 @@ func runMigrations(db *sql.DB) error {
 		}
 
 		if err := m.fn(tx); err != nil {
-			tx.Rollback()
+			_ = tx.Rollback()
 			return fmt.Errorf("conversation: migration v%d (%s): %w", m.version, m.description, err)
 		}
 
@@ -74,7 +74,7 @@ func runMigrations(db *sql.DB) error {
 			`INSERT INTO conversation_schema_version (version, description, applied_at) VALUES (?, ?, ?)`,
 			m.version, m.description, time.Now().UnixMilli(),
 		); err != nil {
-			tx.Rollback()
+			_ = tx.Rollback()
 			return fmt.Errorf("conversation: record version %d: %w", m.version, err)
 		}
 

--- a/conversation/migration_test.go
+++ b/conversation/migration_test.go
@@ -14,7 +14,7 @@ func openTestDB(t *testing.T) *sql.DB {
 		t.Fatalf("open :memory: db: %v", err)
 	}
 	db.SetMaxOpenConns(1)
-	t.Cleanup(func() { db.Close() })
+	t.Cleanup(func() { _ = db.Close() })
 	return db
 }
 

--- a/conversation/store.go
+++ b/conversation/store.go
@@ -100,7 +100,7 @@ func (s *SQLiteStore) List(ctx context.Context) ([]Summary, error) {
 	if err != nil {
 		return nil, fmt.Errorf("conversation: list: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var summaries []Summary
 	for rows.Next() {

--- a/feedback/migration_test.go
+++ b/feedback/migration_test.go
@@ -13,7 +13,7 @@ func openTestDB(t *testing.T) *sql.DB {
 	if err != nil {
 		t.Fatalf("open test db: %v", err)
 	}
-	t.Cleanup(func() { db.Close() })
+	t.Cleanup(func() { _ = db.Close() })
 	return db
 }
 

--- a/feedback/store.go
+++ b/feedback/store.go
@@ -164,7 +164,7 @@ func (s *SQLiteSignalStore) GetAggregatesBatch(ctx context.Context, chunkKeys []
 	if err != nil {
 		return nil, fmt.Errorf("feedback: get aggregates batch: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	result := make(map[string]Aggregate, len(chunkKeys))
 	for rows.Next() {
@@ -193,7 +193,7 @@ func (s *SQLiteSignalStore) RecomputeAggregates(ctx context.Context, lambda floa
 	if err != nil {
 		return fmt.Errorf("feedback: recompute query signals: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	scores := make(map[string]float64)
 	for rows.Next() {

--- a/fingerprint/migration.go
+++ b/fingerprint/migration.go
@@ -89,7 +89,7 @@ func runMigrations(db *sql.DB) error {
 		}
 
 		if err := m.fn(tx); err != nil {
-			tx.Rollback()
+			_ = tx.Rollback()
 			return fmt.Errorf("fingerprint: migration v%d (%s): %w", m.version, m.description, err)
 		}
 
@@ -97,7 +97,7 @@ func runMigrations(db *sql.DB) error {
 			`INSERT INTO fingerprint_schema_version (version, description, applied_at) VALUES (?, ?, ?)`,
 			m.version, m.description, time.Now().UnixMilli(),
 		); err != nil {
-			tx.Rollback()
+			_ = tx.Rollback()
 			return fmt.Errorf("fingerprint: record version %d: %w", m.version, err)
 		}
 

--- a/fingerprint/migration_test.go
+++ b/fingerprint/migration_test.go
@@ -37,6 +37,6 @@ func openTestDB(t *testing.T) *sql.DB {
 	if err != nil {
 		t.Fatalf("open test db: %v", err)
 	}
-	t.Cleanup(func() { db.Close() })
+	t.Cleanup(func() { _ = db.Close() })
 	return db
 }

--- a/fingerprint/probe_test.go
+++ b/fingerprint/probe_test.go
@@ -20,7 +20,7 @@ func newTestProber(handler http.Handler) (*OllamaProber, *httptest.Server) {
 // TestDetectKind_Capabilities verifies Tier 1: capabilities array.
 func TestDetectKind_Capabilities(t *testing.T) {
 	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"details":      map[string]any{"family": "qwen2"},
 			"template":     "{{ .System }}\n{{ .Prompt }}",
 			"capabilities": []string{"completion", "tools"},
@@ -46,7 +46,7 @@ func TestDetectKind_Capabilities(t *testing.T) {
 // TestDetectKind_Embedding verifies embedding detection from capabilities.
 func TestDetectKind_Embedding(t *testing.T) {
 	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"details":      map[string]any{"family": "nomic-bert"},
 			"capabilities": []string{"embedding"},
 		})
@@ -69,7 +69,7 @@ func TestDetectKind_Embedding(t *testing.T) {
 func TestDetectKind_Heuristic(t *testing.T) {
 	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// No capabilities, but has template (chat model).
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"details":  map[string]any{"family": "llama"},
 			"template": "{{ .System }}\n{{ .Prompt }}",
 		})
@@ -92,7 +92,7 @@ func TestDetectKind_Heuristic(t *testing.T) {
 func TestDetectKind_HeuristicEmbedding(t *testing.T) {
 	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Known embedding family, no capabilities.
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"details": map[string]any{"family": "bert"},
 		})
 	}))
@@ -116,12 +116,12 @@ func TestDetectKind_Probe(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/show":
 			// No capabilities, no template, unknown family
-			json.NewEncoder(w).Encode(map[string]any{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"details": map[string]any{"family": "custom"},
 			})
 		case "/api/chat":
 			// Chat succeeds — this model is a chat model
-			json.NewEncoder(w).Encode(map[string]any{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"model":   "custom-model",
 				"message": map[string]any{"role": "assistant", "content": "hi"},
 				"done":    true,
@@ -149,16 +149,16 @@ func TestDetectKind_ProbeEmbedding(t *testing.T) {
 	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/show":
-			json.NewEncoder(w).Encode(map[string]any{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"details": map[string]any{"family": "custom"},
 			})
 		case "/api/chat":
 			// Chat fails
 			w.WriteHeader(http.StatusBadRequest)
-			w.Write([]byte(`{"error":"not a chat model"}`))
+			_, _ = w.Write([]byte(`{"error":"not a chat model"}`))
 		case "/api/embed":
 			// Embedding succeeds
-			json.NewEncoder(w).Encode(map[string]any{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"embeddings": [][]float64{{0.1, 0.2, 0.3}},
 			})
 		default:
@@ -184,12 +184,12 @@ func TestDetectKind_ProbeUnknown(t *testing.T) {
 	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/show":
-			json.NewEncoder(w).Encode(map[string]any{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"details": map[string]any{"family": "custom"},
 			})
 		default:
 			w.WriteHeader(http.StatusBadRequest)
-			w.Write([]byte(`{"error":"not supported"}`))
+			_, _ = w.Write([]byte(`{"error":"not supported"}`))
 		}
 	}))
 	defer srv.Close()
@@ -210,7 +210,7 @@ func TestDetectKind_ProbeUnknown(t *testing.T) {
 func TestDetectKind_ShowError(t *testing.T) {
 	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte(`{"error":"model not found"}`))
+		_, _ = w.Write([]byte(`{"error":"model not found"}`))
 	}))
 	defer srv.Close()
 
@@ -223,7 +223,7 @@ func TestDetectKind_ShowError(t *testing.T) {
 // TestProbeChat verifies chat metric extraction.
 func TestProbeChat(t *testing.T) {
 	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"model":                "test-model",
 			"message":              map[string]any{"role": "assistant", "content": "Hello!"},
 			"done":                 true,
@@ -256,7 +256,7 @@ func TestProbeChat(t *testing.T) {
 // TestProbeChat_ColdStart verifies cold start detection.
 func TestProbeChat_ColdStart(t *testing.T) {
 	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"model":          "test-model",
 			"message":        map[string]any{"role": "assistant", "content": "Hi"},
 			"done":           true,
@@ -281,7 +281,7 @@ func TestProbeChat_ColdStart(t *testing.T) {
 func TestProbeChat_Error(t *testing.T) {
 	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(`{"error":"model unavailable"}`))
+		_, _ = w.Write([]byte(`{"error":"model unavailable"}`))
 	}))
 	defer srv.Close()
 
@@ -299,7 +299,7 @@ func TestProbeEmbedding(t *testing.T) {
 	}
 
 	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"embeddings": [][]float64{vec},
 		})
 	}))
@@ -321,7 +321,7 @@ func TestProbeEmbedding(t *testing.T) {
 func TestProbeEmbedding_Error(t *testing.T) {
 	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(`{"error":"not an embedding model"}`))
+		_, _ = w.Write([]byte(`{"error":"not an embedding model"}`))
 	}))
 	defer srv.Close()
 

--- a/fingerprint/profiler_test.go
+++ b/fingerprint/profiler_test.go
@@ -671,11 +671,11 @@ func TestProfiler_EnsureProfile_Singleflight_DifferentDigest(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
-		profiler.EnsureProfile(context.Background(), testBackend, testModel, "sha256:digest1")
+		_, _ = profiler.EnsureProfile(context.Background(), testBackend, testModel, "sha256:digest1")
 	}()
 	go func() {
 		defer wg.Done()
-		profiler.EnsureProfile(context.Background(), testBackend, testModel, "sha256:digest2")
+		_, _ = profiler.EnsureProfile(context.Background(), testBackend, testModel, "sha256:digest2")
 	}()
 	wg.Wait()
 

--- a/fingerprint/resource_linux.go
+++ b/fingerprint/resource_linux.go
@@ -22,7 +22,7 @@ func Detect() (ResourceProfile, error) {
 	if err != nil {
 		return rp, fmt.Errorf("fingerprint: open /proc/meminfo: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {

--- a/fingerprint/store.go
+++ b/fingerprint/store.go
@@ -174,7 +174,7 @@ func (s *SQLiteStore) Save(ctx context.Context, profile Profile) error {
 		profile.PeakMemoryMB, profile.GPULayersUsed,
 	)
 	if err != nil {
-		tx.Rollback()
+		_ = tx.Rollback()
 		return fmt.Errorf("fingerprint: save %q/%q: %w", profile.BackendID, profile.ModelName, err)
 	}
 
@@ -184,7 +184,7 @@ func (s *SQLiteStore) Save(ctx context.Context, profile Profile) error {
 			`DELETE FROM fingerprint_failures WHERE backend_id = ? AND model_name = ?`,
 			profile.BackendID, profile.ModelName,
 		); err != nil {
-			tx.Rollback()
+			_ = tx.Rollback()
 			return fmt.Errorf("fingerprint: save: clear failure %q/%q: %w", profile.BackendID, profile.ModelName, err)
 		}
 	}

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -21,7 +21,7 @@ func TestNewServerDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewServer() error = %v", err)
 	}
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 
 	if s.ollamaURL != defaultOllamaURL {
 		t.Errorf("ollamaURL = %q, want %q", s.ollamaURL, defaultOllamaURL)
@@ -48,7 +48,7 @@ func TestNewServerWithOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewServer() error = %v", err)
 	}
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 
 	if s.ollamaURL != customURL {
 		t.Errorf("ollamaURL = %q, want %q", s.ollamaURL, customURL)
@@ -82,7 +82,7 @@ func TestNewServerUsesConfiguredOllamaProvider(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewServer() error = %v", err)
 	}
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 
 	if s.ollamaURL != mock.URL {
 		t.Fatalf("ollamaURL = %q, want %q", s.ollamaURL, mock.URL)
@@ -127,7 +127,7 @@ func TestNewServerWithoutAutoDiscoveredConfigContinues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewServer() error = %v", err)
 	}
-	defer s.Close()
+	defer func() { _ = s.Close() }()
 
 	if s.cfg != nil {
 		t.Fatalf("cfg = %#v, want nil when no config is found", s.cfg)

--- a/mcp/testutil_test.go
+++ b/mcp/testutil_test.go
@@ -40,7 +40,7 @@ func newTestEnv(t *testing.T, mockHandler http.Handler) testEnv {
 	// Connect the MCP server to its transport.
 	serverSession, sErr := s.mcpServer.Connect(ctx, serverTransport, nil)
 	if sErr != nil {
-		s.Close()
+		_ = s.Close()
 		mock.Close()
 		t.Fatalf("newTestEnv: server.Connect() error = %v", sErr)
 	}
@@ -53,7 +53,7 @@ func newTestEnv(t *testing.T, mockHandler http.Handler) testEnv {
 
 	session, cErr := client.Connect(ctx, clientTransport, nil)
 	if cErr != nil {
-		s.Close()
+		_ = s.Close()
 		mock.Close()
 		t.Fatalf("newTestEnv: client.Connect() error = %v", cErr)
 	}
@@ -62,9 +62,9 @@ func newTestEnv(t *testing.T, mockHandler http.Handler) testEnv {
 		server:  s,
 		session: session,
 		cleanup: func() {
-			session.Close()
-			serverSession.Close()
-			s.Close()
+			_ = session.Close()
+			_ = serverSession.Close()
+			_ = s.Close()
 			mock.Close()
 		},
 	}

--- a/ollama/chat_test.go
+++ b/ollama/chat_test.go
@@ -78,7 +78,7 @@ func TestChatStream(t *testing.T) {
 				t.Errorf("marshal chunk: %v", err)
 				return
 			}
-			fmt.Fprintf(w, "%s\n", data)
+			_, _ = fmt.Fprintf(w, "%s\n", data)
 		}
 	}))
 	defer srv.Close()
@@ -118,7 +118,7 @@ func TestChatStreamCallbackError(t *testing.T) {
 			t.Errorf("marshal chunk: %v", err)
 			return
 		}
-		fmt.Fprintf(w, "%s\n", data)
+		_, _ = fmt.Fprintf(w, "%s\n", data)
 	}))
 	defer srv.Close()
 
@@ -138,7 +138,7 @@ func TestChatStreamCallbackError(t *testing.T) {
 func TestChatServerError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("model not found"))
+		_, _ = w.Write([]byte("model not found"))
 	}))
 	defer srv.Close()
 
@@ -262,7 +262,7 @@ func TestChatStreamWithTools(t *testing.T) {
 				t.Errorf("marshal chunk: %v", err)
 				return
 			}
-			fmt.Fprintf(w, "%s\n", data)
+			_, _ = fmt.Fprintf(w, "%s\n", data)
 		}
 	}))
 	defer srv.Close()

--- a/ollama/client.go
+++ b/ollama/client.go
@@ -70,7 +70,7 @@ func (c *Client) IsAvailable(ctx context.Context) bool {
 	if err != nil {
 		return false
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	return resp.StatusCode == http.StatusOK
 }
 
@@ -97,7 +97,7 @@ func (c *Client) doJSON(ctx context.Context, method, path string, body any, dst 
 	if err != nil {
 		return fmt.Errorf("ollama: request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return newAPIError(resp.StatusCode, resp.Body)
@@ -128,7 +128,7 @@ func (c *Client) doStream(ctx context.Context, path string, body any, fn func(js
 	if err != nil {
 		return fmt.Errorf("ollama: request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return newAPIError(resp.StatusCode, resp.Body)

--- a/ollama/embed_test.go
+++ b/ollama/embed_test.go
@@ -15,7 +15,7 @@ func TestEmbed(t *testing.T) {
 		}
 
 		var req EmbedRequest
-		json.NewDecoder(r.Body).Decode(&req)
+		_ = json.NewDecoder(r.Body).Decode(&req)
 		if req.Model != "nomic-embed-text" {
 			t.Errorf("expected model %q, got %q", "nomic-embed-text", req.Model)
 		}
@@ -23,7 +23,7 @@ func TestEmbed(t *testing.T) {
 		resp := EmbedResponse{
 			Embeddings: [][]float64{{0.1, 0.2, 0.3, 0.4}},
 		}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer srv.Close()
 
@@ -43,7 +43,7 @@ func TestEmbed(t *testing.T) {
 func TestEmbedEmptyResponse(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := EmbedResponse{Embeddings: [][]float64{}}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer srv.Close()
 
@@ -61,7 +61,7 @@ func TestEmbedBatch(t *testing.T) {
 		resp := EmbedResponse{
 			Embeddings: [][]float64{{float64(callCount), 0.0, 0.0}},
 		}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer srv.Close()
 

--- a/ollama/models_test.go
+++ b/ollama/models_test.go
@@ -24,7 +24,7 @@ func TestListModels(t *testing.T) {
 				{Name: "nomic-embed-text", Size: 300000000},
 			},
 		}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer srv.Close()
 
@@ -56,7 +56,7 @@ func TestShowModel(t *testing.T) {
 			},
 			Digest: "sha256:abc123def456",
 		}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer srv.Close()
 
@@ -99,7 +99,7 @@ func TestPullModel(t *testing.T) {
 		}
 		for _, u := range updates {
 			data, _ := json.Marshal(u)
-			fmt.Fprintf(w, "%s\n", data)
+			_, _ = fmt.Fprintf(w, "%s\n", data)
 		}
 	}))
 	defer srv.Close()
@@ -134,7 +134,7 @@ func TestAvailableModels(t *testing.T) {
 				{Name: "qwen3:8b", Size: 5000000000},
 			},
 		}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer srv.Close()
 
@@ -182,7 +182,7 @@ func TestListModelsServerError(t *testing.T) {
 
 func TestShowModel_NewFields(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"details": map[string]any{
 				"parameter_size":     "27B",
 				"quantization_level": "Q4_K_M",
@@ -215,7 +215,7 @@ func TestShowModel_NewFields(t *testing.T) {
 func TestAPIError_ErrorsAs(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(`{"error":"model not found"}`))
+		_, _ = w.Write([]byte(`{"error":"model not found"}`))
 	}))
 	defer srv.Close()
 
@@ -239,7 +239,7 @@ func TestAPIError_ErrorsAs(t *testing.T) {
 func TestChatStream_APIError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(`{"error":"bad request"}`))
+		_, _ = w.Write([]byte(`{"error":"bad request"}`))
 	}))
 	defer srv.Close()
 

--- a/prefetch/engine_test.go
+++ b/prefetch/engine_test.go
@@ -343,7 +343,7 @@ func TestEngine_WatchPrefetches(t *testing.T) {
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	go engine.Watch(ctx)
+	go func() { _ = engine.Watch(ctx) }()
 
 	// Give Watch time to detect state and prefetch.
 	time.Sleep(100 * time.Millisecond)
@@ -369,7 +369,7 @@ func TestEngine_WatchStateChange(t *testing.T) {
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	go engine.Watch(ctx)
+	go func() { _ = engine.Watch(ctx) }()
 
 	// Let initial state be processed.
 	time.Sleep(50 * time.Millisecond)

--- a/prefetch/scored_retriever_test.go
+++ b/prefetch/scored_retriever_test.go
@@ -80,7 +80,7 @@ func newMockEmbedServer(embedding []float64) *httptest.Server {
 			Embeddings: [][]float64{embedding},
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 }
 
@@ -190,7 +190,7 @@ func TestScoredRetriever_EmbedError(t *testing.T) {
 	// Server that returns an error.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]string{"error": "model not found"})
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "model not found"})
 	}))
 	defer server.Close()
 

--- a/rag/gitignore.go
+++ b/rag/gitignore.go
@@ -92,10 +92,7 @@ func parsePattern(line string) (gitignorePattern, bool) {
 		// Check if pattern contains / (other than in leading **/ prefix).
 		// Leading **/ is special syntax meaning "match in all directories"
 		// and its / does NOT trigger anchoring.
-		checkStr := line
-		if strings.HasPrefix(checkStr, "**/") {
-			checkStr = checkStr[3:]
-		}
+		checkStr := strings.TrimPrefix(line, "**/")
 		if strings.Contains(checkStr, "/") {
 			anchored = true
 		}
@@ -211,7 +208,7 @@ func (m *gitignoreMatcher) addFromFile(filePath string, baseDir string) error {
 		}
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {

--- a/rag/gitignore_test.go
+++ b/rag/gitignore_test.go
@@ -355,7 +355,7 @@ func TestGitignoreMatcherAddFromFile(t *testing.T) {
 	// Write a .gitignore file
 	gitignorePath := tmpDir + "/.gitignore"
 	content := "*.log\n# comment\n!important.log\nbuild/\n"
-	os.WriteFile(gitignorePath, []byte(content), 0644)
+	_ = os.WriteFile(gitignorePath, []byte(content), 0644)
 
 	m := newGitignoreMatcher()
 	err := m.addFromFile(gitignorePath, ".")

--- a/rag/indexer.go
+++ b/rag/indexer.go
@@ -326,7 +326,7 @@ func (idx *Indexer) IndexDirectory(ctx context.Context, dir string, opts ...Inde
 			return nil
 		})
 	}
-	g.Wait()
+	_ = g.Wait()
 
 	if len(indexErrors) > 0 {
 		return fmt.Errorf("rag: index directory %q completed with %d errors: %s",

--- a/rag/indexer_test.go
+++ b/rag/indexer_test.go
@@ -26,7 +26,7 @@ func newMockEmbedServer(dim int) *httptest.Server {
 		emb := make([]float64, dim)
 		emb[0] = 0.5
 		resp := ollama.EmbedResponse{Embeddings: [][]float64{emb}}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 }
 
@@ -39,7 +39,7 @@ func TestIndexerIndexFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSQLiteStore() error: %v", err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	idx := NewIndexer(client, store, WithEmbeddingModel("test-embed"))
 
@@ -66,16 +66,16 @@ func TestIndexerReindex(t *testing.T) {
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	idx := NewIndexer(client, store)
 	testFile := filepath.Join("..", "testdata", "sample.go")
 
 	// Index twice — should not duplicate
-	idx.IndexFile(context.Background(), testFile)
+	_ = idx.IndexFile(context.Background(), testFile)
 	stats1, _ := store.Stats(context.Background())
 
-	idx.IndexFile(context.Background(), testFile)
+	_ = idx.IndexFile(context.Background(), testFile)
 	stats2, _ := store.Stats(context.Background())
 
 	if stats2.TotalChunks != stats1.TotalChunks {
@@ -89,15 +89,15 @@ func TestIndexerIndexDirectory(t *testing.T) {
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	idx := NewIndexer(client, store)
 
 	// Create a temp directory with some files
 	tmpDir := t.TempDir()
-	os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
-	os.WriteFile(filepath.Join(tmpDir, "util.py"), []byte("def helper():\n    pass\n"), 0644)
-	os.WriteFile(filepath.Join(tmpDir, "data.csv"), []byte("a,b,c\n1,2,3\n"), 0644) // should be skipped
+	_ = os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "util.py"), []byte("def helper():\n    pass\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "data.csv"), []byte("a,b,c\n1,2,3\n"), 0644) // should be skipped
 
 	err := idx.IndexDirectory(context.Background(), tmpDir)
 	if err != nil {
@@ -120,7 +120,7 @@ func TestIndexerContextCancellation(t *testing.T) {
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	idx := NewIndexer(client, store)
 
@@ -128,7 +128,7 @@ func TestIndexerContextCancellation(t *testing.T) {
 	cancel() // cancel immediately
 
 	tmpDir := t.TempDir()
-	os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n"), 0644)
 
 	err := idx.IndexDirectory(ctx, tmpDir)
 	if err == nil {
@@ -142,7 +142,7 @@ func TestIndexerPreservesDataOnEmbedFailure(t *testing.T) {
 	defer goodSrv.Close()
 
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	goodClient := ollama.NewClient(ollama.WithBaseURL(goodSrv.URL))
 	idx := NewIndexer(goodClient, store, WithEmbeddingModel("test-embed"))
@@ -160,7 +160,7 @@ func TestIndexerPreservesDataOnEmbedFailure(t *testing.T) {
 	// Now try to re-index with a broken embed server
 	badSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(`{"error":"model not found"}`))
+		_, _ = w.Write([]byte(`{"error":"model not found"}`))
 	}))
 	defer badSrv.Close()
 
@@ -185,7 +185,7 @@ func TestIndexerReindexEmptyFileRemovesChunks(t *testing.T) {
 	defer srv.Close()
 
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	idx := NewIndexer(client, store, WithEmbeddingModel("test-embed"))
@@ -224,7 +224,7 @@ func TestIndexerDuplicateContentDifferentPositions(t *testing.T) {
 	defer srv.Close()
 
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	chunker, _ := NewSlidingWindowChunker(30, 0)
@@ -233,7 +233,7 @@ func TestIndexerDuplicateContentDifferentPositions(t *testing.T) {
 	// Create a file with duplicate lines that will end up in different chunks
 	tmpDir := t.TempDir()
 	content := "return nil\nreturn nil\nreturn nil\nreturn nil\nreturn nil\n"
-	os.WriteFile(filepath.Join(tmpDir, "dup.go"), []byte(content), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "dup.go"), []byte(content), 0644)
 
 	if err := idx.IndexFile(context.Background(), filepath.Join(tmpDir, "dup.go")); err != nil {
 		t.Fatalf("IndexFile() error: %v", err)
@@ -253,7 +253,7 @@ func TestIndexerWithCustomChunker(t *testing.T) {
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	chunker, _ := NewSlidingWindowChunker(50, 10)
 	idx := NewIndexer(client, store, WithChunker(chunker))
@@ -280,7 +280,7 @@ func newCountingEmbedServer(dim int, counter *atomic.Int32) *httptest.Server {
 		emb := make([]float64, dim)
 		emb[0] = 0.5
 		resp := ollama.EmbedResponse{Embeddings: [][]float64{emb}}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 }
 
@@ -291,7 +291,7 @@ func TestIndexerConcurrentIndexDirectory(t *testing.T) {
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	idx := NewIndexer(client, store)
 
@@ -300,7 +300,7 @@ func TestIndexerConcurrentIndexDirectory(t *testing.T) {
 	for i := 0; i < numFiles; i++ {
 		name := fmt.Sprintf("file%d.go", i)
 		content := fmt.Sprintf("package main\n\nfunc F%d() {}\n", i)
-		os.WriteFile(filepath.Join(tmpDir, name), []byte(content), 0644)
+		_ = os.WriteFile(filepath.Join(tmpDir, name), []byte(content), 0644)
 	}
 
 	err := idx.IndexDirectory(context.Background(), tmpDir, WithConcurrency(3))
@@ -323,12 +323,12 @@ func TestIndexerConcurrencyValidation(t *testing.T) {
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	idx := NewIndexer(client, store)
 
 	tmpDir := t.TempDir()
-	os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
 
 	// WithConcurrency(0) should not panic or deadlock — clamped to 1
 	if err := idx.IndexDirectory(context.Background(), tmpDir, WithConcurrency(0)); err != nil {
@@ -345,20 +345,20 @@ func TestIndexerConcurrentErrorAggregation(t *testing.T) {
 	// Server that always fails embedding
 	failSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(`{"error":"model not found"}`))
+		_, _ = w.Write([]byte(`{"error":"model not found"}`))
 	}))
 	defer failSrv.Close()
 
 	client := ollama.NewClient(ollama.WithBaseURL(failSrv.URL))
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	idx := NewIndexer(client, store)
 
 	tmpDir := t.TempDir()
-	os.WriteFile(filepath.Join(tmpDir, "a.go"), []byte("package a\n\nfunc A() {}\n"), 0644)
-	os.WriteFile(filepath.Join(tmpDir, "b.go"), []byte("package b\n\nfunc B() {}\n"), 0644)
-	os.WriteFile(filepath.Join(tmpDir, "c.go"), []byte("package c\n\nfunc C() {}\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "a.go"), []byte("package a\n\nfunc A() {}\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "b.go"), []byte("package b\n\nfunc B() {}\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "c.go"), []byte("package c\n\nfunc C() {}\n"), 0644)
 
 	err := idx.IndexDirectory(context.Background(), tmpDir, WithConcurrency(2))
 	if err == nil {
@@ -377,28 +377,28 @@ func TestIndexerGitignoreNestedScoping(t *testing.T) {
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 	idx := NewIndexer(client, store)
 
 	tmpDir := t.TempDir()
 
 	// Root .gitignore ignores *.log
-	os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("*.log\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("*.log\n"), 0644)
 
 	// src/.gitignore ignores *.tmp
-	os.MkdirAll(filepath.Join(tmpDir, "src"), 0755)
-	os.WriteFile(filepath.Join(tmpDir, "src", ".gitignore"), []byte("*.tmp\n"), 0644)
+	_ = os.MkdirAll(filepath.Join(tmpDir, "src"), 0755)
+	_ = os.WriteFile(filepath.Join(tmpDir, "src", ".gitignore"), []byte("*.tmp\n"), 0644)
 
 	// lib/ has no .gitignore
-	os.MkdirAll(filepath.Join(tmpDir, "lib"), 0755)
+	_ = os.MkdirAll(filepath.Join(tmpDir, "lib"), 0755)
 
 	// Create test files
-	os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
-	os.WriteFile(filepath.Join(tmpDir, "app.log"), []byte("log data\n"), 0644)          // ignored by root
-	os.WriteFile(filepath.Join(tmpDir, "src", "util.go"), []byte("package src\n"), 0644)
-	os.WriteFile(filepath.Join(tmpDir, "src", "cache.tmp"), []byte("temp\n"), 0644)     // ignored by src
-	os.WriteFile(filepath.Join(tmpDir, "src", "debug.log"), []byte("log\n"), 0644)      // ignored by root
-	os.WriteFile(filepath.Join(tmpDir, "lib", "helper.go"), []byte("package lib\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "app.log"), []byte("log data\n"), 0644)          // ignored by root
+	_ = os.WriteFile(filepath.Join(tmpDir, "src", "util.go"), []byte("package src\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "src", "cache.tmp"), []byte("temp\n"), 0644)     // ignored by src
+	_ = os.WriteFile(filepath.Join(tmpDir, "src", "debug.log"), []byte("log\n"), 0644)      // ignored by root
+	_ = os.WriteFile(filepath.Join(tmpDir, "lib", "helper.go"), []byte("package lib\n"), 0644)
 
 	err := idx.IndexDirectory(context.Background(), tmpDir)
 	if err != nil {
@@ -418,17 +418,17 @@ func TestIndexerGitignoreNegation(t *testing.T) {
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 	idx := NewIndexer(client, store)
 
 	tmpDir := t.TempDir()
 
 	// Root: ignore all .gen.go, but un-ignore important.gen.go
-	os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("*.gen.go\n!important.gen.go\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("*.gen.go\n!important.gen.go\n"), 0644)
 
-	os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
-	os.WriteFile(filepath.Join(tmpDir, "schema.gen.go"), []byte("package main\n"), 0644)    // ignored
-	os.WriteFile(filepath.Join(tmpDir, "important.gen.go"), []byte("package main\n"), 0644) // NOT ignored
+	_ = os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "schema.gen.go"), []byte("package main\n"), 0644)    // ignored
+	_ = os.WriteFile(filepath.Join(tmpDir, "important.gen.go"), []byte("package main\n"), 0644) // NOT ignored
 
 	err := idx.IndexDirectory(context.Background(), tmpDir)
 	if err != nil {
@@ -448,18 +448,18 @@ func TestIndexerGitignoreDirectorySkip(t *testing.T) {
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 	idx := NewIndexer(client, store)
 
 	tmpDir := t.TempDir()
 
 	// Ignore the build/ directory
-	os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("build/\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("build/\n"), 0644)
 
-	os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
-	os.MkdirAll(filepath.Join(tmpDir, "build", "deep", "nested"), 0755)
-	os.WriteFile(filepath.Join(tmpDir, "build", "output.go"), []byte("package build\n"), 0644)
-	os.WriteFile(filepath.Join(tmpDir, "build", "deep", "nested", "inner.go"), []byte("package nested\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
+	_ = os.MkdirAll(filepath.Join(tmpDir, "build", "deep", "nested"), 0755)
+	_ = os.WriteFile(filepath.Join(tmpDir, "build", "output.go"), []byte("package build\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "build", "deep", "nested", "inner.go"), []byte("package nested\n"), 0644)
 
 	err := idx.IndexDirectory(context.Background(), tmpDir)
 	if err != nil {
@@ -479,17 +479,17 @@ func TestIndexerGitignoreWithExcludePriority(t *testing.T) {
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 	idx := NewIndexer(client, store)
 
 	tmpDir := t.TempDir()
 
 	// .gitignore tries to un-ignore vendor/
-	os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("!vendor/\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("!vendor/\n"), 0644)
 
-	os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
-	os.MkdirAll(filepath.Join(tmpDir, "vendor"), 0755)
-	os.WriteFile(filepath.Join(tmpDir, "vendor", "dep.go"), []byte("package dep\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
+	_ = os.MkdirAll(filepath.Join(tmpDir, "vendor"), 0755)
+	_ = os.WriteFile(filepath.Join(tmpDir, "vendor", "dep.go"), []byte("package dep\n"), 0644)
 
 	// Default WithExclude includes "vendor"
 	err := idx.IndexDirectory(context.Background(), tmpDir)
@@ -510,21 +510,21 @@ func TestIndexerGitignorePathScoped(t *testing.T) {
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 	idx := NewIndexer(client, store)
 
 	tmpDir := t.TempDir()
 
 	// Path-scoped rule: only ignore generated/ under src/
-	os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("src/generated/\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("src/generated/\n"), 0644)
 
-	os.MkdirAll(filepath.Join(tmpDir, "src", "generated"), 0755)
-	os.MkdirAll(filepath.Join(tmpDir, "lib", "generated"), 0755)
+	_ = os.MkdirAll(filepath.Join(tmpDir, "src", "generated"), 0755)
+	_ = os.MkdirAll(filepath.Join(tmpDir, "lib", "generated"), 0755)
 
-	os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
-	os.WriteFile(filepath.Join(tmpDir, "src", "app.go"), []byte("package src\n"), 0644)
-	os.WriteFile(filepath.Join(tmpDir, "src", "generated", "proto.go"), []byte("package gen\n"), 0644) // ignored
-	os.WriteFile(filepath.Join(tmpDir, "lib", "generated", "types.go"), []byte("package gen\n"), 0644) // NOT ignored
+	_ = os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "src", "app.go"), []byte("package src\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "src", "generated", "proto.go"), []byte("package gen\n"), 0644) // ignored
+	_ = os.WriteFile(filepath.Join(tmpDir, "lib", "generated", "types.go"), []byte("package gen\n"), 0644) // NOT ignored
 
 	err := idx.IndexDirectory(context.Background(), tmpDir)
 	if err != nil {
@@ -544,14 +544,14 @@ func TestIndexerNoGitignore(t *testing.T) {
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 	idx := NewIndexer(client, store)
 
 	tmpDir := t.TempDir()
 
 	// No .gitignore file
-	os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
-	os.WriteFile(filepath.Join(tmpDir, "util.py"), []byte("def helper():\n    pass\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "util.py"), []byte("def helper():\n    pass\n"), 0644)
 
 	err := idx.IndexDirectory(context.Background(), tmpDir)
 	if err != nil {
@@ -570,21 +570,21 @@ func TestIndexerGitignoreSiblingScoping(t *testing.T) {
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 	idx := NewIndexer(client, store)
 
 	tmpDir := t.TempDir()
 
-	os.MkdirAll(filepath.Join(tmpDir, "src"), 0755)
-	os.MkdirAll(filepath.Join(tmpDir, "lib"), 0755)
+	_ = os.MkdirAll(filepath.Join(tmpDir, "src"), 0755)
+	_ = os.MkdirAll(filepath.Join(tmpDir, "lib"), 0755)
 
 	// src/.gitignore ignores *.gen.go
-	os.WriteFile(filepath.Join(tmpDir, "src", ".gitignore"), []byte("*.gen.go\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "src", ".gitignore"), []byte("*.gen.go\n"), 0644)
 
-	os.WriteFile(filepath.Join(tmpDir, "src", "app.go"), []byte("package src\n"), 0644)
-	os.WriteFile(filepath.Join(tmpDir, "src", "schema.gen.go"), []byte("package src\n"), 0644) // ignored by src rule
-	os.WriteFile(filepath.Join(tmpDir, "lib", "types.gen.go"), []byte("package lib\n"), 0644)  // NOT ignored
-	os.WriteFile(filepath.Join(tmpDir, "lib", "helper.go"), []byte("package lib\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "src", "app.go"), []byte("package src\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "src", "schema.gen.go"), []byte("package src\n"), 0644) // ignored by src rule
+	_ = os.WriteFile(filepath.Join(tmpDir, "lib", "types.gen.go"), []byte("package lib\n"), 0644)  // NOT ignored
+	_ = os.WriteFile(filepath.Join(tmpDir, "lib", "helper.go"), []byte("package lib\n"), 0644)
 
 	err := idx.IndexDirectory(context.Background(), tmpDir)
 	if err != nil {
@@ -604,17 +604,17 @@ func TestIndexerGitignoreDirectoryUnignore(t *testing.T) {
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 	idx := NewIndexer(client, store)
 
 	tmpDir := t.TempDir()
 
 	// Ignore build/, then un-ignore it — subtree should be walked
-	os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("build/\n!build/\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("build/\n!build/\n"), 0644)
 
-	os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
-	os.MkdirAll(filepath.Join(tmpDir, "build"), 0755)
-	os.WriteFile(filepath.Join(tmpDir, "build", "output.go"), []byte("package build\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
+	_ = os.MkdirAll(filepath.Join(tmpDir, "build"), 0755)
+	_ = os.WriteFile(filepath.Join(tmpDir, "build", "output.go"), []byte("package build\n"), 0644)
 
 	err := idx.IndexDirectory(context.Background(), tmpDir)
 	if err != nil {
@@ -634,22 +634,22 @@ func TestIndexerGitignoreOverlappingNestedRules(t *testing.T) {
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 	idx := NewIndexer(client, store)
 
 	tmpDir := t.TempDir()
 
 	// Root: ignore *.log, then un-ignore *.log
-	os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("*.log\n!*.log\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("*.log\n!*.log\n"), 0644)
 
 	// src/: re-ignore *.log (overrides parent negation)
-	os.MkdirAll(filepath.Join(tmpDir, "src"), 0755)
-	os.WriteFile(filepath.Join(tmpDir, "src", ".gitignore"), []byte("*.log\n"), 0644)
+	_ = os.MkdirAll(filepath.Join(tmpDir, "src"), 0755)
+	_ = os.WriteFile(filepath.Join(tmpDir, "src", ".gitignore"), []byte("*.log\n"), 0644)
 
-	os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
-	os.WriteFile(filepath.Join(tmpDir, "root.log"), []byte("root log\n"), 0644)        // NOT ignored (root negation)
-	os.WriteFile(filepath.Join(tmpDir, "src", "app.go"), []byte("package src\n"), 0644)
-	os.WriteFile(filepath.Join(tmpDir, "src", "debug.log"), []byte("src log\n"), 0644) // ignored (nested re-ignore)
+	_ = os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "root.log"), []byte("root log\n"), 0644)        // NOT ignored (root negation)
+	_ = os.WriteFile(filepath.Join(tmpDir, "src", "app.go"), []byte("package src\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "src", "debug.log"), []byte("src log\n"), 0644) // ignored (nested re-ignore)
 
 	err := idx.IndexDirectory(context.Background(), tmpDir,
 		WithExtensions(".go", ".log")) // include .log in extensions
@@ -670,14 +670,14 @@ func TestIndexerGitignoreAlreadyIndexedFileSurvives(t *testing.T) {
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 	idx := NewIndexer(client, store)
 
 	tmpDir := t.TempDir()
 
 	// First run: no .gitignore, index everything
-	os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
-	os.WriteFile(filepath.Join(tmpDir, "util.go"), []byte("package main\n\nfunc util() {}\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "util.go"), []byte("package main\n\nfunc util() {}\n"), 0644)
 
 	err := idx.IndexDirectory(context.Background(), tmpDir)
 	if err != nil {
@@ -690,7 +690,7 @@ func TestIndexerGitignoreAlreadyIndexedFileSurvives(t *testing.T) {
 	}
 
 	// Second run: add .gitignore that ignores util.go
-	os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("util.go\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("util.go\n"), 0644)
 
 	err = idx.IndexDirectory(context.Background(), tmpDir)
 	if err != nil {
@@ -710,19 +710,19 @@ func TestIndexerGitignoreNegationInsideIgnoredDir(t *testing.T) {
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 	idx := NewIndexer(client, store)
 
 	tmpDir := t.TempDir()
 
 	// Ignore build/ directory, then try to un-ignore a file inside it.
 	// The negation cannot work because SkipDir prevents the walk from reaching the file.
-	os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("build/\n!build/keep.go\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("build/\n!build/keep.go\n"), 0644)
 
-	os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
-	os.MkdirAll(filepath.Join(tmpDir, "build"), 0755)
-	os.WriteFile(filepath.Join(tmpDir, "build", "keep.go"), []byte("package build\n"), 0644)
-	os.WriteFile(filepath.Join(tmpDir, "build", "other.go"), []byte("package build\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
+	_ = os.MkdirAll(filepath.Join(tmpDir, "build"), 0755)
+	_ = os.WriteFile(filepath.Join(tmpDir, "build", "keep.go"), []byte("package build\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "build", "other.go"), []byte("package build\n"), 0644)
 
 	err := idx.IndexDirectory(context.Background(), tmpDir)
 	if err != nil {

--- a/rag/indexer_unix_test.go
+++ b/rag/indexer_unix_test.go
@@ -21,16 +21,16 @@ func TestIndexerConcurrentPartialFailure(t *testing.T) {
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	idx := NewIndexer(client, store)
 
 	tmpDir := t.TempDir()
-	os.WriteFile(filepath.Join(tmpDir, "good.go"), []byte("package good\n\nfunc Good() {}\n"), 0644)
+	_ = os.WriteFile(filepath.Join(tmpDir, "good.go"), []byte("package good\n\nfunc Good() {}\n"), 0644)
 
 	badFile := filepath.Join(tmpDir, "bad.go")
-	os.WriteFile(badFile, []byte("package bad\n"), 0644)
-	os.Chmod(badFile, 0000)
+	_ = os.WriteFile(badFile, []byte("package bad\n"), 0644)
+	_ = os.Chmod(badFile, 0000)
 
 	// Verify the chmod actually prevents reading on this platform.
 	if _, err := os.ReadFile(badFile); err == nil {

--- a/rag/migration.go
+++ b/rag/migration.go
@@ -180,7 +180,7 @@ func runMigrations(db *sql.DB) error {
 		}
 
 		if err := m.fn(tx); err != nil {
-			tx.Rollback()
+			_ = tx.Rollback()
 			return fmt.Errorf("rag: migration v%d (%s): %w", m.version, m.description, err)
 		}
 
@@ -193,7 +193,7 @@ func runMigrations(db *sql.DB) error {
 			`INSERT INTO rag_schema_version (version, description, applied_at) VALUES (?, ?, ?)`,
 			m.version, m.description, time.Now().Unix(),
 		); err != nil {
-			tx.Rollback()
+			_ = tx.Rollback()
 			return fmt.Errorf("rag: record version %d: %w", m.version, err)
 		}
 
@@ -253,7 +253,7 @@ func recordVersionsUpTo(db *sql.DB, upTo int) error {
 			`INSERT OR IGNORE INTO rag_schema_version (version, description, applied_at) VALUES (?, ?, ?)`,
 			m.version, m.description+" (pre-existing)", now,
 		); err != nil {
-			tx.Rollback()
+			_ = tx.Rollback()
 			return fmt.Errorf("rag: record version %d: %w", m.version, err)
 		}
 	}

--- a/rag/migration_test.go
+++ b/rag/migration_test.go
@@ -60,7 +60,7 @@ func TestMigrationExistingDB(t *testing.T) {
 		t.Fatalf("open db: %v", err)
 	}
 	db.SetMaxOpenConns(1)
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	// Create the old schema (no rag_schema_version, no indexed_at, no FTS5).
 	oldSchema := `
@@ -117,7 +117,7 @@ func TestMigrationExistingDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("query indexed_at: %v", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	for rows.Next() {
 		var id string
 		var indexedAt int64
@@ -162,7 +162,7 @@ func TestIndexedAtWrittenOnStore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("query indexed_at: %v", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	for rows.Next() {
 		var id string
@@ -382,7 +382,7 @@ func TestMigrationIdempotency(t *testing.T) {
 		t.Fatalf("open db: %v", err)
 	}
 	db.SetMaxOpenConns(1)
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	if err := runMigrations(db); err != nil {
 		t.Fatalf("first runMigrations() error: %v", err)
@@ -460,7 +460,7 @@ func TestFTS5UpsertConsistency(t *testing.T) {
 	if err != nil {
 		t.Fatalf("content-sync read: %v", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	for rows.Next() {
 		var rowid int64
 		var content, source string
@@ -482,7 +482,7 @@ func TestMigrationHalfAppliedV2(t *testing.T) {
 		t.Fatalf("open db: %v", err)
 	}
 	db.SetMaxOpenConns(1)
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	// Create v2-shaped schema: chunks table with indexed_at + FTS5.
 	v2Schema := `
@@ -549,7 +549,7 @@ func TestMigrationHalfAppliedV2WithV1Recorded(t *testing.T) {
 		t.Fatalf("open db: %v", err)
 	}
 	db.SetMaxOpenConns(1)
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	// Create v2-shaped schema.
 	v2Schema := `

--- a/rag/parquet/export.go
+++ b/rag/parquet/export.go
@@ -134,10 +134,10 @@ func ExportDataset(
 	tmpClosed := false
 	cleanup := func() {
 		if !tmpClosed {
-			tmpFile.Close()
+			_ = tmpFile.Close()
 			tmpClosed = true
 		}
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 	}
 	success := false
 	defer func() {
@@ -223,7 +223,7 @@ func exportTyped[T any](
 	// closeWriter is a helper for error paths. Writer close errors on error
 	// paths are secondary to the primary error, but we close to release resources.
 	closeWriter := func() {
-		writer.Close()
+		_ = writer.Close()
 	}
 
 	// Step 5: Get iterator from source.

--- a/rag/parquet/export_test.go
+++ b/rag/parquet/export_test.go
@@ -94,9 +94,9 @@ func TestRoundTripFloat32(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	reader := pq.NewGenericReader[embeddingRowF32](f)
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 
 	rows := make([]embeddingRowF32, 1)
 	n, err := reader.Read(rows)
@@ -164,9 +164,9 @@ func TestRoundTripFloat64(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	reader := pq.NewGenericReader[embeddingRowF64](f)
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 
 	rows := make([]embeddingRowF64, 1)
 	n, err := reader.Read(rows)
@@ -531,7 +531,7 @@ func TestRowGroupBoundaries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	fi, err := f.Stat()
 	if err != nil {
 		t.Fatalf("stat: %v", err)
@@ -948,9 +948,9 @@ func readF32Rows(t *testing.T, path string) []embeddingRowF32 {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	reader := pq.NewGenericReader[embeddingRowF32](f)
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 
 	rows := make([]embeddingRowF32, 100)
 	n, readErr := reader.Read(rows)
@@ -966,7 +966,7 @@ func readFileMetadata(t *testing.T, path string) map[string]string {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	fi, err := f.Stat()
 	if err != nil {
 		t.Fatalf("stat: %v", err)

--- a/rag/retriever_test.go
+++ b/rag/retriever_test.go
@@ -15,13 +15,13 @@ func TestRetrieverRetrieve(t *testing.T) {
 	// Mock embed server returns a fixed vector
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := ollama.EmbedResponse{Embeddings: [][]float64{{1.0, 0.0, 0.0}}}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer srv.Close()
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	// Pre-populate store
 	chunks := []Chunk{
@@ -32,7 +32,7 @@ func TestRetrieverRetrieve(t *testing.T) {
 		{0.9, 0.1, 0.0}, // similar to query
 		{0.0, 0.0, 1.0}, // orthogonal to query
 	}
-	store.Store(context.Background(), chunks, embeddings)
+	_ = store.Store(context.Background(), chunks, embeddings)
 
 	retriever := NewRetriever(client, store)
 	results, err := retriever.Retrieve(context.Background(), "test query", 2)
@@ -51,7 +51,7 @@ func TestRetrieverRetrieve(t *testing.T) {
 func TestRetrieverBuildContext(t *testing.T) {
 	client := ollama.NewClient()
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	retriever := NewRetriever(client, store)
 
@@ -87,7 +87,7 @@ func TestRetrieverBuildContext(t *testing.T) {
 func TestRetrieverBuildContextEmpty(t *testing.T) {
 	client := ollama.NewClient()
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	retriever := NewRetriever(client, store)
 	ctx := retriever.BuildContext(nil, 1000)
@@ -99,7 +99,7 @@ func TestRetrieverBuildContextEmpty(t *testing.T) {
 func TestRetrieverBuildContextTruncation(t *testing.T) {
 	client := ollama.NewClient()
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	retriever := NewRetriever(client, store)
 
@@ -124,20 +124,20 @@ func TestRetrieverBuildContextTruncation(t *testing.T) {
 func TestRetrieverWithCustomModel(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req ollama.EmbedRequest
-		json.NewDecoder(r.Body).Decode(&req)
+		_ = json.NewDecoder(r.Body).Decode(&req)
 		if req.Model != "custom-embed" {
 			t.Errorf("expected model %q, got %q", "custom-embed", req.Model)
 		}
 		resp := ollama.EmbedResponse{Embeddings: [][]float64{{1.0, 0.0}}}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer srv.Close()
 
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
 	store, _ := NewSQLiteStore(":memory:")
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
-	store.Store(context.Background(),
+	_ = store.Store(context.Background(),
 		[]Chunk{{ID: "c1", Content: "test", Source: "a.go", Metadata: map[string]string{}}},
 		[][]float64{{1.0, 0.0}},
 	)

--- a/rag/scorer_keyword.go
+++ b/rag/scorer_keyword.go
@@ -56,7 +56,7 @@ func (s *KeywordScorer) ScoreBatch(ctx context.Context, chunks []Chunk, query st
 		// than silently returning zero scores.
 		return nil, fmt.Errorf("rag: keyword FTS5 query: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	// Build map of chunk ID -> raw BM25 score.
 	bm25Scores := make(map[string]float64)

--- a/rag/scorer_keyword_test.go
+++ b/rag/scorer_keyword_test.go
@@ -245,7 +245,7 @@ func TestKeywordScorerPropagatesDatabaseErrors(t *testing.T) {
 		t.Fatalf("open db: %v", err)
 	}
 	db.SetMaxOpenConns(1)
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	scorer := NewKeywordScorer(db)
 	chunks := []Chunk{

--- a/rag/scorer_temporal.go
+++ b/rag/scorer_temporal.go
@@ -47,7 +47,7 @@ func (s *TemporalScorer) ScoreBatch(ctx context.Context, chunks []Chunk, query s
 	if err != nil {
 		return nil, fmt.Errorf("rag: query indexed_at: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	timestamps := make(map[string]int64)
 	for rows.Next() {

--- a/rag/search_multi.go
+++ b/rag/search_multi.go
@@ -127,7 +127,7 @@ func (s *SQLiteStore) loadChunksWithEmbeddings(ctx context.Context) ([]Chunk, []
 	if err != nil {
 		return nil, nil, fmt.Errorf("rag: query chunks: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var chunks []Chunk
 	var embeddings [][]float64

--- a/rag/sqlite_store.go
+++ b/rag/sqlite_store.go
@@ -42,13 +42,13 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 		// File-backed databases: enable WAL mode for better concurrent read performance.
 		// WAL is not meaningful for :memory: databases.
 		if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
-			db.Close()
+			_ = db.Close()
 			return nil, fmt.Errorf("rag: set WAL mode: %w", err)
 		}
 	}
 
 	if err := runMigrations(db); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, err
 	}
 
@@ -106,7 +106,7 @@ func (s *SQLiteStore) insertChunksTx(ctx context.Context, tx *sql.Tx, chunks []C
 	if err != nil {
 		return fmt.Errorf("rag: prepare insert: %w", err)
 	}
-	defer stmt.Close()
+	defer func() { _ = stmt.Close() }()
 
 	now := time.Now().Unix()
 	for i, chunk := range chunks {
@@ -139,7 +139,7 @@ func (s *SQLiteStore) Store(ctx context.Context, chunks []Chunk, embeddings [][]
 	if err != nil {
 		return fmt.Errorf("rag: begin transaction: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 
 	if err := s.insertChunksTx(ctx, tx, chunks, embeddings); err != nil {
 		return err
@@ -167,7 +167,7 @@ func (s *SQLiteStore) ReplaceSource(ctx context.Context, source string, chunks [
 	if err != nil {
 		return fmt.Errorf("rag: replace source %q: begin transaction: %w", source, err)
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 
 	if _, err := tx.ExecContext(ctx, `DELETE FROM chunks WHERE source = ?`, source); err != nil {
 		return fmt.Errorf("rag: replace source %q: delete existing chunks: %w", source, err)
@@ -192,7 +192,7 @@ func (s *SQLiteStore) Search(ctx context.Context, queryEmbedding []float64, k in
 	if err != nil {
 		return nil, fmt.Errorf("rag: query chunks: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var results []SearchResult
 	for rows.Next() {
@@ -314,7 +314,7 @@ func (s *SQLiteStore) ExportChunks(ctx context.Context, filter *ExportFilter) (i
 		return nil, fmt.Errorf("rag: export chunks: %w", err)
 	}
 	return func(yield func(ExportedChunk, error) bool) {
-		defer rows.Close()
+		defer func() { _ = rows.Close() }()
 		for rows.Next() {
 			if err := ctx.Err(); err != nil {
 				yield(ExportedChunk{}, err)

--- a/rag/sqlite_store_test.go
+++ b/rag/sqlite_store_test.go
@@ -12,7 +12,7 @@ func newTestStore(t *testing.T) *SQLiteStore {
 	if err != nil {
 		t.Fatalf("NewSQLiteStore() error: %v", err)
 	}
-	t.Cleanup(func() { store.Close() })
+	t.Cleanup(func() { _ = store.Close() })
 	return store
 }
 
@@ -61,7 +61,7 @@ func TestSQLiteStoreDeleteBySource(t *testing.T) {
 	}
 	embeddings := [][]float64{{1.0, 0.0}, {0.0, 1.0}}
 
-	store.Store(ctx, chunks, embeddings)
+	_ = store.Store(ctx, chunks, embeddings)
 
 	if err := store.DeleteBySource(ctx, "a.go"); err != nil {
 		t.Fatalf("DeleteBySource() error: %v", err)
@@ -84,7 +84,7 @@ func TestSQLiteStoreStats(t *testing.T) {
 	}
 	embeddings := [][]float64{{1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 0}}
 
-	store.Store(ctx, chunks, embeddings)
+	_ = store.Store(ctx, chunks, embeddings)
 
 	stats, err := store.Stats(ctx)
 	if err != nil {
@@ -157,11 +157,11 @@ func TestSQLiteStoreUpsert(t *testing.T) {
 
 	// Insert initial chunk
 	chunks := []Chunk{{ID: "c1", Content: "original", Source: "a.go", StartLine: 1, EndLine: 1, Metadata: map[string]string{}}}
-	store.Store(ctx, chunks, [][]float64{{1.0, 0.0}})
+	_ = store.Store(ctx, chunks, [][]float64{{1.0, 0.0}})
 
 	// Upsert with same ID, different content
 	chunks[0].Content = "updated"
-	store.Store(ctx, chunks, [][]float64{{0.0, 1.0}})
+	_ = store.Store(ctx, chunks, [][]float64{{0.0, 1.0}})
 
 	stats, _ := store.Stats(ctx)
 	if stats.TotalChunks != 1 {
@@ -437,7 +437,7 @@ func TestSchemaMigrationIndexes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("query indexes: %v", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	indexes := make(map[string]bool)
 	for rows.Next() {

--- a/rag/stable_key_test.go
+++ b/rag/stable_key_test.go
@@ -631,7 +631,7 @@ func TestIndexerStableKeyWithWorkspaceRoot(t *testing.T) {
 		emb := make([]float64, 4)
 		emb[0] = 0.5
 		resp := ollama.EmbedResponse{Embeddings: [][]float64{emb}}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer srv.Close()
 
@@ -640,11 +640,11 @@ func TestIndexerStableKeyWithWorkspaceRoot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSQLiteStore() error: %v", err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	tmpDir := t.TempDir()
 	goFile := filepath.Join(tmpDir, "main.go")
-	os.WriteFile(goFile, []byte("package main\n\nfunc Hello() {\n\treturn\n}\n"), 0644)
+	_ = os.WriteFile(goFile, []byte("package main\n\nfunc Hello() {\n\treturn\n}\n"), 0644)
 
 	idx := NewIndexer(client, store,
 		WithEmbeddingModel("test-embed"),
@@ -689,7 +689,7 @@ func TestIndexerStableKeyWithoutWorkspaceRoot(t *testing.T) {
 		emb := make([]float64, 4)
 		emb[0] = 0.5
 		resp := ollama.EmbedResponse{Embeddings: [][]float64{emb}}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer srv.Close()
 
@@ -698,11 +698,11 @@ func TestIndexerStableKeyWithoutWorkspaceRoot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSQLiteStore() error: %v", err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	tmpDir := t.TempDir()
 	goFile := filepath.Join(tmpDir, "main.go")
-	os.WriteFile(goFile, []byte("package main\n\nfunc Hello() {\n\treturn\n}\n"), 0644)
+	_ = os.WriteFile(goFile, []byte("package main\n\nfunc Hello() {\n\treturn\n}\n"), 0644)
 
 	// No WithWorkspaceRoot -- StableKey should be empty.
 	idx := NewIndexer(client, store, WithEmbeddingModel("test-embed"))
@@ -732,7 +732,7 @@ func TestIndexDirectoryStableKeyConsistency(t *testing.T) {
 		emb := make([]float64, 4)
 		emb[0] = 0.5
 		resp := ollama.EmbedResponse{Embeddings: [][]float64{emb}}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer srv.Close()
 
@@ -741,12 +741,12 @@ func TestIndexDirectoryStableKeyConsistency(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSQLiteStore() error: %v", err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	tmpDir := t.TempDir()
 	subDir := filepath.Join(tmpDir, "pkg")
-	os.MkdirAll(subDir, 0755)
-	os.WriteFile(filepath.Join(subDir, "util.go"), []byte("package pkg\n\nfunc Helper() {\n\treturn\n}\n"), 0644)
+	_ = os.MkdirAll(subDir, 0755)
+	_ = os.WriteFile(filepath.Join(subDir, "util.go"), []byte("package pkg\n\nfunc Helper() {\n\treturn\n}\n"), 0644)
 
 	idx := NewIndexer(client, store, WithEmbeddingModel("test-embed"))
 
@@ -784,7 +784,7 @@ func TestIndexFileAndIndexDirectoryProduceSameKey(t *testing.T) {
 		emb := make([]float64, 4)
 		emb[0] = 0.5
 		resp := ollama.EmbedResponse{Embeddings: [][]float64{emb}}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer srv.Close()
 
@@ -792,14 +792,14 @@ func TestIndexFileAndIndexDirectoryProduceSameKey(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	goFile := filepath.Join(tmpDir, "consistent.go")
-	os.WriteFile(goFile, []byte(content), 0644)
+	_ = os.WriteFile(goFile, []byte(content), 0644)
 
 	// Method 1: IndexFile with explicit workspace root.
 	store1, err := NewSQLiteStore(":memory:")
 	if err != nil {
 		t.Fatalf("store1 error: %v", err)
 	}
-	defer store1.Close()
+	defer func() { _ = store1.Close() }()
 
 	idx1 := NewIndexer(client, store1,
 		WithEmbeddingModel("test-embed"),
@@ -814,7 +814,7 @@ func TestIndexFileAndIndexDirectoryProduceSameKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("store2 error: %v", err)
 	}
-	defer store2.Close()
+	defer func() { _ = store2.Close() }()
 
 	idx2 := NewIndexer(client, store2, WithEmbeddingModel("test-embed"))
 	if err := idx2.IndexDirectory(context.Background(), tmpDir); err != nil {


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` with two jobs: `ci` (lint + race-enabled tests on Ubuntu) and `darwin-smoke` (compile-only on macOS)
- Adds `.golangci.yml` with explicit v2 linter set (errcheck, govet, ineffassign, staticcheck) and fixes all findings across 46 files
- Go version read from `go.mod` — no hardcoded version to maintain
- Concurrency cancels stale PR runs while preserving push builds on develop/main
- Aligns README Go version with go.mod (1.24+ → 1.25+)

## Test plan

- [x] `ci` job passes on the PR (lint clean, all 11 packages pass with `-race`)
- [x] `darwin-smoke` job passes (compile-only, validates `fingerprint/resource_darwin.go`)
- [ ] Verify concurrency group cancels a stale run by pushing a quick follow-up commit (optional)

Generated with [Claude Code](https://claude.com/claude-code)

Closes #8