### PR TITLE
feat(rag): diff-aware incremental indexing with StableKey continuity

### DIFF
--- a/rag/chunk_diff.go
+++ b/rag/chunk_diff.go
@@ -60,14 +60,12 @@ func diffChunks(oldChunks []ChunkWithEmbedding, newChunks []Chunk) chunkDiff {
 	// Also track which old chunk IDs made it into the map so we can
 	// correctly identify duplicates as deleted.
 	oldByKey := make(map[string]ChunkWithEmbedding, len(oldChunks))
-	oldIDInMap := make(map[string]bool, len(oldChunks))
 	for _, old := range oldChunks {
 		if old.Chunk.StableKey == "" {
 			continue
 		}
 		if _, exists := oldByKey[old.Chunk.StableKey]; !exists {
 			oldByKey[old.Chunk.StableKey] = old
-			oldIDInMap[old.Chunk.ID] = true
 		}
 	}
 

--- a/rag/chunk_diff.go
+++ b/rag/chunk_diff.go
@@ -1,0 +1,115 @@
+package rag
+
+// chunkDiff holds the result of comparing old stored chunks against newly
+// chunked content for a single source file. Each chunk is classified as
+// unchanged, modified, added, or deleted based on StableKey matching and
+// content hash comparison.
+type chunkDiff struct {
+	// unchanged chunks: StableKey matches and content hash is identical.
+	// The stored embedding can be reused without re-embedding.
+	unchanged []unchangedChunk
+	// modified chunks: StableKey matches but content hash differs.
+	// These need re-embedding.
+	modified []modifiedChunk
+	// added chunks: no StableKey match in old set, need embedding.
+	added []Chunk
+	// deletedIDs: old chunk IDs whose StableKey was not matched by any
+	// new chunk. These should be removed from the store.
+	deletedIDs []string
+}
+
+// unchangedChunk pairs a new chunk (with current position metadata) with
+// the stored embedding that can be reused. The chunk field carries the new
+// chunk's metadata (StartLine, EndLine may have shifted) while embedding
+// is carried over from the old stored chunk.
+type unchangedChunk struct {
+	chunk     Chunk     // new chunk (may have different StartLine/EndLine)
+	embedding []float64 // embedding from store (content unchanged)
+}
+
+// modifiedChunk pairs a new chunk with the old chunk ID it replaces.
+// The content has changed so the embedding must be recomputed, but the
+// StableKey match tells us this is an update rather than a delete+add.
+type modifiedChunk struct {
+	chunk Chunk  // new chunk content + StableKey
+	oldID string // old chunk ID (for tracking only; ReplaceSource handles cleanup)
+}
+
+// diffChunks compares old stored chunks against newly produced chunks,
+// matching on StableKey and comparing content hashes to classify each
+// chunk as unchanged, modified, added, or deleted.
+//
+// Algorithm:
+//  1. Build a map of old chunks keyed by StableKey (first occurrence wins
+//     if duplicates exist).
+//  2. For each new chunk, look up its StableKey in the old map:
+//     - Empty StableKey -> Added (cannot match).
+//     - StableKey found and contentHash matches -> Unchanged (reuse embedding).
+//     - StableKey found but contentHash differs -> Modified (re-embed).
+//     - StableKey not found -> Added.
+//  3. Old chunks whose StableKey was never matched -> Deleted.
+//
+// This is a pure function with no side effects or I/O.
+//
+// Precondition: all chunks in newChunks should have StableKeys computed
+// (though some may be empty, which means they cannot match).
+func diffChunks(oldChunks []ChunkWithEmbedding, newChunks []Chunk) chunkDiff {
+	var result chunkDiff
+
+	// Build map: StableKey -> ChunkWithEmbedding (first occurrence wins).
+	// Also track which old chunk IDs made it into the map so we can
+	// correctly identify duplicates as deleted.
+	oldByKey := make(map[string]ChunkWithEmbedding, len(oldChunks))
+	oldIDInMap := make(map[string]bool, len(oldChunks))
+	for _, old := range oldChunks {
+		if old.Chunk.StableKey == "" {
+			continue
+		}
+		if _, exists := oldByKey[old.Chunk.StableKey]; !exists {
+			oldByKey[old.Chunk.StableKey] = old
+			oldIDInMap[old.Chunk.ID] = true
+		}
+	}
+
+	// Track which old chunk IDs were matched by a new chunk.
+	matchedOldIDs := make(map[string]bool, len(oldByKey))
+
+	for _, nc := range newChunks {
+		if nc.StableKey == "" {
+			result.added = append(result.added, nc)
+			continue
+		}
+
+		old, found := oldByKey[nc.StableKey]
+		if !found {
+			result.added = append(result.added, nc)
+			continue
+		}
+
+		matchedOldIDs[old.Chunk.ID] = true
+
+		if contentHash(old.Chunk.Content) == contentHash(nc.Content) {
+			result.unchanged = append(result.unchanged, unchangedChunk{
+				chunk:     nc,
+				embedding: old.Embedding,
+			})
+		} else {
+			result.modified = append(result.modified, modifiedChunk{
+				chunk: nc,
+				oldID: old.Chunk.ID,
+			})
+		}
+	}
+
+	// Any old chunk that was not matched is deleted. This includes:
+	// - Old chunks with empty StableKeys (never entered the map).
+	// - Old chunks whose StableKey was a duplicate (not the first occurrence).
+	// - Old chunks whose StableKey had no corresponding new chunk.
+	for _, old := range oldChunks {
+		if !matchedOldIDs[old.Chunk.ID] {
+			result.deletedIDs = append(result.deletedIDs, old.Chunk.ID)
+		}
+	}
+
+	return result
+}

--- a/rag/chunk_diff_test.go
+++ b/rag/chunk_diff_test.go
@@ -1,0 +1,507 @@
+package rag
+
+import (
+	"testing"
+)
+
+// TestDiffChunksAllUnchanged verifies that when all new chunks have matching
+// StableKeys and identical content, everything is classified as unchanged
+// with embeddings carried through.
+func TestDiffChunksAllUnchanged(t *testing.T) {
+	old := []ChunkWithEmbedding{
+		{
+			Chunk:     Chunk{ID: "c1", Content: "func Hello() {}", StableKey: "main.go::Hello#0"},
+			Embedding: []float64{1.0, 0.0},
+		},
+		{
+			Chunk:     Chunk{ID: "c2", Content: "func World() {}", StableKey: "main.go::World#0"},
+			Embedding: []float64{0.0, 1.0},
+		},
+	}
+
+	newChunks := []Chunk{
+		{ID: "n1", Content: "func Hello() {}", StableKey: "main.go::Hello#0", StartLine: 1},
+		{ID: "n2", Content: "func World() {}", StableKey: "main.go::World#0", StartLine: 5},
+	}
+
+	diff := diffChunks(old, newChunks)
+
+	if len(diff.unchanged) != 2 {
+		t.Errorf("unchanged = %d, want 2", len(diff.unchanged))
+	}
+	if len(diff.modified) != 0 {
+		t.Errorf("modified = %d, want 0", len(diff.modified))
+	}
+	if len(diff.added) != 0 {
+		t.Errorf("added = %d, want 0", len(diff.added))
+	}
+	if len(diff.deletedIDs) != 0 {
+		t.Errorf("deletedIDs = %d, want 0", len(diff.deletedIDs))
+	}
+
+	// Verify cached embeddings are carried through.
+	if len(diff.unchanged[0].embedding) != 2 {
+		t.Error("unchanged[0] embedding not carried through")
+	}
+}
+
+// TestDiffChunksSingleModified verifies that a chunk with the same StableKey
+// but different content is classified as modified with the old ID recorded.
+func TestDiffChunksSingleModified(t *testing.T) {
+	old := []ChunkWithEmbedding{
+		{
+			Chunk:     Chunk{ID: "c1", Content: "func Hello() { return 1 }", StableKey: "main.go::Hello#0"},
+			Embedding: []float64{1.0, 0.0},
+		},
+		{
+			Chunk:     Chunk{ID: "c2", Content: "func World() {}", StableKey: "main.go::World#0"},
+			Embedding: []float64{0.0, 1.0},
+		},
+	}
+
+	newChunks := []Chunk{
+		{ID: "n1", Content: "func Hello() { return 42 }", StableKey: "main.go::Hello#0"},
+		{ID: "n2", Content: "func World() {}", StableKey: "main.go::World#0"},
+	}
+
+	diff := diffChunks(old, newChunks)
+
+	if len(diff.unchanged) != 1 {
+		t.Errorf("unchanged = %d, want 1", len(diff.unchanged))
+	}
+	if len(diff.modified) != 1 {
+		t.Errorf("modified = %d, want 1", len(diff.modified))
+	}
+	if diff.modified[0].chunk.Content != "func Hello() { return 42 }" {
+		t.Errorf("modified content = %q, unexpected", diff.modified[0].chunk.Content)
+	}
+	if diff.modified[0].oldID != "c1" {
+		t.Errorf("modified oldID = %q, want %q", diff.modified[0].oldID, "c1")
+	}
+	if len(diff.added) != 0 {
+		t.Errorf("added = %d, want 0", len(diff.added))
+	}
+	if len(diff.deletedIDs) != 0 {
+		t.Errorf("deletedIDs = %d, want 0", len(diff.deletedIDs))
+	}
+}
+
+// TestDiffChunksNewChunkAdded verifies that a new chunk with a StableKey
+// not present in the old set is classified as added.
+func TestDiffChunksNewChunkAdded(t *testing.T) {
+	old := []ChunkWithEmbedding{
+		{
+			Chunk:     Chunk{ID: "c1", Content: "func Hello() {}", StableKey: "main.go::Hello#0"},
+			Embedding: []float64{1.0, 0.0},
+		},
+	}
+
+	newChunks := []Chunk{
+		{ID: "n1", Content: "func Hello() {}", StableKey: "main.go::Hello#0"},
+		{ID: "n2", Content: "func NewFunc() {}", StableKey: "main.go::NewFunc#0"},
+	}
+
+	diff := diffChunks(old, newChunks)
+
+	if len(diff.unchanged) != 1 {
+		t.Errorf("unchanged = %d, want 1", len(diff.unchanged))
+	}
+	if len(diff.added) != 1 {
+		t.Errorf("added = %d, want 1", len(diff.added))
+	}
+	if diff.added[0].StableKey != "main.go::NewFunc#0" {
+		t.Errorf("added StableKey = %q, want %q", diff.added[0].StableKey, "main.go::NewFunc#0")
+	}
+	if len(diff.deletedIDs) != 0 {
+		t.Errorf("deletedIDs = %d, want 0", len(diff.deletedIDs))
+	}
+}
+
+// TestDiffChunksChunkDeleted verifies that an old chunk with a StableKey
+// not present in the new set is classified as deleted by ID.
+func TestDiffChunksChunkDeleted(t *testing.T) {
+	old := []ChunkWithEmbedding{
+		{
+			Chunk:     Chunk{ID: "c1", Content: "func Hello() {}", StableKey: "main.go::Hello#0"},
+			Embedding: []float64{1.0, 0.0},
+		},
+		{
+			Chunk:     Chunk{ID: "c2", Content: "func Removed() {}", StableKey: "main.go::Removed#0"},
+			Embedding: []float64{0.0, 1.0},
+		},
+	}
+
+	newChunks := []Chunk{
+		{ID: "n1", Content: "func Hello() {}", StableKey: "main.go::Hello#0"},
+	}
+
+	diff := diffChunks(old, newChunks)
+
+	if len(diff.unchanged) != 1 {
+		t.Errorf("unchanged = %d, want 1", len(diff.unchanged))
+	}
+	if len(diff.deletedIDs) != 1 {
+		t.Errorf("deletedIDs = %d, want 1", len(diff.deletedIDs))
+	}
+	if diff.deletedIDs[0] != "c2" {
+		t.Errorf("deletedIDs[0] = %q, want %q", diff.deletedIDs[0], "c2")
+	}
+}
+
+// TestDiffChunksFullRewrite verifies that when all StableKeys change,
+// everything old is deleted and everything new is added.
+func TestDiffChunksFullRewrite(t *testing.T) {
+	old := []ChunkWithEmbedding{
+		{
+			Chunk:     Chunk{ID: "c1", Content: "func Old1() {}", StableKey: "main.go::Old1#0"},
+			Embedding: []float64{1.0},
+		},
+		{
+			Chunk:     Chunk{ID: "c2", Content: "func Old2() {}", StableKey: "main.go::Old2#0"},
+			Embedding: []float64{0.0},
+		},
+	}
+
+	newChunks := []Chunk{
+		{ID: "n1", Content: "func New1() {}", StableKey: "main.go::New1#0"},
+		{ID: "n2", Content: "func New2() {}", StableKey: "main.go::New2#0"},
+	}
+
+	diff := diffChunks(old, newChunks)
+
+	if len(diff.unchanged) != 0 {
+		t.Errorf("unchanged = %d, want 0", len(diff.unchanged))
+	}
+	if len(diff.modified) != 0 {
+		t.Errorf("modified = %d, want 0", len(diff.modified))
+	}
+	if len(diff.added) != 2 {
+		t.Errorf("added = %d, want 2", len(diff.added))
+	}
+	if len(diff.deletedIDs) != 2 {
+		t.Errorf("deletedIDs = %d, want 2", len(diff.deletedIDs))
+	}
+}
+
+// TestDiffChunksEmptyStableKey verifies that new chunks with empty StableKeys
+// are always classified as added (they can never match).
+func TestDiffChunksEmptyStableKey(t *testing.T) {
+	old := []ChunkWithEmbedding{
+		{
+			Chunk:     Chunk{ID: "c1", Content: "old content", StableKey: "main.go::Foo#0"},
+			Embedding: []float64{1.0},
+		},
+	}
+
+	newChunks := []Chunk{
+		{ID: "n1", Content: "new content", StableKey: ""}, // no StableKey
+	}
+
+	diff := diffChunks(old, newChunks)
+
+	// Empty StableKey chunks are always "added" -- they can never match.
+	if len(diff.added) != 1 {
+		t.Errorf("added = %d, want 1", len(diff.added))
+	}
+	// Old chunk with no match in new set is "deleted".
+	if len(diff.deletedIDs) != 1 {
+		t.Errorf("deletedIDs = %d, want 1", len(diff.deletedIDs))
+	}
+}
+
+// TestDiffChunksNoOldChunks verifies that when there are no old chunks
+// (first-time index), all new chunks are classified as added.
+func TestDiffChunksNoOldChunks(t *testing.T) {
+	newChunks := []Chunk{
+		{ID: "n1", Content: "func Hello() {}", StableKey: "main.go::Hello#0"},
+		{ID: "n2", Content: "func World() {}", StableKey: "main.go::World#0"},
+	}
+
+	diff := diffChunks(nil, newChunks)
+
+	if len(diff.added) != 2 {
+		t.Errorf("added = %d, want 2", len(diff.added))
+	}
+	if len(diff.unchanged) != 0 {
+		t.Errorf("unchanged = %d, want 0", len(diff.unchanged))
+	}
+	if len(diff.deletedIDs) != 0 {
+		t.Errorf("deletedIDs = %d, want 0", len(diff.deletedIDs))
+	}
+}
+
+// TestDiffChunksNoNewChunks verifies that when there are no new chunks,
+// all old chunks are classified as deleted.
+func TestDiffChunksNoNewChunks(t *testing.T) {
+	old := []ChunkWithEmbedding{
+		{
+			Chunk:     Chunk{ID: "c1", Content: "func Hello() {}", StableKey: "main.go::Hello#0"},
+			Embedding: []float64{1.0},
+		},
+		{
+			Chunk:     Chunk{ID: "c2", Content: "func World() {}", StableKey: "main.go::World#0"},
+			Embedding: []float64{0.0},
+		},
+	}
+
+	diff := diffChunks(old, nil)
+
+	if len(diff.deletedIDs) != 2 {
+		t.Errorf("deletedIDs = %d, want 2", len(diff.deletedIDs))
+	}
+	if len(diff.added) != 0 {
+		t.Errorf("added = %d, want 0", len(diff.added))
+	}
+	if len(diff.unchanged) != 0 {
+		t.Errorf("unchanged = %d, want 0", len(diff.unchanged))
+	}
+	if len(diff.modified) != 0 {
+		t.Errorf("modified = %d, want 0", len(diff.modified))
+	}
+}
+
+// TestDiffChunksMixed verifies correct classification when there is a mix
+// of unchanged, modified, added, and deleted chunks.
+func TestDiffChunksMixed(t *testing.T) {
+	old := []ChunkWithEmbedding{
+		{
+			Chunk:     Chunk{ID: "c1", Content: "func Unchanged() {}", StableKey: "main.go::Unchanged#0"},
+			Embedding: []float64{1.0, 0.0, 0.0},
+		},
+		{
+			Chunk:     Chunk{ID: "c2", Content: "func Modified() { v1 }", StableKey: "main.go::Modified#0"},
+			Embedding: []float64{0.0, 1.0, 0.0},
+		},
+		{
+			Chunk:     Chunk{ID: "c3", Content: "func Deleted() {}", StableKey: "main.go::Deleted#0"},
+			Embedding: []float64{0.0, 0.0, 1.0},
+		},
+	}
+
+	newChunks := []Chunk{
+		{ID: "n1", Content: "func Unchanged() {}", StableKey: "main.go::Unchanged#0"},
+		{ID: "n2", Content: "func Modified() { v2 }", StableKey: "main.go::Modified#0"},
+		{ID: "n3", Content: "func Added() {}", StableKey: "main.go::Added#0"},
+	}
+
+	diff := diffChunks(old, newChunks)
+
+	if len(diff.unchanged) != 1 {
+		t.Errorf("unchanged = %d, want 1", len(diff.unchanged))
+	}
+	if diff.unchanged[0].chunk.StableKey != "main.go::Unchanged#0" {
+		t.Errorf("unchanged StableKey = %q, want %q", diff.unchanged[0].chunk.StableKey, "main.go::Unchanged#0")
+	}
+
+	if len(diff.modified) != 1 {
+		t.Errorf("modified = %d, want 1", len(diff.modified))
+	}
+	if diff.modified[0].chunk.StableKey != "main.go::Modified#0" {
+		t.Errorf("modified StableKey = %q, want %q", diff.modified[0].chunk.StableKey, "main.go::Modified#0")
+	}
+	if diff.modified[0].oldID != "c2" {
+		t.Errorf("modified oldID = %q, want %q", diff.modified[0].oldID, "c2")
+	}
+
+	if len(diff.added) != 1 {
+		t.Errorf("added = %d, want 1", len(diff.added))
+	}
+	if diff.added[0].StableKey != "main.go::Added#0" {
+		t.Errorf("added StableKey = %q, want %q", diff.added[0].StableKey, "main.go::Added#0")
+	}
+
+	if len(diff.deletedIDs) != 1 {
+		t.Errorf("deletedIDs = %d, want 1", len(diff.deletedIDs))
+	}
+	if diff.deletedIDs[0] != "c3" {
+		t.Errorf("deletedIDs[0] = %q, want %q", diff.deletedIDs[0], "c3")
+	}
+}
+
+// TestDiffChunksDuplicateStableKeys verifies that when old chunks have
+// duplicate StableKeys (shouldn't happen in practice), the first occurrence
+// wins in the map and subsequent duplicates are treated as deleted.
+func TestDiffChunksDuplicateStableKeys(t *testing.T) {
+	old := []ChunkWithEmbedding{
+		{
+			Chunk:     Chunk{ID: "c1", Content: "first", StableKey: "main.go::Dup#0"},
+			Embedding: []float64{1.0},
+		},
+		{
+			Chunk:     Chunk{ID: "c2", Content: "second", StableKey: "main.go::Dup#0"},
+			Embedding: []float64{0.0},
+		},
+	}
+
+	newChunks := []Chunk{
+		{ID: "n1", Content: "first", StableKey: "main.go::Dup#0"},
+	}
+
+	diff := diffChunks(old, newChunks)
+
+	// Should match the first occurrence in old (c1).
+	if len(diff.unchanged) != 1 {
+		t.Errorf("unchanged = %d, want 1", len(diff.unchanged))
+	}
+	// c2 is not matched (duplicate key, only first is used).
+	if len(diff.deletedIDs) != 1 {
+		t.Errorf("deletedIDs = %d, want 1", len(diff.deletedIDs))
+	}
+	if len(diff.deletedIDs) == 1 && diff.deletedIDs[0] != "c2" {
+		t.Errorf("deletedIDs[0] = %q, want %q", diff.deletedIDs[0], "c2")
+	}
+}
+
+// TestDiffChunksOrdinalShift verifies that when a function grows from
+// 1 chunk to 2 chunks, the original ordinal is modified and the new
+// ordinal is added.
+func TestDiffChunksOrdinalShift(t *testing.T) {
+	// Function grows from 1 chunk to 2 chunks.
+	old := []ChunkWithEmbedding{
+		{
+			Chunk:     Chunk{ID: "c1", Content: "func Foo() { small }", StableKey: "main.go::Foo#0"},
+			Embedding: []float64{1.0},
+		},
+	}
+
+	newChunks := []Chunk{
+		{ID: "n1", Content: "func Foo() { much bigger now }", StableKey: "main.go::Foo#0"},
+		{ID: "n2", Content: "// Foo continued", StableKey: "main.go::Foo#1"},
+	}
+
+	diff := diffChunks(old, newChunks)
+
+	// Foo#0 content changed -> modified.
+	if len(diff.modified) != 1 {
+		t.Errorf("modified = %d, want 1", len(diff.modified))
+	}
+	// Foo#1 is new.
+	if len(diff.added) != 1 {
+		t.Errorf("added = %d, want 1", len(diff.added))
+	}
+	if len(diff.deletedIDs) != 0 {
+		t.Errorf("deletedIDs = %d, want 0", len(diff.deletedIDs))
+	}
+}
+
+// TestDiffChunksPreservesNewChunkMetadata verifies that modified chunks
+// use the new chunk's metadata (StartLine, EndLine, etc.) not the old.
+func TestDiffChunksPreservesNewChunkMetadata(t *testing.T) {
+	old := []ChunkWithEmbedding{
+		{
+			Chunk: Chunk{
+				ID: "c1", Content: "func Hello() { return 1 }",
+				StableKey: "main.go::Hello#0", StartLine: 5, EndLine: 7,
+			},
+			Embedding: []float64{1.0},
+		},
+	}
+
+	newChunks := []Chunk{
+		{
+			ID: "n1", Content: "func Hello() { return 42 }",
+			StableKey: "main.go::Hello#0", StartLine: 10, EndLine: 12,
+		},
+	}
+
+	diff := diffChunks(old, newChunks)
+
+	if len(diff.modified) != 1 {
+		t.Fatalf("modified = %d, want 1", len(diff.modified))
+	}
+	// Modified chunk should use the NEW chunk's metadata (StartLine, etc.)
+	if diff.modified[0].chunk.StartLine != 10 {
+		t.Errorf("modified chunk StartLine = %d, want 10", diff.modified[0].chunk.StartLine)
+	}
+	if diff.modified[0].chunk.EndLine != 12 {
+		t.Errorf("modified chunk EndLine = %d, want 12", diff.modified[0].chunk.EndLine)
+	}
+}
+
+// TestDiffChunksUnchangedPreservesNewMetadata verifies that unchanged chunks
+// carry the new chunk's position metadata even though content is the same.
+// This is important when lines above a function are inserted, shifting its
+// StartLine without changing its content.
+func TestDiffChunksUnchangedPreservesNewMetadata(t *testing.T) {
+	old := []ChunkWithEmbedding{
+		{
+			Chunk: Chunk{
+				ID: "c1", Content: "func Hello() {}",
+				StableKey: "main.go::Hello#0", StartLine: 5, EndLine: 7,
+			},
+			Embedding: []float64{1.0, 2.0},
+		},
+	}
+
+	newChunks := []Chunk{
+		{
+			ID: "n1", Content: "func Hello() {}",
+			StableKey: "main.go::Hello#0", StartLine: 15, EndLine: 17,
+		},
+	}
+
+	diff := diffChunks(old, newChunks)
+
+	if len(diff.unchanged) != 1 {
+		t.Fatalf("unchanged = %d, want 1", len(diff.unchanged))
+	}
+	// Should use the new chunk's metadata (shifted StartLine).
+	if diff.unchanged[0].chunk.StartLine != 15 {
+		t.Errorf("unchanged chunk StartLine = %d, want 15", diff.unchanged[0].chunk.StartLine)
+	}
+	// Should carry through the old embedding.
+	if len(diff.unchanged[0].embedding) != 2 {
+		t.Errorf("unchanged embedding length = %d, want 2", len(diff.unchanged[0].embedding))
+	}
+	if diff.unchanged[0].embedding[0] != 1.0 || diff.unchanged[0].embedding[1] != 2.0 {
+		t.Errorf("unchanged embedding = %v, want [1.0 2.0]", diff.unchanged[0].embedding)
+	}
+}
+
+// TestDiffChunksBothEmpty verifies that diffing two empty sets produces
+// an empty result with no panics.
+func TestDiffChunksBothEmpty(t *testing.T) {
+	diff := diffChunks(nil, nil)
+
+	if len(diff.unchanged) != 0 {
+		t.Errorf("unchanged = %d, want 0", len(diff.unchanged))
+	}
+	if len(diff.modified) != 0 {
+		t.Errorf("modified = %d, want 0", len(diff.modified))
+	}
+	if len(diff.added) != 0 {
+		t.Errorf("added = %d, want 0", len(diff.added))
+	}
+	if len(diff.deletedIDs) != 0 {
+		t.Errorf("deletedIDs = %d, want 0", len(diff.deletedIDs))
+	}
+}
+
+// TestDiffChunksOldEmptyStableKeysDeleted verifies that old chunks with
+// empty StableKeys are classified as deleted (they can never be matched).
+func TestDiffChunksOldEmptyStableKeysDeleted(t *testing.T) {
+	old := []ChunkWithEmbedding{
+		{
+			Chunk:     Chunk{ID: "c1", Content: "legacy chunk", StableKey: ""},
+			Embedding: []float64{1.0},
+		},
+	}
+
+	newChunks := []Chunk{
+		{ID: "n1", Content: "new chunk", StableKey: "main.go::Func#0"},
+	}
+
+	diff := diffChunks(old, newChunks)
+
+	// Old chunk with empty StableKey can never match -> deleted.
+	if len(diff.deletedIDs) != 1 {
+		t.Errorf("deletedIDs = %d, want 1", len(diff.deletedIDs))
+	}
+	if len(diff.deletedIDs) == 1 && diff.deletedIDs[0] != "c1" {
+		t.Errorf("deletedIDs[0] = %q, want %q", diff.deletedIDs[0], "c1")
+	}
+	// New chunk has no match -> added.
+	if len(diff.added) != 1 {
+		t.Errorf("added = %d, want 1", len(diff.added))
+	}
+}

--- a/rag/chunker.go
+++ b/rag/chunker.go
@@ -31,6 +31,10 @@ type SlidingWindowChunker struct {
 	overlap int
 }
 
+func (sw *SlidingWindowChunker) sourceSignature() string {
+	return fmt.Sprintf("%T:max=%d:overlap=%d", sw, sw.maxSize, sw.overlap)
+}
+
 // ChunkerOption configures a chunker.
 type ChunkerOption func(*codeChunker)
 

--- a/rag/chunker_code.go
+++ b/rag/chunker_code.go
@@ -15,6 +15,10 @@ type codeChunker struct {
 	language string
 }
 
+func (c *codeChunker) sourceSignature() string {
+	return fmt.Sprintf("%T:max=%d:overlap=%d:language=%s", c, c.maxSize, c.overlap, c.language)
+}
+
 // NewCodeChunker returns a chunker that respects code boundaries.
 // It splits on function/method/class boundaries rather than arbitrary line counts.
 // Falls back to sliding window for non-code files.

--- a/rag/incremental.go
+++ b/rag/incremental.go
@@ -28,6 +28,13 @@ type sourceHashChecker interface {
 	GetSourceHash(ctx context.Context, source string) (string, error)
 }
 
+// chunkerSignatureProvider lets built-in chunkers describe the configuration
+// that affects chunk boundaries. Configuration changes must invalidate the
+// source signature even when the concrete chunker type stays the same.
+type chunkerSignatureProvider interface {
+	sourceSignature() string
+}
+
 // sourceSignatureVersion identifies the persisted source signature format.
 // Bump this when the index inputs change in a way that requires full re-embed.
 const sourceSignatureVersion = 1
@@ -68,12 +75,19 @@ func parseSourceSignature(raw string) (sourceSignature, bool) {
 	return sig, true
 }
 
+func chunkerSignature(chunker Chunker) string {
+	if sig, ok := chunker.(chunkerSignatureProvider); ok {
+		return sig.sourceSignature()
+	}
+	return fmt.Sprintf("%T", chunker)
+}
+
 func (idx *Indexer) currentSourceSignature(content string) sourceSignature {
 	return sourceSignature{
 		Version:          sourceSignatureVersion,
 		ContentHash:      contentHash(content),
 		EmbeddingModel:   idx.model,
-		Chunker:          fmt.Sprintf("%T", idx.chunker),
+		Chunker:          chunkerSignature(idx.chunker),
 		StableKeyVersion: stableKeyVersion,
 	}
 }

--- a/rag/incremental.go
+++ b/rag/incremental.go
@@ -1,0 +1,35 @@
+package rag
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+)
+
+// ChunkWithEmbedding pairs a stored chunk with its embedding vector.
+// Used by GetBySource to return chunk data needed for incremental comparison.
+type ChunkWithEmbedding struct {
+	Chunk     Chunk
+	Embedding []float64
+}
+
+// sourceChunkLoader is an optional store capability for loading existing
+// chunks with embeddings by source path. Required for incremental indexing.
+// Implementations should return chunks ordered by start_line.
+type sourceChunkLoader interface {
+	GetBySource(ctx context.Context, source string) ([]ChunkWithEmbedding, error)
+}
+
+// sourceHashChecker is an optional store capability for fast file-level
+// change detection. Returns the stored content hash for a source, or
+// empty string if not found.
+type sourceHashChecker interface {
+	GetSourceHash(ctx context.Context, source string) (string, error)
+}
+
+// contentHash computes a SHA-256 hex digest of the given content.
+// Used to detect chunk-level and file-level content changes.
+func contentHash(content string) string {
+	h := sha256.Sum256([]byte(content))
+	return fmt.Sprintf("%x", h)
+}

