### PR TITLE
feat(provider): Provider Intelligence Layer Phase 1

### DIFF
--- a/provider/catalog.go
+++ b/provider/catalog.go
@@ -1,0 +1,221 @@
+// provider/catalog.go
+package provider
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+//go:embed catalog.json
+var catalogJSON []byte
+
+// catalogData is the top-level JSON structure for the embedded model catalog.
+type catalogData struct {
+	Families map[string]catalogFamily `json:"families"`
+}
+
+// catalogFamily is the JSON representation of a model family entry.
+// Each family defines shared properties (FIM tokens, think mode, context window)
+// and a map of size-keyed variants with resource requirements.
+type catalogFamily struct {
+	FIM           *catalogFIM               `json:"fim"`
+	ThinkMode     string                    `json:"think_mode"`
+	ThinkTags     *catalogThinkTags         `json:"think_tags"`
+	Caps          []string                  `json:"caps"`
+	ContextWindow int                       `json:"context_window"`
+	Dimensions    int                       `json:"dimensions"`
+	Variants      map[string]catalogVariant `json:"variants"`
+}
+
+// catalogFIM is the JSON representation of FIM (Fill-in-the-Middle) configuration.
+type catalogFIM struct {
+	Prefix          string `json:"prefix"`
+	Suffix          string `json:"suffix"`
+	Middle          string `json:"middle"`
+	PrefixBudgetPct int    `json:"prefix_budget_pct"`
+}
+
+// catalogThinkTags is the JSON representation of thinking delimiters.
+type catalogThinkTags struct {
+	Open  string `json:"open"`
+	Close string `json:"close"`
+}
+
+// catalogVariant is the JSON representation of a specific model size variant.
+type catalogVariant struct {
+	RAMRequired     float64 `json:"ram_required"`
+	RAMRecommended  float64 `json:"ram_recommended"`
+	VRAMRecommended float64 `json:"vram_recommended"`
+	Quality         string  `json:"quality"`
+	Speed           string  `json:"speed"`
+}
+
+// staticCatalog provides lookup methods over the embedded catalog data.
+// It is created once at startup from the parsed catalog.json and used by
+// ModelRegistry for the static layer of three-layer profile merge.
+type staticCatalog struct {
+	data catalogData
+}
+
+// loadCatalog parses the embedded catalog.json into a catalogData structure.
+func loadCatalog() (*catalogData, error) {
+	var data catalogData
+	if err := json.Unmarshal(catalogJSON, &data); err != nil {
+		return nil, fmt.Errorf("provider: load catalog: %w", err)
+	}
+	return &data, nil
+}
+
+// newStaticCatalog creates a staticCatalog from parsed catalog data.
+func newStaticCatalog(data *catalogData) *staticCatalog {
+	return &staticCatalog{data: *data}
+}
+
+// lookup returns a ModelProfile for an exact family + param size match.
+// Returns nil if the family or variant is not found in the catalog.
+func (sc *staticCatalog) lookup(family, paramSize string) *ModelProfile {
+	family = strings.ToLower(family)
+	paramSize = strings.ToLower(paramSize)
+
+	fam, ok := sc.data.Families[family]
+	if !ok {
+		return nil
+	}
+
+	variant, ok := fam.Variants[paramSize]
+	if !ok {
+		return nil
+	}
+
+	return sc.buildProfile(family, &fam, &variant)
+}
+
+// lookupFamily returns a ModelProfile with family-level metadata (FIM tokens,
+// think mode, context window) but without variant-specific resource data.
+// Returns nil if the family is not found in the catalog.
+func (sc *staticCatalog) lookupFamily(family string) *ModelProfile {
+	family = strings.ToLower(family)
+
+	fam, ok := sc.data.Families[family]
+	if !ok {
+		return nil
+	}
+
+	return sc.buildProfile(family, &fam, nil)
+}
+
+// families returns all family names present in the catalog.
+func (sc *staticCatalog) families() []string {
+	names := make([]string, 0, len(sc.data.Families))
+	for name := range sc.data.Families {
+		names = append(names, name)
+	}
+	return names
+}
+
+// buildProfile constructs a ModelProfile from catalog data. If variant is nil,
+// only family-level data is populated and resource fields remain zero-valued.
+func (sc *staticCatalog) buildProfile(family string, fam *catalogFamily, variant *catalogVariant) *ModelProfile {
+	p := &ModelProfile{
+		Family:        family,
+		ThinkMode:     parseThinkMode(fam.ThinkMode),
+		Caps:          parseCaps(fam.Caps),
+		ContextWindow: fam.ContextWindow,
+		Dimensions:    fam.Dimensions,
+		Source:        SourceStatic,
+	}
+
+	if fam.FIM != nil {
+		p.FIM = &FIMConfig{
+			Prefix:          fam.FIM.Prefix,
+			Suffix:          fam.FIM.Suffix,
+			Middle:          fam.FIM.Middle,
+			PrefixBudgetPct: fam.FIM.PrefixBudgetPct,
+		}
+	}
+
+	if fam.ThinkTags != nil {
+		p.ThinkTags = &ThinkTags{
+			Open:  fam.ThinkTags.Open,
+			Close: fam.ThinkTags.Close,
+		}
+	}
+
+	if variant != nil {
+		p.Resources = ResourceProfile{
+			RAMRequired:     variant.RAMRequired,
+			RAMRecommended:  variant.RAMRecommended,
+			VRAMRecommended: variant.VRAMRecommended,
+		}
+		p.Quality = parseTier(variant.Quality)
+		p.Speed = parseTier(variant.Speed)
+	}
+
+	return p
+}
+
+// parseThinkMode converts a string think_mode value from JSON to ThinkMode.
+func parseThinkMode(s string) ThinkMode {
+	switch strings.ToLower(s) {
+	case "none":
+		return ThinkNone
+	case "always":
+		return ThinkAlways
+	case "toggle":
+		return ThinkToggle
+	case "auto":
+		return ThinkAuto
+	default:
+		return ThinkNone
+	}
+}
+
+// parseTier converts a string tier name to a Tier value.
+// Supports both quality names (basic, good, great, best) and speed aliases
+// (fast, medium, slow) so that catalog JSON can use descriptive labels.
+func parseTier(s string) Tier {
+	switch strings.ToLower(s) {
+	case "basic":
+		return TierBasic
+	case "good":
+		return TierGood
+	case "great":
+		return TierGreat
+	case "best":
+		return TierBest
+	// Speed tier aliases: fast=great throughput, medium=good, slow=basic.
+	case "fast":
+		return TierGreat
+	case "medium":
+		return TierGood
+	case "slow":
+		return TierBasic
+	default:
+		return TierBasic
+	}
+}
+
+// parseCaps converts a string slice of capability names from catalog JSON
+// to a Capability bitmask. The catalog uses higher-level labels:
+//   - "completion" implies CapChat | CapGenerate | CapStream
+//   - "tools" implies CapToolCall
+//   - "embedding" implies CapEmbed
+//   - "thinking" implies CapThinking
+func parseCaps(caps []string) Capability {
+	var c Capability
+	for _, s := range caps {
+		switch strings.ToLower(s) {
+		case "completion":
+			c |= CapChat | CapGenerate | CapStream
+		case "tools":
+			c |= CapToolCall
+		case "embedding":
+			c |= CapEmbed
+		case "thinking":
+			c |= CapThinking
+		}
+	}
+	return c
+}

--- a/provider/catalog.json
+++ b/provider/catalog.json
@@ -1,0 +1,269 @@
+{
+  "families": {
+    "qwen2.5": {
+      "fim": {
+        "prefix": "<|fim_prefix|>",
+        "suffix": "<|fim_suffix|>",
+        "middle": "<|fim_middle|>",
+        "prefix_budget_pct": 75
+      },
+      "think_mode": "none",
+      "caps": ["completion", "tools"],
+      "context_window": 32768,
+      "variants": {
+        "0.5b": { "ram_required": 1.0, "ram_recommended": 1.5, "vram_recommended": 1.0, "quality": "basic", "speed": "fast" },
+        "1.5b": { "ram_required": 1.5, "ram_recommended": 2.5, "vram_recommended": 1.5, "quality": "basic", "speed": "fast" },
+        "3b":   { "ram_required": 2.5, "ram_recommended": 4.0, "vram_recommended": 2.5, "quality": "basic", "speed": "fast" },
+        "7b":   { "ram_required": 5.0, "ram_recommended": 8.0, "vram_recommended": 5.0, "quality": "good", "speed": "fast" },
+        "14b":  { "ram_required": 9.0, "ram_recommended": 12.0, "vram_recommended": 9.0, "quality": "good", "speed": "medium" },
+        "32b":  { "ram_required": 20.0, "ram_recommended": 24.0, "vram_recommended": 20.0, "quality": "great", "speed": "medium" },
+        "72b":  { "ram_required": 44.0, "ram_recommended": 52.0, "vram_recommended": 44.0, "quality": "best", "speed": "slow" }
+      }
+    },
+    "qwen3": {
+      "fim": {
+        "prefix": "<|fim_prefix|>",
+        "suffix": "<|fim_suffix|>",
+        "middle": "<|fim_middle|>",
+        "prefix_budget_pct": 75
+      },
+      "think_mode": "toggle",
+      "think_tags": { "open": "<think>", "close": "</think>" },
+      "caps": ["completion", "tools"],
+      "context_window": 40960,
+      "variants": {
+        "0.6b": { "ram_required": 1.5, "ram_recommended": 2.0, "vram_recommended": 1.5, "quality": "basic", "speed": "fast" },
+        "1.7b": { "ram_required": 2.0, "ram_recommended": 3.0, "vram_recommended": 2.0, "quality": "basic", "speed": "fast" },
+        "4b":   { "ram_required": 3.5, "ram_recommended": 5.0, "vram_recommended": 3.5, "quality": "good", "speed": "fast" },
+        "8b":   { "ram_required": 5.0, "ram_recommended": 8.0, "vram_recommended": 5.0, "quality": "good", "speed": "fast" },
+        "14b":  { "ram_required": 9.0, "ram_recommended": 12.0, "vram_recommended": 9.0, "quality": "great", "speed": "medium" },
+        "30b":  { "ram_required": 19.0, "ram_recommended": 24.0, "vram_recommended": 19.0, "quality": "great", "speed": "medium" },
+        "32b":  { "ram_required": 20.0, "ram_recommended": 24.0, "vram_recommended": 20.0, "quality": "great", "speed": "medium" },
+        "235b": { "ram_required": 140.0, "ram_recommended": 160.0, "vram_recommended": 140.0, "quality": "best", "speed": "slow" }
+      }
+    },
+    "qwen3.5": {
+      "fim": {
+        "prefix": "<|fim_prefix|>",
+        "suffix": "<|fim_suffix|>",
+        "middle": "<|fim_middle|>",
+        "prefix_budget_pct": 75
+      },
+      "think_mode": "toggle",
+      "think_tags": { "open": "<think>", "close": "</think>" },
+      "caps": ["completion", "tools"],
+      "context_window": 131072,
+      "variants": {
+        "7b":  { "ram_required": 5.0, "ram_recommended": 8.0, "vram_recommended": 5.0, "quality": "good", "speed": "fast" },
+        "14b": { "ram_required": 9.0, "ram_recommended": 12.0, "vram_recommended": 9.0, "quality": "great", "speed": "medium" },
+        "27b": { "ram_required": 17.0, "ram_recommended": 22.0, "vram_recommended": 17.0, "quality": "great", "speed": "medium" },
+        "35b": { "ram_required": 22.0, "ram_recommended": 28.0, "vram_recommended": 22.0, "quality": "great", "speed": "medium" }
+      }
+    },
+    "deepseek-r1": {
+      "fim": null,
+      "think_mode": "always",
+      "think_tags": { "open": "<think>", "close": "</think>" },
+      "caps": ["completion"],
+      "context_window": 65536,
+      "variants": {
+        "1.5b": { "ram_required": 1.5, "ram_recommended": 2.5, "vram_recommended": 1.5, "quality": "basic", "speed": "fast" },
+        "7b":   { "ram_required": 5.0, "ram_recommended": 8.0, "vram_recommended": 5.0, "quality": "good", "speed": "fast" },
+        "8b":   { "ram_required": 5.5, "ram_recommended": 8.0, "vram_recommended": 5.5, "quality": "good", "speed": "fast" },
+        "14b":  { "ram_required": 9.0, "ram_recommended": 12.0, "vram_recommended": 9.0, "quality": "great", "speed": "medium" },
+        "32b":  { "ram_required": 20.0, "ram_recommended": 24.0, "vram_recommended": 20.0, "quality": "great", "speed": "medium" },
+        "70b":  { "ram_required": 44.0, "ram_recommended": 52.0, "vram_recommended": 44.0, "quality": "best", "speed": "slow" }
+      }
+    },
+    "deepseek-coder-v2": {
+      "fim": {
+        "prefix": "<|fim_prefix|>",
+        "suffix": "<|fim_suffix|>",
+        "middle": "<|fim_middle|>",
+        "prefix_budget_pct": 70
+      },
+      "think_mode": "none",
+      "caps": ["completion", "tools"],
+      "context_window": 65536,
+      "variants": {
+        "16b": { "ram_required": 10.0, "ram_recommended": 14.0, "vram_recommended": 10.0, "quality": "great", "speed": "medium" }
+      }
+    },
+    "codellama": {
+      "fim": {
+        "prefix": "<PRE>",
+        "suffix": " <SUF>",
+        "middle": " <MID>",
+        "prefix_budget_pct": 65
+      },
+      "think_mode": "none",
+      "caps": ["completion"],
+      "context_window": 16384,
+      "variants": {
+        "7b":  { "ram_required": 5.0, "ram_recommended": 7.0, "vram_recommended": 5.0, "quality": "good", "speed": "fast" },
+        "13b": { "ram_required": 8.5, "ram_recommended": 12.0, "vram_recommended": 8.5, "quality": "good", "speed": "medium" },
+        "34b": { "ram_required": 21.0, "ram_recommended": 26.0, "vram_recommended": 21.0, "quality": "great", "speed": "medium" },
+        "70b": { "ram_required": 44.0, "ram_recommended": 52.0, "vram_recommended": 44.0, "quality": "great", "speed": "slow" }
+      }
+    },
+    "starcoder": {
+      "fim": {
+        "prefix": "<fim_prefix>",
+        "suffix": "<fim_suffix>",
+        "middle": "<fim_middle>",
+        "prefix_budget_pct": 70
+      },
+      "think_mode": "none",
+      "caps": ["completion"],
+      "context_window": 8192,
+      "variants": {
+        "1b":  { "ram_required": 1.5, "ram_recommended": 2.5, "vram_recommended": 1.5, "quality": "basic", "speed": "fast" },
+        "3b":  { "ram_required": 2.5, "ram_recommended": 4.0, "vram_recommended": 2.5, "quality": "basic", "speed": "fast" },
+        "7b":  { "ram_required": 5.0, "ram_recommended": 7.0, "vram_recommended": 5.0, "quality": "good", "speed": "fast" },
+        "15b": { "ram_required": 10.0, "ram_recommended": 14.0, "vram_recommended": 10.0, "quality": "good", "speed": "medium" }
+      }
+    },
+    "starcoder2": {
+      "fim": {
+        "prefix": "<fim_prefix>",
+        "suffix": "<fim_suffix>",
+        "middle": "<fim_middle>",
+        "prefix_budget_pct": 70
+      },
+      "think_mode": "none",
+      "caps": ["completion"],
+      "context_window": 16384,
+      "variants": {
+        "3b":  { "ram_required": 2.5, "ram_recommended": 4.0, "vram_recommended": 2.5, "quality": "good", "speed": "fast" },
+        "7b":  { "ram_required": 5.0, "ram_recommended": 7.0, "vram_recommended": 5.0, "quality": "good", "speed": "fast" },
+        "15b": { "ram_required": 10.0, "ram_recommended": 14.0, "vram_recommended": 10.0, "quality": "great", "speed": "medium" }
+      }
+    },
+    "llama3": {
+      "fim": null,
+      "think_mode": "none",
+      "caps": ["completion", "tools"],
+      "context_window": 8192,
+      "variants": {
+        "8b":  { "ram_required": 5.0, "ram_recommended": 8.0, "vram_recommended": 5.0, "quality": "good", "speed": "fast" },
+        "70b": { "ram_required": 44.0, "ram_recommended": 52.0, "vram_recommended": 44.0, "quality": "great", "speed": "slow" }
+      }
+    },
+    "llama3.1": {
+      "fim": null,
+      "think_mode": "none",
+      "caps": ["completion", "tools"],
+      "context_window": 131072,
+      "variants": {
+        "8b":  { "ram_required": 5.0, "ram_recommended": 8.0, "vram_recommended": 5.0, "quality": "good", "speed": "fast" },
+        "70b": { "ram_required": 44.0, "ram_recommended": 52.0, "vram_recommended": 44.0, "quality": "best", "speed": "slow" }
+      }
+    },
+    "llama3.2": {
+      "fim": null,
+      "think_mode": "none",
+      "caps": ["completion", "tools"],
+      "context_window": 131072,
+      "variants": {
+        "1b": { "ram_required": 1.5, "ram_recommended": 2.5, "vram_recommended": 1.5, "quality": "basic", "speed": "fast" },
+        "3b": { "ram_required": 2.5, "ram_recommended": 4.0, "vram_recommended": 2.5, "quality": "basic", "speed": "fast" }
+      }
+    },
+    "llama3.3": {
+      "fim": null,
+      "think_mode": "none",
+      "caps": ["completion", "tools"],
+      "context_window": 131072,
+      "variants": {
+        "70b": { "ram_required": 44.0, "ram_recommended": 52.0, "vram_recommended": 44.0, "quality": "best", "speed": "slow" }
+      }
+    },
+    "gemma2": {
+      "fim": null,
+      "think_mode": "none",
+      "caps": ["completion"],
+      "context_window": 8192,
+      "variants": {
+        "2b":  { "ram_required": 2.0, "ram_recommended": 3.0, "vram_recommended": 2.0, "quality": "basic", "speed": "fast" },
+        "9b":  { "ram_required": 6.0, "ram_recommended": 9.0, "vram_recommended": 6.0, "quality": "good", "speed": "fast" },
+        "27b": { "ram_required": 17.0, "ram_recommended": 22.0, "vram_recommended": 17.0, "quality": "great", "speed": "medium" }
+      }
+    },
+    "gemma3": {
+      "fim": null,
+      "think_mode": "toggle",
+      "think_tags": { "open": "<think>", "close": "</think>" },
+      "caps": ["completion", "tools"],
+      "context_window": 131072,
+      "variants": {
+        "1b":  { "ram_required": 1.5, "ram_recommended": 2.5, "vram_recommended": 1.5, "quality": "basic", "speed": "fast" },
+        "4b":  { "ram_required": 3.5, "ram_recommended": 5.0, "vram_recommended": 3.5, "quality": "good", "speed": "fast" },
+        "12b": { "ram_required": 8.0, "ram_recommended": 11.0, "vram_recommended": 8.0, "quality": "good", "speed": "medium" },
+        "27b": { "ram_required": 17.0, "ram_recommended": 22.0, "vram_recommended": 17.0, "quality": "great", "speed": "medium" }
+      }
+    },
+    "phi3": {
+      "fim": null,
+      "think_mode": "none",
+      "caps": ["completion", "tools"],
+      "context_window": 4096,
+      "variants": {
+        "3.8b": { "ram_required": 3.0, "ram_recommended": 4.5, "vram_recommended": 3.0, "quality": "good", "speed": "fast" },
+        "14b":  { "ram_required": 9.0, "ram_recommended": 12.0, "vram_recommended": 9.0, "quality": "good", "speed": "medium" }
+      }
+    },
+    "phi4": {
+      "fim": null,
+      "think_mode": "none",
+      "caps": ["completion", "tools"],
+      "context_window": 16384,
+      "variants": {
+        "14b": { "ram_required": 9.0, "ram_recommended": 12.0, "vram_recommended": 9.0, "quality": "great", "speed": "medium" }
+      }
+    },
+    "mistral": {
+      "fim": {
+        "prefix": "[PREFIX]",
+        "suffix": "[SUFFIX]",
+        "middle": "[MIDDLE]",
+        "prefix_budget_pct": 70
+      },
+      "think_mode": "none",
+      "caps": ["completion", "tools"],
+      "context_window": 32768,
+      "variants": {
+        "7b": { "ram_required": 5.0, "ram_recommended": 7.0, "vram_recommended": 5.0, "quality": "good", "speed": "fast" }
+      }
+    },
+    "mixtral": {
+      "fim": null,
+      "think_mode": "none",
+      "caps": ["completion", "tools"],
+      "context_window": 32768,
+      "variants": {
+        "8x7b":  { "ram_required": 28.0, "ram_recommended": 36.0, "vram_recommended": 28.0, "quality": "great", "speed": "medium" },
+        "8x22b": { "ram_required": 84.0, "ram_recommended": 96.0, "vram_recommended": 84.0, "quality": "best", "speed": "slow" }
+      }
+    },
+    "nomic-embed-text": {
+      "fim": null,
+      "think_mode": "none",
+      "caps": ["embedding"],
+      "context_window": 8192,
+      "dimensions": 768,
+      "variants": {
+        "latest": { "ram_required": 0.5, "ram_recommended": 1.0, "vram_recommended": 0.5, "quality": "good", "speed": "fast" }
+      }
+    },
+    "mxbai-embed-large": {
+      "fim": null,
+      "think_mode": "none",
+      "caps": ["embedding"],
+      "context_window": 512,
+      "dimensions": 1024,
+      "variants": {
+        "latest": { "ram_required": 0.7, "ram_recommended": 1.2, "vram_recommended": 0.7, "quality": "great", "speed": "fast" }
+      }
+    }
+  }
+}

--- a/provider/catalog_test.go
+++ b/provider/catalog_test.go
@@ -1,0 +1,527 @@
+package provider
+
+import "testing"
+
+func TestCatalogLoad(t *testing.T) {
+	cat, err := loadCatalog()
+	if err != nil {
+		t.Fatalf("loadCatalog() error: %v", err)
+	}
+	if len(cat.Families) == 0 {
+		t.Fatal("loadCatalog() returned empty catalog")
+	}
+
+	// Spot-check that all required families are present.
+	families := []string{
+		"qwen2.5", "qwen3", "qwen3.5",
+		"deepseek-r1", "deepseek-coder-v2",
+		"codellama", "starcoder", "starcoder2",
+		"llama3", "llama3.1", "llama3.2", "llama3.3",
+		"gemma2", "gemma3",
+		"phi3", "phi4",
+		"mistral", "mixtral",
+		"nomic-embed-text", "mxbai-embed-large",
+	}
+	for _, f := range families {
+		if _, ok := cat.Families[f]; !ok {
+			t.Errorf("catalog missing family %q", f)
+		}
+	}
+}
+
+func TestCatalogLookupExact(t *testing.T) {
+	cat, err := loadCatalog()
+	if err != nil {
+		t.Fatalf("loadCatalog() error: %v", err)
+	}
+
+	sc := newStaticCatalog(cat)
+
+	tests := []struct {
+		name       string
+		family     string
+		paramSize  string
+		wantFIM    bool
+		wantThink  ThinkMode
+		wantRAMMin float64
+	}{
+		{
+			name:       "qwen3 8b has FIM and toggle think",
+			family:     "qwen3",
+			paramSize:  "8b",
+			wantFIM:    true,
+			wantThink:  ThinkToggle,
+			wantRAMMin: 5.0,
+		},
+		{
+			name:       "deepseek-r1 7b has no FIM but always thinks",
+			family:     "deepseek-r1",
+			paramSize:  "7b",
+			wantFIM:    false,
+			wantThink:  ThinkAlways,
+			wantRAMMin: 5.0,
+		},
+		{
+			name:       "codellama 7b has FIM with PRE/SUF/MID tokens",
+			family:     "codellama",
+			paramSize:  "7b",
+			wantFIM:    true,
+			wantThink:  ThinkNone,
+			wantRAMMin: 5.0,
+		},
+		{
+			name:       "starcoder2 15b has FIM",
+			family:     "starcoder2",
+			paramSize:  "15b",
+			wantFIM:    true,
+			wantThink:  ThinkNone,
+			wantRAMMin: 10.0,
+		},
+		{
+			name:       "llama3 8b has no FIM and no think",
+			family:     "llama3",
+			paramSize:  "8b",
+			wantFIM:    false,
+			wantThink:  ThinkNone,
+			wantRAMMin: 5.0,
+		},
+		{
+			name:       "gemma2 27b has no FIM and no think",
+			family:     "gemma2",
+			paramSize:  "27b",
+			wantFIM:    false,
+			wantThink:  ThinkNone,
+			wantRAMMin: 17.0,
+		},
+		{
+			name:       "phi3 3.8b has no FIM and no think",
+			family:     "phi3",
+			paramSize:  "3.8b",
+			wantFIM:    false,
+			wantThink:  ThinkNone,
+			wantRAMMin: 3.0,
+		},
+		{
+			name:       "mistral 7b has FIM with bracket tokens",
+			family:     "mistral",
+			paramSize:  "7b",
+			wantFIM:    true,
+			wantThink:  ThinkNone,
+			wantRAMMin: 5.0,
+		},
+		{
+			name:       "qwen2.5 72b is best quality",
+			family:     "qwen2.5",
+			paramSize:  "72b",
+			wantFIM:    true,
+			wantThink:  ThinkNone,
+			wantRAMMin: 44.0,
+		},
+		{
+			name:       "deepseek-coder-v2 16b has FIM and no think",
+			family:     "deepseek-coder-v2",
+			paramSize:  "16b",
+			wantFIM:    true,
+			wantThink:  ThinkNone,
+			wantRAMMin: 10.0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile := sc.lookup(tt.family, tt.paramSize)
+			if profile == nil {
+				t.Fatalf("lookup(%q, %q) returned nil", tt.family, tt.paramSize)
+			}
+			if (profile.FIM != nil) != tt.wantFIM {
+				t.Errorf("FIM: got %v, want hasFIM=%v", profile.FIM, tt.wantFIM)
+			}
+			if profile.ThinkMode != tt.wantThink {
+				t.Errorf("ThinkMode = %v, want %v", profile.ThinkMode, tt.wantThink)
+			}
+			if profile.Resources.RAMRequired < tt.wantRAMMin {
+				t.Errorf("RAMRequired = %f, want >= %f", profile.Resources.RAMRequired, tt.wantRAMMin)
+			}
+		})
+	}
+}
+
+func TestCatalogLookupFamilyOnly(t *testing.T) {
+	cat, err := loadCatalog()
+	if err != nil {
+		t.Fatalf("loadCatalog() error: %v", err)
+	}
+
+	sc := newStaticCatalog(cat)
+
+	// lookupFamily returns family-level info without variant resource data.
+	profile := sc.lookupFamily("qwen3")
+	if profile == nil {
+		t.Fatal("lookupFamily(qwen3) returned nil")
+	}
+	if profile.FIM == nil {
+		t.Error("expected FIM config for qwen3 family")
+	}
+	if profile.ThinkMode != ThinkToggle {
+		t.Errorf("ThinkMode = %v, want ThinkToggle", profile.ThinkMode)
+	}
+	if profile.ContextWindow != 40960 {
+		t.Errorf("ContextWindow = %d, want 40960", profile.ContextWindow)
+	}
+	// Family-only lookup should have zero resource profile.
+	if profile.Resources.RAMRequired != 0 {
+		t.Errorf("RAMRequired = %f, want 0 for family-only lookup", profile.Resources.RAMRequired)
+	}
+}
+
+func TestCatalogLookupMiss(t *testing.T) {
+	cat, err := loadCatalog()
+	if err != nil {
+		t.Fatalf("loadCatalog() error: %v", err)
+	}
+
+	sc := newStaticCatalog(cat)
+
+	// Unknown family returns nil.
+	profile := sc.lookup("nonexistent-model", "8b")
+	if profile != nil {
+		t.Errorf("lookup(nonexistent) should return nil, got %+v", profile)
+	}
+
+	profile = sc.lookupFamily("nonexistent-model")
+	if profile != nil {
+		t.Errorf("lookupFamily(nonexistent) should return nil, got %+v", profile)
+	}
+
+	// Known family but unknown variant returns nil.
+	profile = sc.lookup("qwen3", "999b")
+	if profile != nil {
+		t.Errorf("lookup(qwen3, 999b) should return nil, got %+v", profile)
+	}
+}
+
+func TestCatalogFIMTokens(t *testing.T) {
+	cat, err := loadCatalog()
+	if err != nil {
+		t.Fatalf("loadCatalog() error: %v", err)
+	}
+
+	sc := newStaticCatalog(cat)
+
+	tests := []struct {
+		family     string
+		wantPrefix string
+		wantSuffix string
+		wantMiddle string
+	}{
+		{"qwen3", "<|fim_prefix|>", "<|fim_suffix|>", "<|fim_middle|>"},
+		{"qwen2.5", "<|fim_prefix|>", "<|fim_suffix|>", "<|fim_middle|>"},
+		{"codellama", "<PRE>", " <SUF>", " <MID>"},
+		{"starcoder2", "<fim_prefix>", "<fim_suffix>", "<fim_middle>"},
+		{"starcoder", "<fim_prefix>", "<fim_suffix>", "<fim_middle>"},
+		{"mistral", "[PREFIX]", "[SUFFIX]", "[MIDDLE]"},
+		{"deepseek-coder-v2", "<|fim_prefix|>", "<|fim_suffix|>", "<|fim_middle|>"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.family, func(t *testing.T) {
+			profile := sc.lookupFamily(tt.family)
+			if profile == nil {
+				t.Fatalf("lookupFamily(%q) returned nil", tt.family)
+			}
+			if profile.FIM == nil {
+				t.Fatalf("FIM config is nil for %q", tt.family)
+			}
+			if profile.FIM.Prefix != tt.wantPrefix {
+				t.Errorf("FIM.Prefix = %q, want %q", profile.FIM.Prefix, tt.wantPrefix)
+			}
+			if profile.FIM.Suffix != tt.wantSuffix {
+				t.Errorf("FIM.Suffix = %q, want %q", profile.FIM.Suffix, tt.wantSuffix)
+			}
+			if profile.FIM.Middle != tt.wantMiddle {
+				t.Errorf("FIM.Middle = %q, want %q", profile.FIM.Middle, tt.wantMiddle)
+			}
+		})
+	}
+}
+
+func TestCatalogEmbeddingDimensions(t *testing.T) {
+	cat, err := loadCatalog()
+	if err != nil {
+		t.Fatalf("loadCatalog() error: %v", err)
+	}
+
+	sc := newStaticCatalog(cat)
+
+	tests := []struct {
+		family string
+		want   int
+	}{
+		{"nomic-embed-text", 768},
+		{"mxbai-embed-large", 1024},
+		{"qwen3", 0},
+		{"llama3", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.family, func(t *testing.T) {
+			profile := sc.lookupFamily(tt.family)
+			if profile == nil {
+				t.Fatalf("lookupFamily(%q) returned nil", tt.family)
+			}
+			if profile.Dimensions != tt.want {
+				t.Errorf("Dimensions = %d, want %d", profile.Dimensions, tt.want)
+			}
+		})
+	}
+}
+
+func TestCatalogToModelProfile(t *testing.T) {
+	cat, err := loadCatalog()
+	if err != nil {
+		t.Fatalf("loadCatalog() error: %v", err)
+	}
+
+	sc := newStaticCatalog(cat)
+
+	t.Run("qwen3 8b full profile", func(t *testing.T) {
+		p := sc.lookup("qwen3", "8b")
+		if p == nil {
+			t.Fatal("lookup returned nil")
+		}
+		if p.Family != "qwen3" {
+			t.Errorf("Family = %q, want %q", p.Family, "qwen3")
+		}
+		if p.Source != SourceStatic {
+			t.Errorf("Source = %v, want SourceStatic", p.Source)
+		}
+		if p.ThinkMode != ThinkToggle {
+			t.Errorf("ThinkMode = %v, want ThinkToggle", p.ThinkMode)
+		}
+		if p.ThinkTags == nil {
+			t.Fatal("ThinkTags is nil")
+		}
+		if p.ThinkTags.Open != "<think>" || p.ThinkTags.Close != "</think>" {
+			t.Errorf("ThinkTags = %+v, want <think>/<think>", p.ThinkTags)
+		}
+		if p.FIM == nil {
+			t.Fatal("FIM is nil")
+		}
+		if p.FIM.Prefix != "<|fim_prefix|>" {
+			t.Errorf("FIM.Prefix = %q, want %q", p.FIM.Prefix, "<|fim_prefix|>")
+		}
+		if p.Resources.RAMRequired != 5.0 {
+			t.Errorf("RAMRequired = %f, want 5.0", p.Resources.RAMRequired)
+		}
+		if p.Resources.RAMRecommended != 8.0 {
+			t.Errorf("RAMRecommended = %f, want 8.0", p.Resources.RAMRecommended)
+		}
+		if p.Quality != TierGood {
+			t.Errorf("Quality = %v, want TierGood", p.Quality)
+		}
+		// Speed "fast" maps to TierGreat.
+		if p.Speed != TierGreat {
+			t.Errorf("Speed = %v, want TierGreat", p.Speed)
+		}
+		if p.ContextWindow != 40960 {
+			t.Errorf("ContextWindow = %d, want 40960", p.ContextWindow)
+		}
+		// Capabilities: "completion" + "tools" -> chat|generate|stream|tool_call.
+		wantCaps := CapChat | CapGenerate | CapStream | CapToolCall
+		if p.Caps != wantCaps {
+			t.Errorf("Caps = %v, want %v", p.Caps, wantCaps)
+		}
+	})
+
+	t.Run("nomic-embed-text embedding profile", func(t *testing.T) {
+		p := sc.lookup("nomic-embed-text", "latest")
+		if p == nil {
+			t.Fatal("lookup returned nil")
+		}
+		if p.Dimensions != 768 {
+			t.Errorf("Dimensions = %d, want 768", p.Dimensions)
+		}
+		if !p.Caps.Has(CapEmbed) {
+			t.Error("expected CapEmbed capability")
+		}
+		if p.Caps.Has(CapChat) {
+			t.Error("embedding model should not have CapChat")
+		}
+		if p.FIM != nil {
+			t.Errorf("embedding model should have nil FIM, got %+v", p.FIM)
+		}
+		if p.Resources.RAMRequired != 0.5 {
+			t.Errorf("RAMRequired = %f, want 0.5", p.Resources.RAMRequired)
+		}
+	})
+
+	t.Run("deepseek-r1 always think", func(t *testing.T) {
+		p := sc.lookup("deepseek-r1", "32b")
+		if p == nil {
+			t.Fatal("lookup returned nil")
+		}
+		if p.ThinkMode != ThinkAlways {
+			t.Errorf("ThinkMode = %v, want ThinkAlways", p.ThinkMode)
+		}
+		if p.FIM != nil {
+			t.Errorf("deepseek-r1 should have nil FIM, got %+v", p.FIM)
+		}
+		if p.Resources.RAMRequired != 20.0 {
+			t.Errorf("RAMRequired = %f, want 20.0", p.Resources.RAMRequired)
+		}
+	})
+
+	t.Run("mixtral MoE variant", func(t *testing.T) {
+		p := sc.lookup("mixtral", "8x7b")
+		if p == nil {
+			t.Fatal("lookup returned nil")
+		}
+		if p.Resources.RAMRequired != 28.0 {
+			t.Errorf("RAMRequired = %f, want 28.0", p.Resources.RAMRequired)
+		}
+		if p.Quality != TierGreat {
+			t.Errorf("Quality = %v, want TierGreat", p.Quality)
+		}
+	})
+}
+
+func TestCatalogFamilies(t *testing.T) {
+	cat, err := loadCatalog()
+	if err != nil {
+		t.Fatalf("loadCatalog() error: %v", err)
+	}
+
+	sc := newStaticCatalog(cat)
+	names := sc.families()
+
+	if len(names) < 20 {
+		t.Errorf("families() returned %d families, want at least 20", len(names))
+	}
+
+	// Ensure the list contains expected entries.
+	nameSet := make(map[string]bool, len(names))
+	for _, n := range names {
+		nameSet[n] = true
+	}
+	for _, want := range []string{"qwen3", "deepseek-r1", "codellama", "nomic-embed-text"} {
+		if !nameSet[want] {
+			t.Errorf("families() missing %q", want)
+		}
+	}
+}
+
+func TestCatalogCaseInsensitive(t *testing.T) {
+	cat, err := loadCatalog()
+	if err != nil {
+		t.Fatalf("loadCatalog() error: %v", err)
+	}
+
+	sc := newStaticCatalog(cat)
+
+	// lookup normalizes to lowercase, so mixed-case input should still match.
+	p := sc.lookup("Qwen3", "8B")
+	if p == nil {
+		t.Fatal("lookup(Qwen3, 8B) returned nil -- case insensitivity failed")
+	}
+	if p.Family != "qwen3" {
+		t.Errorf("Family = %q, want %q", p.Family, "qwen3")
+	}
+
+	p = sc.lookupFamily("DEEPSEEK-R1")
+	if p == nil {
+		t.Fatal("lookupFamily(DEEPSEEK-R1) returned nil -- case insensitivity failed")
+	}
+}
+
+func TestParseThinkMode(t *testing.T) {
+	tests := []struct {
+		input string
+		want  ThinkMode
+	}{
+		{"none", ThinkNone},
+		{"always", ThinkAlways},
+		{"toggle", ThinkToggle},
+		{"auto", ThinkAuto},
+		{"None", ThinkNone},
+		{"ALWAYS", ThinkAlways},
+		{"", ThinkNone},
+		{"unknown", ThinkNone},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parseThinkMode(tt.input)
+			if got != tt.want {
+				t.Errorf("parseThinkMode(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseTier(t *testing.T) {
+	tests := []struct {
+		input string
+		want  Tier
+	}{
+		{"basic", TierBasic},
+		{"good", TierGood},
+		{"great", TierGreat},
+		{"best", TierBest},
+		{"fast", TierGreat},
+		{"medium", TierGood},
+		{"slow", TierBasic},
+		{"", TierBasic},
+		{"unknown", TierBasic},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parseTier(tt.input)
+			if got != tt.want {
+				t.Errorf("parseTier(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseCaps(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  Capability
+	}{
+		{
+			name:  "completion gives chat+generate+stream",
+			input: []string{"completion"},
+			want:  CapChat | CapGenerate | CapStream,
+		},
+		{
+			name:  "tools gives tool_call",
+			input: []string{"tools"},
+			want:  CapToolCall,
+		},
+		{
+			name:  "embedding gives embed",
+			input: []string{"embedding"},
+			want:  CapEmbed,
+		},
+		{
+			name:  "completion+tools combined",
+			input: []string{"completion", "tools"},
+			want:  CapChat | CapGenerate | CapStream | CapToolCall,
+		},
+		{
+			name:  "empty input gives none",
+			input: nil,
+			want:  0,
+		},
+		{
+			name:  "unknown cap ignored",
+			input: []string{"completion", "nonexistent"},
+			want:  CapChat | CapGenerate | CapStream,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseCaps(tt.input)
+			if got != tt.want {
+				t.Errorf("parseCaps(%v) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/provider/collect.go
+++ b/provider/collect.go
@@ -1,0 +1,67 @@
+package provider
+
+import "strings"
+
+// Collect wraps a streaming ChatResponse callback to accumulate the
+// aggregated final response. Chunks stream to fn in real-time; call
+// getFinal after streaming completes (or is cancelled) to retrieve
+// the accumulated result.
+//
+// Streaming callbacks are delta-oriented: resp.Content and resp.Thinking
+// contain only the newly emitted text for that chunk. Collect turns
+// those deltas into a final aggregated response.
+//
+// If fn is nil, chunks are accumulated without forwarding.
+//
+// Usage:
+//
+//	callback, getFinal := provider.Collect(myHandler)
+//	err := p.ChatStream(ctx, req, callback)
+//	final := getFinal()
+func Collect(fn func(ChatResponse) error) (wrapped func(ChatResponse) error, getFinal func() ChatResponse) {
+	var (
+		contentBuf  strings.Builder
+		thinkingBuf strings.Builder
+		result      ChatResponse
+	)
+
+	wrapped = func(resp ChatResponse) error {
+		if resp.Content != "" {
+			contentBuf.WriteString(resp.Content)
+		}
+		if resp.Thinking != "" {
+			thinkingBuf.WriteString(resp.Thinking)
+		}
+
+		if resp.Model != "" {
+			result.Model = resp.Model
+		}
+		if resp.Provider != "" {
+			result.Provider = resp.Provider
+		}
+
+		if len(resp.ToolCalls) > 0 {
+			result.ToolCalls = append(result.ToolCalls, resp.ToolCalls...)
+		}
+
+		if resp.Done {
+			result.Done = true
+			result.Partial = resp.Partial
+			result.Usage = resp.Usage
+			result.Latency = resp.Latency
+		}
+
+		if fn != nil {
+			return fn(resp)
+		}
+		return nil
+	}
+
+	getFinal = func() ChatResponse {
+		result.Content = contentBuf.String()
+		result.Thinking = thinkingBuf.String()
+		return result
+	}
+
+	return wrapped, getFinal
+}

--- a/provider/collect_test.go
+++ b/provider/collect_test.go
@@ -1,0 +1,164 @@
+package provider
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCollect_NormalFlow(t *testing.T) {
+	var chunks []ChatResponse
+	inner := func(resp ChatResponse) error {
+		chunks = append(chunks, resp)
+		return nil
+	}
+
+	wrapped, getFinal := Collect(inner)
+
+	responses := []ChatResponse{
+		{Content: "Hello ", Done: false},
+		{Content: "world!", Done: false},
+		{Thinking: "I thought about it", Done: false},
+		{Content: "", Done: true, Usage: Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15}},
+	}
+
+	for _, resp := range responses {
+		if err := wrapped(resp); err != nil {
+			t.Fatalf("wrapped() error: %v", err)
+		}
+	}
+
+	if len(chunks) != len(responses) {
+		t.Fatalf("inner received %d chunks, want %d", len(chunks), len(responses))
+	}
+
+	final := getFinal()
+	if final.Content != "Hello world!" {
+		t.Errorf("final.Content = %q, want %q", final.Content, "Hello world!")
+	}
+	if final.Thinking != "I thought about it" {
+		t.Errorf("final.Thinking = %q, want %q", final.Thinking, "I thought about it")
+	}
+	if !final.Done {
+		t.Error("final.Done should be true")
+	}
+	if final.Usage.TotalTokens != 15 {
+		t.Errorf("final.Usage.TotalTokens = %d, want 15", final.Usage.TotalTokens)
+	}
+}
+
+func TestCollect_ErrorPropagation(t *testing.T) {
+	wantErr := errors.New("sink error")
+	inner := func(resp ChatResponse) error {
+		return wantErr
+	}
+
+	wrapped, getFinal := Collect(inner)
+
+	err := wrapped(ChatResponse{Content: "Hello"})
+	if !errors.Is(err, wantErr) {
+		t.Errorf("wrapped() error = %v, want %v", err, wantErr)
+	}
+
+	final := getFinal()
+	if final.Content != "Hello" {
+		t.Errorf("final.Content = %q, want %q", final.Content, "Hello")
+	}
+}
+
+func TestCollect_Partial(t *testing.T) {
+	inner := func(resp ChatResponse) error { return nil }
+	wrapped, getFinal := Collect(inner)
+
+	responses := []ChatResponse{
+		{Content: "Hello ", Done: false},
+		{Content: "wor", Done: true, Partial: true},
+	}
+	for _, resp := range responses {
+		if err := wrapped(resp); err != nil {
+			t.Fatalf("wrapped() error: %v", err)
+		}
+	}
+
+	final := getFinal()
+	if final.Content != "Hello wor" {
+		t.Errorf("final.Content = %q, want %q", final.Content, "Hello wor")
+	}
+	if !final.Partial {
+		t.Error("final.Partial should be true")
+	}
+}
+
+func TestCollect_NilInner(t *testing.T) {
+	wrapped, getFinal := Collect(nil)
+
+	if err := wrapped(ChatResponse{Content: "test"}); err != nil {
+		t.Fatalf("wrapped() error: %v", err)
+	}
+
+	final := getFinal()
+	if final.Content != "test" {
+		t.Errorf("final.Content = %q, want %q", final.Content, "test")
+	}
+}
+
+func TestCollect_Empty(t *testing.T) {
+	inner := func(resp ChatResponse) error { return nil }
+	_, getFinal := Collect(inner)
+
+	final := getFinal()
+	if final.Content != "" {
+		t.Errorf("final.Content = %q, want empty", final.Content)
+	}
+	if final.Done {
+		t.Error("final.Done should be false for empty stream")
+	}
+}
+
+func TestCollect_ModelAndProvider(t *testing.T) {
+	inner := func(resp ChatResponse) error { return nil }
+	wrapped, getFinal := Collect(inner)
+
+	responses := []ChatResponse{
+		{Content: "chunk1", Model: "qwen3:8b", Provider: "ollama", Done: false},
+		{Content: "chunk2", Done: true, Model: "qwen3:8b", Provider: "ollama"},
+	}
+	for _, resp := range responses {
+		if err := wrapped(resp); err != nil {
+			t.Fatalf("wrapped() error: %v", err)
+		}
+	}
+
+	final := getFinal()
+	if final.Model != "qwen3:8b" {
+		t.Errorf("final.Model = %q, want %q", final.Model, "qwen3:8b")
+	}
+	if final.Provider != "ollama" {
+		t.Errorf("final.Provider = %q, want %q", final.Provider, "ollama")
+	}
+}
+
+func TestCollect_ToolCalls(t *testing.T) {
+	inner := func(resp ChatResponse) error { return nil }
+	wrapped, getFinal := Collect(inner)
+
+	toolCalls := []ToolCall{
+		{ID: "1", Type: "function", Function: ToolCallFunction{Name: "search"}},
+	}
+	responses := []ChatResponse{
+		{Content: "Let me search", Done: false},
+		{ToolCalls: toolCalls, Done: true},
+	}
+	for _, resp := range responses {
+		if err := wrapped(resp); err != nil {
+			t.Fatalf("wrapped() error: %v", err)
+		}
+	}
+
+	final := getFinal()
+	if len(final.ToolCalls) != 1 {
+		t.Fatalf("final.ToolCalls len = %d, want 1", len(final.ToolCalls))
+	}
+	if final.ToolCalls[0].Function.Name != "search" {
+		t.Errorf("final.ToolCalls[0].Function.Name = %q, want %q", final.ToolCalls[0].Function.Name, "search")
+	}
+}

--- a/provider/collect_test.go
+++ b/provider/collect_test.go
@@ -88,6 +88,30 @@ func TestCollect_Partial(t *testing.T) {
 	}
 }
 
+func TestCollect_PartialMetadataOnly(t *testing.T) {
+	inner := func(resp ChatResponse) error { return nil }
+	wrapped, getFinal := Collect(inner)
+
+	responses := []ChatResponse{
+		{Content: "Hello ", Done: false},
+		{Content: "world", Done: false},
+		{Done: true, Partial: true},
+	}
+	for _, resp := range responses {
+		if err := wrapped(resp); err != nil {
+			t.Fatalf("wrapped() error: %v", err)
+		}
+	}
+
+	final := getFinal()
+	if final.Content != "Hello world" {
+		t.Errorf("final.Content = %q, want %q", final.Content, "Hello world")
+	}
+	if !final.Partial {
+		t.Error("final.Partial should be true")
+	}
+}
+
 func TestCollect_NilInner(t *testing.T) {
 	wrapped, getFinal := Collect(nil)
 

--- a/provider/model_key.go
+++ b/provider/model_key.go
@@ -1,0 +1,179 @@
+// provider/model_key.go
+package provider
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ParsedModel holds the decomposed components of an Ollama model name.
+// Model names follow the pattern: family[-variant]:paramSize[-variant][-quant]
+//
+// This is a best-effort parser for catalog matching, not a strict validator.
+// Unknown or ambiguous names are parsed conservatively: unrecognized parts
+// are left in the Variant field so callers always get a usable Family.
+type ParsedModel struct {
+	Raw       string // "qwen3.5:35b-a3b-q4_K_M"
+	Family    string // "qwen3.5"
+	Variant   string // "a3b" (MoE active params), "coder", "instruct", etc.
+	ParamSize string // "35b", "8x7b"
+	Quant     string // "q4_k_m" (lowercased)
+	Tag       string // "latest" if unspecified
+}
+
+// knownVariantSuffixes are variant identifiers that appear as suffixes on the
+// family portion of the model name (before the colon), e.g. "qwen2.5-coder".
+// These are checked after compound family matching, so "deepseek-coder-v2"
+// will not be incorrectly split at "-coder".
+var knownVariantSuffixes = []string{
+	"-coder",
+	"-code",
+	"-chat",
+	"-instruct",
+	"-vision",
+	"-math",
+}
+
+// knownCompoundFamilies are model family prefixes that include hyphens as part
+// of their identity and should not be split at hyphens. Order matters: longer
+// prefixes must appear before shorter ones so that "deepseek-coder-v2" matches
+// before "deepseek-coder".
+var knownCompoundFamilies = []string{
+	"deepseek-coder-v2",
+	"deepseek-coder",
+	"deepseek-r1",
+	"deepseek-v2",
+	"nomic-embed-text",
+	"all-minilm",
+	"mxbai-embed-large",
+	"qwen3-coder-next",
+	"solar-pro",
+}
+
+// paramSizeRe matches parameter size patterns: "8b", "70b", "3.8b", "0.6b", "8x7b".
+var paramSizeRe = regexp.MustCompile(`^(\d+(?:\.\d+)?(?:x\d+)?b)$`)
+
+// quantRe matches quantization level patterns: "q4_K_M", "q8_0", "fp16", "f16", "f32".
+var quantRe = regexp.MustCompile(`^(?i)(q\d+[a-z0-9_]*|fp16|f16|f32|fp32)$`)
+
+// activeParamRe matches MoE active parameter patterns like "a3b", "a3.5b".
+var activeParamRe = regexp.MustCompile(`^a\d+(?:\.\d+)?b$`)
+
+// tagVariantRe matches known variant keywords that appear in the tag portion
+// of the model name, e.g. "instruct", "chat", "code".
+var tagVariantRe = regexp.MustCompile(`^(?i)(instruct|chat|code|coder|vision|math|text)$`)
+
+// ParseModelName decomposes an Ollama model name string into its constituent
+// parts: family, variant, parameter size, and quantization level.
+//
+// Examples:
+//
+//	"qwen3:8b"                  -> Family: "qwen3", ParamSize: "8b"
+//	"qwen3.5:35b-a3b-q4_K_M"   -> Family: "qwen3.5", Variant: "a3b", ParamSize: "35b", Quant: "q4_k_m"
+//	"qwen2.5-coder:7b"         -> Family: "qwen2.5", Variant: "coder", ParamSize: "7b"
+//	"codellama:latest"          -> Family: "codellama", Tag: "latest"
+//	"nomic-embed-text"          -> Family: "nomic-embed-text", Tag: "latest"
+func ParseModelName(name string) ParsedModel {
+	p := ParsedModel{Raw: name}
+
+	if name == "" {
+		return p
+	}
+
+	// Split on colon: family[:tag]
+	family, tag := splitModelTag(name)
+	p.Tag = tag
+
+	// Extract variant from family part (e.g., "qwen2.5-coder" -> family="qwen2.5", variant="coder")
+	family, familyVariant := extractFamilyVariant(family)
+	p.Family = family
+
+	// Parse the tag into components
+	if tag != "latest" && tag != "" {
+		parts := strings.Split(tag, "-")
+		var paramSize string
+		var quant string
+		var activeParam string
+		var otherParts []string
+
+		for _, part := range parts {
+			lowerPart := strings.ToLower(part)
+			switch {
+			case paramSize == "" && paramSizeRe.MatchString(lowerPart):
+				paramSize = lowerPart
+			case quantRe.MatchString(part):
+				quant = strings.ToLower(part)
+			case activeParamRe.MatchString(lowerPart):
+				activeParam = lowerPart
+			default:
+				otherParts = append(otherParts, part)
+			}
+		}
+
+		p.ParamSize = paramSize
+		p.Quant = quant
+
+		// Determine variant priority:
+		// 1. MoE active param from tag (e.g., "a3b") -- most specific
+		// 2. Family-level variant (e.g., "coder" from "qwen2.5-coder")
+		// 3. Remaining tag parts that look like variant keywords (e.g., "instruct")
+		// 4. All remaining unclassified tag parts joined together
+		if activeParam != "" {
+			p.Variant = activeParam
+		} else if familyVariant != "" {
+			p.Variant = familyVariant
+		} else if len(otherParts) > 0 {
+			// Filter out version-like suffixes (e.g., "v0.3") from variant parts
+			// by keeping them attached. Join all remaining parts as the variant.
+			p.Variant = strings.ToLower(strings.Join(otherParts, "-"))
+		}
+	} else if familyVariant != "" {
+		p.Variant = familyVariant
+	}
+
+	return p
+}
+
+// NormalizedFamily returns the lowercase family name suitable for catalog
+// lookup. For models with variant suffixes in the family (e.g., "qwen2.5-coder"),
+// this returns just the base family ("qwen2.5").
+func (p ParsedModel) NormalizedFamily() string {
+	return strings.ToLower(p.Family)
+}
+
+// splitModelTag splits a model name into base and tag at the colon.
+// If no colon is present, tag defaults to "latest".
+func splitModelTag(name string) (base, tag string) {
+	idx := strings.LastIndex(name, ":")
+	if idx < 0 {
+		return name, "latest"
+	}
+	return name[:idx], name[idx+1:]
+}
+
+// extractFamilyVariant splits the family portion at known variant suffixes.
+// Returns the base family and variant (empty if none found).
+//
+// Known compound families (e.g., "deepseek-coder-v2") are returned intact
+// without splitting, since the hyphens are part of the family identity.
+func extractFamilyVariant(family string) (base, variant string) {
+	lower := strings.ToLower(family)
+
+	// Check if the family is a known compound family (don't split these).
+	for _, compound := range knownCompoundFamilies {
+		if lower == compound || strings.HasPrefix(lower, compound+"-") {
+			return family, ""
+		}
+	}
+
+	// Check for known variant suffixes.
+	for _, suffix := range knownVariantSuffixes {
+		if strings.HasSuffix(lower, suffix) {
+			base = family[:len(family)-len(suffix)]
+			variant = strings.TrimPrefix(suffix, "-")
+			return base, variant
+		}
+	}
+
+	return family, ""
+}

--- a/provider/model_key_test.go
+++ b/provider/model_key_test.go
@@ -1,0 +1,459 @@
+package provider
+
+import "testing"
+
+func TestParseModelName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  ParsedModel
+	}{
+		// --- Basic models with param size ---
+		{
+			name:  "simple model with size tag",
+			input: "qwen3:8b",
+			want: ParsedModel{
+				Raw:       "qwen3:8b",
+				Family:    "qwen3",
+				Variant:   "",
+				ParamSize: "8b",
+				Quant:     "",
+				Tag:       "8b",
+			},
+		},
+		{
+			name:  "gemma2 with size",
+			input: "gemma2:9b",
+			want: ParsedModel{
+				Raw:       "gemma2:9b",
+				Family:    "gemma2",
+				Variant:   "",
+				ParamSize: "9b",
+				Quant:     "",
+				Tag:       "9b",
+			},
+		},
+		{
+			name:  "starcoder2 with size",
+			input: "starcoder2:15b",
+			want: ParsedModel{
+				Raw:       "starcoder2:15b",
+				Family:    "starcoder2",
+				Variant:   "",
+				ParamSize: "15b",
+				Quant:     "",
+				Tag:       "15b",
+			},
+		},
+		{
+			name:  "phi4 with size",
+			input: "phi4:14b",
+			want: ParsedModel{
+				Raw:       "phi4:14b",
+				Family:    "phi4",
+				Variant:   "",
+				ParamSize: "14b",
+				Quant:     "",
+				Tag:       "14b",
+			},
+		},
+
+		// --- Fractional param sizes ---
+		{
+			name:  "phi3 with fractional size",
+			input: "phi3:3.8b",
+			want: ParsedModel{
+				Raw:       "phi3:3.8b",
+				Family:    "phi3",
+				Variant:   "",
+				ParamSize: "3.8b",
+				Quant:     "",
+				Tag:       "3.8b",
+			},
+		},
+
+		// --- Quantization levels ---
+		{
+			name:  "model with quant in tag",
+			input: "qwen3:8b-q4_K_M",
+			want: ParsedModel{
+				Raw:       "qwen3:8b-q4_K_M",
+				Family:    "qwen3",
+				Variant:   "",
+				ParamSize: "8b",
+				Quant:     "q4_k_m",
+				Tag:       "8b-q4_K_M",
+			},
+		},
+		{
+			name:  "gemma3 with size and quant",
+			input: "gemma3:27b-q8_0",
+			want: ParsedModel{
+				Raw:       "gemma3:27b-q8_0",
+				Family:    "gemma3",
+				Variant:   "",
+				ParamSize: "27b",
+				Quant:     "q8_0",
+				Tag:       "27b-q8_0",
+			},
+		},
+		{
+			name:  "llama3 with size and quant",
+			input: "llama3:8b-q8_0",
+			want: ParsedModel{
+				Raw:       "llama3:8b-q8_0",
+				Family:    "llama3",
+				Variant:   "",
+				ParamSize: "8b",
+				Quant:     "q8_0",
+				Tag:       "8b-q8_0",
+			},
+		},
+		{
+			name:  "fp16 quant level",
+			input: "qwen3:8b-fp16",
+			want: ParsedModel{
+				Raw:       "qwen3:8b-fp16",
+				Family:    "qwen3",
+				Variant:   "",
+				ParamSize: "8b",
+				Quant:     "fp16",
+				Tag:       "8b-fp16",
+			},
+		},
+
+		// --- MoE active params ---
+		{
+			name:  "MoE model with active params and quant",
+			input: "qwen3.5:35b-a3b-q4_K_M",
+			want: ParsedModel{
+				Raw:       "qwen3.5:35b-a3b-q4_K_M",
+				Family:    "qwen3.5",
+				Variant:   "a3b",
+				ParamSize: "35b",
+				Quant:     "q4_k_m",
+				Tag:       "35b-a3b-q4_K_M",
+			},
+		},
+		{
+			name:  "MoE model with active params no quant",
+			input: "qwen3.5:35b-a3b",
+			want: ParsedModel{
+				Raw:       "qwen3.5:35b-a3b",
+				Family:    "qwen3.5",
+				Variant:   "a3b",
+				ParamSize: "35b",
+				Quant:     "",
+				Tag:       "35b-a3b",
+			},
+		},
+
+		// --- Mixtral-style MoE param sizes ---
+		{
+			name:  "mixtral MoE format",
+			input: "mixtral:8x7b-q4_K_M",
+			want: ParsedModel{
+				Raw:       "mixtral:8x7b-q4_K_M",
+				Family:    "mixtral",
+				Variant:   "",
+				ParamSize: "8x7b",
+				Quant:     "q4_k_m",
+				Tag:       "8x7b-q4_K_M",
+			},
+		},
+
+		// --- Family-level variants ---
+		{
+			name:  "coder variant in family",
+			input: "qwen2.5-coder:7b",
+			want: ParsedModel{
+				Raw:       "qwen2.5-coder:7b",
+				Family:    "qwen2.5",
+				Variant:   "coder",
+				ParamSize: "7b",
+				Quant:     "",
+				Tag:       "7b",
+			},
+		},
+
+		// --- Tag-level variants ---
+		{
+			name:  "instruct variant in tag",
+			input: "mistral:7b-instruct-q4_0",
+			want: ParsedModel{
+				Raw:       "mistral:7b-instruct-q4_0",
+				Family:    "mistral",
+				Variant:   "instruct",
+				ParamSize: "7b",
+				Quant:     "q4_0",
+				Tag:       "7b-instruct-q4_0",
+			},
+		},
+		{
+			name:  "instruct variant with version suffix",
+			input: "mistral:7b-instruct-v0.3",
+			want: ParsedModel{
+				Raw:       "mistral:7b-instruct-v0.3",
+				Family:    "mistral",
+				Variant:   "instruct-v0.3",
+				ParamSize: "7b",
+				Quant:     "",
+				Tag:       "7b-instruct-v0.3",
+			},
+		},
+		{
+			name:  "codellama instruct with quant",
+			input: "codellama:13b-instruct-q4_K_M",
+			want: ParsedModel{
+				Raw:       "codellama:13b-instruct-q4_K_M",
+				Family:    "codellama",
+				Variant:   "instruct",
+				ParamSize: "13b",
+				Quant:     "q4_k_m",
+				Tag:       "13b-instruct-q4_K_M",
+			},
+		},
+
+		// --- Compound families ---
+		{
+			name:  "deepseek-r1 compound family",
+			input: "deepseek-r1:70b",
+			want: ParsedModel{
+				Raw:       "deepseek-r1:70b",
+				Family:    "deepseek-r1",
+				Variant:   "",
+				ParamSize: "70b",
+				Quant:     "",
+				Tag:       "70b",
+			},
+		},
+		{
+			name:  "deepseek-r1 smaller size",
+			input: "deepseek-r1:7b",
+			want: ParsedModel{
+				Raw:       "deepseek-r1:7b",
+				Family:    "deepseek-r1",
+				Variant:   "",
+				ParamSize: "7b",
+				Quant:     "",
+				Tag:       "7b",
+			},
+		},
+		{
+			name:  "deepseek-coder-v2 compound family",
+			input: "deepseek-coder-v2:16b",
+			want: ParsedModel{
+				Raw:       "deepseek-coder-v2:16b",
+				Family:    "deepseek-coder-v2",
+				Variant:   "",
+				ParamSize: "16b",
+				Quant:     "",
+				Tag:       "16b",
+			},
+		},
+
+		// --- Embedding models ---
+		{
+			name:  "nomic-embed-text with latest tag",
+			input: "nomic-embed-text:latest",
+			want: ParsedModel{
+				Raw:       "nomic-embed-text:latest",
+				Family:    "nomic-embed-text",
+				Variant:   "",
+				ParamSize: "",
+				Quant:     "",
+				Tag:       "latest",
+			},
+		},
+		{
+			name:  "nomic-embed-text no tag",
+			input: "nomic-embed-text",
+			want: ParsedModel{
+				Raw:       "nomic-embed-text",
+				Family:    "nomic-embed-text",
+				Variant:   "",
+				ParamSize: "",
+				Quant:     "",
+				Tag:       "latest",
+			},
+		},
+
+		// --- No tag / latest tag ---
+		{
+			name:  "no tag defaults to latest",
+			input: "llama3.2",
+			want: ParsedModel{
+				Raw:       "llama3.2",
+				Family:    "llama3.2",
+				Variant:   "",
+				ParamSize: "",
+				Quant:     "",
+				Tag:       "latest",
+			},
+		},
+		{
+			name:  "explicit latest tag",
+			input: "codellama:latest",
+			want: ParsedModel{
+				Raw:       "codellama:latest",
+				Family:    "codellama",
+				Variant:   "",
+				ParamSize: "",
+				Quant:     "",
+				Tag:       "latest",
+			},
+		},
+		{
+			name:  "qwen3-coder-next with latest tag",
+			input: "qwen3-coder-next:latest",
+			want: ParsedModel{
+				Raw:       "qwen3-coder-next:latest",
+				Family:    "qwen3-coder-next",
+				Variant:   "",
+				ParamSize: "",
+				Quant:     "",
+				Tag:       "latest",
+			},
+		},
+
+		// --- Edge cases ---
+		{
+			name:  "empty string",
+			input: "",
+			want: ParsedModel{
+				Raw:       "",
+				Family:    "",
+				Variant:   "",
+				ParamSize: "",
+				Quant:     "",
+				Tag:       "",
+			},
+		},
+		{
+			name:  "family only no size",
+			input: "mistral",
+			want: ParsedModel{
+				Raw:       "mistral",
+				Family:    "mistral",
+				Variant:   "",
+				ParamSize: "",
+				Quant:     "",
+				Tag:       "latest",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseModelName(tt.input)
+			if got.Raw != tt.want.Raw {
+				t.Errorf("Raw = %q, want %q", got.Raw, tt.want.Raw)
+			}
+			if got.Family != tt.want.Family {
+				t.Errorf("Family = %q, want %q", got.Family, tt.want.Family)
+			}
+			if got.Variant != tt.want.Variant {
+				t.Errorf("Variant = %q, want %q", got.Variant, tt.want.Variant)
+			}
+			if got.ParamSize != tt.want.ParamSize {
+				t.Errorf("ParamSize = %q, want %q", got.ParamSize, tt.want.ParamSize)
+			}
+			if got.Quant != tt.want.Quant {
+				t.Errorf("Quant = %q, want %q", got.Quant, tt.want.Quant)
+			}
+			if got.Tag != tt.want.Tag {
+				t.Errorf("Tag = %q, want %q", got.Tag, tt.want.Tag)
+			}
+		})
+	}
+}
+
+func TestParsedModelNormalizedFamily(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"qwen3:8b", "qwen3"},
+		{"qwen2.5-coder:7b", "qwen2.5"},
+		{"Llama3.2:8b", "llama3.2"},
+		{"DeepSeek-R1:7b", "deepseek-r1"},
+		{"STARCODER2:15b", "starcoder2"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := ParseModelName(tt.input).NormalizedFamily()
+			if got != tt.want {
+				t.Errorf("NormalizedFamily() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseModelNamePreservesRaw(t *testing.T) {
+	inputs := []string{
+		"qwen3:8b",
+		"qwen3.5:35b-a3b-q4_K_M",
+		"nomic-embed-text",
+		"",
+		"codellama:latest",
+	}
+	for _, input := range inputs {
+		got := ParseModelName(input)
+		if got.Raw != input {
+			t.Errorf("ParseModelName(%q).Raw = %q, want %q", input, got.Raw, input)
+		}
+	}
+}
+
+func TestSplitModelTag(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantBase string
+		wantTag  string
+	}{
+		{"with colon", "qwen3:8b", "qwen3", "8b"},
+		{"no colon", "qwen3", "qwen3", "latest"},
+		{"multiple colons", "registry:5000/model:tag", "registry:5000/model", "tag"},
+		{"colon at end", "model:", "model", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base, tag := splitModelTag(tt.input)
+			if base != tt.wantBase {
+				t.Errorf("base = %q, want %q", base, tt.wantBase)
+			}
+			if tag != tt.wantTag {
+				t.Errorf("tag = %q, want %q", tag, tt.wantTag)
+			}
+		})
+	}
+}
+
+func TestExtractFamilyVariant(t *testing.T) {
+	tests := []struct {
+		name        string
+		family      string
+		wantBase    string
+		wantVariant string
+	}{
+		{"plain family", "qwen3", "qwen3", ""},
+		{"coder suffix", "qwen2.5-coder", "qwen2.5", "coder"},
+		{"instruct suffix", "llama3-instruct", "llama3", "instruct"},
+		{"compound family", "deepseek-r1", "deepseek-r1", ""},
+		{"compound coder-v2", "deepseek-coder-v2", "deepseek-coder-v2", ""},
+		{"nomic-embed-text", "nomic-embed-text", "nomic-embed-text", ""},
+		{"chat suffix", "llama3-chat", "llama3", "chat"},
+		{"vision suffix", "llava-vision", "llava", "vision"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base, variant := extractFamilyVariant(tt.family)
+			if base != tt.wantBase {
+				t.Errorf("base = %q, want %q", base, tt.wantBase)
+			}
+			if variant != tt.wantVariant {
+				t.Errorf("variant = %q, want %q", variant, tt.wantVariant)
+			}
+		})
+	}
+}

--- a/provider/model_profile.go
+++ b/provider/model_profile.go
@@ -1,0 +1,169 @@
+package provider
+
+import "time"
+
+// ---------------------------------------------------------------------------
+// Tier
+// ---------------------------------------------------------------------------
+
+// Tier represents a quality or speed classification for a model.
+// Quality tiers rank model output fidelity; speed tiers rank throughput.
+type Tier int
+
+const (
+	// TierBasic is the lowest tier -- small/fast models with limited quality.
+	TierBasic Tier = iota
+	// TierGood represents capable models suitable for most tasks.
+	TierGood
+	// TierGreat represents high-quality models for demanding tasks.
+	TierGreat
+	// TierBest represents the highest quality models available.
+	TierBest
+)
+
+// String returns the human-readable tier name.
+func (t Tier) String() string {
+	switch t {
+	case TierBasic:
+		return "basic"
+	case TierGood:
+		return "good"
+	case TierGreat:
+		return "great"
+	case TierBest:
+		return "best"
+	default:
+		return "unknown"
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ProfileSource
+// ---------------------------------------------------------------------------
+
+// ProfileSource indicates the origin of a ModelProfile's data.
+type ProfileSource int
+
+const (
+	// SourceStatic means the profile came from the embedded catalog.
+	SourceStatic ProfileSource = iota
+	// SourceFingerprint means the profile came from the fingerprint store.
+	SourceFingerprint
+	// SourceRuntime means the profile came from a live provider query.
+	SourceRuntime
+	// SourceMerged means the profile was assembled from multiple sources.
+	SourceMerged
+)
+
+// String returns the human-readable source name.
+func (s ProfileSource) String() string {
+	switch s {
+	case SourceStatic:
+		return "static"
+	case SourceFingerprint:
+		return "fingerprint"
+	case SourceRuntime:
+		return "runtime"
+	case SourceMerged:
+		return "merged"
+	default:
+		return "unknown"
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ResourceProfile
+// ---------------------------------------------------------------------------
+
+// ResourceProfile describes a model's resource requirements.
+type ResourceProfile struct {
+	ParameterSize   string  // "8B", "70B"
+	QuantLevel      string  // "Q4_K_M", "Q8_0"
+	RAMRequired     float64 // GB minimum to load
+	RAMRecommended  float64 // GB for good performance
+	VRAMRecommended float64 // GB if GPU offload available
+}
+
+// kvScaleFactor is the RAM scale factor per 1024 context tokens for KV cache.
+// This default assumes approximately 0.5 GB of additional RAM per 1K context
+// tokens, which is a reasonable estimate across common quantization levels.
+const kvScaleFactor = 0.5
+
+// RAMAtContext estimates RAM usage at a specific context window size.
+// It accounts for KV cache scaling using the formula:
+//
+//	base_ram + (ctx_size / 1024) * kv_scale_factor
+//
+// where base_ram is RAMRequired and kv_scale_factor is 0.5 GB per 1K tokens.
+// When ctxSize is zero the method returns RAMRequired unchanged.
+func (rp ResourceProfile) RAMAtContext(ctxSize int) float64 {
+	return rp.RAMRequired + (float64(ctxSize)/1024.0)*kvScaleFactor
+}
+
+// ---------------------------------------------------------------------------
+// ModelProfile
+// ---------------------------------------------------------------------------
+
+// ModelProfile holds the complete, merged metadata for a specific model
+// on a specific provider. This is the central data structure that the
+// Router, completion engine, and consumers use for decision-making.
+//
+// Profiles are constructed by the ModelRegistry's three-layer merge:
+// static catalog defaults, enriched by fingerprint observations, then
+// overridden by live runtime data from the provider. The Source field
+// records which layers contributed to this profile.
+type ModelProfile struct {
+	Key           ModelKey        // canonical provider-qualified identity
+	Name          string          // display name
+	Family        string          // normalized: "qwen3", "deepseek-r1", "codellama"
+	Provider      string          // provider name
+	Resources     ResourceProfile // resource requirements
+	Caps          Capability      // authoritative per-model capabilities after merge
+	FIM           *FIMConfig      // nil if model doesn't support FIM
+	ThinkMode     ThinkMode       // reasoning behavior
+	ThinkTags     *ThinkTags      // nil uses default <think></think>
+	Quality       Tier            // basic, good, great, best
+	Speed         Tier            // basic=slow, good=medium, great=fast, best=fastest
+	ContextWindow int             // max context tokens
+	Dimensions    int             // embedding dimensions, 0 if not embedding model
+	Source        ProfileSource   // static, fingerprint, runtime, merged
+	Digest        string          // model digest for staleness detection
+	UpdatedAt     time.Time       // when this profile was last computed
+}
+
+// ---------------------------------------------------------------------------
+// RecommendOpts
+// ---------------------------------------------------------------------------
+
+// RecommendOpts configures the ModelRegistry.Recommend method, specifying
+// constraints and preferences for model selection. The Router uses this to
+// request a ranked list of provider-qualified candidates.
+type RecommendOpts struct {
+	// RequestedModel is an optional canonical selector or unqualified model name.
+	// When set, Recommend narrows its search to models matching this name.
+	RequestedModel string
+
+	// UseCase describes the intended use: "chat", "fim", "embedding",
+	// "reasoning", "code-review". Used for capability inference and ranking.
+	UseCase string
+
+	// AvailableRAM is the amount of RAM (in GB) the caller can allocate.
+	// Models whose RAMAtContext(ContextSize) exceeds this are filtered out.
+	AvailableRAM float64
+
+	// ContextSize is the desired context window in tokens. Used together
+	// with AvailableRAM for resource-aware filtering via RAMAtContext.
+	ContextSize int
+
+	// PreferWarm, when true, biases ranking toward models that are already
+	// loaded in the provider's memory.
+	PreferWarm bool
+
+	// PreferredProviders is a soft preference for specific backends.
+	// Models from these providers are ranked higher, all else being equal.
+	PreferredProviders []string
+
+	// RequiredCaps is a bitmask of capabilities the model must support.
+	// Models missing any of the required capabilities are filtered out.
+	RequiredCaps Capability
+}

--- a/provider/model_profile.go
+++ b/provider/model_profile.go
@@ -140,11 +140,11 @@ type ModelProfile struct {
 // request a ranked list of provider-qualified candidates.
 type RecommendOpts struct {
 	// RequestedModel is an optional canonical selector or unqualified model name.
-	// When set, Recommend narrows its search to models matching this name.
+	// Reserved for Phase 2 (Router) — not yet used by Recommend.
 	RequestedModel string
 
 	// UseCase describes the intended use: "chat", "fim", "embedding",
-	// "reasoning", "code-review". Used for capability inference and ranking.
+	// "reasoning", "code-review". Reserved for Phase 2 — not yet used by Recommend.
 	UseCase string
 
 	// AvailableRAM is the amount of RAM (in GB) the caller can allocate.
@@ -156,11 +156,11 @@ type RecommendOpts struct {
 	ContextSize int
 
 	// PreferWarm, when true, biases ranking toward models that are already
-	// loaded in the provider's memory.
+	// loaded in the provider's memory. Reserved for Phase 2 (WarmthTracker).
 	PreferWarm bool
 
 	// PreferredProviders is a soft preference for specific backends.
-	// Models from these providers are ranked higher, all else being equal.
+	// Reserved for Phase 2 — not yet used by Recommend.
 	PreferredProviders []string
 
 	// RequiredCaps is a bitmask of capabilities the model must support.

--- a/provider/model_profile_test.go
+++ b/provider/model_profile_test.go
@@ -1,0 +1,260 @@
+package provider
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTierString(t *testing.T) {
+	tests := []struct {
+		tier Tier
+		want string
+	}{
+		{TierBasic, "basic"},
+		{TierGood, "good"},
+		{TierGreat, "great"},
+		{TierBest, "best"},
+		{Tier(99), "unknown"},
+	}
+	for _, tt := range tests {
+		if got := tt.tier.String(); got != tt.want {
+			t.Errorf("Tier(%d).String() = %q, want %q", tt.tier, got, tt.want)
+		}
+	}
+}
+
+func TestProfileSourceString(t *testing.T) {
+	tests := []struct {
+		src  ProfileSource
+		want string
+	}{
+		{SourceStatic, "static"},
+		{SourceFingerprint, "fingerprint"},
+		{SourceRuntime, "runtime"},
+		{SourceMerged, "merged"},
+		{ProfileSource(99), "unknown"},
+	}
+	for _, tt := range tests {
+		if got := tt.src.String(); got != tt.want {
+			t.Errorf("ProfileSource(%d).String() = %q, want %q", tt.src, got, tt.want)
+		}
+	}
+}
+
+func TestRAMAtContext(t *testing.T) {
+	tests := []struct {
+		name    string
+		rp      ResourceProfile
+		ctxSize int
+		want    float64
+	}{
+		{
+			name: "8B model at 4096 context",
+			rp: ResourceProfile{
+				ParameterSize:  "8B",
+				QuantLevel:     "Q4_K_M",
+				RAMRequired:    5.0,
+				RAMRecommended: 8.0,
+			},
+			ctxSize: 4096,
+			want:    5.0 + (4096.0/1024.0)*0.5, // 5.0 + 2.0 = 7.0
+		},
+		{
+			name: "70B model at 32768 context",
+			rp: ResourceProfile{
+				ParameterSize:  "70B",
+				QuantLevel:     "Q4_K_M",
+				RAMRequired:    40.0,
+				RAMRecommended: 48.0,
+			},
+			ctxSize: 32768,
+			want:    40.0 + (32768.0/1024.0)*0.5, // 40.0 + 16.0 = 56.0
+		},
+		{
+			name:    "zero context returns base RAM",
+			rp:      ResourceProfile{RAMRequired: 5.0},
+			ctxSize: 0,
+			want:    5.0,
+		},
+		{
+			name: "1024 context adds exactly kvScaleFactor",
+			rp: ResourceProfile{
+				ParameterSize: "3B",
+				RAMRequired:   2.0,
+			},
+			ctxSize: 1024,
+			want:    2.0 + 0.5, // 2.5
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.rp.RAMAtContext(tt.ctxSize)
+			if got != tt.want {
+				t.Errorf("RAMAtContext(%d) = %f, want %f", tt.ctxSize, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestModelProfileConstruction(t *testing.T) {
+	now := time.Now()
+	profile := ModelProfile{
+		Key:      ModelKey{Provider: "ollama", Model: "qwen3:8b"},
+		Name:     "Qwen 3 8B",
+		Family:   "qwen3",
+		Provider: "ollama",
+		Resources: ResourceProfile{
+			ParameterSize:   "8B",
+			QuantLevel:      "Q4_K_M",
+			RAMRequired:     5.0,
+			RAMRecommended:  8.0,
+			VRAMRecommended: 6.0,
+		},
+		Caps: CapChat | CapStream | CapThinking,
+		FIM: &FIMConfig{
+			Prefix:          "<|fim_prefix|>",
+			Suffix:          "<|fim_suffix|>",
+			Middle:          "<|fim_middle|>",
+			PrefixBudgetPct: 75,
+		},
+		ThinkMode:     ThinkToggle,
+		ThinkTags:     &ThinkTags{Open: "<think>", Close: "</think>"},
+		Quality:       TierGood,
+		Speed:         TierGood,
+		ContextWindow: 32768,
+		Dimensions:    0,
+		Source:        SourceMerged,
+		Digest:        "sha256:abc123",
+		UpdatedAt:     now,
+	}
+
+	// Verify key fields.
+	if got := profile.Key.String(); got != "ollama/qwen3:8b" {
+		t.Errorf("Key.String() = %q, want %q", got, "ollama/qwen3:8b")
+	}
+	if profile.Family != "qwen3" {
+		t.Errorf("Family = %q, want %q", profile.Family, "qwen3")
+	}
+	if !profile.Caps.Has(CapChat | CapStream) {
+		t.Error("Caps should have CapChat|CapStream")
+	}
+	if !profile.Caps.Has(CapThinking) {
+		t.Error("Caps should have CapThinking")
+	}
+	if profile.Caps.Has(CapEmbed) {
+		t.Error("Caps should not have CapEmbed")
+	}
+	if profile.FIM == nil {
+		t.Fatal("FIM should not be nil")
+	}
+	if profile.FIM.Prefix != "<|fim_prefix|>" {
+		t.Errorf("FIM.Prefix = %q, want %q", profile.FIM.Prefix, "<|fim_prefix|>")
+	}
+	if profile.ThinkMode != ThinkToggle {
+		t.Errorf("ThinkMode = %v, want ThinkToggle", profile.ThinkMode)
+	}
+	if profile.Quality.String() != "good" {
+		t.Errorf("Quality.String() = %q, want %q", profile.Quality.String(), "good")
+	}
+	if profile.Speed.String() != "good" {
+		t.Errorf("Speed.String() = %q, want %q", profile.Speed.String(), "good")
+	}
+	if profile.ContextWindow != 32768 {
+		t.Errorf("ContextWindow = %d, want %d", profile.ContextWindow, 32768)
+	}
+	if profile.Dimensions != 0 {
+		t.Errorf("Dimensions = %d, want 0 for non-embedding model", profile.Dimensions)
+	}
+	if profile.Source != SourceMerged {
+		t.Errorf("Source = %v, want SourceMerged", profile.Source)
+	}
+	if profile.Digest != "sha256:abc123" {
+		t.Errorf("Digest = %q, want %q", profile.Digest, "sha256:abc123")
+	}
+	if profile.UpdatedAt != now {
+		t.Errorf("UpdatedAt = %v, want %v", profile.UpdatedAt, now)
+	}
+
+	// Verify RAMAtContext through the profile's Resources.
+	ram := profile.Resources.RAMAtContext(32768)
+	expectedRAM := 5.0 + (32768.0/1024.0)*0.5 // 5.0 + 16.0 = 21.0
+	if ram != expectedRAM {
+		t.Errorf("Resources.RAMAtContext(32768) = %f, want %f", ram, expectedRAM)
+	}
+}
+
+func TestModelProfileEmbeddingModel(t *testing.T) {
+	profile := ModelProfile{
+		Key:        ModelKey{Provider: "ollama", Model: "nomic-embed-text"},
+		Name:       "Nomic Embed Text",
+		Family:     "nomic-embed",
+		Provider:   "ollama",
+		Caps:       CapEmbed,
+		Quality:    TierGood,
+		Speed:      TierGreat,
+		Dimensions: 768,
+		Source:     SourceStatic,
+	}
+
+	if !profile.Caps.Has(CapEmbed) {
+		t.Error("embedding model should have CapEmbed")
+	}
+	if profile.Caps.Has(CapChat) {
+		t.Error("embedding model should not have CapChat")
+	}
+	if profile.Dimensions != 768 {
+		t.Errorf("Dimensions = %d, want 768", profile.Dimensions)
+	}
+	if profile.FIM != nil {
+		t.Error("embedding model should have nil FIM")
+	}
+}
+
+func TestModelProfileNilThinkTags(t *testing.T) {
+	profile := ModelProfile{
+		Key:       ModelKey{Provider: "ollama", Model: "codellama:7b"},
+		ThinkMode: ThinkNone,
+		ThinkTags: nil,
+	}
+
+	if profile.ThinkTags != nil {
+		t.Error("ThinkTags should be nil for ThinkNone models")
+	}
+	if profile.ThinkMode != ThinkNone {
+		t.Errorf("ThinkMode = %v, want ThinkNone", profile.ThinkMode)
+	}
+}
+
+func TestRecommendOptsConstruction(t *testing.T) {
+	opts := RecommendOpts{
+		RequestedModel:     "qwen3:8b",
+		UseCase:            "chat",
+		AvailableRAM:       16.0,
+		ContextSize:        8192,
+		PreferWarm:         true,
+		PreferredProviders: []string{"ollama"},
+		RequiredCaps:       CapChat | CapStream,
+	}
+
+	if opts.RequestedModel != "qwen3:8b" {
+		t.Errorf("RequestedModel = %q, want %q", opts.RequestedModel, "qwen3:8b")
+	}
+	if opts.UseCase != "chat" {
+		t.Errorf("UseCase = %q, want %q", opts.UseCase, "chat")
+	}
+	if opts.AvailableRAM != 16.0 {
+		t.Errorf("AvailableRAM = %f, want 16.0", opts.AvailableRAM)
+	}
+	if opts.ContextSize != 8192 {
+		t.Errorf("ContextSize = %d, want 8192", opts.ContextSize)
+	}
+	if !opts.PreferWarm {
+		t.Error("PreferWarm should be true")
+	}
+	if len(opts.PreferredProviders) != 1 || opts.PreferredProviders[0] != "ollama" {
+		t.Errorf("PreferredProviders = %v, want [ollama]", opts.PreferredProviders)
+	}
+	if !opts.RequiredCaps.Has(CapChat | CapStream) {
+		t.Error("RequiredCaps should have CapChat|CapStream")
+	}
+}

--- a/provider/model_registry.go
+++ b/provider/model_registry.go
@@ -1,0 +1,509 @@
+// provider/model_registry.go
+package provider
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/fingerprint"
+)
+
+// ProviderResolver provides the subset of Registry methods needed by
+// ModelRegistry to query providers and resolve model keys. This interface
+// decouples ModelRegistry from the concrete Registry type for testability.
+type ProviderResolver interface {
+	// Resolve finds a provider by the ModelKey's Provider field.
+	Resolve(key ModelKey) (Provider, error)
+
+	// ProvidersForModel returns all providers that advertise the given model.
+	ProvidersForModel(model string) ([]Provider, error)
+
+	// All returns every registered provider.
+	All() []Provider
+}
+
+// ModelRegistry maintains merged model profiles combining runtime provider
+// data, static catalog knowledge, and fingerprint observations. It is the
+// single source of truth for model capabilities and resource requirements.
+//
+// Profiles are cached by ModelKey after the first Lookup. The initial
+// implementation returns the cached profile on cache hit without digest
+// revalidation; callers that need freshness guarantees must use Refresh.
+type ModelRegistry struct {
+	mu        sync.RWMutex
+	profiles  map[ModelKey]*ModelProfile
+	catalog   *staticCatalog
+	fpStore   fingerprint.Store
+	providers ProviderResolver
+}
+
+// NewModelRegistry creates a ModelRegistry backed by the given provider
+// resolver and fingerprint store. The static catalog is loaded from the
+// embedded catalog.json at construction time. The fingerprint store may
+// be nil if fingerprint enrichment is not available.
+func NewModelRegistry(providers ProviderResolver, fpStore fingerprint.Store) (*ModelRegistry, error) {
+	catData, err := loadCatalog()
+	if err != nil {
+		return nil, fmt.Errorf("provider: new model registry: %w", err)
+	}
+
+	return &ModelRegistry{
+		profiles:  make(map[ModelKey]*ModelProfile),
+		catalog:   newStaticCatalog(catData),
+		fpStore:   fpStore,
+		providers: providers,
+	}, nil
+}
+
+// Lookup returns the merged ModelProfile for a provider-qualified model key.
+// Results are cached by ModelKey. The initial implementation returns the cached
+// profile on cache hit; callers that need digest revalidation must use Refresh.
+func (r *ModelRegistry) Lookup(ctx context.Context, key ModelKey) (*ModelProfile, error) {
+	// Check cache first.
+	r.mu.RLock()
+	if cached, ok := r.profiles[key]; ok {
+		r.mu.RUnlock()
+		return cached, nil
+	}
+	r.mu.RUnlock()
+
+	return r.buildProfile(ctx, key)
+}
+
+// Refresh forces a re-merge for the given model key, bypassing the cache.
+// Used when the caller knows or suspects the model has been updated.
+func (r *ModelRegistry) Refresh(ctx context.Context, key ModelKey) (*ModelProfile, error) {
+	// Remove cached entry.
+	r.mu.Lock()
+	delete(r.profiles, key)
+	r.mu.Unlock()
+
+	return r.buildProfile(ctx, key)
+}
+
+// LookupAny returns merged profiles for an unqualified model name across
+// all providers that advertise it. Returns one ModelProfile per provider.
+func (r *ModelRegistry) LookupAny(ctx context.Context, model string) ([]*ModelProfile, error) {
+	providers, err := r.providers.ProvidersForModel(model)
+	if err != nil {
+		return nil, err
+	}
+
+	var profiles []*ModelProfile
+	var firstErr error
+
+	for _, p := range providers {
+		key := ModelKey{Provider: p.Name(), Model: model}
+		profile, lookupErr := r.Lookup(ctx, key)
+		if lookupErr != nil {
+			if firstErr == nil {
+				firstErr = lookupErr
+			}
+			continue
+		}
+		profiles = append(profiles, profile)
+	}
+
+	if len(profiles) == 0 {
+		return nil, fmt.Errorf("provider: lookup any %q: all providers failed: %w", model, firstErr)
+	}
+
+	return profiles, nil
+}
+
+// All returns merged profiles for every model across every registered
+// provider. Errors for individual models are skipped silently to provide
+// best-effort results even when some providers are unhealthy.
+func (r *ModelRegistry) All(ctx context.Context) ([]*ModelProfile, error) {
+	allProviders := r.providers.All()
+	var profiles []*ModelProfile
+
+	for _, p := range allProviders {
+		models, err := p.Models(ctx)
+		if err != nil {
+			continue
+		}
+		for _, mi := range models {
+			key := ModelKey{Provider: p.Name(), Model: mi.Name}
+			profile, err := r.Lookup(ctx, key)
+			if err != nil {
+				continue
+			}
+			profiles = append(profiles, profile)
+		}
+	}
+
+	return profiles, nil
+}
+
+// Recommend returns a ranked list of model profiles matching the given
+// criteria. Results are filtered by required capabilities and available
+// RAM, then sorted by quality tier descending. The Router makes the
+// final selection from this candidate list.
+func (r *ModelRegistry) Recommend(ctx context.Context, opts RecommendOpts) ([]*ModelProfile, error) {
+	all, err := r.All(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("provider: recommend: %w", err)
+	}
+
+	var candidates []*ModelProfile
+
+	for _, p := range all {
+		// Filter by required capabilities.
+		if opts.RequiredCaps != 0 && (p.Caps&opts.RequiredCaps) != opts.RequiredCaps {
+			continue
+		}
+
+		// Filter by RAM.
+		if opts.AvailableRAM > 0 {
+			ramNeeded := p.Resources.RAMRequired
+			if opts.ContextSize > 0 {
+				ramNeeded = p.Resources.RAMAtContext(opts.ContextSize)
+			}
+			if ramNeeded > opts.AvailableRAM {
+				continue
+			}
+		}
+
+		// Filter by context size.
+		if opts.ContextSize > 0 && p.ContextWindow > 0 && p.ContextWindow < opts.ContextSize {
+			continue
+		}
+
+		candidates = append(candidates, p)
+	}
+
+	// Sort by quality descending, then speed descending for ties.
+	sortProfiles(candidates)
+
+	return candidates, nil
+}
+
+// FIMConfigFor returns the FIM configuration for a given model, or nil
+// if the model does not support Fill-in-the-Middle. This is a convenience
+// wrapper around Lookup.
+func (r *ModelRegistry) FIMConfigFor(ctx context.Context, key ModelKey) (*FIMConfig, error) {
+	profile, err := r.Lookup(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	return profile.FIM, nil
+}
+
+// buildProfile performs the three-layer merge for a model key and caches
+// the result. The merge layers in order of ascending precedence are:
+//  1. Static catalog: FIM tokens, think_mode, quality/speed tiers, RAM estimates
+//  2. Fingerprint: capability probing data, benchmarked resource observations
+//  3. Runtime: context_window, parameter_size, quant_level, digest (freshest)
+func (r *ModelRegistry) buildProfile(ctx context.Context, key ModelKey) (*ModelProfile, error) {
+	// Layer 1: Runtime query.
+	runtimeInfo, err := r.queryRuntime(ctx, key)
+	if err != nil {
+		return nil, fmt.Errorf("provider: lookup %v: %w", key, err)
+	}
+
+	// Layer 2: Static catalog match.
+	parsed := ParseModelName(key.Model)
+	staticProfile := r.catalog.lookup(parsed.NormalizedFamily(), parsed.ParamSize)
+	if staticProfile == nil {
+		// Try family-only lookup for family-level metadata (FIM, think mode).
+		staticProfile = r.catalog.lookupFamily(parsed.NormalizedFamily())
+	}
+	if staticProfile == nil && runtimeInfo.Family != "" {
+		// Fall back to runtime-reported family.
+		staticProfile = r.catalog.lookupFamily(strings.ToLower(runtimeInfo.Family))
+	}
+
+	// Layer 3: Fingerprint enrichment.
+	var fpProfile *fingerprint.Profile
+	if r.fpStore != nil {
+		fpProfile, _ = r.fpStore.Get(ctx, key.Provider, key.Model)
+		// Ignore errors -- fingerprint is optional enrichment.
+	}
+
+	// Merge layers.
+	profile := r.merge(key, runtimeInfo, staticProfile, fpProfile, parsed)
+
+	// Cache the result.
+	r.mu.Lock()
+	r.profiles[key] = profile
+	r.mu.Unlock()
+
+	return profile, nil
+}
+
+// queryRuntime asks the provider for model information by resolving the
+// provider and scanning its model list.
+func (r *ModelRegistry) queryRuntime(ctx context.Context, key ModelKey) (*ModelInfo, error) {
+	p, err := r.providers.Resolve(key)
+	if err != nil {
+		return nil, err
+	}
+
+	models, err := p.Models(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("query models from %q: %w", key.Provider, err)
+	}
+
+	for i := range models {
+		if models[i].Name == key.Model {
+			return &models[i], nil
+		}
+	}
+
+	return nil, fmt.Errorf("model %q not found on %q", key.Model, key.Provider)
+}
+
+// merge combines runtime, static, and fingerprint data into a single
+// ModelProfile. Precedence (lowest to highest):
+//   - Static catalog: FIM tokens, think_mode, quality/speed tiers, RAM estimates
+//   - Fingerprint: capability probing data, benchmarked resource observations
+//   - Runtime: context_window, dimensions, parameter_size, quant_level (freshest)
+func (r *ModelRegistry) merge(
+	key ModelKey,
+	runtime *ModelInfo,
+	static *ModelProfile,
+	fp *fingerprint.Profile,
+	parsed ParsedModel,
+) *ModelProfile {
+	profile := &ModelProfile{
+		Key:       key,
+		Name:      key.Model,
+		Provider:  key.Provider,
+		Source:    SourceMerged,
+		UpdatedAt: time.Now(),
+	}
+
+	// Start with static catalog (lowest precedence).
+	if static != nil {
+		profile.Family = static.Family
+		profile.FIM = static.FIM
+		profile.ThinkMode = static.ThinkMode
+		profile.ThinkTags = static.ThinkTags
+		profile.Quality = static.Quality
+		profile.Speed = static.Speed
+		profile.Caps = static.Caps
+		profile.Dimensions = static.Dimensions
+		profile.Resources = static.Resources
+
+		if static.ContextWindow > 0 {
+			profile.ContextWindow = static.ContextWindow
+		}
+	}
+
+	// Apply fingerprint enrichment (medium precedence).
+	if fp != nil {
+		fpCaps := parseCaps(fp.Capabilities)
+		if fpCaps != 0 {
+			profile.Caps |= fpCaps
+		}
+		if fp.PeakMemoryMB > 0 {
+			// Fingerprint observed actual memory -- more accurate than catalog estimate.
+			observedGB := float64(fp.PeakMemoryMB) / 1024.0
+			if observedGB > profile.Resources.RAMRequired {
+				profile.Resources.RAMRequired = observedGB
+			}
+		}
+	}
+
+	// Apply runtime data (highest precedence).
+	if runtime != nil {
+		if runtime.Family != "" && profile.Family == "" {
+			profile.Family = strings.ToLower(runtime.Family)
+		}
+		if runtime.ParameterSize != "" {
+			profile.Resources.ParameterSize = runtime.ParameterSize
+		}
+		if runtime.QuantLevel != "" {
+			profile.Resources.QuantLevel = runtime.QuantLevel
+		}
+		if runtime.ContextWindow > 0 {
+			profile.ContextWindow = runtime.ContextWindow
+		}
+		if runtime.Digest != "" {
+			profile.Digest = runtime.Digest
+		}
+
+		// Merge runtime capabilities.
+		rtCaps := parseCaps(runtime.Capabilities)
+		if rtCaps != 0 {
+			profile.Caps |= rtCaps
+		}
+	}
+
+	// Dynamic inference fallback for unknown models.
+	if static == nil {
+		inferred := inferProfile(runtime)
+		if inferred != nil {
+			if profile.FIM == nil {
+				profile.FIM = inferred.FIM
+			}
+			if profile.ThinkMode == ThinkNone {
+				profile.ThinkMode = inferred.ThinkMode
+			}
+			if profile.Quality == TierBasic && inferred.Quality > TierBasic {
+				profile.Quality = inferred.Quality
+			}
+			if profile.Speed == TierBasic && inferred.Speed > TierBasic {
+				profile.Speed = inferred.Speed
+			}
+		}
+
+		// Estimate resources if catalog didn't provide them.
+		if profile.Resources.RAMRequired == 0 && runtime != nil {
+			profile.Resources = estimateResources(runtime.ParameterSize, runtime.QuantLevel)
+			profile.Resources.ParameterSize = runtime.ParameterSize
+			profile.Resources.QuantLevel = runtime.QuantLevel
+		}
+	}
+
+	// Set family from parsed name if still empty.
+	if profile.Family == "" {
+		profile.Family = parsed.NormalizedFamily()
+	}
+
+	return profile
+}
+
+// inferProfile generates a basic ModelProfile from runtime model info for
+// models not found in the static catalog. It uses heuristics based on
+// family name patterns and capabilities.
+func inferProfile(info *ModelInfo) *ModelProfile {
+	if info == nil {
+		return nil
+	}
+
+	p := &ModelProfile{}
+
+	// Infer think mode from family patterns.
+	family := strings.ToLower(info.Family)
+	switch {
+	case strings.Contains(family, "deepseek") && strings.Contains(family, "r1"):
+		p.ThinkMode = ThinkAlways
+	case strings.HasPrefix(family, "qwen3") || strings.HasPrefix(family, "gemma3"):
+		p.ThinkMode = ThinkToggle
+	default:
+		p.ThinkMode = ThinkAuto // safe default for unknown models
+	}
+
+	// Estimate quality tier from parameter count.
+	paramCount := parseParamCount(info.ParameterSize)
+	switch {
+	case paramCount >= 30:
+		p.Quality = TierGreat
+		p.Speed = TierBasic // slow
+	case paramCount >= 7:
+		p.Quality = TierGood
+		p.Speed = TierGood // medium
+	default:
+		p.Quality = TierBasic
+		p.Speed = TierGreat // fast
+	}
+
+	return p
+}
+
+// estimateResources estimates RAM requirements from parameter size and
+// quantization level for models not in the catalog.
+//
+// RAM formula: bytes_per_param * param_count_billions * 1.2 (overhead for
+// KV cache and runtime buffers).
+//
+// Quantization multipliers (bytes per parameter):
+//   - Q4_K_M: ~0.55
+//   - Q8_0:   ~1.0
+//   - FP16:   ~2.0
+//   - Default: ~0.55 (most Ollama models are Q4)
+func estimateResources(paramSize, quantLevel string) ResourceProfile {
+	paramCount := parseParamCount(paramSize) // billions
+	if paramCount == 0 {
+		return ResourceProfile{}
+	}
+
+	bytesPerParam := quantBytesPerParam(quantLevel)
+	const overhead = 1.2
+
+	ramGB := paramCount * bytesPerParam * overhead
+	recommendedGB := ramGB * 1.3
+
+	return ResourceProfile{
+		ParameterSize:  paramSize,
+		QuantLevel:     quantLevel,
+		RAMRequired:    math.Round(ramGB*10) / 10,
+		RAMRecommended: math.Round(recommendedGB*10) / 10,
+	}
+}
+
+// parseParamCount extracts the numeric parameter count in billions from
+// strings like "8B", "70B", "8x7b", "3.8B", "137M".
+func parseParamCount(s string) float64 {
+	s = strings.TrimSpace(strings.ToLower(s))
+	if s == "" {
+		return 0
+	}
+
+	// Handle MoE format: "8x7b" -> 56
+	if idx := strings.Index(s, "x"); idx > 0 {
+		experts, _ := strconv.ParseFloat(s[:idx], 64)
+		rest := strings.TrimSuffix(s[idx+1:], "b")
+		perExpert, _ := strconv.ParseFloat(rest, 64)
+		if experts > 0 && perExpert > 0 {
+			return experts * perExpert
+		}
+	}
+
+	// Handle millions: "137M" -> 0.137
+	if strings.HasSuffix(s, "m") {
+		val, err := strconv.ParseFloat(strings.TrimSuffix(s, "m"), 64)
+		if err == nil {
+			return val / 1000.0
+		}
+	}
+
+	// Handle billions: "8B", "3.8B", "70B"
+	s = strings.TrimSuffix(s, "b")
+	val, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0
+	}
+	return val
+}
+
+// quantBytesPerParam returns the approximate bytes per parameter for a
+// given quantization level.
+func quantBytesPerParam(quant string) float64 {
+	quant = strings.ToLower(strings.TrimSpace(quant))
+	switch {
+	case strings.HasPrefix(quant, "q4"):
+		return 0.55
+	case strings.HasPrefix(quant, "q5"):
+		return 0.7
+	case strings.HasPrefix(quant, "q6"):
+		return 0.8
+	case strings.HasPrefix(quant, "q8"):
+		return 1.0
+	case quant == "fp16" || quant == "f16":
+		return 2.0
+	case quant == "fp32" || quant == "f32":
+		return 4.0
+	default:
+		return 0.55 // default to Q4 (most common on Ollama)
+	}
+}
+
+// sortProfiles sorts profiles by quality descending, then speed descending.
+// Uses sort.Slice for clarity and correctness.
+func sortProfiles(profiles []*ModelProfile) {
+	sort.Slice(profiles, func(i, j int) bool {
+		if profiles[i].Quality != profiles[j].Quality {
+			return profiles[i].Quality > profiles[j].Quality
+		}
+		return profiles[i].Speed > profiles[j].Speed
+	})
+}

--- a/provider/model_registry.go
+++ b/provider/model_registry.go
@@ -221,6 +221,11 @@ func (r *ModelRegistry) buildProfile(ctx context.Context, key ModelKey) (*ModelP
 	// Layer 2: Static catalog match.
 	parsed := ParseModelName(key.Model)
 	staticProfile := r.catalog.lookup(parsed.NormalizedFamily(), parsed.ParamSize)
+	if staticProfile == nil && parsed.ParamSize == "" && parsed.Tag != "" {
+		// Some catalog-only variants are keyed by tag (for example ":latest")
+		// rather than by parsed parameter size.
+		staticProfile = r.catalog.lookup(parsed.NormalizedFamily(), parsed.Tag)
+	}
 	if staticProfile == nil {
 		// Try family-only lookup for family-level metadata (FIM, think mode).
 		staticProfile = r.catalog.lookupFamily(parsed.NormalizedFamily())

--- a/provider/model_registry.go
+++ b/provider/model_registry.go
@@ -118,15 +118,21 @@ func (r *ModelRegistry) LookupAny(ctx context.Context, model string) ([]*ModelPr
 }
 
 // All returns merged profiles for every model across every registered
-// provider. Errors for individual models are skipped silently to provide
-// best-effort results even when some providers are unhealthy.
+// provider. Individual lookup errors are skipped to provide best-effort
+// results, but if ALL providers fail, an error is returned.
 func (r *ModelRegistry) All(ctx context.Context) ([]*ModelProfile, error) {
 	allProviders := r.providers.All()
+	if len(allProviders) == 0 {
+		return nil, nil
+	}
+
 	var profiles []*ModelProfile
+	var providerErrors int
 
 	for _, p := range allProviders {
 		models, err := p.Models(ctx)
 		if err != nil {
+			providerErrors++
 			continue
 		}
 		for _, mi := range models {
@@ -137,6 +143,10 @@ func (r *ModelRegistry) All(ctx context.Context) ([]*ModelProfile, error) {
 			}
 			profiles = append(profiles, profile)
 		}
+	}
+
+	if len(profiles) == 0 && providerErrors == len(allProviders) {
+		return nil, fmt.Errorf("provider: model registry: all %d providers failed", providerErrors)
 	}
 
 	return profiles, nil

--- a/provider/model_registry_test.go
+++ b/provider/model_registry_test.go
@@ -1,0 +1,1067 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/fingerprint"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers: mock provider resolver and mock providers for ModelRegistry
+// ---------------------------------------------------------------------------
+
+// mrMockProviderRegistry implements ProviderResolver for ModelRegistry tests.
+// The prefix "mr" distinguishes it from the mockProvider in registry_test.go.
+type mrMockProviderRegistry struct {
+	providers map[string]Provider
+}
+
+func (m *mrMockProviderRegistry) Resolve(key ModelKey) (Provider, error) {
+	p, ok := m.providers[key.Provider]
+	if !ok {
+		return nil, fmt.Errorf("provider: unknown provider %q", key.Provider)
+	}
+	return p, nil
+}
+
+func (m *mrMockProviderRegistry) ProvidersForModel(model string) ([]Provider, error) {
+	var matches []Provider
+	for _, p := range m.providers {
+		models, _ := p.Models(context.Background())
+		for _, mi := range models {
+			if mi.Name == model {
+				matches = append(matches, p)
+			}
+		}
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("provider: no provider found for model %q", model)
+	}
+	return matches, nil
+}
+
+func (m *mrMockProviderRegistry) All() []Provider {
+	all := make([]Provider, 0, len(m.providers))
+	for _, p := range m.providers {
+		all = append(all, p)
+	}
+	return all
+}
+
+// mrMockProvider implements a minimal Provider for ModelRegistry tests.
+type mrMockProvider struct {
+	name   string
+	models []ModelInfo
+	caps   Capability
+}
+
+func (m *mrMockProvider) Name() string            { return m.name }
+func (m *mrMockProvider) Capabilities() Capability { return m.caps }
+
+func (m *mrMockProvider) Health(_ context.Context) error { return nil }
+
+func (m *mrMockProvider) Models(_ context.Context) ([]ModelInfo, error) {
+	return m.models, nil
+}
+
+func (m *mrMockProvider) Chat(_ context.Context, _ ChatRequest) (*ChatResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mrMockProvider) ChatStream(_ context.Context, _ ChatRequest, _ func(ChatResponse) error) error {
+	return errors.New("not implemented")
+}
+
+func (m *mrMockProvider) Generate(_ context.Context, _ GenerateRequest) (*GenerateResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mrMockProvider) GenerateStream(_ context.Context, _ GenerateRequest, _ func(GenerateResponse) error) error {
+	return errors.New("not implemented")
+}
+
+func (m *mrMockProvider) Embed(_ context.Context, _ EmbedRequest) (*EmbedResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+// mrCountingProvider wraps mrMockProvider to count Models() calls.
+type mrCountingProvider struct {
+	*mrMockProvider
+	callCount *int
+}
+
+func (c *mrCountingProvider) Models(_ context.Context) ([]ModelInfo, error) {
+	*c.callCount++
+	return c.models, nil
+}
+
+// mrMockFingerprintStore implements fingerprint.Store for testing.
+type mrMockFingerprintStore struct {
+	profiles map[string]*fingerprint.Profile
+}
+
+func newMrMockFingerprintStore() *mrMockFingerprintStore {
+	return &mrMockFingerprintStore{
+		profiles: make(map[string]*fingerprint.Profile),
+	}
+}
+
+func (m *mrMockFingerprintStore) Get(_ context.Context, backendID, modelName string) (*fingerprint.Profile, error) {
+	key := backendID + "\x00" + modelName
+	p, ok := m.profiles[key]
+	if !ok {
+		return nil, fingerprint.ErrNotFound
+	}
+	return p, nil
+}
+
+func (m *mrMockFingerprintStore) GetFailure(_ context.Context, _, _ string) (*fingerprint.FailureInfo, error) {
+	return nil, fingerprint.ErrNotFound
+}
+
+func (m *mrMockFingerprintStore) Save(_ context.Context, profile fingerprint.Profile) error {
+	key := profile.BackendID + "\x00" + profile.ModelName
+	m.profiles[key] = &profile
+	return nil
+}
+
+func (m *mrMockFingerprintStore) NeedsFingerprint(_ context.Context, _, _, _ string) (bool, error) {
+	return false, nil
+}
+
+func (m *mrMockFingerprintStore) SaveFailure(_ context.Context, _, _, _, _ string) error {
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// TestModelRegistry_Lookup_CatalogMatch
+// ---------------------------------------------------------------------------
+
+func TestModelRegistry_Lookup_CatalogMatch(t *testing.T) {
+	ctx := context.Background()
+
+	prov := &mrMockProvider{
+		name: "ollama",
+		caps: CapChat | CapGenerate | CapStream | CapEmbed,
+		models: []ModelInfo{
+			{
+				Name:          "qwen3:8b",
+				Family:        "qwen3",
+				ParameterSize: "8B",
+				QuantLevel:    "Q4_K_M",
+				ContextWindow: 40960,
+				Digest:        "abc123",
+				Capabilities:  []string{"completion", "tools"},
+			},
+		},
+	}
+
+	reg := &mrMockProviderRegistry{
+		providers: map[string]Provider{"ollama": prov},
+	}
+
+	mr, err := NewModelRegistry(reg, newMrMockFingerprintStore())
+	if err != nil {
+		t.Fatalf("NewModelRegistry() error: %v", err)
+	}
+
+	key := ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+	profile, err := mr.Lookup(ctx, key)
+	if err != nil {
+		t.Fatalf("Lookup() error: %v", err)
+	}
+
+	// Verify runtime fields merged.
+	if profile.Key != key {
+		t.Errorf("Key = %v, want %v", profile.Key, key)
+	}
+	if profile.Resources.ParameterSize != "8B" {
+		t.Errorf("ParameterSize = %q, want %q", profile.Resources.ParameterSize, "8B")
+	}
+	if profile.Resources.QuantLevel != "Q4_K_M" {
+		t.Errorf("QuantLevel = %q, want %q", profile.Resources.QuantLevel, "Q4_K_M")
+	}
+	if profile.ContextWindow != 40960 {
+		t.Errorf("ContextWindow = %d, want %d", profile.ContextWindow, 40960)
+	}
+	if profile.Digest != "abc123" {
+		t.Errorf("Digest = %q, want %q", profile.Digest, "abc123")
+	}
+
+	// Verify static catalog fields merged (qwen3 has FIM + toggle think).
+	if profile.FIM == nil {
+		t.Fatal("expected FIM config from catalog, got nil")
+	}
+	if profile.FIM.Prefix != "<|fim_prefix|>" {
+		t.Errorf("FIM.Prefix = %q, want %q", profile.FIM.Prefix, "<|fim_prefix|>")
+	}
+	if profile.ThinkMode != ThinkToggle {
+		t.Errorf("ThinkMode = %v, want ThinkToggle", profile.ThinkMode)
+	}
+
+	// Verify source is merged.
+	if profile.Source != SourceMerged {
+		t.Errorf("Source = %v, want SourceMerged", profile.Source)
+	}
+
+	// Verify family was resolved.
+	if profile.Family != "qwen3" {
+		t.Errorf("Family = %q, want %q", profile.Family, "qwen3")
+	}
+
+	// Verify catalog-provided resource data was populated.
+	if profile.Resources.RAMRequired == 0 {
+		t.Error("expected RAMRequired > 0 from catalog")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestModelRegistry_Lookup_UnknownModel
+// ---------------------------------------------------------------------------
+
+func TestModelRegistry_Lookup_UnknownModel(t *testing.T) {
+	ctx := context.Background()
+
+	prov := &mrMockProvider{
+		name: "ollama",
+		caps: CapChat,
+		models: []ModelInfo{
+			{
+				Name:          "some-new-model:7b",
+				Family:        "somenew",
+				ParameterSize: "7B",
+				QuantLevel:    "Q4_K_M",
+				ContextWindow: 8192,
+				Digest:        "new123",
+				Capabilities:  []string{"completion"},
+			},
+		},
+	}
+
+	reg := &mrMockProviderRegistry{
+		providers: map[string]Provider{"ollama": prov},
+	}
+
+	mr, err := NewModelRegistry(reg, newMrMockFingerprintStore())
+	if err != nil {
+		t.Fatalf("NewModelRegistry() error: %v", err)
+	}
+
+	key := ModelKey{Provider: "ollama", Model: "some-new-model:7b"}
+	profile, err := mr.Lookup(ctx, key)
+	if err != nil {
+		t.Fatalf("Lookup() error: %v", err)
+	}
+
+	// Dynamic inference should still produce a usable profile.
+	if profile.ContextWindow != 8192 {
+		t.Errorf("ContextWindow = %d, want %d", profile.ContextWindow, 8192)
+	}
+	if profile.Resources.ParameterSize != "7B" {
+		t.Errorf("ParameterSize = %q, want %q", profile.Resources.ParameterSize, "7B")
+	}
+	// RAM should be estimated from param size + quant.
+	if profile.Resources.RAMRequired <= 0 {
+		t.Errorf("expected estimated RAMRequired > 0, got %f", profile.Resources.RAMRequired)
+	}
+	// Quality should be inferred from 7B param count.
+	if profile.Quality != TierGood {
+		t.Errorf("Quality = %v, want TierGood (inferred from 7B)", profile.Quality)
+	}
+	// Source should still be merged (even though catalog didn't match).
+	if profile.Source != SourceMerged {
+		t.Errorf("Source = %v, want SourceMerged", profile.Source)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestModelRegistry_Lookup_CacheHit
+// ---------------------------------------------------------------------------
+
+func TestModelRegistry_Lookup_CacheHit(t *testing.T) {
+	ctx := context.Background()
+
+	callCount := 0
+	prov := &mrMockProvider{
+		name: "ollama",
+		caps: CapChat,
+		models: []ModelInfo{
+			{
+				Name:          "qwen3:8b",
+				Family:        "qwen3",
+				ParameterSize: "8B",
+				ContextWindow: 40960,
+				Digest:        "abc123",
+			},
+		},
+	}
+
+	countingProv := &mrCountingProvider{
+		mrMockProvider: prov,
+		callCount:      &callCount,
+	}
+
+	reg := &mrMockProviderRegistry{
+		providers: map[string]Provider{"ollama": countingProv},
+	}
+
+	mr, err := NewModelRegistry(reg, newMrMockFingerprintStore())
+	if err != nil {
+		t.Fatalf("NewModelRegistry() error: %v", err)
+	}
+
+	key := ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+
+	// First lookup -- should call provider.
+	_, err = mr.Lookup(ctx, key)
+	if err != nil {
+		t.Fatalf("first Lookup() error: %v", err)
+	}
+
+	// Second lookup -- should use cache, no provider call.
+	_, err = mr.Lookup(ctx, key)
+	if err != nil {
+		t.Fatalf("second Lookup() error: %v", err)
+	}
+
+	if callCount != 1 {
+		t.Errorf("expected 1 provider call, got %d (cache miss on second call)", callCount)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestModelRegistry_Refresh
+// ---------------------------------------------------------------------------
+
+func TestModelRegistry_Refresh(t *testing.T) {
+	ctx := context.Background()
+
+	prov := &mrMockProvider{
+		name: "ollama",
+		caps: CapChat,
+		models: []ModelInfo{
+			{
+				Name:          "qwen3:8b",
+				Family:        "qwen3",
+				ParameterSize: "8B",
+				ContextWindow: 40960,
+				Digest:        "abc123",
+			},
+		},
+	}
+
+	reg := &mrMockProviderRegistry{
+		providers: map[string]Provider{"ollama": prov},
+	}
+
+	mr, err := NewModelRegistry(reg, newMrMockFingerprintStore())
+	if err != nil {
+		t.Fatalf("NewModelRegistry() error: %v", err)
+	}
+
+	key := ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+
+	// Lookup with initial digest.
+	profile1, err := mr.Lookup(ctx, key)
+	if err != nil {
+		t.Fatalf("first Lookup() error: %v", err)
+	}
+	if profile1.Digest != "abc123" {
+		t.Fatalf("initial Digest = %q, want %q", profile1.Digest, "abc123")
+	}
+
+	// Simulate model update by changing digest.
+	prov.models[0].Digest = "def456"
+
+	// Normal Lookup should still return cached (stale) profile.
+	profile2, err := mr.Lookup(ctx, key)
+	if err != nil {
+		t.Fatalf("cached Lookup() error: %v", err)
+	}
+	if profile2.Digest != "abc123" {
+		t.Errorf("cached Digest = %q, want %q (should be stale)", profile2.Digest, "abc123")
+	}
+
+	// Refresh should detect staleness and re-merge.
+	profile3, err := mr.Refresh(ctx, key)
+	if err != nil {
+		t.Fatalf("Refresh() error: %v", err)
+	}
+	if profile3.Digest != "def456" {
+		t.Errorf("refreshed Digest = %q, want %q", profile3.Digest, "def456")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestModelRegistry_LookupAny
+// ---------------------------------------------------------------------------
+
+func TestModelRegistry_LookupAny(t *testing.T) {
+	ctx := context.Background()
+
+	p1 := &mrMockProvider{
+		name: "ollama",
+		caps: CapChat,
+		models: []ModelInfo{
+			{Name: "qwen3:8b", Family: "qwen3", ParameterSize: "8B", ContextWindow: 40960, Digest: "aaa"},
+		},
+	}
+
+	p2 := &mrMockProvider{
+		name: "lmstudio",
+		caps: CapChat,
+		models: []ModelInfo{
+			{Name: "qwen3:8b", Family: "qwen3", ParameterSize: "8B", ContextWindow: 40960, Digest: "bbb"},
+		},
+	}
+
+	reg := &mrMockProviderRegistry{
+		providers: map[string]Provider{"ollama": p1, "lmstudio": p2},
+	}
+
+	mr, err := NewModelRegistry(reg, newMrMockFingerprintStore())
+	if err != nil {
+		t.Fatalf("NewModelRegistry() error: %v", err)
+	}
+
+	profiles, err := mr.LookupAny(ctx, "qwen3:8b")
+	if err != nil {
+		t.Fatalf("LookupAny() error: %v", err)
+	}
+
+	if len(profiles) != 2 {
+		t.Fatalf("LookupAny() returned %d profiles, want 2", len(profiles))
+	}
+
+	// Should have one from each provider.
+	providerNames := make(map[string]bool)
+	for _, p := range profiles {
+		providerNames[p.Key.Provider] = true
+	}
+	if !providerNames["ollama"] || !providerNames["lmstudio"] {
+		t.Errorf("expected profiles from both providers, got %v", providerNames)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestModelRegistry_FIMConfigFor
+// ---------------------------------------------------------------------------
+
+func TestModelRegistry_FIMConfigFor(t *testing.T) {
+	ctx := context.Background()
+
+	prov := &mrMockProvider{
+		name: "ollama",
+		caps: CapChat | CapGenerate,
+		models: []ModelInfo{
+			{
+				Name:          "qwen3:8b",
+				Family:        "qwen3",
+				ParameterSize: "8B",
+				ContextWindow: 40960,
+				Digest:        "abc123",
+			},
+			{
+				Name:          "llama3.1:8b",
+				Family:        "llama",
+				ParameterSize: "8B",
+				ContextWindow: 131072,
+				Digest:        "xyz789",
+			},
+		},
+	}
+
+	reg := &mrMockProviderRegistry{
+		providers: map[string]Provider{"ollama": prov},
+	}
+
+	mr, err := NewModelRegistry(reg, newMrMockFingerprintStore())
+	if err != nil {
+		t.Fatalf("NewModelRegistry() error: %v", err)
+	}
+
+	// qwen3 has FIM tokens in the catalog.
+	fimCfg, err := mr.FIMConfigFor(ctx, ModelKey{Provider: "ollama", Model: "qwen3:8b"})
+	if err != nil {
+		t.Fatalf("FIMConfigFor(qwen3) error: %v", err)
+	}
+	if fimCfg == nil {
+		t.Fatal("expected FIMConfig for qwen3, got nil")
+	}
+	if fimCfg.Prefix != "<|fim_prefix|>" {
+		t.Errorf("FIM.Prefix = %q, want %q", fimCfg.Prefix, "<|fim_prefix|>")
+	}
+
+	// llama3.1 has no FIM in the catalog.
+	fimCfg, err = mr.FIMConfigFor(ctx, ModelKey{Provider: "ollama", Model: "llama3.1:8b"})
+	if err != nil {
+		t.Fatalf("FIMConfigFor(llama3.1) error: %v", err)
+	}
+	if fimCfg != nil {
+		t.Errorf("expected nil FIMConfig for llama3.1, got %+v", fimCfg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestModelRegistry_Recommend
+// ---------------------------------------------------------------------------
+
+func TestModelRegistry_Recommend(t *testing.T) {
+	ctx := context.Background()
+
+	prov := &mrMockProvider{
+		name: "ollama",
+		caps: CapChat | CapGenerate | CapEmbed | CapStream,
+		models: []ModelInfo{
+			{Name: "qwen3:8b", Family: "qwen3", ParameterSize: "8B", ContextWindow: 40960, Digest: "a1", Capabilities: []string{"completion", "tools"}},
+			{Name: "qwen3:32b", Family: "qwen3", ParameterSize: "32B", ContextWindow: 40960, Digest: "a2", Capabilities: []string{"completion", "tools"}},
+			{Name: "nomic-embed-text:latest", Family: "nomic-embed-text", ParameterSize: "137M", ContextWindow: 8192, Digest: "a3", Capabilities: []string{"embedding"}},
+		},
+	}
+
+	reg := &mrMockProviderRegistry{
+		providers: map[string]Provider{"ollama": prov},
+	}
+
+	mr, err := NewModelRegistry(reg, newMrMockFingerprintStore())
+	if err != nil {
+		t.Fatalf("NewModelRegistry() error: %v", err)
+	}
+
+	t.Run("filter by CapGenerate", func(t *testing.T) {
+		profiles, err := mr.Recommend(ctx, RecommendOpts{
+			RequiredCaps: CapGenerate,
+		})
+		if err != nil {
+			t.Fatalf("Recommend() error: %v", err)
+		}
+
+		// Should exclude embedding model which lacks CapGenerate.
+		for _, p := range profiles {
+			if p.Caps&CapGenerate == 0 {
+				t.Errorf("recommended model %q lacks CapGenerate", p.Name)
+			}
+		}
+		if len(profiles) == 0 {
+			t.Fatal("expected at least one recommendation with CapGenerate")
+		}
+	})
+
+	t.Run("filter by CapGenerate and RAM", func(t *testing.T) {
+		profiles, err := mr.Recommend(ctx, RecommendOpts{
+			RequiredCaps: CapGenerate,
+			AvailableRAM: 10.0,
+		})
+		if err != nil {
+			t.Fatalf("Recommend() error: %v", err)
+		}
+
+		// 32b model requires ~20GB, so it should be excluded with 10GB limit.
+		for _, p := range profiles {
+			if p.Resources.RAMRequired > 10.0 {
+				t.Errorf("recommended model %q needs %.1f GB RAM, exceeds 10 GB limit",
+					p.Name, p.Resources.RAMRequired)
+			}
+		}
+	})
+
+	t.Run("filter by CapEmbed for embedding", func(t *testing.T) {
+		profiles, err := mr.Recommend(ctx, RecommendOpts{
+			RequiredCaps: CapEmbed,
+		})
+		if err != nil {
+			t.Fatalf("Recommend(embedding) error: %v", err)
+		}
+
+		if len(profiles) == 0 {
+			t.Fatal("expected at least one embedding recommendation")
+		}
+		for _, p := range profiles {
+			if p.Caps&CapEmbed == 0 {
+				t.Errorf("recommended model %q lacks CapEmbed", p.Name)
+			}
+		}
+	})
+
+	t.Run("sorted by quality descending", func(t *testing.T) {
+		profiles, err := mr.Recommend(ctx, RecommendOpts{
+			RequiredCaps: CapGenerate,
+		})
+		if err != nil {
+			t.Fatalf("Recommend() error: %v", err)
+		}
+
+		for i := 1; i < len(profiles); i++ {
+			if profiles[i].Quality > profiles[i-1].Quality {
+				t.Errorf("profiles not sorted: %q (quality=%v) ranked after %q (quality=%v)",
+					profiles[i].Name, profiles[i].Quality,
+					profiles[i-1].Name, profiles[i-1].Quality)
+			}
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestModelRegistry_FingerprintEnrichment
+// ---------------------------------------------------------------------------
+
+func TestModelRegistry_FingerprintEnrichment(t *testing.T) {
+	ctx := context.Background()
+
+	prov := &mrMockProvider{
+		name: "ollama",
+		caps: CapChat,
+		models: []ModelInfo{
+			{
+				Name:          "qwen3:8b",
+				Family:        "qwen3",
+				ParameterSize: "8B",
+				ContextWindow: 40960,
+				Digest:        "abc123",
+			},
+		},
+	}
+
+	reg := &mrMockProviderRegistry{
+		providers: map[string]Provider{"ollama": prov},
+	}
+
+	fpStore := newMrMockFingerprintStore()
+
+	// Pre-populate fingerprint data.
+	fpStore.profiles["ollama\x00qwen3:8b"] = &fingerprint.Profile{
+		BackendID:                 "ollama",
+		ModelName:                 "qwen3:8b",
+		ModelDigest:               "abc123",
+		ModelKind:                 fingerprint.ModelKindChat,
+		Capabilities:              []string{"completion", "tools"},
+		GenerationTokensPerSecond: 42.5,
+		PromptLatency:             50 * time.Millisecond,
+		PeakMemoryMB:              6500,
+		GPULayersUsed:             33,
+		TestedAt:                  time.Now(),
+		ProfileVersion:            1,
+	}
+
+	mr, err := NewModelRegistry(reg, fpStore)
+	if err != nil {
+		t.Fatalf("NewModelRegistry() error: %v", err)
+	}
+
+	key := ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+	profile, err := mr.Lookup(ctx, key)
+	if err != nil {
+		t.Fatalf("Lookup() error: %v", err)
+	}
+
+	// Verify the profile was enriched from fingerprint data.
+	if profile.Source != SourceMerged {
+		t.Errorf("Source = %v, want SourceMerged", profile.Source)
+	}
+	if profile.FIM == nil {
+		t.Error("expected FIM config from catalog after merge")
+	}
+
+	// Fingerprint reported 6500MB peak -- verify RAM was updated.
+	// 6500 MB = 6.3476 GB, which should be at least as high as
+	// the catalog's 5.0 GB for qwen3:8b.
+	expectedMinRAM := 6500.0 / 1024.0
+	if profile.Resources.RAMRequired < expectedMinRAM {
+		t.Errorf("RAMRequired = %.2f, expected >= %.2f (from fingerprint PeakMemoryMB=6500)",
+			profile.Resources.RAMRequired, expectedMinRAM)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestModelRegistry_NilFingerprintStore
+// ---------------------------------------------------------------------------
+
+func TestModelRegistry_NilFingerprintStore(t *testing.T) {
+	ctx := context.Background()
+
+	prov := &mrMockProvider{
+		name: "ollama",
+		caps: CapChat,
+		models: []ModelInfo{
+			{Name: "qwen3:8b", Family: "qwen3", ParameterSize: "8B", ContextWindow: 40960, Digest: "abc"},
+		},
+	}
+
+	reg := &mrMockProviderRegistry{
+		providers: map[string]Provider{"ollama": prov},
+	}
+
+	// Pass nil fingerprint store -- should not panic.
+	mr, err := NewModelRegistry(reg, nil)
+	if err != nil {
+		t.Fatalf("NewModelRegistry() error: %v", err)
+	}
+
+	key := ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+	profile, err := mr.Lookup(ctx, key)
+	if err != nil {
+		t.Fatalf("Lookup() error: %v", err)
+	}
+	if profile.FIM == nil {
+		t.Error("expected FIM config from catalog even without fingerprint store")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestModelRegistry_Lookup_ProviderError
+// ---------------------------------------------------------------------------
+
+func TestModelRegistry_Lookup_ProviderError(t *testing.T) {
+	ctx := context.Background()
+
+	reg := &mrMockProviderRegistry{
+		providers: map[string]Provider{},
+	}
+
+	mr, err := NewModelRegistry(reg, newMrMockFingerprintStore())
+	if err != nil {
+		t.Fatalf("NewModelRegistry() error: %v", err)
+	}
+
+	// Unknown provider should return error.
+	_, err = mr.Lookup(ctx, ModelKey{Provider: "missing", Model: "qwen3:8b"})
+	if err == nil {
+		t.Fatal("expected error for unknown provider")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestModelRegistry_Lookup_ModelNotFound
+// ---------------------------------------------------------------------------
+
+func TestModelRegistry_Lookup_ModelNotFound(t *testing.T) {
+	ctx := context.Background()
+
+	prov := &mrMockProvider{
+		name:   "ollama",
+		caps:   CapChat,
+		models: []ModelInfo{},
+	}
+
+	reg := &mrMockProviderRegistry{
+		providers: map[string]Provider{"ollama": prov},
+	}
+
+	mr, err := NewModelRegistry(reg, newMrMockFingerprintStore())
+	if err != nil {
+		t.Fatalf("NewModelRegistry() error: %v", err)
+	}
+
+	_, err = mr.Lookup(ctx, ModelKey{Provider: "ollama", Model: "nonexistent:7b"})
+	if err == nil {
+		t.Fatal("expected error for model not found on provider")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestModelRegistry_All
+// ---------------------------------------------------------------------------
+
+func TestModelRegistry_All(t *testing.T) {
+	ctx := context.Background()
+
+	prov := &mrMockProvider{
+		name: "ollama",
+		caps: CapChat | CapEmbed,
+		models: []ModelInfo{
+			{Name: "qwen3:8b", Family: "qwen3", ParameterSize: "8B", ContextWindow: 40960, Digest: "a1"},
+			{Name: "llama3:8b", Family: "llama3", ParameterSize: "8B", ContextWindow: 8192, Digest: "a2"},
+		},
+	}
+
+	reg := &mrMockProviderRegistry{
+		providers: map[string]Provider{"ollama": prov},
+	}
+
+	mr, err := NewModelRegistry(reg, newMrMockFingerprintStore())
+	if err != nil {
+		t.Fatalf("NewModelRegistry() error: %v", err)
+	}
+
+	profiles, err := mr.All(ctx)
+	if err != nil {
+		t.Fatalf("All() error: %v", err)
+	}
+
+	if len(profiles) != 2 {
+		t.Fatalf("All() returned %d profiles, want 2", len(profiles))
+	}
+
+	names := make(map[string]bool)
+	for _, p := range profiles {
+		names[p.Name] = true
+	}
+	if !names["qwen3:8b"] || !names["llama3:8b"] {
+		t.Errorf("All() names = %v, want qwen3:8b and llama3:8b", names)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestEstimateResources
+// ---------------------------------------------------------------------------
+
+func TestEstimateResources(t *testing.T) {
+	tests := []struct {
+		name      string
+		paramSize string
+		quant     string
+		wantMin   float64 // minimum RAM required (sanity check)
+		wantMax   float64 // maximum RAM required (sanity check)
+	}{
+		{
+			name:      "8B Q4_K_M",
+			paramSize: "8B",
+			quant:     "Q4_K_M",
+			wantMin:   4.0,
+			wantMax:   8.0,
+		},
+		{
+			name:      "70B Q4_K_M",
+			paramSize: "70B",
+			quant:     "Q4_K_M",
+			wantMin:   40.0,
+			wantMax:   55.0,
+		},
+		{
+			name:      "8B FP16",
+			paramSize: "8B",
+			quant:     "fp16",
+			wantMin:   15.0,
+			wantMax:   25.0,
+		},
+		{
+			name:      "137M Q4_K_M (embedding model)",
+			paramSize: "137M",
+			quant:     "Q4_K_M",
+			wantMin:   0.05,
+			wantMax:   0.3,
+		},
+		{
+			name:      "8x7B Q4_K_M (MoE)",
+			paramSize: "8x7B",
+			quant:     "Q4_K_M",
+			wantMin:   30.0,
+			wantMax:   45.0,
+		},
+		{
+			name:      "empty param size",
+			paramSize: "",
+			quant:     "Q4_K_M",
+			wantMin:   0,
+			wantMax:   0,
+		},
+		{
+			name:      "3.8B Q4_K_M",
+			paramSize: "3.8B",
+			quant:     "Q4_K_M",
+			wantMin:   2.0,
+			wantMax:   4.0,
+		},
+		{
+			name:      "8B Q8_0",
+			paramSize: "8B",
+			quant:     "Q8_0",
+			wantMin:   8.0,
+			wantMax:   12.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rp := estimateResources(tt.paramSize, tt.quant)
+			if rp.RAMRequired < tt.wantMin {
+				t.Errorf("RAMRequired = %.2f, want >= %.2f", rp.RAMRequired, tt.wantMin)
+			}
+			if rp.RAMRequired > tt.wantMax {
+				t.Errorf("RAMRequired = %.2f, want <= %.2f", rp.RAMRequired, tt.wantMax)
+			}
+			// Recommended should be at least as high as required. For very small
+			// models (e.g. 137M), rounding to one decimal can make them equal.
+			if rp.RAMRequired > 0 && rp.RAMRecommended < rp.RAMRequired {
+				t.Errorf("RAMRecommended (%.2f) should be >= RAMRequired (%.2f)",
+					rp.RAMRecommended, rp.RAMRequired)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestInferProfile
+// ---------------------------------------------------------------------------
+
+func TestInferProfile(t *testing.T) {
+	tests := []struct {
+		name          string
+		info          *ModelInfo
+		wantThink     ThinkMode
+		wantQuality   Tier
+		wantSpeed     Tier
+		wantNilResult bool
+	}{
+		{
+			name:          "nil info",
+			info:          nil,
+			wantNilResult: true,
+		},
+		{
+			name:        "small model (2B)",
+			info:        &ModelInfo{ParameterSize: "2B", Family: "unknown"},
+			wantThink:   ThinkAuto,
+			wantQuality: TierBasic,
+			wantSpeed:   TierGreat,
+		},
+		{
+			name:        "medium model (8B)",
+			info:        &ModelInfo{ParameterSize: "8B", Family: "unknown"},
+			wantThink:   ThinkAuto,
+			wantQuality: TierGood,
+			wantSpeed:   TierGood,
+		},
+		{
+			name:        "large model (70B)",
+			info:        &ModelInfo{ParameterSize: "70B", Family: "unknown"},
+			wantThink:   ThinkAuto,
+			wantQuality: TierGreat,
+			wantSpeed:   TierBasic,
+		},
+		{
+			name:        "qwen3 family infers toggle think",
+			info:        &ModelInfo{ParameterSize: "8B", Family: "qwen3"},
+			wantThink:   ThinkToggle,
+			wantQuality: TierGood,
+			wantSpeed:   TierGood,
+		},
+		{
+			name:        "deepseek-r1 family infers always think",
+			info:        &ModelInfo{ParameterSize: "8B", Family: "deepseek-r1"},
+			wantThink:   ThinkAlways,
+			wantQuality: TierGood,
+			wantSpeed:   TierGood,
+		},
+		{
+			name:        "gemma3 family infers toggle think",
+			info:        &ModelInfo{ParameterSize: "12B", Family: "gemma3"},
+			wantThink:   ThinkToggle,
+			wantQuality: TierGood,
+			wantSpeed:   TierGood,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := inferProfile(tt.info)
+			if tt.wantNilResult {
+				if result != nil {
+					t.Errorf("expected nil result, got %+v", result)
+				}
+				return
+			}
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+			if result.ThinkMode != tt.wantThink {
+				t.Errorf("ThinkMode = %v, want %v", result.ThinkMode, tt.wantThink)
+			}
+			if result.Quality != tt.wantQuality {
+				t.Errorf("Quality = %v, want %v", result.Quality, tt.wantQuality)
+			}
+			if result.Speed != tt.wantSpeed {
+				t.Errorf("Speed = %v, want %v", result.Speed, tt.wantSpeed)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestParseParamCount
+// ---------------------------------------------------------------------------
+
+func TestParseParamCount(t *testing.T) {
+	tests := []struct {
+		input string
+		want  float64
+	}{
+		{"8B", 8.0},
+		{"70b", 70.0},
+		{"3.8B", 3.8},
+		{"0.6b", 0.6},
+		{"137M", 0.137},
+		{"8x7b", 56.0},
+		{"", 0},
+		{"invalid", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parseParamCount(tt.input)
+			if got != tt.want {
+				t.Errorf("parseParamCount(%q) = %f, want %f", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestQuantBytesPerParam
+// ---------------------------------------------------------------------------
+
+func TestQuantBytesPerParam(t *testing.T) {
+	tests := []struct {
+		quant string
+		want  float64
+	}{
+		{"Q4_K_M", 0.55},
+		{"q4_0", 0.55},
+		{"Q5_K_M", 0.7},
+		{"Q6_K", 0.8},
+		{"Q8_0", 1.0},
+		{"fp16", 2.0},
+		{"f16", 2.0},
+		{"fp32", 4.0},
+		{"f32", 4.0},
+		{"", 0.55},     // default
+		{"unknown", 0.55}, // default
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.quant, func(t *testing.T) {
+			got := quantBytesPerParam(tt.quant)
+			if got != tt.want {
+				t.Errorf("quantBytesPerParam(%q) = %f, want %f", tt.quant, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestSortProfiles
+// ---------------------------------------------------------------------------
+
+func TestSortProfiles(t *testing.T) {
+	profiles := []*ModelProfile{
+		{Name: "basic-fast", Quality: TierBasic, Speed: TierGreat},
+		{Name: "great-slow", Quality: TierGreat, Speed: TierBasic},
+		{Name: "good-medium", Quality: TierGood, Speed: TierGood},
+		{Name: "great-fast", Quality: TierGreat, Speed: TierGreat},
+		{Name: "good-fast", Quality: TierGood, Speed: TierGreat},
+	}
+
+	sortProfiles(profiles)
+
+	// Expected order: great-fast, great-slow, good-fast, good-medium, basic-fast
+	expected := []string{"great-fast", "great-slow", "good-fast", "good-medium", "basic-fast"}
+	for i, want := range expected {
+		if profiles[i].Name != want {
+			t.Errorf("position %d: got %q, want %q", i, profiles[i].Name, want)
+		}
+	}
+}

--- a/provider/model_registry_test.go
+++ b/provider/model_registry_test.go
@@ -59,7 +59,7 @@ type mrMockProvider struct {
 	caps   Capability
 }
 
-func (m *mrMockProvider) Name() string            { return m.name }
+func (m *mrMockProvider) Name() string             { return m.name }
 func (m *mrMockProvider) Capabilities() Capability { return m.caps }
 
 func (m *mrMockProvider) Health(_ context.Context) error { return nil }
@@ -216,6 +216,52 @@ func TestModelRegistry_Lookup_CatalogMatch(t *testing.T) {
 	// Verify catalog-provided resource data was populated.
 	if profile.Resources.RAMRequired == 0 {
 		t.Error("expected RAMRequired > 0 from catalog")
+	}
+}
+
+func TestModelRegistry_Lookup_LatestVariantCatalogMatch(t *testing.T) {
+	ctx := context.Background()
+
+	prov := &mrMockProvider{
+		name: "ollama",
+		caps: CapEmbed,
+		models: []ModelInfo{
+			{
+				Name:          "nomic-embed-text:latest",
+				Family:        "nomic-embed-text",
+				ParameterSize: "137M",
+				ContextWindow: 8192,
+				Digest:        "embed123",
+				Capabilities:  []string{"embedding"},
+			},
+		},
+	}
+
+	reg := &mrMockProviderRegistry{
+		providers: map[string]Provider{"ollama": prov},
+	}
+
+	mr, err := NewModelRegistry(reg, newMrMockFingerprintStore())
+	if err != nil {
+		t.Fatalf("NewModelRegistry() error: %v", err)
+	}
+
+	profile, err := mr.Lookup(ctx, ModelKey{Provider: "ollama", Model: "nomic-embed-text:latest"})
+	if err != nil {
+		t.Fatalf("Lookup() error: %v", err)
+	}
+
+	if profile.Resources.RAMRequired != 0.5 {
+		t.Errorf("RAMRequired = %f, want 0.5", profile.Resources.RAMRequired)
+	}
+	if profile.Resources.RAMRecommended != 1.0 {
+		t.Errorf("RAMRecommended = %f, want 1.0", profile.Resources.RAMRecommended)
+	}
+	if profile.Quality != TierGood {
+		t.Errorf("Quality = %v, want %v", profile.Quality, TierGood)
+	}
+	if profile.Speed != TierGreat {
+		t.Errorf("Speed = %v, want %v", profile.Speed, TierGreat)
 	}
 }
 
@@ -584,6 +630,19 @@ func TestModelRegistry_Recommend(t *testing.T) {
 			if p.Caps&CapEmbed == 0 {
 				t.Errorf("recommended model %q lacks CapEmbed", p.Name)
 			}
+		}
+	})
+
+	t.Run("filter latest-only variant by RAM", func(t *testing.T) {
+		profiles, err := mr.Recommend(ctx, RecommendOpts{
+			RequiredCaps: CapEmbed,
+			AvailableRAM: 0.4,
+		})
+		if err != nil {
+			t.Fatalf("Recommend(embedding, RAM) error: %v", err)
+		}
+		if len(profiles) != 0 {
+			t.Fatalf("expected no recommendations under 0.4 GB RAM, got %d", len(profiles))
 		}
 	})
 
@@ -1028,7 +1087,7 @@ func TestQuantBytesPerParam(t *testing.T) {
 		{"f16", 2.0},
 		{"fp32", 4.0},
 		{"f32", 4.0},
-		{"", 0.55},     // default
+		{"", 0.55},        // default
 		{"unknown", 0.55}, // default
 	}
 

--- a/provider/ollama.go
+++ b/provider/ollama.go
@@ -74,6 +74,21 @@ func NewOllamaProvider(client *ollama.Client, opts ...OllamaOption) *OllamaProvi
 	return p
 }
 
+func (p *OllamaProvider) thinkToggleActive(opts ModelOptions) bool {
+	return opts.Think != nil && *opts.Think
+}
+
+func (p *OllamaProvider) shouldExtractThinking(opts ModelOptions) bool {
+	switch p.thinkMode {
+	case ThinkNone:
+		return false
+	case ThinkToggle:
+		return p.thinkToggleActive(opts)
+	default:
+		return true
+	}
+}
+
 // Name returns the canonical provider identifier "ollama".
 func (p *OllamaProvider) Name() string {
 	return "ollama"
@@ -139,8 +154,11 @@ func (p *OllamaProvider) Chat(ctx context.Context, req ChatRequest) (*ChatRespon
 		return nil, fmt.Errorf("provider: ollama: chat: %w", err)
 	}
 
-	// Extract thinking from the complete response using regex.
-	content, thinking := ExtractThinking(oResp.Message.Content, p.thinkTags)
+	content := oResp.Message.Content
+	thinking := ""
+	if p.shouldExtractThinking(req.Options) {
+		content, thinking = ExtractThinking(oResp.Message.Content, p.thinkTags)
+	}
 
 	return &ChatResponse{
 		Model:     oResp.Model,
@@ -219,6 +237,9 @@ func (p *OllamaProvider) ChatStream(ctx context.Context, req ChatRequest, fn fun
 		},
 		Budget: p.thinkBudget,
 	})
+	if p.thinkMode == ThinkToggle {
+		parser.SetActive(p.thinkToggleActive(req.Options))
+	}
 
 	streamErr := p.client.ChatStream(ctx, oReq, func(oResp ollama.ChatResponse) error {
 		chunksReceived++
@@ -444,13 +465,11 @@ func (p *OllamaProvider) Embed(ctx context.Context, req EmbedRequest) (*EmbedRes
 	// Use DoChan so each caller respects its own context deadline.
 	// singleflight.Do would block until the winner's request completes,
 	// ignoring other callers' cancelled contexts.
+	sharedCtx := context.WithoutCancel(ctx)
 	ch := p.embedGroup.DoChan(key, func() (any, error) {
 		embeddings := make([][]float64, len(req.Input))
 		for i, text := range req.Input {
-			if ctx.Err() != nil {
-				return nil, fmt.Errorf("provider: ollama: embed: %w", ctx.Err())
-			}
-			emb, embedErr := p.client.Embed(ctx, req.Model, text)
+			emb, embedErr := p.client.Embed(sharedCtx, req.Model, text)
 			if embedErr != nil {
 				return nil, fmt.Errorf("provider: ollama: embed: %w", embedErr)
 			}

--- a/provider/ollama.go
+++ b/provider/ollama.go
@@ -1,0 +1,461 @@
+// provider/ollama.go
+
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+// ---------------------------------------------------------------------------
+// OllamaOption — functional options for OllamaProvider
+// ---------------------------------------------------------------------------
+
+// OllamaOption configures an OllamaProvider.
+type OllamaOption func(*OllamaProvider)
+
+// WithThinkMode sets the ThinkMode used when constructing per-request ThinkParsers.
+func WithThinkMode(mode ThinkMode) OllamaOption {
+	return func(p *OllamaProvider) {
+		p.thinkMode = mode
+	}
+}
+
+// WithThinkTags overrides the default think tag delimiters.
+func WithThinkTags(tags ThinkTags) OllamaOption {
+	return func(p *OllamaProvider) {
+		p.thinkTags = tags
+	}
+}
+
+// WithThinkBudget sets a budget constraint for thinking extraction.
+func WithThinkBudget(budget *ThinkBudget) OllamaOption {
+	return func(p *OllamaProvider) {
+		p.thinkBudget = budget
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OllamaProvider
+// ---------------------------------------------------------------------------
+
+// OllamaProvider implements the Provider interface by delegating to an
+// ollama.Client. It adds think-tag extraction on chat responses (streaming
+// and non-streaming) and graceful cancellation with partial results on all
+// streaming methods.
+type OllamaProvider struct {
+	client      *ollama.Client
+	thinkMode   ThinkMode
+	thinkTags   ThinkTags
+	thinkBudget *ThinkBudget
+}
+
+// NewOllamaProvider creates a Provider backed by the given ollama.Client.
+// Options configure think-tag parsing behavior. By default, ThinkAuto mode
+// with standard <think></think> tags is used.
+func NewOllamaProvider(client *ollama.Client, opts ...OllamaOption) *OllamaProvider {
+	p := &OllamaProvider{
+		client:    client,
+		thinkMode: ThinkAuto,
+		thinkTags: DefaultThinkTags(),
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// Name returns the canonical provider identifier "ollama".
+func (p *OllamaProvider) Name() string {
+	return "ollama"
+}
+
+// Capabilities returns the bitmask of features the Ollama backend supports.
+func (p *OllamaProvider) Capabilities() Capability {
+	return CapChat | CapGenerate | CapEmbed | CapStream | CapToolCall
+}
+
+// Health checks whether the Ollama server is reachable and responsive.
+func (p *OllamaProvider) Health(ctx context.Context) error {
+	if p.client.IsAvailable(ctx) {
+		return nil
+	}
+	return fmt.Errorf("provider: ollama: server is not available")
+}
+
+// Models returns the list of models available from the Ollama server,
+// enriched with detailed metadata from /api/show for each model.
+func (p *OllamaProvider) Models(ctx context.Context) ([]ModelInfo, error) {
+	oModels, err := p.client.ListModels(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("provider: ollama: list models: %w", err)
+	}
+
+	models := make([]ModelInfo, len(oModels))
+	for i, m := range oModels {
+		// Fetch detailed info for each model.
+		detail, showErr := p.client.ShowModel(ctx, m.Name)
+		if showErr != nil {
+			// Fallback: use basic info from list.
+			models[i] = ModelInfo{
+				Name: m.Name,
+			}
+			continue
+		}
+		models[i] = ModelInfo{
+			Name:          detail.Name,
+			Family:        detail.Family,
+			ParameterSize: detail.ParamSize,
+			QuantLevel:    detail.QuantLevel,
+			Capabilities:  detail.Capabilities,
+			Digest:        detail.Digest,
+		}
+	}
+	return models, nil
+}
+
+// ---------------------------------------------------------------------------
+// Chat (non-streaming)
+// ---------------------------------------------------------------------------
+
+// Chat sends a non-streaming chat request, translating between provider and
+// ollama types. The response content is processed through ExtractThinking to
+// separate any reasoning from the final answer.
+func (p *OllamaProvider) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error) {
+	oReq := toOllamaChatRequest(req)
+	oReq.Stream = false
+
+	oResp, err := p.client.Chat(ctx, oReq)
+	if err != nil {
+		return nil, fmt.Errorf("provider: ollama: chat: %w", err)
+	}
+
+	// Extract thinking from the complete response using regex.
+	content, thinking := ExtractThinking(oResp.Message.Content, p.thinkTags)
+
+	return &ChatResponse{
+		Model:     oResp.Model,
+		Provider:  "ollama",
+		Content:   content,
+		Thinking:  thinking,
+		ToolCalls: toProviderToolCalls(oResp.Message.ToolCalls),
+		Done:      true,
+		Usage: Usage{
+			PromptTokens:     oResp.PromptEvalCount,
+			CompletionTokens: oResp.EvalCount,
+			TotalTokens:      oResp.PromptEvalCount + oResp.EvalCount,
+		},
+		Latency: LatencyInfo{
+			LoadDuration:       time.Duration(oResp.LoadDuration),
+			PromptEvalDuration: time.Duration(oResp.PromptEvalDuration),
+			GenerationDuration: time.Duration(oResp.EvalDuration),
+		},
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// ChatStream (streaming with think-tag extraction)
+// ---------------------------------------------------------------------------
+
+// ChatStream sends a streaming chat request. Each chunk is processed through
+// a per-request ThinkParser to separate reasoning from content in real time.
+//
+// If the context is cancelled after at least one chunk has been received, a
+// final synthetic chunk with Partial=true and Done=true is emitted containing
+// accumulated content so far, then the context error is returned.
+func (p *OllamaProvider) ChatStream(ctx context.Context, req ChatRequest, fn func(ChatResponse) error) error {
+	if fn == nil {
+		return fmt.Errorf("provider: ollama: chat stream: callback function is required")
+	}
+
+	oReq := toOllamaChatRequest(req)
+	oReq.Stream = true
+
+	// Build a per-request ThinkParser with callbacks that emit chunks.
+	var lastModel string
+	var lastToolCalls []ToolCall
+	var lastUsage Usage
+	var lastLatency LatencyInfo
+	var thinkingBuf strings.Builder
+	var contentBuf strings.Builder
+	chunksReceived := 0
+	var callbackErr error
+	lastDone := false
+
+	parser := NewThinkParser(ThinkParserConfig{
+		Mode: p.thinkMode,
+		Tags: p.thinkTags,
+		OnThinking: func(s string) error {
+			thinkingBuf.WriteString(s)
+			resp := ChatResponse{
+				Model:    lastModel,
+				Provider: "ollama",
+				Thinking: s,
+			}
+			if err := fn(resp); err != nil {
+				callbackErr = err
+				return err
+			}
+			return nil
+		},
+		OnContent: func(s string) error {
+			contentBuf.WriteString(s)
+			resp := ChatResponse{
+				Model:    lastModel,
+				Provider: "ollama",
+				Content:  s,
+			}
+			if err := fn(resp); err != nil {
+				callbackErr = err
+				return err
+			}
+			return nil
+		},
+		Budget: p.thinkBudget,
+	})
+
+	streamErr := p.client.ChatStream(ctx, oReq, func(oResp ollama.ChatResponse) error {
+		chunksReceived++
+		lastModel = oResp.Model
+
+		if len(oResp.Message.ToolCalls) > 0 {
+			lastToolCalls = toProviderToolCalls(oResp.Message.ToolCalls)
+		}
+
+		// Feed content through the think parser.
+		if oResp.Message.Content != "" {
+			if err := parser.Process(oResp.Message.Content); err != nil {
+				return err
+			}
+		}
+
+		// On the final chunk, flush the parser and emit Done with usage/latency.
+		if oResp.Done {
+			lastDone = true
+			lastUsage = Usage{
+				PromptTokens:     oResp.PromptEvalCount,
+				CompletionTokens: oResp.EvalCount,
+				TotalTokens:      oResp.PromptEvalCount + oResp.EvalCount,
+			}
+			lastLatency = LatencyInfo{
+				LoadDuration:       time.Duration(oResp.LoadDuration),
+				PromptEvalDuration: time.Duration(oResp.PromptEvalDuration),
+				GenerationDuration: time.Duration(oResp.EvalDuration),
+			}
+
+			if err := parser.Flush(); err != nil {
+				return err
+			}
+
+			doneResp := ChatResponse{
+				Model:     oResp.Model,
+				Provider:  "ollama",
+				ToolCalls: lastToolCalls,
+				Done:      true,
+				Usage:     lastUsage,
+				Latency:   lastLatency,
+			}
+			return fn(doneResp)
+		}
+
+		// Emit tool calls as they arrive (separate from content/thinking).
+		if len(oResp.Message.ToolCalls) > 0 {
+			tcResp := ChatResponse{
+				Model:     oResp.Model,
+				Provider:  "ollama",
+				ToolCalls: toProviderToolCalls(oResp.Message.ToolCalls),
+			}
+			return fn(tcResp)
+		}
+
+		return nil
+	})
+
+	// Graceful cancellation: if context was cancelled after receiving chunks,
+	// emit a partial result so consumers can use what was generated.
+	if streamErr != nil && ctx.Err() != nil && chunksReceived > 0 && !lastDone {
+		// Flush any remaining parser state.
+		_ = parser.Flush()
+
+		partial := ChatResponse{
+			Model:     req.Model,
+			Provider:  "ollama",
+			Content:   contentBuf.String(),
+			Thinking:  thinkingBuf.String(),
+			ToolCalls: lastToolCalls,
+			Done:      true,
+			Partial:   true,
+			Usage:     lastUsage,
+			Latency:   lastLatency,
+		}
+		// Best-effort delivery of partial result; ignore callback error.
+		_ = fn(partial)
+		return fmt.Errorf("provider: ollama: chat stream: %w", ctx.Err())
+	}
+
+	if streamErr != nil {
+		// If the error originated from the user callback, return it directly
+		// to avoid double-wrapping.
+		if callbackErr != nil {
+			return fmt.Errorf("provider: ollama: chat stream: %w", streamErr)
+		}
+		return fmt.Errorf("provider: ollama: chat stream: %w", streamErr)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Generate (stub — Task 2)
+// ---------------------------------------------------------------------------
+
+// Generate sends a non-streaming text generation request.
+func (p *OllamaProvider) Generate(_ context.Context, _ GenerateRequest) (*GenerateResponse, error) {
+	return nil, fmt.Errorf("provider: ollama: Generate not yet implemented")
+}
+
+// GenerateStream sends a streaming text generation request.
+func (p *OllamaProvider) GenerateStream(_ context.Context, _ GenerateRequest, _ func(GenerateResponse) error) error {
+	return fmt.Errorf("provider: ollama: GenerateStream not yet implemented")
+}
+
+// ---------------------------------------------------------------------------
+// Embed (stub — Task 2)
+// ---------------------------------------------------------------------------
+
+// Embed generates vector embeddings for the given input texts.
+func (p *OllamaProvider) Embed(_ context.Context, _ EmbedRequest) (*EmbedResponse, error) {
+	return nil, fmt.Errorf("provider: ollama: Embed not yet implemented")
+}
+
+// ---------------------------------------------------------------------------
+// Type mapping helpers
+// ---------------------------------------------------------------------------
+
+// toOllamaChatRequest converts a provider ChatRequest to an ollama ChatRequest.
+func toOllamaChatRequest(req ChatRequest) ollama.ChatRequest {
+	msgs := make([]ollama.ChatMessage, len(req.Messages))
+	for i, m := range req.Messages {
+		msgs[i] = ollama.ChatMessage{
+			Role:       m.Role,
+			Content:    m.Content,
+			ToolName:   m.ToolName,
+			ToolCallID: m.ToolCallID,
+			ToolCalls:  toOllamaToolCalls(m.ToolCalls),
+		}
+	}
+
+	oReq := ollama.ChatRequest{
+		Model:    req.Model,
+		Messages: msgs,
+		Stream:   req.Stream,
+		Tools:    toOllamaTools(req.Tools),
+	}
+	if opts := toOllamaOptions(req.Options); opts != nil {
+		oReq.Options = opts
+	}
+	return oReq
+}
+
+// toOllamaOptions converts provider ModelOptions to ollama ModelOptions.
+// Returns nil when all fields are zero-valued, matching ollama's omitempty behavior.
+func toOllamaOptions(opts ModelOptions) *ollama.ModelOptions {
+	o := &ollama.ModelOptions{
+		NumPredict: opts.NumPredict,
+		NumCtx:     opts.NumCtx,
+		Stop:       opts.Stop,
+	}
+	if opts.Temperature != nil {
+		o.Temperature = *opts.Temperature
+	}
+	if opts.TopP != nil {
+		o.TopP = *opts.TopP
+	}
+	if opts.RepeatPenalty != nil {
+		o.RepeatPenalty = *opts.RepeatPenalty
+	}
+
+	// Return nil if everything is zero to match omitempty.
+	if o.Temperature == 0 && o.TopP == 0 && o.NumPredict == 0 &&
+		o.NumCtx == 0 && len(o.Stop) == 0 && o.RepeatPenalty == 0 {
+		return nil
+	}
+	return o
+}
+
+// toOllamaTools converts provider Tools to ollama Tools.
+func toOllamaTools(tools []Tool) []ollama.Tool {
+	if len(tools) == 0 {
+		return nil
+	}
+	result := make([]ollama.Tool, len(tools))
+	for i, t := range tools {
+		result[i] = ollama.Tool{
+			Type: t.Type,
+			Function: ollama.ToolFunction{
+				Name:        t.Function.Name,
+				Description: t.Function.Description,
+				Parameters:  t.Function.Parameters,
+			},
+		}
+	}
+	return result
+}
+
+// toOllamaToolCalls converts provider ToolCalls to ollama ToolCalls.
+// The provider uses json.RawMessage for arguments while ollama uses map[string]any,
+// so a JSON unmarshal is performed for each call.
+func toOllamaToolCalls(calls []ToolCall) []ollama.ToolCall {
+	if len(calls) == 0 {
+		return nil
+	}
+	result := make([]ollama.ToolCall, len(calls))
+	for i, c := range calls {
+		var args map[string]any
+		if len(c.Function.Arguments) > 0 {
+			// Best-effort unmarshal; nil on failure.
+			_ = json.Unmarshal(c.Function.Arguments, &args)
+		}
+		result[i] = ollama.ToolCall{
+			ID:   c.ID,
+			Type: c.Type,
+			Function: ollama.ToolCallFunction{
+				Index:     c.Function.Index,
+				Name:      c.Function.Name,
+				Arguments: args,
+			},
+		}
+	}
+	return result
+}
+
+// toProviderToolCalls converts ollama ToolCalls to provider ToolCalls.
+// The ollama package uses map[string]any for arguments while the provider uses
+// json.RawMessage, so a JSON marshal is performed for each call.
+func toProviderToolCalls(calls []ollama.ToolCall) []ToolCall {
+	if len(calls) == 0 {
+		return nil
+	}
+	result := make([]ToolCall, len(calls))
+	for i, c := range calls {
+		var args json.RawMessage
+		if c.Function.Arguments != nil {
+			// Best-effort marshal; nil on failure.
+			args, _ = json.Marshal(c.Function.Arguments)
+		}
+		result[i] = ToolCall{
+			ID:   c.ID,
+			Type: c.Type,
+			Function: ToolCallFunction{
+				Index:     c.Function.Index,
+				Name:      c.Function.Name,
+				Arguments: args,
+			},
+		}
+	}
+	return result
+}

--- a/provider/ollama.go
+++ b/provider/ollama.go
@@ -471,7 +471,16 @@ func (p *OllamaProvider) Embed(ctx context.Context, req EmbedRequest) (*EmbedRes
 		if res.Err != nil {
 			return nil, res.Err
 		}
-		return res.Val.(*EmbedResponse), nil
+		// Defensive copy: singleflight shares the result pointer among all
+		// callers. Copy the response so consumers cannot corrupt shared state.
+		shared := res.Val.(*EmbedResponse)
+		copied := *shared
+		copied.Embeddings = make([][]float64, len(shared.Embeddings))
+		for i, emb := range shared.Embeddings {
+			copied.Embeddings[i] = make([]float64, len(emb))
+			copy(copied.Embeddings[i], emb)
+		}
+		return &copied, nil
 	case <-ctx.Done():
 		return nil, fmt.Errorf("provider: ollama: embed: %w", ctx.Err())
 	}
@@ -547,9 +556,10 @@ func toOllamaOptions(opts ModelOptions) *ollama.ModelOptions {
 		o.RepeatPenalty = *opts.RepeatPenalty
 	}
 
-	// Return nil if everything is zero to match omitempty.
-	if o.Temperature == 0 && o.TopP == 0 && o.NumPredict == 0 &&
-		o.NumCtx == 0 && len(o.Stop) == 0 && o.RepeatPenalty == 0 {
+	// Return nil only if no options were explicitly set.
+	// Check the source pointer fields to distinguish "not set" from "set to zero".
+	if opts.Temperature == nil && opts.TopP == nil && opts.RepeatPenalty == nil &&
+		opts.NumPredict == 0 && opts.NumCtx == 0 && len(opts.Stop) == 0 {
 		return nil
 	}
 	return o

--- a/provider/ollama.go
+++ b/provider/ollama.go
@@ -4,12 +4,15 @@ package provider
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/kstruzzieri/go-llm/ollama"
+	"golang.org/x/sync/singleflight"
 )
 
 // ---------------------------------------------------------------------------
@@ -53,6 +56,7 @@ type OllamaProvider struct {
 	thinkMode   ThinkMode
 	thinkTags   ThinkTags
 	thinkBudget *ThinkBudget
+	embedGroup  singleflight.Group
 }
 
 // NewOllamaProvider creates a Provider backed by the given ollama.Client.
@@ -310,26 +314,166 @@ func (p *OllamaProvider) ChatStream(ctx context.Context, req ChatRequest, fn fun
 }
 
 // ---------------------------------------------------------------------------
-// Generate (stub — Task 2)
+// Generate (non-streaming)
 // ---------------------------------------------------------------------------
 
-// Generate sends a non-streaming text generation request.
-func (p *OllamaProvider) Generate(_ context.Context, _ GenerateRequest) (*GenerateResponse, error) {
-	return nil, fmt.Errorf("provider: ollama: Generate not yet implemented")
+// Generate sends a non-streaming text generation request, translating between
+// provider and ollama types.
+func (p *OllamaProvider) Generate(ctx context.Context, req GenerateRequest) (*GenerateResponse, error) {
+	oReq := toOllamaGenerateRequest(req)
+	oReq.Stream = false
+
+	oResp, err := p.client.Generate(ctx, oReq)
+	if err != nil {
+		return nil, fmt.Errorf("provider: ollama: generate: %w", err)
+	}
+
+	return &GenerateResponse{
+		Model:    oResp.Model,
+		Provider: "ollama",
+		Response: oResp.Response,
+		Done:     true,
+		Usage: Usage{
+			CompletionTokens: oResp.EvalCount,
+		},
+		Latency: LatencyInfo{
+			GenerationDuration: time.Duration(oResp.EvalDuration),
+		},
+	}, nil
 }
 
-// GenerateStream sends a streaming text generation request.
-func (p *OllamaProvider) GenerateStream(_ context.Context, _ GenerateRequest, _ func(GenerateResponse) error) error {
-	return fmt.Errorf("provider: ollama: GenerateStream not yet implemented")
+// ---------------------------------------------------------------------------
+// GenerateStream (streaming with graceful cancellation)
+// ---------------------------------------------------------------------------
+
+// GenerateStream sends a streaming text generation request. Each chunk is
+// forwarded to fn with the provider-level GenerateResponse type.
+//
+// If the context is cancelled after at least one chunk has been received, a
+// final synthetic chunk with Partial=true and Done=true is emitted containing
+// the accumulated response so far, then the context error is returned.
+func (p *OllamaProvider) GenerateStream(ctx context.Context, req GenerateRequest, fn func(GenerateResponse) error) error {
+	if fn == nil {
+		return fmt.Errorf("provider: ollama: generate stream: callback function is required")
+	}
+
+	oReq := toOllamaGenerateRequest(req)
+	oReq.Stream = true
+
+	var accumulated strings.Builder
+	var lastUsage Usage
+	var lastLatency LatencyInfo
+	chunksReceived := 0
+	lastDone := false
+	var callbackErr error
+
+	streamErr := p.client.GenerateStream(ctx, oReq, func(oResp ollama.GenerateResponse) error {
+		chunksReceived++
+		accumulated.WriteString(oResp.Response)
+
+		if oResp.Done {
+			lastDone = true
+			lastUsage = Usage{
+				CompletionTokens: oResp.EvalCount,
+			}
+			lastLatency = LatencyInfo{
+				GenerationDuration: time.Duration(oResp.EvalDuration),
+			}
+		}
+
+		resp := GenerateResponse{
+			Model:    oResp.Model,
+			Provider: "ollama",
+			Response: oResp.Response,
+			Done:     oResp.Done,
+			Usage:    lastUsage,
+			Latency:  lastLatency,
+		}
+		if err := fn(resp); err != nil {
+			callbackErr = err
+			return err
+		}
+		return nil
+	})
+
+	// Graceful cancellation: if context was cancelled after receiving chunks,
+	// emit a partial result so consumers can use what was generated.
+	if streamErr != nil && ctx.Err() != nil && chunksReceived > 0 && !lastDone {
+		partial := GenerateResponse{
+			Model:    req.Model,
+			Provider: "ollama",
+			Response: accumulated.String(),
+			Done:     true,
+			Partial:  true,
+			Usage:    lastUsage,
+			Latency:  lastLatency,
+		}
+		// Best-effort delivery of partial result; ignore callback error.
+		_ = fn(partial)
+		return fmt.Errorf("provider: ollama: generate stream: %w", ctx.Err())
+	}
+
+	if streamErr != nil {
+		if callbackErr != nil {
+			return fmt.Errorf("provider: ollama: generate stream: %w", streamErr)
+		}
+		return fmt.Errorf("provider: ollama: generate stream: %w", streamErr)
+	}
+	return nil
 }
 
 // ---------------------------------------------------------------------------
-// Embed (stub — Task 2)
+// Embed (with singleflight deduplication)
 // ---------------------------------------------------------------------------
 
-// Embed generates vector embeddings for the given input texts.
-func (p *OllamaProvider) Embed(_ context.Context, _ EmbedRequest) (*EmbedResponse, error) {
-	return nil, fmt.Errorf("provider: ollama: Embed not yet implemented")
+// Embed generates vector embeddings for the given input texts. Concurrent
+// identical requests (same model and inputs) are deduplicated via singleflight
+// to avoid redundant computation during batch RAG indexing.
+func (p *OllamaProvider) Embed(ctx context.Context, req EmbedRequest) (*EmbedResponse, error) {
+	if req.Model == "" {
+		return nil, fmt.Errorf("provider: ollama: embed: model name is required")
+	}
+	if len(req.Input) == 0 {
+		return nil, fmt.Errorf("provider: ollama: embed: at least one input text is required")
+	}
+
+	// Build singleflight key from model + hash of all inputs.
+	key := embedKey(req.Model, req.Input)
+
+	result, err, _ := p.embedGroup.Do(key, func() (any, error) {
+		embeddings := make([][]float64, len(req.Input))
+		for i, text := range req.Input {
+			if ctx.Err() != nil {
+				return nil, fmt.Errorf("provider: ollama: embed: %w", ctx.Err())
+			}
+			emb, embedErr := p.client.Embed(ctx, req.Model, text)
+			if embedErr != nil {
+				return nil, fmt.Errorf("provider: ollama: embed: %w", embedErr)
+			}
+			embeddings[i] = emb
+		}
+		return &EmbedResponse{
+			Model:      req.Model,
+			Provider:   "ollama",
+			Embeddings: embeddings,
+			Usage: Usage{
+				PromptTokens: len(req.Input),
+			},
+		}, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return result.(*EmbedResponse), nil
+}
+
+// embedKey builds a singleflight dedup key from the model name and input texts.
+// Inputs are joined with a null byte separator to avoid collisions, then hashed
+// with SHA-256 for a fixed-size key component.
+func embedKey(model string, inputs []string) string {
+	h := sha256.Sum256([]byte(strings.Join(inputs, "\x00")))
+	return model + ":" + hex.EncodeToString(h[:])
 }
 
 // ---------------------------------------------------------------------------
@@ -354,6 +498,21 @@ func toOllamaChatRequest(req ChatRequest) ollama.ChatRequest {
 		Messages: msgs,
 		Stream:   req.Stream,
 		Tools:    toOllamaTools(req.Tools),
+	}
+	if opts := toOllamaOptions(req.Options); opts != nil {
+		oReq.Options = opts
+	}
+	return oReq
+}
+
+// toOllamaGenerateRequest converts a provider GenerateRequest to an ollama GenerateRequest.
+func toOllamaGenerateRequest(req GenerateRequest) ollama.GenerateRequest {
+	oReq := ollama.GenerateRequest{
+		Model:  req.Model,
+		Prompt: req.Prompt,
+		System: req.System,
+		Suffix: req.Suffix,
+		Stream: req.Stream,
 	}
 	if opts := toOllamaOptions(req.Options); opts != nil {
 		oReq.Options = opts

--- a/provider/ollama.go
+++ b/provider/ollama.go
@@ -169,9 +169,10 @@ func (p *OllamaProvider) Chat(ctx context.Context, req ChatRequest) (*ChatRespon
 // ChatStream sends a streaming chat request. Each chunk is processed through
 // a per-request ThinkParser to separate reasoning from content in real time.
 //
-// If the context is cancelled after at least one chunk has been received, a
-// final synthetic chunk with Partial=true and Done=true is emitted containing
-// accumulated content so far, then the context error is returned.
+// If the context is cancelled after at least one chunk has been received, the
+// parser is flushed and a final synthetic chunk with Partial=true and Done=true
+// is emitted without replaying prior content deltas, then the context error is
+// returned.
 func (p *OllamaProvider) ChatStream(ctx context.Context, req ChatRequest, fn func(ChatResponse) error) error {
 	if fn == nil {
 		return fmt.Errorf("provider: ollama: chat stream: callback function is required")
@@ -185,8 +186,6 @@ func (p *OllamaProvider) ChatStream(ctx context.Context, req ChatRequest, fn fun
 	var lastToolCalls []ToolCall
 	var lastUsage Usage
 	var lastLatency LatencyInfo
-	var thinkingBuf strings.Builder
-	var contentBuf strings.Builder
 	chunksReceived := 0
 	var callbackErr error
 	lastDone := false
@@ -195,7 +194,6 @@ func (p *OllamaProvider) ChatStream(ctx context.Context, req ChatRequest, fn fun
 		Mode: p.thinkMode,
 		Tags: p.thinkTags,
 		OnThinking: func(s string) error {
-			thinkingBuf.WriteString(s)
 			resp := ChatResponse{
 				Model:    lastModel,
 				Provider: "ollama",
@@ -208,7 +206,6 @@ func (p *OllamaProvider) ChatStream(ctx context.Context, req ChatRequest, fn fun
 			return nil
 		},
 		OnContent: func(s string) error {
-			contentBuf.WriteString(s)
 			resp := ChatResponse{
 				Model:    lastModel,
 				Provider: "ollama",
@@ -286,11 +283,14 @@ func (p *OllamaProvider) ChatStream(ctx context.Context, req ChatRequest, fn fun
 		// Flush any remaining parser state.
 		_ = parser.Flush()
 
+		model := lastModel
+		if model == "" {
+			model = req.Model
+		}
+
 		partial := ChatResponse{
-			Model:     req.Model,
+			Model:     model,
 			Provider:  "ollama",
-			Content:   contentBuf.String(),
-			Thinking:  thinkingBuf.String(),
 			ToolCalls: lastToolCalls,
 			Done:      true,
 			Partial:   true,
@@ -350,8 +350,8 @@ func (p *OllamaProvider) Generate(ctx context.Context, req GenerateRequest) (*Ge
 // forwarded to fn with the provider-level GenerateResponse type.
 //
 // If the context is cancelled after at least one chunk has been received, a
-// final synthetic chunk with Partial=true and Done=true is emitted containing
-// the accumulated response so far, then the context error is returned.
+// final synthetic chunk with Partial=true and Done=true is emitted without
+// replaying prior response deltas, then the context error is returned.
 func (p *OllamaProvider) GenerateStream(ctx context.Context, req GenerateRequest, fn func(GenerateResponse) error) error {
 	if fn == nil {
 		return fmt.Errorf("provider: ollama: generate stream: callback function is required")
@@ -360,7 +360,7 @@ func (p *OllamaProvider) GenerateStream(ctx context.Context, req GenerateRequest
 	oReq := toOllamaGenerateRequest(req)
 	oReq.Stream = true
 
-	var accumulated strings.Builder
+	var lastModel string
 	var lastUsage Usage
 	var lastLatency LatencyInfo
 	chunksReceived := 0
@@ -369,7 +369,7 @@ func (p *OllamaProvider) GenerateStream(ctx context.Context, req GenerateRequest
 
 	streamErr := p.client.GenerateStream(ctx, oReq, func(oResp ollama.GenerateResponse) error {
 		chunksReceived++
-		accumulated.WriteString(oResp.Response)
+		lastModel = oResp.Model
 
 		if oResp.Done {
 			lastDone = true
@@ -399,10 +399,13 @@ func (p *OllamaProvider) GenerateStream(ctx context.Context, req GenerateRequest
 	// Graceful cancellation: if context was cancelled after receiving chunks,
 	// emit a partial result so consumers can use what was generated.
 	if streamErr != nil && ctx.Err() != nil && chunksReceived > 0 && !lastDone {
+		model := lastModel
+		if model == "" {
+			model = req.Model
+		}
 		partial := GenerateResponse{
-			Model:    req.Model,
+			Model:    model,
 			Provider: "ollama",
-			Response: accumulated.String(),
 			Done:     true,
 			Partial:  true,
 			Usage:    lastUsage,

--- a/provider/ollama.go
+++ b/provider/ollama.go
@@ -81,7 +81,7 @@ func (p *OllamaProvider) Name() string {
 
 // Capabilities returns the bitmask of features the Ollama backend supports.
 func (p *OllamaProvider) Capabilities() Capability {
-	return CapChat | CapGenerate | CapEmbed | CapStream | CapToolCall
+	return CapChat | CapGenerate | CapEmbed | CapStream | CapToolCall | CapThinking
 }
 
 // Health checks whether the Ollama server is reachable and responsive.
@@ -303,10 +303,8 @@ func (p *OllamaProvider) ChatStream(ctx context.Context, req ChatRequest, fn fun
 	}
 
 	if streamErr != nil {
-		// If the error originated from the user callback, return it directly
-		// to avoid double-wrapping.
 		if callbackErr != nil {
-			return fmt.Errorf("provider: ollama: chat stream: %w", streamErr)
+			return callbackErr // already has caller context; don't re-wrap
 		}
 		return fmt.Errorf("provider: ollama: chat stream: %w", streamErr)
 	}
@@ -418,7 +416,7 @@ func (p *OllamaProvider) GenerateStream(ctx context.Context, req GenerateRequest
 
 	if streamErr != nil {
 		if callbackErr != nil {
-			return fmt.Errorf("provider: ollama: generate stream: %w", streamErr)
+			return callbackErr // already has caller context; don't re-wrap
 		}
 		return fmt.Errorf("provider: ollama: generate stream: %w", streamErr)
 	}
@@ -443,7 +441,10 @@ func (p *OllamaProvider) Embed(ctx context.Context, req EmbedRequest) (*EmbedRes
 	// Build singleflight key from model + hash of all inputs.
 	key := embedKey(req.Model, req.Input)
 
-	result, err, _ := p.embedGroup.Do(key, func() (any, error) {
+	// Use DoChan so each caller respects its own context deadline.
+	// singleflight.Do would block until the winner's request completes,
+	// ignoring other callers' cancelled contexts.
+	ch := p.embedGroup.DoChan(key, func() (any, error) {
 		embeddings := make([][]float64, len(req.Input))
 		for i, text := range req.Input {
 			if ctx.Err() != nil {
@@ -465,10 +466,15 @@ func (p *OllamaProvider) Embed(ctx context.Context, req EmbedRequest) (*EmbedRes
 		}, nil
 	})
 
-	if err != nil {
-		return nil, err
+	select {
+	case res := <-ch:
+		if res.Err != nil {
+			return nil, res.Err
+		}
+		return res.Val.(*EmbedResponse), nil
+	case <-ctx.Done():
+		return nil, fmt.Errorf("provider: ollama: embed: %w", ctx.Err())
 	}
-	return result.(*EmbedResponse), nil
 }
 
 // embedKey builds a singleflight dedup key from the model name and input texts.

--- a/provider/ollama_test.go
+++ b/provider/ollama_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -708,5 +710,531 @@ func TestToOllamaToolCalls_RoundTrip(t *testing.T) {
 	}
 	if back[0].Function.Name != "search" {
 		t.Errorf("round-trip: Name = %q, want %q", back[0].Function.Name, "search")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Generate (non-streaming)
+// ---------------------------------------------------------------------------
+
+func TestOllamaProvider_Generate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/generate" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		var req ollama.GenerateRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.Stream {
+			t.Error("expected stream=false for non-streaming generate")
+		}
+		if req.Model != "qwen3:8b" {
+			t.Errorf("model = %q, want %q", req.Model, "qwen3:8b")
+		}
+		if req.Prompt != "Complete this:" {
+			t.Errorf("prompt = %q, want %q", req.Prompt, "Complete this:")
+		}
+
+		resp := ollama.GenerateResponse{
+			Model:         "qwen3:8b",
+			Response:      "Generated text here.",
+			Done:          true,
+			EvalCount:     10,
+			EvalDuration:  5000000,
+			TotalDuration: 6000000,
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	p := NewOllamaProvider(c)
+
+	resp, err := p.Generate(context.Background(), GenerateRequest{
+		Model:  "qwen3:8b",
+		Prompt: "Complete this:",
+	})
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+	if resp.Response != "Generated text here." {
+		t.Errorf("Response = %q, want %q", resp.Response, "Generated text here.")
+	}
+	if resp.Provider != "ollama" {
+		t.Errorf("Provider = %q, want %q", resp.Provider, "ollama")
+	}
+	if resp.Model != "qwen3:8b" {
+		t.Errorf("Model = %q, want %q", resp.Model, "qwen3:8b")
+	}
+	if !resp.Done {
+		t.Error("expected Done=true")
+	}
+	if resp.Usage.CompletionTokens != 10 {
+		t.Errorf("Usage.CompletionTokens = %d, want 10", resp.Usage.CompletionTokens)
+	}
+	if resp.Latency.GenerationDuration != time.Duration(5000000) {
+		t.Errorf("Latency.GenerationDuration = %v, want 5ms", resp.Latency.GenerationDuration)
+	}
+}
+
+func TestOllamaProvider_Generate_WithOptions(t *testing.T) {
+	var receivedOpts ollama.ModelOptions
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollama.GenerateRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.Options != nil {
+			receivedOpts = *req.Options
+		}
+		if req.System != "You are a code assistant." {
+			t.Errorf("System = %q, want %q", req.System, "You are a code assistant.")
+		}
+		if req.Suffix != "// end" {
+			t.Errorf("Suffix = %q, want %q", req.Suffix, "// end")
+		}
+		resp := ollama.GenerateResponse{
+			Model:    "qwen3:8b",
+			Response: "ok",
+			Done:     true,
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	p := NewOllamaProvider(c)
+
+	_, err := p.Generate(context.Background(), GenerateRequest{
+		Model:  "qwen3:8b",
+		Prompt: "function add(",
+		System: "You are a code assistant.",
+		Suffix: "// end",
+		Options: ModelOptions{
+			Temperature: Ptr(0.3),
+			NumPredict:  50,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+	if receivedOpts.Temperature != 0.3 {
+		t.Errorf("Temperature = %f, want 0.3", receivedOpts.Temperature)
+	}
+	if receivedOpts.NumPredict != 50 {
+		t.Errorf("NumPredict = %d, want 50", receivedOpts.NumPredict)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GenerateStream
+// ---------------------------------------------------------------------------
+
+func TestOllamaProvider_GenerateStream(t *testing.T) {
+	chunks := []ollama.GenerateResponse{
+		{Model: "qwen3:8b", Response: "Hello ", Done: false},
+		{Model: "qwen3:8b", Response: "world!", Done: false},
+		{Model: "qwen3:8b", Response: "", Done: true, EvalCount: 4, EvalDuration: 2000000},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		for _, chunk := range chunks {
+			data, _ := json.Marshal(chunk)
+			_, _ = fmt.Fprintf(w, "%s\n", data)
+		}
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	p := NewOllamaProvider(c)
+
+	var received []GenerateResponse
+	err := p.GenerateStream(context.Background(), GenerateRequest{
+		Model:  "qwen3:8b",
+		Prompt: "Complete:",
+	}, func(resp GenerateResponse) error {
+		received = append(received, resp)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("GenerateStream() error: %v", err)
+	}
+	if len(received) != 3 {
+		t.Fatalf("expected 3 chunks, got %d", len(received))
+	}
+	if received[0].Response != "Hello " {
+		t.Errorf("chunk[0].Response = %q, want %q", received[0].Response, "Hello ")
+	}
+	if received[0].Provider != "ollama" {
+		t.Errorf("chunk[0].Provider = %q, want %q", received[0].Provider, "ollama")
+	}
+	if received[1].Response != "world!" {
+		t.Errorf("chunk[1].Response = %q, want %q", received[1].Response, "world!")
+	}
+	if !received[2].Done {
+		t.Error("last chunk should have Done=true")
+	}
+	if received[2].Usage.CompletionTokens != 4 {
+		t.Errorf("last chunk Usage.CompletionTokens = %d, want 4", received[2].Usage.CompletionTokens)
+	}
+}
+
+func TestOllamaProvider_GenerateStream_GracefulCancellation(t *testing.T) {
+	ready := make(chan struct{})
+	serverDone := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		chunk := ollama.GenerateResponse{
+			Model:    "qwen3:8b",
+			Response: "partial output",
+			Done:     false,
+		}
+		data, _ := json.Marshal(chunk)
+		_, _ = fmt.Fprintf(w, "%s\n", data)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		close(ready)
+		<-serverDone
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	p := NewOllamaProvider(c)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var received []GenerateResponse
+	done := make(chan error, 1)
+	go func() {
+		done <- p.GenerateStream(ctx, GenerateRequest{
+			Model:  "qwen3:8b",
+			Prompt: "Generate something long",
+		}, func(resp GenerateResponse) error {
+			received = append(received, resp)
+			return nil
+		})
+	}()
+
+	<-ready
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	err := <-done
+	close(serverDone)
+
+	if err == nil {
+		t.Fatal("expected error after cancellation")
+	}
+	if !strings.Contains(err.Error(), "provider: ollama:") {
+		t.Errorf("error should contain 'provider: ollama:' prefix, got: %v", err)
+	}
+
+	gotPartial := false
+	for _, r := range received {
+		if r.Partial && r.Done {
+			gotPartial = true
+			if r.Response != "partial output" {
+				t.Errorf("partial Response = %q, want %q", r.Response, "partial output")
+			}
+		}
+	}
+	if !gotPartial {
+		t.Error("expected a partial result chunk after cancellation")
+	}
+}
+
+func TestOllamaProvider_GenerateStream_NilCallback(t *testing.T) {
+	c := ollama.NewClient()
+	p := NewOllamaProvider(c)
+
+	err := p.GenerateStream(context.Background(), GenerateRequest{
+		Model:  "qwen3:8b",
+		Prompt: "Hi",
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error for nil callback")
+	}
+	if !strings.Contains(err.Error(), "callback function is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestOllamaProvider_GenerateStream_CallbackError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		chunk := ollama.GenerateResponse{
+			Model:    "qwen3:8b",
+			Response: "hello",
+			Done:     false,
+		}
+		data, _ := json.Marshal(chunk)
+		_, _ = fmt.Fprintf(w, "%s\n", data)
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	p := NewOllamaProvider(c)
+
+	callbackErr := fmt.Errorf("consumer stopped")
+	err := p.GenerateStream(context.Background(), GenerateRequest{
+		Model:  "qwen3:8b",
+		Prompt: "Hi",
+	}, func(_ GenerateResponse) error {
+		return callbackErr
+	})
+	if err == nil {
+		t.Fatal("expected error from callback")
+	}
+	if !strings.Contains(err.Error(), "consumer stopped") {
+		t.Errorf("expected callback error in chain, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Embed
+// ---------------------------------------------------------------------------
+
+func TestOllamaProvider_Embed(t *testing.T) {
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		resp := ollama.EmbedResponse{
+			Embeddings: [][]float64{{0.1, 0.2, 0.3}},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	p := NewOllamaProvider(c)
+
+	resp, err := p.Embed(context.Background(), EmbedRequest{
+		Model: "nomic-embed-text",
+		Input: []string{"hello world", "goodbye world"},
+	})
+	if err != nil {
+		t.Fatalf("Embed() error: %v", err)
+	}
+	if len(resp.Embeddings) != 2 {
+		t.Fatalf("expected 2 embeddings, got %d", len(resp.Embeddings))
+	}
+	if resp.Provider != "ollama" {
+		t.Errorf("Provider = %q, want %q", resp.Provider, "ollama")
+	}
+	if resp.Model != "nomic-embed-text" {
+		t.Errorf("Model = %q, want %q", resp.Model, "nomic-embed-text")
+	}
+	if resp.Usage.PromptTokens != 2 {
+		t.Errorf("Usage.PromptTokens = %d, want 2", resp.Usage.PromptTokens)
+	}
+	if got := atomic.LoadInt32(&callCount); got != 2 {
+		t.Errorf("expected 2 API calls (one per input), got %d", got)
+	}
+	// Verify embedding values.
+	for i, emb := range resp.Embeddings {
+		if len(emb) != 3 {
+			t.Errorf("embedding[%d] length = %d, want 3", i, len(emb))
+		}
+	}
+}
+
+func TestOllamaProvider_Embed_Validation(t *testing.T) {
+	c := ollama.NewClient()
+	p := NewOllamaProvider(c)
+
+	tests := []struct {
+		name    string
+		req     EmbedRequest
+		wantErr string
+	}{
+		{
+			name:    "empty model",
+			req:     EmbedRequest{Input: []string{"hello"}},
+			wantErr: "model name is required",
+		},
+		{
+			name:    "empty input",
+			req:     EmbedRequest{Model: "nomic-embed-text"},
+			wantErr: "at least one input text is required",
+		},
+		{
+			name:    "nil input",
+			req:     EmbedRequest{Model: "nomic-embed-text", Input: nil},
+			wantErr: "at least one input text is required",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := p.Embed(context.Background(), tt.req)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want to contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestOllamaProvider_Embed_Singleflight(t *testing.T) {
+	// Track how many times the server is actually called. We use an atomic
+	// counter because concurrent goroutines will hit the handler in parallel.
+	var serverCalls int32
+
+	// Add a small delay in the handler so concurrent requests overlap.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&serverCalls, 1)
+		time.Sleep(50 * time.Millisecond)
+		resp := ollama.EmbedResponse{
+			Embeddings: [][]float64{{0.1, 0.2, 0.3}},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	p := NewOllamaProvider(c)
+
+	req := EmbedRequest{
+		Model: "nomic-embed-text",
+		Input: []string{"identical text"},
+	}
+
+	const concurrency = 5
+	var wg sync.WaitGroup
+	errs := make([]error, concurrency)
+	results := make([]*EmbedResponse, concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			resp, err := p.Embed(context.Background(), req)
+			errs[idx] = err
+			results[idx] = resp
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: Embed() error: %v", i, err)
+		}
+	}
+
+	// With singleflight, only 1 request's worth of embed calls should hit
+	// the server (1 input text = 1 server call), not 5.
+	got := atomic.LoadInt32(&serverCalls)
+	if got != 1 {
+		t.Errorf("expected 1 server call (singleflight dedup), got %d", got)
+	}
+
+	// All results should be valid and identical (shared via singleflight).
+	for i, resp := range results {
+		if resp == nil {
+			t.Errorf("goroutine %d: nil response", i)
+			continue
+		}
+		if len(resp.Embeddings) != 1 {
+			t.Errorf("goroutine %d: expected 1 embedding, got %d", i, len(resp.Embeddings))
+		}
+		if resp.Provider != "ollama" {
+			t.Errorf("goroutine %d: Provider = %q, want %q", i, resp.Provider, "ollama")
+		}
+	}
+}
+
+func TestOllamaProvider_Embed_DifferentRequestsNotDeduplicated(t *testing.T) {
+	var serverCalls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&serverCalls, 1)
+		resp := ollama.EmbedResponse{
+			Embeddings: [][]float64{{0.1, 0.2, 0.3}},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	p := NewOllamaProvider(c)
+
+	// Two sequential requests with different inputs should both hit the server.
+	_, err := p.Embed(context.Background(), EmbedRequest{
+		Model: "nomic-embed-text",
+		Input: []string{"first text"},
+	})
+	if err != nil {
+		t.Fatalf("first Embed() error: %v", err)
+	}
+
+	_, err = p.Embed(context.Background(), EmbedRequest{
+		Model: "nomic-embed-text",
+		Input: []string{"second text"},
+	})
+	if err != nil {
+		t.Fatalf("second Embed() error: %v", err)
+	}
+
+	got := atomic.LoadInt32(&serverCalls)
+	if got != 2 {
+		t.Errorf("expected 2 server calls for different inputs, got %d", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// toOllamaGenerateRequest helper
+// ---------------------------------------------------------------------------
+
+func TestToOllamaGenerateRequest(t *testing.T) {
+	req := GenerateRequest{
+		Model:  "qwen3:8b",
+		Prompt: "Complete this code:",
+		System: "You are a code assistant.",
+		Suffix: "// end of function",
+		Options: ModelOptions{
+			Temperature: Ptr(0.3),
+			NumPredict:  200,
+			NumCtx:      4096,
+		},
+	}
+
+	oReq := toOllamaGenerateRequest(req)
+
+	if oReq.Model != "qwen3:8b" {
+		t.Errorf("Model = %q, want %q", oReq.Model, "qwen3:8b")
+	}
+	if oReq.Prompt != "Complete this code:" {
+		t.Errorf("Prompt = %q, want %q", oReq.Prompt, "Complete this code:")
+	}
+	if oReq.System != "You are a code assistant." {
+		t.Errorf("System = %q, want %q", oReq.System, "You are a code assistant.")
+	}
+	if oReq.Suffix != "// end of function" {
+		t.Errorf("Suffix = %q, want %q", oReq.Suffix, "// end of function")
+	}
+	if oReq.Options == nil {
+		t.Fatal("Options should not be nil")
+	}
+	if oReq.Options.Temperature != 0.3 {
+		t.Errorf("Options.Temperature = %f, want 0.3", oReq.Options.Temperature)
+	}
+	if oReq.Options.NumPredict != 200 {
+		t.Errorf("Options.NumPredict = %d, want 200", oReq.Options.NumPredict)
+	}
+	if oReq.Options.NumCtx != 4096 {
+		t.Errorf("Options.NumCtx = %d, want 4096", oReq.Options.NumCtx)
+	}
+}
+
+func TestToOllamaGenerateRequest_NoOptions(t *testing.T) {
+	req := GenerateRequest{
+		Model:  "qwen3:8b",
+		Prompt: "Hello",
+	}
+
+	oReq := toOllamaGenerateRequest(req)
+
+	if oReq.Options != nil {
+		t.Errorf("expected nil Options for zero-value ModelOptions, got %+v", oReq.Options)
 	}
 }

--- a/provider/ollama_test.go
+++ b/provider/ollama_test.go
@@ -486,16 +486,24 @@ func TestOllamaProvider_ChatStream_GracefulCancellation(t *testing.T) {
 
 	// Should have at least the content chunk and the partial result.
 	gotPartial := false
+	contentDeltas := ""
 	for _, r := range received {
+		contentDeltas += r.Content
 		if r.Partial && r.Done {
 			gotPartial = true
-			if r.Content != "partial content" {
-				t.Errorf("partial Content = %q, want %q", r.Content, "partial content")
+			if r.Content != "" {
+				t.Errorf("partial Content = %q, want empty delta-preserving partial chunk", r.Content)
+			}
+			if r.Thinking != "" {
+				t.Errorf("partial Thinking = %q, want empty delta-preserving partial chunk", r.Thinking)
 			}
 		}
 	}
 	if !gotPartial {
 		t.Error("expected a partial result chunk after cancellation")
+	}
+	if contentDeltas != "partial content" {
+		t.Errorf("combined content deltas = %q, want %q", contentDeltas, "partial content")
 	}
 }
 
@@ -931,16 +939,21 @@ func TestOllamaProvider_GenerateStream_GracefulCancellation(t *testing.T) {
 	}
 
 	gotPartial := false
+	responseDeltas := ""
 	for _, r := range received {
+		responseDeltas += r.Response
 		if r.Partial && r.Done {
 			gotPartial = true
-			if r.Response != "partial output" {
-				t.Errorf("partial Response = %q, want %q", r.Response, "partial output")
+			if r.Response != "" {
+				t.Errorf("partial Response = %q, want empty delta-preserving partial chunk", r.Response)
 			}
 		}
 	}
 	if !gotPartial {
 		t.Error("expected a partial result chunk after cancellation")
+	}
+	if responseDeltas != "partial output" {
+		t.Errorf("combined response deltas = %q, want %q", responseDeltas, "partial output")
 	}
 }
 

--- a/provider/ollama_test.go
+++ b/provider/ollama_test.go
@@ -215,6 +215,39 @@ func TestOllamaProvider_Chat_NoThinkTags(t *testing.T) {
 	}
 }
 
+func TestOllamaProvider_Chat_ThinkToggleDisabled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := ollama.ChatResponse{
+			Model:   "qwen3:8b",
+			Message: ollama.ChatMessage{Role: "assistant", Content: "<think>Let me reason about this.</think>The answer is 42."},
+			Done:    true,
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	p := NewOllamaProvider(c, WithThinkMode(ThinkToggle))
+
+	resp, err := p.Chat(context.Background(), ChatRequest{
+		Model:    "qwen3:8b",
+		Messages: []ChatMessage{{Role: "user", Content: "What is the meaning of life?"}},
+		Options: ModelOptions{
+			Think: Ptr(false),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Chat() error: %v", err)
+	}
+	if resp.Thinking != "" {
+		t.Errorf("Thinking = %q, want empty", resp.Thinking)
+	}
+	want := "<think>Let me reason about this.</think>The answer is 42."
+	if resp.Content != want {
+		t.Errorf("Content = %q, want %q", resp.Content, want)
+	}
+}
+
 func TestOllamaProvider_Chat_WithOptions(t *testing.T) {
 	var receivedOpts ollama.ModelOptions
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -423,6 +456,76 @@ func TestOllamaProvider_ChatStream_FragmentedTags(t *testing.T) {
 	}
 	if content != "content" {
 		t.Errorf("content = %q, want %q", content, "content")
+	}
+}
+
+func TestOllamaProvider_ChatStream_ThinkToggle(t *testing.T) {
+	chunks := []ollama.ChatResponse{
+		{Model: "qwen3:8b", Message: ollama.ChatMessage{Role: "assistant", Content: "<think>Let me"}, Done: false},
+		{Model: "qwen3:8b", Message: ollama.ChatMessage{Role: "assistant", Content: " think.</think>The answer"}, Done: false},
+		{Model: "qwen3:8b", Message: ollama.ChatMessage{Role: "assistant", Content: " is 42."}, Done: false},
+		{Model: "qwen3:8b", Message: ollama.ChatMessage{Role: "assistant", Content: ""}, Done: true},
+	}
+
+	for _, tt := range []struct {
+		name         string
+		think        bool
+		wantThinking string
+		wantContent  string
+	}{
+		{
+			name:         "enabled",
+			think:        true,
+			wantThinking: "Let me think.",
+			wantContent:  "The answer is 42.",
+		},
+		{
+			name:         "disabled",
+			think:        false,
+			wantThinking: "",
+			wantContent:  "<think>Let me think.</think>The answer is 42.",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				for _, chunk := range chunks {
+					data, _ := json.Marshal(chunk)
+					_, _ = fmt.Fprintf(w, "%s\n", data)
+				}
+			}))
+			defer srv.Close()
+
+			c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+			p := NewOllamaProvider(c, WithThinkMode(ThinkToggle))
+
+			var thinkingChunks []string
+			var contentChunks []string
+			err := p.ChatStream(context.Background(), ChatRequest{
+				Model:    "qwen3:8b",
+				Messages: []ChatMessage{{Role: "user", Content: "What is the meaning of life?"}},
+				Options: ModelOptions{
+					Think: Ptr(tt.think),
+				},
+			}, func(resp ChatResponse) error {
+				if resp.Thinking != "" {
+					thinkingChunks = append(thinkingChunks, resp.Thinking)
+				}
+				if resp.Content != "" {
+					contentChunks = append(contentChunks, resp.Content)
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("ChatStream() error: %v", err)
+			}
+
+			if got := strings.Join(thinkingChunks, ""); got != tt.wantThinking {
+				t.Errorf("thinking = %q, want %q", got, tt.wantThinking)
+			}
+			if got := strings.Join(contentChunks, ""); got != tt.wantContent {
+				t.Errorf("content = %q, want %q", got, tt.wantContent)
+			}
+		})
 	}
 }
 
@@ -1154,6 +1257,70 @@ func TestOllamaProvider_Embed_Singleflight(t *testing.T) {
 		if resp.Provider != "ollama" {
 			t.Errorf("goroutine %d: Provider = %q, want %q", i, resp.Provider, "ollama")
 		}
+	}
+}
+
+func TestOllamaProvider_Embed_SingleflightLeaderCancellationDoesNotCancelFollowers(t *testing.T) {
+	var serverCalls int32
+	started := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&serverCalls, 1)
+		select {
+		case <-started:
+		default:
+			close(started)
+		}
+		time.Sleep(100 * time.Millisecond)
+		resp := ollama.EmbedResponse{
+			Embeddings: [][]float64{{0.1, 0.2, 0.3}},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	p := NewOllamaProvider(c)
+	req := EmbedRequest{
+		Model: "nomic-embed-text",
+		Input: []string{"identical text"},
+	}
+
+	leaderCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	leaderDone := make(chan error, 1)
+	go func() {
+		_, err := p.Embed(leaderCtx, req)
+		leaderDone <- err
+	}()
+
+	<-started
+
+	followerDone := make(chan struct {
+		resp *EmbedResponse
+		err  error
+	}, 1)
+	go func() {
+		resp, err := p.Embed(context.Background(), req)
+		followerDone <- struct {
+			resp *EmbedResponse
+			err  error
+		}{resp: resp, err: err}
+	}()
+
+	if err := <-leaderDone; err == nil {
+		t.Fatal("expected leader request to be canceled")
+	}
+
+	follower := <-followerDone
+	if follower.err != nil {
+		t.Fatalf("follower Embed() error: %v", follower.err)
+	}
+	if follower.resp == nil || len(follower.resp.Embeddings) != 1 {
+		t.Fatalf("follower response = %#v, want one embedding", follower.resp)
+	}
+	if got := atomic.LoadInt32(&serverCalls); got != 1 {
+		t.Errorf("expected 1 server call, got %d", got)
 	}
 }
 

--- a/provider/ollama_test.go
+++ b/provider/ollama_test.go
@@ -1,0 +1,712 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+// ---------------------------------------------------------------------------
+// Name and Capabilities
+// ---------------------------------------------------------------------------
+
+func TestOllamaProvider_Name(t *testing.T) {
+	c := ollama.NewClient()
+	p := NewOllamaProvider(c)
+	if got := p.Name(); got != "ollama" {
+		t.Errorf("Name() = %q, want %q", got, "ollama")
+	}
+}
+
+func TestOllamaProvider_Capabilities(t *testing.T) {
+	c := ollama.NewClient()
+	p := NewOllamaProvider(c)
+	caps := p.Capabilities()
+
+	tests := []struct {
+		name string
+		cap  Capability
+	}{
+		{"CapChat", CapChat},
+		{"CapGenerate", CapGenerate},
+		{"CapEmbed", CapEmbed},
+		{"CapStream", CapStream},
+		{"CapToolCall", CapToolCall},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !caps.Has(tt.cap) {
+				t.Errorf("Capabilities() missing %s", tt.name)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Health
+// ---------------------------------------------------------------------------
+
+func TestOllamaProvider_Health(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantErr    bool
+	}{
+		{"healthy", http.StatusOK, false},
+		{"unhealthy", http.StatusInternalServerError, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+			}))
+			defer srv.Close()
+
+			c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+			p := NewOllamaProvider(c)
+			err := p.Health(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Health() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && !strings.Contains(err.Error(), "provider: ollama:") {
+				t.Errorf("error should contain 'provider: ollama:' prefix, got: %v", err)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Chat (non-streaming)
+// ---------------------------------------------------------------------------
+
+func TestOllamaProvider_Chat(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		var req ollama.ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.Stream {
+			t.Error("expected stream=false for non-streaming chat")
+		}
+		if req.Model != "qwen3:8b" {
+			t.Errorf("model = %q, want %q", req.Model, "qwen3:8b")
+		}
+		if len(req.Messages) != 1 || req.Messages[0].Content != "Hello" {
+			t.Errorf("unexpected messages: %+v", req.Messages)
+		}
+
+		resp := ollama.ChatResponse{
+			Model:              "qwen3:8b",
+			Message:            ollama.ChatMessage{Role: "assistant", Content: "Hi there!"},
+			Done:               true,
+			PromptEvalCount:    5,
+			EvalCount:          3,
+			LoadDuration:       1000000,
+			PromptEvalDuration: 2000000,
+			EvalDuration:       3000000,
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	p := NewOllamaProvider(c)
+
+	resp, err := p.Chat(context.Background(), ChatRequest{
+		Model:    "qwen3:8b",
+		Messages: []ChatMessage{{Role: "user", Content: "Hello"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat() error: %v", err)
+	}
+	if resp.Content != "Hi there!" {
+		t.Errorf("Content = %q, want %q", resp.Content, "Hi there!")
+	}
+	if resp.Provider != "ollama" {
+		t.Errorf("Provider = %q, want %q", resp.Provider, "ollama")
+	}
+	if resp.Model != "qwen3:8b" {
+		t.Errorf("Model = %q, want %q", resp.Model, "qwen3:8b")
+	}
+	if !resp.Done {
+		t.Error("expected Done=true")
+	}
+	if resp.Usage.PromptTokens != 5 {
+		t.Errorf("Usage.PromptTokens = %d, want 5", resp.Usage.PromptTokens)
+	}
+	if resp.Usage.CompletionTokens != 3 {
+		t.Errorf("Usage.CompletionTokens = %d, want 3", resp.Usage.CompletionTokens)
+	}
+	if resp.Usage.TotalTokens != 8 {
+		t.Errorf("Usage.TotalTokens = %d, want 8", resp.Usage.TotalTokens)
+	}
+	if resp.Latency.LoadDuration != time.Duration(1000000) {
+		t.Errorf("Latency.LoadDuration = %v, want 1ms", resp.Latency.LoadDuration)
+	}
+}
+
+func TestOllamaProvider_Chat_ThinkExtraction(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := ollama.ChatResponse{
+			Model:   "qwen3:8b",
+			Message: ollama.ChatMessage{Role: "assistant", Content: "<think>Let me reason about this.</think>The answer is 42."},
+			Done:    true,
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	p := NewOllamaProvider(c)
+
+	resp, err := p.Chat(context.Background(), ChatRequest{
+		Model:    "qwen3:8b",
+		Messages: []ChatMessage{{Role: "user", Content: "What is the meaning of life?"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat() error: %v", err)
+	}
+	if resp.Thinking != "Let me reason about this." {
+		t.Errorf("Thinking = %q, want %q", resp.Thinking, "Let me reason about this.")
+	}
+	if resp.Content != "The answer is 42." {
+		t.Errorf("Content = %q, want %q", resp.Content, "The answer is 42.")
+	}
+}
+
+func TestOllamaProvider_Chat_NoThinkTags(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := ollama.ChatResponse{
+			Model:   "qwen3:8b",
+			Message: ollama.ChatMessage{Role: "assistant", Content: "Just a plain answer."},
+			Done:    true,
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	p := NewOllamaProvider(c)
+
+	resp, err := p.Chat(context.Background(), ChatRequest{
+		Model:    "qwen3:8b",
+		Messages: []ChatMessage{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat() error: %v", err)
+	}
+	if resp.Thinking != "" {
+		t.Errorf("Thinking = %q, want empty", resp.Thinking)
+	}
+	if resp.Content != "Just a plain answer." {
+		t.Errorf("Content = %q, want %q", resp.Content, "Just a plain answer.")
+	}
+}
+
+func TestOllamaProvider_Chat_WithOptions(t *testing.T) {
+	var receivedOpts ollama.ModelOptions
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollama.ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.Options != nil {
+			receivedOpts = *req.Options
+		}
+		resp := ollama.ChatResponse{
+			Model:   "qwen3:8b",
+			Message: ollama.ChatMessage{Role: "assistant", Content: "ok"},
+			Done:    true,
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	p := NewOllamaProvider(c)
+
+	_, err := p.Chat(context.Background(), ChatRequest{
+		Model:    "qwen3:8b",
+		Messages: []ChatMessage{{Role: "user", Content: "Hi"}},
+		Options: ModelOptions{
+			Temperature: Ptr(0.7),
+			NumPredict:  100,
+			NumCtx:      4096,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Chat() error: %v", err)
+	}
+	if receivedOpts.Temperature != 0.7 {
+		t.Errorf("Temperature = %f, want 0.7", receivedOpts.Temperature)
+	}
+	if receivedOpts.NumPredict != 100 {
+		t.Errorf("NumPredict = %d, want 100", receivedOpts.NumPredict)
+	}
+	if receivedOpts.NumCtx != 4096 {
+		t.Errorf("NumCtx = %d, want 4096", receivedOpts.NumCtx)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ChatStream
+// ---------------------------------------------------------------------------
+
+func TestOllamaProvider_ChatStream(t *testing.T) {
+	chunks := []ollama.ChatResponse{
+		{Model: "qwen3:8b", Message: ollama.ChatMessage{Role: "assistant", Content: "Hello "}, Done: false},
+		{Model: "qwen3:8b", Message: ollama.ChatMessage{Role: "assistant", Content: "world!"}, Done: false},
+		{Model: "qwen3:8b", Message: ollama.ChatMessage{Role: "assistant", Content: ""}, Done: true, EvalCount: 4, PromptEvalCount: 2},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		for _, chunk := range chunks {
+			data, _ := json.Marshal(chunk)
+			_, _ = fmt.Fprintf(w, "%s\n", data)
+		}
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	// Use ThinkNone to get passthrough behavior for plain text.
+	p := NewOllamaProvider(c, WithThinkMode(ThinkNone))
+
+	var received []ChatResponse
+	err := p.ChatStream(context.Background(), ChatRequest{
+		Model:    "qwen3:8b",
+		Messages: []ChatMessage{{Role: "user", Content: "Hi"}},
+	}, func(resp ChatResponse) error {
+		received = append(received, resp)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ChatStream() error: %v", err)
+	}
+
+	// With ThinkNone passthrough, we expect: content("Hello "), content("world!"), done.
+	if len(received) < 3 {
+		t.Fatalf("expected at least 3 chunks, got %d", len(received))
+	}
+
+	// All should have provider set.
+	for i, r := range received {
+		if r.Provider != "ollama" {
+			t.Errorf("chunk[%d].Provider = %q, want %q", i, r.Provider, "ollama")
+		}
+	}
+
+	// Last chunk should be Done with usage.
+	last := received[len(received)-1]
+	if !last.Done {
+		t.Error("last chunk should have Done=true")
+	}
+	if last.Usage.CompletionTokens != 4 {
+		t.Errorf("last chunk Usage.CompletionTokens = %d, want 4", last.Usage.CompletionTokens)
+	}
+	if last.Usage.PromptTokens != 2 {
+		t.Errorf("last chunk Usage.PromptTokens = %d, want 2", last.Usage.PromptTokens)
+	}
+}
+
+func TestOllamaProvider_ChatStream_ThinkExtraction(t *testing.T) {
+	chunks := []ollama.ChatResponse{
+		{Model: "qwen3:8b", Message: ollama.ChatMessage{Role: "assistant", Content: "<think>Let me"}, Done: false},
+		{Model: "qwen3:8b", Message: ollama.ChatMessage{Role: "assistant", Content: " think.</think>The answer"}, Done: false},
+		{Model: "qwen3:8b", Message: ollama.ChatMessage{Role: "assistant", Content: " is 42."}, Done: false},
+		{Model: "qwen3:8b", Message: ollama.ChatMessage{Role: "assistant", Content: ""}, Done: true},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		for _, chunk := range chunks {
+			data, _ := json.Marshal(chunk)
+			_, _ = fmt.Fprintf(w, "%s\n", data)
+		}
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	p := NewOllamaProvider(c, WithThinkMode(ThinkAlways))
+
+	var thinkingChunks []string
+	var contentChunks []string
+	var gotDone bool
+
+	err := p.ChatStream(context.Background(), ChatRequest{
+		Model:    "qwen3:8b",
+		Messages: []ChatMessage{{Role: "user", Content: "Think about this"}},
+	}, func(resp ChatResponse) error {
+		if resp.Thinking != "" {
+			thinkingChunks = append(thinkingChunks, resp.Thinking)
+		}
+		if resp.Content != "" {
+			contentChunks = append(contentChunks, resp.Content)
+		}
+		if resp.Done {
+			gotDone = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ChatStream() error: %v", err)
+	}
+
+	if !gotDone {
+		t.Error("expected final chunk with Done=true")
+	}
+
+	thinking := strings.Join(thinkingChunks, "")
+	content := strings.Join(contentChunks, "")
+
+	if thinking != "Let me think." {
+		t.Errorf("accumulated thinking = %q, want %q", thinking, "Let me think.")
+	}
+	if content != "The answer is 42." {
+		t.Errorf("accumulated content = %q, want %q", content, "The answer is 42.")
+	}
+}
+
+func TestOllamaProvider_ChatStream_FragmentedTags(t *testing.T) {
+	// The <think> tag is split across two chunks: "<thi" then "nk>..."
+	chunks := []ollama.ChatResponse{
+		{Model: "qwen3:8b", Message: ollama.ChatMessage{Role: "assistant", Content: "<thi"}, Done: false},
+		{Model: "qwen3:8b", Message: ollama.ChatMessage{Role: "assistant", Content: "nk>reasoning</think>content"}, Done: false},
+		{Model: "qwen3:8b", Message: ollama.ChatMessage{Role: "assistant", Content: ""}, Done: true},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		for _, chunk := range chunks {
+			data, _ := json.Marshal(chunk)
+			_, _ = fmt.Fprintf(w, "%s\n", data)
+		}
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	p := NewOllamaProvider(c, WithThinkMode(ThinkAlways))
+
+	var thinkingChunks []string
+	var contentChunks []string
+
+	err := p.ChatStream(context.Background(), ChatRequest{
+		Model:    "qwen3:8b",
+		Messages: []ChatMessage{{Role: "user", Content: "test"}},
+	}, func(resp ChatResponse) error {
+		if resp.Thinking != "" {
+			thinkingChunks = append(thinkingChunks, resp.Thinking)
+		}
+		if resp.Content != "" {
+			contentChunks = append(contentChunks, resp.Content)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ChatStream() error: %v", err)
+	}
+
+	thinking := strings.Join(thinkingChunks, "")
+	content := strings.Join(contentChunks, "")
+
+	if thinking != "reasoning" {
+		t.Errorf("thinking = %q, want %q", thinking, "reasoning")
+	}
+	if content != "content" {
+		t.Errorf("content = %q, want %q", content, "content")
+	}
+}
+
+func TestOllamaProvider_ChatStream_GracefulCancellation(t *testing.T) {
+	// Server sends one chunk then blocks until the serverDone channel is closed,
+	// simulating a long-running stream that gets cancelled by the client.
+	ready := make(chan struct{})
+	serverDone := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		chunk := ollama.ChatResponse{
+			Model:   "qwen3:8b",
+			Message: ollama.ChatMessage{Role: "assistant", Content: "partial content"},
+			Done:    false,
+		}
+		data, _ := json.Marshal(chunk)
+		_, _ = fmt.Fprintf(w, "%s\n", data)
+		// Flush to ensure the client sees the chunk.
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		// Signal that the chunk was sent.
+		close(ready)
+		// Block until test cleanup signals us to exit.
+		<-serverDone
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	p := NewOllamaProvider(c, WithThinkMode(ThinkNone))
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var received []ChatResponse
+	done := make(chan error, 1)
+	go func() {
+		done <- p.ChatStream(ctx, ChatRequest{
+			Model:    "qwen3:8b",
+			Messages: []ChatMessage{{Role: "user", Content: "Hi"}},
+		}, func(resp ChatResponse) error {
+			received = append(received, resp)
+			return nil
+		})
+	}()
+
+	// Wait for the first chunk to be processed, then cancel.
+	<-ready
+	// Small delay to ensure the chunk is processed by the stream handler.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	err := <-done
+	// Unblock the server handler so httptest.Server.Close() returns promptly.
+	close(serverDone)
+
+	if err == nil {
+		t.Fatal("expected error after cancellation")
+	}
+	if !strings.Contains(err.Error(), "provider: ollama:") {
+		t.Errorf("error should contain 'provider: ollama:' prefix, got: %v", err)
+	}
+
+	// Should have at least the content chunk and the partial result.
+	gotPartial := false
+	for _, r := range received {
+		if r.Partial && r.Done {
+			gotPartial = true
+			if r.Content != "partial content" {
+				t.Errorf("partial Content = %q, want %q", r.Content, "partial content")
+			}
+		}
+	}
+	if !gotPartial {
+		t.Error("expected a partial result chunk after cancellation")
+	}
+}
+
+func TestOllamaProvider_ChatStream_CallbackError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		chunk := ollama.ChatResponse{
+			Model:   "qwen3:8b",
+			Message: ollama.ChatMessage{Role: "assistant", Content: "hello"},
+			Done:    false,
+		}
+		data, _ := json.Marshal(chunk)
+		_, _ = fmt.Fprintf(w, "%s\n", data)
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	p := NewOllamaProvider(c, WithThinkMode(ThinkNone))
+
+	callbackErr := fmt.Errorf("consumer stopped")
+	err := p.ChatStream(context.Background(), ChatRequest{
+		Model:    "qwen3:8b",
+		Messages: []ChatMessage{{Role: "user", Content: "Hi"}},
+	}, func(_ ChatResponse) error {
+		return callbackErr
+	})
+	if err == nil {
+		t.Fatal("expected error from callback")
+	}
+	if !strings.Contains(err.Error(), "consumer stopped") {
+		t.Errorf("expected callback error in chain, got: %v", err)
+	}
+}
+
+func TestOllamaProvider_ChatStream_NilCallback(t *testing.T) {
+	c := ollama.NewClient()
+	p := NewOllamaProvider(c)
+
+	err := p.ChatStream(context.Background(), ChatRequest{
+		Model:    "qwen3:8b",
+		Messages: []ChatMessage{{Role: "user", Content: "Hi"}},
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error for nil callback")
+	}
+	if !strings.Contains(err.Error(), "callback function is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Functional options
+// ---------------------------------------------------------------------------
+
+func TestOllamaProvider_WithThinkMode(t *testing.T) {
+	c := ollama.NewClient()
+	p := NewOllamaProvider(c, WithThinkMode(ThinkAlways))
+	if p.thinkMode != ThinkAlways {
+		t.Errorf("thinkMode = %v, want ThinkAlways", p.thinkMode)
+	}
+}
+
+func TestOllamaProvider_WithThinkTags(t *testing.T) {
+	customTags := ThinkTags{Open: "<reasoning>", Close: "</reasoning>"}
+	c := ollama.NewClient()
+	p := NewOllamaProvider(c, WithThinkTags(customTags))
+	if p.thinkTags != customTags {
+		t.Errorf("thinkTags = %+v, want %+v", p.thinkTags, customTags)
+	}
+}
+
+func TestOllamaProvider_DefaultThinkMode(t *testing.T) {
+	c := ollama.NewClient()
+	p := NewOllamaProvider(c)
+	if p.thinkMode != ThinkAuto {
+		t.Errorf("default thinkMode = %v, want ThinkAuto", p.thinkMode)
+	}
+	if p.thinkTags != DefaultThinkTags() {
+		t.Errorf("default thinkTags = %+v, want %+v", p.thinkTags, DefaultThinkTags())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Type mapping helpers
+// ---------------------------------------------------------------------------
+
+func TestToOllamaChatRequest(t *testing.T) {
+	req := ChatRequest{
+		Model: "qwen3:8b",
+		Messages: []ChatMessage{
+			{Role: "system", Content: "You are helpful."},
+			{Role: "user", Content: "Hello"},
+		},
+		Options: ModelOptions{
+			Temperature: Ptr(0.5),
+			NumCtx:      8192,
+		},
+		Tools: []Tool{
+			{
+				Type: "function",
+				Function: ToolFunction{
+					Name:        "search",
+					Description: "Search the web",
+					Parameters:  json.RawMessage(`{"type":"object"}`),
+				},
+			},
+		},
+	}
+
+	oReq := toOllamaChatRequest(req)
+
+	if oReq.Model != "qwen3:8b" {
+		t.Errorf("Model = %q, want %q", oReq.Model, "qwen3:8b")
+	}
+	if len(oReq.Messages) != 2 {
+		t.Fatalf("Messages len = %d, want 2", len(oReq.Messages))
+	}
+	if oReq.Messages[0].Role != "system" {
+		t.Errorf("Messages[0].Role = %q, want %q", oReq.Messages[0].Role, "system")
+	}
+	if oReq.Options == nil {
+		t.Fatal("Options should not be nil")
+	}
+	if oReq.Options.Temperature != 0.5 {
+		t.Errorf("Options.Temperature = %f, want 0.5", oReq.Options.Temperature)
+	}
+	if oReq.Options.NumCtx != 8192 {
+		t.Errorf("Options.NumCtx = %d, want 8192", oReq.Options.NumCtx)
+	}
+	if len(oReq.Tools) != 1 {
+		t.Fatalf("Tools len = %d, want 1", len(oReq.Tools))
+	}
+	if oReq.Tools[0].Function.Name != "search" {
+		t.Errorf("Tools[0].Function.Name = %q, want %q", oReq.Tools[0].Function.Name, "search")
+	}
+}
+
+func TestToOllamaOptions_NilOnZero(t *testing.T) {
+	opts := toOllamaOptions(ModelOptions{})
+	if opts != nil {
+		t.Errorf("expected nil for zero-value options, got %+v", opts)
+	}
+}
+
+func TestToProviderToolCalls(t *testing.T) {
+	calls := []ollama.ToolCall{
+		{
+			ID:   "call_1",
+			Type: "function",
+			Function: ollama.ToolCallFunction{
+				Index:     0,
+				Name:      "get_weather",
+				Arguments: map[string]any{"city": "Tokyo"},
+			},
+		},
+	}
+
+	result := toProviderToolCalls(calls)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(result))
+	}
+	if result[0].ID != "call_1" {
+		t.Errorf("ID = %q, want %q", result[0].ID, "call_1")
+	}
+	if result[0].Function.Name != "get_weather" {
+		t.Errorf("Name = %q, want %q", result[0].Function.Name, "get_weather")
+	}
+	// Arguments should be valid JSON.
+	var args map[string]any
+	if err := json.Unmarshal(result[0].Function.Arguments, &args); err != nil {
+		t.Fatalf("failed to unmarshal arguments: %v", err)
+	}
+	if args["city"] != "Tokyo" {
+		t.Errorf("args[city] = %v, want %q", args["city"], "Tokyo")
+	}
+}
+
+func TestToProviderToolCalls_Empty(t *testing.T) {
+	result := toProviderToolCalls(nil)
+	if result != nil {
+		t.Errorf("expected nil for empty input, got %v", result)
+	}
+}
+
+func TestToOllamaToolCalls_RoundTrip(t *testing.T) {
+	providerCalls := []ToolCall{
+		{
+			ID:   "call_1",
+			Type: "function",
+			Function: ToolCallFunction{
+				Index:     0,
+				Name:      "search",
+				Arguments: json.RawMessage(`{"query":"test"}`),
+			},
+		},
+	}
+
+	ollamaCalls := toOllamaToolCalls(providerCalls)
+	if len(ollamaCalls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(ollamaCalls))
+	}
+	if ollamaCalls[0].Function.Name != "search" {
+		t.Errorf("Name = %q, want %q", ollamaCalls[0].Function.Name, "search")
+	}
+	if ollamaCalls[0].Function.Arguments["query"] != "test" {
+		t.Errorf("Arguments[query] = %v, want %q", ollamaCalls[0].Function.Arguments["query"], "test")
+	}
+
+	// Round-trip back to provider.
+	back := toProviderToolCalls(ollamaCalls)
+	if len(back) != 1 {
+		t.Fatalf("round-trip: expected 1 call, got %d", len(back))
+	}
+	if back[0].Function.Name != "search" {
+		t.Errorf("round-trip: Name = %q, want %q", back[0].Function.Name, "search")
+	}
+}

--- a/provider/registry.go
+++ b/provider/registry.go
@@ -1,0 +1,176 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// Registry is a thread-safe collection of named providers.
+// It maintains an index mapping model names to the providers that advertise them,
+// enabling model-based provider lookup via Resolve and ProvidersForModel.
+type Registry struct {
+	mu         sync.RWMutex
+	providers  map[string]Provider
+	modelIndex map[string][]string // model name -> provider names advertising it
+}
+
+// NewRegistry creates an empty provider registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		providers:  make(map[string]Provider),
+		modelIndex: make(map[string][]string),
+	}
+}
+
+// Register adds a provider to the registry. Returns an error if the provider is
+// nil, has an empty name, or a provider with the same name is already registered.
+func (r *Registry) Register(p Provider) error {
+	if p == nil {
+		return fmt.Errorf("provider: register: provider must not be nil")
+	}
+	name := p.Name()
+	if name == "" {
+		return fmt.Errorf("provider: register: provider name must not be empty")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.providers[name]; exists {
+		return fmt.Errorf("provider: register: provider %q is already registered", name)
+	}
+	r.providers[name] = p
+	return nil
+}
+
+// Unregister removes a provider from the registry and clears its model index
+// entries. Returns an error if the provider is not found.
+func (r *Registry) Unregister(name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.providers[name]; !exists {
+		return fmt.Errorf("provider: unregister: provider %q not found", name)
+	}
+
+	delete(r.providers, name)
+
+	// Remove this provider from all model index entries.
+	for model, providerNames := range r.modelIndex {
+		filtered := providerNames[:0]
+		for _, pn := range providerNames {
+			if pn != name {
+				filtered = append(filtered, pn)
+			}
+		}
+		if len(filtered) == 0 {
+			delete(r.modelIndex, model)
+		} else {
+			r.modelIndex[model] = filtered
+		}
+	}
+	return nil
+}
+
+// Get retrieves a provider by name. Returns the provider and true if found,
+// or nil and false if not registered.
+func (r *Registry) Get(name string) (Provider, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p, ok := r.providers[name]
+	return p, ok
+}
+
+// All returns all registered providers. The returned slice is a copy and safe
+// to iterate without holding a lock.
+func (r *Registry) All() []Provider {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]Provider, 0, len(r.providers))
+	for _, p := range r.providers {
+		result = append(result, p)
+	}
+	return result
+}
+
+// Resolve finds a provider by the ModelKey's Provider field. Returns an error
+// if the named provider is not registered.
+func (r *Registry) Resolve(key ModelKey) (Provider, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	p, ok := r.providers[key.Provider]
+	if !ok {
+		return nil, fmt.Errorf("provider: resolve: provider %q not found", key.Provider)
+	}
+	return p, nil
+}
+
+// ProvidersForModel returns all providers that advertise the given model name.
+// The model index is populated by RefreshModels. Returns an error if no
+// providers have the model.
+func (r *Registry) ProvidersForModel(model string) ([]Provider, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	providerNames, ok := r.modelIndex[model]
+	if !ok || len(providerNames) == 0 {
+		return nil, fmt.Errorf("provider: no providers found for model %q", model)
+	}
+
+	result := make([]Provider, 0, len(providerNames))
+	for _, name := range providerNames {
+		if p, exists := r.providers[name]; exists {
+			result = append(result, p)
+		}
+	}
+	if len(result) == 0 {
+		return nil, fmt.Errorf("provider: no providers found for model %q", model)
+	}
+	return result, nil
+}
+
+// RefreshModels queries the named provider for its available models and updates
+// the registry's model index. This must be called after registration to populate
+// the model index for ProvidersForModel lookups.
+func (r *Registry) RefreshModels(ctx context.Context, providerName string) error {
+	r.mu.RLock()
+	p, ok := r.providers[providerName]
+	r.mu.RUnlock()
+
+	if !ok {
+		return fmt.Errorf("provider: refresh models: provider %q not found", providerName)
+	}
+
+	models, err := p.Models(ctx)
+	if err != nil {
+		return fmt.Errorf("provider: refresh models for %q: %w", providerName, err)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Remove old entries for this provider.
+	for model, providerNames := range r.modelIndex {
+		filtered := providerNames[:0]
+		for _, pn := range providerNames {
+			if pn != providerName {
+				filtered = append(filtered, pn)
+			}
+		}
+		if len(filtered) == 0 {
+			delete(r.modelIndex, model)
+		} else {
+			r.modelIndex[model] = filtered
+		}
+	}
+
+	// Add new entries.
+	for _, m := range models {
+		r.modelIndex[m.Name] = append(r.modelIndex[m.Name], providerName)
+	}
+
+	return nil
+}

--- a/provider/registry_test.go
+++ b/provider/registry_test.go
@@ -1,0 +1,448 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// mockProvider is a minimal Provider implementation for Registry tests.
+type mockProvider struct {
+	name    string
+	caps    Capability
+	models  []ModelInfo
+	healthy bool
+	err     error
+}
+
+func (m *mockProvider) Name() string             { return m.name }
+func (m *mockProvider) Capabilities() Capability  { return m.caps }
+
+func (m *mockProvider) Health(_ context.Context) error {
+	if !m.healthy {
+		return m.err
+	}
+	return nil
+}
+
+func (m *mockProvider) Models(_ context.Context) ([]ModelInfo, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.models, nil
+}
+
+func (m *mockProvider) Chat(_ context.Context, _ ChatRequest) (*ChatResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockProvider) ChatStream(_ context.Context, _ ChatRequest, _ func(ChatResponse) error) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (m *mockProvider) Generate(_ context.Context, _ GenerateRequest) (*GenerateResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockProvider) GenerateStream(_ context.Context, _ GenerateRequest, _ func(GenerateResponse) error) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (m *mockProvider) Embed(_ context.Context, _ EmbedRequest) (*EmbedResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// ---------------------------------------------------------------------------
+// Core operations: Register, Get, Unregister, All
+// ---------------------------------------------------------------------------
+
+func TestRegistry_Register(t *testing.T) {
+	r := NewRegistry()
+
+	p := &mockProvider{name: "test-provider"}
+	if err := r.Register(p); err != nil {
+		t.Fatalf("Register() error: %v", err)
+	}
+
+	// Verify the provider is retrievable.
+	got, ok := r.Get("test-provider")
+	if !ok {
+		t.Fatal("expected provider to be found after Register")
+	}
+	if got.Name() != "test-provider" {
+		t.Errorf("Name() = %q, want %q", got.Name(), "test-provider")
+	}
+
+	// Duplicate registration should fail.
+	if err := r.Register(p); err == nil {
+		t.Fatal("expected error for duplicate registration")
+	}
+}
+
+func TestRegistry_Register_Nil(t *testing.T) {
+	r := NewRegistry()
+	if err := r.Register(nil); err == nil {
+		t.Fatal("expected error for nil provider")
+	}
+}
+
+func TestRegistry_Register_EmptyName(t *testing.T) {
+	r := NewRegistry()
+	p := &mockProvider{name: ""}
+	if err := r.Register(p); err == nil {
+		t.Fatal("expected error for empty provider name")
+	}
+}
+
+func TestRegistry_Get(t *testing.T) {
+	r := NewRegistry()
+	p := &mockProvider{name: "ollama"}
+	_ = r.Register(p)
+
+	tests := []struct {
+		name   string
+		lookup string
+		wantOK bool
+	}{
+		{"found", "ollama", true},
+		{"not found", "missing", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := r.Get(tt.lookup)
+			if ok != tt.wantOK {
+				t.Errorf("Get(%q) ok = %v, want %v", tt.lookup, ok, tt.wantOK)
+			}
+			if tt.wantOK && got.Name() != "ollama" {
+				t.Errorf("Get(%q) name = %q, want %q", tt.lookup, got.Name(), "ollama")
+			}
+		})
+	}
+}
+
+func TestRegistry_Unregister(t *testing.T) {
+	r := NewRegistry()
+	p := &mockProvider{name: "ollama"}
+	_ = r.Register(p)
+
+	if err := r.Unregister("ollama"); err != nil {
+		t.Fatalf("Unregister() error: %v", err)
+	}
+
+	if _, ok := r.Get("ollama"); ok {
+		t.Error("expected provider to be removed after Unregister")
+	}
+
+	// Unregister again should fail.
+	if err := r.Unregister("ollama"); err == nil {
+		t.Fatal("expected error for unregistering non-existent provider")
+	}
+}
+
+func TestRegistry_All(t *testing.T) {
+	r := NewRegistry()
+	_ = r.Register(&mockProvider{name: "a"})
+	_ = r.Register(&mockProvider{name: "b"})
+
+	all := r.All()
+	if len(all) != 2 {
+		t.Fatalf("All() returned %d providers, want 2", len(all))
+	}
+
+	names := map[string]bool{}
+	for _, p := range all {
+		names[p.Name()] = true
+	}
+	if !names["a"] || !names["b"] {
+		t.Errorf("All() names = %v, want {a, b}", names)
+	}
+}
+
+func TestRegistry_All_Empty(t *testing.T) {
+	r := NewRegistry()
+	all := r.All()
+	if len(all) != 0 {
+		t.Errorf("All() on empty registry returned %d, want 0", len(all))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Resolution: Resolve, ProvidersForModel, RefreshModels
+// ---------------------------------------------------------------------------
+
+func TestRegistry_Resolve(t *testing.T) {
+	r := NewRegistry()
+	p := &mockProvider{name: "ollama"}
+	_ = r.Register(p)
+
+	tests := []struct {
+		name    string
+		key     ModelKey
+		wantErr bool
+	}{
+		{"found", ModelKey{Provider: "ollama", Model: "qwen3:8b"}, false},
+		{"not found", ModelKey{Provider: "missing", Model: "qwen3:8b"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := r.Resolve(tt.key)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Resolve() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got.Name() != "ollama" {
+				t.Errorf("Resolve() provider name = %q, want %q", got.Name(), "ollama")
+			}
+		})
+	}
+}
+
+func TestRegistry_RefreshModels(t *testing.T) {
+	r := NewRegistry()
+	p := &mockProvider{
+		name: "ollama",
+		models: []ModelInfo{
+			{Name: "qwen3:8b"},
+			{Name: "nomic-embed-text"},
+		},
+	}
+	_ = r.Register(p)
+
+	if err := r.RefreshModels(context.Background(), "ollama"); err != nil {
+		t.Fatalf("RefreshModels() error: %v", err)
+	}
+
+	// Verify ProvidersForModel works after refresh.
+	providers, err := r.ProvidersForModel("qwen3:8b")
+	if err != nil {
+		t.Fatalf("ProvidersForModel(qwen3:8b) error: %v", err)
+	}
+	if len(providers) != 1 {
+		t.Fatalf("expected 1 provider for qwen3:8b, got %d", len(providers))
+	}
+	if providers[0].Name() != "ollama" {
+		t.Errorf("provider name = %q, want %q", providers[0].Name(), "ollama")
+	}
+
+	// Verify second model is also indexed.
+	providers, err = r.ProvidersForModel("nomic-embed-text")
+	if err != nil {
+		t.Fatalf("ProvidersForModel(nomic-embed-text) error: %v", err)
+	}
+	if len(providers) != 1 || providers[0].Name() != "ollama" {
+		t.Errorf("unexpected providers for nomic-embed-text: %v", providers)
+	}
+}
+
+func TestRegistry_RefreshModels_NotFound(t *testing.T) {
+	r := NewRegistry()
+	if err := r.RefreshModels(context.Background(), "missing"); err == nil {
+		t.Fatal("expected error for missing provider")
+	}
+}
+
+func TestRegistry_RefreshModels_ProviderError(t *testing.T) {
+	r := NewRegistry()
+	p := &mockProvider{
+		name: "broken",
+		err:  fmt.Errorf("connection refused"),
+	}
+	_ = r.Register(p)
+
+	err := r.RefreshModels(context.Background(), "broken")
+	if err == nil {
+		t.Fatal("expected error when provider.Models fails")
+	}
+}
+
+func TestRegistry_RefreshModels_UpdatesIndex(t *testing.T) {
+	r := NewRegistry()
+	p := &mockProvider{
+		name: "ollama",
+		models: []ModelInfo{
+			{Name: "model-a"},
+		},
+	}
+	_ = r.Register(p)
+	_ = r.RefreshModels(context.Background(), "ollama")
+
+	// Verify model-a is indexed.
+	_, err := r.ProvidersForModel("model-a")
+	if err != nil {
+		t.Fatalf("expected model-a to be indexed: %v", err)
+	}
+
+	// Update available models -- model-a removed, model-b added.
+	p.models = []ModelInfo{
+		{Name: "model-b"},
+	}
+	_ = r.RefreshModels(context.Background(), "ollama")
+
+	// model-a should no longer be indexed.
+	_, err = r.ProvidersForModel("model-a")
+	if err == nil {
+		t.Error("expected model-a to be removed from index after refresh")
+	}
+
+	// model-b should now be indexed.
+	providers, err := r.ProvidersForModel("model-b")
+	if err != nil {
+		t.Fatalf("expected model-b to be indexed: %v", err)
+	}
+	if len(providers) != 1 || providers[0].Name() != "ollama" {
+		t.Errorf("unexpected providers for model-b: %v", providers)
+	}
+}
+
+func TestRegistry_ProvidersForModel_NotFound(t *testing.T) {
+	r := NewRegistry()
+	_, err := r.ProvidersForModel("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for model with no providers")
+	}
+}
+
+func TestRegistry_ProvidersForModel_MultipleProviders(t *testing.T) {
+	r := NewRegistry()
+	p1 := &mockProvider{
+		name:   "ollama",
+		models: []ModelInfo{{Name: "qwen3:8b"}},
+	}
+	p2 := &mockProvider{
+		name:   "lmstudio",
+		models: []ModelInfo{{Name: "qwen3:8b"}, {Name: "llama3:8b"}},
+	}
+	_ = r.Register(p1)
+	_ = r.Register(p2)
+	_ = r.RefreshModels(context.Background(), "ollama")
+	_ = r.RefreshModels(context.Background(), "lmstudio")
+
+	providers, err := r.ProvidersForModel("qwen3:8b")
+	if err != nil {
+		t.Fatalf("ProvidersForModel() error: %v", err)
+	}
+	if len(providers) != 2 {
+		t.Fatalf("expected 2 providers for qwen3:8b, got %d", len(providers))
+	}
+
+	// llama3:8b should only have lmstudio.
+	providers, err = r.ProvidersForModel("llama3:8b")
+	if err != nil {
+		t.Fatalf("ProvidersForModel(llama3:8b) error: %v", err)
+	}
+	if len(providers) != 1 || providers[0].Name() != "lmstudio" {
+		t.Errorf("expected lmstudio for llama3:8b, got %v", providers)
+	}
+}
+
+func TestRegistry_Unregister_ClearsModelIndex(t *testing.T) {
+	r := NewRegistry()
+	p := &mockProvider{
+		name:   "ollama",
+		models: []ModelInfo{{Name: "qwen3:8b"}},
+	}
+	_ = r.Register(p)
+	_ = r.RefreshModels(context.Background(), "ollama")
+
+	// Verify model is indexed.
+	_, err := r.ProvidersForModel("qwen3:8b")
+	if err != nil {
+		t.Fatalf("expected model to be indexed: %v", err)
+	}
+
+	// Unregister.
+	_ = r.Unregister("ollama")
+
+	// Model should no longer be indexed.
+	_, err = r.ProvidersForModel("qwen3:8b")
+	if err == nil {
+		t.Error("expected model to be removed from index after Unregister")
+	}
+}
+
+func TestRegistry_Unregister_PreservesOtherProviderIndex(t *testing.T) {
+	r := NewRegistry()
+	p1 := &mockProvider{
+		name:   "ollama",
+		models: []ModelInfo{{Name: "shared-model"}},
+	}
+	p2 := &mockProvider{
+		name:   "lmstudio",
+		models: []ModelInfo{{Name: "shared-model"}},
+	}
+	_ = r.Register(p1)
+	_ = r.Register(p2)
+	_ = r.RefreshModels(context.Background(), "ollama")
+	_ = r.RefreshModels(context.Background(), "lmstudio")
+
+	// Unregister ollama -- lmstudio should still be indexed for the shared model.
+	_ = r.Unregister("ollama")
+
+	providers, err := r.ProvidersForModel("shared-model")
+	if err != nil {
+		t.Fatalf("expected shared-model to still be indexed: %v", err)
+	}
+	if len(providers) != 1 || providers[0].Name() != "lmstudio" {
+		t.Errorf("expected only lmstudio for shared-model, got %v", providers)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Thread safety
+// ---------------------------------------------------------------------------
+
+func TestRegistry_ConcurrentAccess(t *testing.T) {
+	r := NewRegistry()
+	const numGoroutines = 50
+
+	// Pre-register a provider for read operations.
+	seed := &mockProvider{
+		name:   "seed",
+		models: []ModelInfo{{Name: "seed-model"}},
+	}
+	_ = r.Register(seed)
+	_ = r.RefreshModels(context.Background(), "seed")
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+
+			name := fmt.Sprintf("provider-%d", idx)
+			p := &mockProvider{
+				name:   name,
+				models: []ModelInfo{{Name: fmt.Sprintf("model-%d", idx)}},
+			}
+
+			// Register.
+			_ = r.Register(p)
+
+			// Get.
+			r.Get(name)
+
+			// All.
+			r.All()
+
+			// Resolve.
+			_, _ = r.Resolve(ModelKey{Provider: name, Model: "any"})
+
+			// RefreshModels.
+			_ = r.RefreshModels(context.Background(), name)
+
+			// ProvidersForModel.
+			_, _ = r.ProvidersForModel("seed-model")
+
+			// Unregister.
+			_ = r.Unregister(name)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// The seed provider should still be intact.
+	if _, ok := r.Get("seed"); !ok {
+		t.Error("seed provider should still exist after concurrent operations")
+	}
+}

--- a/provider/think.go
+++ b/provider/think.go
@@ -423,6 +423,26 @@ func (p *ThinkParser) Reset() {
 	p.budgetExceeded = false
 }
 
+// SetActive controls whether a ThinkToggle parser actively parses think tags.
+// When active is true, the parser behaves like ThinkAlways (parses tags).
+// When active is false, the parser behaves like ThinkNone (passthrough).
+//
+// This method is only meaningful when the parser's mode is ThinkToggle.
+// For other modes it is a no-op. The Provider calls SetActive based on
+// whether it injected /think or /no_think into the prompt for this request.
+//
+// Must be called before Process, typically after Reset for a new request.
+func (p *ThinkParser) SetActive(active bool) {
+	if p.origMode != ThinkToggle {
+		return
+	}
+	if active {
+		p.mode = ThinkAlways
+	} else {
+		p.mode = ThinkNone
+	}
+}
+
 // Metrics returns the accumulated thinking and content metrics for the current
 // (or most recent) response. Call after Flush for complete results.
 func (p *ThinkParser) Metrics() ThinkMetrics {

--- a/provider/think.go
+++ b/provider/think.go
@@ -234,17 +234,18 @@ func (p *ThinkParser) processChunk(chunk string) error {
 			} else if len(tag) <= len(p.tags.Open) && p.tags.Open[:len(tag)] == tag {
 				// Still a valid prefix of the open tag: keep accumulating.
 			} else {
-				// Mismatch: emit accumulated tagBuf as content.
-				buf := tag
+				// Mismatch: if the current byte is '<', let it restart tag
+				// detection instead of emitting it twice.
+				buf, restart := splitRestartTag(tag, ch)
 				p.tagBuf.Reset()
 				p.state = stateContent
-				p.contentTokens += estimateTokens(buf)
-				if err := p.OnContent(buf); err != nil {
-					return err
+				if buf != "" {
+					p.contentTokens += estimateTokens(buf)
+					if err := p.OnContent(buf); err != nil {
+						return err
+					}
 				}
-				// Re-process current character in stateContent.
-				// The character might be '<' starting a new potential tag.
-				if ch == '<' {
+				if restart {
 					p.state = stateTagOpen
 					p.tagBuf.WriteByte(ch)
 				}
@@ -286,15 +287,17 @@ func (p *ThinkParser) processChunk(chunk string) error {
 			} else if len(tag) <= len(p.tags.Close) && p.tags.Close[:len(tag)] == tag {
 				// Still a valid prefix of the close tag: keep accumulating.
 			} else {
-				// Mismatch: emit accumulated tagBuf as thinking.
-				buf := tag
+				// Mismatch: if the current byte is '<', let it restart close-tag
+				// detection instead of emitting it twice.
+				buf, restart := splitRestartTag(tag, ch)
 				p.tagBuf.Reset()
 				p.state = stateThinking
-				if err := p.emitThinking(buf); err != nil {
-					return err
+				if buf != "" {
+					if err := p.emitThinking(buf); err != nil {
+						return err
+					}
 				}
-				// Re-process current character in stateThinking.
-				if ch == '<' {
+				if restart {
 					p.state = stateTagClose
 					p.tagBuf.WriteByte(ch)
 				}
@@ -302,6 +305,13 @@ func (p *ThinkParser) processChunk(chunk string) error {
 		}
 	}
 	return nil
+}
+
+func splitRestartTag(tag string, ch byte) (emit string, restart bool) {
+	if ch == '<' && len(tag) > 0 {
+		return tag[:len(tag)-1], true
+	}
+	return tag, false
 }
 
 // emitThinking sends thinking content via the callback, applying budget constraints.

--- a/provider/think.go
+++ b/provider/think.go
@@ -1,0 +1,440 @@
+package provider
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Parse state
+// ---------------------------------------------------------------------------
+
+// parseState tracks the current position in the think-tag state machine.
+type parseState int
+
+const (
+	// stateContent means we are outside any think block, emitting content.
+	stateContent parseState = iota
+	// stateTagOpen means we saw '<' and are accumulating bytes that may
+	// match the open tag (e.g. "<think>").
+	stateTagOpen
+	// stateThinking means we are inside a think block, emitting thinking.
+	stateThinking
+	// stateTagClose means we saw '<' inside a think block and are
+	// accumulating bytes that may match the close tag (e.g. "</think>").
+	stateTagClose
+)
+
+// sniffLimit is the number of characters ThinkAuto inspects before deciding
+// whether the stream contains think tags.
+const sniffLimit = 64
+
+// ---------------------------------------------------------------------------
+// ThinkParserConfig
+// ---------------------------------------------------------------------------
+
+// ThinkParserConfig holds the parameters for constructing a ThinkParser.
+type ThinkParserConfig struct {
+	// Mode controls whether thinking is parsed. ThinkNone disables parsing
+	// entirely (passthrough). ThinkAuto sniffs the first sniffLimit chars.
+	Mode ThinkMode
+
+	// Tags defines the open/close delimiters for thinking blocks.
+	Tags ThinkTags
+
+	// OnThinking is called with thinking content extracted from within tags.
+	OnThinking func(string) error
+
+	// OnContent is called with non-thinking content.
+	OnContent func(string) error
+
+	// Budget optionally constrains thinking resources. May be nil.
+	Budget *ThinkBudget
+}
+
+// ---------------------------------------------------------------------------
+// ThinkParser
+// ---------------------------------------------------------------------------
+
+// ThinkParser is a streaming state machine that separates model output into
+// thinking and content streams by detecting configurable XML-like tags.
+// It is designed for single-goroutine use within a streaming response handler.
+//
+// Usage:
+//
+//	p := NewThinkParser(cfg)
+//	for chunk := range stream {
+//	    if err := p.Process(chunk); err != nil { ... }
+//	}
+//	if err := p.Flush(); err != nil { ... }
+//	metrics := p.Metrics()
+type ThinkParser struct {
+	// OnThinking is the callback for thinking content. It may be replaced
+	// between calls to Reset to redirect output.
+	OnThinking func(string) error
+
+	// OnContent is the callback for non-thinking content. It may be replaced
+	// between calls to Reset to redirect output.
+	OnContent func(string) error
+
+	origMode ThinkMode // original mode from config, preserved across Reset
+	mode     ThinkMode
+	tags     ThinkTags
+	budget   *ThinkBudget
+
+	state  parseState
+	tagBuf strings.Builder // accumulates partial tag matches
+
+	// Auto-detection state.
+	autoResolved bool   // true once ThinkAuto has decided
+	sniffBuf     string // accumulates up to sniffLimit chars for auto mode
+
+	// Metrics tracking.
+	thinkingTokens int
+	contentTokens  int
+	thinkStart     time.Time     // when the current thinking block began
+	thinkDuration  time.Duration // accumulated thinking duration
+
+	// Budget enforcement.
+	budgetExceeded bool
+}
+
+// NewThinkParser creates a ThinkParser with the given configuration.
+func NewThinkParser(cfg ThinkParserConfig) *ThinkParser {
+	return &ThinkParser{
+		OnThinking: cfg.OnThinking,
+		OnContent:  cfg.OnContent,
+		origMode:   cfg.Mode,
+		mode:       cfg.Mode,
+		tags:       cfg.Tags,
+		budget:     cfg.Budget,
+		state:      stateContent,
+	}
+}
+
+// Process feeds a streaming chunk into the parser. It returns an error if a
+// callback returns an error or if a budget cancel is triggered.
+func (p *ThinkParser) Process(chunk string) error {
+	if len(chunk) == 0 {
+		return nil
+	}
+
+	// ThinkNone: complete passthrough, no parsing at all.
+	if p.mode == ThinkNone {
+		p.contentTokens += estimateTokens(chunk)
+		return p.OnContent(chunk)
+	}
+
+	// ThinkAuto: sniff the first sniffLimit chars to decide.
+	if p.mode == ThinkAuto && !p.autoResolved {
+		return p.processAutoSniff(chunk)
+	}
+
+	return p.processChunk(chunk)
+}
+
+// processAutoSniff handles the initial sniffing phase in ThinkAuto mode.
+func (p *ThinkParser) processAutoSniff(chunk string) error {
+	p.sniffBuf += chunk
+	if len(p.sniffBuf) >= sniffLimit {
+		return p.resolveAuto()
+	}
+	// Check if the open tag is already present in what we have so far.
+	if strings.Contains(p.sniffBuf, p.tags.Open) {
+		return p.resolveAuto()
+	}
+	// Check if a prefix of the open tag is present at the end of sniffBuf,
+	// meaning the tag might span the next chunk. Keep sniffing.
+	if p.hasPartialTagPrefix(p.sniffBuf, p.tags.Open) {
+		return nil
+	}
+	// If we've accumulated enough with no tag and no partial match, resolve.
+	if len(p.sniffBuf) >= sniffLimit {
+		return p.resolveAuto()
+	}
+	return nil
+}
+
+// hasPartialTagPrefix reports whether s ends with a non-empty prefix of tag.
+func (p *ThinkParser) hasPartialTagPrefix(s, tag string) bool {
+	for i := 1; i < len(tag) && i <= len(s); i++ {
+		if s[len(s)-i:] == tag[:i] {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveAuto decides whether to activate parsing or passthrough.
+func (p *ThinkParser) resolveAuto() error {
+	p.autoResolved = true
+	if strings.Contains(p.sniffBuf, p.tags.Open) {
+		// Tags detected: switch to always mode and replay buffer.
+		p.mode = ThinkAlways
+		buf := p.sniffBuf
+		p.sniffBuf = ""
+		return p.processChunk(buf)
+	}
+	// No tags: switch to passthrough for the rest of the stream.
+	p.mode = ThinkNone
+	buf := p.sniffBuf
+	p.sniffBuf = ""
+	p.contentTokens += estimateTokens(buf)
+	return p.OnContent(buf)
+}
+
+// processChunk runs the state machine over a chunk of text.
+func (p *ThinkParser) processChunk(chunk string) error {
+	// Fast path: no '<' in chunk and we're in a stable state.
+	if !strings.Contains(chunk, "<") {
+		switch p.state {
+		case stateContent:
+			p.contentTokens += estimateTokens(chunk)
+			return p.OnContent(chunk)
+		case stateThinking:
+			return p.emitThinking(chunk)
+		default:
+			// stateTagOpen or stateTagClose: we need char-by-char
+		}
+	}
+
+	for i := 0; i < len(chunk); i++ {
+		ch := chunk[i]
+
+		switch p.state {
+		case stateContent:
+			if ch == '<' {
+				p.state = stateTagOpen
+				p.tagBuf.Reset()
+				p.tagBuf.WriteByte(ch)
+			} else {
+				// Accumulate content. Find the next '<' for batch emit.
+				end := strings.IndexByte(chunk[i:], '<')
+				if end == -1 {
+					seg := chunk[i:]
+					p.contentTokens += estimateTokens(seg)
+					if err := p.OnContent(seg); err != nil {
+						return err
+					}
+					return nil
+				}
+				seg := chunk[i : i+end]
+				p.contentTokens += estimateTokens(seg)
+				if err := p.OnContent(seg); err != nil {
+					return err
+				}
+				i += end - 1 // loop will increment
+			}
+
+		case stateTagOpen:
+			p.tagBuf.WriteByte(ch)
+			tag := p.tagBuf.String()
+			if tag == p.tags.Open {
+				// Matched the open tag: enter thinking.
+				p.state = stateThinking
+				p.tagBuf.Reset()
+				p.thinkStart = time.Now()
+			} else if len(tag) <= len(p.tags.Open) && p.tags.Open[:len(tag)] == tag {
+				// Still a valid prefix of the open tag: keep accumulating.
+			} else {
+				// Mismatch: emit accumulated tagBuf as content.
+				buf := tag
+				p.tagBuf.Reset()
+				p.state = stateContent
+				p.contentTokens += estimateTokens(buf)
+				if err := p.OnContent(buf); err != nil {
+					return err
+				}
+				// Re-process current character in stateContent.
+				// The character might be '<' starting a new potential tag.
+				if ch == '<' {
+					p.state = stateTagOpen
+					p.tagBuf.WriteByte(ch)
+				}
+			}
+
+		case stateThinking:
+			if ch == '<' {
+				p.state = stateTagClose
+				p.tagBuf.Reset()
+				p.tagBuf.WriteByte(ch)
+			} else {
+				// Accumulate thinking. Find the next '<' for batch emit.
+				end := strings.IndexByte(chunk[i:], '<')
+				if end == -1 {
+					seg := chunk[i:]
+					if err := p.emitThinking(seg); err != nil {
+						return err
+					}
+					return nil
+				}
+				seg := chunk[i : i+end]
+				if err := p.emitThinking(seg); err != nil {
+					return err
+				}
+				i += end - 1 // loop will increment
+			}
+
+		case stateTagClose:
+			p.tagBuf.WriteByte(ch)
+			tag := p.tagBuf.String()
+			if tag == p.tags.Close {
+				// Matched the close tag: exit thinking.
+				if !p.thinkStart.IsZero() {
+					p.thinkDuration += time.Since(p.thinkStart)
+					p.thinkStart = time.Time{}
+				}
+				p.state = stateContent
+				p.tagBuf.Reset()
+			} else if len(tag) <= len(p.tags.Close) && p.tags.Close[:len(tag)] == tag {
+				// Still a valid prefix of the close tag: keep accumulating.
+			} else {
+				// Mismatch: emit accumulated tagBuf as thinking.
+				buf := tag
+				p.tagBuf.Reset()
+				p.state = stateThinking
+				if err := p.emitThinking(buf); err != nil {
+					return err
+				}
+				// Re-process current character in stateThinking.
+				if ch == '<' {
+					p.state = stateTagClose
+					p.tagBuf.WriteByte(ch)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// emitThinking sends thinking content via the callback, applying budget constraints.
+func (p *ThinkParser) emitThinking(s string) error {
+	tokens := estimateTokens(s)
+	p.thinkingTokens += tokens
+
+	if err := p.checkBudget(); err != nil {
+		return err
+	}
+
+	if p.budgetExceeded {
+		return nil // skip the callback but still track tokens
+	}
+
+	return p.OnThinking(s)
+}
+
+// checkBudget evaluates whether the thinking budget has been exceeded.
+func (p *ThinkParser) checkBudget() error {
+	if p.budget == nil || p.budgetExceeded {
+		return nil
+	}
+
+	exceeded := p.budget.MaxTokens > 0 && p.thinkingTokens > p.budget.MaxTokens
+	if p.budget.MaxTime > 0 && !p.thinkStart.IsZero() && time.Since(p.thinkStart) > p.budget.MaxTime {
+		exceeded = true
+	}
+
+	if exceeded {
+		p.budgetExceeded = true
+		if p.budget.OnExceeded == ThinkBudgetCancel {
+			return fmt.Errorf("provider: thinking budget exceeded")
+		}
+	}
+	return nil
+}
+
+// Flush emits any remaining buffered content after the stream ends. It must
+// be called after the last Process call to ensure all data is emitted.
+func (p *ThinkParser) Flush() error {
+	// Handle ThinkAuto sniff buffer that never resolved.
+	if p.mode == ThinkAuto && !p.autoResolved {
+		p.autoResolved = true
+		if p.sniffBuf != "" {
+			// Check if open tag is in the buffer.
+			if strings.Contains(p.sniffBuf, p.tags.Open) {
+				p.mode = ThinkAlways
+				buf := p.sniffBuf
+				p.sniffBuf = ""
+				if err := p.processChunk(buf); err != nil {
+					return err
+				}
+				return p.flushTagBuf()
+			}
+			buf := p.sniffBuf
+			p.sniffBuf = ""
+			p.contentTokens += estimateTokens(buf)
+			return p.OnContent(buf)
+		}
+		return nil
+	}
+
+	return p.flushTagBuf()
+}
+
+// flushTagBuf emits any remaining partial tag buffer.
+func (p *ThinkParser) flushTagBuf() error {
+	// Close any open think duration.
+	if !p.thinkStart.IsZero() {
+		p.thinkDuration += time.Since(p.thinkStart)
+		p.thinkStart = time.Time{}
+	}
+
+	if p.tagBuf.Len() == 0 {
+		return nil
+	}
+	buf := p.tagBuf.String()
+	p.tagBuf.Reset()
+
+	switch p.state {
+	case stateTagOpen:
+		// Was trying to match an open tag in content — emit as content.
+		p.state = stateContent
+		p.contentTokens += estimateTokens(buf)
+		return p.OnContent(buf)
+	case stateTagClose:
+		// Was trying to match a close tag in thinking — emit as thinking.
+		p.state = stateThinking
+		p.thinkingTokens += estimateTokens(buf)
+		if p.budgetExceeded {
+			return nil
+		}
+		return p.OnThinking(buf)
+	default:
+		// Shouldn't happen, but emit as content to be safe.
+		p.contentTokens += estimateTokens(buf)
+		return p.OnContent(buf)
+	}
+}
+
+// Reset prepares the parser for a new response, clearing all accumulated state
+// and metrics. The Mode, Tags, and Budget configuration are preserved. The
+// OnThinking and OnContent callbacks may be replaced after calling Reset.
+func (p *ThinkParser) Reset() {
+	p.mode = p.origMode
+	p.state = stateContent
+	p.tagBuf.Reset()
+	p.autoResolved = false
+	p.sniffBuf = ""
+	p.thinkingTokens = 0
+	p.contentTokens = 0
+	p.thinkStart = time.Time{}
+	p.thinkDuration = 0
+	p.budgetExceeded = false
+}
+
+// Metrics returns the accumulated thinking and content metrics for the current
+// (or most recent) response. Call after Flush for complete results.
+func (p *ThinkParser) Metrics() ThinkMetrics {
+	total := p.thinkingTokens + p.contentTokens
+	var ratio float64
+	if total > 0 {
+		ratio = float64(p.thinkingTokens) / float64(total)
+	}
+	return ThinkMetrics{
+		ThinkingTokens: p.thinkingTokens,
+		ContentTokens:  p.contentTokens,
+		ThinkRatio:     ratio,
+		ThinkDuration:  p.thinkDuration,
+	}
+}

--- a/provider/think.go
+++ b/provider/think.go
@@ -149,10 +149,6 @@ func (p *ThinkParser) processAutoSniff(chunk string) error {
 	if p.hasPartialTagPrefix(p.sniffBuf, p.tags.Open) {
 		return nil
 	}
-	// If we've accumulated enough with no tag and no partial match, resolve.
-	if len(p.sniffBuf) >= sniffLimit {
-		return p.resolveAuto()
-	}
 	return nil
 }
 

--- a/provider/think_extract.go
+++ b/provider/think_extract.go
@@ -1,0 +1,62 @@
+package provider
+
+import (
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// regexpCache caches compiled regexps keyed by the tag pair to avoid
+// recompilation on every call.
+var (
+	regexpCacheMu sync.Mutex
+	regexpCache   = make(map[ThinkTags]*regexp.Regexp)
+)
+
+// getThinkRegexp returns a compiled regexp for the given tag pair,
+// caching it for reuse.
+func getThinkRegexp(tags ThinkTags) *regexp.Regexp {
+	regexpCacheMu.Lock()
+	defer regexpCacheMu.Unlock()
+
+	if re, ok := regexpCache[tags]; ok {
+		return re
+	}
+
+	pattern := regexp.QuoteMeta(tags.Open) + `([\s\S]*?)` + regexp.QuoteMeta(tags.Close)
+	re := regexp.MustCompile(pattern)
+	regexpCache[tags] = re
+	return re
+}
+
+// ExtractThinking extracts thinking content from a complete (non-streaming)
+// response. It uses regex matching since the full response is already
+// buffered. Multiple think blocks are joined with newlines.
+//
+// Returns the cleaned content (think blocks removed) and the extracted
+// thinking text. If no think blocks are found, cleaned equals the original
+// content and thinking is empty.
+func ExtractThinking(content string, tags ThinkTags) (cleaned string, thinking string) {
+	if content == "" {
+		return "", ""
+	}
+
+	re := getThinkRegexp(tags)
+	matches := re.FindAllStringSubmatch(content, -1)
+
+	if len(matches) == 0 {
+		return content, ""
+	}
+
+	var thinkParts []string
+	for _, match := range matches {
+		if len(match) > 1 {
+			thinkParts = append(thinkParts, match[1])
+		}
+	}
+
+	cleaned = re.ReplaceAllString(content, "")
+	thinking = strings.Join(thinkParts, "\n")
+
+	return cleaned, thinking
+}

--- a/provider/think_extract_test.go
+++ b/provider/think_extract_test.go
@@ -1,0 +1,99 @@
+package provider
+
+import (
+	"testing"
+)
+
+func TestExtractThinking(t *testing.T) {
+	defaultTags := DefaultThinkTags()
+
+	tests := []struct {
+		name         string
+		content      string
+		tags         ThinkTags
+		wantCleaned  string
+		wantThinking string
+	}{
+		{
+			name:         "basic extraction",
+			content:      "<think>reasoning here</think>The answer is 42",
+			tags:         defaultTags,
+			wantCleaned:  "The answer is 42",
+			wantThinking: "reasoning here",
+		},
+		{
+			name:         "no think tags",
+			content:      "Just a plain response",
+			tags:         defaultTags,
+			wantCleaned:  "Just a plain response",
+			wantThinking: "",
+		},
+		{
+			name:         "empty think block",
+			content:      "<think></think>The answer",
+			tags:         defaultTags,
+			wantCleaned:  "The answer",
+			wantThinking: "",
+		},
+		{
+			name:         "multiple think blocks",
+			content:      "<think>first</think>middle<think>second</think>end",
+			tags:         defaultTags,
+			wantCleaned:  "middleend",
+			wantThinking: "first\nsecond",
+		},
+		{
+			name:         "think at end (unclosed)",
+			content:      "content<think>dangling",
+			tags:         defaultTags,
+			wantCleaned:  "content<think>dangling",
+			wantThinking: "",
+		},
+		{
+			name:         "custom tags",
+			content:      "<reasoning>deep thoughts</reasoning>answer",
+			tags:         ThinkTags{Open: "<reasoning>", Close: "</reasoning>"},
+			wantCleaned:  "answer",
+			wantThinking: "deep thoughts",
+		},
+		{
+			name:         "multiline thinking",
+			content:      "<think>\nLine 1\nLine 2\n</think>Response",
+			tags:         defaultTags,
+			wantCleaned:  "Response",
+			wantThinking: "\nLine 1\nLine 2\n",
+		},
+		{
+			name:         "thinking only (no content after)",
+			content:      "<think>just thinking</think>",
+			tags:         defaultTags,
+			wantCleaned:  "",
+			wantThinking: "just thinking",
+		},
+		{
+			name:         "content before think",
+			content:      "prefix <think>thought</think> suffix",
+			tags:         defaultTags,
+			wantCleaned:  "prefix  suffix",
+			wantThinking: "thought",
+		},
+		{
+			name:         "empty input",
+			content:      "",
+			tags:         defaultTags,
+			wantCleaned:  "",
+			wantThinking: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleaned, thinking := ExtractThinking(tt.content, tt.tags)
+			if cleaned != tt.wantCleaned {
+				t.Errorf("cleaned = %q, want %q", cleaned, tt.wantCleaned)
+			}
+			if thinking != tt.wantThinking {
+				t.Errorf("thinking = %q, want %q", thinking, tt.wantThinking)
+			}
+		})
+	}
+}

--- a/provider/think_test.go
+++ b/provider/think_test.go
@@ -1,0 +1,942 @@
+package provider
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// collect is a test helper that creates onThinking and onContent callbacks
+// capturing all emitted text into two slices.
+func collect() (onThinking, onContent func(string) error, thinking, content *[]string) {
+	var th, ct []string
+	onTh := func(s string) error { th = append(th, s); return nil }
+	onCt := func(s string) error { ct = append(ct, s); return nil }
+	return onTh, onCt, &th, &ct
+}
+
+func joined(parts *[]string) string {
+	if parts == nil {
+		return ""
+	}
+	return strings.Join(*parts, "")
+}
+
+func TestThinkParser_BasicThinking(t *testing.T) {
+	onTh, onCt, thinking, content := collect()
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+	})
+
+	chunks := []string{"<think>", "reasoning here", "</think>", "the answer"}
+	for _, c := range chunks {
+		if err := p.Process(c); err != nil {
+			t.Fatalf("Process(%q) error: %v", c, err)
+		}
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	if got := joined(thinking); got != "reasoning here" {
+		t.Errorf("thinking = %q, want %q", got, "reasoning here")
+	}
+	if got := joined(content); got != "the answer" {
+		t.Errorf("content = %q, want %q", got, "the answer")
+	}
+}
+
+func TestThinkParser_FragmentedOpenTag(t *testing.T) {
+	tests := []struct {
+		name    string
+		chunks  []string
+		wantTh  string
+		wantCt  string
+	}{
+		{
+			name:   "split after <",
+			chunks: []string{"<", "think>reasoning</think>answer"},
+			wantTh: "reasoning",
+			wantCt: "answer",
+		},
+		{
+			name:   "split after <th",
+			chunks: []string{"<th", "ink>reasoning</think>answer"},
+			wantTh: "reasoning",
+			wantCt: "answer",
+		},
+		{
+			name:   "split after <think",
+			chunks: []string{"<think", ">reasoning</think>answer"},
+			wantTh: "reasoning",
+			wantCt: "answer",
+		},
+		{
+			name:   "char by char open tag",
+			chunks: []string{"<", "t", "h", "i", "n", "k", ">", "r", "</think>a"},
+			wantTh: "r",
+			wantCt: "a",
+		},
+		{
+			name:   "split in middle of open tag with content before",
+			chunks: []string{"hello<thi", "nk>thinking</think>done"},
+			wantTh: "thinking",
+			wantCt: "hellodone",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			onTh, onCt, thinking, content := collect()
+			p := NewThinkParser(ThinkParserConfig{
+				Mode:       ThinkAlways,
+				Tags:       DefaultThinkTags(),
+				OnThinking: onTh,
+				OnContent:  onCt,
+			})
+			for _, c := range tt.chunks {
+				if err := p.Process(c); err != nil {
+					t.Fatalf("Process(%q): %v", c, err)
+				}
+			}
+			if err := p.Flush(); err != nil {
+				t.Fatalf("Flush: %v", err)
+			}
+			if got := joined(thinking); got != tt.wantTh {
+				t.Errorf("thinking = %q, want %q", got, tt.wantTh)
+			}
+			if got := joined(content); got != tt.wantCt {
+				t.Errorf("content = %q, want %q", got, tt.wantCt)
+			}
+		})
+	}
+}
+
+func TestThinkParser_FragmentedCloseTag(t *testing.T) {
+	tests := []struct {
+		name    string
+		chunks  []string
+		wantTh  string
+		wantCt  string
+	}{
+		{
+			name:   "split after </",
+			chunks: []string{"<think>reasoning</", "think>answer"},
+			wantTh: "reasoning",
+			wantCt: "answer",
+		},
+		{
+			name:   "split after </thi",
+			chunks: []string{"<think>reasoning</thi", "nk>answer"},
+			wantTh: "reasoning",
+			wantCt: "answer",
+		},
+		{
+			name:   "char by char close tag",
+			chunks: []string{"<think>r<", "/", "t", "h", "i", "n", "k", ">", "a"},
+			wantTh: "r",
+			wantCt: "a",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			onTh, onCt, thinking, content := collect()
+			p := NewThinkParser(ThinkParserConfig{
+				Mode:       ThinkAlways,
+				Tags:       DefaultThinkTags(),
+				OnThinking: onTh,
+				OnContent:  onCt,
+			})
+			for _, c := range tt.chunks {
+				if err := p.Process(c); err != nil {
+					t.Fatalf("Process(%q): %v", c, err)
+				}
+			}
+			if err := p.Flush(); err != nil {
+				t.Fatalf("Flush: %v", err)
+			}
+			if got := joined(thinking); got != tt.wantTh {
+				t.Errorf("thinking = %q, want %q", got, tt.wantTh)
+			}
+			if got := joined(content); got != tt.wantCt {
+				t.Errorf("content = %q, want %q", got, tt.wantCt)
+			}
+		})
+	}
+}
+
+func TestThinkParser_NoThinkTags(t *testing.T) {
+	onTh, onCt, thinking, content := collect()
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+	})
+
+	for _, c := range []string{"just ", "plain ", "text"} {
+		if err := p.Process(c); err != nil {
+			t.Fatalf("Process(%q): %v", c, err)
+		}
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	if got := joined(thinking); got != "" {
+		t.Errorf("thinking = %q, want empty", got)
+	}
+	if got := joined(content); got != "just plain text" {
+		t.Errorf("content = %q, want %q", got, "just plain text")
+	}
+}
+
+func TestThinkParser_ThinkNone_Passthrough(t *testing.T) {
+	onTh, onCt, thinking, content := collect()
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkNone,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+	})
+
+	input := "<think>reasoning</think>answer"
+	if err := p.Process(input); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	if got := joined(thinking); got != "" {
+		t.Errorf("thinking = %q, want empty (ThinkNone)", got)
+	}
+	// In ThinkNone mode, everything including tags passes through as content.
+	if got := joined(content); got != input {
+		t.Errorf("content = %q, want %q", got, input)
+	}
+}
+
+func TestThinkParser_ThinkAuto_Detects(t *testing.T) {
+	t.Run("detects tags in first 64 chars", func(t *testing.T) {
+		onTh, onCt, thinking, content := collect()
+		p := NewThinkParser(ThinkParserConfig{
+			Mode:       ThinkAuto,
+			Tags:       DefaultThinkTags(),
+			OnThinking: onTh,
+			OnContent:  onCt,
+		})
+
+		if err := p.Process("<think>auto reasoning</think>answer"); err != nil {
+			t.Fatalf("Process error: %v", err)
+		}
+		if err := p.Flush(); err != nil {
+			t.Fatalf("Flush error: %v", err)
+		}
+
+		if got := joined(thinking); got != "auto reasoning" {
+			t.Errorf("thinking = %q, want %q", got, "auto reasoning")
+		}
+		if got := joined(content); got != "answer" {
+			t.Errorf("content = %q, want %q", got, "answer")
+		}
+	})
+
+	t.Run("drops to passthrough when no tags found", func(t *testing.T) {
+		onTh, onCt, thinking, content := collect()
+		p := NewThinkParser(ThinkParserConfig{
+			Mode:       ThinkAuto,
+			Tags:       DefaultThinkTags(),
+			OnThinking: onTh,
+			OnContent:  onCt,
+		})
+
+		// Send more than 64 chars with no think tags at all.
+		long := strings.Repeat("x", 70)
+		if err := p.Process(long); err != nil {
+			t.Fatalf("Process error: %v", err)
+		}
+		if err := p.Flush(); err != nil {
+			t.Fatalf("Flush error: %v", err)
+		}
+
+		if got := joined(thinking); got != "" {
+			t.Errorf("thinking = %q, want empty", got)
+		}
+		if got := joined(content); got != long {
+			t.Errorf("content len = %d, want %d", len(got), len(long))
+		}
+	})
+
+	t.Run("detects tags across multiple chunks within 64 chars", func(t *testing.T) {
+		onTh, onCt, thinking, content := collect()
+		p := NewThinkParser(ThinkParserConfig{
+			Mode:       ThinkAuto,
+			Tags:       DefaultThinkTags(),
+			OnThinking: onTh,
+			OnContent:  onCt,
+		})
+
+		// Feed small chunks that together form a think tag.
+		if err := p.Process("<thi"); err != nil {
+			t.Fatalf("Process error: %v", err)
+		}
+		if err := p.Process("nk>auto</think>done"); err != nil {
+			t.Fatalf("Process error: %v", err)
+		}
+		if err := p.Flush(); err != nil {
+			t.Fatalf("Flush error: %v", err)
+		}
+
+		if got := joined(thinking); got != "auto" {
+			t.Errorf("thinking = %q, want %q", got, "auto")
+		}
+		if got := joined(content); got != "done" {
+			t.Errorf("content = %q, want %q", got, "done")
+		}
+	})
+}
+
+func TestThinkParser_MultipleThinkBlocks(t *testing.T) {
+	onTh, onCt, thinking, content := collect()
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+	})
+
+	input := "<think>A</think>middle<think>B</think>end"
+	if err := p.Process(input); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	if got := joined(thinking); got != "AB" {
+		t.Errorf("thinking = %q, want %q", got, "AB")
+	}
+	if got := joined(content); got != "middleend" {
+		t.Errorf("content = %q, want %q", got, "middleend")
+	}
+}
+
+func TestThinkParser_EmptyThinkBlock(t *testing.T) {
+	onTh, onCt, thinking, content := collect()
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+	})
+
+	if err := p.Process("<think></think>answer"); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	if got := joined(thinking); got != "" {
+		t.Errorf("thinking = %q, want empty", got)
+	}
+	if got := joined(content); got != "answer" {
+		t.Errorf("content = %q, want %q", got, "answer")
+	}
+}
+
+func TestThinkParser_StreamEndsMidOpenTag(t *testing.T) {
+	// Stream ends while we're trying to match an open tag (stateTagOpen).
+	// The partial tag buffer should be emitted as content on Flush.
+	onTh, onCt, thinking, content := collect()
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+	})
+
+	if err := p.Process("hello<thi"); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	if got := joined(thinking); got != "" {
+		t.Errorf("thinking = %q, want empty", got)
+	}
+	if got := joined(content); got != "hello<thi" {
+		t.Errorf("content = %q, want %q", got, "hello<thi")
+	}
+}
+
+func TestThinkParser_StreamEndsMidCloseTag(t *testing.T) {
+	// Stream ends while we're trying to match a close tag (stateTagClose).
+	// We're inside a thinking block, so the partial tag buffer should be
+	// emitted as thinking on Flush.
+	onTh, onCt, thinking, content := collect()
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+	})
+
+	if err := p.Process("<think>reasoning</thi"); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	if got := joined(thinking); got != "reasoning</thi" {
+		t.Errorf("thinking = %q, want %q", got, "reasoning</thi")
+	}
+	if got := joined(content); got != "" {
+		t.Errorf("content = %q, want empty", got)
+	}
+}
+
+func TestThinkParser_CustomTags(t *testing.T) {
+	onTh, onCt, thinking, content := collect()
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       ThinkTags{Open: "<reasoning>", Close: "</reasoning>"},
+		OnThinking: onTh,
+		OnContent:  onCt,
+	})
+
+	input := "<reasoning>custom thinking</reasoning>result"
+	if err := p.Process(input); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	if got := joined(thinking); got != "custom thinking" {
+		t.Errorf("thinking = %q, want %q", got, "custom thinking")
+	}
+	if got := joined(content); got != "result" {
+		t.Errorf("content = %q, want %q", got, "result")
+	}
+}
+
+func TestThinkParser_FalsePositiveOpenTag(t *testing.T) {
+	// "x < y" contains a '<' but doesn't start a think tag.
+	onTh, onCt, thinking, content := collect()
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+	})
+
+	if err := p.Process("x < y is true"); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	if got := joined(thinking); got != "" {
+		t.Errorf("thinking = %q, want empty", got)
+	}
+	if got := joined(content); got != "x < y is true" {
+		t.Errorf("content = %q, want %q", got, "x < y is true")
+	}
+}
+
+func TestThinkParser_FalsePositiveCloseTag(t *testing.T) {
+	// "</div>" inside a thinking block is not the close tag.
+	onTh, onCt, thinking, content := collect()
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+	})
+
+	input := "<think>some </div> html</think>answer"
+	if err := p.Process(input); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	if got := joined(thinking); got != "some </div> html" {
+		t.Errorf("thinking = %q, want %q", got, "some </div> html")
+	}
+	if got := joined(content); got != "answer" {
+		t.Errorf("content = %q, want %q", got, "answer")
+	}
+}
+
+func TestThinkParser_CallbackErrorPropagation(t *testing.T) {
+	t.Run("onContent error", func(t *testing.T) {
+		errTest := errors.New("content callback error")
+		p := NewThinkParser(ThinkParserConfig{
+			Mode:       ThinkAlways,
+			Tags:       DefaultThinkTags(),
+			OnThinking: func(string) error { return nil },
+			OnContent:  func(string) error { return errTest },
+		})
+
+		err := p.Process("hello")
+		if !errors.Is(err, errTest) {
+			t.Errorf("got error %v, want %v", err, errTest)
+		}
+	})
+
+	t.Run("onThinking error", func(t *testing.T) {
+		errTest := errors.New("thinking callback error")
+		p := NewThinkParser(ThinkParserConfig{
+			Mode:       ThinkAlways,
+			Tags:       DefaultThinkTags(),
+			OnThinking: func(string) error { return errTest },
+			OnContent:  func(string) error { return nil },
+		})
+
+		err := p.Process("<think>reasoning</think>")
+		if !errors.Is(err, errTest) {
+			t.Errorf("got error %v, want %v", err, errTest)
+		}
+	})
+}
+
+func TestThinkParser_ResetAndReuse(t *testing.T) {
+	onTh, onCt, thinking, content := collect()
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+	})
+
+	// First response: use longer strings so token estimates are distinct.
+	// "first reasoning block" = 21 chars => ~5 tokens
+	// "the first content" = 17 chars => ~4 tokens
+	if err := p.Process("<think>first reasoning block</think>the first content"); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	m1 := p.Metrics()
+	if m1.ThinkingTokens == 0 {
+		t.Error("first response should have thinking tokens")
+	}
+
+	// Reset and collect new buffers.
+	onTh2, onCt2, thinking2, content2 := collect()
+	p.Reset()
+
+	// Verify metrics are zeroed after reset.
+	mReset := p.Metrics()
+	if mReset.ThinkingTokens != 0 || mReset.ContentTokens != 0 {
+		t.Errorf("after Reset: ThinkingTokens=%d, ContentTokens=%d; want both 0",
+			mReset.ThinkingTokens, mReset.ContentTokens)
+	}
+
+	// Reconfigure callbacks for second response.
+	p.OnThinking = onTh2
+	p.OnContent = onCt2
+
+	// "second" = 6 chars => ~1 token; "two" = 3 chars => ~1 token
+	if err := p.Process("<think>second</think>two"); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	// Verify first response was correct.
+	if got := joined(thinking); got != "first reasoning block" {
+		t.Errorf("first thinking = %q, want %q", got, "first reasoning block")
+	}
+	if got := joined(content); got != "the first content" {
+		t.Errorf("first content = %q, want %q", got, "the first content")
+	}
+
+	// Verify second response is independent.
+	if got := joined(thinking2); got != "second" {
+		t.Errorf("second thinking = %q, want %q", got, "second")
+	}
+	if got := joined(content2); got != "two" {
+		t.Errorf("second content = %q, want %q", got, "two")
+	}
+
+	// Verify metrics reflect only the second response.
+	m2 := p.Metrics()
+	if m2.ThinkingTokens == m1.ThinkingTokens {
+		t.Errorf("second ThinkingTokens (%d) should differ from first (%d)",
+			m2.ThinkingTokens, m1.ThinkingTokens)
+	}
+}
+
+func TestThinkParser_Metrics(t *testing.T) {
+	onTh, onCt := func(string) error { return nil }, func(string) error { return nil }
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+	})
+
+	// "reasoning text" = 14 chars, ~3 tokens (14/4)
+	// "the answer" = 10 chars, ~2 tokens (10/4)
+	if err := p.Process("<think>reasoning text</think>the answer"); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	m := p.Metrics()
+	if m.ThinkingTokens != estimateTokens("reasoning text") {
+		t.Errorf("ThinkingTokens = %d, want %d", m.ThinkingTokens, estimateTokens("reasoning text"))
+	}
+	if m.ContentTokens != estimateTokens("the answer") {
+		t.Errorf("ContentTokens = %d, want %d", m.ContentTokens, estimateTokens("the answer"))
+	}
+
+	wantRatio := float64(m.ThinkingTokens) / float64(m.ThinkingTokens+m.ContentTokens)
+	if m.ThinkRatio != wantRatio {
+		t.Errorf("ThinkRatio = %v, want %v", m.ThinkRatio, wantRatio)
+	}
+}
+
+func TestThinkParser_BudgetSkip_MaxTokens(t *testing.T) {
+	var thinkCalls int
+	onTh := func(s string) error { thinkCalls++; return nil }
+	onCt := func(string) error { return nil }
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+		Budget: &ThinkBudget{
+			MaxTokens:  1, // very low budget
+			OnExceeded: ThinkBudgetSkip,
+		},
+	})
+
+	// The thinking content exceeds 1 token budget.
+	// "lots of thinking content here" is ~7 tokens.
+	if err := p.Process("<think>lots of thinking content here</think>answer"); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	// After budget exceeded, onThinking should stop being called for
+	// subsequent think text, but the state machine should still transition properly.
+	m := p.Metrics()
+	if m.ThinkingTokens == 0 {
+		t.Error("ThinkingTokens should still track even when budget exceeded")
+	}
+}
+
+func TestThinkParser_BudgetMaxTime(t *testing.T) {
+	var thinkChunks []string
+	onTh := func(s string) error { thinkChunks = append(thinkChunks, s); return nil }
+	onCt := func(string) error { return nil }
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+		Budget: &ThinkBudget{
+			MaxTime:    1 * time.Nanosecond, // effectively immediate expiry
+			OnExceeded: ThinkBudgetSkip,
+		},
+	})
+
+	// Give the time budget a chance to expire.
+	time.Sleep(2 * time.Nanosecond)
+
+	if err := p.Process("<think>thinking after budget</think>done"); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	// Thinking tokens should still be tracked in metrics.
+	m := p.Metrics()
+	if m.ThinkingTokens == 0 {
+		t.Error("ThinkingTokens should track even when time budget exceeded")
+	}
+}
+
+func TestThinkParser_NestedThinkTag(t *testing.T) {
+	// Nested <think> inside thinking: the first </think> closes the block.
+	onTh, onCt, thinking, content := collect()
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+	})
+
+	input := "<think>outer <think>inner</think>after"
+	if err := p.Process(input); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	// The inner <think> is just text inside the thinking block.
+	// The first </think> closes the block.
+	if got := joined(thinking); got != "outer <think>inner" {
+		t.Errorf("thinking = %q, want %q", got, "outer <think>inner")
+	}
+	if got := joined(content); got != "after" {
+		t.Errorf("content = %q, want %q", got, "after")
+	}
+}
+
+func TestThinkParser_FastPath_NoAngleBracket(t *testing.T) {
+	var contentCalls int
+	onCt := func(string) error { contentCalls++; return nil }
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       DefaultThinkTags(),
+		OnThinking: func(string) error { return nil },
+		OnContent:  onCt,
+	})
+
+	// A large chunk with no '<' should be handled in a single callback.
+	big := strings.Repeat("hello world ", 100)
+	if err := p.Process(big); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+
+	if contentCalls != 1 {
+		t.Errorf("contentCalls = %d, want 1 (fast path)", contentCalls)
+	}
+}
+
+func TestThinkParser_FastPath_NoAngleBracket_InThinking(t *testing.T) {
+	var thinkCalls int
+	onTh := func(string) error { thinkCalls++; return nil }
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  func(string) error { return nil },
+	})
+
+	// Enter thinking state first.
+	if err := p.Process("<think>"); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+
+	// Now send a large chunk with no '<' — should be single callback as thinking.
+	thinkCalls = 0
+	big := strings.Repeat("reasoning step ", 100)
+	if err := p.Process(big); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+
+	if thinkCalls != 1 {
+		t.Errorf("thinkCalls = %d, want 1 (fast path in thinking)", thinkCalls)
+	}
+}
+
+func TestThinkParser_ComplexFragmented(t *testing.T) {
+	// A complex scenario where both open and close tags are fragmented
+	// across multiple small chunks.
+	onTh, onCt, thinking, content := collect()
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+	})
+
+	chunks := []string{
+		"pre",
+		"<",
+		"think",
+		">",
+		"mid",
+		"dle",
+		"<",
+		"/think",
+		">",
+		"post",
+	}
+	for _, c := range chunks {
+		if err := p.Process(c); err != nil {
+			t.Fatalf("Process(%q): %v", c, err)
+		}
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	if got := joined(thinking); got != "middle" {
+		t.Errorf("thinking = %q, want %q", got, "middle")
+	}
+	if got := joined(content); got != "prepost" {
+		t.Errorf("content = %q, want %q", got, "prepost")
+	}
+}
+
+func TestThinkParser_ThinkAuto_NoTagsEarlyFlush(t *testing.T) {
+	// In auto mode, if we never reach 64 chars and no tags found, Flush
+	// should emit the sniff buffer as content.
+	onTh, onCt, thinking, content := collect()
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAuto,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+	})
+
+	if err := p.Process("short"); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	if got := joined(thinking); got != "" {
+		t.Errorf("thinking = %q, want empty", got)
+	}
+	if got := joined(content); got != "short" {
+		t.Errorf("content = %q, want %q", got, "short")
+	}
+}
+
+func TestThinkParser_ContentBeforeAndAfterThink(t *testing.T) {
+	onTh, onCt, thinking, content := collect()
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+	})
+
+	if err := p.Process("before<think>inside</think>after"); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	if got := joined(thinking); got != "inside" {
+		t.Errorf("thinking = %q, want %q", got, "inside")
+	}
+	if got := joined(content); got != "beforeafter" {
+		t.Errorf("content = %q, want %q", got, "beforeafter")
+	}
+}
+
+func TestThinkParser_BudgetCancel(t *testing.T) {
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       DefaultThinkTags(),
+		OnThinking: func(string) error { return nil },
+		OnContent:  func(string) error { return nil },
+		Budget: &ThinkBudget{
+			MaxTokens:  1,
+			OnExceeded: ThinkBudgetCancel,
+		},
+	})
+
+	err := p.Process("<think>lots of thinking content that exceeds budget</think>answer")
+	if err == nil {
+		t.Fatal("expected error when budget cancel is triggered")
+	}
+	if !strings.Contains(err.Error(), "budget") {
+		t.Errorf("error %q should mention budget", err.Error())
+	}
+}
+
+func TestThinkParser_MetricsThinkDuration(t *testing.T) {
+	onTh := func(string) error { return nil }
+	onCt := func(string) error { return nil }
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+	})
+
+	if err := p.Process("<think>"); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+
+	// Small sleep to ensure measurable duration.
+	time.Sleep(5 * time.Millisecond)
+
+	if err := p.Process("thinking</think>done"); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	m := p.Metrics()
+	if m.ThinkDuration < 5*time.Millisecond {
+		t.Errorf("ThinkDuration = %v, want >= 5ms", m.ThinkDuration)
+	}
+}
+
+func TestThinkParser_MetricsZeroTokens(t *testing.T) {
+	// When there are zero tokens, ThinkRatio should be 0.
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       DefaultThinkTags(),
+		OnThinking: func(string) error { return nil },
+		OnContent:  func(string) error { return nil },
+	})
+
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	m := p.Metrics()
+	if m.ThinkRatio != 0 {
+		t.Errorf("ThinkRatio = %v, want 0", m.ThinkRatio)
+	}
+}
+
+func TestThinkParser_AngleBracketInsideContent(t *testing.T) {
+	// A '<' that starts to match but doesn't complete the open tag should
+	// emit the partial match and continue as content.
+	onTh, onCt, thinking, content := collect()
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+	})
+
+	if err := p.Process("<div>not a think tag</div>"); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	if got := joined(thinking); got != "" {
+		t.Errorf("thinking = %q, want empty", got)
+	}
+	if got := joined(content); got != "<div>not a think tag</div>" {
+		t.Errorf("content = %q, want %q", got, "<div>not a think tag</div>")
+	}
+}

--- a/provider/think_test.go
+++ b/provider/think_test.go
@@ -940,3 +940,134 @@ func TestThinkParser_AngleBracketInsideContent(t *testing.T) {
 		t.Errorf("content = %q, want %q", got, "<div>not a think tag</div>")
 	}
 }
+
+func TestThinkParser_ThinkToggle_SetActiveTrue(t *testing.T) {
+	onTh, onCt, thinking, content := collect()
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkToggle,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+	})
+
+	// Activate reasoning for this request.
+	p.SetActive(true)
+
+	for _, chunk := range []string{"<think>reasoning</think>", "answer"} {
+		if err := p.Process(chunk); err != nil {
+			t.Fatalf("Process(%q) error: %v", chunk, err)
+		}
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush() error: %v", err)
+	}
+
+	if got := joined(thinking); got != "reasoning" {
+		t.Errorf("thinking = %q, want %q", got, "reasoning")
+	}
+	if got := joined(content); got != "answer" {
+		t.Errorf("content = %q, want %q", got, "answer")
+	}
+}
+
+func TestThinkParser_ThinkToggle_SetActiveFalse(t *testing.T) {
+	onTh, onCt, thinking, content := collect()
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkToggle,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+	})
+
+	// Deactivate reasoning — passthrough mode.
+	p.SetActive(false)
+
+	input := "<think>this should pass through</think>as content"
+	if err := p.Process(input); err != nil {
+		t.Fatalf("Process() error: %v", err)
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush() error: %v", err)
+	}
+
+	// Everything should be content, including the tags.
+	if got := joined(thinking); got != "" {
+		t.Errorf("thinking = %q, want empty", got)
+	}
+	if got := joined(content); got != input {
+		t.Errorf("content = %q, want %q", got, input)
+	}
+}
+
+func TestThinkParser_ThinkToggle_ResetAndToggle(t *testing.T) {
+	onTh, onCt, thinking, content := collect()
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkToggle,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+	})
+
+	// Request 1: reasoning active.
+	p.SetActive(true)
+	if err := p.Process("<think>thought1</think>answer1"); err != nil {
+		t.Fatalf("Process() error: %v", err)
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush() error: %v", err)
+	}
+	if got := joined(thinking); got != "thought1" {
+		t.Errorf("req1 thinking = %q, want %q", got, "thought1")
+	}
+	if got := joined(content); got != "answer1" {
+		t.Errorf("req1 content = %q, want %q", got, "answer1")
+	}
+
+	// Reset for request 2.
+	p.Reset()
+	*thinking = nil
+	*content = nil
+
+	// Request 2: reasoning disabled.
+	p.SetActive(false)
+	input := "no reasoning here"
+	if err := p.Process(input); err != nil {
+		t.Fatalf("Process() error: %v", err)
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush() error: %v", err)
+	}
+	if got := joined(thinking); got != "" {
+		t.Errorf("req2 thinking = %q, want empty", got)
+	}
+	if got := joined(content); got != input {
+		t.Errorf("req2 content = %q, want %q", got, input)
+	}
+}
+
+func TestThinkParser_SetActive_NoopForNonToggle(t *testing.T) {
+	onTh, onCt, thinking, content := collect()
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+	})
+
+	// SetActive should be a no-op for ThinkAlways.
+	p.SetActive(false)
+
+	// Should still parse tags (not passthrough).
+	if err := p.Process("<think>thought</think>answer"); err != nil {
+		t.Fatalf("Process() error: %v", err)
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush() error: %v", err)
+	}
+	if got := joined(thinking); got != "thought" {
+		t.Errorf("thinking = %q, want %q", got, "thought")
+	}
+	if got := joined(content); got != "answer" {
+		t.Errorf("content = %q, want %q", got, "answer")
+	}
+}

--- a/provider/think_test.go
+++ b/provider/think_test.go
@@ -52,10 +52,10 @@ func TestThinkParser_BasicThinking(t *testing.T) {
 
 func TestThinkParser_FragmentedOpenTag(t *testing.T) {
 	tests := []struct {
-		name    string
-		chunks  []string
-		wantTh  string
-		wantCt  string
+		name   string
+		chunks []string
+		wantTh string
+		wantCt string
 	}{
 		{
 			name:   "split after <",
@@ -118,10 +118,10 @@ func TestThinkParser_FragmentedOpenTag(t *testing.T) {
 
 func TestThinkParser_FragmentedCloseTag(t *testing.T) {
 	tests := []struct {
-		name    string
-		chunks  []string
-		wantTh  string
-		wantCt  string
+		name   string
+		chunks []string
+		wantTh string
+		wantCt string
 	}{
 		{
 			name:   "split after </",
@@ -938,6 +938,54 @@ func TestThinkParser_AngleBracketInsideContent(t *testing.T) {
 	}
 	if got := joined(content); got != "<div>not a think tag</div>" {
 		t.Errorf("content = %q, want %q", got, "<div>not a think tag</div>")
+	}
+}
+
+func TestThinkParser_OpenTagMismatchRestartDoesNotDuplicateAngleBracket(t *testing.T) {
+	onTh, onCt, thinking, content := collect()
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+	})
+
+	if err := p.Process("<<think>reasoning</think>done"); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	if got := joined(thinking); got != "reasoning" {
+		t.Errorf("thinking = %q, want %q", got, "reasoning")
+	}
+	if got := joined(content); got != "<done" {
+		t.Errorf("content = %q, want %q", got, "<done")
+	}
+}
+
+func TestThinkParser_CloseTagMismatchRestartDoesNotDuplicateAngleBracket(t *testing.T) {
+	onTh, onCt, thinking, content := collect()
+	p := NewThinkParser(ThinkParserConfig{
+		Mode:       ThinkAlways,
+		Tags:       DefaultThinkTags(),
+		OnThinking: onTh,
+		OnContent:  onCt,
+	})
+
+	if err := p.Process("<think>reason<</think>done"); err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	if got := joined(thinking); got != "reason<" {
+		t.Errorf("thinking = %q, want %q", got, "reason<")
+	}
+	if got := joined(content); got != "done" {
+		t.Errorf("content = %q, want %q", got, "done")
 	}
 }
 

--- a/provider/types.go
+++ b/provider/types.go
@@ -1,0 +1,383 @@
+// Package provider defines the provider-agnostic abstraction layer for LLM
+// backends. It contains all shared types, interfaces, and capability flags
+// that allow consumers to work with different model providers (Ollama, OpenAI,
+// Anthropic, etc.) through a single unified API.
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Capability bitmask
+// ---------------------------------------------------------------------------
+
+// Capability is a bitmask describing what a provider or model supports.
+// Use bitwise OR to combine capabilities and the Has method to test them.
+type Capability uint32
+
+const (
+	// CapChat indicates the provider supports multi-turn chat completions.
+	CapChat Capability = 1 << iota
+	// CapGenerate indicates the provider supports raw text generation.
+	CapGenerate
+	// CapEmbed indicates the provider supports embedding generation.
+	CapEmbed
+	// CapStream indicates the provider supports streaming responses.
+	CapStream
+	// CapToolCall indicates the provider supports tool/function calling.
+	CapToolCall
+	// CapThinking indicates the provider supports extended thinking mode.
+	CapThinking
+)
+
+// capNames maps each single-bit capability to its string representation.
+var capNames = []struct {
+	bit  Capability
+	name string
+}{
+	{CapChat, "chat"},
+	{CapGenerate, "generate"},
+	{CapEmbed, "embed"},
+	{CapStream, "stream"},
+	{CapToolCall, "tool_call"},
+	{CapThinking, "thinking"},
+}
+
+// Has reports whether c includes every bit in flag.
+func (c Capability) Has(flag Capability) bool {
+	return c&flag == flag
+}
+
+// String returns a human-readable representation such as "chat|stream".
+// When no bits are set it returns "none".
+func (c Capability) String() string {
+	if c == 0 {
+		return "none"
+	}
+	var parts []string
+	for _, cn := range capNames {
+		if c.Has(cn.bit) {
+			parts = append(parts, cn.name)
+		}
+	}
+	if len(parts) == 0 {
+		return "none"
+	}
+	return strings.Join(parts, "|")
+}
+
+// ---------------------------------------------------------------------------
+// ModelKey
+// ---------------------------------------------------------------------------
+
+// ModelKey uniquely identifies a model by its provider and model name.
+type ModelKey struct {
+	// Provider is the backend name (e.g. "ollama", "openai").
+	Provider string
+	// Model is the model identifier (e.g. "qwen3:8b", "gpt-4o").
+	Model string
+}
+
+// String returns the key in "provider/model" format.
+func (k ModelKey) String() string {
+	return k.Provider + "/" + k.Model
+}
+
+// ---------------------------------------------------------------------------
+// Provider interface
+// ---------------------------------------------------------------------------
+
+// Provider is the core abstraction for an LLM backend. Every provider must
+// implement at minimum Name, Capabilities, Health, and Models. The generation
+// methods (Chat, ChatStream, Generate, GenerateStream, Embed) may return
+// an error if the corresponding capability is not supported.
+type Provider interface {
+	// Name returns the provider identifier (e.g. "ollama").
+	Name() string
+
+	// Capabilities returns the bitmask of features this provider supports.
+	Capabilities() Capability
+
+	// Health checks whether the provider backend is reachable and ready.
+	Health(ctx context.Context) error
+
+	// Models returns the list of models available from this provider.
+	Models(ctx context.Context) ([]ModelInfo, error)
+
+	// Chat sends a chat completion request and returns the full response.
+	Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error)
+
+	// ChatStream sends a chat completion request and invokes fn for each
+	// partial response chunk. The final chunk has Done set to true.
+	ChatStream(ctx context.Context, req ChatRequest, fn func(ChatResponse) error) error
+
+	// Generate sends a raw text generation request and returns the response.
+	Generate(ctx context.Context, req GenerateRequest) (*GenerateResponse, error)
+
+	// GenerateStream sends a generation request and invokes fn for each
+	// partial response chunk. The final chunk has Done set to true.
+	GenerateStream(ctx context.Context, req GenerateRequest, fn func(GenerateResponse) error) error
+
+	// Embed generates vector embeddings for the given input texts.
+	Embed(ctx context.Context, req EmbedRequest) (*EmbedResponse, error)
+}
+
+// ---------------------------------------------------------------------------
+// Chat types
+// ---------------------------------------------------------------------------
+
+// ChatMessage represents a single message in a multi-turn conversation.
+type ChatMessage struct {
+	Role       string     `json:"role"`                   // system, user, assistant, tool
+	Content    string     `json:"content"`
+	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`   // present when assistant invokes tools
+	ToolName   string     `json:"tool_name,omitempty"`    // set when role="tool"
+	ToolCallID string     `json:"tool_call_id,omitempty"` // correlates result with call
+}
+
+// Tool defines a tool the model may invoke during chat.
+type Tool struct {
+	Type     string       `json:"type"`     // always "function"
+	Function ToolFunction `json:"function"`
+}
+
+// ToolFunction describes a callable function available to the model.
+type ToolFunction struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Parameters  json.RawMessage `json:"parameters"` // JSON Schema
+}
+
+// ToolCall represents a tool invocation returned by the model.
+type ToolCall struct {
+	ID       string           `json:"id,omitempty"` // unique call ID
+	Type     string           `json:"type"`         // "function"
+	Function ToolCallFunction `json:"function"`
+}
+
+// ToolCallFunction holds the name and parsed arguments of a tool call.
+type ToolCallFunction struct {
+	Index     int            `json:"index"`
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments"`
+}
+
+// ChatRequest is the provider-agnostic request for a chat completion.
+type ChatRequest struct {
+	Model     string        `json:"model"`
+	Messages  []ChatMessage `json:"messages"`
+	Options   *ModelOptions `json:"options,omitempty"`
+	Tools     []Tool        `json:"tools,omitempty"`
+	ThinkMode ThinkMode     `json:"think_mode,omitempty"`
+}
+
+// ChatResponse is the provider-agnostic response from a chat completion.
+type ChatResponse struct {
+	Content   string       `json:"content"`
+	Thinking  string       `json:"thinking,omitempty"`
+	ToolCalls []ToolCall   `json:"tool_calls,omitempty"`
+	Done      bool         `json:"done"`
+	Partial   bool         `json:"partial,omitempty"` // true for streaming chunks
+	Usage     *Usage       `json:"usage,omitempty"`
+	Latency   *LatencyInfo `json:"latency,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// Generate types
+// ---------------------------------------------------------------------------
+
+// GenerateRequest is the provider-agnostic request for raw text generation.
+type GenerateRequest struct {
+	Model   string        `json:"model"`
+	Prompt  string        `json:"prompt"`
+	System  string        `json:"system,omitempty"`
+	Suffix  string        `json:"suffix,omitempty"` // for Fill-in-the-Middle
+	Options *ModelOptions `json:"options,omitempty"`
+}
+
+// GenerateResponse is the provider-agnostic response from text generation.
+type GenerateResponse struct {
+	Response   string                `json:"response"`
+	Done       bool                  `json:"done"`
+	Partial    bool                  `json:"partial,omitempty"`
+	Usage      *Usage                `json:"usage,omitempty"`
+	Latency    *LatencyInfo          `json:"latency,omitempty"`
+	Confidence *CompletionConfidence `json:"confidence,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// Embed types
+// ---------------------------------------------------------------------------
+
+// EmbedRequest is the provider-agnostic request for embedding generation.
+type EmbedRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+// EmbedResponse is the provider-agnostic response from embedding generation.
+type EmbedResponse struct {
+	Embeddings [][]float64 `json:"embeddings"`
+}
+
+// ---------------------------------------------------------------------------
+// Model configuration
+// ---------------------------------------------------------------------------
+
+// ModelOptions controls generation parameters. Pointer fields are optional;
+// nil means "use the provider's default". Use the Ptr helper to set values.
+type ModelOptions struct {
+	Temperature   *float64 `json:"temperature,omitempty"`
+	TopP          *float64 `json:"top_p,omitempty"`
+	NumPredict    int      `json:"num_predict,omitempty"`
+	NumCtx        int      `json:"num_ctx,omitempty"`
+	Stop          []string `json:"stop,omitempty"`
+	RepeatPenalty *float64 `json:"repeat_penalty,omitempty"`
+}
+
+// ModelInfo holds metadata about a model available from a provider.
+type ModelInfo struct {
+	Name          string   `json:"name"`
+	Family        string   `json:"family,omitempty"`
+	ParameterSize string   `json:"parameter_size,omitempty"`
+	QuantLevel    string   `json:"quantization_level,omitempty"`
+	Capabilities  []string `json:"capabilities,omitempty"`
+	ContextWindow int      `json:"context_window,omitempty"`
+	Digest        string   `json:"digest,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// Usage and latency
+// ---------------------------------------------------------------------------
+
+// Usage reports token consumption for a request.
+type Usage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+// LatencyInfo captures timing breakdowns from the provider backend.
+type LatencyInfo struct {
+	LoadDuration       time.Duration `json:"load_duration"`
+	PromptEvalDuration time.Duration `json:"prompt_eval_duration"`
+	GenerationDuration time.Duration `json:"generation_duration"`
+}
+
+// ---------------------------------------------------------------------------
+// Thinking / extended reasoning
+// ---------------------------------------------------------------------------
+
+// ThinkMode controls whether the model uses extended thinking (chain-of-thought).
+type ThinkMode int
+
+const (
+	// ThinkNone disables thinking entirely.
+	ThinkNone ThinkMode = iota
+	// ThinkAlways forces thinking on every request.
+	ThinkAlways
+	// ThinkToggle lets the caller explicitly enable/disable per request.
+	ThinkToggle
+	// ThinkAuto lets the provider decide based on query complexity.
+	ThinkAuto
+)
+
+// String returns the human-readable name of the think mode.
+func (m ThinkMode) String() string {
+	switch m {
+	case ThinkNone:
+		return "none"
+	case ThinkAlways:
+		return "always"
+	case ThinkToggle:
+		return "toggle"
+	case ThinkAuto:
+		return "auto"
+	default:
+		return "unknown"
+	}
+}
+
+// ThinkTags defines the delimiters used to wrap thinking blocks in model output.
+type ThinkTags struct {
+	Open  string
+	Close string
+}
+
+// DefaultThinkTags returns the standard thinking delimiters used by most models.
+func DefaultThinkTags() ThinkTags {
+	return ThinkTags{Open: "<think>", Close: "</think>"}
+}
+
+// ThinkBudgetAction specifies what to do when a thinking budget is exceeded.
+type ThinkBudgetAction int
+
+const (
+	// ThinkBudgetSkip silently omits the thinking content when the budget is exceeded.
+	ThinkBudgetSkip ThinkBudgetAction = iota
+	// ThinkBudgetCancel cancels the entire request when the budget is exceeded.
+	ThinkBudgetCancel
+)
+
+// ThinkBudget constrains the resources spent on extended thinking.
+type ThinkBudget struct {
+	MaxTokens  int               `json:"max_tokens,omitempty"`
+	MaxTime    time.Duration     `json:"max_time,omitempty"`
+	OnExceeded ThinkBudgetAction `json:"on_exceeded,omitempty"`
+}
+
+// ThinkMetrics captures statistics about a thinking/reasoning response.
+type ThinkMetrics struct {
+	ThinkingTokens int           `json:"thinking_tokens"`
+	ContentTokens  int           `json:"content_tokens"`
+	ThinkRatio     float64       `json:"think_ratio"`
+	ThinkDuration  time.Duration `json:"think_duration"`
+}
+
+// ---------------------------------------------------------------------------
+// FIM (Fill-in-the-Middle)
+// ---------------------------------------------------------------------------
+
+// FIMConfig holds the token markers and budget for Fill-in-the-Middle completion.
+type FIMConfig struct {
+	Prefix          string `json:"prefix"`
+	Suffix          string `json:"suffix"`
+	Middle          string `json:"middle"`
+	PrefixBudgetPct int    `json:"prefix_budget_pct,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// Completion confidence
+// ---------------------------------------------------------------------------
+
+// CompletionConfidence scores how confident the model is in a generation result.
+type CompletionConfidence struct {
+	Score      float64 `json:"score"`
+	AvgLogProb float64 `json:"avg_log_prob"`
+	MinLogProb float64 `json:"min_log_prob"`
+	DropOffIdx int     `json:"drop_off_idx"`
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Ptr returns a pointer to v. It is a convenience for setting optional pointer
+// fields in ModelOptions and similar structs.
+func Ptr[T any](v T) *T {
+	return &v
+}
+
+// estimateTokens provides a rough token count estimate using the len/4 heuristic.
+// This is intentionally imprecise and suitable only for budget estimation.
+func estimateTokens(s string) int {
+	n := len(s) / 4
+	if n == 0 && len(s) > 0 {
+		return 1
+	}
+	return n
+}

--- a/provider/types.go
+++ b/provider/types.go
@@ -132,7 +132,7 @@ type Provider interface {
 
 // ChatMessage represents a single message in a multi-turn conversation.
 type ChatMessage struct {
-	Role       string     `json:"role"`                   // system, user, assistant, tool
+	Role       string     `json:"role"` // system, user, assistant, tool
 	Content    string     `json:"content"`
 	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`   // present when assistant invokes tools
 	ToolName   string     `json:"tool_name,omitempty"`    // set when role="tool"
@@ -141,7 +141,7 @@ type ChatMessage struct {
 
 // Tool defines a tool the model may invoke during chat.
 type Tool struct {
-	Type     string       `json:"type"`     // always "function"
+	Type     string       `json:"type"` // always "function"
 	Function ToolFunction `json:"function"`
 }
 
@@ -177,14 +177,14 @@ type ChatRequest struct {
 
 // ChatResponse is the provider-agnostic response from a chat completion.
 type ChatResponse struct {
-	Model     string     `json:"model"`
-	Provider  string     `json:"provider"`
-	Content   string     `json:"content"`
-	Thinking  string     `json:"thinking,omitempty"`
-	ToolCalls []ToolCall `json:"tool_calls,omitempty"`
-	Done      bool       `json:"done"`
-	Partial   bool       `json:"partial,omitempty"`
-	Usage     Usage      `json:"usage,omitempty"`
+	Model     string      `json:"model"`
+	Provider  string      `json:"provider"`
+	Content   string      `json:"content"`
+	Thinking  string      `json:"thinking,omitempty"`
+	ToolCalls []ToolCall  `json:"tool_calls,omitempty"`
+	Done      bool        `json:"done"`
+	Partial   bool        `json:"partial,omitempty"`
+	Usage     Usage       `json:"usage,omitempty"`
 	Latency   LatencyInfo `json:"latency,omitempty"`
 }
 
@@ -245,6 +245,7 @@ type ModelOptions struct {
 	NumCtx        int      `json:"num_ctx,omitempty"`
 	Stop          []string `json:"stop,omitempty"`
 	RepeatPenalty *float64 `json:"repeat_penalty,omitempty"`
+	Think         *bool    `json:"think,omitempty"` // only used when ThinkMode is ThinkToggle
 }
 
 // ModelInfo holds metadata about a model available from a provider.

--- a/provider/types.go
+++ b/provider/types.go
@@ -161,29 +161,31 @@ type ToolCall struct {
 
 // ToolCallFunction holds the name and parsed arguments of a tool call.
 type ToolCallFunction struct {
-	Index     int            `json:"index"`
-	Name      string         `json:"name"`
-	Arguments map[string]any `json:"arguments"`
+	Index     int             `json:"index"`
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
 }
 
 // ChatRequest is the provider-agnostic request for a chat completion.
 type ChatRequest struct {
-	Model     string        `json:"model"`
-	Messages  []ChatMessage `json:"messages"`
-	Options   *ModelOptions `json:"options,omitempty"`
-	Tools     []Tool        `json:"tools,omitempty"`
-	ThinkMode ThinkMode     `json:"think_mode,omitempty"`
+	Model    string        `json:"model"`
+	Messages []ChatMessage `json:"messages"`
+	Options  ModelOptions  `json:"options,omitempty"`
+	Tools    []Tool        `json:"tools,omitempty"`
+	Stream   bool          `json:"stream"`
 }
 
 // ChatResponse is the provider-agnostic response from a chat completion.
 type ChatResponse struct {
-	Content   string       `json:"content"`
-	Thinking  string       `json:"thinking,omitempty"`
-	ToolCalls []ToolCall   `json:"tool_calls,omitempty"`
-	Done      bool         `json:"done"`
-	Partial   bool         `json:"partial,omitempty"` // true for streaming chunks
-	Usage     *Usage       `json:"usage,omitempty"`
-	Latency   *LatencyInfo `json:"latency,omitempty"`
+	Model     string     `json:"model"`
+	Provider  string     `json:"provider"`
+	Content   string     `json:"content"`
+	Thinking  string     `json:"thinking,omitempty"`
+	ToolCalls []ToolCall `json:"tool_calls,omitempty"`
+	Done      bool       `json:"done"`
+	Partial   bool       `json:"partial,omitempty"`
+	Usage     Usage      `json:"usage,omitempty"`
+	Latency   LatencyInfo `json:"latency,omitempty"`
 }
 
 // ---------------------------------------------------------------------------
@@ -192,20 +194,23 @@ type ChatResponse struct {
 
 // GenerateRequest is the provider-agnostic request for raw text generation.
 type GenerateRequest struct {
-	Model   string        `json:"model"`
-	Prompt  string        `json:"prompt"`
-	System  string        `json:"system,omitempty"`
-	Suffix  string        `json:"suffix,omitempty"` // for Fill-in-the-Middle
-	Options *ModelOptions `json:"options,omitempty"`
+	Model   string       `json:"model"`
+	Prompt  string       `json:"prompt"`
+	System  string       `json:"system,omitempty"`
+	Suffix  string       `json:"suffix,omitempty"` // presence triggers FIM mode
+	Options ModelOptions `json:"options,omitempty"`
+	Stream  bool         `json:"stream"`
 }
 
 // GenerateResponse is the provider-agnostic response from text generation.
 type GenerateResponse struct {
+	Model      string                `json:"model"`
+	Provider   string                `json:"provider"`
 	Response   string                `json:"response"`
 	Done       bool                  `json:"done"`
 	Partial    bool                  `json:"partial,omitempty"`
-	Usage      *Usage                `json:"usage,omitempty"`
-	Latency    *LatencyInfo          `json:"latency,omitempty"`
+	Usage      Usage                 `json:"usage,omitempty"`
+	Latency    LatencyInfo           `json:"latency,omitempty"`
 	Confidence *CompletionConfidence `json:"confidence,omitempty"`
 }
 
@@ -221,7 +226,10 @@ type EmbedRequest struct {
 
 // EmbedResponse is the provider-agnostic response from embedding generation.
 type EmbedResponse struct {
+	Model      string      `json:"model"`
+	Provider   string      `json:"provider"`
 	Embeddings [][]float64 `json:"embeddings"`
+	Usage      Usage       `json:"usage,omitempty"`
 }
 
 // ---------------------------------------------------------------------------

--- a/provider/types_test.go
+++ b/provider/types_test.go
@@ -1,0 +1,289 @@
+package provider
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCapability_Has(t *testing.T) {
+	tests := []struct {
+		name string
+		cap  Capability
+		flag Capability
+		want bool
+	}{
+		{name: "single bit set and tested", cap: CapChat, flag: CapChat, want: true},
+		{name: "single bit not set", cap: CapChat, flag: CapEmbed, want: false},
+		{name: "multi-bit contains single", cap: CapChat | CapStream, flag: CapStream, want: true},
+		{name: "multi-bit missing single", cap: CapChat | CapStream, flag: CapEmbed, want: false},
+		{name: "multi-bit flag subset match", cap: CapChat | CapStream | CapEmbed, flag: CapChat | CapEmbed, want: true},
+		{name: "multi-bit flag partial miss", cap: CapChat | CapStream, flag: CapChat | CapEmbed, want: false},
+		{name: "zero has zero", cap: 0, flag: 0, want: true},
+		{name: "nonzero has zero", cap: CapChat, flag: 0, want: true},
+		{name: "zero lacks any bit", cap: 0, flag: CapChat, want: false},
+		{name: "all caps has thinking", cap: CapChat | CapGenerate | CapEmbed | CapStream | CapToolCall | CapThinking, flag: CapThinking, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cap.Has(tt.flag)
+			if got != tt.want {
+				t.Errorf("Capability(%d).Has(%d) = %v, want %v", tt.cap, tt.flag, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCapability_String(t *testing.T) {
+	tests := []struct {
+		name string
+		cap  Capability
+		want string
+	}{
+		{name: "none", cap: 0, want: "none"},
+		{name: "single chat", cap: CapChat, want: "chat"},
+		{name: "single embed", cap: CapEmbed, want: "embed"},
+		{name: "chat and stream", cap: CapChat | CapStream, want: "chat|stream"},
+		{name: "generate and embed", cap: CapGenerate | CapEmbed, want: "generate|embed"},
+		{name: "all capabilities", cap: CapChat | CapGenerate | CapEmbed | CapStream | CapToolCall | CapThinking, want: "chat|generate|embed|stream|tool_call|thinking"},
+		{name: "thinking only", cap: CapThinking, want: "thinking"},
+		{name: "tool_call and thinking", cap: CapToolCall | CapThinking, want: "tool_call|thinking"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cap.String()
+			if got != tt.want {
+				t.Errorf("Capability(%d).String() = %q, want %q", tt.cap, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestModelKey_String(t *testing.T) {
+	tests := []struct {
+		name string
+		key  ModelKey
+		want string
+	}{
+		{name: "ollama model", key: ModelKey{Provider: "ollama", Model: "qwen3:8b"}, want: "ollama/qwen3:8b"},
+		{name: "openai model", key: ModelKey{Provider: "openai", Model: "gpt-4o"}, want: "openai/gpt-4o"},
+		{name: "empty provider", key: ModelKey{Provider: "", Model: "test"}, want: "/test"},
+		{name: "empty model", key: ModelKey{Provider: "ollama", Model: ""}, want: "ollama/"},
+		{name: "both empty", key: ModelKey{Provider: "", Model: ""}, want: "/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.key.String()
+			if got != tt.want {
+				t.Errorf("ModelKey{%q, %q}.String() = %q, want %q", tt.key.Provider, tt.key.Model, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestThinkMode_String(t *testing.T) {
+	tests := []struct {
+		name string
+		mode ThinkMode
+		want string
+	}{
+		{name: "none", mode: ThinkNone, want: "none"},
+		{name: "always", mode: ThinkAlways, want: "always"},
+		{name: "toggle", mode: ThinkToggle, want: "toggle"},
+		{name: "auto", mode: ThinkAuto, want: "auto"},
+		{name: "unknown value", mode: ThinkMode(99), want: "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.mode.String()
+			if got != tt.want {
+				t.Errorf("ThinkMode(%d).String() = %q, want %q", tt.mode, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultThinkTags(t *testing.T) {
+	tags := DefaultThinkTags()
+	if tags.Open != "<think>" {
+		t.Errorf("DefaultThinkTags().Open = %q, want %q", tags.Open, "<think>")
+	}
+	if tags.Close != "</think>" {
+		t.Errorf("DefaultThinkTags().Close = %q, want %q", tags.Close, "</think>")
+	}
+}
+
+func TestPtr(t *testing.T) {
+	t.Run("float64", func(t *testing.T) {
+		p := Ptr(0.7)
+		if p == nil {
+			t.Fatal("Ptr(0.7) returned nil")
+		}
+		if *p != 0.7 {
+			t.Errorf("*Ptr(0.7) = %v, want 0.7", *p)
+		}
+	})
+
+	t.Run("int", func(t *testing.T) {
+		p := Ptr(42)
+		if p == nil {
+			t.Fatal("Ptr(42) returned nil")
+		}
+		if *p != 42 {
+			t.Errorf("*Ptr(42) = %v, want 42", *p)
+		}
+	})
+
+	t.Run("string", func(t *testing.T) {
+		p := Ptr("hello")
+		if p == nil {
+			t.Fatal("Ptr returned nil")
+		}
+		if *p != "hello" {
+			t.Errorf("*Ptr(\"hello\") = %q, want \"hello\"", *p)
+		}
+	})
+}
+
+func TestEstimateTokens(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  int
+	}{
+		{name: "empty string", input: "", want: 0},
+		{name: "short string", input: "hi", want: 1},
+		{name: "single char", input: "a", want: 1},
+		{name: "three chars", input: "abc", want: 1},
+		{name: "four chars", input: "abcd", want: 1},
+		{name: "eight chars", input: "abcdefgh", want: 2},
+		{name: "typical sentence", input: "The quick brown fox jumps over the lazy dog.", want: 11},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := estimateTokens(tt.input)
+			if got != tt.want {
+				t.Errorf("estimateTokens(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestModelOptions_PointerFields(t *testing.T) {
+	// Verify that nil pointer fields represent "use default" semantics.
+	opts := ModelOptions{}
+	if opts.Temperature != nil {
+		t.Error("zero-value ModelOptions should have nil Temperature")
+	}
+	if opts.TopP != nil {
+		t.Error("zero-value ModelOptions should have nil TopP")
+	}
+	if opts.RepeatPenalty != nil {
+		t.Error("zero-value ModelOptions should have nil RepeatPenalty")
+	}
+
+	// Verify that Ptr sets values correctly.
+	opts = ModelOptions{
+		Temperature:   Ptr(0.8),
+		TopP:          Ptr(0.9),
+		NumPredict:    256,
+		NumCtx:        4096,
+		Stop:          []string{"\n"},
+		RepeatPenalty: Ptr(1.1),
+	}
+	if *opts.Temperature != 0.8 {
+		t.Errorf("Temperature = %v, want 0.8", *opts.Temperature)
+	}
+	if *opts.TopP != 0.9 {
+		t.Errorf("TopP = %v, want 0.9", *opts.TopP)
+	}
+	if *opts.RepeatPenalty != 1.1 {
+		t.Errorf("RepeatPenalty = %v, want 1.1", *opts.RepeatPenalty)
+	}
+}
+
+func TestThinkBudget(t *testing.T) {
+	budget := ThinkBudget{
+		MaxTokens:  1000,
+		MaxTime:    5 * time.Second,
+		OnExceeded: ThinkBudgetCancel,
+	}
+	if budget.MaxTokens != 1000 {
+		t.Errorf("MaxTokens = %d, want 1000", budget.MaxTokens)
+	}
+	if budget.MaxTime != 5*time.Second {
+		t.Errorf("MaxTime = %v, want 5s", budget.MaxTime)
+	}
+	if budget.OnExceeded != ThinkBudgetCancel {
+		t.Errorf("OnExceeded = %d, want ThinkBudgetCancel(%d)", budget.OnExceeded, ThinkBudgetCancel)
+	}
+}
+
+func TestThinkMetrics(t *testing.T) {
+	m := ThinkMetrics{
+		ThinkingTokens: 200,
+		ContentTokens:  800,
+		ThinkRatio:     0.2,
+		ThinkDuration:  3 * time.Second,
+	}
+	if m.ThinkingTokens+m.ContentTokens != 1000 {
+		t.Errorf("total tokens = %d, want 1000", m.ThinkingTokens+m.ContentTokens)
+	}
+	if m.ThinkRatio != 0.2 {
+		t.Errorf("ThinkRatio = %v, want 0.2", m.ThinkRatio)
+	}
+}
+
+func TestCapability_BitwiseOps(t *testing.T) {
+	// Verify that capabilities compose correctly with bitwise OR.
+	combined := CapChat | CapStream | CapToolCall
+	if combined&CapChat == 0 {
+		t.Error("combined should include CapChat")
+	}
+	if combined&CapStream == 0 {
+		t.Error("combined should include CapStream")
+	}
+	if combined&CapToolCall == 0 {
+		t.Error("combined should include CapToolCall")
+	}
+	if combined&CapEmbed != 0 {
+		t.Error("combined should not include CapEmbed")
+	}
+	if combined&CapThinking != 0 {
+		t.Error("combined should not include CapThinking")
+	}
+}
+
+func TestFIMConfig(t *testing.T) {
+	cfg := FIMConfig{
+		Prefix:          "<|fim_prefix|>",
+		Suffix:          "<|fim_suffix|>",
+		Middle:          "<|fim_middle|>",
+		PrefixBudgetPct: 75,
+	}
+	if cfg.PrefixBudgetPct != 75 {
+		t.Errorf("PrefixBudgetPct = %d, want 75", cfg.PrefixBudgetPct)
+	}
+	if cfg.Prefix != "<|fim_prefix|>" {
+		t.Errorf("Prefix = %q, want %q", cfg.Prefix, "<|fim_prefix|>")
+	}
+}
+
+func TestCompletionConfidence(t *testing.T) {
+	cc := CompletionConfidence{
+		Score:      0.95,
+		AvgLogProb: -0.5,
+		MinLogProb: -2.1,
+		DropOffIdx: 42,
+	}
+	if cc.Score != 0.95 {
+		t.Errorf("Score = %v, want 0.95", cc.Score)
+	}
+	if cc.DropOffIdx != 42 {
+		t.Errorf("DropOffIdx = %d, want 42", cc.DropOffIdx)
+	}
+}


### PR DESCRIPTION
## Summary

Adds the `provider/` package implementing Phase 1 of the Provider Intelligence Layer (#48):

- **Provider interface** -- 9-method abstraction for LLM backends with Capability bitmask, normalized request/response types, and ModelKey identity
- **OllamaProvider** -- wraps `ollama.Client` with streaming ThinkParser integration, graceful cancellation (Partial flag), singleflight embed deduplication, and type mapping
- **ThinkParser** -- 4-state streaming state machine for `<think>` tag extraction with configurable tags, ThinkAuto/ThinkToggle/ThinkAlways modes, budget enforcement (MaxTokens/MaxTime), and metrics
- **Provider Registry** -- thread-safe provider lifecycle management with model index and multi-provider resolution
- **ModelRegistry** -- three-layer merge (static catalog <- fingerprint <- runtime) with cache, dynamic inference for unknown models, RAM estimation, and Recommend
- **Static Catalog** -- 20 model families (Qwen, DeepSeek, CodeLlama, StarCoder, Llama, Gemma, Phi, Mistral) with FIM tokens, think modes, context windows, and resource profiles
- **ParseModelName** -- decomposes Ollama model names into family/variant/paramSize/quant for catalog matching

## Test plan

- [x] All 12 packages pass `go test -race ./...`
- [x] `golangci-lint run ./...` reports 0 issues
- [x] Full /code-review cycle -- all issues fixed
- [x] Full /criticize-review cycle -- blocking issues fixed (singleflight defensive copy, Temperature=0 preservation, All() error propagation)
- [x] CI passes on this PR

Refs #48

Generated with [Claude Code](https://claude.com/claude-code)