--- a/rag/incremental.go
+++ b/rag/incremental.go
@@ -3,6 +3,7 @@ package rag
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 )
 
@@ -21,10 +22,70 @@ type sourceChunkLoader interface {
 }
 
 // sourceHashChecker is an optional store capability for fast file-level
-// change detection. Returns the stored content hash for a source, or
-// empty string if not found.
+// change detection. Returns the stored source index signature for a
+// source, or empty string if not found.
 type sourceHashChecker interface {
 	GetSourceHash(ctx context.Context, source string) (string, error)
+}
+
+// sourceSignatureVersion identifies the persisted source signature format.
+// Bump this when the index inputs change in a way that requires full re-embed.
+const sourceSignatureVersion = 1
+
+// sourceSignature captures the inputs that determine whether persisted
+// embeddings can be safely reused for a source file.
+type sourceSignature struct {
+	Version          int    `json:"version"`
+	ContentHash      string `json:"content_hash"`
+	EmbeddingModel   string `json:"embedding_model"`
+	Chunker          string `json:"chunker"`
+	StableKeyVersion string `json:"stable_key_version"`
+}
+
+func (s sourceSignature) String() string {
+	data, err := json.Marshal(s)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func (s sourceSignature) compatibleWith(other sourceSignature) bool {
+	return s.Version == other.Version &&
+		s.EmbeddingModel == other.EmbeddingModel &&
+		s.Chunker == other.Chunker &&
+		s.StableKeyVersion == other.StableKeyVersion
+}
+
+func parseSourceSignature(raw string) (sourceSignature, bool) {
+	var sig sourceSignature
+	if err := json.Unmarshal([]byte(raw), &sig); err != nil {
+		return sourceSignature{}, false
+	}
+	if sig.Version == 0 || sig.ContentHash == "" {
+		return sourceSignature{}, false
+	}
+	return sig, true
+}
+
+func (idx *Indexer) currentSourceSignature(content string) sourceSignature {
+	return sourceSignature{
+		Version:          sourceSignatureVersion,
+		ContentHash:      contentHash(content),
+		EmbeddingModel:   idx.model,
+		Chunker:          fmt.Sprintf("%T", idx.chunker),
+		StableKeyVersion: stableKeyVersion,
+	}
+}
+
+func (idx *Indexer) requiresFullReembed(stored string, current sourceSignature) bool {
+	storedSig, ok := parseSourceSignature(stored)
+	if !ok {
+		// Legacy rows only stored a raw content hash, so the embedding model
+		// and chunker identity are unknown. Re-embed once to upgrade safely.
+		return true
+	}
+	return !storedSig.compatibleWith(current)
 }
 
 // contentHash computes a SHA-256 hex digest of the given content.

--- a/rag/incremental_test.go
+++ b/rag/incremental_test.go
@@ -193,3 +193,23 @@ func TestMockSourceHashChecker(t *testing.T) {
 		t.Errorf("hash = %q, want empty string", hash)
 	}
 }
+
+func TestChunkerSignatureIncludesConfig(t *testing.T) {
+	swA, err := NewSlidingWindowChunker(64, 8)
+	if err != nil {
+		t.Fatalf("NewSlidingWindowChunker() error: %v", err)
+	}
+	swB, err := NewSlidingWindowChunker(96, 8)
+	if err != nil {
+		t.Fatalf("NewSlidingWindowChunker() error: %v", err)
+	}
+	if gotA, gotB := chunkerSignature(swA), chunkerSignature(swB); gotA == gotB {
+		t.Errorf("sliding window chunker signatures should differ when config changes: %q == %q", gotA, gotB)
+	}
+
+	codeA := NewCodeChunker(WithMaxChunkSize(128), WithOverlap(16), WithLanguage("go"))
+	codeB := NewCodeChunker(WithMaxChunkSize(256), WithOverlap(16), WithLanguage("go"))
+	if gotA, gotB := chunkerSignature(codeA), chunkerSignature(codeB); gotA == gotB {
+		t.Errorf("code chunker signatures should differ when config changes: %q == %q", gotA, gotB)
+	}
+}

--- a/rag/incremental_test.go
+++ b/rag/incremental_test.go
@@ -1,0 +1,199 @@
+package rag
+
+import (
+	"context"
+	"testing"
+)
+
+func TestContentHash(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantLen int // SHA-256 hex = 64 chars
+	}{
+		{"non-empty string", "hello world", 64},
+		{"empty string", "", 64},
+		{"unicode content", "func main() { fmt.Println(\"こんにちは\") }", 64},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := contentHash(tt.input)
+			if len(got) != tt.wantLen {
+				t.Errorf("contentHash(%q) length = %d, want %d", tt.input, len(got), tt.wantLen)
+			}
+		})
+	}
+
+	t.Run("deterministic", func(t *testing.T) {
+		a := contentHash("some content")
+		b := contentHash("some content")
+		if a != b {
+			t.Errorf("contentHash is not deterministic: %q != %q", a, b)
+		}
+	})
+
+	t.Run("different inputs produce different hashes", func(t *testing.T) {
+		a := contentHash("hello")
+		b := contentHash("world")
+		if a == b {
+			t.Errorf("different inputs produced same hash: %q", a)
+		}
+	})
+
+	t.Run("empty string has a hash", func(t *testing.T) {
+		got := contentHash("")
+		if got == "" {
+			t.Error("contentHash(\"\") returned empty string")
+		}
+		// SHA-256 of empty string is well-known.
+		want := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+		if got != want {
+			t.Errorf("contentHash(\"\") = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestChunkWithEmbedding(t *testing.T) {
+	chunk := Chunk{
+		ID:        "test-id",
+		Content:   "func main() {}",
+		Source:    "main.go",
+		StartLine: 1,
+		EndLine:   3,
+		Language:  "go",
+		Metadata:  map[string]string{"key": "value"},
+	}
+	embedding := []float64{0.1, 0.2, 0.3}
+
+	cwe := ChunkWithEmbedding{
+		Chunk:     chunk,
+		Embedding: embedding,
+	}
+
+	if cwe.Chunk.ID != "test-id" {
+		t.Errorf("Chunk.ID = %q, want %q", cwe.Chunk.ID, "test-id")
+	}
+	if cwe.Chunk.Content != "func main() {}" {
+		t.Errorf("Chunk.Content = %q, want %q", cwe.Chunk.Content, "func main() {}")
+	}
+	if cwe.Chunk.Source != "main.go" {
+		t.Errorf("Chunk.Source = %q, want %q", cwe.Chunk.Source, "main.go")
+	}
+	if len(cwe.Embedding) != 3 {
+		t.Errorf("Embedding length = %d, want 3", len(cwe.Embedding))
+	}
+	if cwe.Embedding[0] != 0.1 || cwe.Embedding[1] != 0.2 || cwe.Embedding[2] != 0.3 {
+		t.Errorf("Embedding = %v, want [0.1 0.2 0.3]", cwe.Embedding)
+	}
+}
+
+// TestSourceChunkLoaderInterface verifies that sourceChunkLoader compiles
+// and can be used as an interface type in type assertions.
+func TestSourceChunkLoaderInterface(t *testing.T) {
+	var store VectorStore = newTestStore(t)
+
+	// sourceChunkLoader is optional — SQLiteStore does not implement it yet.
+	// This test verifies the interface is well-formed by attempting a type assertion.
+	if _, ok := store.(sourceChunkLoader); ok {
+		t.Log("SQLiteStore implements sourceChunkLoader (will be added in a later task)")
+	}
+}
+
+// TestSourceHashCheckerInterface verifies that sourceHashChecker compiles
+// and can be used as an interface type in type assertions.
+func TestSourceHashCheckerInterface(t *testing.T) {
+	var store VectorStore = newTestStore(t)
+
+	// sourceHashChecker is optional — SQLiteStore does not implement it yet.
+	// This test verifies the interface is well-formed by attempting a type assertion.
+	if _, ok := store.(sourceHashChecker); ok {
+		t.Log("SQLiteStore implements sourceHashChecker (will be added in a later task)")
+	}
+}
+
+// mockSourceChunkLoader is a test double that implements sourceChunkLoader.
+type mockSourceChunkLoader struct {
+	chunks map[string][]ChunkWithEmbedding
+}
+
+func (m *mockSourceChunkLoader) GetBySource(_ context.Context, source string) ([]ChunkWithEmbedding, error) {
+	return m.chunks[source], nil
+}
+
+// mockSourceHashChecker is a test double that implements sourceHashChecker.
+type mockSourceHashChecker struct {
+	hashes map[string]string
+}
+
+func (m *mockSourceHashChecker) GetSourceHash(_ context.Context, source string) (string, error) {
+	return m.hashes[source], nil
+}
+
+// TestMockSourceChunkLoader verifies that the mock satisfies the interface
+// and returns expected data.
+func TestMockSourceChunkLoader(t *testing.T) {
+	mock := &mockSourceChunkLoader{
+		chunks: map[string][]ChunkWithEmbedding{
+			"main.go": {
+				{
+					Chunk:     Chunk{ID: "c1", Content: "func main()", Source: "main.go", StartLine: 1, EndLine: 5},
+					Embedding: []float64{1.0, 0.0},
+				},
+			},
+		},
+	}
+
+	var loader sourceChunkLoader = mock
+	ctx := context.Background()
+
+	results, err := loader.GetBySource(ctx, "main.go")
+	if err != nil {
+		t.Fatalf("GetBySource() error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Chunk.ID != "c1" {
+		t.Errorf("Chunk.ID = %q, want %q", results[0].Chunk.ID, "c1")
+	}
+
+	// Non-existent source returns nil/empty.
+	results, err = loader.GetBySource(ctx, "nonexistent.go")
+	if err != nil {
+		t.Fatalf("GetBySource() error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("got %d results for nonexistent source, want 0", len(results))
+	}
+}
+
+// TestMockSourceHashChecker verifies that the mock satisfies the interface
+// and returns expected data.
+func TestMockSourceHashChecker(t *testing.T) {
+	mock := &mockSourceHashChecker{
+		hashes: map[string]string{
+			"main.go": "abc123",
+		},
+	}
+
+	var checker sourceHashChecker = mock
+	ctx := context.Background()
+
+	hash, err := checker.GetSourceHash(ctx, "main.go")
+	if err != nil {
+		t.Fatalf("GetSourceHash() error: %v", err)
+	}
+	if hash != "abc123" {
+		t.Errorf("hash = %q, want %q", hash, "abc123")
+	}
+
+	// Non-existent source returns empty string.
+	hash, err = checker.GetSourceHash(ctx, "nonexistent.go")
+	if err != nil {
+		t.Fatalf("GetSourceHash() error: %v", err)
+	}
+	if hash != "" {
+		t.Errorf("hash = %q, want empty string", hash)
+	}
+}

--- a/rag/incremental_test.go
+++ b/rag/incremental_test.go
@@ -1,0 +1,195 @@
+package rag
+
+import (
+	"context"
+	"testing"
+)
+
+func TestContentHash(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantLen int // SHA-256 hex = 64 chars
+	}{
+		{"non-empty string", "hello world", 64},
+		{"empty string", "", 64},
+		{"unicode content", "func main() { fmt.Println(\"こんにちは\") }", 64},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := contentHash(tt.input)
+			if len(got) != tt.wantLen {
+				t.Errorf("contentHash(%q) length = %d, want %d", tt.input, len(got), tt.wantLen)
+			}
+		})
+	}
+
+	t.Run("deterministic", func(t *testing.T) {
+		a := contentHash("some content")
+		b := contentHash("some content")
+		if a != b {
+			t.Errorf("contentHash is not deterministic: %q != %q", a, b)
+		}
+	})
+
+	t.Run("different inputs produce different hashes", func(t *testing.T) {
+		a := contentHash("hello")
+		b := contentHash("world")
+		if a == b {
+			t.Errorf("different inputs produced same hash: %q", a)
+		}
+	})
+
+	t.Run("empty string has a hash", func(t *testing.T) {
+		got := contentHash("")
+		if got == "" {
+			t.Error("contentHash(\"\") returned empty string")
+		}
+		// SHA-256 of empty string is well-known.
+		want := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+		if got != want {
+			t.Errorf("contentHash(\"\") = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestChunkWithEmbedding(t *testing.T) {
+	chunk := Chunk{
+		ID:        "test-id",
+		Content:   "func main() {}",
+		Source:    "main.go",
+		StartLine: 1,
+		EndLine:   3,
+		Language:  "go",
+		Metadata:  map[string]string{"key": "value"},
+	}
+	embedding := []float64{0.1, 0.2, 0.3}
+
+	cwe := ChunkWithEmbedding{
+		Chunk:     chunk,
+		Embedding: embedding,
+	}
+
+	if cwe.Chunk.ID != "test-id" {
+		t.Errorf("Chunk.ID = %q, want %q", cwe.Chunk.ID, "test-id")
+	}
+	if cwe.Chunk.Content != "func main() {}" {
+		t.Errorf("Chunk.Content = %q, want %q", cwe.Chunk.Content, "func main() {}")
+	}
+	if cwe.Chunk.Source != "main.go" {
+		t.Errorf("Chunk.Source = %q, want %q", cwe.Chunk.Source, "main.go")
+	}
+	if len(cwe.Embedding) != 3 {
+		t.Errorf("Embedding length = %d, want 3", len(cwe.Embedding))
+	}
+	if cwe.Embedding[0] != 0.1 || cwe.Embedding[1] != 0.2 || cwe.Embedding[2] != 0.3 {
+		t.Errorf("Embedding = %v, want [0.1 0.2 0.3]", cwe.Embedding)
+	}
+}
+
+// TestSourceChunkLoaderInterface verifies that sourceChunkLoader compiles
+// and can be used as an interface type in type assertions.
+func TestSourceChunkLoaderInterface(t *testing.T) {
+	var store VectorStore = newTestStore(t)
+
+	if _, ok := store.(sourceChunkLoader); ok {
+		t.Log("SQLiteStore implements sourceChunkLoader")
+	}
+}
+
+// TestSourceHashCheckerInterface verifies that sourceHashChecker compiles
+// and can be used as an interface type in type assertions.
+func TestSourceHashCheckerInterface(t *testing.T) {
+	var store VectorStore = newTestStore(t)
+
+	if _, ok := store.(sourceHashChecker); ok {
+		t.Log("SQLiteStore implements sourceHashChecker")
+	}
+}
+
+// mockSourceChunkLoader is a test double that implements sourceChunkLoader.
+type mockSourceChunkLoader struct {
+	chunks map[string][]ChunkWithEmbedding
+}
+
+func (m *mockSourceChunkLoader) GetBySource(_ context.Context, source string) ([]ChunkWithEmbedding, error) {
+	return m.chunks[source], nil
+}
+
+// mockSourceHashChecker is a test double that implements sourceHashChecker.
+type mockSourceHashChecker struct {
+	hashes map[string]string
+}
+
+func (m *mockSourceHashChecker) GetSourceHash(_ context.Context, source string) (string, error) {
+	return m.hashes[source], nil
+}
+
+// TestMockSourceChunkLoader verifies that the mock satisfies the interface
+// and returns expected data.
+func TestMockSourceChunkLoader(t *testing.T) {
+	mock := &mockSourceChunkLoader{
+		chunks: map[string][]ChunkWithEmbedding{
+			"main.go": {
+				{
+					Chunk:     Chunk{ID: "c1", Content: "func main()", Source: "main.go", StartLine: 1, EndLine: 5},
+					Embedding: []float64{1.0, 0.0},
+				},
+			},
+		},
+	}
+
+	var loader sourceChunkLoader = mock
+	ctx := context.Background()
+
+	results, err := loader.GetBySource(ctx, "main.go")
+	if err != nil {
+		t.Fatalf("GetBySource() error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Chunk.ID != "c1" {
+		t.Errorf("Chunk.ID = %q, want %q", results[0].Chunk.ID, "c1")
+	}
+
+	// Non-existent source returns nil/empty.
+	results, err = loader.GetBySource(ctx, "nonexistent.go")
+	if err != nil {
+		t.Fatalf("GetBySource() error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("got %d results for nonexistent source, want 0", len(results))
+	}
+}
+
+// TestMockSourceHashChecker verifies that the mock satisfies the interface
+// and returns expected data.
+func TestMockSourceHashChecker(t *testing.T) {
+	mock := &mockSourceHashChecker{
+		hashes: map[string]string{
+			"main.go": "abc123",
+		},
+	}
+
+	var checker sourceHashChecker = mock
+	ctx := context.Background()
+
+	hash, err := checker.GetSourceHash(ctx, "main.go")
+	if err != nil {
+		t.Fatalf("GetSourceHash() error: %v", err)
+	}
+	if hash != "abc123" {
+		t.Errorf("hash = %q, want %q", hash, "abc123")
+	}
+
+	// Non-existent source returns empty string.
+	hash, err = checker.GetSourceHash(ctx, "nonexistent.go")
+	if err != nil {
+		t.Fatalf("GetSourceHash() error: %v", err)
+	}
+	if hash != "" {
+		t.Errorf("hash = %q, want empty string", hash)
+	}
+}

--- a/rag/indexer.go
+++ b/rag/indexer.go
@@ -31,6 +31,12 @@ type atomicSourceReplacer interface {
 	ReplaceSource(ctx context.Context, source string, chunks []Chunk, embeddings [][]float64) error
 }
 
+// atomicSourceReplacerWithHash extends atomicSourceReplacer to include
+// the source content hash for incremental indexing change detection.
+type atomicSourceReplacerWithHash interface {
+	ReplaceSourceWithHash(ctx context.Context, source string, chunks []Chunk, embeddings [][]float64, sourceHash string) error
+}
+
 // IndexerOption configures an Indexer.
 type IndexerOption func(*Indexer)
 
@@ -76,8 +82,16 @@ func NewIndexer(client *ollama.Client, store VectorStore, opts ...IndexerOption)
 }
 
 func (idx *Indexer) replaceSource(ctx context.Context, path string, chunks []Chunk, embeddings [][]float64) error {
+	return idx.replaceSourceWithHash(ctx, path, chunks, embeddings, "")
+}
+
+func (idx *Indexer) replaceSourceWithHash(ctx context.Context, path string, chunks []Chunk, embeddings [][]float64, sourceHash string) error {
 	idx.storeMu.Lock()
 	defer idx.storeMu.Unlock()
+
+	if replacer, ok := idx.store.(atomicSourceReplacerWithHash); ok {
+		return replacer.ReplaceSourceWithHash(ctx, path, chunks, embeddings, sourceHash)
+	}
 
 	if replacer, ok := idx.store.(atomicSourceReplacer); ok {
 		return replacer.ReplaceSource(ctx, path, chunks, embeddings)

--- a/rag/indexer.go
+++ b/rag/indexer.go
@@ -183,6 +183,7 @@ type indexDirConfig struct {
 	extensions  map[string]bool
 	exclude     []string
 	concurrency int
+	incremental bool
 }
 
 // WithExtensions sets which file extensions to index (default: .go, .py, .ts, .tsx, .js, .md).
@@ -210,6 +211,17 @@ func WithExclude(patterns ...string) IndexDirOption {
 func WithConcurrency(n int) IndexDirOption {
 	return func(cfg *indexDirConfig) {
 		cfg.concurrency = n
+	}
+}
+
+// WithIncremental enables incremental indexing for IndexDirectory.
+// When enabled, each file uses IndexFileIncremental which diffs against
+// stored chunks and only embeds changed content. Files indexed for the
+// first time or whose store lacks incremental support transparently
+// fall back to full indexing.
+func WithIncremental() IndexDirOption {
+	return func(cfg *indexDirConfig) {
+		cfg.incremental = true
 	}
 }
 
@@ -334,9 +346,15 @@ func (idx *Indexer) IndexDirectory(ctx context.Context, dir string, opts ...Inde
 			break
 		}
 		g.Go(func() error {
-			if err := idx.IndexFile(ctx, path); err != nil {
+			var indexErr error
+			if cfg.incremental {
+				indexErr = idx.IndexFileIncremental(ctx, path)
+			} else {
+				indexErr = idx.IndexFile(ctx, path)
+			}
+			if indexErr != nil {
 				mu.Lock()
-				indexErrors = append(indexErrors, fmt.Sprintf("index %q: %v", path, err))
+				indexErrors = append(indexErrors, fmt.Sprintf("index %q: %v", path, indexErr))
 				mu.Unlock()
 			}
 			return nil

--- a/rag/indexer.go
+++ b/rag/indexer.go
@@ -166,9 +166,9 @@ func (idx *Indexer) IndexFile(ctx context.Context, path string) error {
 		return fmt.Errorf("rag: embed chunks for %q: %w", path, err)
 	}
 
-	// Step 3: Replace old chunks with new ones. Store the content hash so
-	// subsequent IndexFileIncremental calls can use the fast path.
-	sourceHash := contentHash(content)
+	// Step 3: Replace old chunks with new ones. Store the source signature so
+	// subsequent IndexFileIncremental calls can safely use the fast path.
+	sourceHash := idx.currentSourceSignature(content).String()
 	if err := idx.replaceSourceWithHash(ctx, path, chunks, embeddings, sourceHash); err != nil {
 		return fmt.Errorf("rag: replace chunks for %q: %w", path, err)
 	}

--- a/rag/indexer.go
+++ b/rag/indexer.go
@@ -166,8 +166,10 @@ func (idx *Indexer) IndexFile(ctx context.Context, path string) error {
 		return fmt.Errorf("rag: embed chunks for %q: %w", path, err)
 	}
 
-	// Step 3: Replace old chunks with new ones.
-	if err := idx.replaceSource(ctx, path, chunks, embeddings); err != nil {
+	// Step 3: Replace old chunks with new ones. Store the content hash so
+	// subsequent IndexFileIncremental calls can use the fast path.
+	sourceHash := contentHash(content)
+	if err := idx.replaceSourceWithHash(ctx, path, chunks, embeddings, sourceHash); err != nil {
 		return fmt.Errorf("rag: replace chunks for %q: %w", path, err)
 	}
 

--- a/rag/indexer_incremental.go
+++ b/rag/indexer_incremental.go
@@ -151,6 +151,13 @@ func (idx *Indexer) indexIncremental(ctx context.Context, path string, newChunks
 
 	// Short circuit: nothing changed.
 	if len(diff.modified) == 0 && len(diff.added) == 0 && len(diff.deletedIDs) == 0 {
+		// Persist the source hash if it wasn't stored yet (e.g. migrated V3 database).
+		// Without this, the file-level fast path never activates for pre-existing data.
+		if checker, ok := idx.store.(sourceHashChecker); ok {
+			if stored, _ := checker.GetSourceHash(ctx, path); stored != sourceHash {
+				idx.updateSourceHash(ctx, path, sourceHash)
+			}
+		}
 		return nil
 	}
 
@@ -195,4 +202,16 @@ func (idx *Indexer) indexIncremental(ctx context.Context, path string, newChunks
 		return fmt.Errorf("rag: replace chunks for %q: %w", path, err)
 	}
 	return nil
+}
+
+// updateSourceHash updates the source_content_hash for all chunks of a source
+// without re-inserting them. Used when chunks are unchanged but the hash was
+// not previously stored (e.g. databases migrated from V3).
+func (idx *Indexer) updateSourceHash(ctx context.Context, source, hash string) {
+	type hashUpdater interface {
+		UpdateSourceHash(ctx context.Context, source, hash string) error
+	}
+	if u, ok := idx.store.(hashUpdater); ok {
+		_ = u.UpdateSourceHash(ctx, source, hash)
+	}
 }

--- a/rag/indexer_incremental.go
+++ b/rag/indexer_incremental.go
@@ -59,13 +59,18 @@ func (idx *Indexer) IndexFileIncremental(ctx context.Context, path string) error
 		return nil
 	}
 
-	// Fast path: if the file content hash matches the stored hash, skip entirely.
-	// This avoids chunking, GetBySource, and all comparison work.
-	fileHash := contentHash(content)
+	// Fast path: if the full source signature matches the stored signature, skip
+	// entirely. This avoids chunking, GetBySource, and all comparison work.
+	currentSig := idx.currentSourceSignature(content)
+	sourceHash := currentSig.String()
+	forceFullReembed := false
 	if checker, ok := idx.store.(sourceHashChecker); ok {
 		storedHash, hashErr := checker.GetSourceHash(ctx, path)
-		if hashErr == nil && storedHash != "" && storedHash == fileHash {
-			return nil
+		if hashErr == nil && storedHash != "" {
+			if storedHash == sourceHash {
+				return nil
+			}
+			forceFullReembed = idx.requiresFullReembed(storedHash, currentSig)
 		}
 	}
 
@@ -94,8 +99,8 @@ func (idx *Indexer) IndexFileIncremental(ctx context.Context, path string) error
 	}
 
 	// Try incremental path.
-	if idx.canDoIncremental(chunks) {
-		err := idx.indexIncremental(ctx, path, chunks, fileHash)
+	if !forceFullReembed && idx.canDoIncremental(chunks) {
+		err := idx.indexIncremental(ctx, path, chunks, sourceHash)
 		if err == nil {
 			return nil
 		}
@@ -118,7 +123,7 @@ func (idx *Indexer) IndexFileIncremental(ctx context.Context, path string) error
 		return fmt.Errorf("rag: embed chunks for %q: %w", path, err)
 	}
 
-	if err := idx.replaceSourceWithHash(ctx, path, chunks, embeddings, fileHash); err != nil {
+	if err := idx.replaceSourceWithHash(ctx, path, chunks, embeddings, sourceHash); err != nil {
 		return fmt.Errorf("rag: replace chunks for %q: %w", path, err)
 	}
 	return nil
@@ -127,7 +132,7 @@ func (idx *Indexer) IndexFileIncremental(ctx context.Context, path string) error
 // indexIncremental is the internal incremental indexing path.
 // It assumes preconditions have been checked (store supports GetBySource,
 // workspace root is set, StableKeys are computed). The sourceHash is the
-// pre-computed content hash that will be stored alongside the new chunks.
+// pre-computed source signature that will be stored alongside the new chunks.
 //
 // Returns a non-nil error on any failure. The caller falls back to full
 // re-indexing when this returns an error.
@@ -214,8 +219,8 @@ func (idx *Indexer) indexIncremental(ctx context.Context, path string, newChunks
 }
 
 // updateSourceHash updates the source_content_hash for all chunks of a source
-// without re-inserting them. Used when chunks are unchanged but the hash was
-// not previously stored (e.g. databases migrated from V3).
+// without re-inserting them. Used when chunks are unchanged but the signature
+// was not previously stored (e.g. databases migrated from V3).
 func (idx *Indexer) updateSourceHash(ctx context.Context, source, hash string) {
 	type hashUpdater interface {
 		UpdateSourceHash(ctx context.Context, source, hash string) error

--- a/rag/indexer_incremental.go
+++ b/rag/indexer_incremental.go
@@ -59,6 +59,16 @@ func (idx *Indexer) IndexFileIncremental(ctx context.Context, path string) error
 		return nil
 	}
 
+	// Fast path: if the file content hash matches the stored hash, skip entirely.
+	// This avoids chunking, GetBySource, and all comparison work.
+	fileHash := contentHash(content)
+	if checker, ok := idx.store.(sourceHashChecker); ok {
+		storedHash, hashErr := checker.GetSourceHash(ctx, path)
+		if hashErr == nil && storedHash != "" && storedHash == fileHash {
+			return nil
+		}
+	}
+
 	// Step 1: Chunk the file (always needed -- chunking is cheap).
 	chunks, err := idx.chunker.Chunk(path, content)
 	if err != nil {
@@ -85,7 +95,7 @@ func (idx *Indexer) IndexFileIncremental(ctx context.Context, path string) error
 
 	// Try incremental path.
 	if idx.canDoIncremental(chunks) {
-		err := idx.indexIncremental(ctx, path, content, chunks)
+		err := idx.indexIncremental(ctx, path, chunks, fileHash)
 		if err == nil {
 			return nil
 		}
@@ -108,8 +118,7 @@ func (idx *Indexer) IndexFileIncremental(ctx context.Context, path string) error
 		return fmt.Errorf("rag: embed chunks for %q: %w", path, err)
 	}
 
-	sourceHash := contentHash(content)
-	if err := idx.replaceSourceWithHash(ctx, path, chunks, embeddings, sourceHash); err != nil {
+	if err := idx.replaceSourceWithHash(ctx, path, chunks, embeddings, fileHash); err != nil {
 		return fmt.Errorf("rag: replace chunks for %q: %w", path, err)
 	}
 	return nil
@@ -117,11 +126,12 @@ func (idx *Indexer) IndexFileIncremental(ctx context.Context, path string) error
 
 // indexIncremental is the internal incremental indexing path.
 // It assumes preconditions have been checked (store supports GetBySource,
-// workspace root is set, StableKeys are computed).
+// workspace root is set, StableKeys are computed). The sourceHash is the
+// pre-computed content hash that will be stored alongside the new chunks.
 //
 // Returns a non-nil error on any failure. The caller falls back to full
 // re-indexing when this returns an error.
-func (idx *Indexer) indexIncremental(ctx context.Context, path string, content string, newChunks []Chunk) error {
+func (idx *Indexer) indexIncremental(ctx context.Context, path string, newChunks []Chunk, sourceHash string) error {
 	loader, ok := idx.store.(sourceChunkLoader)
 	if !ok {
 		return fmt.Errorf("rag: store does not support GetBySource")
@@ -181,7 +191,6 @@ func (idx *Indexer) indexIncremental(ctx context.Context, path string, content s
 	}
 
 	// Atomically replace source with the full new chunk set.
-	sourceHash := contentHash(content)
 	if err := idx.replaceSourceWithHash(ctx, path, newChunks, finalEmbeddings, sourceHash); err != nil {
 		return fmt.Errorf("rag: replace chunks for %q: %w", path, err)
 	}

--- a/rag/indexer_incremental.go
+++ b/rag/indexer_incremental.go
@@ -66,11 +66,17 @@ func (idx *Indexer) IndexFileIncremental(ctx context.Context, path string) error
 	forceFullReembed := false
 	if checker, ok := idx.store.(sourceHashChecker); ok {
 		storedHash, hashErr := checker.GetSourceHash(ctx, path)
-		if hashErr == nil && storedHash != "" {
-			if storedHash == sourceHash {
-				return nil
+		if hashErr == nil {
+			if storedHash == "" {
+				// Rows migrated from earlier schema versions have no persisted
+				// provenance, so unchanged chunks cannot be safely reused.
+				forceFullReembed = true
+			} else {
+				if storedHash == sourceHash {
+					return nil
+				}
+				forceFullReembed = idx.requiresFullReembed(storedHash, currentSig)
 			}
-			forceFullReembed = idx.requiresFullReembed(storedHash, currentSig)
 		}
 	}
 

--- a/rag/indexer_incremental.go
+++ b/rag/indexer_incremental.go
@@ -149,16 +149,22 @@ func (idx *Indexer) indexIncremental(ctx context.Context, path string, newChunks
 	// Diff old vs. new.
 	diff := diffChunks(oldChunks, newChunks)
 
-	// Short circuit: nothing changed.
+	// Short circuit: nothing changed content-wise.
+	// Even though chunk content is unchanged, metadata (StartLine/EndLine) may
+	// have shifted if lines were added/removed between functions. We still need
+	// to write the updated chunks to keep line references accurate.
 	if len(diff.modified) == 0 && len(diff.added) == 0 && len(diff.deletedIDs) == 0 {
-		// Persist the source hash if it wasn't stored yet (e.g. migrated V3 database).
-		// Without this, the file-level fast path never activates for pre-existing data.
-		if checker, ok := idx.store.(sourceHashChecker); ok {
-			if stored, _ := checker.GetSourceHash(ctx, path); stored != sourceHash {
-				idx.updateSourceHash(ctx, path, sourceHash)
+		// Reuse all existing embeddings — no embed calls needed.
+		finalEmbeddings := make([][]float64, len(newChunks))
+		for i, nc := range newChunks {
+			for _, uc := range diff.unchanged {
+				if uc.chunk.StableKey == nc.StableKey {
+					finalEmbeddings[i] = uc.embedding
+					break
+				}
 			}
 		}
-		return nil
+		return idx.replaceSourceWithHash(ctx, path, newChunks, finalEmbeddings, sourceHash)
 	}
 
 	// Build a map from StableKey -> cached embedding for unchanged chunks.
@@ -192,6 +198,9 @@ func (idx *Indexer) indexIncremental(ctx context.Context, path string, newChunks
 		if emb, cached := cachedEmbeddings[nc.StableKey]; cached {
 			finalEmbeddings[i] = emb
 		} else {
+			if freshIdx >= len(freshEmbeddings) {
+				return fmt.Errorf("rag: incremental index %q: embedding count mismatch (expected %d, got %d)", path, len(textsToEmbed), len(freshEmbeddings))
+			}
 			finalEmbeddings[i] = freshEmbeddings[freshIdx]
 			freshIdx++
 		}

--- a/rag/indexer_incremental.go
+++ b/rag/indexer_incremental.go
@@ -1,0 +1,189 @@
+package rag
+
+import (
+	"context"
+	"fmt"
+	"os"
+)
+
+// canDoIncremental checks whether the preconditions for incremental indexing
+// are met: the store supports GetBySource, a workspace root is set, and at
+// least half the chunks have non-empty StableKeys.
+func (idx *Indexer) canDoIncremental(chunks []Chunk) bool {
+	// Store must support GetBySource.
+	if _, ok := idx.store.(sourceChunkLoader); !ok {
+		return false
+	}
+	// Workspace root must be set for StableKey computation.
+	if idx.workspaceRoot == "" {
+		return false
+	}
+	// Need at least one chunk to evaluate.
+	if len(chunks) == 0 {
+		return false
+	}
+	// At least half the chunks should have StableKeys for meaningful matching.
+	keyed := 0
+	for _, c := range chunks {
+		if c.StableKey != "" {
+			keyed++
+		}
+	}
+	return keyed > len(chunks)/2
+}
+
+// IndexFileIncremental indexes a file using incremental diff-aware logic.
+// It re-chunks the entire file, compares against stored chunks via StableKey,
+// and only embeds chunks whose content actually changed.
+//
+// Falls back to full IndexFile behavior when:
+//   - The store does not implement sourceChunkLoader
+//   - No existing chunks are stored for this source
+//   - The workspace root is not set (StableKey computation impossible)
+//   - More than 50% of new chunks have empty StableKeys
+//   - Any error occurs during the incremental path
+//
+// On success, the store contains exactly the same chunks that a full
+// IndexFile would produce. The only difference is fewer embedding API calls.
+func (idx *Indexer) IndexFileIncremental(ctx context.Context, path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("rag: read file %q: %w", path, err)
+	}
+
+	content := string(data)
+	if content == "" {
+		if err := idx.replaceSource(ctx, path, nil, nil); err != nil {
+			return fmt.Errorf("rag: clear chunks for empty file %q: %w", path, err)
+		}
+		return nil
+	}
+
+	// Step 1: Chunk the file (always needed -- chunking is cheap).
+	chunks, err := idx.chunker.Chunk(path, content)
+	if err != nil {
+		return fmt.Errorf("rag: chunk %q: %w", path, err)
+	}
+	if len(chunks) == 0 {
+		if err := idx.replaceSource(ctx, path, nil, nil); err != nil {
+			return fmt.Errorf("rag: clear chunks for %q with no chunk output: %w", path, err)
+		}
+		return nil
+	}
+
+	// Step 1.5: Compute stable keys if workspace root is set.
+	if idx.workspaceRoot != "" {
+		for i := range chunks {
+			key, keyErr := ComputeStableKey(chunks[i], idx.workspaceRoot)
+			if keyErr != nil {
+				// Non-fatal: leave StableKey empty rather than failing the entire index.
+				continue
+			}
+			chunks[i].StableKey = key
+		}
+	}
+
+	// Try incremental path.
+	if idx.canDoIncremental(chunks) {
+		err := idx.indexIncremental(ctx, path, content, chunks)
+		if err == nil {
+			return nil
+		}
+		// Incremental failed -- fall through to full path.
+		// Context cancellation should be propagated immediately.
+		if ctx.Err() != nil {
+			return fmt.Errorf("rag: incremental index %q: %w", path, err)
+		}
+	}
+
+	// Full re-index path (same as IndexFile).
+	texts := make([]string, len(chunks))
+	for i, c := range chunks {
+		texts[i] = c.Content
+	}
+
+	embeddings, err := idx.client.EmbedBatch(ctx, idx.model, texts)
+	if err != nil {
+		// Embedding failed -- preserve existing indexed data for this file.
+		return fmt.Errorf("rag: embed chunks for %q: %w", path, err)
+	}
+
+	sourceHash := contentHash(content)
+	if err := idx.replaceSourceWithHash(ctx, path, chunks, embeddings, sourceHash); err != nil {
+		return fmt.Errorf("rag: replace chunks for %q: %w", path, err)
+	}
+	return nil
+}
+
+// indexIncremental is the internal incremental indexing path.
+// It assumes preconditions have been checked (store supports GetBySource,
+// workspace root is set, StableKeys are computed).
+//
+// Returns a non-nil error on any failure. The caller falls back to full
+// re-indexing when this returns an error.
+func (idx *Indexer) indexIncremental(ctx context.Context, path string, content string, newChunks []Chunk) error {
+	loader, ok := idx.store.(sourceChunkLoader)
+	if !ok {
+		return fmt.Errorf("rag: store does not support GetBySource")
+	}
+
+	oldChunks, err := loader.GetBySource(ctx, path)
+	if err != nil {
+		return fmt.Errorf("rag: load existing chunks for %q: %w", path, err)
+	}
+	if len(oldChunks) == 0 {
+		// First time indexing this file -- fall back to full.
+		return fmt.Errorf("rag: no existing chunks for %q", path)
+	}
+
+	// Diff old vs. new.
+	diff := diffChunks(oldChunks, newChunks)
+
+	// Short circuit: nothing changed.
+	if len(diff.modified) == 0 && len(diff.added) == 0 && len(diff.deletedIDs) == 0 {
+		return nil
+	}
+
+	// Build a map from StableKey -> cached embedding for unchanged chunks.
+	cachedEmbeddings := make(map[string][]float64, len(diff.unchanged))
+	for _, uc := range diff.unchanged {
+		cachedEmbeddings[uc.chunk.StableKey] = uc.embedding
+	}
+
+	// Identify which newChunks need fresh embeddings (in order).
+	var textsToEmbed []string
+	for _, nc := range newChunks {
+		if _, cached := cachedEmbeddings[nc.StableKey]; cached {
+			continue // unchanged, will use cached embedding
+		}
+		textsToEmbed = append(textsToEmbed, nc.Content)
+	}
+
+	// Embed only changed chunks.
+	var freshEmbeddings [][]float64
+	if len(textsToEmbed) > 0 {
+		freshEmbeddings, err = idx.client.EmbedBatch(ctx, idx.model, textsToEmbed)
+		if err != nil {
+			return fmt.Errorf("rag: embed changed chunks for %q: %w", path, err)
+		}
+	}
+
+	// Assemble final embeddings aligned 1:1 with newChunks.
+	finalEmbeddings := make([][]float64, len(newChunks))
+	freshIdx := 0
+	for i, nc := range newChunks {
+		if emb, cached := cachedEmbeddings[nc.StableKey]; cached {
+			finalEmbeddings[i] = emb
+		} else {
+			finalEmbeddings[i] = freshEmbeddings[freshIdx]
+			freshIdx++
+		}
+	}
+
+	// Atomically replace source with the full new chunk set.
+	sourceHash := contentHash(content)
+	if err := idx.replaceSourceWithHash(ctx, path, newChunks, finalEmbeddings, sourceHash); err != nil {
+		return fmt.Errorf("rag: replace chunks for %q: %w", path, err)
+	}
+	return nil
+}

--- a/rag/indexer_incremental_test.go
+++ b/rag/indexer_incremental_test.go
@@ -760,6 +760,86 @@ func TestIndexFileIncremental_HashSkip(t *testing.T) {
 	}
 }
 
+func TestIndexFileIncremental_HashInvalidatedByEmbeddingModel(t *testing.T) {
+	var embedCount atomic.Int32
+	srv := newBatchCountingEmbedServer(4, &embedCount)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+
+	innerStore, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("NewSQLiteStore() error: %v", err)
+	}
+	defer func() { _ = innerStore.Close() }()
+
+	var getBySourceCount atomic.Int32
+	store := &countingGetBySourceStore{
+		SQLiteStore:      innerStore,
+		getBySourceCount: &getBySourceCount,
+	}
+
+	var chunkCount atomic.Int32
+	chunker := &countingChunker{
+		inner:   NewCodeChunker(),
+		counter: &chunkCount,
+	}
+
+	tmpDir := t.TempDir()
+	goFile := filepath.Join(tmpDir, "main.go")
+	content := "package main\n\nfunc Hello() {\n\treturn 1\n}\n"
+	if err := os.WriteFile(goFile, []byte(content), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	idx1 := NewIndexer(client, store,
+		WithEmbeddingModel("test-embed-a"),
+		WithWorkspaceRoot(tmpDir),
+		WithChunker(chunker),
+	)
+	if err := idx1.IndexFile(context.Background(), goFile); err != nil {
+		t.Fatalf("initial IndexFile() error: %v", err)
+	}
+
+	hashBefore, err := innerStore.GetSourceHash(context.Background(), goFile)
+	if err != nil {
+		t.Fatalf("GetSourceHash() error: %v", err)
+	}
+	if hashBefore == "" {
+		t.Fatal("expected non-empty source hash after initial index")
+	}
+
+	embedCount.Store(0)
+	chunkCount.Store(0)
+	getBySourceCount.Store(0)
+
+	idx2 := NewIndexer(client, store,
+		WithEmbeddingModel("test-embed-b"),
+		WithWorkspaceRoot(tmpDir),
+		WithChunker(chunker),
+	)
+	if err := idx2.IndexFileIncremental(context.Background(), goFile); err != nil {
+		t.Fatalf("IndexFileIncremental() error: %v", err)
+	}
+
+	hashAfter, err := innerStore.GetSourceHash(context.Background(), goFile)
+	if err != nil {
+		t.Fatalf("GetSourceHash() after model change error: %v", err)
+	}
+	if hashAfter == hashBefore {
+		t.Error("expected source hash to change after embedding model change")
+	}
+	if got := embedCount.Load(); got == 0 {
+		t.Error("expected embed calls after embedding model change")
+	}
+	if got := chunkCount.Load(); got == 0 {
+		t.Error("expected chunking after embedding model change")
+	}
+	if got := getBySourceCount.Load(); got != 0 {
+		t.Errorf("expected 0 GetBySource calls on forced full re-embed, got %d", got)
+	}
+}
+
 func TestIndexFileIncremental_HashMismatch(t *testing.T) {
 	// After editing a file, the source hash should differ and the incremental
 	// path should run (chunking + selective embedding).
@@ -846,8 +926,9 @@ func TestIndexFileIncremental_HashMismatch(t *testing.T) {
 }
 
 func TestIndexFile_StoresHash(t *testing.T) {
-	// Verify that a full IndexFile (not incremental) stores the content hash
-	// so that subsequent IndexFileIncremental calls can use the fast path.
+	// Verify that a full IndexFile (not incremental) stores the source
+	// signature so that subsequent IndexFileIncremental calls can use the
+	// fast path only when the indexing inputs still match.
 
 	var embedCount atomic.Int32
 	srv := newBatchCountingEmbedServer(4, &embedCount)
@@ -893,8 +974,8 @@ func TestIndexFile_StoresHash(t *testing.T) {
 		t.Fatal("expected non-empty source_content_hash after IndexFile")
 	}
 
-	// Verify the hash matches the expected value.
-	expectedHash := contentHash(content)
+	// Verify the stored signature matches the expected value.
+	expectedHash := idx.currentSourceSignature(content).String()
 	if hash != expectedHash {
 		t.Errorf("stored hash = %q, want %q", hash, expectedHash)
 	}

--- a/rag/indexer_incremental_test.go
+++ b/rag/indexer_incremental_test.go
@@ -653,3 +653,265 @@ func TestIndexFileIncremental_EmptyFile(t *testing.T) {
 		t.Errorf("expected 0 chunks after indexing empty file, got %d", statsAfter.TotalChunks)
 	}
 }
+
+// --- Source hash fast path tests ---
+
+// countingChunker wraps a Chunker and counts how many times Chunk is called.
+type countingChunker struct {
+	inner   Chunker
+	counter *atomic.Int32
+}
+
+func (c *countingChunker) Chunk(source string, content string) ([]Chunk, error) {
+	c.counter.Add(1)
+	return c.inner.Chunk(source, content)
+}
+
+// countingGetBySourceStore wraps a *SQLiteStore and counts GetBySource calls.
+type countingGetBySourceStore struct {
+	*SQLiteStore
+	getBySourceCount *atomic.Int32
+}
+
+func (s *countingGetBySourceStore) GetBySource(ctx context.Context, source string) ([]ChunkWithEmbedding, error) {
+	s.getBySourceCount.Add(1)
+	return s.SQLiteStore.GetBySource(ctx, source)
+}
+
+func TestIndexFileIncremental_HashSkip(t *testing.T) {
+	// This test proves the source-hash fast path exists and works.
+	// On the second call with unchanged content:
+	//   - 0 embed calls (no embedding work)
+	//   - 0 Chunk() calls (no chunking work)
+	//   - 0 GetBySource calls (no store lookup for old chunks)
+	// This distinguishes the fast path from the incremental "all chunks unchanged"
+	// path, which would still chunk and call GetBySource.
+
+	var embedCount atomic.Int32
+	srv := newBatchCountingEmbedServer(4, &embedCount)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+
+	innerStore, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("NewSQLiteStore() error: %v", err)
+	}
+	defer func() { _ = innerStore.Close() }()
+
+	var getBySourceCount atomic.Int32
+	store := &countingGetBySourceStore{
+		SQLiteStore:      innerStore,
+		getBySourceCount: &getBySourceCount,
+	}
+
+	var chunkCount atomic.Int32
+	chunker := &countingChunker{
+		inner:   NewCodeChunker(),
+		counter: &chunkCount,
+	}
+
+	tmpDir := t.TempDir()
+	goFile := filepath.Join(tmpDir, "main.go")
+	content := "package main\n\nfunc Hello() {\n\treturn 1\n}\n"
+	if err := os.WriteFile(goFile, []byte(content), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	idx := NewIndexer(client, store,
+		WithEmbeddingModel("test-embed"),
+		WithWorkspaceRoot(tmpDir),
+		WithChunker(chunker),
+	)
+
+	// First call: full index (stores source_content_hash).
+	if err := idx.IndexFileIncremental(context.Background(), goFile); err != nil {
+		t.Fatalf("initial IndexFileIncremental() error: %v", err)
+	}
+
+	// Verify hash was stored.
+	hash, err := innerStore.GetSourceHash(context.Background(), goFile)
+	if err != nil {
+		t.Fatalf("GetSourceHash() error: %v", err)
+	}
+	if hash == "" {
+		t.Fatal("expected non-empty source_content_hash after indexing")
+	}
+
+	// Reset all counters.
+	embedCount.Store(0)
+	chunkCount.Store(0)
+	getBySourceCount.Store(0)
+
+	// Second call: same content -- should hit hash fast path.
+	if err := idx.IndexFileIncremental(context.Background(), goFile); err != nil {
+		t.Fatalf("second IndexFileIncremental() error: %v", err)
+	}
+
+	// Verify the fast path: no embedding, no chunking, no GetBySource.
+	if got := embedCount.Load(); got != 0 {
+		t.Errorf("expected 0 embed calls for hash-matched file, got %d", got)
+	}
+	if got := chunkCount.Load(); got != 0 {
+		t.Errorf("expected 0 Chunk() calls for hash-matched file, got %d", got)
+	}
+	if got := getBySourceCount.Load(); got != 0 {
+		t.Errorf("expected 0 GetBySource calls for hash-matched file, got %d", got)
+	}
+}
+
+func TestIndexFileIncremental_HashMismatch(t *testing.T) {
+	// After editing a file, the source hash should differ and the incremental
+	// path should run (chunking + selective embedding).
+
+	var embedCount atomic.Int32
+	srv := newBatchCountingEmbedServer(4, &embedCount)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	store, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("NewSQLiteStore() error: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	var chunkCount atomic.Int32
+	chunker := &countingChunker{
+		inner:   NewCodeChunker(),
+		counter: &chunkCount,
+	}
+
+	tmpDir := t.TempDir()
+	goFile := filepath.Join(tmpDir, "main.go")
+
+	if err := os.WriteFile(goFile, []byte("package main\n\nfunc Hello() {\n\treturn 1\n}\n"), 0644); err != nil {
+		t.Fatalf("write initial file: %v", err)
+	}
+
+	idx := NewIndexer(client, store,
+		WithEmbeddingModel("test-embed"),
+		WithWorkspaceRoot(tmpDir),
+		WithChunker(chunker),
+	)
+
+	// Full index.
+	if err := idx.IndexFileIncremental(context.Background(), goFile); err != nil {
+		t.Fatalf("initial IndexFileIncremental() error: %v", err)
+	}
+
+	// Verify the stored hash matches initial content.
+	hashBefore, err := store.GetSourceHash(context.Background(), goFile)
+	if err != nil {
+		t.Fatalf("GetSourceHash() error: %v", err)
+	}
+	if hashBefore == "" {
+		t.Fatal("expected non-empty hash after initial index")
+	}
+
+	// Reset counters.
+	embedCount.Store(0)
+	chunkCount.Store(0)
+
+	// Edit the file.
+	if err := os.WriteFile(goFile, []byte("package main\n\nfunc Hello() {\n\treturn 42\n}\n"), 0644); err != nil {
+		t.Fatalf("write edited file: %v", err)
+	}
+
+	// Incremental index with changed content.
+	if err := idx.IndexFileIncremental(context.Background(), goFile); err != nil {
+		t.Fatalf("IndexFileIncremental() after edit error: %v", err)
+	}
+
+	// The hash should have changed.
+	hashAfter, err := store.GetSourceHash(context.Background(), goFile)
+	if err != nil {
+		t.Fatalf("GetSourceHash() after edit error: %v", err)
+	}
+	if hashAfter == hashBefore {
+		t.Error("expected source hash to change after file edit")
+	}
+	if hashAfter == "" {
+		t.Error("expected non-empty source hash after re-index")
+	}
+
+	// Should have chunked (hash mismatch means no fast path).
+	if got := chunkCount.Load(); got == 0 {
+		t.Error("expected at least 1 Chunk() call for changed file")
+	}
+
+	// Should have embedded changed chunk(s).
+	if got := embedCount.Load(); got == 0 {
+		t.Error("expected embed calls for changed file")
+	}
+}
+
+func TestIndexFile_StoresHash(t *testing.T) {
+	// Verify that a full IndexFile (not incremental) stores the content hash
+	// so that subsequent IndexFileIncremental calls can use the fast path.
+
+	var embedCount atomic.Int32
+	srv := newBatchCountingEmbedServer(4, &embedCount)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	store, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("NewSQLiteStore() error: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	var chunkCount atomic.Int32
+	chunker := &countingChunker{
+		inner:   NewCodeChunker(),
+		counter: &chunkCount,
+	}
+
+	tmpDir := t.TempDir()
+	goFile := filepath.Join(tmpDir, "main.go")
+	content := "package main\n\nfunc Hello() {\n\treturn 1\n}\n"
+	if err := os.WriteFile(goFile, []byte(content), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	idx := NewIndexer(client, store,
+		WithEmbeddingModel("test-embed"),
+		WithWorkspaceRoot(tmpDir),
+		WithChunker(chunker),
+	)
+
+	// Full IndexFile (not incremental).
+	if err := idx.IndexFile(context.Background(), goFile); err != nil {
+		t.Fatalf("IndexFile() error: %v", err)
+	}
+
+	// Verify hash was stored.
+	hash, err := store.GetSourceHash(context.Background(), goFile)
+	if err != nil {
+		t.Fatalf("GetSourceHash() error: %v", err)
+	}
+	if hash == "" {
+		t.Fatal("expected non-empty source_content_hash after IndexFile")
+	}
+
+	// Verify the hash matches the expected value.
+	expectedHash := contentHash(content)
+	if hash != expectedHash {
+		t.Errorf("stored hash = %q, want %q", hash, expectedHash)
+	}
+
+	// Reset counters.
+	embedCount.Store(0)
+	chunkCount.Store(0)
+
+	// Now IndexFileIncremental should skip via hash fast path.
+	if err := idx.IndexFileIncremental(context.Background(), goFile); err != nil {
+		t.Fatalf("IndexFileIncremental() error: %v", err)
+	}
+
+	if got := embedCount.Load(); got != 0 {
+		t.Errorf("expected 0 embed calls after hash match, got %d", got)
+	}
+	if got := chunkCount.Load(); got != 0 {
+		t.Errorf("expected 0 Chunk() calls after hash match, got %d", got)
+	}
+}

--- a/rag/indexer_incremental_test.go
+++ b/rag/indexer_incremental_test.go
@@ -840,6 +840,163 @@ func TestIndexFileIncremental_HashInvalidatedByEmbeddingModel(t *testing.T) {
 	}
 }
 
+func TestIndexFileIncremental_EmptyStoredHashForcesFullReembed(t *testing.T) {
+	var embedCount atomic.Int32
+	srv := newBatchCountingEmbedServer(4, &embedCount)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+
+	innerStore, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("NewSQLiteStore() error: %v", err)
+	}
+	defer func() { _ = innerStore.Close() }()
+
+	var getBySourceCount atomic.Int32
+	store := &countingGetBySourceStore{
+		SQLiteStore:      innerStore,
+		getBySourceCount: &getBySourceCount,
+	}
+
+	var chunkCount atomic.Int32
+	chunker := &countingChunker{
+		inner:   NewCodeChunker(),
+		counter: &chunkCount,
+	}
+
+	tmpDir := t.TempDir()
+	goFile := filepath.Join(tmpDir, "main.go")
+	content := "package main\n\nfunc Hello() {\n\treturn 1\n}\n"
+	if err := os.WriteFile(goFile, []byte(content), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	idx1 := NewIndexer(client, store,
+		WithEmbeddingModel("test-embed-a"),
+		WithWorkspaceRoot(tmpDir),
+		WithChunker(chunker),
+	)
+	if err := idx1.IndexFile(context.Background(), goFile); err != nil {
+		t.Fatalf("initial IndexFile() error: %v", err)
+	}
+
+	if err := innerStore.UpdateSourceHash(context.Background(), goFile, ""); err != nil {
+		t.Fatalf("UpdateSourceHash() error: %v", err)
+	}
+	hashBefore, err := innerStore.GetSourceHash(context.Background(), goFile)
+	if err != nil {
+		t.Fatalf("GetSourceHash() before reindex error: %v", err)
+	}
+	if hashBefore != "" {
+		t.Fatalf("expected empty stored hash after backfill reset, got %q", hashBefore)
+	}
+
+	embedCount.Store(0)
+	chunkCount.Store(0)
+	getBySourceCount.Store(0)
+
+	idx2 := NewIndexer(client, store,
+		WithEmbeddingModel("test-embed-b"),
+		WithWorkspaceRoot(tmpDir),
+		WithChunker(chunker),
+	)
+	if err := idx2.IndexFileIncremental(context.Background(), goFile); err != nil {
+		t.Fatalf("IndexFileIncremental() error: %v", err)
+	}
+
+	hashAfter, err := innerStore.GetSourceHash(context.Background(), goFile)
+	if err != nil {
+		t.Fatalf("GetSourceHash() after reindex error: %v", err)
+	}
+	if hashAfter == "" {
+		t.Fatal("expected non-empty source hash after forced full re-embed")
+	}
+	if got := embedCount.Load(); got == 0 {
+		t.Error("expected embed calls when stored source hash is empty")
+	}
+	if got := chunkCount.Load(); got == 0 {
+		t.Error("expected chunking when stored source hash is empty")
+	}
+	if got := getBySourceCount.Load(); got != 0 {
+		t.Errorf("expected 0 GetBySource calls on forced full re-embed, got %d", got)
+	}
+}
+
+func TestIndexFileIncremental_HashInvalidatedByChunkerConfig(t *testing.T) {
+	var embedCount atomic.Int32
+	srv := newBatchCountingEmbedServer(4, &embedCount)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	store, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("NewSQLiteStore() error: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	content := "alpha\nbeta\ngamma\ndelta\nepsilon\nzeta\neta\ntheta\n"
+	tmpDir := t.TempDir()
+	txtFile := filepath.Join(tmpDir, "notes.txt")
+	if err := os.WriteFile(txtFile, []byte(content), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	chunkerA, err := NewSlidingWindowChunker(18, 0)
+	if err != nil {
+		t.Fatalf("NewSlidingWindowChunker() error: %v", err)
+	}
+	idx1 := NewIndexer(client, store,
+		WithEmbeddingModel("test-embed"),
+		WithWorkspaceRoot(tmpDir),
+		WithChunker(chunkerA),
+	)
+	if err := idx1.IndexFile(context.Background(), txtFile); err != nil {
+		t.Fatalf("initial IndexFile() error: %v", err)
+	}
+
+	hashBefore, err := store.GetSourceHash(context.Background(), txtFile)
+	if err != nil {
+		t.Fatalf("GetSourceHash() error: %v", err)
+	}
+	if hashBefore == "" {
+		t.Fatal("expected non-empty source hash after initial index")
+	}
+
+	embedCount.Store(0)
+
+	var chunkCount atomic.Int32
+	chunkerB, err := NewSlidingWindowChunker(28, 0)
+	if err != nil {
+		t.Fatalf("NewSlidingWindowChunker() error: %v", err)
+	}
+	idx2 := NewIndexer(client, store,
+		WithEmbeddingModel("test-embed"),
+		WithWorkspaceRoot(tmpDir),
+		WithChunker(&countingChunker{
+			inner:   chunkerB,
+			counter: &chunkCount,
+		}),
+	)
+	if err := idx2.IndexFileIncremental(context.Background(), txtFile); err != nil {
+		t.Fatalf("IndexFileIncremental() error: %v", err)
+	}
+
+	hashAfter, err := store.GetSourceHash(context.Background(), txtFile)
+	if err != nil {
+		t.Fatalf("GetSourceHash() after config change error: %v", err)
+	}
+	if hashAfter == hashBefore {
+		t.Error("expected source hash to change after chunker config change")
+	}
+	if got := chunkCount.Load(); got == 0 {
+		t.Error("expected chunking after chunker config change")
+	}
+	if got := embedCount.Load(); got == 0 {
+		t.Error("expected embed calls after chunker config change")
+	}
+}
+
 func TestIndexFileIncremental_HashMismatch(t *testing.T) {
 	// After editing a file, the source hash should differ and the incremental
 	// path should run (chunking + selective embedding).

--- a/rag/indexer_incremental_test.go
+++ b/rag/indexer_incremental_test.go
@@ -1,0 +1,655 @@
+package rag
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+// --- canDoIncremental tests ---
+
+func TestCanDoIncremental_RequiresStoreCapability(t *testing.T) {
+	srv := newMockEmbedServer(4)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	store := &minimalVectorStore{}
+	idx := NewIndexer(client, store, WithWorkspaceRoot("/tmp/test"))
+
+	chunks := []Chunk{
+		{StableKey: "file.go::Foo#0"},
+		{StableKey: "file.go::Bar#0"},
+	}
+
+	if idx.canDoIncremental(chunks) {
+		t.Error("canDoIncremental should return false for store without sourceChunkLoader")
+	}
+}
+
+func TestCanDoIncremental_RequiresWorkspaceRoot(t *testing.T) {
+	srv := newMockEmbedServer(4)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	store, _ := NewSQLiteStore(":memory:")
+	defer func() { _ = store.Close() }()
+
+	// No WithWorkspaceRoot.
+	idx := NewIndexer(client, store)
+
+	chunks := []Chunk{
+		{StableKey: "file.go::Foo#0"},
+	}
+
+	if idx.canDoIncremental(chunks) {
+		t.Error("canDoIncremental should return false without workspace root")
+	}
+}
+
+func TestCanDoIncremental_RequiresStableKeys(t *testing.T) {
+	srv := newMockEmbedServer(4)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	store, _ := NewSQLiteStore(":memory:")
+	defer func() { _ = store.Close() }()
+
+	idx := NewIndexer(client, store, WithWorkspaceRoot("/tmp/test"))
+
+	// More than 50% empty StableKeys.
+	chunks := []Chunk{
+		{StableKey: "file.go::Foo#0"},
+		{StableKey: ""},
+		{StableKey: ""},
+	}
+
+	if idx.canDoIncremental(chunks) {
+		t.Error("canDoIncremental should return false when <50%% have StableKeys")
+	}
+}
+
+func TestCanDoIncremental_EmptyChunks(t *testing.T) {
+	srv := newMockEmbedServer(4)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	store, _ := NewSQLiteStore(":memory:")
+	defer func() { _ = store.Close() }()
+
+	idx := NewIndexer(client, store, WithWorkspaceRoot("/tmp/test"))
+
+	if idx.canDoIncremental(nil) {
+		t.Error("canDoIncremental should return false for nil chunks")
+	}
+	if idx.canDoIncremental([]Chunk{}) {
+		t.Error("canDoIncremental should return false for empty chunks")
+	}
+}
+
+func TestCanDoIncremental_Success(t *testing.T) {
+	srv := newMockEmbedServer(4)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	store, _ := NewSQLiteStore(":memory:")
+	defer func() { _ = store.Close() }()
+
+	idx := NewIndexer(client, store, WithWorkspaceRoot("/tmp/test"))
+
+	chunks := []Chunk{
+		{StableKey: "file.go::Foo#0"},
+		{StableKey: "file.go::Bar#0"},
+		{StableKey: ""},
+	}
+
+	if !idx.canDoIncremental(chunks) {
+		t.Error("canDoIncremental should return true when >50%% have StableKeys")
+	}
+}
+
+// --- minimalVectorStore: satisfies VectorStore but nothing else ---
+
+type minimalVectorStore struct{}
+
+func (m *minimalVectorStore) Store(_ context.Context, _ []Chunk, _ [][]float64) error { return nil }
+func (m *minimalVectorStore) Search(_ context.Context, _ []float64, _ int) ([]SearchResult, error) {
+	return nil, nil
+}
+func (m *minimalVectorStore) DeleteBySource(_ context.Context, _ string) error { return nil }
+func (m *minimalVectorStore) Stats(_ context.Context) (StoreStats, error)      { return StoreStats{}, nil }
+func (m *minimalVectorStore) Close() error                                     { return nil }
+
+// --- IndexFileIncremental tests ---
+
+// newBatchCountingEmbedServer returns a mock server that counts each individual
+// text embedded (one count per /api/embed call).
+func newBatchCountingEmbedServer(dim int, counter *atomic.Int32) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/embed" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		counter.Add(1)
+		emb := make([]float64, dim)
+		emb[0] = 0.5
+		resp := ollama.EmbedResponse{Embeddings: [][]float64{emb}}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func TestIndexFileIncremental_BasicUpdate(t *testing.T) {
+	var embedCount atomic.Int32
+	srv := newBatchCountingEmbedServer(4, &embedCount)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	store, _ := NewSQLiteStore(":memory:")
+	defer func() { _ = store.Close() }()
+
+	tmpDir := t.TempDir()
+	goFile := filepath.Join(tmpDir, "main.go")
+
+	// Initial content: two functions.
+	initial := "package main\n\nfunc Hello() {\n\treturn 1\n}\n\nfunc World() {\n\treturn 2\n}\n"
+	if err := os.WriteFile(goFile, []byte(initial), 0644); err != nil {
+		t.Fatalf("write initial file: %v", err)
+	}
+
+	idx := NewIndexer(client, store,
+		WithEmbeddingModel("test-embed"),
+		WithWorkspaceRoot(tmpDir),
+	)
+
+	// Full index first.
+	if err := idx.IndexFile(context.Background(), goFile); err != nil {
+		t.Fatalf("initial IndexFile() error: %v", err)
+	}
+	initialEmbeds := embedCount.Load()
+	if initialEmbeds == 0 {
+		t.Fatal("expected at least 1 embed call during initial index")
+	}
+
+	// Reset counter.
+	embedCount.Store(0)
+
+	// Edit: change only the body of Hello.
+	edited := "package main\n\nfunc Hello() {\n\treturn 42\n}\n\nfunc World() {\n\treturn 2\n}\n"
+	if err := os.WriteFile(goFile, []byte(edited), 0644); err != nil {
+		t.Fatalf("write edited file: %v", err)
+	}
+
+	// Incremental index.
+	if err := idx.IndexFileIncremental(context.Background(), goFile); err != nil {
+		t.Fatalf("IndexFileIncremental() error: %v", err)
+	}
+
+	incrementalEmbeds := embedCount.Load()
+	if incrementalEmbeds >= initialEmbeds {
+		t.Errorf("incremental embeds (%d) should be less than initial (%d)", incrementalEmbeds, initialEmbeds)
+	}
+
+	// Verify store has correct chunks.
+	stats, _ := store.Stats(context.Background())
+	if stats.TotalChunks == 0 {
+		t.Error("store has no chunks after incremental index")
+	}
+}
+
+func TestIndexFileIncremental_NoChange(t *testing.T) {
+	var embedCount atomic.Int32
+	srv := newBatchCountingEmbedServer(4, &embedCount)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	store, _ := NewSQLiteStore(":memory:")
+	defer func() { _ = store.Close() }()
+
+	tmpDir := t.TempDir()
+	goFile := filepath.Join(tmpDir, "main.go")
+
+	content := "package main\n\nfunc Hello() {\n\treturn 1\n}\n"
+	if err := os.WriteFile(goFile, []byte(content), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	idx := NewIndexer(client, store,
+		WithEmbeddingModel("test-embed"),
+		WithWorkspaceRoot(tmpDir),
+	)
+
+	// Full index first.
+	if err := idx.IndexFile(context.Background(), goFile); err != nil {
+		t.Fatalf("initial IndexFile() error: %v", err)
+	}
+
+	// Reset counter.
+	embedCount.Store(0)
+
+	// Re-index same content incrementally.
+	if err := idx.IndexFileIncremental(context.Background(), goFile); err != nil {
+		t.Fatalf("IndexFileIncremental() error: %v", err)
+	}
+
+	if embedCount.Load() != 0 {
+		t.Errorf("expected 0 embed calls for unchanged file, got %d", embedCount.Load())
+	}
+}
+
+func TestIndexFileIncremental_FallbackNoOldChunks(t *testing.T) {
+	var embedCount atomic.Int32
+	srv := newBatchCountingEmbedServer(4, &embedCount)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	store, _ := NewSQLiteStore(":memory:")
+	defer func() { _ = store.Close() }()
+
+	tmpDir := t.TempDir()
+	goFile := filepath.Join(tmpDir, "main.go")
+
+	if err := os.WriteFile(goFile, []byte("package main\n\nfunc Hello() {\n\treturn 1\n}\n"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	idx := NewIndexer(client, store,
+		WithEmbeddingModel("test-embed"),
+		WithWorkspaceRoot(tmpDir),
+	)
+
+	// First-time index via IndexFileIncremental -- no old chunks exist.
+	// Should fall back to full indexing.
+	if err := idx.IndexFileIncremental(context.Background(), goFile); err != nil {
+		t.Fatalf("IndexFileIncremental() error: %v", err)
+	}
+
+	if embedCount.Load() == 0 {
+		t.Error("expected embed calls for first-time index (fallback to full)")
+	}
+
+	stats, _ := store.Stats(context.Background())
+	if stats.TotalChunks == 0 {
+		t.Error("expected chunks after first-time incremental (fallback)")
+	}
+}
+
+func TestIndexFileIncremental_FallbackNoStableKeys(t *testing.T) {
+	var embedCount atomic.Int32
+	srv := newBatchCountingEmbedServer(4, &embedCount)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	store, _ := NewSQLiteStore(":memory:")
+	defer func() { _ = store.Close() }()
+
+	tmpDir := t.TempDir()
+	txtFile := filepath.Join(tmpDir, "data.txt")
+
+	// Plain text content that produces no structural symbols -> no StableKeys.
+	content := "line one\nline two\nline three\nline four\nline five\n"
+	if err := os.WriteFile(txtFile, []byte(content), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	// Use a sliding window chunker to produce chunks without symbol metadata.
+	chunker, _ := NewSlidingWindowChunker(30, 0)
+	idx := NewIndexer(client, store,
+		WithEmbeddingModel("test-embed"),
+		WithWorkspaceRoot(tmpDir),
+		WithChunker(chunker),
+	)
+
+	// First full index.
+	if err := idx.IndexFile(context.Background(), txtFile); err != nil {
+		t.Fatalf("initial IndexFile() error: %v", err)
+	}
+	initialEmbeds := embedCount.Load()
+	embedCount.Store(0)
+
+	// Try incremental -- should fall back because StableKeys are empty.
+	// (SlidingWindowChunker produces anchor_hash metadata, but ComputeStableKey
+	// may fail if no symbol_path, section_path, or anchor_hash is found.)
+	if err := idx.IndexFileIncremental(context.Background(), txtFile); err != nil {
+		t.Fatalf("IndexFileIncremental() error: %v", err)
+	}
+
+	// Either falls back to full (embeds everything again) or succeeds
+	// incrementally if anchor_hash provides StableKeys. Either way,
+	// the store should have chunks.
+	stats, _ := store.Stats(context.Background())
+	if stats.TotalChunks == 0 {
+		t.Error("expected chunks after incremental index (with fallback)")
+	}
+	_ = initialEmbeds // used for context only
+}
+
+func TestIndexFileIncremental_FallbackNoWorkspaceRoot(t *testing.T) {
+	var embedCount atomic.Int32
+	srv := newBatchCountingEmbedServer(4, &embedCount)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	store, _ := NewSQLiteStore(":memory:")
+	defer func() { _ = store.Close() }()
+
+	tmpDir := t.TempDir()
+	goFile := filepath.Join(tmpDir, "main.go")
+
+	if err := os.WriteFile(goFile, []byte("package main\n\nfunc Hello() {}\n"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	// No workspace root -- should fall back to full re-index.
+	idx := NewIndexer(client, store, WithEmbeddingModel("test-embed"))
+
+	if err := idx.IndexFileIncremental(context.Background(), goFile); err != nil {
+		t.Fatalf("IndexFileIncremental() error: %v", err)
+	}
+
+	// Should still work (falls back to full), just not incrementally.
+	stats, _ := store.Stats(context.Background())
+	if stats.TotalChunks == 0 {
+		t.Error("expected chunks after fallback index")
+	}
+}
+
+func TestIndexFileIncremental_FallbackCustomStore(t *testing.T) {
+	var embedCount atomic.Int32
+	srv := newBatchCountingEmbedServer(4, &embedCount)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	store := &minimalVectorStore{}
+
+	tmpDir := t.TempDir()
+	goFile := filepath.Join(tmpDir, "main.go")
+	if err := os.WriteFile(goFile, []byte("package main\n\nfunc Hello() {}\n"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	idx := NewIndexer(client, store,
+		WithEmbeddingModel("test-embed"),
+		WithWorkspaceRoot(tmpDir),
+	)
+
+	// Should fall back to full re-index since minimalVectorStore
+	// does not implement sourceChunkLoader.
+	if err := idx.IndexFileIncremental(context.Background(), goFile); err != nil {
+		t.Fatalf("IndexFileIncremental() error: %v", err)
+	}
+
+	if embedCount.Load() == 0 {
+		t.Error("expected embed calls for fallback full index")
+	}
+}
+
+func TestIndexFileIncremental_NewFunction(t *testing.T) {
+	var embedCount atomic.Int32
+	srv := newBatchCountingEmbedServer(4, &embedCount)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	store, _ := NewSQLiteStore(":memory:")
+	defer func() { _ = store.Close() }()
+
+	tmpDir := t.TempDir()
+	goFile := filepath.Join(tmpDir, "main.go")
+
+	initial := "package main\n\nfunc Hello() {\n\treturn 1\n}\n"
+	if err := os.WriteFile(goFile, []byte(initial), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	idx := NewIndexer(client, store,
+		WithEmbeddingModel("test-embed"),
+		WithWorkspaceRoot(tmpDir),
+	)
+
+	if err := idx.IndexFile(context.Background(), goFile); err != nil {
+		t.Fatalf("initial IndexFile() error: %v", err)
+	}
+	initialEmbeds := embedCount.Load()
+	embedCount.Store(0)
+
+	// Add a new function.
+	edited := "package main\n\nfunc Hello() {\n\treturn 1\n}\n\nfunc NewFunc() {\n\treturn 42\n}\n"
+	if err := os.WriteFile(goFile, []byte(edited), 0644); err != nil {
+		t.Fatalf("write edited file: %v", err)
+	}
+
+	if err := idx.IndexFileIncremental(context.Background(), goFile); err != nil {
+		t.Fatalf("IndexFileIncremental() error: %v", err)
+	}
+
+	incrementalEmbeds := embedCount.Load()
+	// Should embed only the new function, not the unchanged Hello.
+	if incrementalEmbeds == 0 {
+		t.Error("expected at least 1 embed call for new function")
+	}
+	if incrementalEmbeds >= initialEmbeds+1 {
+		t.Errorf("incremental embeds (%d) should be fewer than initial+1 (%d)", incrementalEmbeds, initialEmbeds+1)
+	}
+}
+
+func TestIndexFileIncremental_DeleteFunction(t *testing.T) {
+	var embedCount atomic.Int32
+	srv := newBatchCountingEmbedServer(4, &embedCount)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	store, _ := NewSQLiteStore(":memory:")
+	defer func() { _ = store.Close() }()
+
+	tmpDir := t.TempDir()
+	goFile := filepath.Join(tmpDir, "main.go")
+
+	initial := "package main\n\nfunc Hello() {\n\treturn 1\n}\n\nfunc ToBeRemoved() {\n\treturn 2\n}\n"
+	if err := os.WriteFile(goFile, []byte(initial), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	idx := NewIndexer(client, store,
+		WithEmbeddingModel("test-embed"),
+		WithWorkspaceRoot(tmpDir),
+	)
+
+	if err := idx.IndexFile(context.Background(), goFile); err != nil {
+		t.Fatalf("initial IndexFile() error: %v", err)
+	}
+
+	statsBefore, _ := store.Stats(context.Background())
+	embedCount.Store(0)
+
+	// Remove the second function.
+	edited := "package main\n\nfunc Hello() {\n\treturn 1\n}\n"
+	if err := os.WriteFile(goFile, []byte(edited), 0644); err != nil {
+		t.Fatalf("write edited file: %v", err)
+	}
+
+	if err := idx.IndexFileIncremental(context.Background(), goFile); err != nil {
+		t.Fatalf("IndexFileIncremental() error: %v", err)
+	}
+
+	statsAfter, _ := store.Stats(context.Background())
+	if statsAfter.TotalChunks >= statsBefore.TotalChunks {
+		t.Errorf("expected fewer chunks after deletion: before=%d, after=%d",
+			statsBefore.TotalChunks, statsAfter.TotalChunks)
+	}
+
+	// No new content was added, so embed count should be 0.
+	if embedCount.Load() != 0 {
+		t.Errorf("expected 0 embed calls (only deletion), got %d", embedCount.Load())
+	}
+}
+
+func TestIndexFileIncremental_EmbedFailurePreservesData(t *testing.T) {
+	// Initial index with good server.
+	goodSrv := newMockEmbedServer(4)
+	defer goodSrv.Close()
+
+	store, _ := NewSQLiteStore(":memory:")
+	defer func() { _ = store.Close() }()
+
+	goodClient := ollama.NewClient(ollama.WithBaseURL(goodSrv.URL))
+
+	tmpDir := t.TempDir()
+	goFile := filepath.Join(tmpDir, "main.go")
+	if err := os.WriteFile(goFile, []byte("package main\n\nfunc Hello() {\n\treturn 1\n}\n"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	idx := NewIndexer(goodClient, store,
+		WithEmbeddingModel("test-embed"),
+		WithWorkspaceRoot(tmpDir),
+	)
+
+	if err := idx.IndexFile(context.Background(), goFile); err != nil {
+		t.Fatalf("initial IndexFile() error: %v", err)
+	}
+
+	statsBefore, _ := store.Stats(context.Background())
+
+	// Now try incremental with a broken embed server.
+	badSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"model not found"}`))
+	}))
+	defer badSrv.Close()
+
+	badClient := ollama.NewClient(ollama.WithBaseURL(badSrv.URL))
+	badIdx := NewIndexer(badClient, store,
+		WithEmbeddingModel("test-embed"),
+		WithWorkspaceRoot(tmpDir),
+	)
+
+	// Edit the file so incremental path has something to embed.
+	if err := os.WriteFile(goFile, []byte("package main\n\nfunc Hello() {\n\treturn 42\n}\n"), 0644); err != nil {
+		t.Fatalf("write edited file: %v", err)
+	}
+
+	err := badIdx.IndexFileIncremental(context.Background(), goFile)
+	if err == nil {
+		t.Fatal("expected error from broken embed server")
+	}
+
+	// Old data should still be intact.
+	statsAfter, _ := store.Stats(context.Background())
+	if statsAfter.TotalChunks != statsBefore.TotalChunks {
+		t.Errorf("embed failure changed chunk count from %d to %d",
+			statsBefore.TotalChunks, statsAfter.TotalChunks)
+	}
+}
+
+func TestIndexFileIncremental_ConsistentWithFull(t *testing.T) {
+	dim := 4
+	srv := newMockEmbedServer(dim)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+
+	tmpDir := t.TempDir()
+	goFile := filepath.Join(tmpDir, "main.go")
+
+	initial := "package main\n\nfunc Hello() {\n\treturn 1\n}\n\nfunc World() {\n\treturn 2\n}\n"
+	if err := os.WriteFile(goFile, []byte(initial), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	// Store 1: full index, then edit, then incremental.
+	store1, _ := NewSQLiteStore(":memory:")
+	defer func() { _ = store1.Close() }()
+	idx1 := NewIndexer(client, store1, WithEmbeddingModel("test-embed"), WithWorkspaceRoot(tmpDir))
+	if err := idx1.IndexFile(context.Background(), goFile); err != nil {
+		t.Fatalf("store1 initial IndexFile() error: %v", err)
+	}
+
+	edited := "package main\n\nfunc Hello() {\n\treturn 42\n}\n\nfunc World() {\n\treturn 2\n}\n"
+	if err := os.WriteFile(goFile, []byte(edited), 0644); err != nil {
+		t.Fatalf("write edited file: %v", err)
+	}
+	if err := idx1.IndexFileIncremental(context.Background(), goFile); err != nil {
+		t.Fatalf("store1 IndexFileIncremental() error: %v", err)
+	}
+
+	// Store 2: full index of the edited file from scratch.
+	store2, _ := NewSQLiteStore(":memory:")
+	defer func() { _ = store2.Close() }()
+	idx2 := NewIndexer(client, store2, WithEmbeddingModel("test-embed"), WithWorkspaceRoot(tmpDir))
+	if err := idx2.IndexFile(context.Background(), goFile); err != nil {
+		t.Fatalf("store2 IndexFile() error: %v", err)
+	}
+
+	// Compare: both stores should have the same chunks.
+	results1, _ := store1.GetBySource(context.Background(), goFile)
+	results2, _ := store2.GetBySource(context.Background(), goFile)
+
+	if len(results1) != len(results2) {
+		t.Fatalf("chunk count mismatch: incremental=%d, full=%d", len(results1), len(results2))
+	}
+
+	for i := range results1 {
+		if results1[i].Chunk.Content != results2[i].Chunk.Content {
+			t.Errorf("chunk %d content mismatch:\n  incremental: %q\n  full: %q",
+				i, results1[i].Chunk.Content, results2[i].Chunk.Content)
+		}
+		if results1[i].Chunk.StableKey != results2[i].Chunk.StableKey {
+			t.Errorf("chunk %d StableKey mismatch:\n  incremental: %q\n  full: %q",
+				i, results1[i].Chunk.StableKey, results2[i].Chunk.StableKey)
+		}
+		if results1[i].Chunk.StartLine != results2[i].Chunk.StartLine {
+			t.Errorf("chunk %d StartLine mismatch: incremental=%d, full=%d",
+				i, results1[i].Chunk.StartLine, results2[i].Chunk.StartLine)
+		}
+	}
+}
+
+func TestIndexFileIncremental_EmptyFile(t *testing.T) {
+	srv := newMockEmbedServer(4)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	store, _ := NewSQLiteStore(":memory:")
+	defer func() { _ = store.Close() }()
+
+	tmpDir := t.TempDir()
+	goFile := filepath.Join(tmpDir, "main.go")
+
+	// First, index a file with content.
+	if err := os.WriteFile(goFile, []byte("package main\n\nfunc Hello() {}\n"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	idx := NewIndexer(client, store,
+		WithEmbeddingModel("test-embed"),
+		WithWorkspaceRoot(tmpDir),
+	)
+
+	if err := idx.IndexFile(context.Background(), goFile); err != nil {
+		t.Fatalf("initial IndexFile() error: %v", err)
+	}
+
+	statsBefore, _ := store.Stats(context.Background())
+	if statsBefore.TotalChunks == 0 {
+		t.Fatal("expected chunks after initial indexing")
+	}
+
+	// Truncate file to empty.
+	if err := os.WriteFile(goFile, []byte(""), 0644); err != nil {
+		t.Fatalf("truncate file: %v", err)
+	}
+
+	if err := idx.IndexFileIncremental(context.Background(), goFile); err != nil {
+		t.Fatalf("IndexFileIncremental() error: %v", err)
+	}
+
+	statsAfter, _ := store.Stats(context.Background())
+	if statsAfter.TotalChunks != 0 {
+		t.Errorf("expected 0 chunks after indexing empty file, got %d", statsAfter.TotalChunks)
+	}
+}

--- a/rag/indexer_incremental_test.go
+++ b/rag/indexer_incremental_test.go
@@ -915,3 +915,41 @@ func TestIndexFile_StoresHash(t *testing.T) {
 		t.Errorf("expected 0 Chunk() calls after hash match, got %d", got)
 	}
 }
+
+func TestIndexDirectory_WithIncremental(t *testing.T) {
+	var embedCount atomic.Int32
+	srv := newBatchCountingEmbedServer(4, &embedCount)
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	store, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("NewSQLiteStore() error: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	idx := NewIndexer(client, store, WithEmbeddingModel("test-embed"))
+
+	tmpDir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc Hello() {\n\treturn\n}\n"), 0644)
+
+	// First index: full.
+	if err := idx.IndexDirectory(context.Background(), tmpDir); err != nil {
+		t.Fatalf("first IndexDirectory() error: %v", err)
+	}
+	firstEmbedCount := embedCount.Load()
+	if firstEmbedCount == 0 {
+		t.Fatal("expected embed calls on first index")
+	}
+
+	// Reset counter.
+	embedCount.Store(0)
+
+	// Second index with WithIncremental: same content → no embeds.
+	if err := idx.IndexDirectory(context.Background(), tmpDir, WithIncremental()); err != nil {
+		t.Fatalf("incremental IndexDirectory() error: %v", err)
+	}
+	if got := embedCount.Load(); got != 0 {
+		t.Errorf("expected 0 embed calls with WithIncremental on unchanged files, got %d", got)
+	}
+}

--- a/rag/migration.go
+++ b/rag/migration.go
@@ -32,6 +32,11 @@ var migrations = []migration{
 		description: "add stable_key column for chunk identity",
 		fn:          migrateV3,
 	},
+	{
+		version:     4,
+		description: "add source_content_hash for incremental indexing",
+		fn:          migrateV4,
+	},
 }
 
 // migrateV1 creates the baseline chunks table and indexes.
@@ -117,6 +122,17 @@ func migrateV3(tx *sql.Tx) error {
 		if _, err := tx.Exec(stmt); err != nil {
 			return fmt.Errorf("rag: migrate v3: %w", err)
 		}
+	}
+	return nil
+}
+
+// migrateV4 adds the source_content_hash column for fast file-level change
+// detection during incremental indexing. Existing rows default to empty,
+// triggering a full check on next re-index.
+func migrateV4(tx *sql.Tx) error {
+	_, err := tx.Exec(`ALTER TABLE chunks ADD COLUMN source_content_hash TEXT NOT NULL DEFAULT ''`)
+	if err != nil {
+		return fmt.Errorf("rag: migrate v4: %w", err)
 	}
 	return nil
 }

--- a/rag/migration.go
+++ b/rag/migration.go
@@ -126,9 +126,9 @@ func migrateV3(tx *sql.Tx) error {
 	return nil
 }
 
-// migrateV4 adds the source_content_hash column for fast file-level change
-// detection during incremental indexing. Existing rows default to empty,
-// triggering a full check on next re-index.
+// migrateV4 adds the source_content_hash column for persisted source
+// signatures used by fast invalidation during incremental indexing.
+// Existing rows default to empty, triggering a full check on next re-index.
 func migrateV4(tx *sql.Tx) error {
 	_, err := tx.Exec(`ALTER TABLE chunks ADD COLUMN source_content_hash TEXT NOT NULL DEFAULT ''`)
 	if err != nil {

--- a/rag/migration_test.go
+++ b/rag/migration_test.go
@@ -12,14 +12,14 @@ import (
 func TestMigrationFreshDB(t *testing.T) {
 	store := newTestStore(t)
 
-	// Verify rag_schema_version exists with version 3.
+	// Verify rag_schema_version exists with version 4.
 	var maxVersion int
 	err := store.db.QueryRow(`SELECT MAX(version) FROM rag_schema_version`).Scan(&maxVersion)
 	if err != nil {
 		t.Fatalf("query rag_schema_version: %v", err)
 	}
-	if maxVersion != 3 {
-		t.Errorf("max schema version = %d, want 3", maxVersion)
+	if maxVersion != 4 {
+		t.Errorf("max schema version = %d, want 4", maxVersion)
 	}
 
 	// Verify chunks_fts virtual table exists.
@@ -102,14 +102,14 @@ func TestMigrationExistingDB(t *testing.T) {
 		t.Fatalf("runMigrations() error: %v", err)
 	}
 
-	// Verify version upgraded to 3.
+	// Verify version upgraded to 4.
 	var maxVersion int
 	err = db.QueryRow(`SELECT MAX(version) FROM rag_schema_version`).Scan(&maxVersion)
 	if err != nil {
 		t.Fatalf("query schema version: %v", err)
 	}
-	if maxVersion != 3 {
-		t.Errorf("max schema version = %d, want 3", maxVersion)
+	if maxVersion != 4 {
+		t.Errorf("max schema version = %d, want 4", maxVersion)
 	}
 
 	// Verify indexed_at was backfilled (should be non-zero).
@@ -393,13 +393,13 @@ func TestMigrationIdempotency(t *testing.T) {
 		t.Fatalf("second runMigrations() error: %v", err)
 	}
 
-	// Verify version is still 3 (not duplicated).
+	// Verify version is still 4 (not duplicated).
 	var count int
 	if err := db.QueryRow(`SELECT COUNT(*) FROM rag_schema_version`).Scan(&count); err != nil {
 		t.Fatalf("count versions: %v", err)
 	}
-	if count != 3 {
-		t.Errorf("expected 3 version records (v1, v2, v3), got %d", count)
+	if count != 4 {
+		t.Errorf("expected 4 version records (v1, v2, v3, v4), got %d", count)
 	}
 }
 
@@ -473,6 +473,132 @@ func TestFTS5UpsertConsistency(t *testing.T) {
 	}
 }
 
+func TestMigrationV4SourceContentHash(t *testing.T) {
+	store := newTestStore(t)
+
+	// Verify max schema version is 4.
+	var maxVersion int
+	err := store.db.QueryRow(`SELECT MAX(version) FROM rag_schema_version`).Scan(&maxVersion)
+	if err != nil {
+		t.Fatalf("query rag_schema_version: %v", err)
+	}
+	if maxVersion != 4 {
+		t.Errorf("max schema version = %d, want 4", maxVersion)
+	}
+
+	// Verify source_content_hash column exists by inserting and querying it.
+	_, err = store.db.Exec(
+		`INSERT INTO chunks (id, content, source, start_line, end_line, language, metadata, embedding, indexed_at, stable_key, source_content_hash)
+		 VALUES ('test-v4', 'content', 'src.go', 1, 1, 'go', '{}', '[]', 12345, 'key1', 'abc123')`,
+	)
+	if err != nil {
+		t.Fatalf("insert with source_content_hash: %v", err)
+	}
+
+	var hash string
+	err = store.db.QueryRow(`SELECT source_content_hash FROM chunks WHERE id = 'test-v4'`).Scan(&hash)
+	if err != nil {
+		t.Fatalf("query source_content_hash: %v", err)
+	}
+	if hash != "abc123" {
+		t.Errorf("source_content_hash = %q, want %q", hash, "abc123")
+	}
+}
+
+func TestMigrationV4ExistingDB(t *testing.T) {
+	// Simulate a V3-shaped database: chunks table with stable_key but NOT source_content_hash.
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	defer func() { _ = db.Close() }()
+
+	// Create V3-shaped schema with stable_key, indexed_at, FTS5, and triggers.
+	v3Schema := `
+	CREATE TABLE chunks (
+		id TEXT PRIMARY KEY,
+		content TEXT NOT NULL,
+		source TEXT NOT NULL,
+		start_line INTEGER NOT NULL,
+		end_line INTEGER NOT NULL,
+		language TEXT NOT NULL DEFAULT '',
+		metadata TEXT NOT NULL DEFAULT '{}',
+		embedding TEXT NOT NULL,
+		indexed_at INTEGER NOT NULL DEFAULT 0,
+		stable_key TEXT NOT NULL DEFAULT ''
+	);
+	CREATE INDEX idx_chunks_source_line ON chunks(source, start_line);
+	CREATE INDEX idx_chunks_lang_source_line ON chunks(language, source, start_line);
+	CREATE INDEX idx_chunks_stable_key ON chunks(stable_key);
+
+	CREATE VIRTUAL TABLE chunks_fts USING fts5(
+		content, source,
+		content=chunks, content_rowid=rowid
+	);
+	CREATE TRIGGER chunks_ai AFTER INSERT ON chunks BEGIN
+		INSERT INTO chunks_fts(rowid, content, source)
+		VALUES (new.rowid, new.content, new.source);
+	END;
+	CREATE TRIGGER chunks_ad AFTER DELETE ON chunks BEGIN
+		INSERT INTO chunks_fts(chunks_fts, rowid, content, source)
+		VALUES ('delete', old.rowid, old.content, old.source);
+	END;
+	CREATE TRIGGER chunks_au AFTER UPDATE ON chunks BEGIN
+		INSERT INTO chunks_fts(chunks_fts, rowid, content, source)
+		VALUES ('delete', old.rowid, old.content, old.source);
+		INSERT INTO chunks_fts(rowid, content, source)
+		VALUES (new.rowid, new.content, new.source);
+	END;
+
+	CREATE TABLE rag_schema_version (
+		version     INTEGER PRIMARY KEY,
+		description TEXT NOT NULL,
+		applied_at  INTEGER NOT NULL
+	);
+	INSERT INTO rag_schema_version (version, description, applied_at) VALUES (1, 'baseline schema', 1000);
+	INSERT INTO rag_schema_version (version, description, applied_at) VALUES (2, 'add indexed_at, FTS5 index, and sync triggers', 1000);
+	INSERT INTO rag_schema_version (version, description, applied_at) VALUES (3, 'add stable_key column for chunk identity', 1000);
+	`
+	if _, err := db.Exec(v3Schema); err != nil {
+		t.Fatalf("create v3 schema: %v", err)
+	}
+
+	// Insert a row without source_content_hash column.
+	_, err = db.Exec(
+		`INSERT INTO chunks (id, content, source, start_line, end_line, language, metadata, embedding, indexed_at, stable_key)
+		 VALUES ('c1', 'hello world', 'main.go', 1, 5, 'go', '{}', '[0.1, 0.2]', 12345, 'key1')`,
+	)
+	if err != nil {
+		t.Fatalf("insert test data: %v", err)
+	}
+
+	// Run migrations on the V3 database.
+	if err := runMigrations(db); err != nil {
+		t.Fatalf("runMigrations() error: %v", err)
+	}
+
+	// Verify version upgraded to 4.
+	var maxVersion int
+	err = db.QueryRow(`SELECT MAX(version) FROM rag_schema_version`).Scan(&maxVersion)
+	if err != nil {
+		t.Fatalf("query schema version: %v", err)
+	}
+	if maxVersion != 4 {
+		t.Errorf("max schema version = %d, want 4", maxVersion)
+	}
+
+	// Verify existing row has empty default hash.
+	var hash string
+	err = db.QueryRow(`SELECT source_content_hash FROM chunks WHERE id = 'c1'`).Scan(&hash)
+	if err != nil {
+		t.Fatalf("query source_content_hash: %v", err)
+	}
+	if hash != "" {
+		t.Errorf("existing row source_content_hash = %q, want empty string", hash)
+	}
+}
+
 func TestMigrationHalfAppliedV2(t *testing.T) {
 	// Simulate a database where v2 DDL was applied but version was
 	// not recorded (crash between tx.Commit and recordVersion in the
@@ -530,13 +656,13 @@ func TestMigrationHalfAppliedV2(t *testing.T) {
 		t.Fatalf("runMigrations() on half-applied v2: %v", err)
 	}
 
-	// Verify version recorded as 3 (v2 detected, then v3 applied).
+	// Verify version recorded as 4 (v2 detected, then v3+v4 applied).
 	var maxVersion int
 	if err := db.QueryRow(`SELECT MAX(version) FROM rag_schema_version`).Scan(&maxVersion); err != nil {
 		t.Fatalf("query version: %v", err)
 	}
-	if maxVersion != 3 {
-		t.Errorf("max version = %d, want 3", maxVersion)
+	if maxVersion != 4 {
+		t.Errorf("max version = %d, want 4", maxVersion)
 	}
 }
 
@@ -602,12 +728,12 @@ func TestMigrationHalfAppliedV2WithV1Recorded(t *testing.T) {
 		t.Fatalf("runMigrations() on v2 schema with v1 recorded: %v", err)
 	}
 
-	// Verify version is now 3 (v2 detected, then v3 applied).
+	// Verify version is now 4 (v2 detected, then v3+v4 applied).
 	var maxVersion int
 	if err := db.QueryRow(`SELECT MAX(version) FROM rag_schema_version`).Scan(&maxVersion); err != nil {
 		t.Fatalf("query version: %v", err)
 	}
-	if maxVersion != 3 {
-		t.Errorf("max version = %d, want 3", maxVersion)
+	if maxVersion != 4 {
+		t.Errorf("max version = %d, want 4", maxVersion)
 	}
 }

--- a/rag/migration_test.go
+++ b/rag/migration_test.go
@@ -12,14 +12,14 @@ import (
 func TestMigrationFreshDB(t *testing.T) {
 	store := newTestStore(t)
 
-	// Verify rag_schema_version exists with version 3.
+	// Verify rag_schema_version exists with version 4.
 	var maxVersion int
 	err := store.db.QueryRow(`SELECT MAX(version) FROM rag_schema_version`).Scan(&maxVersion)
 	if err != nil {
 		t.Fatalf("query rag_schema_version: %v", err)
 	}
-	if maxVersion != 3 {
-		t.Errorf("max schema version = %d, want 3", maxVersion)
+	if maxVersion != 4 {
+		t.Errorf("max schema version = %d, want 4", maxVersion)
 	}
 
 	// Verify chunks_fts virtual table exists.
@@ -102,14 +102,14 @@ func TestMigrationExistingDB(t *testing.T) {
 		t.Fatalf("runMigrations() error: %v", err)
 	}
 
-	// Verify version upgraded to 3.
+	// Verify version upgraded to 4.
 	var maxVersion int
 	err = db.QueryRow(`SELECT MAX(version) FROM rag_schema_version`).Scan(&maxVersion)
 	if err != nil {
 		t.Fatalf("query schema version: %v", err)
 	}
-	if maxVersion != 3 {
-		t.Errorf("max schema version = %d, want 3", maxVersion)
+	if maxVersion != 4 {
+		t.Errorf("max schema version = %d, want 4", maxVersion)
 	}
 
 	// Verify indexed_at was backfilled (should be non-zero).
@@ -393,13 +393,13 @@ func TestMigrationIdempotency(t *testing.T) {
 		t.Fatalf("second runMigrations() error: %v", err)
 	}
 
-	// Verify version is still 3 (not duplicated).
+	// Verify version is still 4 (not duplicated).
 	var count int
 	if err := db.QueryRow(`SELECT COUNT(*) FROM rag_schema_version`).Scan(&count); err != nil {
 		t.Fatalf("count versions: %v", err)
 	}
-	if count != 3 {
-		t.Errorf("expected 3 version records (v1, v2, v3), got %d", count)
+	if count != 4 {
+		t.Errorf("expected 4 version records (v1, v2, v3, v4), got %d", count)
 	}
 }
 
@@ -530,13 +530,13 @@ func TestMigrationHalfAppliedV2(t *testing.T) {
 		t.Fatalf("runMigrations() on half-applied v2: %v", err)
 	}
 
-	// Verify version recorded as 3 (v2 detected, then v3 applied).
+	// Verify version recorded as 4 (v2 detected, then v3+v4 applied).
 	var maxVersion int
 	if err := db.QueryRow(`SELECT MAX(version) FROM rag_schema_version`).Scan(&maxVersion); err != nil {
 		t.Fatalf("query version: %v", err)
 	}
-	if maxVersion != 3 {
-		t.Errorf("max version = %d, want 3", maxVersion)
+	if maxVersion != 4 {
+		t.Errorf("max version = %d, want 4", maxVersion)
 	}
 }
 
@@ -602,12 +602,12 @@ func TestMigrationHalfAppliedV2WithV1Recorded(t *testing.T) {
 		t.Fatalf("runMigrations() on v2 schema with v1 recorded: %v", err)
 	}
 
-	// Verify version is now 3 (v2 detected, then v3 applied).
+	// Verify version is now 4 (v2 detected, then v3+v4 applied).
 	var maxVersion int
 	if err := db.QueryRow(`SELECT MAX(version) FROM rag_schema_version`).Scan(&maxVersion); err != nil {
 		t.Fatalf("query version: %v", err)
 	}
-	if maxVersion != 3 {
-		t.Errorf("max version = %d, want 3", maxVersion)
+	if maxVersion != 4 {
+		t.Errorf("max version = %d, want 4", maxVersion)
 	}
 }

--- a/rag/sqlite_store.go
+++ b/rag/sqlite_store.go
@@ -161,8 +161,8 @@ func (s *SQLiteStore) ReplaceSource(ctx context.Context, source string, chunks [
 }
 
 // ReplaceSourceWithHash atomically replaces all chunks for a source path
-// and stores the given source content hash on each chunk for fast
-// file-level change detection during subsequent incremental indexes.
+// and stores the given source signature on each chunk for fast file-level
+// invalidation during subsequent incremental indexes.
 func (s *SQLiteStore) ReplaceSourceWithHash(ctx context.Context, source string, chunks []Chunk, embeddings [][]float64, sourceHash string) error {
 	if err := validateStoreInputs(chunks, embeddings); err != nil {
 		return fmt.Errorf("rag: replace source %q: %w", source, err)
@@ -298,9 +298,9 @@ func (s *SQLiteStore) GetBySource(ctx context.Context, source string) ([]ChunkWi
 	return results, nil
 }
 
-// GetSourceHash returns the stored content hash for a source path, or empty
-// string if the source has no chunks or no hash is stored. This enables fast
-// file-level change detection during incremental indexing.
+// GetSourceHash returns the stored source signature for a source path, or
+// empty string if the source has no chunks or no signature is stored. This
+// enables fast file-level invalidation during incremental indexing.
 func (s *SQLiteStore) GetSourceHash(ctx context.Context, source string) (string, error) {
 	var hash string
 	err := s.db.QueryRowContext(ctx,

--- a/rag/sqlite_store.go
+++ b/rag/sqlite_store.go
@@ -315,6 +315,18 @@ func (s *SQLiteStore) GetSourceHash(ctx context.Context, source string) (string,
 	return hash, nil
 }
 
+// UpdateSourceHash updates the source_content_hash for all chunks belonging
+// to the given source. Used to backfill the hash on databases migrated from
+// V3 where chunks exist but the hash column is empty.
+func (s *SQLiteStore) UpdateSourceHash(ctx context.Context, source, hash string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE chunks SET source_content_hash = ? WHERE source = ?`, hash, source)
+	if err != nil {
+		return fmt.Errorf("rag: update source hash for %q: %w", source, err)
+	}
+	return nil
+}
+
 // Stats returns index statistics.
 func (s *SQLiteStore) Stats(ctx context.Context) (StoreStats, error) {
 	var stats StoreStats

--- a/rag/sqlite_store.go
+++ b/rag/sqlite_store.go
@@ -16,8 +16,10 @@ import (
 
 // Compile-time interface satisfaction checks.
 var (
-	_ VectorStore = (*SQLiteStore)(nil)
-	_ Exportable  = (*SQLiteStore)(nil)
+	_ VectorStore       = (*SQLiteStore)(nil)
+	_ Exportable        = (*SQLiteStore)(nil)
+	_ sourceChunkLoader = (*SQLiteStore)(nil)
+	_ sourceHashChecker = (*SQLiteStore)(nil)
 )
 
 // SQLiteStore is a VectorStore backed by SQLite with brute-force cosine similarity.
@@ -241,6 +243,68 @@ func (s *SQLiteStore) DeleteBySource(ctx context.Context, source string) error {
 		return fmt.Errorf("rag: delete by source %q: %w", source, err)
 	}
 	return nil
+}
+
+// GetBySource returns all chunks for a given source path, ordered by start_line,
+// with their embeddings. This supports incremental indexing by allowing comparison
+// of existing chunks against newly generated ones.
+func (s *SQLiteStore) GetBySource(ctx context.Context, source string) ([]ChunkWithEmbedding, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, content, source, start_line, end_line, language,
+		        metadata, embedding, stable_key
+		 FROM chunks WHERE source = ?
+		 ORDER BY start_line`, source)
+	if err != nil {
+		return nil, fmt.Errorf("rag: get by source %q: %w", source, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []ChunkWithEmbedding
+	for rows.Next() {
+		var chunk Chunk
+		var metaJSON, embJSON string
+		if err := rows.Scan(&chunk.ID, &chunk.Content, &chunk.Source,
+			&chunk.StartLine, &chunk.EndLine, &chunk.Language,
+			&metaJSON, &embJSON, &chunk.StableKey); err != nil {
+			return nil, fmt.Errorf("rag: scan chunk for source %q: %w", source, err)
+		}
+
+		chunk.Metadata = make(map[string]string)
+		if err := json.Unmarshal([]byte(metaJSON), &chunk.Metadata); err != nil {
+			return nil, fmt.Errorf("rag: unmarshal metadata for chunk %q: %w", chunk.ID, err)
+		}
+
+		var embedding []float64
+		if err := json.Unmarshal([]byte(embJSON), &embedding); err != nil {
+			return nil, fmt.Errorf("rag: unmarshal embedding for chunk %q: %w", chunk.ID, err)
+		}
+
+		results = append(results, ChunkWithEmbedding{
+			Chunk:     chunk,
+			Embedding: embedding,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rag: iterate chunks for source %q: %w", source, err)
+	}
+	return results, nil
+}
+
+// GetSourceHash returns the stored content hash for a source path, or empty
+// string if the source has no chunks or no hash is stored. This enables fast
+// file-level change detection during incremental indexing.
+func (s *SQLiteStore) GetSourceHash(ctx context.Context, source string) (string, error) {
+	var hash string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT source_content_hash FROM chunks WHERE source = ? LIMIT 1`,
+		source).Scan(&hash)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("rag: get source hash for %q: %w", source, err)
+	}
+	return hash, nil
 }
 
 // Stats returns index statistics.

--- a/rag/sqlite_store.go
+++ b/rag/sqlite_store.go
@@ -16,8 +16,10 @@ import (
 
 // Compile-time interface satisfaction checks.
 var (
-	_ VectorStore = (*SQLiteStore)(nil)
-	_ Exportable  = (*SQLiteStore)(nil)
+	_ VectorStore       = (*SQLiteStore)(nil)
+	_ Exportable        = (*SQLiteStore)(nil)
+	_ sourceChunkLoader = (*SQLiteStore)(nil)
+	_ sourceHashChecker = (*SQLiteStore)(nil)
 )
 
 // SQLiteStore is a VectorStore backed by SQLite with brute-force cosine similarity.
@@ -82,7 +84,7 @@ func validateStoreInputs(chunks []Chunk, embeddings [][]float64) error {
 	return nil
 }
 
-func (s *SQLiteStore) insertChunksTx(ctx context.Context, tx *sql.Tx, chunks []Chunk, embeddings [][]float64) error {
+func (s *SQLiteStore) insertChunksTx(ctx context.Context, tx *sql.Tx, chunks []Chunk, embeddings [][]float64, sourceContentHash string) error {
 	// Use ON CONFLICT ... DO UPDATE instead of INSERT OR REPLACE.
 	// INSERT OR REPLACE deletes the old row and inserts a new one, but
 	// SQLite does not fire DELETE triggers for rows removed by REPLACE
@@ -91,8 +93,8 @@ func (s *SQLiteStore) insertChunksTx(ctx context.Context, tx *sql.Tx, chunks []C
 	// modifies the row in place (preserving its rowid) and fires the
 	// AFTER UPDATE trigger, which correctly maintains FTS5.
 	stmt, err := tx.PrepareContext(ctx,
-		`INSERT INTO chunks (id, content, source, start_line, end_line, language, metadata, embedding, indexed_at, stable_key)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`INSERT INTO chunks (id, content, source, start_line, end_line, language, metadata, embedding, indexed_at, stable_key, source_content_hash)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			 ON CONFLICT(id) DO UPDATE SET
 				content = excluded.content,
 				source = excluded.source,
@@ -102,7 +104,8 @@ func (s *SQLiteStore) insertChunksTx(ctx context.Context, tx *sql.Tx, chunks []C
 				metadata = excluded.metadata,
 				embedding = excluded.embedding,
 				indexed_at = excluded.indexed_at,
-				stable_key = excluded.stable_key`)
+				stable_key = excluded.stable_key,
+				source_content_hash = excluded.source_content_hash`)
 	if err != nil {
 		return fmt.Errorf("rag: prepare insert: %w", err)
 	}
@@ -119,7 +122,7 @@ func (s *SQLiteStore) insertChunksTx(ctx context.Context, tx *sql.Tx, chunks []C
 			return fmt.Errorf("rag: marshal embedding: %w", err)
 		}
 		if _, err := stmt.ExecContext(ctx, chunk.ID, chunk.Content, chunk.Source,
-			chunk.StartLine, chunk.EndLine, chunk.Language, string(metaJSON), string(embJSON), now, chunk.StableKey); err != nil {
+			chunk.StartLine, chunk.EndLine, chunk.Language, string(metaJSON), string(embJSON), now, chunk.StableKey, sourceContentHash); err != nil {
 			return fmt.Errorf("rag: insert chunk %q: %w", chunk.ID, err)
 		}
 	}
@@ -141,7 +144,7 @@ func (s *SQLiteStore) Store(ctx context.Context, chunks []Chunk, embeddings [][]
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	if err := s.insertChunksTx(ctx, tx, chunks, embeddings); err != nil {
+	if err := s.insertChunksTx(ctx, tx, chunks, embeddings, ""); err != nil {
 		return err
 	}
 
@@ -154,6 +157,13 @@ func (s *SQLiteStore) Store(ctx context.Context, chunks []Chunk, embeddings [][]
 // ReplaceSource atomically replaces all chunks for a source path.
 // If insertion fails, the delete is rolled back and existing data is preserved.
 func (s *SQLiteStore) ReplaceSource(ctx context.Context, source string, chunks []Chunk, embeddings [][]float64) error {
+	return s.ReplaceSourceWithHash(ctx, source, chunks, embeddings, "")
+}
+
+// ReplaceSourceWithHash atomically replaces all chunks for a source path
+// and stores the given source content hash on each chunk for fast
+// file-level change detection during subsequent incremental indexes.
+func (s *SQLiteStore) ReplaceSourceWithHash(ctx context.Context, source string, chunks []Chunk, embeddings [][]float64, sourceHash string) error {
 	if err := validateStoreInputs(chunks, embeddings); err != nil {
 		return fmt.Errorf("rag: replace source %q: %w", source, err)
 	}
@@ -174,7 +184,7 @@ func (s *SQLiteStore) ReplaceSource(ctx context.Context, source string, chunks [
 	}
 
 	if len(chunks) > 0 {
-		if err := s.insertChunksTx(ctx, tx, chunks, embeddings); err != nil {
+		if err := s.insertChunksTx(ctx, tx, chunks, embeddings, sourceHash); err != nil {
 			return fmt.Errorf("rag: replace source %q: %w", source, err)
 		}
 	}
@@ -241,6 +251,68 @@ func (s *SQLiteStore) DeleteBySource(ctx context.Context, source string) error {
 		return fmt.Errorf("rag: delete by source %q: %w", source, err)
 	}
 	return nil
+}
+
+// GetBySource returns all chunks for a given source path, ordered by start_line,
+// with their embeddings. This supports incremental indexing by allowing comparison
+// of existing chunks against newly generated ones.
+func (s *SQLiteStore) GetBySource(ctx context.Context, source string) ([]ChunkWithEmbedding, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, content, source, start_line, end_line, language,
+		        metadata, embedding, stable_key
+		 FROM chunks WHERE source = ?
+		 ORDER BY start_line`, source)
+	if err != nil {
+		return nil, fmt.Errorf("rag: get by source %q: %w", source, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []ChunkWithEmbedding
+	for rows.Next() {
+		var chunk Chunk
+		var metaJSON, embJSON string
+		if err := rows.Scan(&chunk.ID, &chunk.Content, &chunk.Source,
+			&chunk.StartLine, &chunk.EndLine, &chunk.Language,
+			&metaJSON, &embJSON, &chunk.StableKey); err != nil {
+			return nil, fmt.Errorf("rag: scan chunk for source %q: %w", source, err)
+		}
+
+		chunk.Metadata = make(map[string]string)
+		if err := json.Unmarshal([]byte(metaJSON), &chunk.Metadata); err != nil {
+			return nil, fmt.Errorf("rag: unmarshal metadata for chunk %q: %w", chunk.ID, err)
+		}
+
+		var embedding []float64
+		if err := json.Unmarshal([]byte(embJSON), &embedding); err != nil {
+			return nil, fmt.Errorf("rag: unmarshal embedding for chunk %q: %w", chunk.ID, err)
+		}
+
+		results = append(results, ChunkWithEmbedding{
+			Chunk:     chunk,
+			Embedding: embedding,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rag: iterate chunks for source %q: %w", source, err)
+	}
+	return results, nil
+}
+
+// GetSourceHash returns the stored content hash for a source path, or empty
+// string if the source has no chunks or no hash is stored. This enables fast
+// file-level change detection during incremental indexing.
+func (s *SQLiteStore) GetSourceHash(ctx context.Context, source string) (string, error) {
+	var hash string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT source_content_hash FROM chunks WHERE source = ? LIMIT 1`,
+		source).Scan(&hash)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("rag: get source hash for %q: %w", source, err)
+	}
+	return hash, nil
 }
 
 // Stats returns index statistics.

--- a/rag/sqlite_store.go
+++ b/rag/sqlite_store.go
@@ -16,8 +16,9 @@ import (
 
 // Compile-time interface satisfaction checks.
 var (
-	_ VectorStore = (*SQLiteStore)(nil)
-	_ Exportable  = (*SQLiteStore)(nil)
+	_ VectorStore      = (*SQLiteStore)(nil)
+	_ Exportable       = (*SQLiteStore)(nil)
+	_ sourceChunkLoader = (*SQLiteStore)(nil)
 )
 
 // SQLiteStore is a VectorStore backed by SQLite with brute-force cosine similarity.
@@ -241,6 +242,51 @@ func (s *SQLiteStore) DeleteBySource(ctx context.Context, source string) error {
 		return fmt.Errorf("rag: delete by source %q: %w", source, err)
 	}
 	return nil
+}
+
+// GetBySource returns all chunks for a given source path, ordered by start_line,
+// with their embeddings. This supports incremental indexing by allowing comparison
+// of existing chunks against newly generated ones.
+func (s *SQLiteStore) GetBySource(ctx context.Context, source string) ([]ChunkWithEmbedding, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, content, source, start_line, end_line, language,
+		        metadata, embedding, stable_key
+		 FROM chunks WHERE source = ?
+		 ORDER BY start_line`, source)
+	if err != nil {
+		return nil, fmt.Errorf("rag: get by source %q: %w", source, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []ChunkWithEmbedding
+	for rows.Next() {
+		var chunk Chunk
+		var metaJSON, embJSON string
+		if err := rows.Scan(&chunk.ID, &chunk.Content, &chunk.Source,
+			&chunk.StartLine, &chunk.EndLine, &chunk.Language,
+			&metaJSON, &embJSON, &chunk.StableKey); err != nil {
+			return nil, fmt.Errorf("rag: scan chunk for source %q: %w", source, err)
+		}
+
+		chunk.Metadata = make(map[string]string)
+		if err := json.Unmarshal([]byte(metaJSON), &chunk.Metadata); err != nil {
+			return nil, fmt.Errorf("rag: unmarshal metadata for chunk %q: %w", chunk.ID, err)
+		}
+
+		var embedding []float64
+		if err := json.Unmarshal([]byte(embJSON), &embedding); err != nil {
+			return nil, fmt.Errorf("rag: unmarshal embedding for chunk %q: %w", chunk.ID, err)
+		}
+
+		results = append(results, ChunkWithEmbedding{
+			Chunk:     chunk,
+			Embedding: embedding,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rag: iterate chunks for source %q: %w", source, err)
+	}
+	return results, nil
 }
 
 // Stats returns index statistics.

--- a/rag/sqlite_store_test.go
+++ b/rag/sqlite_store_test.go
@@ -488,3 +488,379 @@ func TestSQLiteStoreImplementsExportable(t *testing.T) {
 	store := newTestStore(t)
 	var _ Exportable = store // compile-time check
 }
+
+// --- GetBySource tests ---
+
+func TestGetBySourceBasic(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Store 3 chunks: 2 for "main.go" (out of order by start_line), 1 for "other.go".
+	chunks := []Chunk{
+		{
+			ID: "m2", Content: "func helper() {}", Source: "main.go",
+			StartLine: 10, EndLine: 15, Language: "go",
+			Metadata: map[string]string{"kind": "function"}, StableKey: "main.go::helper",
+		},
+		{
+			ID: "m1", Content: "package main", Source: "main.go",
+			StartLine: 1, EndLine: 3, Language: "go",
+			Metadata: map[string]string{"kind": "package"}, StableKey: "main.go::package",
+		},
+		{
+			ID: "o1", Content: "package other", Source: "other.go",
+			StartLine: 1, EndLine: 1, Language: "go",
+			Metadata: map[string]string{}, StableKey: "other.go::package",
+		},
+	}
+	embeddings := [][]float64{
+		{0.1, 0.2, 0.3},
+		{0.4, 0.5, 0.6},
+		{0.7, 0.8, 0.9},
+	}
+
+	if err := store.Store(ctx, chunks, embeddings); err != nil {
+		t.Fatalf("Store() error: %v", err)
+	}
+
+	// GetBySource for "main.go" should return 2 results ordered by start_line.
+	results, err := store.GetBySource(ctx, "main.go")
+	if err != nil {
+		t.Fatalf("GetBySource() error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2", len(results))
+	}
+
+	// First result should be m1 (start_line=1), second m2 (start_line=10).
+	if results[0].Chunk.ID != "m1" {
+		t.Errorf("results[0].Chunk.ID = %q, want %q", results[0].Chunk.ID, "m1")
+	}
+	if results[1].Chunk.ID != "m2" {
+		t.Errorf("results[1].Chunk.ID = %q, want %q", results[1].Chunk.ID, "m2")
+	}
+}
+
+func TestGetBySourceEmpty(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	results, err := store.GetBySource(ctx, "nonexistent.go")
+	if err != nil {
+		t.Fatalf("GetBySource() error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("got %d results for nonexistent source, want 0", len(results))
+	}
+}
+
+func TestGetBySourceImplementsInterface(t *testing.T) {
+	store := newTestStore(t)
+	var _ sourceChunkLoader = store
+}
+
+// --- GetSourceHash tests ---
+
+func TestGetSourceHashBasic(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Manually insert a chunk with source_content_hash set.
+	_, err := store.db.ExecContext(ctx,
+		`INSERT INTO chunks (id, content, source, start_line, end_line, language, metadata, embedding, indexed_at, stable_key, source_content_hash)
+		 VALUES ('h1', 'func main()', 'main.go', 1, 5, 'go', '{}', '[0.1,0.2]', 12345, 'main.go::main', 'deadbeef1234')`)
+	if err != nil {
+		t.Fatalf("insert chunk: %v", err)
+	}
+
+	hash, err := store.GetSourceHash(ctx, "main.go")
+	if err != nil {
+		t.Fatalf("GetSourceHash() error: %v", err)
+	}
+	if hash != "deadbeef1234" {
+		t.Errorf("GetSourceHash() = %q, want %q", hash, "deadbeef1234")
+	}
+}
+
+func TestGetSourceHashEmpty(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	hash, err := store.GetSourceHash(ctx, "nonexistent.go")
+	if err != nil {
+		t.Fatalf("GetSourceHash() error: %v", err)
+	}
+	if hash != "" {
+		t.Errorf("GetSourceHash() = %q, want empty string", hash)
+	}
+}
+
+func TestGetSourceHashNoHashStored(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Insert a chunk with default empty source_content_hash (simulating pre-V4 data).
+	_, err := store.db.ExecContext(ctx,
+		`INSERT INTO chunks (id, content, source, start_line, end_line, language, metadata, embedding, indexed_at, stable_key)
+		 VALUES ('h2', 'package foo', 'foo.go', 1, 1, 'go', '{}', '[0.5]', 12345, 'foo.go::package')`)
+	if err != nil {
+		t.Fatalf("insert chunk: %v", err)
+	}
+
+	hash, err := store.GetSourceHash(ctx, "foo.go")
+	if err != nil {
+		t.Fatalf("GetSourceHash() error: %v", err)
+	}
+	if hash != "" {
+		t.Errorf("GetSourceHash() = %q, want empty string for default", hash)
+	}
+}
+
+func TestGetSourceHashImplementsInterface(t *testing.T) {
+	store := newTestStore(t)
+	var _ sourceHashChecker = store
+}
+
+// --- ReplaceSourceWithHash tests (Task 1.5) ---
+
+func TestReplaceSourceWithHashPopulatesHash(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	chunks := []Chunk{
+		{
+			ID: "c1", Content: "func Hello() {}", Source: "main.go",
+			StartLine: 1, EndLine: 3, Language: "go", Metadata: map[string]string{},
+		},
+		{
+			ID: "c2", Content: "func World() {}", Source: "main.go",
+			StartLine: 5, EndLine: 7, Language: "go", Metadata: map[string]string{},
+		},
+	}
+	embeddings := [][]float64{{1.0, 0.0}, {0.0, 1.0}}
+	sourceHash := "abc123def456abc123def456"
+
+	if err := store.ReplaceSourceWithHash(ctx, "main.go", chunks, embeddings, sourceHash); err != nil {
+		t.Fatalf("ReplaceSourceWithHash() error: %v", err)
+	}
+
+	// All chunks from the same source should have the same source_content_hash.
+	rows, err := store.db.QueryContext(ctx,
+		`SELECT id, source_content_hash FROM chunks WHERE source = 'main.go' ORDER BY id`)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var count int
+	for rows.Next() {
+		var id, hash string
+		if err := rows.Scan(&id, &hash); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if hash != sourceHash {
+			t.Errorf("chunk %q source_content_hash = %q, want %q", id, hash, sourceHash)
+		}
+		count++
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 chunks, got %d", count)
+	}
+}
+
+func TestReplaceSourceWithoutHashLeavesEmpty(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	chunks := []Chunk{
+		{
+			ID: "c1", Content: "func Hello() {}", Source: "main.go",
+			StartLine: 1, EndLine: 3, Language: "go", Metadata: map[string]string{},
+		},
+	}
+	embeddings := [][]float64{{1.0, 0.0}}
+
+	// Standard ReplaceSource (no hash).
+	if err := store.ReplaceSource(ctx, "main.go", chunks, embeddings); err != nil {
+		t.Fatalf("ReplaceSource() error: %v", err)
+	}
+
+	var hash string
+	err := store.db.QueryRowContext(ctx,
+		`SELECT source_content_hash FROM chunks WHERE id = 'c1'`).Scan(&hash)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if hash != "" {
+		t.Errorf("source_content_hash = %q, want empty (no hash provided)", hash)
+	}
+}
+
+func TestInsertChunksPopulatesSourceContentHash(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	chunks := []Chunk{
+		{
+			ID: "c1", Content: "func Hello() {}", Source: "main.go",
+			StartLine: 1, EndLine: 3, Language: "go", Metadata: map[string]string{},
+		},
+		{
+			ID: "c2", Content: "func World() {}", Source: "main.go",
+			StartLine: 5, EndLine: 7, Language: "go", Metadata: map[string]string{},
+		},
+	}
+	embeddings := [][]float64{{1.0, 0.0}, {0.0, 1.0}}
+
+	// Compute hash the same way the indexer would.
+	combined := chunks[0].Content + chunks[1].Content
+	expectedHash := contentHash(combined)
+
+	// Use ReplaceSourceWithHash which flows through insertChunksTx.
+	if err := store.ReplaceSourceWithHash(ctx, "main.go", chunks, embeddings, expectedHash); err != nil {
+		t.Fatalf("ReplaceSourceWithHash() error: %v", err)
+	}
+
+	// All chunks from the same source should have the same source_content_hash.
+	rows, err := store.db.QueryContext(ctx,
+		`SELECT id, source_content_hash FROM chunks WHERE source = 'main.go' ORDER BY id`)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var hashes []string
+	for rows.Next() {
+		var id, hash string
+		if err := rows.Scan(&id, &hash); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if hash == "" {
+			t.Errorf("chunk %q has empty source_content_hash", id)
+		}
+		hashes = append(hashes, hash)
+	}
+
+	if len(hashes) != 2 {
+		t.Fatalf("expected 2 chunks, got %d", len(hashes))
+	}
+	if hashes[0] != hashes[1] {
+		t.Errorf("chunks from same source have different hashes: %q vs %q", hashes[0], hashes[1])
+	}
+	if hashes[0] != expectedHash {
+		t.Errorf("source_content_hash = %q, want %q", hashes[0], expectedHash)
+	}
+}
+
+func TestSourceContentHashChangesOnUpdate(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// First insert.
+	chunks1 := []Chunk{
+		{
+			ID: "c1", Content: "func Hello() {}", Source: "main.go",
+			StartLine: 1, EndLine: 3, Language: "go", Metadata: map[string]string{},
+		},
+	}
+	embeddings1 := [][]float64{{1.0, 0.0}}
+	hash1 := contentHash("func Hello() {}")
+
+	if err := store.ReplaceSourceWithHash(ctx, "main.go", chunks1, embeddings1, hash1); err != nil {
+		t.Fatalf("first ReplaceSourceWithHash() error: %v", err)
+	}
+
+	// Verify first hash.
+	gotHash1, err := store.GetSourceHash(ctx, "main.go")
+	if err != nil {
+		t.Fatalf("GetSourceHash() error: %v", err)
+	}
+	if gotHash1 != hash1 {
+		t.Fatalf("first hash = %q, want %q", gotHash1, hash1)
+	}
+
+	// Second insert with different content.
+	chunks2 := []Chunk{
+		{
+			ID: "c1", Content: "func Goodbye() {}", Source: "main.go",
+			StartLine: 1, EndLine: 3, Language: "go", Metadata: map[string]string{},
+		},
+	}
+	embeddings2 := [][]float64{{0.0, 1.0}}
+	hash2 := contentHash("func Goodbye() {}")
+
+	if err := store.ReplaceSourceWithHash(ctx, "main.go", chunks2, embeddings2, hash2); err != nil {
+		t.Fatalf("second ReplaceSourceWithHash() error: %v", err)
+	}
+
+	// Verify hash changed.
+	gotHash2, err := store.GetSourceHash(ctx, "main.go")
+	if err != nil {
+		t.Fatalf("GetSourceHash() error: %v", err)
+	}
+	if gotHash2 == gotHash1 {
+		t.Errorf("hash did not change after update: %q", gotHash2)
+	}
+	if gotHash2 != hash2 {
+		t.Errorf("second hash = %q, want %q", gotHash2, hash2)
+	}
+}
+
+func TestDifferentSourcesDifferentHashes(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Insert chunks for source A.
+	chunksA := []Chunk{
+		{
+			ID: "a1", Content: "func Alpha() {}", Source: "alpha.go",
+			StartLine: 1, EndLine: 3, Language: "go", Metadata: map[string]string{},
+		},
+	}
+	embeddingsA := [][]float64{{1.0, 0.0}}
+	hashA := contentHash("func Alpha() {}")
+
+	if err := store.ReplaceSourceWithHash(ctx, "alpha.go", chunksA, embeddingsA, hashA); err != nil {
+		t.Fatalf("ReplaceSourceWithHash(alpha) error: %v", err)
+	}
+
+	// Insert chunks for source B.
+	chunksB := []Chunk{
+		{
+			ID: "b1", Content: "func Beta() {}", Source: "beta.go",
+			StartLine: 1, EndLine: 3, Language: "go", Metadata: map[string]string{},
+		},
+	}
+	embeddingsB := [][]float64{{0.0, 1.0}}
+	hashB := contentHash("func Beta() {}")
+
+	if err := store.ReplaceSourceWithHash(ctx, "beta.go", chunksB, embeddingsB, hashB); err != nil {
+		t.Fatalf("ReplaceSourceWithHash(beta) error: %v", err)
+	}
+
+	// Verify different hashes.
+	gotHashA, err := store.GetSourceHash(ctx, "alpha.go")
+	if err != nil {
+		t.Fatalf("GetSourceHash(alpha) error: %v", err)
+	}
+	gotHashB, err := store.GetSourceHash(ctx, "beta.go")
+	if err != nil {
+		t.Fatalf("GetSourceHash(beta) error: %v", err)
+	}
+
+	if gotHashA == "" {
+		t.Error("alpha hash is empty")
+	}
+	if gotHashB == "" {
+		t.Error("beta hash is empty")
+	}
+	if gotHashA == gotHashB {
+		t.Errorf("different sources have same hash: %q", gotHashA)
+	}
+	if gotHashA != hashA {
+		t.Errorf("alpha hash = %q, want %q", gotHashA, hashA)
+	}
+	if gotHashB != hashB {
+		t.Errorf("beta hash = %q, want %q", gotHashB, hashB)
+	}
+}

--- a/rag/sqlite_store_test.go
+++ b/rag/sqlite_store_test.go
@@ -488,3 +488,123 @@ func TestSQLiteStoreImplementsExportable(t *testing.T) {
 	store := newTestStore(t)
 	var _ Exportable = store // compile-time check
 }
+
+// --- GetBySource tests ---
+
+func TestGetBySourceBasic(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Store 3 chunks: 2 for "main.go" (out of order by start_line), 1 for "other.go".
+	chunks := []Chunk{
+		{
+			ID: "m2", Content: "func helper() {}", Source: "main.go",
+			StartLine: 10, EndLine: 15, Language: "go",
+			Metadata: map[string]string{"kind": "function"}, StableKey: "main.go::helper",
+		},
+		{
+			ID: "m1", Content: "package main", Source: "main.go",
+			StartLine: 1, EndLine: 3, Language: "go",
+			Metadata: map[string]string{"kind": "package"}, StableKey: "main.go::package",
+		},
+		{
+			ID: "o1", Content: "package other", Source: "other.go",
+			StartLine: 1, EndLine: 1, Language: "go",
+			Metadata: map[string]string{}, StableKey: "other.go::package",
+		},
+	}
+	embeddings := [][]float64{
+		{0.1, 0.2, 0.3},
+		{0.4, 0.5, 0.6},
+		{0.7, 0.8, 0.9},
+	}
+
+	if err := store.Store(ctx, chunks, embeddings); err != nil {
+		t.Fatalf("Store() error: %v", err)
+	}
+
+	// GetBySource for "main.go" should return 2 results ordered by start_line.
+	results, err := store.GetBySource(ctx, "main.go")
+	if err != nil {
+		t.Fatalf("GetBySource() error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2", len(results))
+	}
+
+	// First result should be m1 (start_line=1), second m2 (start_line=10).
+	if results[0].Chunk.ID != "m1" {
+		t.Errorf("results[0].Chunk.ID = %q, want %q", results[0].Chunk.ID, "m1")
+	}
+	if results[1].Chunk.ID != "m2" {
+		t.Errorf("results[1].Chunk.ID = %q, want %q", results[1].Chunk.ID, "m2")
+	}
+
+	// Verify start_line ordering.
+	if results[0].Chunk.StartLine != 1 {
+		t.Errorf("results[0].Chunk.StartLine = %d, want 1", results[0].Chunk.StartLine)
+	}
+	if results[1].Chunk.StartLine != 10 {
+		t.Errorf("results[1].Chunk.StartLine = %d, want 10", results[1].Chunk.StartLine)
+	}
+
+	// Verify embeddings are correct.
+	// m1 was stored with embedding [0.4, 0.5, 0.6].
+	if len(results[0].Embedding) != 3 {
+		t.Fatalf("results[0].Embedding length = %d, want 3", len(results[0].Embedding))
+	}
+	if results[0].Embedding[0] != 0.4 || results[0].Embedding[1] != 0.5 || results[0].Embedding[2] != 0.6 {
+		t.Errorf("results[0].Embedding = %v, want [0.4 0.5 0.6]", results[0].Embedding)
+	}
+	// m2 was stored with embedding [0.1, 0.2, 0.3].
+	if results[1].Embedding[0] != 0.1 || results[1].Embedding[1] != 0.2 || results[1].Embedding[2] != 0.3 {
+		t.Errorf("results[1].Embedding = %v, want [0.1 0.2 0.3]", results[1].Embedding)
+	}
+
+	// Verify StableKeys.
+	if results[0].Chunk.StableKey != "main.go::package" {
+		t.Errorf("results[0].Chunk.StableKey = %q, want %q", results[0].Chunk.StableKey, "main.go::package")
+	}
+	if results[1].Chunk.StableKey != "main.go::helper" {
+		t.Errorf("results[1].Chunk.StableKey = %q, want %q", results[1].Chunk.StableKey, "main.go::helper")
+	}
+
+	// Verify metadata is populated.
+	if results[0].Chunk.Metadata["kind"] != "package" {
+		t.Errorf("results[0].Chunk.Metadata[\"kind\"] = %q, want %q", results[0].Chunk.Metadata["kind"], "package")
+	}
+	if results[1].Chunk.Metadata["kind"] != "function" {
+		t.Errorf("results[1].Chunk.Metadata[\"kind\"] = %q, want %q", results[1].Chunk.Metadata["kind"], "function")
+	}
+
+	// Verify other fields.
+	if results[0].Chunk.Content != "package main" {
+		t.Errorf("results[0].Chunk.Content = %q, want %q", results[0].Chunk.Content, "package main")
+	}
+	if results[0].Chunk.Language != "go" {
+		t.Errorf("results[0].Chunk.Language = %q, want %q", results[0].Chunk.Language, "go")
+	}
+	if results[0].Chunk.Source != "main.go" {
+		t.Errorf("results[0].Chunk.Source = %q, want %q", results[0].Chunk.Source, "main.go")
+	}
+}
+
+func TestGetBySourceEmpty(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// GetBySource for a nonexistent source returns empty slice, no error.
+	results, err := store.GetBySource(ctx, "nonexistent.go")
+	if err != nil {
+		t.Fatalf("GetBySource() error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("got %d results for nonexistent source, want 0", len(results))
+	}
+}
+
+func TestGetBySourceImplementsInterface(t *testing.T) {
+	store := newTestStore(t)
+	// Compile-time check that *SQLiteStore satisfies sourceChunkLoader.
+	var _ sourceChunkLoader = store
+}

--- a/rag/sqlite_store_test.go
+++ b/rag/sqlite_store_test.go
@@ -488,3 +488,187 @@ func TestSQLiteStoreImplementsExportable(t *testing.T) {
 	store := newTestStore(t)
 	var _ Exportable = store // compile-time check
 }
+
+// --- GetBySource tests ---
+
+func TestGetBySourceBasic(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Store 3 chunks: 2 for "main.go" (out of order by start_line), 1 for "other.go".
+	chunks := []Chunk{
+		{
+			ID: "m2", Content: "func helper() {}", Source: "main.go",
+			StartLine: 10, EndLine: 15, Language: "go",
+			Metadata: map[string]string{"kind": "function"}, StableKey: "main.go::helper",
+		},
+		{
+			ID: "m1", Content: "package main", Source: "main.go",
+			StartLine: 1, EndLine: 3, Language: "go",
+			Metadata: map[string]string{"kind": "package"}, StableKey: "main.go::package",
+		},
+		{
+			ID: "o1", Content: "package other", Source: "other.go",
+			StartLine: 1, EndLine: 1, Language: "go",
+			Metadata: map[string]string{}, StableKey: "other.go::package",
+		},
+	}
+	embeddings := [][]float64{
+		{0.1, 0.2, 0.3},
+		{0.4, 0.5, 0.6},
+		{0.7, 0.8, 0.9},
+	}
+
+	if err := store.Store(ctx, chunks, embeddings); err != nil {
+		t.Fatalf("Store() error: %v", err)
+	}
+
+	// GetBySource for "main.go" should return 2 results ordered by start_line.
+	results, err := store.GetBySource(ctx, "main.go")
+	if err != nil {
+		t.Fatalf("GetBySource() error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2", len(results))
+	}
+
+	// First result should be m1 (start_line=1), second m2 (start_line=10).
+	if results[0].Chunk.ID != "m1" {
+		t.Errorf("results[0].Chunk.ID = %q, want %q", results[0].Chunk.ID, "m1")
+	}
+	if results[1].Chunk.ID != "m2" {
+		t.Errorf("results[1].Chunk.ID = %q, want %q", results[1].Chunk.ID, "m2")
+	}
+
+	// Verify start_line ordering.
+	if results[0].Chunk.StartLine != 1 {
+		t.Errorf("results[0].Chunk.StartLine = %d, want 1", results[0].Chunk.StartLine)
+	}
+	if results[1].Chunk.StartLine != 10 {
+		t.Errorf("results[1].Chunk.StartLine = %d, want 10", results[1].Chunk.StartLine)
+	}
+
+	// Verify embeddings are correct.
+	// m1 was stored with embedding [0.4, 0.5, 0.6].
+	if len(results[0].Embedding) != 3 {
+		t.Fatalf("results[0].Embedding length = %d, want 3", len(results[0].Embedding))
+	}
+	if results[0].Embedding[0] != 0.4 || results[0].Embedding[1] != 0.5 || results[0].Embedding[2] != 0.6 {
+		t.Errorf("results[0].Embedding = %v, want [0.4 0.5 0.6]", results[0].Embedding)
+	}
+	// m2 was stored with embedding [0.1, 0.2, 0.3].
+	if results[1].Embedding[0] != 0.1 || results[1].Embedding[1] != 0.2 || results[1].Embedding[2] != 0.3 {
+		t.Errorf("results[1].Embedding = %v, want [0.1 0.2 0.3]", results[1].Embedding)
+	}
+
+	// Verify StableKeys.
+	if results[0].Chunk.StableKey != "main.go::package" {
+		t.Errorf("results[0].Chunk.StableKey = %q, want %q", results[0].Chunk.StableKey, "main.go::package")
+	}
+	if results[1].Chunk.StableKey != "main.go::helper" {
+		t.Errorf("results[1].Chunk.StableKey = %q, want %q", results[1].Chunk.StableKey, "main.go::helper")
+	}
+
+	// Verify metadata is populated.
+	if results[0].Chunk.Metadata["kind"] != "package" {
+		t.Errorf("results[0].Chunk.Metadata[\"kind\"] = %q, want %q", results[0].Chunk.Metadata["kind"], "package")
+	}
+	if results[1].Chunk.Metadata["kind"] != "function" {
+		t.Errorf("results[1].Chunk.Metadata[\"kind\"] = %q, want %q", results[1].Chunk.Metadata["kind"], "function")
+	}
+
+	// Verify other fields.
+	if results[0].Chunk.Content != "package main" {
+		t.Errorf("results[0].Chunk.Content = %q, want %q", results[0].Chunk.Content, "package main")
+	}
+	if results[0].Chunk.Language != "go" {
+		t.Errorf("results[0].Chunk.Language = %q, want %q", results[0].Chunk.Language, "go")
+	}
+	if results[0].Chunk.Source != "main.go" {
+		t.Errorf("results[0].Chunk.Source = %q, want %q", results[0].Chunk.Source, "main.go")
+	}
+}
+
+func TestGetBySourceEmpty(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// GetBySource for a nonexistent source returns empty slice, no error.
+	results, err := store.GetBySource(ctx, "nonexistent.go")
+	if err != nil {
+		t.Fatalf("GetBySource() error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("got %d results for nonexistent source, want 0", len(results))
+	}
+}
+
+func TestGetBySourceImplementsInterface(t *testing.T) {
+	store := newTestStore(t)
+	// Compile-time check that *SQLiteStore satisfies sourceChunkLoader.
+	var _ sourceChunkLoader = store
+}
+
+// --- GetSourceHash tests ---
+
+func TestGetSourceHashBasic(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Manually insert a chunk with source_content_hash set.
+	_, err := store.db.ExecContext(ctx,
+		`INSERT INTO chunks (id, content, source, start_line, end_line, language, metadata, embedding, indexed_at, stable_key, source_content_hash)
+		 VALUES ('h1', 'func main()', 'main.go', 1, 5, 'go', '{}', '[0.1,0.2]', 12345, 'main.go::main', 'deadbeef1234')`)
+	if err != nil {
+		t.Fatalf("insert chunk: %v", err)
+	}
+
+	hash, err := store.GetSourceHash(ctx, "main.go")
+	if err != nil {
+		t.Fatalf("GetSourceHash() error: %v", err)
+	}
+	if hash != "deadbeef1234" {
+		t.Errorf("GetSourceHash() = %q, want %q", hash, "deadbeef1234")
+	}
+}
+
+func TestGetSourceHashEmpty(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// GetSourceHash for a nonexistent source returns "", nil.
+	hash, err := store.GetSourceHash(ctx, "nonexistent.go")
+	if err != nil {
+		t.Fatalf("GetSourceHash() error: %v", err)
+	}
+	if hash != "" {
+		t.Errorf("GetSourceHash() = %q, want empty string", hash)
+	}
+}
+
+func TestGetSourceHashNoHashStored(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Insert a chunk with default empty source_content_hash (simulating pre-V4 data).
+	_, err := store.db.ExecContext(ctx,
+		`INSERT INTO chunks (id, content, source, start_line, end_line, language, metadata, embedding, indexed_at, stable_key)
+		 VALUES ('h2', 'package foo', 'foo.go', 1, 1, 'go', '{}', '[0.5]', 12345, 'foo.go::package')`)
+	if err != nil {
+		t.Fatalf("insert chunk: %v", err)
+	}
+
+	hash, err := store.GetSourceHash(ctx, "foo.go")
+	if err != nil {
+		t.Fatalf("GetSourceHash() error: %v", err)
+	}
+	if hash != "" {
+		t.Errorf("GetSourceHash() = %q, want empty string for default", hash)
+	}
+}
+
+func TestGetSourceHashImplementsInterface(t *testing.T) {
+	store := newTestStore(t)
+	// Compile-time check that *SQLiteStore satisfies sourceHashChecker.
+	var _ sourceHashChecker = store
+}

--- a/rag/stable_key.go
+++ b/rag/stable_key.go
@@ -8,6 +8,11 @@ import (
 	"strings"
 )
 
+// stableKeyVersion identifies the current stable-key derivation scheme.
+// Bump this when ComputeStableKey semantics change so persisted source
+// signatures force a full re-index instead of reusing stale embeddings.
+const stableKeyVersion = "v1"
+
 // ComputeStableKey derives a logical identity key for a chunk that survives
 // re-indexes and benign line shifts. The key format depends on the metadata
 // available on the chunk:


### PR DESCRIPTION
## Summary

Adds incremental indexing to the `rag/` package so that small file edits do not force whole-file re-embedding (#34):

- **Migration V4** -- adds `source_content_hash` column for file-level change detection
- **Store extensions** -- `GetBySource`, `GetSourceHash`, `UpdateSourceHash`, `ReplaceSourceWithHash` via optional interfaces
- **diffChunks** -- pure function that classifies chunks as unchanged/modified/added/deleted using StableKey matching and content hashing
- **IndexFileIncremental** -- reads, chunks, diffs against stored data, embeds only changed chunks, transparent fallback to full IndexFile on any failure
- **Source hash fast path** -- skips everything (including chunking) when file content hash matches stored hash
- **WithIncremental()** -- IndexDirectory option that wires through the incremental path end-to-end

Performance: editing one function in a 15-chunk file drops embedding calls from 15 to 1 (93% reduction). Unchanged files skip with zero embed calls and zero chunk calls.

## Test plan

- [x] All 12 packages pass `go test -race ./...`
- [x] `golangci-lint run ./...` reports 0 issues
- [x] Full /code-review cycle -- critical hash persistence issue fixed
- [x] Full /criticize-review cycle -- blocking issues fixed (bounds check, stale line numbers, dead code)
- [x] `TestIndexDirectory_WithIncremental` verifies end-to-end wiring
- [x] `TestIndexFileIncremental_ConsistentWithFull` verifies incremental produces same result as full
- [x] CI passes on this PR

Closes #34

Generated with [Claude Code](https://claude.com/claude-code)