### PR TITLE
feat(provider): add Router Core — intelligent model dispatch layer (#48 Phase 2)

### DIFF
--- a/provider/circuit_breaker.go
+++ b/provider/circuit_breaker.go
@@ -23,7 +23,6 @@ type CircuitBreaker struct {
 	state            BreakerState
 	failures         int
 	lastFailure      time.Time
-	lastSuccess      time.Time
 	lastError        error
 	failureThreshold int
 	cooldown         time.Duration
@@ -104,7 +103,6 @@ func (cb *CircuitBreaker) RecordSuccess() {
 
 	cb.failures = 0
 	cb.lastError = nil
-	cb.lastSuccess = time.Now()
 
 	if cb.state == BreakerHalfOpen {
 		cb.state = BreakerClosed

--- a/provider/circuit_breaker.go
+++ b/provider/circuit_breaker.go
@@ -1,0 +1,170 @@
+// circuit_breaker.go implements a three-state circuit breaker
+// (Closed / Open / HalfOpen) for tracking provider health.
+//
+// Failure count decays: if the time between consecutive failures exceeds the
+// cooldown duration, the counter resets to zero before counting the new failure.
+// This prevents transient errors from accumulating across long healthy periods.
+package provider
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	defaultFailureThreshold = 3
+	defaultCooldown         = 30 * time.Second
+)
+
+// CircuitBreaker tracks the health of a single provider endpoint.
+// It is safe for concurrent use.
+type CircuitBreaker struct {
+	mu               sync.Mutex
+	state            BreakerState
+	failures         int
+	lastFailure      time.Time
+	lastSuccess      time.Time
+	lastError        error
+	failureThreshold int
+	cooldown         time.Duration
+}
+
+// BreakerOption configures a CircuitBreaker at construction time.
+type BreakerOption func(*CircuitBreaker)
+
+// WithFailureThreshold sets the number of consecutive failures required to
+// trip the breaker from Closed to Open. Values <= 0 are ignored.
+func WithFailureThreshold(n int) BreakerOption {
+	return func(cb *CircuitBreaker) {
+		if n > 0 {
+			cb.failureThreshold = n
+		}
+	}
+}
+
+// WithCooldown sets the duration the breaker remains Open before
+// transitioning to HalfOpen. Values <= 0 are ignored.
+func WithCooldown(d time.Duration) BreakerOption {
+	return func(cb *CircuitBreaker) {
+		if d > 0 {
+			cb.cooldown = d
+		}
+	}
+}
+
+// NewCircuitBreaker creates a breaker in the Closed state with the given
+// options (or defaults).
+func NewCircuitBreaker(opts ...BreakerOption) *CircuitBreaker {
+	cb := &CircuitBreaker{
+		state:            BreakerClosed,
+		failureThreshold: defaultFailureThreshold,
+		cooldown:         defaultCooldown,
+	}
+	for _, opt := range opts {
+		opt(cb)
+	}
+	return cb
+}
+
+// Allow reports whether a request may proceed.
+//
+//   - Closed: always true.
+//   - Open: false unless the cooldown has elapsed, in which case the breaker
+//     transitions to HalfOpen and returns true (one probe request).
+//   - HalfOpen: false (only one probe is allowed; the first Allow() call
+//     after the cooldown transition already granted it).
+func (cb *CircuitBreaker) Allow() bool {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	switch cb.state {
+	case BreakerClosed:
+		return true
+	case BreakerOpen:
+		if time.Since(cb.lastFailure) >= cb.cooldown {
+			cb.state = BreakerHalfOpen
+			return true
+		}
+		return false
+	case BreakerHalfOpen:
+		// Only one probe is allowed; subsequent calls return false until
+		// the probe result is recorded.
+		return false
+	default:
+		return false
+	}
+}
+
+// RecordSuccess records a successful request. It resets the failure counter
+// and clears the last error. If the breaker is HalfOpen, it transitions to
+// Closed.
+func (cb *CircuitBreaker) RecordSuccess() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	cb.failures = 0
+	cb.lastError = nil
+	cb.lastSuccess = time.Now()
+
+	if cb.state == BreakerHalfOpen {
+		cb.state = BreakerClosed
+	}
+}
+
+// RecordFailure records a failed request. If the time since the last failure
+// exceeds the cooldown, the failure counter decays to zero before counting
+// the new failure. If the breaker is HalfOpen, it immediately transitions
+// back to Open. If failures reach the threshold, the breaker trips to Open.
+func (cb *CircuitBreaker) RecordFailure(err error) {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	now := time.Now()
+
+	// Failure count decay: if enough time has passed since the last failure,
+	// reset the counter so that old transient failures don't accumulate.
+	if !cb.lastFailure.IsZero() && now.Sub(cb.lastFailure) > cb.cooldown {
+		cb.failures = 0
+	}
+
+	cb.failures++
+	cb.lastFailure = now
+	cb.lastError = err
+
+	switch cb.state {
+	case BreakerHalfOpen:
+		// Probe failed — reopen immediately.
+		cb.state = BreakerOpen
+	case BreakerClosed:
+		if cb.failures >= cb.failureThreshold {
+			cb.state = BreakerOpen
+		}
+	}
+}
+
+// State returns the current breaker state.
+func (cb *CircuitBreaker) State() BreakerState {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	return cb.state
+}
+
+// Info returns a snapshot of the breaker's current status. When the breaker
+// is Open, RecoverAt is set to lastFailure + cooldown.
+func (cb *CircuitBreaker) Info() BreakerInfo {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	info := BreakerInfo{
+		State:       cb.state,
+		Failures:    cb.failures,
+		LastFailure: cb.lastFailure,
+		LastError:   cb.lastError,
+	}
+
+	if cb.state == BreakerOpen {
+		info.RecoverAt = cb.lastFailure.Add(cb.cooldown)
+	}
+
+	return info
+}

--- a/provider/circuit_breaker_test.go
+++ b/provider/circuit_breaker_test.go
@@ -1,0 +1,225 @@
+package provider
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestCircuitBreakerInitialState(t *testing.T) {
+	cb := NewCircuitBreaker()
+
+	if cb.State() != BreakerClosed {
+		t.Fatalf("expected initial state BreakerClosed, got %v", cb.State())
+	}
+	if !cb.Allow() {
+		t.Fatal("expected Allow() to return true for a new breaker")
+	}
+}
+
+func TestCircuitBreakerTripsAfterThreshold(t *testing.T) {
+	cb := NewCircuitBreaker(
+		WithFailureThreshold(3),
+		WithCooldown(time.Hour),
+	)
+
+	err := errors.New("backend down")
+	for i := 0; i < 3; i++ {
+		cb.RecordFailure(err)
+	}
+
+	if cb.State() != BreakerOpen {
+		t.Fatalf("expected BreakerOpen after %d failures, got %v", 3, cb.State())
+	}
+	if cb.Allow() {
+		t.Fatal("expected Allow() to return false when breaker is open")
+	}
+}
+
+func TestCircuitBreakerDoesNotTripBelowThreshold(t *testing.T) {
+	cb := NewCircuitBreaker(
+		WithFailureThreshold(3),
+		WithCooldown(time.Hour),
+	)
+
+	err := errors.New("transient error")
+	cb.RecordFailure(err)
+	cb.RecordFailure(err)
+
+	if cb.State() != BreakerClosed {
+		t.Fatalf("expected BreakerClosed with 2 of 3 failures, got %v", cb.State())
+	}
+	if !cb.Allow() {
+		t.Fatal("expected Allow() to return true when below threshold")
+	}
+}
+
+func TestCircuitBreakerRecoversAfterCooldown(t *testing.T) {
+	cb := NewCircuitBreaker(
+		WithFailureThreshold(1),
+		WithCooldown(10*time.Millisecond),
+	)
+
+	cb.RecordFailure(errors.New("fail"))
+	if cb.State() != BreakerOpen {
+		t.Fatalf("expected BreakerOpen, got %v", cb.State())
+	}
+
+	time.Sleep(20 * time.Millisecond)
+
+	if !cb.Allow() {
+		t.Fatal("expected Allow() to return true after cooldown elapsed")
+	}
+	if cb.State() != BreakerHalfOpen {
+		t.Fatalf("expected BreakerHalfOpen after cooldown, got %v", cb.State())
+	}
+}
+
+func TestCircuitBreakerHalfOpenSuccess(t *testing.T) {
+	cb := NewCircuitBreaker(
+		WithFailureThreshold(1),
+		WithCooldown(10*time.Millisecond),
+	)
+
+	// Trip the breaker.
+	cb.RecordFailure(errors.New("fail"))
+	if cb.State() != BreakerOpen {
+		t.Fatalf("expected BreakerOpen, got %v", cb.State())
+	}
+
+	// Wait for cooldown to elapse.
+	time.Sleep(20 * time.Millisecond)
+
+	// Allow should transition to HalfOpen.
+	if !cb.Allow() {
+		t.Fatal("expected Allow() to return true after cooldown")
+	}
+	if cb.State() != BreakerHalfOpen {
+		t.Fatalf("expected BreakerHalfOpen, got %v", cb.State())
+	}
+
+	// A success should close the breaker.
+	cb.RecordSuccess()
+	if cb.State() != BreakerClosed {
+		t.Fatalf("expected BreakerClosed after success in half-open, got %v", cb.State())
+	}
+}
+
+func TestCircuitBreakerHalfOpenFailure(t *testing.T) {
+	cb := NewCircuitBreaker(
+		WithFailureThreshold(1),
+		WithCooldown(10*time.Millisecond),
+	)
+
+	// Trip the breaker.
+	cb.RecordFailure(errors.New("fail"))
+	if cb.State() != BreakerOpen {
+		t.Fatalf("expected BreakerOpen, got %v", cb.State())
+	}
+
+	// Wait for cooldown to elapse.
+	time.Sleep(20 * time.Millisecond)
+
+	// Allow should transition to HalfOpen.
+	if !cb.Allow() {
+		t.Fatal("expected Allow() to return true after cooldown")
+	}
+	if cb.State() != BreakerHalfOpen {
+		t.Fatalf("expected BreakerHalfOpen, got %v", cb.State())
+	}
+
+	// A failure should reopen the breaker.
+	cb.RecordFailure(errors.New("still failing"))
+	if cb.State() != BreakerOpen {
+		t.Fatalf("expected BreakerOpen after failure in half-open, got %v", cb.State())
+	}
+}
+
+func TestCircuitBreakerFailureDecay(t *testing.T) {
+	cb := NewCircuitBreaker(
+		WithFailureThreshold(3),
+		WithCooldown(10*time.Millisecond),
+	)
+
+	err := errors.New("transient")
+	cb.RecordFailure(err)
+	cb.RecordFailure(err)
+
+	// Wait for cooldown to elapse so that failure count decays.
+	time.Sleep(20 * time.Millisecond)
+
+	// This failure should start from 0 after decay, so only 1 failure total.
+	cb.RecordFailure(err)
+
+	if cb.State() != BreakerClosed {
+		t.Fatalf("expected BreakerClosed after failure decay, got %v", cb.State())
+	}
+
+	info := cb.Info()
+	if info.Failures != 1 {
+		t.Fatalf("expected 1 failure after decay, got %d", info.Failures)
+	}
+}
+
+func TestCircuitBreakerSuccessResetsFailures(t *testing.T) {
+	cb := NewCircuitBreaker(
+		WithFailureThreshold(3),
+		WithCooldown(time.Hour),
+	)
+
+	err := errors.New("transient")
+	cb.RecordFailure(err)
+	cb.RecordFailure(err)
+
+	cb.RecordSuccess()
+
+	info := cb.Info()
+	if info.Failures != 0 {
+		t.Fatalf("expected 0 failures after RecordSuccess(), got %d", info.Failures)
+	}
+}
+
+func TestCircuitBreakerInfo(t *testing.T) {
+	cb := NewCircuitBreaker(
+		WithFailureThreshold(2),
+		WithCooldown(time.Hour),
+	)
+
+	// Initially, info should reflect a clean state.
+	info := cb.Info()
+	if info.State != BreakerClosed {
+		t.Fatalf("expected State=BreakerClosed, got %v", info.State)
+	}
+	if info.Failures != 0 {
+		t.Fatalf("expected Failures=0, got %d", info.Failures)
+	}
+	if info.LastError != nil {
+		t.Fatalf("expected LastError=nil, got %v", info.LastError)
+	}
+	if !info.RecoverAt.IsZero() {
+		t.Fatalf("expected RecoverAt to be zero for closed breaker, got %v", info.RecoverAt)
+	}
+
+	// Trip the breaker.
+	testErr := errors.New("server error")
+	cb.RecordFailure(testErr)
+	cb.RecordFailure(testErr)
+
+	info = cb.Info()
+	if info.State != BreakerOpen {
+		t.Fatalf("expected State=BreakerOpen, got %v", info.State)
+	}
+	if info.Failures != 2 {
+		t.Fatalf("expected Failures=2, got %d", info.Failures)
+	}
+	if info.LastError == nil || info.LastError.Error() != testErr.Error() {
+		t.Fatalf("expected LastError=%q, got %v", testErr, info.LastError)
+	}
+	if info.RecoverAt.IsZero() {
+		t.Fatal("expected RecoverAt to be set when breaker is open")
+	}
+	// RecoverAt should be approximately lastFailure + cooldown.
+	if info.RecoverAt.Before(info.LastFailure) {
+		t.Fatal("expected RecoverAt to be after LastFailure")
+	}
+}

--- a/provider/circuit_breaker_test.go
+++ b/provider/circuit_breaker_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"errors"
+	"sync"
 	"testing"
 	"time"
 )
@@ -222,4 +223,19 @@ func TestCircuitBreakerInfo(t *testing.T) {
 	if info.RecoverAt.Before(info.LastFailure) {
 		t.Fatal("expected RecoverAt to be after LastFailure")
 	}
+}
+
+func TestCircuitBreakerConcurrentAccess(t *testing.T) {
+	cb := NewCircuitBreaker(WithFailureThreshold(5), WithCooldown(10*time.Millisecond))
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(3)
+		go func() { defer wg.Done(); cb.Allow() }()
+		go func() { defer wg.Done(); cb.RecordFailure(errors.New("fail")) }()
+		go func() { defer wg.Done(); cb.RecordSuccess() }()
+	}
+	wg.Wait()
+	// No race detected and no panic = pass.
+	_ = cb.State()
+	_ = cb.Info()
 }

--- a/provider/model_profile.go
+++ b/provider/model_profile.go
@@ -124,11 +124,33 @@ type ModelProfile struct {
 	ThinkTags     *ThinkTags      // nil uses default <think></think>
 	Quality       Tier            // basic, good, great, best
 	Speed         Tier            // basic=slow, good=medium, great=fast, best=fastest
-	ContextWindow int             // max context tokens
+	ContextWindow     int             // max context tokens
+	QualityCtxCeiling int             // 0 = same as ContextWindow; quality degrades above this
 	Dimensions    int             // embedding dimensions, 0 if not embedding model
 	Source        ProfileSource   // static, fingerprint, runtime, merged
 	Digest        string          // model digest for staleness detection
 	UpdatedAt     time.Time       // when this profile was last computed
+}
+
+// qualitySensitiveUseCases identifies use cases where output quality degrades
+// when the context window exceeds the model's training context. Models like
+// Qwen3 are trained on 32K but advertise 128K via YaRN — quality is lower
+// above the training context for tasks that require high fidelity.
+var qualitySensitiveUseCases = map[string]bool{
+	"chat":        true,
+	"reasoning":   true,
+	"code-review": true,
+}
+
+// EffectiveContextWindow returns the usable context window for a given use case.
+// For quality-sensitive use cases (chat, reasoning, code-review), it returns
+// QualityCtxCeiling when set. For quantity-sensitive use cases (fim, embedding)
+// or when QualityCtxCeiling is 0, it returns the full ContextWindow.
+func (p *ModelProfile) EffectiveContextWindow(useCase string) int {
+	if p.QualityCtxCeiling > 0 && qualitySensitiveUseCases[useCase] {
+		return p.QualityCtxCeiling
+	}
+	return p.ContextWindow
 }
 
 // ---------------------------------------------------------------------------

--- a/provider/model_profile.go
+++ b/provider/model_profile.go
@@ -113,23 +113,23 @@ func (rp ResourceProfile) RAMAtContext(ctxSize int) float64 {
 // overridden by live runtime data from the provider. The Source field
 // records which layers contributed to this profile.
 type ModelProfile struct {
-	Key           ModelKey        // canonical provider-qualified identity
-	Name          string          // display name
-	Family        string          // normalized: "qwen3", "deepseek-r1", "codellama"
-	Provider      string          // provider name
-	Resources     ResourceProfile // resource requirements
-	Caps          Capability      // authoritative per-model capabilities after merge
-	FIM           *FIMConfig      // nil if model doesn't support FIM
-	ThinkMode     ThinkMode       // reasoning behavior
-	ThinkTags     *ThinkTags      // nil uses default <think></think>
-	Quality       Tier            // basic, good, great, best
-	Speed         Tier            // basic=slow, good=medium, great=fast, best=fastest
+	Key               ModelKey        // canonical provider-qualified identity
+	Name              string          // display name
+	Family            string          // normalized: "qwen3", "deepseek-r1", "codellama"
+	Provider          string          // provider name
+	Resources         ResourceProfile // resource requirements
+	Caps              Capability      // authoritative per-model capabilities after merge
+	FIM               *FIMConfig      // nil if model doesn't support FIM
+	ThinkMode         ThinkMode       // reasoning behavior
+	ThinkTags         *ThinkTags      // nil uses default <think></think>
+	Quality           Tier            // basic, good, great, best
+	Speed             Tier            // basic=slow, good=medium, great=fast, best=fastest
 	ContextWindow     int             // max context tokens
 	QualityCtxCeiling int             // 0 = same as ContextWindow; quality degrades above this
-	Dimensions    int             // embedding dimensions, 0 if not embedding model
-	Source        ProfileSource   // static, fingerprint, runtime, merged
-	Digest        string          // model digest for staleness detection
-	UpdatedAt     time.Time       // when this profile was last computed
+	Dimensions        int             // embedding dimensions, 0 if not embedding model
+	Source            ProfileSource   // static, fingerprint, runtime, merged
+	Digest            string          // model digest for staleness detection
+	UpdatedAt         time.Time       // when this profile was last computed
 }
 
 // qualitySensitiveUseCases identifies use cases where output quality degrades

--- a/provider/model_profile_test.go
+++ b/provider/model_profile_test.go
@@ -225,6 +225,67 @@ func TestModelProfileNilThinkTags(t *testing.T) {
 	}
 }
 
+func TestModelProfileQualityCtxCeiling(t *testing.T) {
+	t.Run("stored correctly", func(t *testing.T) {
+		p := ModelProfile{
+			Key:               ModelKey{Provider: "ollama", Model: "qwen3:32b"},
+			ContextWindow:     131072,
+			QualityCtxCeiling: 32768,
+		}
+		if p.QualityCtxCeiling != 32768 {
+			t.Errorf("QualityCtxCeiling = %d, want 32768", p.QualityCtxCeiling)
+		}
+	})
+
+	t.Run("zero means use ContextWindow", func(t *testing.T) {
+		p := ModelProfile{
+			Key:               ModelKey{Provider: "ollama", Model: "deepseek-r1:8b"},
+			ContextWindow:     65536,
+			QualityCtxCeiling: 0,
+		}
+		// When QualityCtxCeiling is 0, EffectiveContextWindow should return ContextWindow
+		// for any use case.
+		if got := p.EffectiveContextWindow("chat"); got != 65536 {
+			t.Errorf("EffectiveContextWindow(\"chat\") with zero ceiling = %d, want 65536", got)
+		}
+		if got := p.EffectiveContextWindow("fim"); got != 65536 {
+			t.Errorf("EffectiveContextWindow(\"fim\") with zero ceiling = %d, want 65536", got)
+		}
+	})
+}
+
+func TestEffectiveContextWindow(t *testing.T) {
+	p := ModelProfile{
+		Key:               ModelKey{Provider: "ollama", Model: "qwen3:32b"},
+		ContextWindow:     131072,
+		QualityCtxCeiling: 32768,
+	}
+
+	tests := []struct {
+		useCase string
+		want    int
+	}{
+		// Quality-sensitive use cases should respect the ceiling.
+		{"chat", 32768},
+		{"reasoning", 32768},
+		{"code-review", 32768},
+		// Quantity-sensitive use cases should use the full context window.
+		{"fim", 131072},
+		{"embedding", 131072},
+		// Unknown use case should use the full context window.
+		{"unknown", 131072},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.useCase, func(t *testing.T) {
+			got := p.EffectiveContextWindow(tt.useCase)
+			if got != tt.want {
+				t.Errorf("EffectiveContextWindow(%q) = %d, want %d", tt.useCase, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRecommendOptsConstruction(t *testing.T) {
 	opts := RecommendOpts{
 		RequestedModel:     "qwen3:8b",

--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -1,0 +1,452 @@
+// route_plan.go holds the RoutePlan type — the result of Router.Route().
+// A RoutePlan binds an immutable request snapshot to the selected provider,
+// model, scoring, and fallback chain. The Execute methods dispatch to the
+// provider, walk the fallback chain on infrastructure errors, attach
+// RouteOutcome metadata to responses, and handle cancellation without
+// recording circuit-breaker failures.
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// ---------------------------------------------------------------------------
+// RouteRecorder
+// ---------------------------------------------------------------------------
+
+// RouteRecorder receives post-execution signals from RoutePlan.Execute
+// methods. The Router implements this interface to feed the circuit breaker,
+// warmth tracker, and sticky cache.
+type RouteRecorder interface {
+	RecordSuccess(key ModelKey, latency LatencyInfo)
+	RecordFailure(key ModelKey, err error)
+	RecordWarmthUse(key ModelKey)
+}
+
+// ---------------------------------------------------------------------------
+// RoutePlan
+// ---------------------------------------------------------------------------
+
+// RoutePlan holds the selected provider/model, scoring, and fallback chain.
+// It is the result of Router.Route() and the entry point for executing
+// routed requests against a provider.
+type RoutePlan struct {
+	Kind      RouteKind
+	Provider  Provider
+	Model     string
+	Profile   *ModelProfile
+	Request   RoutingRequest // immutable normalized request snapshot
+	Score     float64
+	Budget    BudgetResult
+	Fallbacks []RoutePlan
+	Reason    string
+	Degraded  bool
+	wasSticky bool         // internal: propagated to RouteOutcome
+	recorder  RouteRecorder // internal: set by Router
+}
+
+// String returns a human-readable summary of the route plan.
+func (rp *RoutePlan) String() string {
+	return fmt.Sprintf("%s/%s (score=%.2f, budget=%s, fallbacks=%d): %s",
+		rp.Profile.Key.Provider, rp.Model, rp.Score,
+		rp.Budget.Decision, len(rp.Fallbacks), rp.Reason)
+}
+
+// SetRecorder sets the internal route recorder. This is called by the Router
+// after constructing the plan.
+func (rp *RoutePlan) SetRecorder(r RouteRecorder) {
+	rp.recorder = r
+}
+
+// SetWasSticky marks the plan as having been selected via sticky routing.
+func (rp *RoutePlan) SetWasSticky(v bool) {
+	rp.wasSticky = v
+}
+
+// ---------------------------------------------------------------------------
+// Execute — Chat (non-streaming)
+// ---------------------------------------------------------------------------
+
+// ExecuteChat dispatches a non-streaming chat request to the selected provider,
+// walking the fallback chain on infrastructure errors.
+func (rp *RoutePlan) ExecuteChat(ctx context.Context) (*ChatResponse, error) {
+	if rp.Budget.Decision == BudgetTruncate {
+		return nil, ErrBudgetAdaptationRequired
+	}
+
+	req := rp.buildChatRequest(false)
+	resp, err := rp.Provider.Chat(ctx, req)
+
+	fallbacksUsed := 0
+	if err != nil && IsInfrastructureError(err) {
+		rp.recordFailure(rp.Profile.Key, err)
+
+		for i, fb := range rp.Fallbacks {
+			fbReq := fb.buildChatRequest(false)
+			resp, err = fb.Provider.Chat(ctx, fbReq)
+			if err == nil {
+				fallbacksUsed = i + 1
+				break
+			}
+			if IsInfrastructureError(err) {
+				rp.recordFailure(fb.Profile.Key, err)
+				continue
+			}
+			// Non-infrastructure error (incl. cancellation) — stop trying.
+			break
+		}
+	}
+
+	outcome := rp.handleResult(err, fallbacksUsed)
+	if resp != nil && outcome != nil {
+		resp.RouteOutcome = outcome
+	}
+
+	return resp, err
+}
+
+// ---------------------------------------------------------------------------
+// Execute — Chat stream
+// ---------------------------------------------------------------------------
+
+// ExecuteChatStream dispatches a streaming chat request to the selected
+// provider. Fallback is only attempted before the first user-visible chunk
+// has been delivered.
+func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse) error) error {
+	if rp.Budget.Decision == BudgetTruncate {
+		return ErrBudgetAdaptationRequired
+	}
+
+	req := rp.buildChatRequest(true)
+
+	delivered := false
+	fallbacksUsed := 0
+	var outcome *RouteOutcome
+
+	wrappedFn := func(chunk ChatResponse) error {
+		if !delivered && hasVisibleContent(chunk.Content, chunk.Thinking, chunk.ToolCalls) {
+			delivered = true
+		}
+		if chunk.Done {
+			outcome = rp.handleResult(nil, fallbacksUsed)
+			if outcome != nil {
+				chunk.RouteOutcome = outcome
+			}
+		}
+		return fn(chunk)
+	}
+
+	err := rp.Provider.ChatStream(ctx, req, wrappedFn)
+
+	if err != nil && !delivered && IsInfrastructureError(err) {
+		rp.recordFailure(rp.Profile.Key, err)
+
+		for i, fb := range rp.Fallbacks {
+			fbReq := fb.buildChatRequest(true)
+			delivered = false
+			fallbacksUsed = i + 1
+
+			wrappedFbFn := func(chunk ChatResponse) error {
+				if !delivered && hasVisibleContent(chunk.Content, chunk.Thinking, chunk.ToolCalls) {
+					delivered = true
+				}
+				if chunk.Done {
+					outcome = rp.handleResult(nil, fallbacksUsed)
+					if outcome != nil {
+						chunk.RouteOutcome = outcome
+					}
+				}
+				return fn(chunk)
+			}
+
+			err = fb.Provider.ChatStream(ctx, fbReq, wrappedFbFn)
+			if err == nil {
+				return nil
+			}
+			if IsInfrastructureError(err) {
+				rp.recordFailure(fb.Profile.Key, err)
+				continue
+			}
+			break
+		}
+	}
+
+	// If the stream succeeded (err == nil) but outcome was not yet built
+	// (e.g., provider never sent a Done chunk), still record.
+	if err != nil && outcome == nil {
+		rp.handleResult(err, fallbacksUsed)
+	}
+
+	return err
+}
+
+// ---------------------------------------------------------------------------
+// Execute — Generate (non-streaming)
+// ---------------------------------------------------------------------------
+
+// ExecuteGenerate dispatches a non-streaming generate request to the selected
+// provider, walking the fallback chain on infrastructure errors.
+func (rp *RoutePlan) ExecuteGenerate(ctx context.Context) (*GenerateResponse, error) {
+	if rp.Budget.Decision == BudgetTruncate {
+		return nil, ErrBudgetAdaptationRequired
+	}
+
+	req := rp.buildGenerateRequest(false)
+	resp, err := rp.Provider.Generate(ctx, req)
+
+	fallbacksUsed := 0
+	if err != nil && IsInfrastructureError(err) {
+		rp.recordFailure(rp.Profile.Key, err)
+
+		for i, fb := range rp.Fallbacks {
+			fbReq := fb.buildGenerateRequest(false)
+			resp, err = fb.Provider.Generate(ctx, fbReq)
+			if err == nil {
+				fallbacksUsed = i + 1
+				break
+			}
+			if IsInfrastructureError(err) {
+				rp.recordFailure(fb.Profile.Key, err)
+				continue
+			}
+			break
+		}
+	}
+
+	outcome := rp.handleResult(err, fallbacksUsed)
+	if resp != nil && outcome != nil {
+		resp.RouteOutcome = outcome
+	}
+
+	return resp, err
+}
+
+// ---------------------------------------------------------------------------
+// Execute — Generate stream
+// ---------------------------------------------------------------------------
+
+// ExecuteGenerateStream dispatches a streaming generate request to the selected
+// provider. Fallback is only attempted before the first user-visible chunk.
+func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(GenerateResponse) error) error {
+	if rp.Budget.Decision == BudgetTruncate {
+		return ErrBudgetAdaptationRequired
+	}
+
+	req := rp.buildGenerateRequest(true)
+
+	delivered := false
+	fallbacksUsed := 0
+	var outcome *RouteOutcome
+
+	wrappedFn := func(chunk GenerateResponse) error {
+		if !delivered && chunk.Response != "" {
+			delivered = true
+		}
+		if chunk.Done {
+			outcome = rp.handleResult(nil, fallbacksUsed)
+			if outcome != nil {
+				chunk.RouteOutcome = outcome
+			}
+		}
+		return fn(chunk)
+	}
+
+	err := rp.Provider.GenerateStream(ctx, req, wrappedFn)
+
+	if err != nil && !delivered && IsInfrastructureError(err) {
+		rp.recordFailure(rp.Profile.Key, err)
+
+		for i, fb := range rp.Fallbacks {
+			fbReq := fb.buildGenerateRequest(true)
+			delivered = false
+			fallbacksUsed = i + 1
+
+			wrappedFbFn := func(chunk GenerateResponse) error {
+				if !delivered && chunk.Response != "" {
+					delivered = true
+				}
+				if chunk.Done {
+					outcome = rp.handleResult(nil, fallbacksUsed)
+					if outcome != nil {
+						chunk.RouteOutcome = outcome
+					}
+				}
+				return fn(chunk)
+			}
+
+			err = fb.Provider.GenerateStream(ctx, fbReq, wrappedFbFn)
+			if err == nil {
+				return nil
+			}
+			if IsInfrastructureError(err) {
+				rp.recordFailure(fb.Profile.Key, err)
+				continue
+			}
+			break
+		}
+	}
+
+	if err != nil && outcome == nil {
+		rp.handleResult(err, fallbacksUsed)
+	}
+
+	return err
+}
+
+// ---------------------------------------------------------------------------
+// Execute — Embed
+// ---------------------------------------------------------------------------
+
+// ExecuteEmbed dispatches an embedding request to the selected provider,
+// walking the fallback chain on infrastructure errors.
+func (rp *RoutePlan) ExecuteEmbed(ctx context.Context) (*EmbedResponse, error) {
+	if rp.Budget.Decision == BudgetTruncate {
+		return nil, ErrBudgetAdaptationRequired
+	}
+
+	req := rp.buildEmbedRequest()
+	resp, err := rp.Provider.Embed(ctx, req)
+
+	fallbacksUsed := 0
+	if err != nil && IsInfrastructureError(err) {
+		rp.recordFailure(rp.Profile.Key, err)
+
+		for i, fb := range rp.Fallbacks {
+			fbReq := fb.buildEmbedRequest()
+			resp, err = fb.Provider.Embed(ctx, fbReq)
+			if err == nil {
+				fallbacksUsed = i + 1
+				break
+			}
+			if IsInfrastructureError(err) {
+				rp.recordFailure(fb.Profile.Key, err)
+				continue
+			}
+			break
+		}
+	}
+
+	outcome := rp.handleResult(err, fallbacksUsed)
+	if resp != nil && outcome != nil {
+		resp.RouteOutcome = outcome
+	}
+
+	return resp, err
+}
+
+// ---------------------------------------------------------------------------
+// handleResult — post-execution recorder + outcome builder
+// ---------------------------------------------------------------------------
+
+// handleResult records success/failure/cancellation signals and returns a
+// RouteOutcome for successful executions.
+func (rp *RoutePlan) handleResult(err error, fallbacksUsed int) *RouteOutcome {
+	actualKey := rp.Profile.Key
+	if fallbacksUsed > 0 && fallbacksUsed <= len(rp.Fallbacks) {
+		actualKey = rp.Fallbacks[fallbacksUsed-1].Profile.Key
+	}
+
+	if err == nil {
+		rp.recordSuccess(actualKey, LatencyInfo{})
+		rp.recordWarmthUse(actualKey)
+		return rp.buildOutcome(fallbacksUsed)
+	}
+
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		rp.recordWarmthUse(actualKey) // model IS warm
+		return nil
+	}
+
+	if IsInfrastructureError(err) {
+		rp.recordFailure(actualKey, err)
+	}
+
+	return nil
+}
+
+// buildOutcome constructs a RouteOutcome from the plan and fallback index.
+func (rp *RoutePlan) buildOutcome(fallbacksUsed int) *RouteOutcome {
+	actualKey := rp.Profile.Key
+	if fallbacksUsed > 0 && fallbacksUsed <= len(rp.Fallbacks) {
+		actualKey = rp.Fallbacks[fallbacksUsed-1].Profile.Key
+	}
+
+	return &RouteOutcome{
+		PlannedModel:  rp.Profile.Key,
+		ActualModel:   actualKey,
+		FallbacksUsed: fallbacksUsed,
+		WasSticky:     rp.wasSticky,
+		Score:         rp.Score,
+		Reason:        rp.Reason,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Request builders
+// ---------------------------------------------------------------------------
+
+// buildChatRequest constructs a ChatRequest from the immutable request snapshot.
+func (rp *RoutePlan) buildChatRequest(stream bool) ChatRequest {
+	return ChatRequest{
+		Model:    rp.Model,
+		Messages: rp.Request.Messages,
+		Options:  rp.Request.Options,
+		Tools:    rp.Request.Tools,
+		Stream:   stream,
+	}
+}
+
+// buildGenerateRequest constructs a GenerateRequest from the request snapshot.
+func (rp *RoutePlan) buildGenerateRequest(stream bool) GenerateRequest {
+	return GenerateRequest{
+		Model:   rp.Model,
+		Prompt:  rp.Request.Prompt,
+		System:  rp.Request.System,
+		Suffix:  rp.Request.Suffix,
+		Options: rp.Request.Options,
+		Stream:  stream,
+	}
+}
+
+// buildEmbedRequest constructs an EmbedRequest from the request snapshot.
+func (rp *RoutePlan) buildEmbedRequest() EmbedRequest {
+	return EmbedRequest{
+		Model: rp.Model,
+		Input: rp.Request.Input,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Recorder helpers (nil-safe)
+// ---------------------------------------------------------------------------
+
+func (rp *RoutePlan) recordSuccess(key ModelKey, latency LatencyInfo) {
+	if rp.recorder != nil {
+		rp.recorder.RecordSuccess(key, latency)
+	}
+}
+
+func (rp *RoutePlan) recordFailure(key ModelKey, err error) {
+	if rp.recorder != nil {
+		rp.recorder.RecordFailure(key, err)
+	}
+}
+
+func (rp *RoutePlan) recordWarmthUse(key ModelKey) {
+	if rp.recorder != nil {
+		rp.recorder.RecordWarmthUse(key)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// hasVisibleContent
+// ---------------------------------------------------------------------------
+
+// hasVisibleContent reports whether a streaming chunk contains content
+// that has been "delivered" to the user. Once any visible content has been
+// emitted, provider fallback is no longer safe.
+func hasVisibleContent(content, thinking string, toolCalls []ToolCall) bool {
+	return content != "" || thinking != "" || len(toolCalls) > 0
+}

--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -359,9 +359,9 @@ func (rp *RoutePlan) handleResult(err error, fallbacksUsed int) *RouteOutcome {
 		return nil
 	}
 
-	if IsInfrastructureError(err) {
-		rp.recordFailure(actualKey, err)
-	}
+	// Infrastructure failures are recorded inline by the Execute methods
+	// (once per provider attempt) rather than here, to avoid double-counting
+	// the last-tried provider in the fallback chain.
 
 	return nil
 }

--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -140,42 +140,49 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 
 	err := rp.Provider.ChatStream(ctx, req, wrappedFn)
 
-	if err != nil && !delivered && IsInfrastructureError(err) {
+	if err != nil && IsInfrastructureError(err) {
 		rp.recordFailure(rp.Profile.Key, err)
 
-		for i, fb := range rp.Fallbacks {
-			fbReq := fb.buildChatRequest(true)
-			delivered = false
-			fallbacksUsed = i + 1
+		// Only attempt fallback if no user-visible content was delivered.
+		if !delivered {
+			for i, fb := range rp.Fallbacks {
+				fbReq := fb.buildChatRequest(true)
+				delivered = false
+				fallbacksUsed = i + 1
 
-			wrappedFbFn := func(chunk ChatResponse) error {
-				if !delivered && hasVisibleContent(chunk.Content, chunk.Thinking, chunk.ToolCalls) {
-					delivered = true
-				}
-				if chunk.Done {
-					outcome = rp.handleResult(nil, fallbacksUsed)
-					if outcome != nil {
-						chunk.RouteOutcome = outcome
+				wrappedFbFn := func(chunk ChatResponse) error {
+					if !delivered && hasVisibleContent(chunk.Content, chunk.Thinking, chunk.ToolCalls) {
+						delivered = true
 					}
+					if chunk.Done {
+						outcome = rp.handleResult(nil, fallbacksUsed)
+						if outcome != nil {
+							chunk.RouteOutcome = outcome
+						}
+					}
+					return fn(chunk)
 				}
-				return fn(chunk)
-			}
 
-			err = fb.Provider.ChatStream(ctx, fbReq, wrappedFbFn)
-			if err == nil {
-				return nil
+				err = fb.Provider.ChatStream(ctx, fbReq, wrappedFbFn)
+				if err == nil {
+					return nil
+				}
+				if IsInfrastructureError(err) {
+					rp.recordFailure(fb.Profile.Key, err)
+					// Only continue to next fallback if this one did not deliver content.
+					if delivered {
+						break
+					}
+					continue
+				}
+				break
 			}
-			if IsInfrastructureError(err) {
-				rp.recordFailure(fb.Profile.Key, err)
-				continue
-			}
-			break
 		}
 	}
 
-	// If the stream succeeded (err == nil) but outcome was not yet built
-	// (e.g., provider never sent a Done chunk), still record.
-	if err != nil && outcome == nil {
+	// Record signals for streams that completed without a Done chunk, or
+	// that ended in a non-infrastructure error / cancellation.
+	if outcome == nil {
 		rp.handleResult(err, fallbacksUsed)
 	}
 
@@ -255,40 +262,48 @@ func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(Generate
 
 	err := rp.Provider.GenerateStream(ctx, req, wrappedFn)
 
-	if err != nil && !delivered && IsInfrastructureError(err) {
+	if err != nil && IsInfrastructureError(err) {
 		rp.recordFailure(rp.Profile.Key, err)
 
-		for i, fb := range rp.Fallbacks {
-			fbReq := fb.buildGenerateRequest(true)
-			delivered = false
-			fallbacksUsed = i + 1
+		// Only attempt fallback if no user-visible content was delivered.
+		if !delivered {
+			for i, fb := range rp.Fallbacks {
+				fbReq := fb.buildGenerateRequest(true)
+				delivered = false
+				fallbacksUsed = i + 1
 
-			wrappedFbFn := func(chunk GenerateResponse) error {
-				if !delivered && chunk.Response != "" {
-					delivered = true
-				}
-				if chunk.Done {
-					outcome = rp.handleResult(nil, fallbacksUsed)
-					if outcome != nil {
-						chunk.RouteOutcome = outcome
+				wrappedFbFn := func(chunk GenerateResponse) error {
+					if !delivered && chunk.Response != "" {
+						delivered = true
 					}
+					if chunk.Done {
+						outcome = rp.handleResult(nil, fallbacksUsed)
+						if outcome != nil {
+							chunk.RouteOutcome = outcome
+						}
+					}
+					return fn(chunk)
 				}
-				return fn(chunk)
-			}
 
-			err = fb.Provider.GenerateStream(ctx, fbReq, wrappedFbFn)
-			if err == nil {
-				return nil
+				err = fb.Provider.GenerateStream(ctx, fbReq, wrappedFbFn)
+				if err == nil {
+					return nil
+				}
+				if IsInfrastructureError(err) {
+					rp.recordFailure(fb.Profile.Key, err)
+					if delivered {
+						break
+					}
+					continue
+				}
+				break
 			}
-			if IsInfrastructureError(err) {
-				rp.recordFailure(fb.Profile.Key, err)
-				continue
-			}
-			break
 		}
 	}
 
-	if err != nil && outcome == nil {
+	// Record signals for streams that completed without a Done chunk, or
+	// that ended in a non-infrastructure error / cancellation.
+	if outcome == nil {
 		rp.handleResult(err, fallbacksUsed)
 	}
 

--- a/provider/route_plan_test.go
+++ b/provider/route_plan_test.go
@@ -1,0 +1,686 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// rpMockProvider
+// ---------------------------------------------------------------------------
+
+// rpMockProvider implements the Provider interface for testing RoutePlan
+// execution. It supports configurable responses, errors, and stream chunks,
+// and tracks call counts for verification.
+type rpMockProvider struct {
+	name             string
+	caps             Capability
+	chatResp         *ChatResponse
+	chatErr          error
+	chatStreamChunks []ChatResponse
+	chatStreamErr    error
+	genResp          *GenerateResponse
+	genErr           error
+	genStreamChunks  []GenerateResponse
+	genStreamErr     error
+	embedResp        *EmbedResponse
+	embedErr         error
+	models           []ModelInfo
+	healthErr        error
+	chatCalls        int
+	genCalls         int
+	embedCalls       int
+	mu               sync.Mutex
+}
+
+func (m *rpMockProvider) Name() string         { return m.name }
+func (m *rpMockProvider) Capabilities() Capability { return m.caps }
+func (m *rpMockProvider) Health(_ context.Context) error { return m.healthErr }
+func (m *rpMockProvider) Models(_ context.Context) ([]ModelInfo, error) {
+	return m.models, nil
+}
+
+func (m *rpMockProvider) Chat(_ context.Context, _ ChatRequest) (*ChatResponse, error) {
+	m.mu.Lock()
+	m.chatCalls++
+	m.mu.Unlock()
+	if m.chatErr != nil {
+		return nil, m.chatErr
+	}
+	// Return a copy so tests can inspect without races.
+	resp := *m.chatResp
+	return &resp, nil
+}
+
+func (m *rpMockProvider) ChatStream(_ context.Context, _ ChatRequest, fn func(ChatResponse) error) error {
+	m.mu.Lock()
+	m.chatCalls++
+	m.mu.Unlock()
+	for _, chunk := range m.chatStreamChunks {
+		if err := fn(chunk); err != nil {
+			return err
+		}
+	}
+	return m.chatStreamErr
+}
+
+func (m *rpMockProvider) Generate(_ context.Context, _ GenerateRequest) (*GenerateResponse, error) {
+	m.mu.Lock()
+	m.genCalls++
+	m.mu.Unlock()
+	if m.genErr != nil {
+		return nil, m.genErr
+	}
+	resp := *m.genResp
+	return &resp, nil
+}
+
+func (m *rpMockProvider) GenerateStream(_ context.Context, _ GenerateRequest, fn func(GenerateResponse) error) error {
+	m.mu.Lock()
+	m.genCalls++
+	m.mu.Unlock()
+	for _, chunk := range m.genStreamChunks {
+		if err := fn(chunk); err != nil {
+			return err
+		}
+	}
+	return m.genStreamErr
+}
+
+func (m *rpMockProvider) Embed(_ context.Context, _ EmbedRequest) (*EmbedResponse, error) {
+	m.mu.Lock()
+	m.embedCalls++
+	m.mu.Unlock()
+	if m.embedErr != nil {
+		return nil, m.embedErr
+	}
+	resp := *m.embedResp
+	return &resp, nil
+}
+
+// getChatCalls returns the chat call count in a thread-safe manner.
+func (m *rpMockProvider) getChatCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.chatCalls
+}
+
+// getGenCalls returns the generate call count in a thread-safe manner.
+func (m *rpMockProvider) getGenCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.genCalls
+}
+
+// getEmbedCalls returns the embed call count in a thread-safe manner.
+func (m *rpMockProvider) getEmbedCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.embedCalls
+}
+
+// ---------------------------------------------------------------------------
+// rpMockRecorder
+// ---------------------------------------------------------------------------
+
+// rpMockRecorder implements RouteRecorder and captures signals for assertions.
+type rpMockRecorder struct {
+	mu         sync.Mutex
+	successes  []ModelKey
+	failures   []ModelKey
+	warmthUses []ModelKey
+}
+
+func (r *rpMockRecorder) RecordSuccess(key ModelKey, _ LatencyInfo) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.successes = append(r.successes, key)
+}
+
+func (r *rpMockRecorder) RecordFailure(key ModelKey, _ error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.failures = append(r.failures, key)
+}
+
+func (r *rpMockRecorder) RecordWarmthUse(key ModelKey) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.warmthUses = append(r.warmthUses, key)
+}
+
+func (r *rpMockRecorder) getSuccesses() []ModelKey {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]ModelKey, len(r.successes))
+	copy(out, r.successes)
+	return out
+}
+
+func (r *rpMockRecorder) getFailures() []ModelKey {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]ModelKey, len(r.failures))
+	copy(out, r.failures)
+	return out
+}
+
+func (r *rpMockRecorder) getWarmthUses() []ModelKey {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]ModelKey, len(r.warmthUses))
+	copy(out, r.warmthUses)
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build a basic RoutePlan for tests
+// ---------------------------------------------------------------------------
+
+func newTestPlan(prov *rpMockProvider, rec *rpMockRecorder) *RoutePlan {
+	key := ModelKey{Provider: prov.name, Model: "test-model"}
+	return &RoutePlan{
+		Kind:     RouteKindChat,
+		Provider: prov,
+		Model:    "test-model",
+		Profile: &ModelProfile{
+			Key:           key,
+			Name:          "test-model",
+			Family:        "test",
+			Provider:      prov.name,
+			ContextWindow: 32768,
+		},
+		Request: RoutingRequest{
+			Model:    "test-model",
+			UseCase:  "chat",
+			Messages: []ChatMessage{{Role: "user", Content: "hello"}},
+		},
+		Score:  0.85,
+		Budget: BudgetResult{Decision: BudgetOK},
+		Reason: "best candidate",
+		recorder: rec,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestRoutePlanExecuteChat(t *testing.T) {
+	prov := &rpMockProvider{
+		name: "ollama",
+		caps: CapChat,
+		chatResp: &ChatResponse{
+			Model:   "test-model",
+			Content: "Hello, world!",
+			Done:    true,
+		},
+	}
+	rec := &rpMockRecorder{}
+	plan := newTestPlan(prov, rec)
+
+	resp, err := plan.ExecuteChat(context.Background())
+	if err != nil {
+		t.Fatalf("ExecuteChat returned unexpected error: %v", err)
+	}
+	if resp.Content != "Hello, world!" {
+		t.Errorf("content = %q, want %q", resp.Content, "Hello, world!")
+	}
+	if resp.RouteOutcome == nil {
+		t.Fatal("RouteOutcome is nil, want non-nil")
+	}
+	if resp.RouteOutcome.FallbacksUsed != 0 {
+		t.Errorf("FallbacksUsed = %d, want 0", resp.RouteOutcome.FallbacksUsed)
+	}
+	if resp.RouteOutcome.Score != 0.85 {
+		t.Errorf("Score = %.2f, want 0.85", resp.RouteOutcome.Score)
+	}
+	if resp.RouteOutcome.PlannedModel.Model != "test-model" {
+		t.Errorf("PlannedModel = %v, want test-model", resp.RouteOutcome.PlannedModel)
+	}
+
+	successes := rec.getSuccesses()
+	if len(successes) != 1 {
+		t.Fatalf("successes = %d, want 1", len(successes))
+	}
+	if successes[0].Model != "test-model" {
+		t.Errorf("success key = %v, want test-model", successes[0])
+	}
+
+	warmth := rec.getWarmthUses()
+	if len(warmth) != 1 {
+		t.Fatalf("warmthUses = %d, want 1", len(warmth))
+	}
+}
+
+func TestRoutePlanExecuteChatStreamAttachesRouteOutcome(t *testing.T) {
+	prov := &rpMockProvider{
+		name: "ollama",
+		caps: CapChat | CapStream,
+		chatStreamChunks: []ChatResponse{
+			{Model: "test-model", Content: "Hello", Partial: true},
+			{Model: "test-model", Content: ", world!", Done: true},
+		},
+	}
+	rec := &rpMockRecorder{}
+	plan := newTestPlan(prov, rec)
+	plan.wasSticky = true
+
+	var chunks []ChatResponse
+	err := plan.ExecuteChatStream(context.Background(), func(chunk ChatResponse) error {
+		chunks = append(chunks, chunk)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ExecuteChatStream returned unexpected error: %v", err)
+	}
+
+	if len(chunks) != 2 {
+		t.Fatalf("got %d chunks, want 2", len(chunks))
+	}
+
+	// First chunk should NOT have RouteOutcome.
+	if chunks[0].RouteOutcome != nil {
+		t.Error("first chunk has RouteOutcome, want nil")
+	}
+
+	// Final Done chunk MUST have RouteOutcome.
+	final := chunks[1]
+	if final.RouteOutcome == nil {
+		t.Fatal("final chunk RouteOutcome is nil, want non-nil")
+	}
+	if !final.RouteOutcome.WasSticky {
+		t.Error("WasSticky = false, want true")
+	}
+	if final.RouteOutcome.FallbacksUsed != 0 {
+		t.Errorf("FallbacksUsed = %d, want 0", final.RouteOutcome.FallbacksUsed)
+	}
+}
+
+func TestRoutePlanBudgetTruncateRejectsExecution(t *testing.T) {
+	prov := &rpMockProvider{
+		name: "ollama",
+		caps: CapChat,
+		chatResp: &ChatResponse{
+			Model:   "test-model",
+			Content: "should not get here",
+			Done:    true,
+		},
+	}
+	rec := &rpMockRecorder{}
+	plan := newTestPlan(prov, rec)
+	plan.Budget = BudgetResult{Decision: BudgetTruncate}
+
+	// Chat
+	_, err := plan.ExecuteChat(context.Background())
+	if !errors.Is(err, ErrBudgetAdaptationRequired) {
+		t.Errorf("ExecuteChat error = %v, want ErrBudgetAdaptationRequired", err)
+	}
+
+	// ChatStream
+	err = plan.ExecuteChatStream(context.Background(), func(_ ChatResponse) error {
+		t.Error("callback should not be invoked")
+		return nil
+	})
+	if !errors.Is(err, ErrBudgetAdaptationRequired) {
+		t.Errorf("ExecuteChatStream error = %v, want ErrBudgetAdaptationRequired", err)
+	}
+
+	// Generate
+	plan.genProvider()
+	_, err = plan.ExecuteGenerate(context.Background())
+	if !errors.Is(err, ErrBudgetAdaptationRequired) {
+		t.Errorf("ExecuteGenerate error = %v, want ErrBudgetAdaptationRequired", err)
+	}
+
+	// GenerateStream
+	err = plan.ExecuteGenerateStream(context.Background(), func(_ GenerateResponse) error {
+		t.Error("callback should not be invoked")
+		return nil
+	})
+	if !errors.Is(err, ErrBudgetAdaptationRequired) {
+		t.Errorf("ExecuteGenerateStream error = %v, want ErrBudgetAdaptationRequired", err)
+	}
+
+	// Embed
+	_, err = plan.ExecuteEmbed(context.Background())
+	if !errors.Is(err, ErrBudgetAdaptationRequired) {
+		t.Errorf("ExecuteEmbed error = %v, want ErrBudgetAdaptationRequired", err)
+	}
+
+	// Provider should never have been called.
+	if prov.getChatCalls() != 0 {
+		t.Errorf("chatCalls = %d, want 0", prov.getChatCalls())
+	}
+}
+
+// genProvider is a helper that does nothing; the plan already has a provider.
+// It exists to make the test read clearly.
+func (rp *RoutePlan) genProvider() {}
+
+func TestRoutePlanFallbackOnInfraError(t *testing.T) {
+	infraErr := &HTTPStatusError{StatusCode: 503, Status: "503 Service Unavailable"}
+
+	primaryProv := &rpMockProvider{
+		name:    "primary",
+		caps:    CapChat,
+		chatErr: infraErr,
+	}
+	fallbackProv := &rpMockProvider{
+		name: "fallback",
+		caps: CapChat,
+		chatResp: &ChatResponse{
+			Model:   "fallback-model",
+			Content: "from fallback",
+			Done:    true,
+		},
+	}
+
+	rec := &rpMockRecorder{}
+	primaryKey := ModelKey{Provider: "primary", Model: "primary-model"}
+	fallbackKey := ModelKey{Provider: "fallback", Model: "fallback-model"}
+
+	plan := &RoutePlan{
+		Kind:     RouteKindChat,
+		Provider: primaryProv,
+		Model:    "primary-model",
+		Profile:  &ModelProfile{Key: primaryKey, ContextWindow: 32768},
+		Request: RoutingRequest{
+			Messages: []ChatMessage{{Role: "user", Content: "test"}},
+		},
+		Score:  0.90,
+		Budget: BudgetResult{Decision: BudgetOK},
+		Reason: "primary selected",
+		Fallbacks: []RoutePlan{
+			{
+				Kind:     RouteKindChat,
+				Provider: fallbackProv,
+				Model:    "fallback-model",
+				Profile:  &ModelProfile{Key: fallbackKey, ContextWindow: 32768},
+				Request: RoutingRequest{
+					Messages: []ChatMessage{{Role: "user", Content: "test"}},
+				},
+				Score:  0.70,
+				Budget: BudgetResult{Decision: BudgetOK},
+				Reason: "fallback",
+			},
+		},
+		recorder: rec,
+	}
+
+	resp, err := plan.ExecuteChat(context.Background())
+	if err != nil {
+		t.Fatalf("ExecuteChat returned error: %v", err)
+	}
+	if resp.Content != "from fallback" {
+		t.Errorf("content = %q, want %q", resp.Content, "from fallback")
+	}
+	if resp.RouteOutcome == nil {
+		t.Fatal("RouteOutcome is nil")
+	}
+	if resp.RouteOutcome.FallbacksUsed != 1 {
+		t.Errorf("FallbacksUsed = %d, want 1", resp.RouteOutcome.FallbacksUsed)
+	}
+	if resp.RouteOutcome.ActualModel != fallbackKey {
+		t.Errorf("ActualModel = %v, want %v", resp.RouteOutcome.ActualModel, fallbackKey)
+	}
+	if resp.RouteOutcome.PlannedModel != primaryKey {
+		t.Errorf("PlannedModel = %v, want %v", resp.RouteOutcome.PlannedModel, primaryKey)
+	}
+
+	// Primary should have 1 failure recorded.
+	failures := rec.getFailures()
+	if len(failures) != 1 {
+		t.Fatalf("failures = %d, want 1", len(failures))
+	}
+	if failures[0] != primaryKey {
+		t.Errorf("failed key = %v, want %v", failures[0], primaryKey)
+	}
+
+	// Fallback success should be recorded.
+	successes := rec.getSuccesses()
+	if len(successes) != 1 {
+		t.Fatalf("successes = %d, want 1", len(successes))
+	}
+	if successes[0] != fallbackKey {
+		t.Errorf("success key = %v, want %v", successes[0], fallbackKey)
+	}
+}
+
+func TestRoutePlanChatStreamDoesNotFallbackAfterFirstChunk(t *testing.T) {
+	infraErr := &HTTPStatusError{StatusCode: 503, Status: "503 Service Unavailable"}
+
+	// Primary delivers one content chunk, then returns infra error.
+	primaryProv := &rpMockProvider{
+		name: "primary",
+		caps: CapChat | CapStream,
+		chatStreamChunks: []ChatResponse{
+			{Model: "primary-model", Content: "partial content", Partial: true},
+		},
+		chatStreamErr: infraErr,
+	}
+
+	fallbackProv := &rpMockProvider{
+		name: "fallback",
+		caps: CapChat | CapStream,
+		chatStreamChunks: []ChatResponse{
+			{Model: "fallback-model", Content: "fallback content", Done: true},
+		},
+	}
+
+	rec := &rpMockRecorder{}
+	primaryKey := ModelKey{Provider: "primary", Model: "primary-model"}
+	fallbackKey := ModelKey{Provider: "fallback", Model: "fallback-model"}
+
+	plan := &RoutePlan{
+		Kind:     RouteKindChat,
+		Provider: primaryProv,
+		Model:    "primary-model",
+		Profile:  &ModelProfile{Key: primaryKey, ContextWindow: 32768},
+		Request:  RoutingRequest{Messages: []ChatMessage{{Role: "user", Content: "test"}}},
+		Score:    0.90,
+		Budget:   BudgetResult{Decision: BudgetOK},
+		Reason:   "primary",
+		Fallbacks: []RoutePlan{
+			{
+				Kind:     RouteKindChat,
+				Provider: fallbackProv,
+				Model:    "fallback-model",
+				Profile:  &ModelProfile{Key: fallbackKey, ContextWindow: 32768},
+				Request:  RoutingRequest{Messages: []ChatMessage{{Role: "user", Content: "test"}}},
+				Score:    0.70,
+				Budget:   BudgetResult{Decision: BudgetOK},
+				Reason:   "fallback",
+			},
+		},
+		recorder: rec,
+	}
+
+	var chunks []ChatResponse
+	err := plan.ExecuteChatStream(context.Background(), func(chunk ChatResponse) error {
+		chunks = append(chunks, chunk)
+		return nil
+	})
+
+	// Error should be returned (no fallback after content delivery).
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, infraErr) {
+		t.Errorf("error = %v, want %v", err, infraErr)
+	}
+
+	// Fallback provider should NOT have been called.
+	if fallbackProv.getChatCalls() != 0 {
+		t.Errorf("fallback chatCalls = %d, want 0", fallbackProv.getChatCalls())
+	}
+
+	// One chunk should have been delivered from primary.
+	if len(chunks) != 1 {
+		t.Errorf("chunks = %d, want 1", len(chunks))
+	}
+}
+
+func TestRoutePlanCancellationNotRecorded(t *testing.T) {
+	prov := &rpMockProvider{
+		name:    "ollama",
+		caps:    CapChat,
+		chatErr: context.Canceled,
+	}
+	rec := &rpMockRecorder{}
+	plan := newTestPlan(prov, rec)
+
+	_, err := plan.ExecuteChat(context.Background())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+
+	// No success, no failure — but warmthUse IS recorded.
+	successes := rec.getSuccesses()
+	if len(successes) != 0 {
+		t.Errorf("successes = %d, want 0", len(successes))
+	}
+	failures := rec.getFailures()
+	if len(failures) != 0 {
+		t.Errorf("failures = %d, want 0", len(failures))
+	}
+	warmth := rec.getWarmthUses()
+	if len(warmth) != 1 {
+		t.Errorf("warmthUses = %d, want 1", len(warmth))
+	}
+}
+
+func TestRoutePlanExecuteGenerate(t *testing.T) {
+	prov := &rpMockProvider{
+		name: "ollama",
+		caps: CapGenerate,
+		genResp: &GenerateResponse{
+			Model:    "test-model",
+			Response: "generated text",
+			Done:     true,
+		},
+	}
+	rec := &rpMockRecorder{}
+	plan := newTestPlan(prov, rec)
+	plan.Kind = RouteKindGenerate
+	plan.Request.Prompt = "complete this"
+
+	resp, err := plan.ExecuteGenerate(context.Background())
+	if err != nil {
+		t.Fatalf("ExecuteGenerate returned unexpected error: %v", err)
+	}
+	if resp.Response != "generated text" {
+		t.Errorf("response = %q, want %q", resp.Response, "generated text")
+	}
+	if resp.RouteOutcome == nil {
+		t.Fatal("RouteOutcome is nil, want non-nil")
+	}
+	if resp.RouteOutcome.FallbacksUsed != 0 {
+		t.Errorf("FallbacksUsed = %d, want 0", resp.RouteOutcome.FallbacksUsed)
+	}
+
+	successes := rec.getSuccesses()
+	if len(successes) != 1 {
+		t.Fatalf("successes = %d, want 1", len(successes))
+	}
+}
+
+func TestRoutePlanExecuteGenerateStreamAttachesRouteOutcome(t *testing.T) {
+	prov := &rpMockProvider{
+		name: "ollama",
+		caps: CapGenerate | CapStream,
+		genStreamChunks: []GenerateResponse{
+			{Model: "test-model", Response: "chunk1", Partial: true},
+			{Model: "test-model", Response: "chunk2", Done: true},
+		},
+	}
+	rec := &rpMockRecorder{}
+	plan := newTestPlan(prov, rec)
+	plan.Kind = RouteKindGenerate
+	plan.Request.Prompt = "generate this"
+
+	var chunks []GenerateResponse
+	err := plan.ExecuteGenerateStream(context.Background(), func(chunk GenerateResponse) error {
+		chunks = append(chunks, chunk)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ExecuteGenerateStream returned unexpected error: %v", err)
+	}
+
+	if len(chunks) != 2 {
+		t.Fatalf("got %d chunks, want 2", len(chunks))
+	}
+
+	// First chunk should NOT have RouteOutcome.
+	if chunks[0].RouteOutcome != nil {
+		t.Error("first chunk has RouteOutcome, want nil")
+	}
+
+	// Final Done chunk MUST have RouteOutcome.
+	final := chunks[1]
+	if final.RouteOutcome == nil {
+		t.Fatal("final chunk RouteOutcome is nil, want non-nil")
+	}
+	if final.RouteOutcome.FallbacksUsed != 0 {
+		t.Errorf("FallbacksUsed = %d, want 0", final.RouteOutcome.FallbacksUsed)
+	}
+}
+
+func TestRoutePlanExecuteEmbed(t *testing.T) {
+	prov := &rpMockProvider{
+		name: "ollama",
+		caps: CapEmbed,
+		embedResp: &EmbedResponse{
+			Model:      "embed-model",
+			Embeddings: [][]float64{{0.1, 0.2, 0.3}, {0.4, 0.5, 0.6}},
+		},
+	}
+	rec := &rpMockRecorder{}
+	plan := newTestPlan(prov, rec)
+	plan.Kind = RouteKindEmbed
+	plan.Model = "embed-model"
+	plan.Request.Input = []string{"text1", "text2"}
+
+	resp, err := plan.ExecuteEmbed(context.Background())
+	if err != nil {
+		t.Fatalf("ExecuteEmbed returned unexpected error: %v", err)
+	}
+	if len(resp.Embeddings) != 2 {
+		t.Fatalf("embeddings count = %d, want 2", len(resp.Embeddings))
+	}
+	if resp.RouteOutcome == nil {
+		t.Fatal("RouteOutcome is nil, want non-nil")
+	}
+	if resp.RouteOutcome.FallbacksUsed != 0 {
+		t.Errorf("FallbacksUsed = %d, want 0", resp.RouteOutcome.FallbacksUsed)
+	}
+
+	successes := rec.getSuccesses()
+	if len(successes) != 1 {
+		t.Fatalf("successes = %d, want 1", len(successes))
+	}
+}
+
+func TestRoutePlanString(t *testing.T) {
+	plan := &RoutePlan{
+		Model: "qwen3:8b",
+		Profile: &ModelProfile{
+			Key: ModelKey{Provider: "ollama", Model: "qwen3:8b"},
+		},
+		Score:  0.85,
+		Budget: BudgetResult{Decision: BudgetOK},
+		Fallbacks: []RoutePlan{
+			{Model: "fallback"},
+		},
+		Reason: "best candidate",
+	}
+
+	got := plan.String()
+	want := "ollama/qwen3:8b (score=0.85, budget=ok, fallbacks=1): best candidate"
+	if got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}

--- a/provider/router.go
+++ b/provider/router.go
@@ -1,0 +1,717 @@
+// router.go implements the top-level Router that composes candidate resolution,
+// hard gates, scoring, sticky routing, and RoutePlan construction. It is the
+// single entry point for consumers who want provider-agnostic model routing.
+//
+// Usage:
+//
+//	r, err := provider.NewRouter(modelReg, provReg, opts...)
+//	plan, err := r.Route(ctx, req)
+//	resp, err := plan.ExecuteChat(ctx)
+//
+// Or use the convenience methods which Route + Execute in one step:
+//
+//	resp, err := r.Chat(ctx, req)
+package provider
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// routerDefaults
+// ---------------------------------------------------------------------------
+
+// routerDefaults holds configurable defaults for the Router.
+type routerDefaults struct {
+	stickyTTL        time.Duration
+	hysteresisMargin float64
+	maxStickyEntries int
+	maxFallbacks     int
+	defaultPriority  Priority
+	weightOverrides  map[string]*WeightProfile
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+// Router is the top-level orchestrator for model routing. It resolves
+// candidates from the ModelRegistry, applies hard gates (capability, circuit
+// breaker, RAM, budget), scores surviving candidates, applies sticky routing
+// with hysteresis, and builds a RoutePlan with a fallback chain.
+//
+// Router implements RouteRecorder so that RoutePlans can feed post-execution
+// signals back to the circuit breakers, warmth tracker, and sticky cache.
+type Router struct {
+	mu           sync.RWMutex
+	registry     *ModelRegistry
+	providers    *Registry
+	breakers     map[string]*CircuitBreaker
+	warmth       WarmthSource
+	tokenBudget  *TokenBudgetValidator
+	sticky       *stickyCache
+	availableRAM float64
+	defaultOpts  routerDefaults
+	closed       bool
+	done         chan struct{}
+	closeOnce    sync.Once
+}
+
+// Compile-time assertion that Router implements RouteRecorder.
+var _ RouteRecorder = (*Router)(nil)
+
+// ---------------------------------------------------------------------------
+// RouterOption
+// ---------------------------------------------------------------------------
+
+// RouterOption configures a Router at construction time.
+type RouterOption func(*Router)
+
+// WithWarmthSource sets the warmth source used for warm-model scoring.
+func WithWarmthSource(ws WarmthSource) RouterOption {
+	return func(r *Router) {
+		r.warmth = ws
+	}
+}
+
+// WithStickyTTL sets the TTL for sticky routing cache entries.
+func WithStickyTTL(d time.Duration) RouterOption {
+	return func(r *Router) {
+		if d > 0 {
+			r.defaultOpts.stickyTTL = d
+		}
+	}
+}
+
+// WithHysteresis sets the score margin a challenger must exceed the incumbent
+// by before replacing a sticky route. Values should be in [0, 1).
+func WithHysteresis(margin float64) RouterOption {
+	return func(r *Router) {
+		if margin >= 0 && margin < 1 {
+			r.defaultOpts.hysteresisMargin = margin
+		}
+	}
+}
+
+// WithMaxStickyEntries sets the maximum number of entries in the sticky cache.
+func WithMaxStickyEntries(n int) RouterOption {
+	return func(r *Router) {
+		if n > 0 {
+			r.defaultOpts.maxStickyEntries = n
+		}
+	}
+}
+
+// WithMaxFallbacks sets the maximum number of fallback candidates in a RoutePlan.
+func WithMaxFallbacks(n int) RouterOption {
+	return func(r *Router) {
+		if n >= 0 {
+			r.defaultOpts.maxFallbacks = n
+		}
+	}
+}
+
+// WithDefaultPriority sets the default priority for requests that don't specify one.
+func WithDefaultPriority(p Priority) RouterOption {
+	return func(r *Router) {
+		r.defaultOpts.defaultPriority = p
+	}
+}
+
+// WithWeightOverrides sets per-use-case weight profile overrides. The map
+// keys are use case names (e.g. "chat", "fim").
+func WithWeightOverrides(overrides map[string]*WeightProfile) RouterOption {
+	return func(r *Router) {
+		r.defaultOpts.weightOverrides = overrides
+	}
+}
+
+// WithAvailableRAM sets the available RAM (in GB) for resource-aware filtering.
+// Models whose RAMRequired exceeds this value are filtered out.
+func WithAvailableRAM(gb float64) RouterOption {
+	return func(r *Router) {
+		if gb > 0 {
+			r.availableRAM = gb
+		}
+	}
+}
+
+// WithTokenBudgetValidator sets a custom token budget validator.
+func WithTokenBudgetValidator(v *TokenBudgetValidator) RouterOption {
+	return func(r *Router) {
+		r.tokenBudget = v
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Constructor
+// ---------------------------------------------------------------------------
+
+// NewRouter creates a Router with the given registries and options.
+func NewRouter(registry *ModelRegistry, providers *Registry, opts ...RouterOption) *Router {
+	r := &Router{
+		registry:  registry,
+		providers: providers,
+		breakers:  make(map[string]*CircuitBreaker),
+		defaultOpts: routerDefaults{
+			stickyTTL:        5 * time.Minute,
+			hysteresisMargin: 0.15,
+			maxStickyEntries: 1024,
+			maxFallbacks:     3,
+			defaultPriority:  PriorityNormal,
+			weightOverrides:  make(map[string]*WeightProfile),
+		},
+		done: make(chan struct{}),
+	}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	// Create sticky cache with configured parameters.
+	r.sticky = newStickyCache(r.defaultOpts.stickyTTL, r.defaultOpts.maxStickyEntries)
+
+	// Create default token budget validator if none provided.
+	if r.tokenBudget == nil {
+		r.tokenBudget = NewTokenBudgetValidator()
+	}
+
+	return r
+}
+
+// ---------------------------------------------------------------------------
+// Close
+// ---------------------------------------------------------------------------
+
+// Close shuts down the router. Subsequent calls to Route and convenience
+// methods return ErrRouterClosed. Close is idempotent.
+func (r *Router) Close() error {
+	r.closeOnce.Do(func() {
+		r.mu.Lock()
+		r.closed = true
+		r.mu.Unlock()
+		close(r.done)
+	})
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Route — core routing method
+// ---------------------------------------------------------------------------
+
+// Route selects the best provider/model for the given request and returns a
+// RoutePlan with a fallback chain. The plan can then be executed via
+// ExecuteChat, ExecuteGenerate, or ExecuteEmbed.
+func (r *Router) Route(ctx context.Context, req RoutingRequest) (*RoutePlan, error) {
+	// 1. Check closed.
+	r.mu.RLock()
+	if r.closed {
+		r.mu.RUnlock()
+		return nil, ErrRouterClosed
+	}
+	r.mu.RUnlock()
+
+	// Apply default priority if not set.
+	if req.Priority == 0 && r.defaultOpts.defaultPriority != PriorityBackground {
+		req.Priority = r.defaultOpts.defaultPriority
+	}
+
+	// 2. Resolve candidates.
+	candidates, err := r.resolveCandidates(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if len(candidates) == 0 {
+		return nil, ErrNoViableCandidate
+	}
+
+	// 3. Hard gates + budget + score all candidates.
+	scored := r.scoreAll(ctx, candidates, req)
+
+	// 4. Partition into executable, truncatable, breakered, budgeted.
+	var executable, truncatable []scoredCandidate
+	var allBreakered, allBudgeted bool
+	breakerCount, budgetCount := 0, 0
+
+	for _, sc := range scored {
+		if !sc.bd.capabilityGate {
+			continue
+		}
+		if math.IsInf(sc.bd.breakerPenalty, -1) {
+			breakerCount++
+			continue
+		}
+		switch sc.budget.Decision {
+		case BudgetOK:
+			executable = append(executable, sc)
+		case BudgetTruncate:
+			truncatable = append(truncatable, sc)
+		case BudgetReject:
+			budgetCount++
+		}
+	}
+
+	allBreakered = breakerCount > 0 && len(executable) == 0 && len(truncatable) == 0 && budgetCount == 0
+	allBudgeted = budgetCount > 0 && len(executable) == 0 && len(truncatable) == 0
+
+	// If no executable candidates, determine the best error.
+	if len(executable) == 0 {
+		if len(truncatable) > 0 {
+			// Return best truncatable with adaptation error.
+			sortScoredCandidates(truncatable, r.warmth)
+			winner := truncatable[0]
+			plan := r.buildPlan(winner, nil, req, false)
+			plan.Degraded = true
+			return plan, ErrBudgetAdaptationRequired
+		}
+		if allBreakered {
+			return nil, ErrAllBreakersOpen
+		}
+		if allBudgeted {
+			return nil, ErrBudgetExceeded
+		}
+		return nil, ErrNoViableCandidate
+	}
+
+	// 5. Sort scored candidates.
+	sortScoredCandidates(executable, r.warmth)
+
+	// 6. Sticky routing.
+	wasSticky := false
+	stickyKey := ""
+	if req.AffinityKey != "" && !req.DryRun {
+		stickyKey = StickyKey(req)
+		incumbent, found := r.sticky.get(stickyKey)
+		if found {
+			// Find incumbent in scored list.
+			incumbentIdx := r.findIncumbentScore(incumbent.providerKey, executable)
+			if incumbentIdx >= 0 {
+				challengerScore := executable[0].score
+				incumbentScore := executable[incumbentIdx].score
+
+				// Hysteresis: challenger must exceed incumbent by margin.
+				if challengerScore <= incumbentScore+r.defaultOpts.hysteresisMargin {
+					// Keep incumbent: move it to front.
+					if incumbentIdx != 0 {
+						kept := executable[incumbentIdx]
+						copy(executable[1:incumbentIdx+1], executable[:incumbentIdx])
+						executable[0] = kept
+					}
+					wasSticky = true
+					r.sticky.touch(stickyKey)
+				}
+				// else: challenger wins, replace incumbent below
+			}
+			// else: incumbent not in scored list (breaker opened, etc.) — let challenger win
+		}
+	}
+
+	// 7. Build RoutePlan with fallback chain.
+	var fallbacks []scoredCandidate
+	maxFb := r.defaultOpts.maxFallbacks
+	if maxFb > len(executable)-1 {
+		maxFb = len(executable) - 1
+	}
+	if maxFb > 0 {
+		fallbacks = executable[1 : 1+maxFb]
+	}
+
+	plan := r.buildPlan(executable[0], fallbacks, req, wasSticky)
+
+	// 8. Update sticky cache (skip if DryRun).
+	if req.AffinityKey != "" && !req.DryRun && stickyKey != "" {
+		now := time.Now()
+		r.sticky.put(&routeSticky{
+			key:         stickyKey,
+			providerKey: executable[0].profile.Key,
+			score:       executable[0].score,
+			reason:      buildReason(executable[0]),
+			createdAt:   now,
+			lastUsedAt:  now,
+			expiresAt:   now.Add(r.defaultOpts.stickyTTL),
+		})
+	}
+
+	return plan, nil
+}
+
+// ---------------------------------------------------------------------------
+// RouteRecorder implementation
+// ---------------------------------------------------------------------------
+
+// RecordSuccess records a successful request to the circuit breaker.
+func (r *Router) RecordSuccess(key ModelKey, _ LatencyInfo) {
+	cb := r.getOrCreateBreaker(key.Provider)
+	cb.RecordSuccess()
+}
+
+// RecordFailure records a failed request. Infrastructure errors trigger the
+// circuit breaker and invalidate sticky routes for the provider.
+func (r *Router) RecordFailure(key ModelKey, err error) {
+	if IsInfrastructureError(err) {
+		cb := r.getOrCreateBreaker(key.Provider)
+		cb.RecordFailure(err)
+		r.sticky.invalidateProvider(key.Provider)
+	}
+}
+
+// RecordWarmthUse records a warmth use signal if a warmth source is configured.
+func (r *Router) RecordWarmthUse(key ModelKey) {
+	if r.warmth != nil {
+		r.warmth.RecordUse(key)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Convenience methods
+// ---------------------------------------------------------------------------
+
+// Chat routes and executes a non-streaming chat request.
+func (r *Router) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error) {
+	rr := RoutingRequest{
+		Model:    req.Model,
+		UseCase:  "chat",
+		Messages: req.Messages,
+		Options:  req.Options,
+		Tools:    req.Tools,
+		Priority: r.defaultOpts.defaultPriority,
+	}
+	if len(req.Tools) > 0 {
+		rr.RequiredCaps = CapChat | CapToolCall
+	} else {
+		rr.RequiredCaps = CapChat
+	}
+
+	plan, err := r.Route(ctx, rr)
+	if err != nil {
+		return nil, err
+	}
+	return plan.ExecuteChat(ctx)
+}
+
+// ChatStream routes and executes a streaming chat request.
+func (r *Router) ChatStream(ctx context.Context, req ChatRequest, fn func(ChatResponse) error) error {
+	rr := RoutingRequest{
+		Model:    req.Model,
+		UseCase:  "chat",
+		Messages: req.Messages,
+		Options:  req.Options,
+		Tools:    req.Tools,
+		Priority: r.defaultOpts.defaultPriority,
+	}
+	if len(req.Tools) > 0 {
+		rr.RequiredCaps = CapChat | CapStream | CapToolCall
+	} else {
+		rr.RequiredCaps = CapChat | CapStream
+	}
+
+	plan, err := r.Route(ctx, rr)
+	if err != nil {
+		return err
+	}
+	return plan.ExecuteChatStream(ctx, fn)
+}
+
+// Generate routes and executes a non-streaming generate request.
+// If the request includes a Suffix, FIM mode is inferred and priority is
+// elevated to PriorityHigh.
+func (r *Router) Generate(ctx context.Context, req GenerateRequest) (*GenerateResponse, error) {
+	rr := RoutingRequest{
+		Model:        req.Model,
+		UseCase:      "generate",
+		Prompt:       req.Prompt,
+		System:       req.System,
+		Suffix:       req.Suffix,
+		Options:      req.Options,
+		RequiredCaps: CapGenerate,
+		Priority:     r.defaultOpts.defaultPriority,
+	}
+	if req.Suffix != "" {
+		rr.UseCase = "fim"
+		rr.Priority = PriorityHigh
+	}
+
+	plan, err := r.Route(ctx, rr)
+	if err != nil {
+		return nil, err
+	}
+	return plan.ExecuteGenerate(ctx)
+}
+
+// GenerateStream routes and executes a streaming generate request.
+func (r *Router) GenerateStream(ctx context.Context, req GenerateRequest, fn func(GenerateResponse) error) error {
+	rr := RoutingRequest{
+		Model:        req.Model,
+		UseCase:      "generate",
+		Prompt:       req.Prompt,
+		System:       req.System,
+		Suffix:       req.Suffix,
+		Options:      req.Options,
+		RequiredCaps: CapGenerate | CapStream,
+		Priority:     r.defaultOpts.defaultPriority,
+	}
+	if req.Suffix != "" {
+		rr.UseCase = "fim"
+		rr.Priority = PriorityHigh
+	}
+
+	plan, err := r.Route(ctx, rr)
+	if err != nil {
+		return err
+	}
+	return plan.ExecuteGenerateStream(ctx, fn)
+}
+
+// Embed routes and executes an embedding request.
+func (r *Router) Embed(ctx context.Context, req EmbedRequest) (*EmbedResponse, error) {
+	rr := RoutingRequest{
+		Model:        req.Model,
+		UseCase:      "embedding",
+		Input:        req.Input,
+		RequiredCaps: CapEmbed,
+		Priority:     r.defaultOpts.defaultPriority,
+	}
+
+	plan, err := r.Route(ctx, rr)
+	if err != nil {
+		return nil, err
+	}
+	return plan.ExecuteEmbed(ctx)
+}
+
+// ---------------------------------------------------------------------------
+// Observability
+// ---------------------------------------------------------------------------
+
+// BreakerInfo returns the circuit breaker state for the named provider.
+// Returns false if no breaker exists yet.
+func (r *Router) BreakerInfo(provider string) (BreakerInfo, bool) {
+	r.mu.RLock()
+	cb, ok := r.breakers[provider]
+	r.mu.RUnlock()
+	if !ok {
+		return BreakerInfo{}, false
+	}
+	return cb.Info(), true
+}
+
+// StickyRoutes returns a snapshot of all active sticky routing entries.
+func (r *Router) StickyRoutes() map[string]StickyRouteInfo {
+	return r.sticky.snapshot()
+}
+
+// WarmthSnapshot returns all currently warm models. Returns nil if no
+// warmth source is configured.
+func (r *Router) WarmthSnapshot() []WarmModel {
+	if r.warmth == nil {
+		return nil
+	}
+	return r.warmth.Snapshot()
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+// resolveCandidates resolves model profiles from the request's Model field.
+//   - Empty model: use Recommend with RequiredCaps and AvailableRAM
+//   - Contains "/": qualified lookup via ModelRegistry.Lookup
+//   - Otherwise: unqualified lookup via ModelRegistry.LookupAny
+func (r *Router) resolveCandidates(ctx context.Context, req RoutingRequest) ([]*ModelProfile, error) {
+	if req.Model == "" {
+		return r.registry.Recommend(ctx, RecommendOpts{
+			RequiredCaps: req.RequiredCaps,
+			AvailableRAM: r.availableRAM,
+			PreferWarm:   req.PreferWarm,
+		})
+	}
+
+	if strings.Contains(req.Model, "/") {
+		parts := strings.SplitN(req.Model, "/", 2)
+		key := ModelKey{Provider: parts[0], Model: parts[1]}
+		profile, err := r.registry.Lookup(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+		return []*ModelProfile{profile}, nil
+	}
+
+	return r.registry.LookupAny(ctx, req.Model)
+}
+
+// scoreAll evaluates all candidates against the routing request, applying
+// hard gates (capability, breaker, RAM, budget) and computing weighted scores.
+func (r *Router) scoreAll(_ context.Context, candidates []*ModelProfile, req RoutingRequest) []scoredCandidate {
+	active := r.activeSignals()
+	var customWeights *WeightProfile
+	if wp, ok := r.defaultOpts.weightOverrides[req.UseCase]; ok {
+		customWeights = wp
+	}
+
+	scored := make([]scoredCandidate, 0, len(candidates))
+
+	for _, profile := range candidates {
+		// RAM gate: skip models that exceed available RAM.
+		if r.availableRAM > 0 && profile.Resources.RAMRequired > r.availableRAM {
+			continue
+		}
+
+		// Budget validation.
+		budget := r.tokenBudget.Validate(req, profile)
+
+		// Score the candidate.
+		breaker := r.getOrCreateBreaker(profile.Key.Provider)
+		bd := scoreCandidate(profile, req, budget, r.warmth, nil, breaker)
+
+		// Compute weighted score.
+		score := computeWeightedScore(bd, req.UseCase, active, customWeights)
+
+		// Apply breaker penalty (overrides score if -Inf).
+		if math.IsInf(bd.breakerPenalty, -1) {
+			score = math.Inf(-1)
+		}
+
+		scored = append(scored, scoredCandidate{
+			profile: profile,
+			budget:  budget,
+			score:   score,
+			bd:      bd,
+		})
+	}
+
+	return scored
+}
+
+// activeSignals returns the set of scoring signals that are active based
+// on the router's configuration. Signals backed by absent subsystems
+// (e.g. no warmth tracker) are excluded so they don't penalize candidates.
+func (r *Router) activeSignals() map[string]bool {
+	active := map[string]bool{
+		"headroom": true,
+		"feedback": true,
+		"quality":  true,
+		"speed":    true,
+		"kvcache":  true,
+		"cost":     true,
+	}
+	if r.warmth != nil {
+		active["warmth"] = true
+	}
+	return active
+}
+
+// getOrCreateBreaker returns the circuit breaker for the named provider,
+// creating one if it doesn't exist. Uses double-check locking.
+func (r *Router) getOrCreateBreaker(provider string) *CircuitBreaker {
+	r.mu.RLock()
+	cb, ok := r.breakers[provider]
+	r.mu.RUnlock()
+	if ok {
+		return cb
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Double-check after acquiring write lock.
+	if cb, ok = r.breakers[provider]; ok {
+		return cb
+	}
+
+	cb = NewCircuitBreaker()
+	r.breakers[provider] = cb
+	return cb
+}
+
+// findIncumbentScore finds the index of the incumbent model in the scored
+// list. Returns -1 if not found.
+func (r *Router) findIncumbentScore(key ModelKey, scored []scoredCandidate) int {
+	for i, sc := range scored {
+		if sc.profile.Key == key {
+			return i
+		}
+	}
+	return -1
+}
+
+// buildPlan constructs a RoutePlan from the winning candidate, fallback
+// candidates, the original request, and the sticky state.
+func (r *Router) buildPlan(winner scoredCandidate, fallbacks []scoredCandidate, req RoutingRequest, wasSticky bool) *RoutePlan {
+	prov, err := r.providers.Resolve(winner.profile.Key)
+	if err != nil {
+		// This should not happen since the candidate was resolved from the
+		// registry, but handle gracefully.
+		return &RoutePlan{
+			Kind:    inferRouteKind(req),
+			Model:   winner.profile.Key.Model,
+			Profile: winner.profile,
+			Request: req,
+			Score:   winner.score,
+			Budget:  winner.budget,
+			Reason:  fmt.Sprintf("provider resolution failed: %v", err),
+		}
+	}
+
+	plan := &RoutePlan{
+		Kind:     inferRouteKind(req),
+		Provider: prov,
+		Model:    winner.profile.Key.Model,
+		Profile:  winner.profile,
+		Request:  req,
+		Score:    winner.score,
+		Budget:   winner.budget,
+		Reason:   buildReason(winner),
+	}
+	plan.SetWasSticky(wasSticky)
+	plan.SetRecorder(r)
+
+	// Build fallback chain.
+	for _, fb := range fallbacks {
+		fbProv, fbErr := r.providers.Resolve(fb.profile.Key)
+		if fbErr != nil {
+			continue // skip unresolvable fallbacks
+		}
+		fbPlan := RoutePlan{
+			Kind:     plan.Kind,
+			Provider: fbProv,
+			Model:    fb.profile.Key.Model,
+			Profile:  fb.profile,
+			Request:  req,
+			Score:    fb.score,
+			Budget:   fb.budget,
+			Reason:   buildReason(fb),
+		}
+		plan.Fallbacks = append(plan.Fallbacks, fbPlan)
+	}
+
+	return plan
+}
+
+// buildReason creates a human-readable reason string from a scored candidate.
+func buildReason(sc scoredCandidate) string {
+	parts := []string{
+		fmt.Sprintf("score=%.3f", sc.score),
+		fmt.Sprintf("quality=%s", sc.profile.Quality),
+		fmt.Sprintf("speed=%s", sc.profile.Speed),
+	}
+	if sc.budget.Decision != BudgetOK {
+		parts = append(parts, fmt.Sprintf("budget=%s", sc.budget.Decision))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// inferRouteKind determines the RouteKind from the request's fields.
+func inferRouteKind(req RoutingRequest) RouteKind {
+	if len(req.Input) > 0 {
+		return RouteKindEmbed
+	}
+	if req.Prompt != "" || req.Suffix != "" {
+		return RouteKindGenerate
+	}
+	return RouteKindChat
+}

--- a/provider/router.go
+++ b/provider/router.go
@@ -221,10 +221,9 @@ func (r *Router) Route(ctx context.Context, req RoutingRequest) (*RoutePlan, err
 	}
 	r.mu.RUnlock()
 
-	// Apply default priority if not set.
-	if req.Priority == 0 && r.defaultOpts.defaultPriority != PriorityBackground {
-		req.Priority = r.defaultOpts.defaultPriority
-	}
+	// Priority is used as-is from the request. PriorityBackground (zero value)
+	// is a valid explicit choice, so we do not override it with a default.
+	// Convenience methods set appropriate priorities (e.g., FIM -> PriorityHigh).
 
 	// 2. Resolve candidates.
 	candidates, err := r.resolveCandidates(ctx, req)

--- a/provider/router.go
+++ b/provider/router.go
@@ -191,13 +191,18 @@ func NewRouter(registry *ModelRegistry, providers *Registry, opts ...RouterOptio
 // Close shuts down the router. Subsequent calls to Route and convenience
 // methods return ErrRouterClosed. Close is idempotent.
 func (r *Router) Close() error {
+	var err error
 	r.closeOnce.Do(func() {
 		r.mu.Lock()
 		r.closed = true
 		r.mu.Unlock()
 		close(r.done)
+
+		if r.warmth != nil {
+			err = r.warmth.Close()
+		}
 	})
-	return nil
+	return err
 }
 
 // ---------------------------------------------------------------------------
@@ -265,7 +270,10 @@ func (r *Router) Route(ctx context.Context, req RoutingRequest) (*RoutePlan, err
 			// Return best truncatable with adaptation error.
 			sortScoredCandidates(truncatable, r.warmth)
 			winner := truncatable[0]
-			plan := r.buildPlan(winner, nil, req, false)
+			plan, buildErr := r.buildPlan(winner, nil, req, false)
+			if buildErr != nil {
+				return nil, ErrNoViableCandidate
+			}
 			plan.Degraded = true
 			return plan, ErrBudgetAdaptationRequired
 		}
@@ -321,7 +329,10 @@ func (r *Router) Route(ctx context.Context, req RoutingRequest) (*RoutePlan, err
 		fallbacks = executable[1 : 1+maxFb]
 	}
 
-	plan := r.buildPlan(executable[0], fallbacks, req, wasSticky)
+	plan, buildErr := r.buildPlan(executable[0], fallbacks, req, wasSticky)
+	if buildErr != nil {
+		return nil, fmt.Errorf("router: %w", buildErr)
+	}
 
 	// 8. Update sticky cache (skip if DryRun).
 	if req.AffinityKey != "" && !req.DryRun && stickyKey != "" {
@@ -641,20 +652,10 @@ func (r *Router) findIncumbentScore(key ModelKey, scored []scoredCandidate) int 
 
 // buildPlan constructs a RoutePlan from the winning candidate, fallback
 // candidates, the original request, and the sticky state.
-func (r *Router) buildPlan(winner scoredCandidate, fallbacks []scoredCandidate, req RoutingRequest, wasSticky bool) *RoutePlan {
+func (r *Router) buildPlan(winner scoredCandidate, fallbacks []scoredCandidate, req RoutingRequest, wasSticky bool) (*RoutePlan, error) {
 	prov, err := r.providers.Resolve(winner.profile.Key)
 	if err != nil {
-		// This should not happen since the candidate was resolved from the
-		// registry, but handle gracefully.
-		return &RoutePlan{
-			Kind:    inferRouteKind(req),
-			Model:   winner.profile.Key.Model,
-			Profile: winner.profile,
-			Request: req,
-			Score:   winner.score,
-			Budget:  winner.budget,
-			Reason:  fmt.Sprintf("provider resolution failed: %v", err),
-		}
+		return nil, fmt.Errorf("router: provider resolution failed for %s: %w", winner.profile.Key, err)
 	}
 
 	plan := &RoutePlan{
@@ -689,7 +690,7 @@ func (r *Router) buildPlan(winner scoredCandidate, fallbacks []scoredCandidate, 
 		plan.Fallbacks = append(plan.Fallbacks, fbPlan)
 	}
 
-	return plan
+	return plan, nil
 }
 
 // buildReason creates a human-readable reason string from a scored candidate.

--- a/provider/router_errors.go
+++ b/provider/router_errors.go
@@ -100,7 +100,10 @@ type HTTPStatusError struct {
 
 // Error implements the error interface.
 func (e *HTTPStatusError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Status)
+	if e.Status != "" {
+		return e.Status
+	}
+	return fmt.Sprintf("HTTP %d", e.StatusCode)
 }
 
 // ---------------------------------------------------------------------------

--- a/provider/router_errors.go
+++ b/provider/router_errors.go
@@ -1,0 +1,156 @@
+// router_errors.go defines sentinel errors, error classification, and
+// circuit-breaker state types used by the routing layer. These allow callers
+// to distinguish infrastructure failures (network errors, 5xx, rate limiting)
+// from client-side or application errors.
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Sentinel errors
+// ---------------------------------------------------------------------------
+
+// ErrNoViableCandidate is returned when the router cannot find any
+// provider/model that satisfies the request's capability requirements.
+var ErrNoViableCandidate = errors.New("router: no viable candidate for request")
+
+// ErrAllBreakersOpen is returned when every candidate provider has its
+// circuit breaker in the open state.
+var ErrAllBreakersOpen = errors.New("router: all circuit breakers are open")
+
+// ErrBudgetAdaptationRequired is returned when the request's token budget
+// exceeds what any available model can handle and needs to be adapted.
+var ErrBudgetAdaptationRequired = errors.New("router: budget adaptation required")
+
+// ErrBudgetExceeded is returned when a request would exceed the configured
+// token budget and cannot be routed.
+var ErrBudgetExceeded = errors.New("router: budget exceeded")
+
+// ErrRouterClosed is returned when Route is called on a shut-down router.
+var ErrRouterClosed = errors.New("router: router is closed")
+
+// ---------------------------------------------------------------------------
+// BreakerState
+// ---------------------------------------------------------------------------
+
+// BreakerState represents the current state of a circuit breaker.
+type BreakerState int
+
+const (
+	// BreakerClosed means the circuit is healthy and requests flow normally.
+	BreakerClosed BreakerState = iota
+	// BreakerOpen means the circuit has tripped and requests are rejected.
+	BreakerOpen
+	// BreakerHalfOpen means the circuit is testing whether the backend has recovered.
+	BreakerHalfOpen
+)
+
+// String returns the human-readable name of the breaker state.
+func (s BreakerState) String() string {
+	switch s {
+	case BreakerClosed:
+		return "closed"
+	case BreakerOpen:
+		return "open"
+	case BreakerHalfOpen:
+		return "half-open"
+	default:
+		return "unknown"
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BreakerInfo
+// ---------------------------------------------------------------------------
+
+// BreakerInfo holds the current status of a circuit breaker for a particular
+// provider or model endpoint.
+type BreakerInfo struct {
+	// State is the current circuit breaker state.
+	State BreakerState
+	// Failures is the count of consecutive failures.
+	Failures int
+	// LastFailure is the timestamp of the most recent failure.
+	LastFailure time.Time
+	// LastError is the most recent error that triggered a failure count.
+	LastError error
+	// RecoverAt is the earliest time the breaker will transition to half-open.
+	RecoverAt time.Time
+}
+
+// ---------------------------------------------------------------------------
+// HTTPStatusError
+// ---------------------------------------------------------------------------
+
+// HTTPStatusError represents an HTTP-level error from a provider backend.
+// It carries the status code and status text so callers can classify the
+// failure (e.g. distinguishing 429 rate limiting from 500 server errors).
+type HTTPStatusError struct {
+	// StatusCode is the HTTP status code (e.g. 500, 429).
+	StatusCode int
+	// Status is the HTTP status text (e.g. "500 Internal Server Error").
+	Status string
+}
+
+// Error implements the error interface.
+func (e *HTTPStatusError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Status)
+}
+
+// ---------------------------------------------------------------------------
+// Infrastructure error classification
+// ---------------------------------------------------------------------------
+
+// IsInfrastructureError reports whether err represents a transient
+// infrastructure failure that warrants retry or circuit-breaker action.
+//
+// Infrastructure errors include:
+//   - Network errors (net.OpError, net.DNSError)
+//   - HTTP 5xx server errors
+//   - HTTP 429 rate limiting
+//
+// The following are NOT infrastructure errors:
+//   - nil
+//   - context.Canceled and context.DeadlineExceeded (caller-initiated)
+//   - HTTP 4xx client errors (except 429)
+//   - Generic/unknown errors
+func IsInfrastructureError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Context cancellation and deadline are caller-initiated, not infrastructure.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// Network-level errors are always infrastructure failures.
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return true
+	}
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return true
+	}
+
+	// HTTP status errors: 5xx and 429 are infrastructure, other 4xx are not.
+	var httpErr *HTTPStatusError
+	if errors.As(err, &httpErr) {
+		if httpErr.StatusCode >= 500 {
+			return true
+		}
+		if httpErr.StatusCode == 429 {
+			return true
+		}
+		return false
+	}
+
+	return false
+}

--- a/provider/router_errors_test.go
+++ b/provider/router_errors_test.go
@@ -1,0 +1,187 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+)
+
+func TestIsInfrastructureError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "net.OpError dial",
+			err: &net.OpError{
+				Op:  "dial",
+				Net: "tcp",
+				Err: errors.New("connection refused"),
+			},
+			want: true,
+		},
+		{
+			name: "context.DeadlineExceeded",
+			err:  context.DeadlineExceeded,
+			want: false,
+		},
+		{
+			name: "context.Canceled",
+			err:  context.Canceled,
+			want: false,
+		},
+		{
+			name: "HTTP 500",
+			err:  &HTTPStatusError{StatusCode: 500, Status: "500 Internal Server Error"},
+			want: true,
+		},
+		{
+			name: "HTTP 502",
+			err:  &HTTPStatusError{StatusCode: 502, Status: "502 Bad Gateway"},
+			want: true,
+		},
+		{
+			name: "HTTP 503",
+			err:  &HTTPStatusError{StatusCode: 503, Status: "503 Service Unavailable"},
+			want: true,
+		},
+		{
+			name: "HTTP 400",
+			err:  &HTTPStatusError{StatusCode: 400, Status: "400 Bad Request"},
+			want: false,
+		},
+		{
+			name: "HTTP 404",
+			err:  &HTTPStatusError{StatusCode: 404, Status: "404 Not Found"},
+			want: false,
+		},
+		{
+			name: "HTTP 429",
+			err:  &HTTPStatusError{StatusCode: 429, Status: "429 Too Many Requests"},
+			want: true,
+		},
+		{
+			name: "wrapped HTTP 503",
+			err:  fmt.Errorf("provider error: %w", &HTTPStatusError{StatusCode: 503, Status: "503 Service Unavailable"}),
+			want: true,
+		},
+		{
+			name: "wrapped context.Canceled",
+			err:  fmt.Errorf("request failed: %w", context.Canceled),
+			want: false,
+		},
+		{
+			name: "generic error",
+			err:  errors.New("something went wrong"),
+			want: false,
+		},
+		{
+			name: "connection reset net.OpError read",
+			err: &net.OpError{
+				Op:  "read",
+				Net: "tcp",
+				Err: errors.New("connection reset by peer"),
+			},
+			want: true,
+		},
+		{
+			name: "net.DNSError",
+			err:  &net.DNSError{Err: "no such host", Name: "example.com"},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsInfrastructureError(tt.err)
+			if got != tt.want {
+				t.Errorf("IsInfrastructureError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSentinelErrors(t *testing.T) {
+	sentinels := []struct {
+		name string
+		err  error
+	}{
+		{"ErrNoViableCandidate", ErrNoViableCandidate},
+		{"ErrAllBreakersOpen", ErrAllBreakersOpen},
+		{"ErrBudgetAdaptationRequired", ErrBudgetAdaptationRequired},
+		{"ErrBudgetExceeded", ErrBudgetExceeded},
+		{"ErrRouterClosed", ErrRouterClosed},
+	}
+
+	// Each sentinel should match itself.
+	for _, s := range sentinels {
+		t.Run(s.name+" matches itself", func(t *testing.T) {
+			if !errors.Is(s.err, s.err) {
+				t.Errorf("errors.Is(%v, %v) = false, want true", s.err, s.err)
+			}
+		})
+	}
+
+	// Each sentinel should be distinct from all others.
+	for i, a := range sentinels {
+		for j, b := range sentinels {
+			if i == j {
+				continue
+			}
+			t.Run(a.name+" distinct from "+b.name, func(t *testing.T) {
+				if errors.Is(a.err, b.err) {
+					t.Errorf("errors.Is(%v, %v) = true, want false", a.err, b.err)
+				}
+			})
+		}
+	}
+
+	// Wrapping preserves matching.
+	for _, s := range sentinels {
+		t.Run("wrapped "+s.name, func(t *testing.T) {
+			wrapped := fmt.Errorf("router: %w", s.err)
+			if !errors.Is(wrapped, s.err) {
+				t.Errorf("errors.Is(wrapped, %v) = false, want true", s.err)
+			}
+		})
+	}
+}
+
+func TestBreakerStateString(t *testing.T) {
+	tests := []struct {
+		name  string
+		state BreakerState
+		want  string
+	}{
+		{name: "closed", state: BreakerClosed, want: "closed"},
+		{name: "open", state: BreakerOpen, want: "open"},
+		{name: "half-open", state: BreakerHalfOpen, want: "half-open"},
+		{name: "unknown", state: BreakerState(99), want: "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.state.String()
+			if got != tt.want {
+				t.Errorf("BreakerState(%d).String() = %q, want %q", tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHTTPStatusError_Error(t *testing.T) {
+	err := &HTTPStatusError{StatusCode: 503, Status: "503 Service Unavailable"}
+	got := err.Error()
+	want := "HTTP 503: 503 Service Unavailable"
+	if got != want {
+		t.Errorf("HTTPStatusError.Error() = %q, want %q", got, want)
+	}
+}

--- a/provider/router_errors_test.go
+++ b/provider/router_errors_test.go
@@ -178,10 +178,19 @@ func TestBreakerStateString(t *testing.T) {
 }
 
 func TestHTTPStatusError_Error(t *testing.T) {
-	err := &HTTPStatusError{StatusCode: 503, Status: "503 Service Unavailable"}
-	got := err.Error()
-	want := "HTTP 503: 503 Service Unavailable"
-	if got != want {
-		t.Errorf("HTTPStatusError.Error() = %q, want %q", got, want)
+	tests := []struct {
+		name string
+		err  *HTTPStatusError
+		want string
+	}{
+		{"with status text", &HTTPStatusError{StatusCode: 503, Status: "503 Service Unavailable"}, "503 Service Unavailable"},
+		{"empty status text", &HTTPStatusError{StatusCode: 500}, "HTTP 500"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.want {
+				t.Errorf("HTTPStatusError.Error() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/provider/router_integration_test.go
+++ b/provider/router_integration_test.go
@@ -42,7 +42,7 @@ func setupIntegrationRouter(
 	}
 
 	router := NewRouter(modelReg, provReg, opts...)
-	t.Cleanup(func() { router.Close() })
+	t.Cleanup(func() { _ = router.Close() })
 	return router
 }
 

--- a/provider/router_integration_test.go
+++ b/provider/router_integration_test.go
@@ -1,0 +1,948 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Integration test helpers
+//
+// These tests exercise the full routing pipeline: Registry -> ModelRegistry ->
+// Router -> Route -> RoutePlan -> Execute. They use mock providers (not real
+// Ollama) but wire up the complete system.
+// ---------------------------------------------------------------------------
+
+// setupIntegrationRouter creates a Router with one or more rtMockProviders,
+// wires up both registries, and returns the router. The caller owns cleanup
+// via t.Cleanup. Additional RouterOptions can be passed through.
+func setupIntegrationRouter(
+	t *testing.T,
+	providers []*rtMockProvider,
+	opts ...RouterOption,
+) *Router {
+	t.Helper()
+
+	provReg := NewRegistry()
+	for _, prov := range providers {
+		if err := provReg.Register(prov); err != nil {
+			t.Fatalf("Register(%s) failed: %v", prov.Name(), err)
+		}
+		if err := provReg.RefreshModels(context.Background(), prov.Name()); err != nil {
+			t.Fatalf("RefreshModels(%s) failed: %v", prov.Name(), err)
+		}
+	}
+
+	modelReg, err := NewModelRegistry(provReg, nil)
+	if err != nil {
+		t.Fatalf("NewModelRegistry failed: %v", err)
+	}
+
+	router := NewRouter(modelReg, provReg, opts...)
+	t.Cleanup(func() { router.Close() })
+	return router
+}
+
+// ---------------------------------------------------------------------------
+// TestIntegrationRouteAndExecuteChat
+//
+// End-to-end: route with affinity key, execute chat, verify response content,
+// RouteOutcome, sticky caching, and TTL expiry.
+// ---------------------------------------------------------------------------
+
+func TestIntegrationRouteAndExecuteChat(t *testing.T) {
+	ws := newRTMockWarmthSource()
+	modelKey := ModelKey{Provider: "alpha", Model: "qwen3:8b"}
+	ws.setWarm(modelKey, WarmthInfo{
+		Loaded:    true,
+		Since:     time.Now(),
+		ExpiresAt: time.Now().Add(5 * time.Minute),
+		VRAM:      4.5,
+	})
+
+	prov := &rtMockProvider{
+		name: "alpha",
+		caps: CapChat | CapGenerate | CapEmbed | CapStream,
+		models: []ModelInfo{
+			{
+				Name:          "qwen3:8b",
+				Family:        "qwen3",
+				ParameterSize: "8B",
+				QuantLevel:    "Q4_K_M",
+				ContextWindow: 32768,
+				Capabilities:  []string{"completion", "embedding"},
+			},
+		},
+		chatResp: &ChatResponse{
+			Model:   "qwen3:8b",
+			Content: "Integration test response",
+			Done:    true,
+		},
+	}
+
+	stickyTTL := 200 * time.Millisecond
+	router := setupIntegrationRouter(t, []*rtMockProvider{prov},
+		WithWarmthSource(ws),
+		WithStickyTTL(stickyTTL),
+	)
+
+	ctx := context.Background()
+
+	// --- Step 1: Route with AffinityKey and execute chat ---
+	req := RoutingRequest{
+		Model:       "qwen3:8b",
+		UseCase:     "chat",
+		AffinityKey: "session-abc",
+		Messages:    []ChatMessage{{Role: "user", Content: "hello"}},
+		RequiredCaps: CapChat,
+	}
+
+	plan, err := router.Route(ctx, req)
+	if err != nil {
+		t.Fatalf("Route returned error: %v", err)
+	}
+	if plan == nil {
+		t.Fatal("Route returned nil plan")
+	}
+	if plan.Model != "qwen3:8b" {
+		t.Errorf("plan.Model = %q, want %q", plan.Model, "qwen3:8b")
+	}
+
+	resp, err := plan.ExecuteChat(ctx)
+	if err != nil {
+		t.Fatalf("ExecuteChat returned error: %v", err)
+	}
+	if resp.Content != "Integration test response" {
+		t.Errorf("Content = %q, want %q", resp.Content, "Integration test response")
+	}
+	if resp.RouteOutcome == nil {
+		t.Fatal("RouteOutcome is nil")
+	}
+	if resp.RouteOutcome.FallbacksUsed != 0 {
+		t.Errorf("FallbacksUsed = %d, want 0", resp.RouteOutcome.FallbacksUsed)
+	}
+	if resp.RouteOutcome.PlannedModel != modelKey {
+		t.Errorf("PlannedModel = %v, want %v", resp.RouteOutcome.PlannedModel, modelKey)
+	}
+	if resp.RouteOutcome.ActualModel != modelKey {
+		t.Errorf("ActualModel = %v, want %v", resp.RouteOutcome.ActualModel, modelKey)
+	}
+
+	// --- Step 2: Second Route with same AffinityKey -> verify sticky ---
+	plan2, err := router.Route(ctx, req)
+	if err != nil {
+		t.Fatalf("Route 2 returned error: %v", err)
+	}
+	if plan2.Model != plan.Model {
+		t.Errorf("second route model = %q, want %q (sticky)", plan2.Model, plan.Model)
+	}
+	if plan2.Profile.Key != plan.Profile.Key {
+		t.Errorf("second route key = %v, want %v (sticky)", plan2.Profile.Key, plan.Profile.Key)
+	}
+
+	// Sticky cache should have an entry.
+	stickyRoutes := router.StickyRoutes()
+	if len(stickyRoutes) == 0 {
+		t.Error("StickyRoutes is empty after affinity routing, want >= 1 entry")
+	}
+
+	// --- Step 3: Wait for TTL expiry, route again -> still works ---
+	time.Sleep(stickyTTL + 50*time.Millisecond)
+
+	// After TTL expiry, the sticky entry should be gone from snapshot.
+	stickyRoutesAfter := router.StickyRoutes()
+	if len(stickyRoutesAfter) != 0 {
+		t.Errorf("StickyRoutes after TTL expiry has %d entries, want 0", len(stickyRoutesAfter))
+	}
+
+	// Routing should still succeed (model is still available, just not sticky).
+	plan3, err := router.Route(ctx, req)
+	if err != nil {
+		t.Fatalf("Route 3 (post-TTL) returned error: %v", err)
+	}
+	if plan3.Model != "qwen3:8b" {
+		t.Errorf("post-TTL plan.Model = %q, want %q", plan3.Model, "qwen3:8b")
+	}
+
+	// --- Verify warmth integration ---
+	snapshot := router.WarmthSnapshot()
+	if len(snapshot) == 0 {
+		t.Error("WarmthSnapshot is empty, want at least 1 entry")
+	}
+
+	// Verify breaker is healthy.
+	info, exists := router.BreakerInfo("alpha")
+	if !exists {
+		t.Fatal("BreakerInfo for 'alpha' does not exist after routing")
+	}
+	if info.State != BreakerClosed {
+		t.Errorf("breaker state = %v, want Closed", info.State)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestIntegrationFallbackChain
+//
+// Two providers serve the same model. Primary returns 503, fallback succeeds.
+// ---------------------------------------------------------------------------
+
+func TestIntegrationFallbackChain(t *testing.T) {
+	infraErr := &HTTPStatusError{StatusCode: 503, Status: "503 Service Unavailable"}
+
+	// Provider names chosen so that "aaa-primary" sorts before "zzz-fallback"
+	// alphabetically, ensuring the primary is selected first by the scorer's
+	// tiebreak logic (both providers have identical scores for the same model).
+	primaryProv := &rtMockProvider{
+		name: "aaa-primary",
+		caps: CapChat | CapGenerate | CapEmbed | CapStream,
+		models: []ModelInfo{
+			{
+				Name:          "shared-model:8b",
+				Family:        "qwen3",
+				ParameterSize: "8B",
+				QuantLevel:    "Q4_K_M",
+				ContextWindow: 32768,
+				Capabilities:  []string{"completion", "embedding"},
+			},
+		},
+		chatResp: nil, // will not be used
+		chatErr:  infraErr,
+	}
+
+	fallbackProv := &rtMockProvider{
+		name: "zzz-fallback",
+		caps: CapChat | CapGenerate | CapEmbed | CapStream,
+		models: []ModelInfo{
+			{
+				Name:          "shared-model:8b",
+				Family:        "qwen3",
+				ParameterSize: "8B",
+				QuantLevel:    "Q4_K_M",
+				ContextWindow: 32768,
+				Capabilities:  []string{"completion", "embedding"},
+			},
+		},
+		chatResp: &ChatResponse{
+			Model:   "shared-model:8b",
+			Content: "from fallback provider",
+			Done:    true,
+		},
+	}
+
+	router := setupIntegrationRouter(t, []*rtMockProvider{primaryProv, fallbackProv},
+		WithMaxFallbacks(3),
+	)
+
+	ctx := context.Background()
+
+	// Route to unqualified model name — both providers are candidates.
+	req := RoutingRequest{
+		Model:        "shared-model:8b",
+		UseCase:      "chat",
+		Messages:     []ChatMessage{{Role: "user", Content: "test fallback"}},
+		RequiredCaps: CapChat,
+	}
+
+	plan, err := router.Route(ctx, req)
+	if err != nil {
+		t.Fatalf("Route returned error: %v", err)
+	}
+	if plan == nil {
+		t.Fatal("Route returned nil plan")
+	}
+
+	// The plan should have at least one fallback since both providers serve the model.
+	if len(plan.Fallbacks) == 0 {
+		t.Fatal("plan has 0 fallbacks, want >= 1 (two providers serve the same model)")
+	}
+
+	// Execute — primary fails with 503, fallback should succeed.
+	resp, err := plan.ExecuteChat(ctx)
+	if err != nil {
+		t.Fatalf("ExecuteChat returned error: %v (expected fallback to succeed)", err)
+	}
+	if resp.Content != "from fallback provider" {
+		t.Errorf("Content = %q, want %q", resp.Content, "from fallback provider")
+	}
+	if resp.RouteOutcome == nil {
+		t.Fatal("RouteOutcome is nil")
+	}
+
+	// Because "aaa-primary" sorts before "zzz-fallback" alphabetically,
+	// the primary is selected first. It fails with 503, so the fallback
+	// chain kicks in.
+	if resp.RouteOutcome.FallbacksUsed != 1 {
+		t.Errorf("FallbacksUsed = %d, want 1 (primary should fail, fallback should succeed)",
+			resp.RouteOutcome.FallbacksUsed)
+	}
+	primaryKey := ModelKey{Provider: "aaa-primary", Model: "shared-model:8b"}
+	fallbackKey := ModelKey{Provider: "zzz-fallback", Model: "shared-model:8b"}
+	if resp.RouteOutcome.PlannedModel != primaryKey {
+		t.Errorf("PlannedModel = %v, want %v", resp.RouteOutcome.PlannedModel, primaryKey)
+	}
+	if resp.RouteOutcome.ActualModel != fallbackKey {
+		t.Errorf("ActualModel = %v, want %v", resp.RouteOutcome.ActualModel, fallbackKey)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestIntegrationBudgetAdaptation
+//
+// Model with tiny context window receives a prompt that exceeds the budget.
+// ---------------------------------------------------------------------------
+
+func TestIntegrationBudgetAdaptation(t *testing.T) {
+	prov := &rtMockProvider{
+		name: "tiny",
+		caps: CapChat | CapGenerate | CapEmbed | CapStream,
+		models: []ModelInfo{
+			{
+				Name:          "tiny-model:1b",
+				Family:        "tiny",
+				ParameterSize: "1B",
+				QuantLevel:    "Q4_K_M",
+				ContextWindow: 2048,
+				Capabilities:  []string{"completion"},
+			},
+		},
+		chatResp: &ChatResponse{
+			Model:   "tiny-model:1b",
+			Content: "should not reach here",
+			Done:    true,
+		},
+	}
+
+	router := setupIntegrationRouter(t, []*rtMockProvider{prov})
+	ctx := context.Background()
+
+	// Build a prompt that exceeds the 2048 context window. The token budget
+	// validator estimates tokens as len/4. Context 2048 minus expected output
+	// (2048 for "chat") = 0 budget. Any message should trigger BudgetReject.
+	//
+	// Actually, with context=2048 and expectedOutput=2048, the budget becomes 0,
+	// which triggers BudgetReject since budget==0 means "output budget exceeds
+	// context window".
+	req := RoutingRequest{
+		Model:        "tiny-model:1b",
+		UseCase:      "chat",
+		Messages:     []ChatMessage{{Role: "user", Content: "hello"}},
+		RequiredCaps: CapChat,
+	}
+
+	_, err := router.Route(ctx, req)
+
+	// With ContextWindow=2048 and chat default output reservation of 2048,
+	// the available budget is 0 => BudgetReject => ErrBudgetExceeded.
+	if err == nil {
+		t.Fatal("Route returned nil error, want budget error")
+	}
+
+	if errors.Is(err, ErrBudgetExceeded) {
+		t.Logf("Got expected ErrBudgetExceeded: %v", err)
+	} else if errors.Is(err, ErrBudgetAdaptationRequired) {
+		t.Logf("Got ErrBudgetAdaptationRequired: %v", err)
+		// This means a truncatable plan was returned. Verify ExecuteChat rejects.
+	} else if errors.Is(err, ErrNoViableCandidate) {
+		t.Logf("Got ErrNoViableCandidate (budget rejected, no candidates left): %v", err)
+	} else {
+		t.Errorf("Unexpected error type: %v", err)
+	}
+
+	// Now test with a slightly larger context that triggers BudgetTruncate.
+	// A context of 4096 with chat expectedOutput=2048 leaves budget=2048.
+	// We need input > budget (2048 tokens ~ 8192 chars) but < 1.5x budget.
+	provTruncate := &rtMockProvider{
+		name: "trunc",
+		caps: CapChat | CapGenerate | CapEmbed | CapStream,
+		models: []ModelInfo{
+			{
+				Name:          "trunc-model:1b",
+				Family:        "tiny",
+				ParameterSize: "1B",
+				QuantLevel:    "Q4_K_M",
+				ContextWindow: 4096,
+				Capabilities:  []string{"completion"},
+			},
+		},
+		chatResp: &ChatResponse{
+			Model:   "trunc-model:1b",
+			Content: "should not reach here",
+			Done:    true,
+		},
+	}
+
+	routerTrunc := setupIntegrationRouter(t, []*rtMockProvider{provTruncate})
+
+	// Build a message that produces ~2500 tokens (10000 chars / 4 = 2500 tokens).
+	// Budget is 2048 tokens. 2500 > 2048 but 2500 < 2048*1.5=3072 => BudgetTruncate.
+	bigContent := strings.Repeat("x", 10000)
+	reqTrunc := RoutingRequest{
+		Model:        "trunc-model:1b",
+		UseCase:      "chat",
+		Messages:     []ChatMessage{{Role: "user", Content: bigContent}},
+		RequiredCaps: CapChat,
+	}
+
+	plan, err := routerTrunc.Route(ctx, reqTrunc)
+	if !errors.Is(err, ErrBudgetAdaptationRequired) {
+		t.Fatalf("Route error = %v, want ErrBudgetAdaptationRequired", err)
+	}
+	if plan == nil {
+		t.Fatal("Route returned nil plan with ErrBudgetAdaptationRequired")
+	}
+	if !plan.Degraded {
+		t.Error("plan.Degraded = false, want true for truncatable plan")
+	}
+
+	// Verify ExecuteChat also rejects with ErrBudgetAdaptationRequired.
+	_, execErr := plan.ExecuteChat(ctx)
+	if !errors.Is(execErr, ErrBudgetAdaptationRequired) {
+		t.Errorf("ExecuteChat error = %v, want ErrBudgetAdaptationRequired", execErr)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestIntegrationDryRun
+//
+// DryRun returns a plan without updating the sticky cache.
+// ---------------------------------------------------------------------------
+
+func TestIntegrationDryRun(t *testing.T) {
+	prov := &rtMockProvider{
+		name: "dry",
+		caps: CapChat | CapGenerate | CapEmbed | CapStream,
+		models: []ModelInfo{
+			{
+				Name:          "dry-model:8b",
+				Family:        "qwen3",
+				ParameterSize: "8B",
+				QuantLevel:    "Q4_K_M",
+				ContextWindow: 32768,
+				Capabilities:  []string{"completion", "embedding"},
+			},
+		},
+		chatResp: &ChatResponse{
+			Model:   "dry-model:8b",
+			Content: "dry response",
+			Done:    true,
+		},
+	}
+
+	router := setupIntegrationRouter(t, []*rtMockProvider{prov})
+	ctx := context.Background()
+
+	req := RoutingRequest{
+		Model:       "dry-model:8b",
+		UseCase:     "chat",
+		AffinityKey: "session-dry-run",
+		DryRun:      true,
+		Messages:    []ChatMessage{{Role: "user", Content: "test dry run"}},
+		RequiredCaps: CapChat,
+	}
+
+	plan, err := router.Route(ctx, req)
+	if err != nil {
+		t.Fatalf("Route (DryRun) returned error: %v", err)
+	}
+	if plan == nil {
+		t.Fatal("Route (DryRun) returned nil plan")
+	}
+	if plan.Model != "dry-model:8b" {
+		t.Errorf("plan.Model = %q, want %q", plan.Model, "dry-model:8b")
+	}
+
+	// DryRun must NOT update the sticky cache.
+	routes := router.StickyRoutes()
+	if len(routes) != 0 {
+		t.Errorf("StickyRoutes has %d entries after DryRun, want 0", len(routes))
+	}
+
+	// A subsequent non-dry-run route should create a sticky entry.
+	req.DryRun = false
+	_, err = router.Route(ctx, req)
+	if err != nil {
+		t.Fatalf("Route (non-DryRun) returned error: %v", err)
+	}
+	routes = router.StickyRoutes()
+	if len(routes) == 0 {
+		t.Error("StickyRoutes is empty after non-DryRun route with affinity key")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestIntegrationBreakerStateQuery
+//
+// Verify BreakerInfo reflects failures recorded through the Router's
+// RecordFailure path (triggered by ExecuteChat fallback).
+// ---------------------------------------------------------------------------
+
+func TestIntegrationBreakerStateQuery(t *testing.T) {
+	infraErr := &HTTPStatusError{StatusCode: 500, Status: "500 Internal Server Error"}
+
+	failingProv := &rtMockProvider{
+		name: "breaker-test",
+		caps: CapChat | CapGenerate | CapEmbed | CapStream,
+		models: []ModelInfo{
+			{
+				Name:          "breaker-model:8b",
+				Family:        "qwen3",
+				ParameterSize: "8B",
+				QuantLevel:    "Q4_K_M",
+				ContextWindow: 32768,
+				Capabilities:  []string{"completion"},
+			},
+		},
+		chatErr: infraErr,
+	}
+
+	router := setupIntegrationRouter(t, []*rtMockProvider{failingProv})
+	ctx := context.Background()
+
+	// Route and execute — will fail but not panic.
+	plan, err := router.Route(ctx, RoutingRequest{
+		Model:        "breaker-model:8b",
+		UseCase:      "chat",
+		Messages:     []ChatMessage{{Role: "user", Content: "test"}},
+		RequiredCaps: CapChat,
+	})
+	if err != nil {
+		t.Fatalf("Route returned error: %v", err)
+	}
+
+	// Execute will fail since the provider returns 500.
+	_, execErr := plan.ExecuteChat(ctx)
+	if execErr == nil {
+		t.Fatal("ExecuteChat returned nil error, want infrastructure error")
+	}
+
+	// Breaker should have recorded a failure.
+	info, exists := router.BreakerInfo("breaker-test")
+	if !exists {
+		t.Fatal("BreakerInfo not found for 'breaker-test'")
+	}
+	// The failure went through RecordFailure which only records infrastructure errors.
+	// After one ExecuteChat call failure, Failures should be >= 1.
+	if info.Failures < 1 {
+		t.Errorf("breaker failures = %d, want >= 1", info.Failures)
+	}
+	if info.State != BreakerClosed {
+		// One failure shouldn't trip the breaker (threshold=3).
+		t.Logf("breaker state = %v after 1 failure (may be closed or open depending on attempts)", info.State)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestIntegrationConvenienceMethods
+//
+// End-to-end test of the Router convenience methods (Chat, Generate, Embed)
+// which combine Route + Execute in a single call.
+// ---------------------------------------------------------------------------
+
+func TestIntegrationConvenienceMethods(t *testing.T) {
+	prov := &rtMockProvider{
+		name: "conv",
+		caps: CapChat | CapGenerate | CapEmbed | CapStream,
+		models: []ModelInfo{
+			{
+				Name:          "conv-model:8b",
+				Family:        "qwen3",
+				ParameterSize: "8B",
+				QuantLevel:    "Q4_K_M",
+				ContextWindow: 32768,
+				Capabilities:  []string{"completion", "embedding"},
+			},
+		},
+		chatResp: &ChatResponse{
+			Model:   "conv-model:8b",
+			Content: "convenience chat",
+			Done:    true,
+		},
+		genResp: &GenerateResponse{
+			Model:    "conv-model:8b",
+			Response: "convenience generate",
+			Done:     true,
+		},
+		embedResp: &EmbedResponse{
+			Model:      "conv-model:8b",
+			Embeddings: [][]float64{{0.1, 0.2, 0.3}},
+		},
+	}
+
+	router := setupIntegrationRouter(t, []*rtMockProvider{prov})
+	ctx := context.Background()
+
+	// --- Chat ---
+	chatResp, err := router.Chat(ctx, ChatRequest{
+		Model:    "conv-model:8b",
+		Messages: []ChatMessage{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat returned error: %v", err)
+	}
+	if chatResp.Content != "convenience chat" {
+		t.Errorf("Chat content = %q, want %q", chatResp.Content, "convenience chat")
+	}
+	if chatResp.RouteOutcome == nil {
+		t.Error("Chat RouteOutcome is nil")
+	}
+
+	// --- Generate ---
+	genResp, err := router.Generate(ctx, GenerateRequest{
+		Model:  "conv-model:8b",
+		Prompt: "complete this",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	if genResp.Response != "convenience generate" {
+		t.Errorf("Generate response = %q, want %q", genResp.Response, "convenience generate")
+	}
+	if genResp.RouteOutcome == nil {
+		t.Error("Generate RouteOutcome is nil")
+	}
+
+	// --- Embed ---
+	embedResp, err := router.Embed(ctx, EmbedRequest{
+		Model: "conv-model:8b",
+		Input: []string{"embed this"},
+	})
+	if err != nil {
+		t.Fatalf("Embed returned error: %v", err)
+	}
+	if len(embedResp.Embeddings) != 1 {
+		t.Errorf("Embed embeddings count = %d, want 1", len(embedResp.Embeddings))
+	}
+	if embedResp.RouteOutcome == nil {
+		t.Error("Embed RouteOutcome is nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestIntegrationStickyInvalidationOnFailure
+//
+// Verifies that infrastructure failures invalidate sticky routes for the
+// failed provider, preventing future requests from being sticky-routed to
+// a broken provider.
+// ---------------------------------------------------------------------------
+
+func TestIntegrationStickyInvalidationOnFailure(t *testing.T) {
+	infraErr := &HTTPStatusError{StatusCode: 503, Status: "503 Service Unavailable"}
+
+	prov := &rtMockProvider{
+		name: "sticky-prov",
+		caps: CapChat | CapGenerate | CapEmbed | CapStream,
+		models: []ModelInfo{
+			{
+				Name:          "sticky-model:8b",
+				Family:        "qwen3",
+				ParameterSize: "8B",
+				QuantLevel:    "Q4_K_M",
+				ContextWindow: 32768,
+				Capabilities:  []string{"completion"},
+			},
+		},
+		chatResp: &ChatResponse{
+			Model:   "sticky-model:8b",
+			Content: "sticky response",
+			Done:    true,
+		},
+	}
+
+	router := setupIntegrationRouter(t, []*rtMockProvider{prov},
+		WithStickyTTL(5*time.Minute),
+	)
+	ctx := context.Background()
+
+	// Step 1: Route and execute to create sticky entry.
+	req := RoutingRequest{
+		Model:        "sticky-model:8b",
+		UseCase:      "chat",
+		AffinityKey:  "sticky-session",
+		Messages:     []ChatMessage{{Role: "user", Content: "hello"}},
+		RequiredCaps: CapChat,
+	}
+
+	plan, err := router.Route(ctx, req)
+	if err != nil {
+		t.Fatalf("Route returned error: %v", err)
+	}
+	_, err = plan.ExecuteChat(ctx)
+	if err != nil {
+		t.Fatalf("ExecuteChat returned error: %v", err)
+	}
+
+	// Verify sticky entry exists.
+	routes := router.StickyRoutes()
+	if len(routes) == 0 {
+		t.Fatal("StickyRoutes is empty after successful route + execute")
+	}
+
+	// Step 2: Record infrastructure failure through the Router.
+	// This simulates the RecordFailure path that invalidates sticky routes.
+	router.RecordFailure(
+		ModelKey{Provider: "sticky-prov", Model: "sticky-model:8b"},
+		infraErr,
+	)
+
+	// Sticky routes for this provider should be invalidated.
+	routesAfter := router.StickyRoutes()
+	if len(routesAfter) != 0 {
+		t.Errorf("StickyRoutes has %d entries after RecordFailure, want 0 (invalidated)",
+			len(routesAfter))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestIntegrationClosedRouterRejectsAll
+//
+// After Close(), all routing methods return ErrRouterClosed.
+// ---------------------------------------------------------------------------
+
+func TestIntegrationClosedRouterRejectsAll(t *testing.T) {
+	prov := &rtMockProvider{
+		name: "closed-test",
+		caps: CapChat | CapGenerate | CapEmbed | CapStream,
+		models: []ModelInfo{
+			{
+				Name:          "closed-model:8b",
+				Family:        "qwen3",
+				ParameterSize: "8B",
+				QuantLevel:    "Q4_K_M",
+				ContextWindow: 32768,
+				Capabilities:  []string{"completion", "embedding"},
+			},
+		},
+		chatResp: &ChatResponse{
+			Model:   "closed-model:8b",
+			Content: "should not get here",
+			Done:    true,
+		},
+		genResp: &GenerateResponse{
+			Model:    "closed-model:8b",
+			Response: "should not get here",
+			Done:     true,
+		},
+		embedResp: &EmbedResponse{
+			Model:      "closed-model:8b",
+			Embeddings: [][]float64{{0.1}},
+		},
+	}
+
+	router := setupIntegrationRouter(t, []*rtMockProvider{prov})
+	ctx := context.Background()
+
+	// Close the router.
+	if err := router.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	// Route should fail.
+	_, err := router.Route(ctx, RoutingRequest{
+		Model:   "closed-model:8b",
+		UseCase: "chat",
+	})
+	if !errors.Is(err, ErrRouterClosed) {
+		t.Errorf("Route error = %v, want ErrRouterClosed", err)
+	}
+
+	// Chat convenience should fail.
+	_, err = router.Chat(ctx, ChatRequest{
+		Model:    "closed-model:8b",
+		Messages: []ChatMessage{{Role: "user", Content: "hello"}},
+	})
+	if !errors.Is(err, ErrRouterClosed) {
+		t.Errorf("Chat error = %v, want ErrRouterClosed", err)
+	}
+
+	// Generate convenience should fail.
+	_, err = router.Generate(ctx, GenerateRequest{
+		Model:  "closed-model:8b",
+		Prompt: "test",
+	})
+	if !errors.Is(err, ErrRouterClosed) {
+		t.Errorf("Generate error = %v, want ErrRouterClosed", err)
+	}
+
+	// Embed convenience should fail.
+	_, err = router.Embed(ctx, EmbedRequest{
+		Model: "closed-model:8b",
+		Input: []string{"test"},
+	})
+	if !errors.Is(err, ErrRouterClosed) {
+		t.Errorf("Embed error = %v, want ErrRouterClosed", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestIntegrationWarmthSourceIntegration
+//
+// Verifies that warmth information flows through the entire pipeline:
+// Router creation -> scoring -> WarmthSnapshot -> RecordWarmthUse.
+// ---------------------------------------------------------------------------
+
+func TestIntegrationWarmthSourceIntegration(t *testing.T) {
+	ws := newRTMockWarmthSource()
+	modelKey := ModelKey{Provider: "warm-prov", Model: "warm-model:8b"}
+	ws.setWarm(modelKey, WarmthInfo{
+		Loaded:    true,
+		Since:     time.Now(),
+		ExpiresAt: time.Now().Add(5 * time.Minute),
+		VRAM:      6.0,
+	})
+
+	prov := &rtMockProvider{
+		name: "warm-prov",
+		caps: CapChat | CapGenerate | CapEmbed | CapStream,
+		models: []ModelInfo{
+			{
+				Name:          "warm-model:8b",
+				Family:        "qwen3",
+				ParameterSize: "8B",
+				QuantLevel:    "Q4_K_M",
+				ContextWindow: 32768,
+				Capabilities:  []string{"completion", "embedding"},
+			},
+		},
+		chatResp: &ChatResponse{
+			Model:   "warm-model:8b",
+			Content: "warm response",
+			Done:    true,
+		},
+	}
+
+	router := setupIntegrationRouter(t, []*rtMockProvider{prov},
+		WithWarmthSource(ws),
+	)
+	ctx := context.Background()
+
+	// Verify WarmthSnapshot before routing.
+	snapshot := router.WarmthSnapshot()
+	if len(snapshot) == 0 {
+		t.Fatal("WarmthSnapshot empty before routing")
+	}
+	found := false
+	for _, wm := range snapshot {
+		if wm.Key == modelKey && wm.Info.Loaded {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("warm-model:8b not found in WarmthSnapshot")
+	}
+
+	// Route and execute — should record warmth use via the RecordWarmthUse path.
+	resp, err := router.Chat(ctx, ChatRequest{
+		Model:    "warm-model:8b",
+		Messages: []ChatMessage{{Role: "user", Content: "warm test"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat returned error: %v", err)
+	}
+	if resp.Content != "warm response" {
+		t.Errorf("Content = %q, want %q", resp.Content, "warm response")
+	}
+
+	// Verify RecordUse was called on the warmth source.
+	uses := ws.getUses()
+	if len(uses) == 0 {
+		t.Error("warmth RecordUse not called after successful Chat")
+	}
+	usedModel := false
+	for _, key := range uses {
+		if key == modelKey {
+			usedModel = true
+		}
+	}
+	if !usedModel {
+		t.Errorf("RecordUse not called for %v, called for %v", modelKey, uses)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestIntegrationMultiProviderScoring
+//
+// Two providers with different quality models — the router should prefer the
+// higher-quality model when both are healthy.
+// ---------------------------------------------------------------------------
+
+func TestIntegrationMultiProviderScoring(t *testing.T) {
+	// Provider with a small/fast model.
+	fastProv := &rtMockProvider{
+		name: "fast-prov",
+		caps: CapChat | CapGenerate | CapEmbed | CapStream,
+		models: []ModelInfo{
+			{
+				Name:          "fast-model:1b",
+				Family:        "small",
+				ParameterSize: "1B",
+				QuantLevel:    "Q4_K_M",
+				ContextWindow: 8192,
+				Capabilities:  []string{"completion"},
+			},
+		},
+		chatResp: &ChatResponse{
+			Model:   "fast-model:1b",
+			Content: "from fast",
+			Done:    true,
+		},
+	}
+
+	// Provider with a larger/quality model.
+	qualityProv := &rtMockProvider{
+		name: "quality-prov",
+		caps: CapChat | CapGenerate | CapEmbed | CapStream,
+		models: []ModelInfo{
+			{
+				Name:          "quality-model:8b",
+				Family:        "qwen3",
+				ParameterSize: "8B",
+				QuantLevel:    "Q4_K_M",
+				ContextWindow: 32768,
+				Capabilities:  []string{"completion"},
+			},
+		},
+		chatResp: &ChatResponse{
+			Model:   "quality-model:8b",
+			Content: "from quality",
+			Done:    true,
+		},
+	}
+
+	router := setupIntegrationRouter(t,
+		[]*rtMockProvider{fastProv, qualityProv},
+		WithAvailableRAM(128.0), // plenty of RAM
+	)
+	ctx := context.Background()
+
+	// Route without specifying a model — let the router recommend.
+	plan, err := router.Route(ctx, RoutingRequest{
+		UseCase:      "chat",
+		RequiredCaps: CapChat,
+		Messages:     []ChatMessage{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("Route returned error: %v", err)
+	}
+	if plan == nil {
+		t.Fatal("Route returned nil plan")
+	}
+
+	// Log which model was selected — the 8B model should score higher on
+	// quality for chat use case.
+	t.Logf("Selected model: %s (score=%.3f)", plan.Profile.Key, plan.Score)
+
+	// Execute the winning plan.
+	resp, err := plan.ExecuteChat(ctx)
+	if err != nil {
+		t.Fatalf("ExecuteChat returned error: %v", err)
+	}
+	if resp.Content == "" {
+		t.Error("response content is empty")
+	}
+	if resp.RouteOutcome == nil {
+		t.Error("RouteOutcome is nil")
+	}
+}

--- a/provider/router_score.go
+++ b/provider/router_score.go
@@ -150,11 +150,14 @@ func scoreCandidate(
 	}
 	bd.capabilityGate = true
 
-	// 5. Circuit breaker gate: if the breaker is open, the candidate is
-	//    penalized with -Inf so it sorts to the bottom. Uses State() instead
-	//    of Allow() to avoid the Open→HalfOpen side effect — scoring must be
-	//    read-only. The Allow() call belongs in RoutePlan.Execute*.
-	if breaker != nil && breaker.State() == BreakerOpen {
+	// 5. Circuit breaker gate: if the breaker blocks the request, the
+	//    candidate is penalized with -Inf so it sorts to the bottom.
+	//    Allow() is used intentionally — it transitions Open→HalfOpen after
+	//    cooldown, enabling one probe request. Without this, a tripped
+	//    breaker could never recover. The Router calls scoreCandidate once
+	//    per candidate per Route(), so at most one probe is granted per
+	//    provider per routing pass.
+	if breaker != nil && !breaker.Allow() {
 		bd.breakerPenalty = math.Inf(-1)
 		return bd
 	}

--- a/provider/router_score.go
+++ b/provider/router_score.go
@@ -151,8 +151,10 @@ func scoreCandidate(
 	bd.capabilityGate = true
 
 	// 5. Circuit breaker gate: if the breaker is open, the candidate is
-	//    penalized with -Inf so it sorts to the bottom.
-	if breaker != nil && !breaker.Allow() {
+	//    penalized with -Inf so it sorts to the bottom. Uses State() instead
+	//    of Allow() to avoid the Open→HalfOpen side effect — scoring must be
+	//    read-only. The Allow() call belongs in RoutePlan.Execute*.
+	if breaker != nil && breaker.State() == BreakerOpen {
 		bd.breakerPenalty = math.Inf(-1)
 		return bd
 	}

--- a/provider/router_score.go
+++ b/provider/router_score.go
@@ -1,0 +1,261 @@
+// router_score.go implements the candidate scoring engine for the Router.
+// It evaluates each candidate model against a routing request, producing a
+// weighted composite score. Signals include warmth (model already loaded),
+// context headroom, feedback history, quality tier, speed tier, KV cache
+// affinity, and cost. Active-signal normalization ensures absent subsystems
+// (e.g. no warmth tracker, no feedback store) do not penalize candidates.
+package provider
+
+import (
+	"math"
+	"sort"
+)
+
+// warmthBonusMax is the maximum bonus applied to candidates whose model is
+// currently loaded in provider memory ("warm"). This avoids cold-start latency.
+const warmthBonusMax = 0.3
+
+// ---------------------------------------------------------------------------
+// WeightProfile
+// ---------------------------------------------------------------------------
+
+// WeightProfile holds per-signal integer weights for a specific use case.
+// Higher values mean the signal matters more when computing the composite
+// score. A weight of 0 effectively disables the signal.
+type WeightProfile struct {
+	Warmth   int
+	Headroom int
+	Feedback int
+	Quality  int
+	Speed    int
+	KVCache  int
+	Cost     int
+}
+
+// defaultWeightProfiles maps well-known use cases to their weight tuning.
+// FIM heavily favors KV cache (prefix reuse) and speed. Chat favors quality
+// and feedback. Embedding cares about quality and speed, not warmth/headroom.
+// Reasoning maximizes quality with headroom for long outputs. Code-review
+// balances quality and feedback.
+var defaultWeightProfiles = map[string]*WeightProfile{
+	"fim":         {Warmth: 2, Headroom: 1, Feedback: 1, Quality: 1, Speed: 2, KVCache: 3, Cost: 1},
+	"chat":        {Warmth: 1, Headroom: 2, Feedback: 3, Quality: 4, Speed: 1, KVCache: 0, Cost: 1},
+	"embedding":   {Warmth: 0, Headroom: 0, Feedback: 1, Quality: 3, Speed: 2, KVCache: 0, Cost: 2},
+	"reasoning":   {Warmth: 1, Headroom: 3, Feedback: 3, Quality: 5, Speed: 0, KVCache: 0, Cost: 1},
+	"code-review": {Warmth: 1, Headroom: 3, Feedback: 4, Quality: 3, Speed: 1, KVCache: 0, Cost: 1},
+}
+
+// defaultWeightProfile returns the weight profile for the given use case.
+// Unknown use cases fall back to the "chat" profile.
+func defaultWeightProfile(useCase string) *WeightProfile {
+	if wp, ok := defaultWeightProfiles[useCase]; ok {
+		return wp
+	}
+	return defaultWeightProfiles["chat"]
+}
+
+// ---------------------------------------------------------------------------
+// scoreBreakdown
+// ---------------------------------------------------------------------------
+
+// scoreBreakdown holds the raw signal values computed for a single candidate.
+// These values feed into computeWeightedScore for final ranking.
+type scoreBreakdown struct {
+	warmthBonus    float64 // 0.0–0.3
+	headroomScore  float64 // 0.0–1.0
+	feedbackScore  float64 // default 0.5 when nil
+	qualityTier    float64 // 0.25–1.0
+	speedTier      float64 // 0.25–1.0
+	kvCacheBonus   float64 // default 0
+	costPenalty    float64 // default 0
+	breakerPenalty float64 // 0 or -Inf
+	capabilityGate bool    // false = eliminated
+}
+
+// ---------------------------------------------------------------------------
+// scoredCandidate
+// ---------------------------------------------------------------------------
+
+// scoredCandidate pairs a ModelProfile with its scoring result for sorting
+// and selection by the Router.
+type scoredCandidate struct {
+	profile *ModelProfile
+	budget  BudgetResult
+	score   float64
+	bd      scoreBreakdown
+}
+
+// ---------------------------------------------------------------------------
+// tierToFloat
+// ---------------------------------------------------------------------------
+
+// tierToFloat converts a Tier enum to a normalized float64 value.
+// Basic=0.25, Good=0.50, Great=0.75, Best=1.00. Unknown tiers default to
+// Basic (0.25).
+func tierToFloat(t Tier) float64 {
+	switch t {
+	case TierBasic:
+		return 0.25
+	case TierGood:
+		return 0.50
+	case TierGreat:
+		return 0.75
+	case TierBest:
+		return 1.00
+	default:
+		return 0.25
+	}
+}
+
+// ---------------------------------------------------------------------------
+// scoreCandidate
+// ---------------------------------------------------------------------------
+
+// scoreCandidate evaluates a single candidate model against a routing request
+// and returns a scoreBreakdown. This is a standalone function, not a Router
+// method, so it can be tested and used independently.
+//
+// Parameters:
+//   - profile: the candidate model's metadata
+//   - req: the routing request with capability requirements and use case
+//   - budget: the token budget validation result (headroom feeds scoring)
+//   - warmth: optional warmth source; nil means warmth signal is inactive
+//   - _ : feedback placeholder (reserved for Phase 3)
+//   - breaker: circuit breaker for the candidate; never nil (lazily created)
+func scoreCandidate(
+	profile *ModelProfile,
+	req RoutingRequest,
+	budget BudgetResult,
+	warmth WarmthSource,
+	_ interface{},
+	breaker *CircuitBreaker,
+) scoreBreakdown {
+	var bd scoreBreakdown
+
+	// 1. Compute tier scores.
+	bd.qualityTier = tierToFloat(profile.Quality)
+	bd.speedTier = tierToFloat(profile.Speed)
+
+	// 2. Headroom from budget validation.
+	bd.headroomScore = budget.HeadroomScore
+
+	// 3. Neutral feedback default (Phase 3 will replace this).
+	bd.feedbackScore = 0.5
+
+	// 4. Capability gate: if the request requires capabilities the model
+	//    doesn't have, eliminate the candidate immediately.
+	if req.RequiredCaps != 0 && !profile.Caps.Has(req.RequiredCaps) {
+		bd.capabilityGate = false
+		return bd
+	}
+	bd.capabilityGate = true
+
+	// 5. Circuit breaker gate: if the breaker is open, the candidate is
+	//    penalized with -Inf so it sorts to the bottom.
+	if breaker != nil && !breaker.Allow() {
+		bd.breakerPenalty = math.Inf(-1)
+		return bd
+	}
+
+	// 6. Warmth bonus: models already loaded get a latency advantage.
+	if warmth != nil && warmth.IsWarm(profile.Key) {
+		bd.warmthBonus = warmthBonusMax
+	}
+
+	return bd
+}
+
+// ---------------------------------------------------------------------------
+// computeWeightedScore
+// ---------------------------------------------------------------------------
+
+// computeWeightedScore combines the raw signal values from a scoreBreakdown
+// into a single composite score using the weight profile for the given use
+// case. Only signals present in activeSignals with non-zero weight contribute
+// to the result. This active-signal normalization ensures that absent
+// subsystems (no warmth tracker, no feedback store) do not penalize candidates.
+//
+// If no signals are active, the function returns 0.
+func computeWeightedScore(
+	bd scoreBreakdown,
+	useCase string,
+	activeSignals map[string]bool,
+	customWeights *WeightProfile,
+) float64 {
+	wp := customWeights
+	if wp == nil {
+		wp = defaultWeightProfile(useCase)
+	}
+
+	// Signal name → (normalized value in [0,1], weight).
+	type signal struct {
+		name   string
+		value  float64
+		weight int
+	}
+
+	signals := []signal{
+		{"warmth", bd.warmthBonus / warmthBonusMax, wp.Warmth},
+		{"headroom", bd.headroomScore, wp.Headroom},
+		{"feedback", bd.feedbackScore, wp.Feedback},
+		{"quality", bd.qualityTier, wp.Quality},
+		{"speed", bd.speedTier, wp.Speed},
+		{"kvcache", bd.kvCacheBonus, wp.KVCache},
+		{"cost", 1.0 - bd.costPenalty, wp.Cost},
+	}
+
+	var weightedSum float64
+	var totalWeight float64
+
+	for _, s := range signals {
+		if !activeSignals[s.name] || s.weight <= 0 {
+			continue
+		}
+		w := float64(s.weight)
+		weightedSum += s.value * w
+		totalWeight += w
+	}
+
+	if totalWeight == 0 {
+		return 0
+	}
+
+	return weightedSum / totalWeight
+}
+
+// ---------------------------------------------------------------------------
+// sortScoredCandidates
+// ---------------------------------------------------------------------------
+
+// sortScoredCandidates sorts candidates by descending composite score with
+// deterministic tiebreaking:
+//  1. Prefer warm models (if warmth source is available)
+//  2. Higher context window
+//  3. Alphabetical by ModelKey string representation
+func sortScoredCandidates(candidates []scoredCandidate, warmth WarmthSource) {
+	sort.SliceStable(candidates, func(i, j int) bool {
+		a, b := candidates[i], candidates[j]
+
+		// Primary: higher score wins.
+		if a.score != b.score {
+			return a.score > b.score
+		}
+
+		// Tiebreak 1: prefer warm model.
+		if warmth != nil {
+			aWarm := warmth.IsWarm(a.profile.Key)
+			bWarm := warmth.IsWarm(b.profile.Key)
+			if aWarm != bWarm {
+				return aWarm
+			}
+		}
+
+		// Tiebreak 2: higher context window.
+		if a.profile.ContextWindow != b.profile.ContextWindow {
+			return a.profile.ContextWindow > b.profile.ContextWindow
+		}
+
+		// Tiebreak 3: alphabetical by key.
+		return a.profile.Key.String() < b.profile.Key.String()
+	})
+}

--- a/provider/router_score_test.go
+++ b/provider/router_score_test.go
@@ -1,0 +1,434 @@
+package provider
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// TestTierToFloat
+// ---------------------------------------------------------------------------
+
+func TestTierToFloat(t *testing.T) {
+	tests := []struct {
+		tier Tier
+		want float64
+	}{
+		{TierBasic, 0.25},
+		{TierGood, 0.50},
+		{TierGreat, 0.75},
+		{TierBest, 1.00},
+		{Tier(99), 0.25}, // unknown defaults to Basic
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tier.String(), func(t *testing.T) {
+			got := tierToFloat(tt.tier)
+			if got != tt.want {
+				t.Errorf("tierToFloat(%v) = %v, want %v", tt.tier, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestDefaultWeightProfile
+// ---------------------------------------------------------------------------
+
+func TestDefaultWeightProfile(t *testing.T) {
+	useCases := []string{"fim", "chat", "embedding", "reasoning", "code-review"}
+
+	for _, uc := range useCases {
+		t.Run(uc, func(t *testing.T) {
+			wp := defaultWeightProfile(uc)
+			if wp == nil {
+				t.Fatalf("defaultWeightProfile(%q) returned nil", uc)
+			}
+			// All weights must be non-negative.
+			weights := []struct {
+				name string
+				val  int
+			}{
+				{"Warmth", wp.Warmth},
+				{"Headroom", wp.Headroom},
+				{"Feedback", wp.Feedback},
+				{"Quality", wp.Quality},
+				{"Speed", wp.Speed},
+				{"KVCache", wp.KVCache},
+				{"Cost", wp.Cost},
+			}
+			for _, w := range weights {
+				if w.val < 0 {
+					t.Errorf("%s weight = %d, want >= 0", w.name, w.val)
+				}
+			}
+		})
+	}
+
+	t.Run("unknown falls back to chat", func(t *testing.T) {
+		unknown := defaultWeightProfile("some-unknown-use-case")
+		chat := defaultWeightProfile("chat")
+		if unknown == nil {
+			t.Fatal("defaultWeightProfile for unknown returned nil")
+		}
+		if *unknown != *chat {
+			t.Errorf("unknown profile = %+v, want chat profile %+v", unknown, chat)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestScoreCandidateBasic
+// ---------------------------------------------------------------------------
+
+func TestScoreCandidateBasic(t *testing.T) {
+	profile := &ModelProfile{
+		Key:           ModelKey{Provider: "ollama", Model: "qwen3:8b"},
+		Quality:       TierGood,
+		Speed:         TierGreat,
+		Caps:          CapChat | CapStream,
+		ContextWindow: 32768,
+	}
+
+	req := RoutingRequest{
+		UseCase:      "chat",
+		RequiredCaps: CapChat,
+	}
+
+	budget := BudgetResult{
+		Decision:      BudgetOK,
+		HeadroomScore: 0.8,
+	}
+
+	breaker := NewCircuitBreaker()
+
+	bd := scoreCandidate(profile, req, budget, nil, nil, breaker)
+
+	if !bd.capabilityGate {
+		t.Error("capabilityGate should be true")
+	}
+	if bd.breakerPenalty != 0 {
+		t.Errorf("breakerPenalty = %v, want 0", bd.breakerPenalty)
+	}
+	if bd.qualityTier != 0.5 {
+		t.Errorf("qualityTier = %v, want 0.5", bd.qualityTier)
+	}
+	if bd.speedTier != 0.75 {
+		t.Errorf("speedTier = %v, want 0.75", bd.speedTier)
+	}
+	if bd.headroomScore != 0.8 {
+		t.Errorf("headroomScore = %v, want 0.8", bd.headroomScore)
+	}
+	if bd.feedbackScore != 0.5 {
+		t.Errorf("feedbackScore = %v, want 0.5", bd.feedbackScore)
+	}
+	if bd.warmthBonus != 0.0 {
+		t.Errorf("warmthBonus = %v, want 0.0 (no warmth source)", bd.warmthBonus)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestScoreCandidateCapabilityGate
+// ---------------------------------------------------------------------------
+
+func TestScoreCandidateCapabilityGate(t *testing.T) {
+	profile := &ModelProfile{
+		Key:           ModelKey{Provider: "ollama", Model: "qwen3:8b"},
+		Quality:       TierGood,
+		Speed:         TierGood,
+		Caps:          CapChat, // only Chat, no ToolCall
+		ContextWindow: 32768,
+	}
+
+	req := RoutingRequest{
+		UseCase:      "chat",
+		RequiredCaps: CapChat | CapToolCall, // requires both
+	}
+
+	budget := BudgetResult{
+		Decision:      BudgetOK,
+		HeadroomScore: 0.8,
+	}
+
+	breaker := NewCircuitBreaker()
+
+	bd := scoreCandidate(profile, req, budget, nil, nil, breaker)
+
+	if bd.capabilityGate {
+		t.Error("capabilityGate should be false when model lacks required capabilities")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestScoreCandidateBreakerOpen
+// ---------------------------------------------------------------------------
+
+func TestScoreCandidateBreakerOpen(t *testing.T) {
+	profile := &ModelProfile{
+		Key:           ModelKey{Provider: "ollama", Model: "qwen3:8b"},
+		Quality:       TierGood,
+		Speed:         TierGood,
+		Caps:          CapChat,
+		ContextWindow: 32768,
+	}
+
+	req := RoutingRequest{
+		UseCase:      "chat",
+		RequiredCaps: CapChat,
+	}
+
+	budget := BudgetResult{
+		Decision:      BudgetOK,
+		HeadroomScore: 0.8,
+	}
+
+	// Threshold=1: a single failure opens the breaker.
+	breaker := NewCircuitBreaker(WithFailureThreshold(1))
+	breaker.RecordFailure(fmt.Errorf("test failure"))
+
+	if breaker.State() != BreakerOpen {
+		t.Fatalf("breaker should be open after 1 failure with threshold=1, got %v", breaker.State())
+	}
+
+	bd := scoreCandidate(profile, req, budget, nil, nil, breaker)
+
+	if !bd.capabilityGate {
+		t.Error("capabilityGate should be true (caps matched)")
+	}
+	if !math.IsInf(bd.breakerPenalty, -1) {
+		t.Errorf("breakerPenalty = %v, want -Inf", bd.breakerPenalty)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestScoreCandidateWarmthBonus
+// ---------------------------------------------------------------------------
+
+func TestScoreCandidateWarmthBonus(t *testing.T) {
+	warmKey := ModelKey{Provider: "ollama", Model: "warm-model"}
+	coldKey := ModelKey{Provider: "ollama", Model: "cold-model"}
+
+	warmProfile := &ModelProfile{
+		Key:           warmKey,
+		Quality:       TierGood,
+		Speed:         TierGood,
+		Caps:          CapChat,
+		ContextWindow: 32768,
+	}
+	coldProfile := &ModelProfile{
+		Key:           coldKey,
+		Quality:       TierGood,
+		Speed:         TierGood,
+		Caps:          CapChat,
+		ContextWindow: 32768,
+	}
+
+	req := RoutingRequest{
+		UseCase:      "chat",
+		RequiredCaps: CapChat,
+	}
+
+	budget := BudgetResult{
+		Decision:      BudgetOK,
+		HeadroomScore: 0.8,
+	}
+
+	ws := newMockWarmthSource()
+	ws.SetWarm(warmKey, 4.0)
+	// coldKey is not in the warmth source → IsWarm returns false.
+
+	breakerWarm := NewCircuitBreaker()
+	breakerCold := NewCircuitBreaker()
+
+	bdWarm := scoreCandidate(warmProfile, req, budget, ws, nil, breakerWarm)
+	bdCold := scoreCandidate(coldProfile, req, budget, ws, nil, breakerCold)
+
+	if bdWarm.warmthBonus != warmthBonusMax {
+		t.Errorf("warm model warmthBonus = %v, want %v", bdWarm.warmthBonus, warmthBonusMax)
+	}
+	if bdCold.warmthBonus != 0.0 {
+		t.Errorf("cold model warmthBonus = %v, want 0.0", bdCold.warmthBonus)
+	}
+	if bdWarm.warmthBonus <= bdCold.warmthBonus {
+		t.Error("warm model should have higher warmthBonus than cold model")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestComputeWeightedScoreNormalization
+// ---------------------------------------------------------------------------
+
+func TestComputeWeightedScoreNormalization(t *testing.T) {
+	bd := scoreBreakdown{
+		warmthBonus:    0.3,
+		headroomScore:  0.8,
+		feedbackScore:  0.5,
+		qualityTier:    0.75,
+		speedTier:      0.75,
+		kvCacheBonus:   0,
+		costPenalty:    0,
+		breakerPenalty: 0,
+		capabilityGate: true,
+	}
+
+	activeSignals := map[string]bool{
+		"warmth":   true,
+		"headroom": true,
+		"quality":  true,
+		"speed":    true,
+	}
+
+	score := computeWeightedScore(bd, "chat", activeSignals, nil)
+
+	if score <= 0 || score > 1.0 {
+		t.Errorf("score = %v, want in (0, 1.0]", score)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestComputeWeightedScoreCustomWeights
+// ---------------------------------------------------------------------------
+
+func TestComputeWeightedScoreCustomWeights(t *testing.T) {
+	bd := scoreBreakdown{
+		warmthBonus:    0,
+		headroomScore:  0.5,
+		feedbackScore:  0.5,
+		qualityTier:    1.0, // Best quality
+		speedTier:      0.25,
+		kvCacheBonus:   0,
+		costPenalty:    0,
+		breakerPenalty: 0,
+		capabilityGate: true,
+	}
+
+	activeSignals := map[string]bool{
+		"headroom": true,
+		"quality":  true,
+		"speed":    true,
+	}
+
+	customWeights := &WeightProfile{
+		Warmth:   0,
+		Headroom: 1,
+		Feedback: 0,
+		Quality:  10, // Heavily weighted toward quality
+		Speed:    1,
+		KVCache:  0,
+		Cost:     0,
+	}
+
+	score := computeWeightedScore(bd, "chat", activeSignals, customWeights)
+
+	if score <= 0.7 {
+		t.Errorf("score = %v, want > 0.7 when quality=1.0 and Quality weight=10", score)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestComputeWeightedScoreNoActiveSignals
+// ---------------------------------------------------------------------------
+
+func TestComputeWeightedScoreNoActiveSignals(t *testing.T) {
+	bd := scoreBreakdown{
+		warmthBonus:    0.3,
+		headroomScore:  0.8,
+		qualityTier:    1.0,
+		speedTier:      1.0,
+		capabilityGate: true,
+	}
+
+	activeSignals := map[string]bool{} // empty
+
+	score := computeWeightedScore(bd, "chat", activeSignals, nil)
+
+	if score != 0 {
+		t.Errorf("score = %v, want 0 with no active signals", score)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestTiebreakOrder
+// ---------------------------------------------------------------------------
+
+func TestTiebreakOrder(t *testing.T) {
+	candidates := []scoredCandidate{
+		{
+			profile: &ModelProfile{
+				Key:           ModelKey{Provider: "ollama", Model: "model-b"},
+				ContextWindow: 8192,
+			},
+			score: 0.8,
+		},
+		{
+			profile: &ModelProfile{
+				Key:           ModelKey{Provider: "ollama", Model: "model-a"},
+				ContextWindow: 32768,
+			},
+			score: 0.8,
+		},
+		{
+			profile: &ModelProfile{
+				Key:           ModelKey{Provider: "ollama", Model: "model-c"},
+				ContextWindow: 32768,
+			},
+			score: 0.8,
+		},
+	}
+
+	sortScoredCandidates(candidates, nil)
+
+	// Same score → higher context first.
+	if candidates[0].profile.Key.Model != "model-a" {
+		t.Errorf("first candidate = %v, want model-a (higher context, alphabetical)", candidates[0].profile.Key.Model)
+	}
+	if candidates[1].profile.Key.Model != "model-c" {
+		t.Errorf("second candidate = %v, want model-c (higher context, alphabetical after a)", candidates[1].profile.Key.Model)
+	}
+	if candidates[2].profile.Key.Model != "model-b" {
+		t.Errorf("third candidate = %v, want model-b (lower context)", candidates[2].profile.Key.Model)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestTiebreakPreferWarm
+// ---------------------------------------------------------------------------
+
+func TestTiebreakPreferWarm(t *testing.T) {
+	warmKey := ModelKey{Provider: "ollama", Model: "warm-model"}
+	coldKey := ModelKey{Provider: "ollama", Model: "cold-model"}
+
+	ws := newMockWarmthSource()
+	ws.SetWarm(warmKey, 4.0)
+	// cold-model is not warm.
+
+	candidates := []scoredCandidate{
+		{
+			profile: &ModelProfile{
+				Key:           coldKey,
+				ContextWindow: 32768,
+			},
+			score: 0.8,
+		},
+		{
+			profile: &ModelProfile{
+				Key:           warmKey,
+				ContextWindow: 32768,
+			},
+			score: 0.8,
+		},
+	}
+
+	sortScoredCandidates(candidates, ws)
+
+	// Same score, same context → prefer warm.
+	if candidates[0].profile.Key.Model != "warm-model" {
+		t.Errorf("first candidate = %v, want warm-model (prefer warm tiebreak)",
+			candidates[0].profile.Key.Model)
+	}
+	if candidates[1].profile.Key.Model != "cold-model" {
+		t.Errorf("second candidate = %v, want cold-model",
+			candidates[1].profile.Key.Model)
+	}
+}

--- a/provider/router_sticky.go
+++ b/provider/router_sticky.go
@@ -1,0 +1,189 @@
+// router_sticky.go implements a sticky routing cache with LRU eviction and
+// touch-based TTL expiry. When the router selects a provider/model for a
+// request, the decision is cached under a deterministic sticky key (derived
+// from RoutingRequest fields). Subsequent requests with the same key reuse
+// the cached route, providing session affinity and reducing re-scoring.
+//
+// The cache is bounded by maxEntries. Expired entries are lazily evicted on
+// lookup. When inserting at capacity, expired entries are purged first,
+// then the least-recently-used entry is evicted.
+package provider
+
+import (
+	"sync"
+	"time"
+)
+
+// routeSticky holds a cached routing decision.
+type routeSticky struct {
+	key         string
+	providerKey ModelKey
+	score       float64
+	reason      string
+	createdAt   time.Time
+	lastUsedAt  time.Time
+	expiresAt   time.Time
+}
+
+// StickyRouteInfo is the exported observability view of a cached route.
+type StickyRouteInfo struct {
+	Key        ModelKey
+	Score      float64
+	Reason     string
+	CreatedAt  time.Time
+	LastUsedAt time.Time
+	ExpiresAt  time.Time
+}
+
+// stickyCache is an LRU-bounded, TTL-expiring cache of routing decisions.
+type stickyCache struct {
+	mu         sync.Mutex
+	entries    map[string]*routeSticky
+	ttl        time.Duration
+	maxEntries int
+}
+
+// newStickyCache creates a stickyCache with the given TTL and capacity.
+func newStickyCache(ttl time.Duration, maxEntries int) *stickyCache {
+	return &stickyCache{
+		entries:    make(map[string]*routeSticky),
+		ttl:        ttl,
+		maxEntries: maxEntries,
+	}
+}
+
+// get retrieves an entry by key. Returns nil, false if not found or expired.
+// Expired entries are lazily evicted on lookup.
+func (sc *stickyCache) get(key string) (*routeSticky, bool) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	entry, ok := sc.entries[key]
+	if !ok {
+		return nil, false
+	}
+
+	// Lazy expiry: if the entry has expired, delete it and report a miss.
+	if time.Now().After(entry.expiresAt) {
+		delete(sc.entries, key)
+		return nil, false
+	}
+
+	return entry, true
+}
+
+// put inserts or replaces an entry. If at capacity, expired entries are
+// purged first, then the least-recently-used entry is evicted.
+func (sc *stickyCache) put(entry *routeSticky) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	// Overwrite: if the key already exists, just replace — no eviction needed.
+	if _, exists := sc.entries[entry.key]; exists {
+		sc.entries[entry.key] = entry
+		return
+	}
+
+	// At capacity: evict to make room.
+	if len(sc.entries) >= sc.maxEntries {
+		sc.evictLocked()
+	}
+
+	sc.entries[entry.key] = entry
+}
+
+// touch updates lastUsedAt and extends expiresAt to now + TTL.
+func (sc *stickyCache) touch(key string) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	entry, ok := sc.entries[key]
+	if !ok {
+		return
+	}
+
+	now := time.Now()
+	entry.lastUsedAt = now
+	entry.expiresAt = now.Add(sc.ttl)
+}
+
+// invalidate removes a specific entry by key.
+func (sc *stickyCache) invalidate(key string) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	delete(sc.entries, key)
+}
+
+// invalidateProvider removes all entries routed to the given provider name.
+// This is used when a circuit breaker opens for a provider, ensuring stale
+// affinity routes are cleared.
+func (sc *stickyCache) invalidateProvider(provider string) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	for k, entry := range sc.entries {
+		if entry.providerKey.Provider == provider {
+			delete(sc.entries, k)
+		}
+	}
+}
+
+// snapshot returns an exported copy of all current entries for observability.
+// Expired entries are not included.
+func (sc *stickyCache) snapshot() map[string]StickyRouteInfo {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	now := time.Now()
+	result := make(map[string]StickyRouteInfo, len(sc.entries))
+	for k, entry := range sc.entries {
+		if now.After(entry.expiresAt) {
+			// Skip expired entries in the snapshot (but don't evict here
+			// to keep snapshot read-only from a mutation perspective).
+			continue
+		}
+		result[k] = StickyRouteInfo{
+			Key:        entry.providerKey,
+			Score:      entry.score,
+			Reason:     entry.reason,
+			CreatedAt:  entry.createdAt,
+			LastUsedAt: entry.lastUsedAt,
+			ExpiresAt:  entry.expiresAt,
+		}
+	}
+	return result
+}
+
+// evictLocked removes entries to free capacity. It must be called with sc.mu
+// held. Phase 1: remove all expired entries. Phase 2: if still at capacity,
+// remove the entry with the oldest lastUsedAt (LRU).
+func (sc *stickyCache) evictLocked() {
+	now := time.Now()
+
+	// Phase 1: remove expired entries.
+	for k, entry := range sc.entries {
+		if now.After(entry.expiresAt) {
+			delete(sc.entries, k)
+		}
+	}
+
+	// Phase 2: if still at capacity, evict the LRU entry.
+	if len(sc.entries) >= sc.maxEntries {
+		var oldestKey string
+		var oldestTime time.Time
+		first := true
+
+		for k, entry := range sc.entries {
+			if first || entry.lastUsedAt.Before(oldestTime) {
+				oldestKey = k
+				oldestTime = entry.lastUsedAt
+				first = false
+			}
+		}
+
+		if !first {
+			delete(sc.entries, oldestKey)
+		}
+	}
+}

--- a/provider/router_sticky.go
+++ b/provider/router_sticky.go
@@ -52,24 +52,25 @@ func newStickyCache(ttl time.Duration, maxEntries int) *stickyCache {
 	}
 }
 
-// get retrieves an entry by key. Returns nil, false if not found or expired.
-// Expired entries are lazily evicted on lookup.
-func (sc *stickyCache) get(key string) (*routeSticky, bool) {
+// get retrieves an entry by key. Returns the zero value and false if not found
+// or expired. The returned struct is a copy — safe to read without holding the
+// lock. Expired entries are lazily evicted on lookup.
+func (sc *stickyCache) get(key string) (routeSticky, bool) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 
 	entry, ok := sc.entries[key]
 	if !ok {
-		return nil, false
+		return routeSticky{}, false
 	}
 
 	// Lazy expiry: if the entry has expired, delete it and report a miss.
 	if time.Now().After(entry.expiresAt) {
 		delete(sc.entries, key)
-		return nil, false
+		return routeSticky{}, false
 	}
 
-	return entry, true
+	return *entry, true
 }
 
 // put inserts or replaces an entry. If at capacity, expired entries are

--- a/provider/router_sticky_test.go
+++ b/provider/router_sticky_test.go
@@ -12,8 +12,8 @@ func TestStickyCacheGetMiss(t *testing.T) {
 	if ok {
 		t.Fatal("expected miss on empty cache, got hit")
 	}
-	if got != nil {
-		t.Fatalf("expected nil entry on miss, got %+v", got)
+	if got.key != "" {
+		t.Fatalf("expected zero entry on miss, got %+v", got)
 	}
 }
 
@@ -69,8 +69,8 @@ func TestStickyCacheExpiry(t *testing.T) {
 	if ok {
 		t.Fatal("expected miss after TTL expiry, got hit")
 	}
-	if got != nil {
-		t.Fatal("expected nil entry after expiry")
+	if got.key != "" {
+		t.Fatal("expected zero entry after expiry")
 	}
 }
 

--- a/provider/router_sticky_test.go
+++ b/provider/router_sticky_test.go
@@ -1,0 +1,319 @@
+package provider
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStickyCacheGetMiss(t *testing.T) {
+	sc := newStickyCache(time.Minute, 100)
+
+	got, ok := sc.get("nonexistent")
+	if ok {
+		t.Fatal("expected miss on empty cache, got hit")
+	}
+	if got != nil {
+		t.Fatalf("expected nil entry on miss, got %+v", got)
+	}
+}
+
+func TestStickyCachePutAndGet(t *testing.T) {
+	sc := newStickyCache(time.Minute, 100)
+
+	entry := &routeSticky{
+		key:         "key1",
+		providerKey: ModelKey{Provider: "ollama", Model: "qwen3:8b"},
+		score:       0.85,
+		reason:      "warmth+quality",
+		createdAt:   time.Now(),
+		lastUsedAt:  time.Now(),
+		expiresAt:   time.Now().Add(time.Minute),
+	}
+	sc.put(entry)
+
+	got, ok := sc.get("key1")
+	if !ok {
+		t.Fatal("expected hit after put, got miss")
+	}
+	if got.score != 0.85 {
+		t.Fatalf("expected score 0.85, got %f", got.score)
+	}
+	if got.providerKey.Model != "qwen3:8b" {
+		t.Fatalf("expected model qwen3:8b, got %s", got.providerKey.Model)
+	}
+}
+
+func TestStickyCacheExpiry(t *testing.T) {
+	sc := newStickyCache(10*time.Millisecond, 100)
+
+	now := time.Now()
+	entry := &routeSticky{
+		key:         "ephemeral",
+		providerKey: ModelKey{Provider: "ollama", Model: "tiny"},
+		score:       0.5,
+		reason:      "test",
+		createdAt:   now,
+		lastUsedAt:  now,
+		expiresAt:   now.Add(10 * time.Millisecond),
+	}
+	sc.put(entry)
+
+	// Verify it's there initially.
+	if _, ok := sc.get("ephemeral"); !ok {
+		t.Fatal("expected hit immediately after put")
+	}
+
+	time.Sleep(20 * time.Millisecond)
+
+	got, ok := sc.get("ephemeral")
+	if ok {
+		t.Fatal("expected miss after TTL expiry, got hit")
+	}
+	if got != nil {
+		t.Fatal("expected nil entry after expiry")
+	}
+}
+
+func TestStickyCacheTouch(t *testing.T) {
+	sc := newStickyCache(50*time.Millisecond, 100)
+
+	now := time.Now()
+	entry := &routeSticky{
+		key:         "touchme",
+		providerKey: ModelKey{Provider: "ollama", Model: "qwen3:8b"},
+		score:       0.7,
+		reason:      "touch test",
+		createdAt:   now,
+		lastUsedAt:  now,
+		expiresAt:   now.Add(50 * time.Millisecond),
+	}
+	sc.put(entry)
+
+	// Wait 30ms (past 60% of TTL), then touch to extend.
+	time.Sleep(30 * time.Millisecond)
+	sc.touch("touchme")
+
+	// Wait another 30ms (total 60ms from creation, but only 30ms from touch).
+	time.Sleep(30 * time.Millisecond)
+
+	got, ok := sc.get("touchme")
+	if !ok {
+		t.Fatal("expected hit after touch extended TTL, got miss")
+	}
+	if got.score != 0.7 {
+		t.Fatalf("expected score 0.7, got %f", got.score)
+	}
+}
+
+func TestStickyCacheLRUEviction(t *testing.T) {
+	sc := newStickyCache(time.Minute, 3)
+
+	now := time.Now()
+	// Insert 3 entries with staggered lastUsedAt so LRU order is deterministic.
+	for i, key := range []string{"a", "b", "c"} {
+		sc.put(&routeSticky{
+			key:         key,
+			providerKey: ModelKey{Provider: "ollama", Model: key},
+			score:       float64(i) * 0.1,
+			reason:      "lru test",
+			createdAt:   now,
+			lastUsedAt:  now.Add(time.Duration(i) * time.Millisecond),
+			expiresAt:   now.Add(time.Minute),
+		})
+	}
+
+	// Insert a 4th entry, which should evict "a" (oldest lastUsedAt).
+	sc.put(&routeSticky{
+		key:         "d",
+		providerKey: ModelKey{Provider: "ollama", Model: "d"},
+		score:       0.9,
+		reason:      "new entry",
+		createdAt:   now,
+		lastUsedAt:  now.Add(3 * time.Millisecond),
+		expiresAt:   now.Add(time.Minute),
+	})
+
+	// "a" should be evicted.
+	if _, ok := sc.get("a"); ok {
+		t.Fatal("expected 'a' to be evicted (oldest LRU), but it was found")
+	}
+
+	// "b", "c", "d" should still be present.
+	for _, key := range []string{"b", "c", "d"} {
+		if _, ok := sc.get(key); !ok {
+			t.Fatalf("expected '%s' to be present after LRU eviction", key)
+		}
+	}
+}
+
+func TestStickyCacheInvalidate(t *testing.T) {
+	sc := newStickyCache(time.Minute, 100)
+
+	now := time.Now()
+	sc.put(&routeSticky{
+		key:         "doomed",
+		providerKey: ModelKey{Provider: "ollama", Model: "qwen3:8b"},
+		score:       0.6,
+		reason:      "will be invalidated",
+		createdAt:   now,
+		lastUsedAt:  now,
+		expiresAt:   now.Add(time.Minute),
+	})
+
+	// Verify it exists.
+	if _, ok := sc.get("doomed"); !ok {
+		t.Fatal("expected entry to exist before invalidation")
+	}
+
+	sc.invalidate("doomed")
+
+	if _, ok := sc.get("doomed"); ok {
+		t.Fatal("expected miss after invalidation, got hit")
+	}
+}
+
+func TestStickyCacheInvalidateProvider(t *testing.T) {
+	sc := newStickyCache(time.Minute, 100)
+
+	now := time.Now()
+	// Two entries for "ollama", one for "openai".
+	sc.put(&routeSticky{
+		key:         "ollama1",
+		providerKey: ModelKey{Provider: "ollama", Model: "qwen3:8b"},
+		score:       0.7,
+		reason:      "ollama entry 1",
+		createdAt:   now,
+		lastUsedAt:  now,
+		expiresAt:   now.Add(time.Minute),
+	})
+	sc.put(&routeSticky{
+		key:         "ollama2",
+		providerKey: ModelKey{Provider: "ollama", Model: "qwen3:72b"},
+		score:       0.9,
+		reason:      "ollama entry 2",
+		createdAt:   now,
+		lastUsedAt:  now,
+		expiresAt:   now.Add(time.Minute),
+	})
+	sc.put(&routeSticky{
+		key:         "openai1",
+		providerKey: ModelKey{Provider: "openai", Model: "gpt-4o"},
+		score:       0.8,
+		reason:      "openai entry",
+		createdAt:   now,
+		lastUsedAt:  now,
+		expiresAt:   now.Add(time.Minute),
+	})
+
+	sc.invalidateProvider("ollama")
+
+	// Both ollama entries should be gone.
+	if _, ok := sc.get("ollama1"); ok {
+		t.Fatal("expected ollama1 to be invalidated")
+	}
+	if _, ok := sc.get("ollama2"); ok {
+		t.Fatal("expected ollama2 to be invalidated")
+	}
+
+	// openai entry should survive.
+	if _, ok := sc.get("openai1"); !ok {
+		t.Fatal("expected openai1 to survive provider invalidation")
+	}
+}
+
+func TestStickyCacheSnapshot(t *testing.T) {
+	sc := newStickyCache(time.Minute, 100)
+
+	now := time.Now()
+	sc.put(&routeSticky{
+		key:         "snap1",
+		providerKey: ModelKey{Provider: "ollama", Model: "qwen3:8b"},
+		score:       0.75,
+		reason:      "snapshot test",
+		createdAt:   now,
+		lastUsedAt:  now,
+		expiresAt:   now.Add(time.Minute),
+	})
+
+	snap := sc.snapshot()
+	if len(snap) != 1 {
+		t.Fatalf("expected 1 entry in snapshot, got %d", len(snap))
+	}
+
+	info, ok := snap["snap1"]
+	if !ok {
+		t.Fatal("expected 'snap1' in snapshot")
+	}
+	if info.Key != (ModelKey{Provider: "ollama", Model: "qwen3:8b"}) {
+		t.Fatalf("unexpected key in snapshot: %+v", info.Key)
+	}
+	if info.Score != 0.75 {
+		t.Fatalf("expected score 0.75 in snapshot, got %f", info.Score)
+	}
+}
+
+func TestHysteresisCheck(t *testing.T) {
+	// The hysteresis formula: keep incumbent if
+	//   challengerScore < incumbentScore * (1 + margin)
+	// i.e. challenger must exceed incumbent*(1+margin) to unseat.
+	const margin = 0.15
+
+	tests := []struct {
+		name           string
+		incumbentScore float64
+		challengerScore float64
+		margin         float64
+		wantKeep       bool // true = keep incumbent
+	}{
+		{
+			name:           "challenger far better",
+			incumbentScore: 0.70,
+			challengerScore: 0.90,
+			margin:         margin,
+			wantKeep:       false, // 0.90 >= 0.70*1.15=0.805
+		},
+		{
+			name:           "challenger marginally better",
+			incumbentScore: 0.70,
+			challengerScore: 0.78,
+			margin:         margin,
+			wantKeep:       true, // 0.78 < 0.805
+		},
+		{
+			name:           "challenger at margin boundary",
+			incumbentScore: 0.70,
+			challengerScore: 0.805,
+			margin:         margin,
+			wantKeep:       false, // 0.805 >= 0.805
+		},
+		{
+			name:           "challenger equal",
+			incumbentScore: 0.70,
+			challengerScore: 0.70,
+			margin:         margin,
+			wantKeep:       true, // 0.70 < 0.805
+		},
+		{
+			name:           "challenger worse",
+			incumbentScore: 0.70,
+			challengerScore: 0.60,
+			margin:         margin,
+			wantKeep:       true, // 0.60 < 0.805
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			threshold := tt.incumbentScore * (1 + tt.margin)
+			keepIncumbent := tt.challengerScore < threshold
+
+			if keepIncumbent != tt.wantKeep {
+				t.Errorf(
+					"challenger=%.3f incumbent=%.3f margin=%.2f threshold=%.3f: got keep=%v, want keep=%v",
+					tt.challengerScore, tt.incumbentScore, tt.margin, threshold,
+					keepIncumbent, tt.wantKeep,
+				)
+			}
+		})
+	}
+}

--- a/provider/router_test.go
+++ b/provider/router_test.go
@@ -223,7 +223,7 @@ func setupTestRouter(t *testing.T, opts ...RouterOption) (*Router, *rtMockProvid
 	}
 
 	router := NewRouter(modelReg, provReg, opts...)
-	t.Cleanup(func() { router.Close() })
+	t.Cleanup(func() { _ = router.Close() })
 
 	return router, prov
 }
@@ -596,7 +596,7 @@ func TestRouterWithAvailableRAM(t *testing.T) {
 
 	// Create router with only 8 GB available RAM.
 	router := NewRouter(modelReg, provReg, WithAvailableRAM(8.0))
-	t.Cleanup(func() { router.Close() })
+	t.Cleanup(func() { _ = router.Close() })
 
 	// Route without specifying a model — the large model should be filtered.
 	plan, err := router.Route(context.Background(), RoutingRequest{

--- a/provider/router_test.go
+++ b/provider/router_test.go
@@ -1,0 +1,799 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// rtMockProvider — mock Provider for Router tests
+// ---------------------------------------------------------------------------
+
+// rtMockProvider implements Provider for Router-level tests. It advertises
+// configurable models and returns canned responses. The "rt" prefix avoids
+// collision with mocks in other test files (rpMockProvider, mrMockProvider).
+type rtMockProvider struct {
+	name      string
+	caps      Capability
+	models    []ModelInfo
+	chatResp  *ChatResponse
+	chatErr   error
+	genResp   *GenerateResponse
+	genErr    error
+	embedResp *EmbedResponse
+	embedErr  error
+	healthErr error
+
+	mu        sync.Mutex
+	chatCalls int
+	genCalls  int
+	embedCalls int
+}
+
+func (m *rtMockProvider) Name() string             { return m.name }
+func (m *rtMockProvider) Capabilities() Capability { return m.caps }
+func (m *rtMockProvider) Health(_ context.Context) error { return m.healthErr }
+func (m *rtMockProvider) Models(_ context.Context) ([]ModelInfo, error) {
+	return m.models, nil
+}
+
+func (m *rtMockProvider) Chat(_ context.Context, _ ChatRequest) (*ChatResponse, error) {
+	m.mu.Lock()
+	m.chatCalls++
+	m.mu.Unlock()
+	if m.chatErr != nil {
+		return nil, m.chatErr
+	}
+	resp := *m.chatResp
+	return &resp, nil
+}
+
+func (m *rtMockProvider) ChatStream(_ context.Context, _ ChatRequest, fn func(ChatResponse) error) error {
+	m.mu.Lock()
+	m.chatCalls++
+	m.mu.Unlock()
+	if m.chatErr != nil {
+		return m.chatErr
+	}
+	return fn(ChatResponse{Model: m.chatResp.Model, Content: m.chatResp.Content, Done: true})
+}
+
+func (m *rtMockProvider) Generate(_ context.Context, _ GenerateRequest) (*GenerateResponse, error) {
+	m.mu.Lock()
+	m.genCalls++
+	m.mu.Unlock()
+	if m.genErr != nil {
+		return nil, m.genErr
+	}
+	resp := *m.genResp
+	return &resp, nil
+}
+
+func (m *rtMockProvider) GenerateStream(_ context.Context, _ GenerateRequest, fn func(GenerateResponse) error) error {
+	m.mu.Lock()
+	m.genCalls++
+	m.mu.Unlock()
+	if m.genErr != nil {
+		return m.genErr
+	}
+	return fn(GenerateResponse{Model: m.genResp.Model, Response: m.genResp.Response, Done: true})
+}
+
+func (m *rtMockProvider) Embed(_ context.Context, _ EmbedRequest) (*EmbedResponse, error) {
+	m.mu.Lock()
+	m.embedCalls++
+	m.mu.Unlock()
+	if m.embedErr != nil {
+		return nil, m.embedErr
+	}
+	resp := *m.embedResp
+	return &resp, nil
+}
+
+func (m *rtMockProvider) getChatCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.chatCalls
+}
+
+// ---------------------------------------------------------------------------
+// rtMockWarmthSource — mock WarmthSource for Router tests
+// ---------------------------------------------------------------------------
+
+type rtMockWarmthSource struct {
+	mu       sync.Mutex
+	warmKeys map[ModelKey]*WarmthInfo
+	uses     []ModelKey
+}
+
+func newRTMockWarmthSource() *rtMockWarmthSource {
+	return &rtMockWarmthSource{
+		warmKeys: make(map[ModelKey]*WarmthInfo),
+	}
+}
+
+func (w *rtMockWarmthSource) setWarm(key ModelKey, info WarmthInfo) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.warmKeys[key] = &info
+}
+
+func (w *rtMockWarmthSource) IsWarm(key ModelKey) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	info, ok := w.warmKeys[key]
+	return ok && info.Loaded
+}
+
+func (w *rtMockWarmthSource) WarmthState(key ModelKey) *WarmthInfo {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	info, ok := w.warmKeys[key]
+	if !ok {
+		return nil
+	}
+	copy := *info
+	return &copy
+}
+
+func (w *rtMockWarmthSource) RecordUse(key ModelKey) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.uses = append(w.uses, key)
+}
+
+func (w *rtMockWarmthSource) Snapshot() []WarmModel {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	var result []WarmModel
+	for key, info := range w.warmKeys {
+		if info.Loaded {
+			result = append(result, WarmModel{Key: key, Info: *info})
+		}
+	}
+	return result
+}
+
+func (w *rtMockWarmthSource) Close() error { return nil }
+
+func (w *rtMockWarmthSource) getUses() []ModelKey {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	out := make([]ModelKey, len(w.uses))
+	copy(out, w.uses)
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// setupTestRouter — creates a Router with one mock provider and model
+// ---------------------------------------------------------------------------
+
+// setupTestRouter creates a Router pre-configured with a single "test"
+// provider serving a "qwen3:8b" model. Returns the router, the provider
+// mock, and a cleanup function.
+func setupTestRouter(t *testing.T, opts ...RouterOption) (*Router, *rtMockProvider) {
+	t.Helper()
+
+	prov := &rtMockProvider{
+		name: "test",
+		caps: CapChat | CapGenerate | CapEmbed | CapStream,
+		models: []ModelInfo{
+			{
+				Name:          "qwen3:8b",
+				Family:        "qwen3",
+				ParameterSize: "8B",
+				QuantLevel:    "Q4_K_M",
+				ContextWindow: 32768,
+				Capabilities:  []string{"completion", "embedding"},
+			},
+		},
+		chatResp: &ChatResponse{
+			Model:   "qwen3:8b",
+			Content: "Hello from router!",
+			Done:    true,
+		},
+		genResp: &GenerateResponse{
+			Model:    "qwen3:8b",
+			Response: "Generated text",
+			Done:     true,
+		},
+		embedResp: &EmbedResponse{
+			Model:      "qwen3:8b",
+			Embeddings: [][]float64{{0.1, 0.2, 0.3}},
+		},
+	}
+
+	// Set up provider registry and register mock.
+	provReg := NewRegistry()
+	if err := provReg.Register(prov); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+	if err := provReg.RefreshModels(context.Background(), "test"); err != nil {
+		t.Fatalf("RefreshModels failed: %v", err)
+	}
+
+	// Set up model registry.
+	modelReg, err := NewModelRegistry(provReg, nil)
+	if err != nil {
+		t.Fatalf("NewModelRegistry failed: %v", err)
+	}
+
+	router := NewRouter(modelReg, provReg, opts...)
+	t.Cleanup(func() { router.Close() })
+
+	return router, prov
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestRouterRouteQualifiedModel(t *testing.T) {
+	router, _ := setupTestRouter(t)
+
+	plan, err := router.Route(context.Background(), RoutingRequest{
+		Model:   "test/qwen3:8b",
+		UseCase: "chat",
+	})
+	if err != nil {
+		t.Fatalf("Route returned error: %v", err)
+	}
+	if plan == nil {
+		t.Fatal("Route returned nil plan")
+	}
+	if plan.Model != "qwen3:8b" {
+		t.Errorf("plan.Model = %q, want %q", plan.Model, "qwen3:8b")
+	}
+	if plan.Profile.Key.Provider != "test" {
+		t.Errorf("plan.Profile.Key.Provider = %q, want %q", plan.Profile.Key.Provider, "test")
+	}
+	if plan.Provider == nil {
+		t.Error("plan.Provider is nil, want non-nil")
+	}
+	if plan.Score <= 0 {
+		t.Errorf("plan.Score = %f, want positive", plan.Score)
+	}
+}
+
+func TestRouterRouteUnqualifiedModel(t *testing.T) {
+	router, _ := setupTestRouter(t)
+
+	plan, err := router.Route(context.Background(), RoutingRequest{
+		Model:   "qwen3:8b",
+		UseCase: "chat",
+	})
+	if err != nil {
+		t.Fatalf("Route returned error: %v", err)
+	}
+	if plan == nil {
+		t.Fatal("Route returned nil plan")
+	}
+	if plan.Model != "qwen3:8b" {
+		t.Errorf("plan.Model = %q, want %q", plan.Model, "qwen3:8b")
+	}
+	if plan.Profile.Key.Provider != "test" {
+		t.Errorf("plan.Profile.Key.Provider = %q, want %q", plan.Profile.Key.Provider, "test")
+	}
+}
+
+func TestRouterRouteClosed(t *testing.T) {
+	router, _ := setupTestRouter(t)
+
+	// Close the router.
+	if err := router.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	_, err := router.Route(context.Background(), RoutingRequest{
+		Model:   "qwen3:8b",
+		UseCase: "chat",
+	})
+	if !errors.Is(err, ErrRouterClosed) {
+		t.Errorf("error = %v, want ErrRouterClosed", err)
+	}
+}
+
+func TestRouterRouteNoViableCandidate(t *testing.T) {
+	router, _ := setupTestRouter(t)
+
+	// Request a model that doesn't exist.
+	_, err := router.Route(context.Background(), RoutingRequest{
+		Model:   "nonexistent-model:99b",
+		UseCase: "chat",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	// The error comes from LookupAny which tries ProvidersForModel — it won't
+	// find the model. This surfaces as a lookup error rather than
+	// ErrNoViableCandidate directly, but the key point is it fails.
+	// Check it's not nil and contains a useful message.
+	if err.Error() == "" {
+		t.Error("error message is empty")
+	}
+}
+
+func TestRouterRouteBreakerOpen(t *testing.T) {
+	router, _ := setupTestRouter(t)
+
+	// Trip the circuit breaker by recording 3 infrastructure failures.
+	infraErr := &HTTPStatusError{StatusCode: 503, Status: "503 Service Unavailable"}
+	cb := router.getOrCreateBreaker("test")
+	cb.RecordFailure(infraErr)
+	cb.RecordFailure(infraErr)
+	cb.RecordFailure(infraErr)
+
+	// Verify breaker is open.
+	if cb.State() != BreakerOpen {
+		t.Fatalf("breaker state = %v, want Open", cb.State())
+	}
+
+	_, err := router.Route(context.Background(), RoutingRequest{
+		Model:   "qwen3:8b",
+		UseCase: "chat",
+	})
+	if !errors.Is(err, ErrAllBreakersOpen) {
+		t.Errorf("error = %v, want ErrAllBreakersOpen", err)
+	}
+}
+
+func TestRouterChatConvenience(t *testing.T) {
+	router, prov := setupTestRouter(t)
+
+	resp, err := router.Chat(context.Background(), ChatRequest{
+		Model:    "qwen3:8b",
+		Messages: []ChatMessage{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat returned error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("Chat returned nil response")
+	}
+	if resp.Content != "Hello from router!" {
+		t.Errorf("Content = %q, want %q", resp.Content, "Hello from router!")
+	}
+	if resp.RouteOutcome == nil {
+		t.Fatal("RouteOutcome is nil, want non-nil")
+	}
+	if resp.RouteOutcome.PlannedModel.Model != "qwen3:8b" {
+		t.Errorf("PlannedModel = %v, want qwen3:8b", resp.RouteOutcome.PlannedModel)
+	}
+	if resp.RouteOutcome.ActualModel.Model != "qwen3:8b" {
+		t.Errorf("ActualModel = %v, want qwen3:8b", resp.RouteOutcome.ActualModel)
+	}
+	if resp.RouteOutcome.FallbacksUsed != 0 {
+		t.Errorf("FallbacksUsed = %d, want 0", resp.RouteOutcome.FallbacksUsed)
+	}
+
+	if prov.getChatCalls() != 1 {
+		t.Errorf("chatCalls = %d, want 1", prov.getChatCalls())
+	}
+}
+
+func TestRouterStickyRouting(t *testing.T) {
+	router, _ := setupTestRouter(t)
+
+	req := RoutingRequest{
+		Model:       "qwen3:8b",
+		UseCase:     "chat",
+		AffinityKey: "session-123",
+		Messages:    []ChatMessage{{Role: "user", Content: "hello"}},
+	}
+
+	// First route.
+	plan1, err := router.Route(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Route 1 returned error: %v", err)
+	}
+
+	// Second route with same affinity key.
+	plan2, err := router.Route(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Route 2 returned error: %v", err)
+	}
+
+	// Both should route to the same model.
+	if plan1.Model != plan2.Model {
+		t.Errorf("plan1.Model = %q, plan2.Model = %q, want same", plan1.Model, plan2.Model)
+	}
+	if plan1.Profile.Key != plan2.Profile.Key {
+		t.Errorf("plan1 key = %v, plan2 key = %v, want same", plan1.Profile.Key, plan2.Profile.Key)
+	}
+
+	// Sticky routes should be non-empty.
+	routes := router.StickyRoutes()
+	if len(routes) == 0 {
+		t.Error("StickyRoutes is empty, want at least 1 entry")
+	}
+}
+
+func TestRouterDryRunDoesNotUpdateSticky(t *testing.T) {
+	router, _ := setupTestRouter(t)
+
+	req := RoutingRequest{
+		Model:       "qwen3:8b",
+		UseCase:     "chat",
+		AffinityKey: "session-dry",
+		Messages:    []ChatMessage{{Role: "user", Content: "hello"}},
+		DryRun:      true,
+	}
+
+	plan, err := router.Route(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Route returned error: %v", err)
+	}
+	if plan == nil {
+		t.Fatal("Route returned nil plan")
+	}
+
+	routes := router.StickyRoutes()
+	if len(routes) != 0 {
+		t.Errorf("StickyRoutes has %d entries, want 0 (DryRun should not update cache)",
+			len(routes))
+	}
+}
+
+func TestRouterBreakerInfo(t *testing.T) {
+	router, _ := setupTestRouter(t)
+
+	// Before any request, breaker should not exist.
+	_, exists := router.BreakerInfo("test")
+	if exists {
+		t.Error("BreakerInfo exists before request, want false")
+	}
+
+	// Route a request to create the breaker lazily.
+	_, err := router.Route(context.Background(), RoutingRequest{
+		Model:   "qwen3:8b",
+		UseCase: "chat",
+	})
+	if err != nil {
+		t.Fatalf("Route returned error: %v", err)
+	}
+
+	// After routing, breaker should exist.
+	info, exists := router.BreakerInfo("test")
+	if !exists {
+		t.Fatal("BreakerInfo does not exist after request, want true")
+	}
+	if info.State != BreakerClosed {
+		t.Errorf("breaker state = %v, want Closed", info.State)
+	}
+	if info.Failures != 0 {
+		t.Errorf("breaker failures = %d, want 0", info.Failures)
+	}
+}
+
+func TestRouterCloseIdempotent(t *testing.T) {
+	router, _ := setupTestRouter(t)
+
+	// Close twice — should not panic.
+	if err := router.Close(); err != nil {
+		t.Fatalf("first Close returned error: %v", err)
+	}
+	if err := router.Close(); err != nil {
+		t.Fatalf("second Close returned error: %v", err)
+	}
+
+	// Verify it's closed.
+	_, err := router.Route(context.Background(), RoutingRequest{
+		Model:   "qwen3:8b",
+		UseCase: "chat",
+	})
+	if !errors.Is(err, ErrRouterClosed) {
+		t.Errorf("error = %v, want ErrRouterClosed", err)
+	}
+}
+
+func TestRouterWithWarmthSource(t *testing.T) {
+	ws := newRTMockWarmthSource()
+	key := ModelKey{Provider: "test", Model: "qwen3:8b"}
+	ws.setWarm(key, WarmthInfo{
+		Loaded:    true,
+		Since:     time.Now(),
+		ExpiresAt: time.Now().Add(5 * time.Minute),
+		VRAM:      4.5,
+	})
+
+	router, _ := setupTestRouter(t, WithWarmthSource(ws))
+
+	// Verify warmth snapshot.
+	snapshot := router.WarmthSnapshot()
+	if len(snapshot) == 0 {
+		t.Fatal("WarmthSnapshot is empty, want at least 1 entry")
+	}
+	found := false
+	for _, wm := range snapshot {
+		if wm.Key == key {
+			found = true
+			if !wm.Info.Loaded {
+				t.Error("model not loaded in warmth info")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("model %v not found in WarmthSnapshot", key)
+	}
+
+	// Route and verify warmth is used in scoring.
+	plan, err := router.Route(context.Background(), RoutingRequest{
+		Model:   "qwen3:8b",
+		UseCase: "chat",
+	})
+	if err != nil {
+		t.Fatalf("Route returned error: %v", err)
+	}
+	if plan.Score <= 0 {
+		t.Errorf("plan.Score = %f, want positive", plan.Score)
+	}
+}
+
+func TestRouterWithAvailableRAM(t *testing.T) {
+	// Set up two providers: one with a small model, one with a large model.
+	smallProv := &rtMockProvider{
+		name: "small",
+		caps: CapChat | CapGenerate | CapEmbed | CapStream,
+		models: []ModelInfo{
+			{
+				Name:          "small-model:1b",
+				Family:        "small",
+				ParameterSize: "1B",
+				QuantLevel:    "Q4_K_M",
+				ContextWindow: 8192,
+				Capabilities:  []string{"chat", "generate", "stream"},
+			},
+		},
+		chatResp: &ChatResponse{
+			Model:   "small-model:1b",
+			Content: "from small",
+			Done:    true,
+		},
+	}
+
+	largeProv := &rtMockProvider{
+		name: "large",
+		caps: CapChat | CapGenerate | CapEmbed | CapStream,
+		models: []ModelInfo{
+			{
+				Name:          "large-model:70b",
+				Family:        "large",
+				ParameterSize: "70B",
+				QuantLevel:    "Q4_K_M",
+				ContextWindow: 32768,
+				Capabilities:  []string{"chat", "generate", "stream"},
+			},
+		},
+		chatResp: &ChatResponse{
+			Model:   "large-model:70b",
+			Content: "from large",
+			Done:    true,
+		},
+	}
+
+	provReg := NewRegistry()
+	if err := provReg.Register(smallProv); err != nil {
+		t.Fatalf("Register small failed: %v", err)
+	}
+	if err := provReg.Register(largeProv); err != nil {
+		t.Fatalf("Register large failed: %v", err)
+	}
+	if err := provReg.RefreshModels(context.Background(), "small"); err != nil {
+		t.Fatalf("RefreshModels small failed: %v", err)
+	}
+	if err := provReg.RefreshModels(context.Background(), "large"); err != nil {
+		t.Fatalf("RefreshModels large failed: %v", err)
+	}
+
+	modelReg, err := NewModelRegistry(provReg, nil)
+	if err != nil {
+		t.Fatalf("NewModelRegistry failed: %v", err)
+	}
+
+	// Create router with only 8 GB available RAM.
+	router := NewRouter(modelReg, provReg, WithAvailableRAM(8.0))
+	t.Cleanup(func() { router.Close() })
+
+	// Route without specifying a model — the large model should be filtered.
+	plan, err := router.Route(context.Background(), RoutingRequest{
+		UseCase: "chat",
+	})
+	if err != nil {
+		t.Fatalf("Route returned error: %v", err)
+	}
+	if plan == nil {
+		t.Fatal("Route returned nil plan")
+	}
+
+	// The 70B model requires ~46 GB RAM at Q4, so it should be filtered out.
+	// Only the small model should survive.
+	if plan.Model != "small-model:1b" {
+		t.Errorf("plan.Model = %q, want %q (70B should be filtered by RAM)", plan.Model, "small-model:1b")
+	}
+}
+
+func TestRouterGenerateConvenience(t *testing.T) {
+	router, _ := setupTestRouter(t)
+
+	resp, err := router.Generate(context.Background(), GenerateRequest{
+		Model:  "qwen3:8b",
+		Prompt: "Complete this",
+	})
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("Generate returned nil response")
+	}
+	if resp.Response != "Generated text" {
+		t.Errorf("Response = %q, want %q", resp.Response, "Generated text")
+	}
+	if resp.RouteOutcome == nil {
+		t.Fatal("RouteOutcome is nil")
+	}
+}
+
+func TestRouterEmbedConvenience(t *testing.T) {
+	router, _ := setupTestRouter(t)
+
+	resp, err := router.Embed(context.Background(), EmbedRequest{
+		Model: "qwen3:8b",
+		Input: []string{"embed this"},
+	})
+	if err != nil {
+		t.Fatalf("Embed returned error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("Embed returned nil response")
+	}
+	if len(resp.Embeddings) != 1 {
+		t.Errorf("Embeddings count = %d, want 1", len(resp.Embeddings))
+	}
+	if resp.RouteOutcome == nil {
+		t.Fatal("RouteOutcome is nil")
+	}
+}
+
+func TestRouterRecordSuccess(t *testing.T) {
+	router, _ := setupTestRouter(t)
+	key := ModelKey{Provider: "test", Model: "qwen3:8b"}
+
+	// Get breaker created first.
+	_ = router.getOrCreateBreaker("test")
+
+	// Record success.
+	router.RecordSuccess(key, LatencyInfo{})
+
+	info, exists := router.BreakerInfo("test")
+	if !exists {
+		t.Fatal("BreakerInfo does not exist")
+	}
+	if info.State != BreakerClosed {
+		t.Errorf("breaker state = %v, want Closed", info.State)
+	}
+}
+
+func TestRouterRecordFailureTripsBreaker(t *testing.T) {
+	router, _ := setupTestRouter(t)
+	key := ModelKey{Provider: "test", Model: "qwen3:8b"}
+	infraErr := &HTTPStatusError{StatusCode: 500, Status: "500 Internal Server Error"}
+
+	// Record enough failures to trip.
+	router.RecordFailure(key, infraErr)
+	router.RecordFailure(key, infraErr)
+	router.RecordFailure(key, infraErr)
+
+	info, exists := router.BreakerInfo("test")
+	if !exists {
+		t.Fatal("BreakerInfo does not exist")
+	}
+	if info.State != BreakerOpen {
+		t.Errorf("breaker state = %v, want Open", info.State)
+	}
+}
+
+func TestRouterRecordWarmthUse(t *testing.T) {
+	ws := newRTMockWarmthSource()
+	router, _ := setupTestRouter(t, WithWarmthSource(ws))
+	key := ModelKey{Provider: "test", Model: "qwen3:8b"}
+
+	router.RecordWarmthUse(key)
+
+	uses := ws.getUses()
+	if len(uses) != 1 {
+		t.Fatalf("warmth uses = %d, want 1", len(uses))
+	}
+	if uses[0] != key {
+		t.Errorf("warmth use key = %v, want %v", uses[0], key)
+	}
+}
+
+func TestRouterRecordWarmthUseNilSource(t *testing.T) {
+	router, _ := setupTestRouter(t) // no warmth source
+	key := ModelKey{Provider: "test", Model: "qwen3:8b"}
+
+	// Should not panic.
+	router.RecordWarmthUse(key)
+}
+
+func TestRouterWarmthSnapshotNilSource(t *testing.T) {
+	router, _ := setupTestRouter(t)
+
+	snapshot := router.WarmthSnapshot()
+	if snapshot != nil {
+		t.Errorf("WarmthSnapshot = %v, want nil (no warmth source)", snapshot)
+	}
+}
+
+func TestRouterInferRouteKind(t *testing.T) {
+	tests := []struct {
+		name string
+		req  RoutingRequest
+		want RouteKind
+	}{
+		{"chat", RoutingRequest{Messages: []ChatMessage{{Role: "user", Content: "hi"}}}, RouteKindChat},
+		{"generate", RoutingRequest{Prompt: "complete"}, RouteKindGenerate},
+		{"fim", RoutingRequest{Suffix: "suffix"}, RouteKindGenerate},
+		{"embed", RoutingRequest{Input: []string{"text"}}, RouteKindEmbed},
+		{"default", RoutingRequest{}, RouteKindChat},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := inferRouteKind(tt.req)
+			if got != tt.want {
+				t.Errorf("inferRouteKind() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRouterOptions(t *testing.T) {
+	router, _ := setupTestRouter(t,
+		WithStickyTTL(10*time.Minute),
+		WithHysteresis(0.20),
+		WithMaxStickyEntries(512),
+		WithMaxFallbacks(5),
+		WithDefaultPriority(PriorityHigh),
+	)
+
+	if router.defaultOpts.stickyTTL != 10*time.Minute {
+		t.Errorf("stickyTTL = %v, want 10m", router.defaultOpts.stickyTTL)
+	}
+	if router.defaultOpts.hysteresisMargin != 0.20 {
+		t.Errorf("hysteresisMargin = %f, want 0.20", router.defaultOpts.hysteresisMargin)
+	}
+	if router.defaultOpts.maxStickyEntries != 512 {
+		t.Errorf("maxStickyEntries = %d, want 512", router.defaultOpts.maxStickyEntries)
+	}
+	if router.defaultOpts.maxFallbacks != 5 {
+		t.Errorf("maxFallbacks = %d, want 5", router.defaultOpts.maxFallbacks)
+	}
+	if router.defaultOpts.defaultPriority != PriorityHigh {
+		t.Errorf("defaultPriority = %v, want PriorityHigh", router.defaultOpts.defaultPriority)
+	}
+}
+
+func TestRouterBuildReason(t *testing.T) {
+	sc := scoredCandidate{
+		profile: &ModelProfile{
+			Quality: TierGreat,
+			Speed:   TierGood,
+		},
+		budget: BudgetResult{Decision: BudgetOK},
+		score:  0.75,
+	}
+
+	reason := buildReason(sc)
+	if reason == "" {
+		t.Error("buildReason returned empty string")
+	}
+	// Should contain the score.
+	if !strings.Contains(reason, "0.750") {
+		t.Errorf("reason = %q, should contain score", reason)
+	}
+}

--- a/provider/routing_request.go
+++ b/provider/routing_request.go
@@ -1,0 +1,224 @@
+// routing_request.go defines the types and helpers for constructing routing
+// requests. A RoutingRequest captures everything the router needs to select
+// the best provider/model for a given task: capability requirements, priority,
+// budget class, and a deterministic sticky key for affinity routing.
+package provider
+
+import (
+	"crypto/sha256"
+	"fmt"
+)
+
+// ---------------------------------------------------------------------------
+// Priority
+// ---------------------------------------------------------------------------
+
+// Priority indicates the urgency of a routing request. Higher values are
+// more urgent and may receive preferential treatment during contention.
+type Priority int
+
+const (
+	// PriorityBackground is for low-urgency tasks (e.g. background indexing).
+	PriorityBackground Priority = iota
+	// PriorityNormal is the default priority for interactive requests.
+	PriorityNormal
+	// PriorityHigh is for user-visible, latency-sensitive requests.
+	PriorityHigh
+	// PriorityCritical is for requests that must not be dropped or delayed.
+	PriorityCritical
+)
+
+// String returns the human-readable name of the priority level.
+func (p Priority) String() string {
+	switch p {
+	case PriorityBackground:
+		return "background"
+	case PriorityNormal:
+		return "normal"
+	case PriorityHigh:
+		return "high"
+	case PriorityCritical:
+		return "critical"
+	default:
+		return "unknown"
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RouteKind
+// ---------------------------------------------------------------------------
+
+// RouteKind identifies the category of LLM operation being routed.
+type RouteKind int
+
+const (
+	// RouteKindChat routes to a chat completion endpoint.
+	RouteKindChat RouteKind = iota
+	// RouteKindGenerate routes to a raw text generation endpoint.
+	RouteKindGenerate
+	// RouteKindEmbed routes to an embedding generation endpoint.
+	RouteKindEmbed
+)
+
+// String returns the human-readable name of the route kind.
+func (k RouteKind) String() string {
+	switch k {
+	case RouteKindChat:
+		return "chat"
+	case RouteKindGenerate:
+		return "generate"
+	case RouteKindEmbed:
+		return "embed"
+	default:
+		return "unknown"
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RoutingRequest
+// ---------------------------------------------------------------------------
+
+// RoutingRequest captures all the information the router needs to select the
+// best provider and model for a given task. It is provider-agnostic and
+// contains capability requirements, budget hints, and affinity metadata.
+//
+// NOTE: Phase 2 intentionally omits a ThinkBudget field. Extended thinking
+// budget integration will be added in a future phase once the router's
+// budget adaptation logic is proven.
+type RoutingRequest struct {
+	// Model is the preferred model name (may be empty to let the router choose).
+	Model string
+	// UseCase identifies the caller's intent (e.g. "chat", "fim", "code-review").
+	UseCase string
+	// RequiredCaps is the bitmask of capabilities the target must support.
+	RequiredCaps Capability
+	// Messages is the conversation history for chat-style requests.
+	Messages []ChatMessage
+	// Prompt is the raw prompt for generate-style requests.
+	Prompt string
+	// System is the system prompt, if any.
+	System string
+	// Suffix is the suffix for FIM (Fill-in-the-Middle) requests.
+	Suffix string
+	// Input is the list of texts for embedding requests.
+	Input []string
+	// Tools is the list of tools available for tool-calling requests.
+	Tools []Tool
+	// Options holds generation parameters (temperature, num_predict, etc.).
+	Options ModelOptions
+	// ExpectedOutput is the estimated output token count for budget planning.
+	ExpectedOutput int
+	// PreferWarm hints that the router should prefer a model already loaded in memory.
+	PreferWarm bool
+	// Priority indicates the urgency of this request.
+	Priority Priority
+	// AffinityKey is a caller-supplied key for sticky routing (e.g. session ID).
+	AffinityKey string
+	// DryRun, when true, returns the routing decision without executing the request.
+	DryRun bool
+}
+
+// ---------------------------------------------------------------------------
+// Default expected outputs
+// ---------------------------------------------------------------------------
+
+// defaultExpectedOutputs maps well-known use cases to their typical output
+// token budget. The "chat" entry doubles as the fallback for unknown use cases.
+var defaultExpectedOutputs = map[string]int{
+	"fim":         200,
+	"chat":        2048,
+	"embedding":   0,
+	"code-review": 4096,
+	"reasoning":   4096,
+}
+
+// DefaultExpectedOutput returns the default expected output token count for
+// the given use case. Unknown use cases fall back to the chat default (2048).
+func DefaultExpectedOutput(useCase string) int {
+	if v, ok := defaultExpectedOutputs[useCase]; ok {
+		return v
+	}
+	return defaultExpectedOutputs["chat"]
+}
+
+// ---------------------------------------------------------------------------
+// Budget classification
+// ---------------------------------------------------------------------------
+
+// inputBudgetClass categorizes the estimated input token count into a coarse
+// bucket for use in sticky key computation and routing heuristics.
+func inputBudgetClass(tokens int) string {
+	switch {
+	case tokens < 2048:
+		return "small"
+	case tokens < 8192:
+		return "medium"
+	default:
+		return "large"
+	}
+}
+
+// outputBudgetClass categorizes the expected output token count into a coarse
+// bucket for use in sticky key computation and routing heuristics.
+func outputBudgetClass(tokens int) string {
+	switch {
+	case tokens < 512:
+		return "small"
+	case tokens < 2048:
+		return "medium"
+	default:
+		return "large"
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Sticky key
+// ---------------------------------------------------------------------------
+
+// StickyKey computes a deterministic 128-bit hex string that uniquely
+// identifies the routing characteristics of this request. Two requests with
+// the same sticky key should be routed to the same provider/model, enabling
+// session affinity and cache reuse.
+//
+// The key is derived from: affinity_key, model, use_case, required_caps,
+// priority, input budget class, and output budget class.
+func (r *RoutingRequest) StickyKey() string {
+	inputTokens := r.estimateRoutingInputTokens()
+	inClass := inputBudgetClass(inputTokens)
+	outClass := outputBudgetClass(r.ExpectedOutput)
+
+	data := fmt.Sprintf("%s|%s|%s|%d|%d|%s|%s",
+		r.AffinityKey,
+		r.Model,
+		r.UseCase,
+		r.RequiredCaps,
+		r.Priority,
+		inClass,
+		outClass,
+	)
+
+	hash := sha256.Sum256([]byte(data))
+	// Return first 128 bits (16 bytes) as hex.
+	return fmt.Sprintf("%x", hash[:16])
+}
+
+// ---------------------------------------------------------------------------
+// Token estimation
+// ---------------------------------------------------------------------------
+
+// estimateRoutingInputTokens provides a rough estimate of the total input
+// tokens across all text-bearing fields of the routing request. It uses the
+// package-level estimateTokens heuristic (len/4).
+func (r *RoutingRequest) estimateRoutingInputTokens() int {
+	total := 0
+	for _, m := range r.Messages {
+		total += estimateTokens(m.Content)
+	}
+	total += estimateTokens(r.Prompt)
+	total += estimateTokens(r.System)
+	total += estimateTokens(r.Suffix)
+	for _, s := range r.Input {
+		total += estimateTokens(s)
+	}
+	return total
+}

--- a/provider/routing_request.go
+++ b/provider/routing_request.go
@@ -182,17 +182,22 @@ func outputBudgetClass(tokens int) string {
 //
 // The key is derived from: affinity_key, model, use_case, required_caps,
 // priority, input budget class, and output budget class.
-func (r *RoutingRequest) StickyKey() string {
-	inputTokens := r.estimateRoutingInputTokens()
+func StickyKey(req RoutingRequest) string {
+	expectedOut := req.ExpectedOutput
+	if expectedOut == 0 {
+		expectedOut = DefaultExpectedOutput(req.UseCase)
+	}
+
+	inputTokens := estimateRoutingInputTokens(req)
 	inClass := inputBudgetClass(inputTokens)
-	outClass := outputBudgetClass(r.ExpectedOutput)
+	outClass := outputBudgetClass(expectedOut)
 
 	data := fmt.Sprintf("%s|%s|%s|%d|%d|%s|%s",
-		r.AffinityKey,
-		r.Model,
-		r.UseCase,
-		r.RequiredCaps,
-		r.Priority,
+		req.AffinityKey,
+		req.Model,
+		req.UseCase,
+		req.RequiredCaps,
+		req.Priority,
 		inClass,
 		outClass,
 	)
@@ -209,15 +214,15 @@ func (r *RoutingRequest) StickyKey() string {
 // estimateRoutingInputTokens provides a rough estimate of the total input
 // tokens across all text-bearing fields of the routing request. It uses the
 // package-level estimateTokens heuristic (len/4).
-func (r *RoutingRequest) estimateRoutingInputTokens() int {
+func estimateRoutingInputTokens(req RoutingRequest) int {
 	total := 0
-	for _, m := range r.Messages {
+	for _, m := range req.Messages {
 		total += estimateTokens(m.Content)
 	}
-	total += estimateTokens(r.Prompt)
-	total += estimateTokens(r.System)
-	total += estimateTokens(r.Suffix)
-	for _, s := range r.Input {
+	total += estimateTokens(req.Prompt)
+	total += estimateTokens(req.System)
+	total += estimateTokens(req.Suffix)
+	for _, s := range req.Input {
 		total += estimateTokens(s)
 	}
 	return total

--- a/provider/routing_request_test.go
+++ b/provider/routing_request_test.go
@@ -87,8 +87,8 @@ func TestStickyKeyDeterminism(t *testing.T) {
 		ExpectedOutput: 2048,
 	}
 
-	key1 := req.StickyKey()
-	key2 := req.StickyKey()
+	key1 := StickyKey(req)
+	key2 := StickyKey(req)
 
 	if key1 == "" {
 		t.Fatal("StickyKey() returned empty string")
@@ -111,26 +111,26 @@ func TestStickyKeyDiffers(t *testing.T) {
 		ExpectedOutput: 2048,
 	}
 
-	baseKey := base.StickyKey()
+	baseKey := StickyKey(base)
 
 	// Different AffinityKey
 	diffAffinity := base
 	diffAffinity.AffinityKey = "session-456"
-	if diffAffinity.StickyKey() == baseKey {
+	if StickyKey(diffAffinity) == baseKey {
 		t.Error("different AffinityKey should produce different StickyKey")
 	}
 
 	// Different Priority
 	diffPriority := base
 	diffPriority.Priority = PriorityCritical
-	if diffPriority.StickyKey() == baseKey {
+	if StickyKey(diffPriority) == baseKey {
 		t.Error("different Priority should produce different StickyKey")
 	}
 
 	// Different UseCase
 	diffUseCase := base
 	diffUseCase.UseCase = "fim"
-	if diffUseCase.StickyKey() == baseKey {
+	if StickyKey(diffUseCase) == baseKey {
 		t.Error("different UseCase should produce different StickyKey")
 	}
 }
@@ -194,7 +194,7 @@ func TestEstimateRoutingInputTokens(t *testing.T) {
 				{Role: "user", Content: "hello world test message here"},
 			},
 		}
-		tokens := req.estimateRoutingInputTokens()
+		tokens := estimateRoutingInputTokens(req)
 		if tokens <= 0 {
 			t.Errorf("expected positive token count, got %d", tokens)
 		}
@@ -204,7 +204,7 @@ func TestEstimateRoutingInputTokens(t *testing.T) {
 		req := RoutingRequest{
 			Prompt: "generate some code for me please",
 		}
-		tokens := req.estimateRoutingInputTokens()
+		tokens := estimateRoutingInputTokens(req)
 		if tokens <= 0 {
 			t.Errorf("expected positive token count, got %d", tokens)
 		}
@@ -214,7 +214,7 @@ func TestEstimateRoutingInputTokens(t *testing.T) {
 		req := RoutingRequest{
 			System: "you are a helpful assistant",
 		}
-		tokens := req.estimateRoutingInputTokens()
+		tokens := estimateRoutingInputTokens(req)
 		if tokens <= 0 {
 			t.Errorf("expected positive token count, got %d", tokens)
 		}
@@ -224,7 +224,7 @@ func TestEstimateRoutingInputTokens(t *testing.T) {
 		req := RoutingRequest{
 			Suffix: "some suffix content here for FIM",
 		}
-		tokens := req.estimateRoutingInputTokens()
+		tokens := estimateRoutingInputTokens(req)
 		if tokens <= 0 {
 			t.Errorf("expected positive token count, got %d", tokens)
 		}
@@ -234,7 +234,7 @@ func TestEstimateRoutingInputTokens(t *testing.T) {
 		req := RoutingRequest{
 			Input: []string{"text to embed number one", "text to embed number two"},
 		}
-		tokens := req.estimateRoutingInputTokens()
+		tokens := estimateRoutingInputTokens(req)
 		if tokens <= 0 {
 			t.Errorf("expected positive token count, got %d", tokens)
 		}
@@ -242,7 +242,7 @@ func TestEstimateRoutingInputTokens(t *testing.T) {
 
 	t.Run("empty request returns zero", func(t *testing.T) {
 		req := RoutingRequest{}
-		tokens := req.estimateRoutingInputTokens()
+		tokens := estimateRoutingInputTokens(req)
 		if tokens != 0 {
 			t.Errorf("expected 0 tokens for empty request, got %d", tokens)
 		}
@@ -259,16 +259,16 @@ func TestEstimateRoutingInputTokens(t *testing.T) {
 			Suffix: "suffix text",
 			Input:  []string{"embed this"},
 		}
-		tokens := req.estimateRoutingInputTokens()
+		tokens := estimateRoutingInputTokens(req)
 
 		// Each field alone should contribute less than all combined.
 		msgOnly := RoutingRequest{Messages: req.Messages}
 		promptOnly := RoutingRequest{Prompt: req.Prompt}
 
-		if tokens <= msgOnly.estimateRoutingInputTokens() {
+		if tokens <= estimateRoutingInputTokens(msgOnly) {
 			t.Error("combined should be greater than messages alone")
 		}
-		if tokens <= promptOnly.estimateRoutingInputTokens() {
+		if tokens <= estimateRoutingInputTokens(promptOnly) {
 			t.Error("combined should be greater than prompt alone")
 		}
 	})

--- a/provider/routing_request_test.go
+++ b/provider/routing_request_test.go
@@ -1,0 +1,275 @@
+package provider
+
+import (
+	"testing"
+)
+
+func TestPriorityString(t *testing.T) {
+	tests := []struct {
+		name     string
+		priority Priority
+		want     string
+	}{
+		{name: "background", priority: PriorityBackground, want: "background"},
+		{name: "normal", priority: PriorityNormal, want: "normal"},
+		{name: "high", priority: PriorityHigh, want: "high"},
+		{name: "critical", priority: PriorityCritical, want: "critical"},
+		{name: "unknown", priority: Priority(99), want: "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.priority.String()
+			if got != tt.want {
+				t.Errorf("Priority(%d).String() = %q, want %q", tt.priority, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRouteKindString(t *testing.T) {
+	tests := []struct {
+		name string
+		kind RouteKind
+		want string
+	}{
+		{name: "chat", kind: RouteKindChat, want: "chat"},
+		{name: "generate", kind: RouteKindGenerate, want: "generate"},
+		{name: "embed", kind: RouteKindEmbed, want: "embed"},
+		{name: "unknown", kind: RouteKind(99), want: "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.kind.String()
+			if got != tt.want {
+				t.Errorf("RouteKind(%d).String() = %q, want %q", tt.kind, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultExpectedOutput(t *testing.T) {
+	tests := []struct {
+		name    string
+		useCase string
+		want    int
+	}{
+		{name: "fim", useCase: "fim", want: 200},
+		{name: "chat", useCase: "chat", want: 2048},
+		{name: "embedding", useCase: "embedding", want: 0},
+		{name: "code-review", useCase: "code-review", want: 4096},
+		{name: "reasoning", useCase: "reasoning", want: 4096},
+		{name: "unknown falls back to chat default", useCase: "unknown", want: 2048},
+		{name: "empty falls back to chat default", useCase: "", want: 2048},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DefaultExpectedOutput(tt.useCase)
+			if got != tt.want {
+				t.Errorf("DefaultExpectedOutput(%q) = %d, want %d", tt.useCase, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStickyKeyDeterminism(t *testing.T) {
+	req := RoutingRequest{
+		AffinityKey:  "session-123",
+		Model:        "qwen3:8b",
+		UseCase:      "chat",
+		RequiredCaps: CapChat | CapStream,
+		Priority:     PriorityNormal,
+		Messages: []ChatMessage{
+			{Role: "user", Content: "hello world, this is a test message"},
+		},
+		ExpectedOutput: 2048,
+	}
+
+	key1 := req.StickyKey()
+	key2 := req.StickyKey()
+
+	if key1 == "" {
+		t.Fatal("StickyKey() returned empty string")
+	}
+	if key1 != key2 {
+		t.Errorf("StickyKey() not deterministic: %q != %q", key1, key2)
+	}
+}
+
+func TestStickyKeyDiffers(t *testing.T) {
+	base := RoutingRequest{
+		AffinityKey:  "session-123",
+		Model:        "qwen3:8b",
+		UseCase:      "chat",
+		RequiredCaps: CapChat | CapStream,
+		Priority:     PriorityNormal,
+		Messages: []ChatMessage{
+			{Role: "user", Content: "hello world, this is a test message"},
+		},
+		ExpectedOutput: 2048,
+	}
+
+	baseKey := base.StickyKey()
+
+	// Different AffinityKey
+	diffAffinity := base
+	diffAffinity.AffinityKey = "session-456"
+	if diffAffinity.StickyKey() == baseKey {
+		t.Error("different AffinityKey should produce different StickyKey")
+	}
+
+	// Different Priority
+	diffPriority := base
+	diffPriority.Priority = PriorityCritical
+	if diffPriority.StickyKey() == baseKey {
+		t.Error("different Priority should produce different StickyKey")
+	}
+
+	// Different UseCase
+	diffUseCase := base
+	diffUseCase.UseCase = "fim"
+	if diffUseCase.StickyKey() == baseKey {
+		t.Error("different UseCase should produce different StickyKey")
+	}
+}
+
+func TestInputBudgetClass(t *testing.T) {
+	tests := []struct {
+		name   string
+		tokens int
+		want   string
+	}{
+		{name: "zero", tokens: 0, want: "small"},
+		{name: "1000", tokens: 1000, want: "small"},
+		{name: "2047", tokens: 2047, want: "small"},
+		{name: "2048 boundary", tokens: 2048, want: "medium"},
+		{name: "5000", tokens: 5000, want: "medium"},
+		{name: "8191", tokens: 8191, want: "medium"},
+		{name: "8192 boundary", tokens: 8192, want: "large"},
+		{name: "100000", tokens: 100000, want: "large"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := inputBudgetClass(tt.tokens)
+			if got != tt.want {
+				t.Errorf("inputBudgetClass(%d) = %q, want %q", tt.tokens, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOutputBudgetClass(t *testing.T) {
+	tests := []struct {
+		name   string
+		tokens int
+		want   string
+	}{
+		{name: "zero", tokens: 0, want: "small"},
+		{name: "200", tokens: 200, want: "small"},
+		{name: "511", tokens: 511, want: "small"},
+		{name: "512 boundary", tokens: 512, want: "medium"},
+		{name: "1000", tokens: 1000, want: "medium"},
+		{name: "2047", tokens: 2047, want: "medium"},
+		{name: "2048 boundary", tokens: 2048, want: "large"},
+		{name: "10000", tokens: 10000, want: "large"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := outputBudgetClass(tt.tokens)
+			if got != tt.want {
+				t.Errorf("outputBudgetClass(%d) = %q, want %q", tt.tokens, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEstimateRoutingInputTokens(t *testing.T) {
+	t.Run("messages contribute tokens", func(t *testing.T) {
+		req := RoutingRequest{
+			Messages: []ChatMessage{
+				{Role: "user", Content: "hello world test message here"},
+			},
+		}
+		tokens := req.estimateRoutingInputTokens()
+		if tokens <= 0 {
+			t.Errorf("expected positive token count, got %d", tokens)
+		}
+	})
+
+	t.Run("prompt contributes tokens", func(t *testing.T) {
+		req := RoutingRequest{
+			Prompt: "generate some code for me please",
+		}
+		tokens := req.estimateRoutingInputTokens()
+		if tokens <= 0 {
+			t.Errorf("expected positive token count, got %d", tokens)
+		}
+	})
+
+	t.Run("system contributes tokens", func(t *testing.T) {
+		req := RoutingRequest{
+			System: "you are a helpful assistant",
+		}
+		tokens := req.estimateRoutingInputTokens()
+		if tokens <= 0 {
+			t.Errorf("expected positive token count, got %d", tokens)
+		}
+	})
+
+	t.Run("suffix contributes tokens", func(t *testing.T) {
+		req := RoutingRequest{
+			Suffix: "some suffix content here for FIM",
+		}
+		tokens := req.estimateRoutingInputTokens()
+		if tokens <= 0 {
+			t.Errorf("expected positive token count, got %d", tokens)
+		}
+	})
+
+	t.Run("input strings contribute tokens", func(t *testing.T) {
+		req := RoutingRequest{
+			Input: []string{"text to embed number one", "text to embed number two"},
+		}
+		tokens := req.estimateRoutingInputTokens()
+		if tokens <= 0 {
+			t.Errorf("expected positive token count, got %d", tokens)
+		}
+	})
+
+	t.Run("empty request returns zero", func(t *testing.T) {
+		req := RoutingRequest{}
+		tokens := req.estimateRoutingInputTokens()
+		if tokens != 0 {
+			t.Errorf("expected 0 tokens for empty request, got %d", tokens)
+		}
+	})
+
+	t.Run("all fields accumulate", func(t *testing.T) {
+		req := RoutingRequest{
+			Messages: []ChatMessage{
+				{Role: "system", Content: "you are helpful"},
+				{Role: "user", Content: "hello world"},
+			},
+			Prompt: "some prompt",
+			System: "system text",
+			Suffix: "suffix text",
+			Input:  []string{"embed this"},
+		}
+		tokens := req.estimateRoutingInputTokens()
+
+		// Each field alone should contribute less than all combined.
+		msgOnly := RoutingRequest{Messages: req.Messages}
+		promptOnly := RoutingRequest{Prompt: req.Prompt}
+
+		if tokens <= msgOnly.estimateRoutingInputTokens() {
+			t.Error("combined should be greater than messages alone")
+		}
+		if tokens <= promptOnly.estimateRoutingInputTokens() {
+			t.Error("combined should be greater than prompt alone")
+		}
+	})
+}

--- a/provider/token_budget.go
+++ b/provider/token_budget.go
@@ -118,6 +118,17 @@ func (v *TokenBudgetValidator) Validate(req RoutingRequest, profile *ModelProfil
 	expectedOut := v.expectedOutput(req)
 	effectiveCtx := profile.EffectiveContextWindow(req.UseCase)
 
+	// Guard: a zero or negative effective context means the profile is
+	// misconfigured or uninitialized. Reject with a clear reason.
+	if effectiveCtx <= 0 {
+		return BudgetResult{
+			Decision:      BudgetReject,
+			RequestTokens: inputTokens,
+			BudgetTokens:  0,
+			Reason:        "model has no context window configured",
+		}
+	}
+
 	// Budget is the context window minus the reserved output tokens, clamped to 0.
 	budget := effectiveCtx - expectedOut
 	if budget < 0 {
@@ -130,8 +141,6 @@ func (v *TokenBudgetValidator) Validate(req RoutingRequest, profile *ModelProfil
 			Decision:      BudgetReject,
 			RequestTokens: inputTokens,
 			BudgetTokens:  0,
-			HeadroomPct:   0,
-			HeadroomScore: 0,
 			Reason:        "output budget exceeds context window",
 		}
 	}

--- a/provider/token_budget.go
+++ b/provider/token_budget.go
@@ -1,0 +1,191 @@
+// token_budget.go validates whether a routing request fits within a candidate
+// model's context window. It produces a BudgetResult with a decision (OK,
+// Truncate, Reject), headroom metrics, and a human-readable reason. The
+// HeadroomScore feeds into candidate scoring: 1.0 at <50% utilization,
+// linear drop to 0.0 at 100%.
+package provider
+
+import "fmt"
+
+// ---------------------------------------------------------------------------
+// BudgetDecision
+// ---------------------------------------------------------------------------
+
+// BudgetDecision indicates whether a routing request fits within the
+// candidate model's context budget.
+type BudgetDecision int
+
+const (
+	// BudgetOK means the request fits within the model's context budget.
+	BudgetOK BudgetDecision = iota
+	// BudgetTruncate means the request can fit if the input is trimmed.
+	BudgetTruncate
+	// BudgetReject means the request cannot fit in the model's context.
+	BudgetReject
+)
+
+// String returns the human-readable name of the budget decision.
+func (d BudgetDecision) String() string {
+	switch d {
+	case BudgetOK:
+		return "ok"
+	case BudgetTruncate:
+		return "truncate"
+	case BudgetReject:
+		return "reject"
+	default:
+		return "unknown"
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BudgetResult
+// ---------------------------------------------------------------------------
+
+// BudgetResult holds the outcome of a token budget validation. It includes
+// the decision, the token counts, headroom metrics, and a human-readable
+// reason explaining the decision.
+type BudgetResult struct {
+	// Decision is the routing outcome: OK, Truncate, or Reject.
+	Decision BudgetDecision
+	// RequestTokens is the estimated input token count for the request.
+	RequestTokens int
+	// BudgetTokens is the available input budget (context window minus
+	// reserved output tokens).
+	BudgetTokens int
+	// HeadroomPct is the fraction of budget remaining (0.0–1.0).
+	HeadroomPct float64
+	// HeadroomScore is a quality-weighted score: 1.0 at <50% utilization,
+	// linear drop to 0.0 at 100% utilization.
+	HeadroomScore float64
+	// Reason is a human-readable explanation of the decision.
+	Reason string
+}
+
+// ---------------------------------------------------------------------------
+// TokenBudgetValidator
+// ---------------------------------------------------------------------------
+
+// TokenBudgetValidator checks whether a RoutingRequest fits within a
+// ModelProfile's effective context window. It reserves output tokens per
+// use case and computes headroom metrics for candidate scoring.
+type TokenBudgetValidator struct {
+	outputDefaults map[string]int
+}
+
+// BudgetOption configures a TokenBudgetValidator.
+type BudgetOption func(*TokenBudgetValidator)
+
+// WithOutputDefault sets a custom default output token reservation for a
+// specific use case. This overrides the built-in default from
+// DefaultExpectedOutput.
+func WithOutputDefault(useCase string, tokens int) BudgetOption {
+	return func(v *TokenBudgetValidator) {
+		v.outputDefaults[useCase] = tokens
+	}
+}
+
+// NewTokenBudgetValidator creates a TokenBudgetValidator with the given
+// options. Without options the validator uses DefaultExpectedOutput for
+// output token reservations.
+func NewTokenBudgetValidator(opts ...BudgetOption) *TokenBudgetValidator {
+	v := &TokenBudgetValidator{
+		outputDefaults: make(map[string]int),
+	}
+	for _, opt := range opts {
+		opt(v)
+	}
+	return v
+}
+
+// expectedOutput returns the output token reservation for the given use case.
+// It checks, in order: the request's ExpectedOutput field, custom defaults
+// set via WithOutputDefault, and finally the package-level DefaultExpectedOutput.
+func (v *TokenBudgetValidator) expectedOutput(req RoutingRequest) int {
+	if req.ExpectedOutput > 0 {
+		return req.ExpectedOutput
+	}
+	if tokens, ok := v.outputDefaults[req.UseCase]; ok {
+		return tokens
+	}
+	return DefaultExpectedOutput(req.UseCase)
+}
+
+// Validate checks whether req fits within profile's effective context window
+// and returns a BudgetResult with the decision and headroom metrics.
+func (v *TokenBudgetValidator) Validate(req RoutingRequest, profile *ModelProfile) BudgetResult {
+	inputTokens := estimateRoutingInputTokens(req)
+	expectedOut := v.expectedOutput(req)
+	effectiveCtx := profile.EffectiveContextWindow(req.UseCase)
+
+	// Budget is the context window minus the reserved output tokens, clamped to 0.
+	budget := effectiveCtx - expectedOut
+	if budget < 0 {
+		budget = 0
+	}
+
+	// If there is no budget at all, reject immediately.
+	if budget == 0 {
+		return BudgetResult{
+			Decision:      BudgetReject,
+			RequestTokens: inputTokens,
+			BudgetTokens:  0,
+			HeadroomPct:   0,
+			HeadroomScore: 0,
+			Reason:        "output budget exceeds context window",
+		}
+	}
+
+	// Compute utilization and headroom.
+	utilization := float64(inputTokens) / float64(budget)
+
+	headroomPct := 1.0 - utilization
+	if headroomPct < 0 {
+		headroomPct = 0
+	}
+
+	headroomScore := computeHeadroomScore(utilization)
+
+	// Decide.
+	var decision BudgetDecision
+	var reason string
+
+	switch {
+	case inputTokens <= budget:
+		decision = BudgetOK
+		reason = fmt.Sprintf("input %d tokens fits within %d budget (%.0f%% utilization)",
+			inputTokens, budget, utilization*100)
+	case float64(inputTokens) < float64(budget)*1.5:
+		decision = BudgetTruncate
+		reason = fmt.Sprintf("input %d tokens exceeds %d budget but can be truncated (%.0f%% utilization)",
+			inputTokens, budget, utilization*100)
+	default:
+		decision = BudgetReject
+		reason = fmt.Sprintf("input %d tokens far exceeds %d budget (%.0f%% utilization)",
+			inputTokens, budget, utilization*100)
+	}
+
+	return BudgetResult{
+		Decision:      decision,
+		RequestTokens: inputTokens,
+		BudgetTokens:  budget,
+		HeadroomPct:   headroomPct,
+		HeadroomScore: headroomScore,
+		Reason:        reason,
+	}
+}
+
+// computeHeadroomScore maps utilization to a quality score:
+//   - utilization <= 0.5 → 1.0
+//   - utilization >= 1.0 → 0.0
+//   - between → linear: 2.0 * (1.0 - utilization)
+func computeHeadroomScore(utilization float64) float64 {
+	switch {
+	case utilization <= 0.5:
+		return 1.0
+	case utilization >= 1.0:
+		return 0.0
+	default:
+		return 2.0 * (1.0 - utilization)
+	}
+}

--- a/provider/token_budget_test.go
+++ b/provider/token_budget_test.go
@@ -263,3 +263,17 @@ func TestTokenBudgetWithOutputDefault(t *testing.T) {
 		t.Errorf("expected BudgetTokens = %d, got %d", expectedBudget, result.BudgetTokens)
 	}
 }
+
+func TestTokenBudgetZeroContextWindow(t *testing.T) {
+	v := NewTokenBudgetValidator()
+	profile := &ModelProfile{ContextWindow: 0}
+	req := RoutingRequest{UseCase: "chat", Prompt: "hello"}
+
+	result := v.Validate(req, profile)
+	if result.Decision != BudgetReject {
+		t.Errorf("Decision = %v, want BudgetReject for zero context window", result.Decision)
+	}
+	if result.Reason != "model has no context window configured" {
+		t.Errorf("Reason = %q, want 'model has no context window configured'", result.Reason)
+	}
+}

--- a/provider/token_budget_test.go
+++ b/provider/token_budget_test.go
@@ -1,0 +1,265 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// BudgetDecision.String
+// ---------------------------------------------------------------------------
+
+func TestBudgetDecisionString(t *testing.T) {
+	tests := []struct {
+		d    BudgetDecision
+		want string
+	}{
+		{BudgetOK, "ok"},
+		{BudgetTruncate, "truncate"},
+		{BudgetReject, "reject"},
+		{BudgetDecision(99), "unknown"},
+	}
+	for _, tt := range tests {
+		if got := tt.d.String(); got != tt.want {
+			t.Errorf("BudgetDecision(%d).String() = %q, want %q", tt.d, got, tt.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TokenBudgetValidator tests
+// ---------------------------------------------------------------------------
+
+func TestTokenBudgetValidateOK(t *testing.T) {
+	v := NewTokenBudgetValidator()
+	req := RoutingRequest{
+		UseCase: "chat",
+		Prompt:  "Hello, how are you?", // ~5 tokens
+	}
+	profile := &ModelProfile{
+		ContextWindow: 32768,
+	}
+
+	result := v.Validate(req, profile)
+
+	if result.Decision != BudgetOK {
+		t.Errorf("expected BudgetOK, got %v (reason: %s)", result.Decision, result.Reason)
+	}
+	if result.HeadroomScore < 0.9 {
+		t.Errorf("expected HeadroomScore > 0.9 for short prompt in 32K context, got %f", result.HeadroomScore)
+	}
+	if result.BudgetTokens != 32768-2048 {
+		t.Errorf("expected BudgetTokens = %d, got %d", 32768-2048, result.BudgetTokens)
+	}
+}
+
+func TestTokenBudgetValidateReject(t *testing.T) {
+	v := NewTokenBudgetValidator()
+	// 8000 chars ≈ 2000 tokens (len/4 estimation)
+	largePrompt := strings.Repeat("x", 8000)
+	req := RoutingRequest{
+		UseCase: "chat",
+		Prompt:  largePrompt,
+	}
+	profile := &ModelProfile{
+		ContextWindow: 1024,
+	}
+
+	result := v.Validate(req, profile)
+
+	if result.Decision != BudgetReject {
+		t.Errorf("expected BudgetReject, got %v (reason: %s)", result.Decision, result.Reason)
+	}
+}
+
+func TestTokenBudgetValidateTruncate(t *testing.T) {
+	v := NewTokenBudgetValidator()
+	// 9000 chars ≈ 2250 tokens (len/4)
+	// chat default output = 2048, so budget = 4096 - 2048 = 2048
+	// 2250 > 2048 (budget) but 2250 < 2048*1.5=3072 → BudgetTruncate
+	mediumPrompt := strings.Repeat("x", 9000)
+	req := RoutingRequest{
+		UseCase: "chat",
+		Prompt:  mediumPrompt,
+	}
+	profile := &ModelProfile{
+		ContextWindow: 4096,
+	}
+
+	result := v.Validate(req, profile)
+
+	if result.Decision != BudgetTruncate {
+		t.Errorf("expected BudgetTruncate, got %v (reason: %s)", result.Decision, result.Reason)
+	}
+}
+
+func TestTokenBudgetPerUseCaseOutput(t *testing.T) {
+	v := NewTokenBudgetValidator()
+	contextWindow := 32768
+
+	tests := []struct {
+		useCase       string
+		expectedBudget int
+	}{
+		{"fim", contextWindow - 200},
+		{"chat", contextWindow - 2048},
+		{"embedding", contextWindow - 0},
+		{"code-review", contextWindow - 4096},
+		{"reasoning", contextWindow - 4096},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.useCase, func(t *testing.T) {
+			req := RoutingRequest{
+				UseCase: tt.useCase,
+				Prompt:  "test",
+			}
+			profile := &ModelProfile{
+				ContextWindow: contextWindow,
+			}
+			result := v.Validate(req, profile)
+			if result.BudgetTokens != tt.expectedBudget {
+				t.Errorf("useCase=%q: BudgetTokens = %d, want %d", tt.useCase, result.BudgetTokens, tt.expectedBudget)
+			}
+		})
+	}
+}
+
+func TestTokenBudgetExplicitExpectedOutput(t *testing.T) {
+	v := NewTokenBudgetValidator()
+	req := RoutingRequest{
+		UseCase:        "chat",
+		Prompt:         "hello",
+		ExpectedOutput: 8192,
+	}
+	profile := &ModelProfile{
+		ContextWindow: 32768,
+	}
+
+	result := v.Validate(req, profile)
+
+	expectedBudget := 32768 - 8192
+	if result.BudgetTokens != expectedBudget {
+		t.Errorf("expected BudgetTokens = %d, got %d", expectedBudget, result.BudgetTokens)
+	}
+	if result.Decision != BudgetOK {
+		t.Errorf("expected BudgetOK, got %v", result.Decision)
+	}
+}
+
+func TestTokenBudgetQualityCtxCeiling(t *testing.T) {
+	v := NewTokenBudgetValidator()
+	profile := &ModelProfile{
+		ContextWindow:     131072,
+		QualityCtxCeiling: 32768,
+	}
+
+	// Chat is quality-sensitive → uses ceiling (32768)
+	chatReq := RoutingRequest{
+		UseCase: "chat",
+		Prompt:  "hello",
+	}
+	chatResult := v.Validate(chatReq, profile)
+	expectedChatBudget := 32768 - 2048
+	if chatResult.BudgetTokens != expectedChatBudget {
+		t.Errorf("chat: BudgetTokens = %d, want %d", chatResult.BudgetTokens, expectedChatBudget)
+	}
+
+	// FIM is not quality-sensitive → uses full window (131072)
+	fimReq := RoutingRequest{
+		UseCase: "fim",
+		Prompt:  "hello",
+	}
+	fimResult := v.Validate(fimReq, profile)
+	expectedFIMBudget := 131072 - 200
+	if fimResult.BudgetTokens != expectedFIMBudget {
+		t.Errorf("fim: BudgetTokens = %d, want %d", fimResult.BudgetTokens, expectedFIMBudget)
+	}
+}
+
+func TestTokenBudgetHeadroomScore(t *testing.T) {
+	tests := []struct {
+		name    string
+		util    float64 // target utilization
+		wantMin float64
+		wantMax float64
+	}{
+		{"10pct", 0.10, 0.99, 1.0},
+		{"40pct", 0.40, 0.99, 1.0},
+		{"75pct", 0.75, 0.40, 0.60},
+		{"95pct", 0.95, 0.0, 0.15},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Build a scenario that produces the desired utilization.
+			// budget = contextWindow - expectedOutput
+			// We use embedding (expectedOutput=0) so budget = contextWindow.
+			// utilization = inputTokens / budget
+			// inputTokens = estimateTokens(prompt) = len(prompt)/4
+			// We want: len(prompt)/4 / contextWindow = tt.util
+			// So: len(prompt) = tt.util * contextWindow * 4
+			contextWindow := 10000
+			promptLen := int(tt.util * float64(contextWindow) * 4)
+			if promptLen < 1 {
+				promptLen = 1
+			}
+			prompt := strings.Repeat("x", promptLen)
+
+			v := NewTokenBudgetValidator()
+			req := RoutingRequest{
+				UseCase: "embedding",
+				Prompt:  prompt,
+			}
+			profile := &ModelProfile{
+				ContextWindow: contextWindow,
+			}
+
+			result := v.Validate(req, profile)
+
+			if result.HeadroomScore < tt.wantMin || result.HeadroomScore > tt.wantMax {
+				t.Errorf("util=%.2f: HeadroomScore = %f, want [%f, %f]",
+					tt.util, result.HeadroomScore, tt.wantMin, tt.wantMax)
+			}
+		})
+	}
+}
+
+func TestTokenBudgetOutputExceedsContext(t *testing.T) {
+	v := NewTokenBudgetValidator()
+	req := RoutingRequest{
+		UseCase:        "chat",
+		Prompt:         "hello",
+		ExpectedOutput: 50000, // bigger than context window
+	}
+	profile := &ModelProfile{
+		ContextWindow: 4096,
+	}
+
+	result := v.Validate(req, profile)
+
+	if result.Decision != BudgetReject {
+		t.Errorf("expected BudgetReject when output exceeds context, got %v", result.Decision)
+	}
+	if result.BudgetTokens != 0 {
+		t.Errorf("expected BudgetTokens = 0, got %d", result.BudgetTokens)
+	}
+}
+
+func TestTokenBudgetWithOutputDefault(t *testing.T) {
+	v := NewTokenBudgetValidator(WithOutputDefault("custom-task", 512))
+	req := RoutingRequest{
+		UseCase: "custom-task",
+		Prompt:  "hello",
+	}
+	profile := &ModelProfile{
+		ContextWindow: 32768,
+	}
+
+	result := v.Validate(req, profile)
+
+	expectedBudget := 32768 - 512
+	if result.BudgetTokens != expectedBudget {
+		t.Errorf("expected BudgetTokens = %d, got %d", expectedBudget, result.BudgetTokens)
+	}
+}

--- a/provider/types.go
+++ b/provider/types.go
@@ -177,15 +177,16 @@ type ChatRequest struct {
 
 // ChatResponse is the provider-agnostic response from a chat completion.
 type ChatResponse struct {
-	Model     string      `json:"model"`
-	Provider  string      `json:"provider"`
-	Content   string      `json:"content"`
-	Thinking  string      `json:"thinking,omitempty"`
-	ToolCalls []ToolCall  `json:"tool_calls,omitempty"`
-	Done      bool        `json:"done"`
-	Partial   bool        `json:"partial,omitempty"`
-	Usage     Usage       `json:"usage,omitempty"`
-	Latency   LatencyInfo `json:"latency,omitempty"`
+	Model        string        `json:"model"`
+	Provider     string        `json:"provider"`
+	Content      string        `json:"content"`
+	Thinking     string        `json:"thinking,omitempty"`
+	ToolCalls    []ToolCall    `json:"tool_calls,omitempty"`
+	Done         bool          `json:"done"`
+	Partial      bool          `json:"partial,omitempty"`
+	Usage        Usage         `json:"usage,omitempty"`
+	Latency      LatencyInfo   `json:"latency,omitempty"`
+	RouteOutcome *RouteOutcome `json:"route_outcome,omitempty"`
 }
 
 // ---------------------------------------------------------------------------
@@ -204,14 +205,15 @@ type GenerateRequest struct {
 
 // GenerateResponse is the provider-agnostic response from text generation.
 type GenerateResponse struct {
-	Model      string                `json:"model"`
-	Provider   string                `json:"provider"`
-	Response   string                `json:"response"`
-	Done       bool                  `json:"done"`
-	Partial    bool                  `json:"partial,omitempty"`
-	Usage      Usage                 `json:"usage,omitempty"`
-	Latency    LatencyInfo           `json:"latency,omitempty"`
-	Confidence *CompletionConfidence `json:"confidence,omitempty"`
+	Model        string                `json:"model"`
+	Provider     string                `json:"provider"`
+	Response     string                `json:"response"`
+	Done         bool                  `json:"done"`
+	Partial      bool                  `json:"partial,omitempty"`
+	Usage        Usage                 `json:"usage,omitempty"`
+	Latency      LatencyInfo           `json:"latency,omitempty"`
+	Confidence   *CompletionConfidence `json:"confidence,omitempty"`
+	RouteOutcome *RouteOutcome         `json:"route_outcome,omitempty"`
 }
 
 // ---------------------------------------------------------------------------
@@ -226,10 +228,11 @@ type EmbedRequest struct {
 
 // EmbedResponse is the provider-agnostic response from embedding generation.
 type EmbedResponse struct {
-	Model      string      `json:"model"`
-	Provider   string      `json:"provider"`
-	Embeddings [][]float64 `json:"embeddings"`
-	Usage      Usage       `json:"usage,omitempty"`
+	Model        string        `json:"model"`
+	Provider     string        `json:"provider"`
+	Embeddings   [][]float64   `json:"embeddings"`
+	Usage        Usage         `json:"usage,omitempty"`
+	RouteOutcome *RouteOutcome `json:"route_outcome,omitempty"`
 }
 
 // ---------------------------------------------------------------------------
@@ -369,6 +372,23 @@ type CompletionConfidence struct {
 	AvgLogProb float64 `json:"avg_log_prob"`
 	MinLogProb float64 `json:"min_log_prob"`
 	DropOffIdx int     `json:"drop_off_idx"`
+}
+
+// ---------------------------------------------------------------------------
+// Route outcome
+// ---------------------------------------------------------------------------
+
+// RouteOutcome captures the Router's decision metadata for a request.
+// It records which model was originally planned, which model actually served
+// the request (after any fallbacks), and scoring information. This is attached
+// to response types so callers can observe routing decisions.
+type RouteOutcome struct {
+	PlannedModel  ModelKey `json:"planned_model"`
+	ActualModel   ModelKey `json:"actual_model"`
+	FallbacksUsed int      `json:"fallbacks_used"`
+	WasSticky     bool     `json:"was_sticky"`
+	Score         float64  `json:"score"`
+	Reason        string   `json:"reason"`
 }
 
 // ---------------------------------------------------------------------------

--- a/provider/types_test.go
+++ b/provider/types_test.go
@@ -287,3 +287,128 @@ func TestCompletionConfidence(t *testing.T) {
 		t.Errorf("DropOffIdx = %d, want 42", cc.DropOffIdx)
 	}
 }
+
+func TestRouteOutcomeOnChatResponse(t *testing.T) {
+	outcome := &RouteOutcome{
+		PlannedModel:  ModelKey{Provider: "ollama", Model: "qwen3:32b"},
+		ActualModel:   ModelKey{Provider: "ollama", Model: "qwen3:8b"},
+		FallbacksUsed: 1,
+		WasSticky:     false,
+		Score:         0.85,
+		Reason:        "primary model overloaded, fell back to smaller variant",
+	}
+	resp := ChatResponse{
+		Model:        "qwen3:8b",
+		Provider:     "ollama",
+		Content:      "Hello!",
+		Done:         true,
+		RouteOutcome: outcome,
+	}
+
+	if resp.RouteOutcome == nil {
+		t.Fatal("RouteOutcome should not be nil")
+	}
+	if resp.RouteOutcome.PlannedModel.String() != "ollama/qwen3:32b" {
+		t.Errorf("PlannedModel = %q, want %q", resp.RouteOutcome.PlannedModel.String(), "ollama/qwen3:32b")
+	}
+	if resp.RouteOutcome.ActualModel.String() != "ollama/qwen3:8b" {
+		t.Errorf("ActualModel = %q, want %q", resp.RouteOutcome.ActualModel.String(), "ollama/qwen3:8b")
+	}
+	if resp.RouteOutcome.FallbacksUsed != 1 {
+		t.Errorf("FallbacksUsed = %d, want 1", resp.RouteOutcome.FallbacksUsed)
+	}
+	if resp.RouteOutcome.WasSticky {
+		t.Error("WasSticky should be false")
+	}
+	if resp.RouteOutcome.Score != 0.85 {
+		t.Errorf("Score = %v, want 0.85", resp.RouteOutcome.Score)
+	}
+	if resp.RouteOutcome.Reason != "primary model overloaded, fell back to smaller variant" {
+		t.Errorf("Reason = %q, want %q", resp.RouteOutcome.Reason, "primary model overloaded, fell back to smaller variant")
+	}
+}
+
+func TestRouteOutcomeNilWhenDirectCall(t *testing.T) {
+	// When a response comes from a direct provider call (no Router),
+	// RouteOutcome should be nil on all response types.
+	chat := ChatResponse{
+		Model:    "qwen3:8b",
+		Provider: "ollama",
+		Content:  "Hello!",
+		Done:     true,
+	}
+	if chat.RouteOutcome != nil {
+		t.Error("ChatResponse.RouteOutcome should be nil for direct calls")
+	}
+
+	gen := GenerateResponse{
+		Model:    "qwen3:8b",
+		Provider: "ollama",
+		Response: "generated text",
+		Done:     true,
+	}
+	if gen.RouteOutcome != nil {
+		t.Error("GenerateResponse.RouteOutcome should be nil for direct calls")
+	}
+
+	embed := EmbedResponse{
+		Model:      "nomic-embed-text",
+		Provider:   "ollama",
+		Embeddings: [][]float64{{0.1, 0.2, 0.3}},
+	}
+	if embed.RouteOutcome != nil {
+		t.Error("EmbedResponse.RouteOutcome should be nil for direct calls")
+	}
+}
+
+func TestRouteOutcomeOnGenerateResponse(t *testing.T) {
+	outcome := &RouteOutcome{
+		PlannedModel:  ModelKey{Provider: "ollama", Model: "qwen3:8b"},
+		ActualModel:   ModelKey{Provider: "ollama", Model: "qwen3:8b"},
+		FallbacksUsed: 0,
+		WasSticky:     true,
+		Score:         0.92,
+		Reason:        "model was warm, sticky routing applied",
+	}
+	resp := GenerateResponse{
+		Model:        "qwen3:8b",
+		Provider:     "ollama",
+		Response:     "func main() {}",
+		Done:         true,
+		RouteOutcome: outcome,
+	}
+
+	if resp.RouteOutcome == nil {
+		t.Fatal("RouteOutcome should not be nil")
+	}
+	if resp.RouteOutcome.WasSticky != true {
+		t.Error("WasSticky should be true")
+	}
+	if resp.RouteOutcome.FallbacksUsed != 0 {
+		t.Errorf("FallbacksUsed = %d, want 0", resp.RouteOutcome.FallbacksUsed)
+	}
+}
+
+func TestRouteOutcomeOnEmbedResponse(t *testing.T) {
+	outcome := &RouteOutcome{
+		PlannedModel:  ModelKey{Provider: "ollama", Model: "nomic-embed-text"},
+		ActualModel:   ModelKey{Provider: "ollama", Model: "nomic-embed-text"},
+		FallbacksUsed: 0,
+		WasSticky:     false,
+		Score:         1.0,
+		Reason:        "only embedding model available",
+	}
+	resp := EmbedResponse{
+		Model:        "nomic-embed-text",
+		Provider:     "ollama",
+		Embeddings:   [][]float64{{0.1, 0.2}},
+		RouteOutcome: outcome,
+	}
+
+	if resp.RouteOutcome == nil {
+		t.Fatal("RouteOutcome should not be nil")
+	}
+	if resp.RouteOutcome.Score != 1.0 {
+		t.Errorf("Score = %v, want 1.0", resp.RouteOutcome.Score)
+	}
+}

--- a/provider/warmth.go
+++ b/provider/warmth.go
@@ -1,0 +1,51 @@
+package provider
+
+import "time"
+
+// WarmthSource abstracts warm-model detection across providers. A model is
+// "warm" when it is loaded in the provider's memory and can serve requests
+// without a cold-start delay.
+//
+// Implementations must be safe for concurrent use.
+type WarmthSource interface {
+	// IsWarm reports whether the model identified by key is currently loaded
+	// and has not expired. Returns false for unknown models.
+	IsWarm(key ModelKey) bool
+
+	// WarmthState returns a copy of the warmth information for key, or nil
+	// if the model is unknown. The returned pointer is safe to mutate without
+	// affecting the source's internal state.
+	WarmthState(key ModelKey) *WarmthInfo
+
+	// RecordUse notes that a request was sent to the model, extending its
+	// expiry window. If the model is unknown, a new warm entry is created.
+	RecordUse(key ModelKey)
+
+	// Snapshot returns all currently loaded (warm) models. Cold or expired
+	// models are excluded.
+	Snapshot() []WarmModel
+
+	// Close releases any resources held by the source (background pollers,
+	// connections, etc.). After Close returns, other methods must not be called.
+	Close() error
+}
+
+// WarmModel pairs a model key with its current warmth information.
+type WarmModel struct {
+	Key  ModelKey
+	Info WarmthInfo
+}
+
+// WarmthInfo describes the current warmth state of a model.
+type WarmthInfo struct {
+	// Loaded is true when the model is resident in the provider's memory.
+	Loaded bool
+	// Since is the time the model was loaded (or last reloaded).
+	Since time.Time
+	// ExpiresAt is the time after which the provider will unload the model
+	// if no further requests arrive. For Ollama the default keep_alive is
+	// 5 minutes.
+	ExpiresAt time.Time
+	// VRAM is the approximate GPU memory consumed by the model, in GB.
+	VRAM float64
+}

--- a/provider/warmth_ollama.go
+++ b/provider/warmth_ollama.go
@@ -218,7 +218,7 @@ func (ws *OllamaWarmthSource) poll(ctx context.Context) {
 	if err != nil {
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return

--- a/provider/warmth_ollama.go
+++ b/provider/warmth_ollama.go
@@ -1,0 +1,290 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	defaultPollInterval = 30 * time.Second
+	defaultKeepAlive    = 5 * time.Minute
+)
+
+// OllamaWarmthSource polls Ollama's /api/ps endpoint to track which models
+// are loaded in memory. It implements the WarmthSource interface and is safe
+// for concurrent use.
+//
+// A background goroutine periodically queries the Ollama server to discover
+// loaded models, their VRAM consumption, and estimated expiry times. Between
+// polls, callers can reactively extend expiry via RecordUse.
+type OllamaWarmthSource struct {
+	mu           sync.RWMutex
+	baseURL      string
+	providerName string
+	models       map[string]*WarmthInfo // model name -> warmth info
+	pollInterval time.Duration
+	keepAlive    time.Duration
+	client       *http.Client
+	cancel       context.CancelFunc
+	closeOnce    sync.Once
+}
+
+// OllamaWarmthOption configures an OllamaWarmthSource.
+type OllamaWarmthOption func(*OllamaWarmthSource)
+
+// WithPollInterval sets the interval between /api/ps polls. Values <= 0 are
+// ignored and the default (30s) is used.
+func WithPollInterval(d time.Duration) OllamaWarmthOption {
+	return func(ws *OllamaWarmthSource) {
+		if d > 0 {
+			ws.pollInterval = d
+		}
+	}
+}
+
+// WithKeepAlive sets the assumed keep_alive duration used when creating new
+// entries via RecordUse. Values <= 0 are ignored and the default (5m) is used.
+func WithKeepAlive(d time.Duration) OllamaWarmthOption {
+	return func(ws *OllamaWarmthSource) {
+		if d > 0 {
+			ws.keepAlive = d
+		}
+	}
+}
+
+// NewOllamaWarmthSource creates a WarmthSource that polls the Ollama server
+// at baseURL for loaded models. The providerName is used to filter ModelKey
+// values — only keys whose Provider matches are considered.
+//
+// A background goroutine is started immediately and runs until Close is called.
+func NewOllamaWarmthSource(baseURL, providerName string, opts ...OllamaWarmthOption) *OllamaWarmthSource {
+	ws := &OllamaWarmthSource{
+		baseURL:      baseURL,
+		providerName: providerName,
+		models:       make(map[string]*WarmthInfo),
+		pollInterval: defaultPollInterval,
+		keepAlive:    defaultKeepAlive,
+		client: &http.Client{
+			Timeout: 5 * time.Second,
+		},
+	}
+	for _, opt := range opts {
+		opt(ws)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ws.cancel = cancel
+	go ws.pollLoop(ctx)
+
+	return ws
+}
+
+// ---------------------------------------------------------------------------
+// WarmthSource interface
+// ---------------------------------------------------------------------------
+
+// IsWarm reports whether the model identified by key is currently loaded and
+// has not expired. Returns false if key.Provider does not match or if the
+// model is unknown.
+func (ws *OllamaWarmthSource) IsWarm(key ModelKey) bool {
+	if key.Provider != ws.providerName {
+		return false
+	}
+	ws.mu.RLock()
+	defer ws.mu.RUnlock()
+	info, ok := ws.models[key.Model]
+	if !ok {
+		return false
+	}
+	return info.Loaded && time.Now().Before(info.ExpiresAt)
+}
+
+// WarmthState returns a copy of the WarmthInfo for key, or nil if the model
+// is unknown or belongs to a different provider.
+func (ws *OllamaWarmthSource) WarmthState(key ModelKey) *WarmthInfo {
+	if key.Provider != ws.providerName {
+		return nil
+	}
+	ws.mu.RLock()
+	defer ws.mu.RUnlock()
+	info, ok := ws.models[key.Model]
+	if !ok {
+		return nil
+	}
+	cp := *info
+	return &cp
+}
+
+// RecordUse notes that a request was sent to the model, extending its expiry
+// window by the configured keep_alive duration. If the model is unknown, a
+// new warm entry is created. Models belonging to a different provider are
+// silently ignored.
+func (ws *OllamaWarmthSource) RecordUse(key ModelKey) {
+	if key.Provider != ws.providerName {
+		return
+	}
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+	info, ok := ws.models[key.Model]
+	if ok {
+		info.ExpiresAt = time.Now().Add(ws.keepAlive)
+	} else {
+		now := time.Now()
+		ws.models[key.Model] = &WarmthInfo{
+			Loaded:    true,
+			Since:     now,
+			ExpiresAt: now.Add(ws.keepAlive),
+			VRAM:      0,
+		}
+	}
+}
+
+// Snapshot returns all currently loaded and non-expired models. Cold or
+// expired models are excluded.
+func (ws *OllamaWarmthSource) Snapshot() []WarmModel {
+	ws.mu.RLock()
+	defer ws.mu.RUnlock()
+	now := time.Now()
+	var out []WarmModel
+	for name, info := range ws.models {
+		if info.Loaded && now.Before(info.ExpiresAt) {
+			out = append(out, WarmModel{
+				Key:  ModelKey{Provider: ws.providerName, Model: name},
+				Info: *info,
+			})
+		}
+	}
+	return out
+}
+
+// Close stops the background poller and releases resources. It is safe to
+// call Close multiple times; subsequent calls are no-ops.
+func (ws *OllamaWarmthSource) Close() error {
+	ws.closeOnce.Do(func() {
+		ws.cancel()
+	})
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Polling
+// ---------------------------------------------------------------------------
+
+// pollLoop runs the initial poll and then ticks at the configured interval
+// until ctx is cancelled.
+func (ws *OllamaWarmthSource) pollLoop(ctx context.Context) {
+	ws.poll(ctx)
+
+	ticker := time.NewTicker(ws.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			ws.poll(ctx)
+		}
+	}
+}
+
+// ollamaPsResponse is the JSON shape returned by Ollama's /api/ps endpoint.
+type ollamaPsResponse struct {
+	Models []ollamaPsModel `json:"models"`
+}
+
+// ollamaPsModel represents a single model entry in the /api/ps response.
+type ollamaPsModel struct {
+	Name      string    `json:"name"`
+	Size      int64     `json:"size"`
+	SizeVRAM  int64     `json:"size_vram"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// poll queries the Ollama /api/ps endpoint and updates internal state. HTTP
+// errors and JSON parse errors are silently ignored to avoid crashing the
+// background poller.
+func (ws *OllamaWarmthSource) poll(ctx context.Context) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ws.baseURL+"/api/ps", nil)
+	if err != nil {
+		return
+	}
+
+	resp, err := ws.client.Do(req)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return
+	}
+
+	var psResp ollamaPsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&psResp); err != nil {
+		return
+	}
+
+	// Build a set of model names currently loaded.
+	loaded := make(map[string]struct{}, len(psResp.Models))
+	for _, m := range psResp.Models {
+		loaded[m.Name] = struct{}{}
+	}
+
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+
+	now := time.Now()
+
+	// Update or create entries for loaded models.
+	for _, m := range psResp.Models {
+		vram := float64(m.SizeVRAM) / (1024 * 1024 * 1024) // bytes to GB
+		info, ok := ws.models[m.Name]
+		if ok {
+			info.Loaded = true
+			info.ExpiresAt = m.ExpiresAt
+			info.VRAM = vram
+		} else {
+			ws.models[m.Name] = &WarmthInfo{
+				Loaded:    true,
+				Since:     now,
+				ExpiresAt: m.ExpiresAt,
+				VRAM:      vram,
+			}
+		}
+	}
+
+	// Mark models not in the response as cold.
+	for name, info := range ws.models {
+		if _, ok := loaded[name]; !ok {
+			info.Loaded = false
+		}
+	}
+}
+
+// compile-time interface check
+var _ WarmthSource = (*OllamaWarmthSource)(nil)
+
+// ---------------------------------------------------------------------------
+// Debug / diagnostic helpers
+// ---------------------------------------------------------------------------
+
+// String returns a human-readable summary of the warmth source state, useful
+// for debugging and logging.
+func (ws *OllamaWarmthSource) String() string {
+	ws.mu.RLock()
+	defer ws.mu.RUnlock()
+	warm := 0
+	now := time.Now()
+	for _, info := range ws.models {
+		if info.Loaded && now.Before(info.ExpiresAt) {
+			warm++
+		}
+	}
+	return fmt.Sprintf("OllamaWarmthSource{url=%s, provider=%s, warm=%d, total=%d}",
+		ws.baseURL, ws.providerName, warm, len(ws.models))
+}

--- a/provider/warmth_ollama_test.go
+++ b/provider/warmth_ollama_test.go
@@ -1,0 +1,411 @@
+package provider
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// compile-time interface check
+var _ WarmthSource = (*OllamaWarmthSource)(nil)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// psHandler returns an http.HandlerFunc that serves a canned /api/ps response.
+// The response can be swapped atomically via setModels.
+type psHandler struct {
+	mu     sync.Mutex
+	models []ollamaPsModel
+}
+
+func newPsHandler(models []ollamaPsModel) *psHandler {
+	return &psHandler{models: models}
+}
+
+func (h *psHandler) setModels(models []ollamaPsModel) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.models = models
+}
+
+func (h *psHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/api/ps" {
+		http.NotFound(w, r)
+		return
+	}
+	h.mu.Lock()
+	models := make([]ollamaPsModel, len(h.models))
+	copy(models, h.models)
+	h.mu.Unlock()
+
+	resp := ollamaPsResponse{Models: models}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestOllamaWarmthSourcePoll(t *testing.T) {
+	expires := time.Now().Add(5 * time.Minute)
+	handler := newPsHandler([]ollamaPsModel{
+		{
+			Name:      "qwen3:8b",
+			Size:      5_000_000_000,
+			SizeVRAM:  4_500_000_000,
+			ExpiresAt: expires,
+		},
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	ws := NewOllamaWarmthSource(srv.URL, "ollama",
+		WithPollInterval(50*time.Millisecond),
+	)
+	defer ws.Close()
+
+	// Wait for at least one poll cycle to complete.
+	time.Sleep(100 * time.Millisecond)
+
+	key := ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+
+	// IsWarm should be true.
+	if !ws.IsWarm(key) {
+		t.Fatal("expected qwen3:8b to be warm after poll")
+	}
+
+	// WarmthState should have VRAM and Loaded.
+	info := ws.WarmthState(key)
+	if info == nil {
+		t.Fatal("WarmthState should not be nil for polled model")
+	}
+	if !info.Loaded {
+		t.Error("Loaded should be true")
+	}
+	expectedVRAM := float64(4_500_000_000) / (1024 * 1024 * 1024)
+	if info.VRAM < expectedVRAM-0.01 || info.VRAM > expectedVRAM+0.01 {
+		t.Errorf("VRAM = %v, want ~%v", info.VRAM, expectedVRAM)
+	}
+	if info.Since.IsZero() {
+		t.Error("Since should not be zero")
+	}
+
+	// Snapshot should contain exactly 1 model.
+	snap := ws.Snapshot()
+	if len(snap) != 1 {
+		t.Fatalf("Snapshot should have 1 model, got %d", len(snap))
+	}
+	if snap[0].Key != key {
+		t.Errorf("Snapshot[0].Key = %v, want %v", snap[0].Key, key)
+	}
+}
+
+func TestOllamaWarmthSourceCold(t *testing.T) {
+	// Empty /api/ps response — no models loaded.
+	handler := newPsHandler(nil)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	ws := NewOllamaWarmthSource(srv.URL, "ollama",
+		WithPollInterval(50*time.Millisecond),
+	)
+	defer ws.Close()
+
+	// Wait for initial poll.
+	time.Sleep(100 * time.Millisecond)
+
+	key := ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+
+	if ws.IsWarm(key) {
+		t.Error("model should not be warm with empty /api/ps response")
+	}
+
+	if ws.WarmthState(key) != nil {
+		t.Error("WarmthState should return nil for unknown model")
+	}
+
+	snap := ws.Snapshot()
+	if len(snap) != 0 {
+		t.Errorf("Snapshot should be empty, got %d models", len(snap))
+	}
+}
+
+func TestOllamaWarmthSourceRecordUse(t *testing.T) {
+	// Use a very long poll interval so no polling happens during the test.
+	handler := newPsHandler(nil)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	ws := NewOllamaWarmthSource(srv.URL, "ollama",
+		WithPollInterval(1*time.Hour),
+	)
+	defer ws.Close()
+
+	key := ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+
+	// Initially cold (poll returned empty, and even if initial poll ran, it was empty).
+	// Wait a moment for initial poll to complete.
+	time.Sleep(50 * time.Millisecond)
+
+	if ws.IsWarm(key) {
+		t.Error("model should be cold initially")
+	}
+
+	// RecordUse should create a warm entry.
+	ws.RecordUse(key)
+
+	if !ws.IsWarm(key) {
+		t.Fatal("model should be warm after RecordUse")
+	}
+
+	info := ws.WarmthState(key)
+	if info == nil {
+		t.Fatal("WarmthState should not be nil after RecordUse")
+	}
+	if !info.Loaded {
+		t.Error("Loaded should be true after RecordUse")
+	}
+	if info.VRAM != 0 {
+		t.Errorf("VRAM = %v, want 0 for RecordUse-created entry", info.VRAM)
+	}
+
+	// RecordUse for a different provider should be a no-op.
+	otherKey := ModelKey{Provider: "openai", Model: "gpt-4o"}
+	ws.RecordUse(otherKey)
+	if ws.IsWarm(otherKey) {
+		t.Error("RecordUse should ignore models from different providers")
+	}
+
+	// RecordUse on an existing model should extend expiry.
+	before := ws.WarmthState(key)
+	time.Sleep(2 * time.Millisecond)
+	ws.RecordUse(key)
+	after := ws.WarmthState(key)
+
+	if !after.ExpiresAt.After(before.ExpiresAt) {
+		t.Error("RecordUse should extend ExpiresAt for existing model")
+	}
+}
+
+func TestOllamaWarmthSourceClose(t *testing.T) {
+	handler := newPsHandler(nil)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	ws := NewOllamaWarmthSource(srv.URL, "ollama",
+		WithPollInterval(1*time.Hour),
+	)
+
+	// First close should succeed.
+	if err := ws.Close(); err != nil {
+		t.Errorf("first Close() = %v, want nil", err)
+	}
+
+	// Second close should also succeed (idempotent).
+	if err := ws.Close(); err != nil {
+		t.Errorf("second Close() = %v, want nil", err)
+	}
+}
+
+func TestOllamaWarmthSourceProviderFilter(t *testing.T) {
+	expires := time.Now().Add(5 * time.Minute)
+	handler := newPsHandler([]ollamaPsModel{
+		{
+			Name:      "qwen3:8b",
+			Size:      5_000_000_000,
+			SizeVRAM:  4_500_000_000,
+			ExpiresAt: expires,
+		},
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	ws := NewOllamaWarmthSource(srv.URL, "ollama",
+		WithPollInterval(50*time.Millisecond),
+	)
+	defer ws.Close()
+
+	// Wait for poll.
+	time.Sleep(100 * time.Millisecond)
+
+	// Same model name but different provider should be filtered out.
+	wrongProvider := ModelKey{Provider: "openai", Model: "qwen3:8b"}
+	if ws.IsWarm(wrongProvider) {
+		t.Error("IsWarm should return false for wrong provider")
+	}
+	if ws.WarmthState(wrongProvider) != nil {
+		t.Error("WarmthState should return nil for wrong provider")
+	}
+}
+
+func TestOllamaWarmthSourceModelUnloaded(t *testing.T) {
+	expires := time.Now().Add(5 * time.Minute)
+	handler := newPsHandler([]ollamaPsModel{
+		{
+			Name:      "qwen3:8b",
+			Size:      5_000_000_000,
+			SizeVRAM:  4_500_000_000,
+			ExpiresAt: expires,
+		},
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	ws := NewOllamaWarmthSource(srv.URL, "ollama",
+		WithPollInterval(50*time.Millisecond),
+	)
+	defer ws.Close()
+
+	key := ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+
+	// Wait for initial poll to see the model.
+	time.Sleep(100 * time.Millisecond)
+	if !ws.IsWarm(key) {
+		t.Fatal("model should be warm after first poll")
+	}
+
+	// Remove the model from /api/ps.
+	handler.setModels(nil)
+
+	// Wait for another poll cycle to pick up the change.
+	time.Sleep(100 * time.Millisecond)
+
+	if ws.IsWarm(key) {
+		t.Error("model should be cold after being removed from /api/ps")
+	}
+
+	info := ws.WarmthState(key)
+	if info == nil {
+		t.Fatal("WarmthState should still return info for previously loaded model")
+	}
+	if info.Loaded {
+		t.Error("Loaded should be false after model is unloaded")
+	}
+}
+
+func TestOllamaWarmthSourceHTTPError(t *testing.T) {
+	// Server that always returns 500.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	ws := NewOllamaWarmthSource(srv.URL, "ollama",
+		WithPollInterval(50*time.Millisecond),
+	)
+	defer ws.Close()
+
+	// Wait for poll attempt — should not crash.
+	time.Sleep(100 * time.Millisecond)
+
+	key := ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+	if ws.IsWarm(key) {
+		t.Error("model should not be warm when server returns errors")
+	}
+}
+
+func TestOllamaWarmthSourceInvalidJSON(t *testing.T) {
+	// Server that returns invalid JSON.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{invalid json`))
+	}))
+	defer srv.Close()
+
+	ws := NewOllamaWarmthSource(srv.URL, "ollama",
+		WithPollInterval(50*time.Millisecond),
+	)
+	defer ws.Close()
+
+	// Wait for poll attempt — should not crash.
+	time.Sleep(100 * time.Millisecond)
+
+	snap := ws.Snapshot()
+	if len(snap) != 0 {
+		t.Errorf("Snapshot should be empty after invalid JSON, got %d", len(snap))
+	}
+}
+
+func TestOllamaWarmthSourceOptions(t *testing.T) {
+	t.Run("WithPollInterval ignores zero", func(t *testing.T) {
+		handler := newPsHandler(nil)
+		srv := httptest.NewServer(handler)
+		defer srv.Close()
+
+		ws := NewOllamaWarmthSource(srv.URL, "ollama",
+			WithPollInterval(0),
+		)
+		defer ws.Close()
+
+		if ws.pollInterval != defaultPollInterval {
+			t.Errorf("pollInterval = %v, want %v", ws.pollInterval, defaultPollInterval)
+		}
+	})
+
+	t.Run("WithPollInterval ignores negative", func(t *testing.T) {
+		handler := newPsHandler(nil)
+		srv := httptest.NewServer(handler)
+		defer srv.Close()
+
+		ws := NewOllamaWarmthSource(srv.URL, "ollama",
+			WithPollInterval(-1*time.Second),
+		)
+		defer ws.Close()
+
+		if ws.pollInterval != defaultPollInterval {
+			t.Errorf("pollInterval = %v, want %v", ws.pollInterval, defaultPollInterval)
+		}
+	})
+
+	t.Run("WithKeepAlive ignores zero", func(t *testing.T) {
+		handler := newPsHandler(nil)
+		srv := httptest.NewServer(handler)
+		defer srv.Close()
+
+		ws := NewOllamaWarmthSource(srv.URL, "ollama",
+			WithKeepAlive(0),
+		)
+		defer ws.Close()
+
+		if ws.keepAlive != defaultKeepAlive {
+			t.Errorf("keepAlive = %v, want %v", ws.keepAlive, defaultKeepAlive)
+		}
+	})
+
+	t.Run("WithKeepAlive accepts positive", func(t *testing.T) {
+		handler := newPsHandler(nil)
+		srv := httptest.NewServer(handler)
+		defer srv.Close()
+
+		ws := NewOllamaWarmthSource(srv.URL, "ollama",
+			WithKeepAlive(10*time.Minute),
+		)
+		defer ws.Close()
+
+		if ws.keepAlive != 10*time.Minute {
+			t.Errorf("keepAlive = %v, want %v", ws.keepAlive, 10*time.Minute)
+		}
+	})
+}
+
+func TestOllamaWarmthSourceString(t *testing.T) {
+	handler := newPsHandler(nil)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	ws := NewOllamaWarmthSource(srv.URL, "ollama",
+		WithPollInterval(1*time.Hour),
+	)
+	defer ws.Close()
+
+	s := ws.String()
+	if s == "" {
+		t.Error("String() should not return empty string")
+	}
+}

--- a/provider/warmth_ollama_test.go
+++ b/provider/warmth_ollama_test.go
@@ -68,7 +68,7 @@ func TestOllamaWarmthSourcePoll(t *testing.T) {
 	ws := NewOllamaWarmthSource(srv.URL, "ollama",
 		WithPollInterval(50*time.Millisecond),
 	)
-	defer ws.Close()
+	defer func() { _ = ws.Close() }()
 
 	// Wait for at least one poll cycle to complete.
 	time.Sleep(100 * time.Millisecond)
@@ -115,7 +115,7 @@ func TestOllamaWarmthSourceCold(t *testing.T) {
 	ws := NewOllamaWarmthSource(srv.URL, "ollama",
 		WithPollInterval(50*time.Millisecond),
 	)
-	defer ws.Close()
+	defer func() { _ = ws.Close() }()
 
 	// Wait for initial poll.
 	time.Sleep(100 * time.Millisecond)
@@ -145,7 +145,7 @@ func TestOllamaWarmthSourceRecordUse(t *testing.T) {
 	ws := NewOllamaWarmthSource(srv.URL, "ollama",
 		WithPollInterval(1*time.Hour),
 	)
-	defer ws.Close()
+	defer func() { _ = ws.Close() }()
 
 	key := ModelKey{Provider: "ollama", Model: "qwen3:8b"}
 
@@ -229,7 +229,7 @@ func TestOllamaWarmthSourceProviderFilter(t *testing.T) {
 	ws := NewOllamaWarmthSource(srv.URL, "ollama",
 		WithPollInterval(50*time.Millisecond),
 	)
-	defer ws.Close()
+	defer func() { _ = ws.Close() }()
 
 	// Wait for poll.
 	time.Sleep(100 * time.Millisecond)
@@ -260,7 +260,7 @@ func TestOllamaWarmthSourceModelUnloaded(t *testing.T) {
 	ws := NewOllamaWarmthSource(srv.URL, "ollama",
 		WithPollInterval(50*time.Millisecond),
 	)
-	defer ws.Close()
+	defer func() { _ = ws.Close() }()
 
 	key := ModelKey{Provider: "ollama", Model: "qwen3:8b"}
 
@@ -299,7 +299,7 @@ func TestOllamaWarmthSourceHTTPError(t *testing.T) {
 	ws := NewOllamaWarmthSource(srv.URL, "ollama",
 		WithPollInterval(50*time.Millisecond),
 	)
-	defer ws.Close()
+	defer func() { _ = ws.Close() }()
 
 	// Wait for poll attempt — should not crash.
 	time.Sleep(100 * time.Millisecond)
@@ -321,7 +321,7 @@ func TestOllamaWarmthSourceInvalidJSON(t *testing.T) {
 	ws := NewOllamaWarmthSource(srv.URL, "ollama",
 		WithPollInterval(50*time.Millisecond),
 	)
-	defer ws.Close()
+	defer func() { _ = ws.Close() }()
 
 	// Wait for poll attempt — should not crash.
 	time.Sleep(100 * time.Millisecond)
@@ -341,7 +341,7 @@ func TestOllamaWarmthSourceOptions(t *testing.T) {
 		ws := NewOllamaWarmthSource(srv.URL, "ollama",
 			WithPollInterval(0),
 		)
-		defer ws.Close()
+		defer func() { _ = ws.Close() }()
 
 		if ws.pollInterval != defaultPollInterval {
 			t.Errorf("pollInterval = %v, want %v", ws.pollInterval, defaultPollInterval)
@@ -356,7 +356,7 @@ func TestOllamaWarmthSourceOptions(t *testing.T) {
 		ws := NewOllamaWarmthSource(srv.URL, "ollama",
 			WithPollInterval(-1*time.Second),
 		)
-		defer ws.Close()
+		defer func() { _ = ws.Close() }()
 
 		if ws.pollInterval != defaultPollInterval {
 			t.Errorf("pollInterval = %v, want %v", ws.pollInterval, defaultPollInterval)
@@ -371,7 +371,7 @@ func TestOllamaWarmthSourceOptions(t *testing.T) {
 		ws := NewOllamaWarmthSource(srv.URL, "ollama",
 			WithKeepAlive(0),
 		)
-		defer ws.Close()
+		defer func() { _ = ws.Close() }()
 
 		if ws.keepAlive != defaultKeepAlive {
 			t.Errorf("keepAlive = %v, want %v", ws.keepAlive, defaultKeepAlive)
@@ -386,7 +386,7 @@ func TestOllamaWarmthSourceOptions(t *testing.T) {
 		ws := NewOllamaWarmthSource(srv.URL, "ollama",
 			WithKeepAlive(10*time.Minute),
 		)
-		defer ws.Close()
+		defer func() { _ = ws.Close() }()
 
 		if ws.keepAlive != 10*time.Minute {
 			t.Errorf("keepAlive = %v, want %v", ws.keepAlive, 10*time.Minute)
@@ -402,7 +402,7 @@ func TestOllamaWarmthSourceString(t *testing.T) {
 	ws := NewOllamaWarmthSource(srv.URL, "ollama",
 		WithPollInterval(1*time.Hour),
 	)
-	defer ws.Close()
+	defer func() { _ = ws.Close() }()
 
 	s := ws.String()
 	if s == "" {

--- a/provider/warmth_test.go
+++ b/provider/warmth_test.go
@@ -90,13 +90,14 @@ func (m *mockWarmthSource) RecordUse(key ModelKey) {
 	}
 }
 
-// Snapshot returns all currently loaded models.
+// Snapshot returns all currently warm (loaded and not expired) models.
 func (m *mockWarmthSource) Snapshot() []WarmModel {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+	now := time.Now()
 	var out []WarmModel
 	for k, info := range m.models {
-		if info.Loaded {
+		if info.Loaded && now.Before(info.ExpiresAt) {
 			out = append(out, WarmModel{Key: k, Info: *info})
 		}
 	}

--- a/provider/warmth_test.go
+++ b/provider/warmth_test.go
@@ -1,0 +1,287 @@
+package provider
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// mockWarmthSource — reusable mock for Tasks 6, 8, 9, and 11
+// ---------------------------------------------------------------------------
+
+// mockWarmthSource is a thread-safe in-memory WarmthSource implementation used
+// for testing throughout the provider package. It tracks warm/cold state per
+// ModelKey and provides test helper methods for setup.
+type mockWarmthSource struct {
+	mu     sync.RWMutex
+	models map[ModelKey]*WarmthInfo
+}
+
+func newMockWarmthSource() *mockWarmthSource {
+	return &mockWarmthSource{
+		models: make(map[ModelKey]*WarmthInfo),
+	}
+}
+
+// SetWarm marks a model as loaded with the given VRAM consumption.
+// ExpiresAt is set to 5 minutes from now (Ollama default keep_alive).
+func (m *mockWarmthSource) SetWarm(key ModelKey, vram float64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	now := time.Now()
+	m.models[key] = &WarmthInfo{
+		Loaded:    true,
+		Since:     now,
+		ExpiresAt: now.Add(5 * time.Minute),
+		VRAM:      vram,
+	}
+}
+
+// SetCold marks a model as unloaded (cold).
+func (m *mockWarmthSource) SetCold(key ModelKey) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	info, ok := m.models[key]
+	if ok {
+		info.Loaded = false
+	}
+}
+
+// IsWarm reports whether the model is loaded and its expiry has not passed.
+func (m *mockWarmthSource) IsWarm(key ModelKey) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	info, ok := m.models[key]
+	if !ok {
+		return false
+	}
+	return info.Loaded && time.Now().Before(info.ExpiresAt)
+}
+
+// WarmthState returns a copy of the WarmthInfo for key, or nil if unknown.
+func (m *mockWarmthSource) WarmthState(key ModelKey) *WarmthInfo {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	info, ok := m.models[key]
+	if !ok {
+		return nil
+	}
+	// Return a copy so callers cannot mutate internal state.
+	cp := *info
+	return &cp
+}
+
+// RecordUse extends ExpiresAt for a known model or creates a new warm entry.
+func (m *mockWarmthSource) RecordUse(key ModelKey) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	info, ok := m.models[key]
+	if ok {
+		info.ExpiresAt = time.Now().Add(5 * time.Minute)
+	} else {
+		now := time.Now()
+		m.models[key] = &WarmthInfo{
+			Loaded:    true,
+			Since:     now,
+			ExpiresAt: now.Add(5 * time.Minute),
+			VRAM:      0,
+		}
+	}
+}
+
+// Snapshot returns all currently loaded models.
+func (m *mockWarmthSource) Snapshot() []WarmModel {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var out []WarmModel
+	for k, info := range m.models {
+		if info.Loaded {
+			out = append(out, WarmModel{Key: k, Info: *info})
+		}
+	}
+	return out
+}
+
+// Close is a no-op for the mock.
+func (m *mockWarmthSource) Close() error {
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestMockWarmthSourceInterface(t *testing.T) {
+	// Compile-time interface satisfaction check.
+	var _ WarmthSource = (*mockWarmthSource)(nil)
+
+	t.Run("initially cold", func(t *testing.T) {
+		ws := newMockWarmthSource()
+		key := ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+
+		if ws.IsWarm(key) {
+			t.Error("unknown model should not be warm")
+		}
+		if ws.WarmthState(key) != nil {
+			t.Error("unknown model should return nil WarmthState")
+		}
+	})
+
+	t.Run("set warm", func(t *testing.T) {
+		ws := newMockWarmthSource()
+		key := ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+
+		ws.SetWarm(key, 4.5)
+
+		if !ws.IsWarm(key) {
+			t.Fatal("model should be warm after SetWarm")
+		}
+
+		info := ws.WarmthState(key)
+		if info == nil {
+			t.Fatal("WarmthState should not be nil after SetWarm")
+		}
+		if !info.Loaded {
+			t.Error("Loaded should be true")
+		}
+		if info.VRAM != 4.5 {
+			t.Errorf("VRAM = %v, want 4.5", info.VRAM)
+		}
+		if info.Since.IsZero() {
+			t.Error("Since should not be zero")
+		}
+		if info.ExpiresAt.IsZero() {
+			t.Error("ExpiresAt should not be zero")
+		}
+		if !info.ExpiresAt.After(info.Since) {
+			t.Error("ExpiresAt should be after Since")
+		}
+	})
+
+	t.Run("warmth state returns copy", func(t *testing.T) {
+		ws := newMockWarmthSource()
+		key := ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+
+		ws.SetWarm(key, 4.5)
+		info1 := ws.WarmthState(key)
+		info2 := ws.WarmthState(key)
+
+		// Mutating the returned copy should not affect subsequent calls.
+		info1.VRAM = 999.0
+		if info2.VRAM != 4.5 {
+			t.Error("WarmthState should return independent copies")
+		}
+	})
+
+	t.Run("set cold", func(t *testing.T) {
+		ws := newMockWarmthSource()
+		key := ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+
+		ws.SetWarm(key, 4.5)
+		ws.SetCold(key)
+
+		if ws.IsWarm(key) {
+			t.Error("model should not be warm after SetCold")
+		}
+
+		info := ws.WarmthState(key)
+		if info == nil {
+			t.Fatal("WarmthState should still return info after SetCold")
+		}
+		if info.Loaded {
+			t.Error("Loaded should be false after SetCold")
+		}
+	})
+
+	t.Run("snapshot returns only loaded models", func(t *testing.T) {
+		ws := newMockWarmthSource()
+		warm := ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+		cold := ModelKey{Provider: "ollama", Model: "qwen3:32b"}
+
+		ws.SetWarm(warm, 4.5)
+		ws.SetWarm(cold, 16.0)
+		ws.SetCold(cold)
+
+		snap := ws.Snapshot()
+		if len(snap) != 1 {
+			t.Fatalf("Snapshot should have 1 model, got %d", len(snap))
+		}
+		if snap[0].Key != warm {
+			t.Errorf("Snapshot[0].Key = %v, want %v", snap[0].Key, warm)
+		}
+		if snap[0].Info.VRAM != 4.5 {
+			t.Errorf("Snapshot[0].Info.VRAM = %v, want 4.5", snap[0].Info.VRAM)
+		}
+	})
+
+	t.Run("record use on unknown model creates warm entry", func(t *testing.T) {
+		ws := newMockWarmthSource()
+		key := ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+
+		ws.RecordUse(key)
+
+		if !ws.IsWarm(key) {
+			t.Error("RecordUse on unknown model should create warm entry")
+		}
+		info := ws.WarmthState(key)
+		if info == nil {
+			t.Fatal("WarmthState should not be nil after RecordUse")
+		}
+		if !info.Loaded {
+			t.Error("Loaded should be true after RecordUse")
+		}
+		if info.VRAM != 0 {
+			t.Errorf("VRAM = %v, want 0 for RecordUse-created entry", info.VRAM)
+		}
+	})
+
+	t.Run("record use extends expiry for known model", func(t *testing.T) {
+		ws := newMockWarmthSource()
+		key := ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+
+		ws.SetWarm(key, 4.5)
+		original := ws.WarmthState(key)
+
+		// Small sleep to ensure time advances.
+		time.Sleep(2 * time.Millisecond)
+
+		ws.RecordUse(key)
+		updated := ws.WarmthState(key)
+
+		if !updated.ExpiresAt.After(original.ExpiresAt) {
+			t.Error("RecordUse should extend ExpiresAt")
+		}
+		// VRAM should be preserved.
+		if updated.VRAM != 4.5 {
+			t.Errorf("VRAM = %v, want 4.5 (should be preserved by RecordUse)", updated.VRAM)
+		}
+	})
+
+	t.Run("close returns nil", func(t *testing.T) {
+		ws := newMockWarmthSource()
+		if err := ws.Close(); err != nil {
+			t.Errorf("Close() = %v, want nil", err)
+		}
+	})
+
+	t.Run("empty snapshot", func(t *testing.T) {
+		ws := newMockWarmthSource()
+		snap := ws.Snapshot()
+		if len(snap) != 0 {
+			t.Errorf("empty source should return 0 models, got %d", len(snap))
+		}
+	})
+
+	t.Run("set cold on unknown is no-op", func(t *testing.T) {
+		ws := newMockWarmthSource()
+		key := ModelKey{Provider: "ollama", Model: "unknown"}
+
+		// Should not panic or create entry.
+		ws.SetCold(key)
+
+		if ws.WarmthState(key) != nil {
+			t.Error("SetCold on unknown model should not create an entry")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Adds the Router, the intelligent dispatch layer that selects the best provider/model for each request using circuit breakers, warmth tracking, token budget validation, candidate scoring, sticky routing, and a fallback chain
- Implements 12 new files and modifies 2 existing files in the `provider/` package (7,861 lines added)
- All 12 project packages pass with `go test -race ./...`

## Architecture

The Router sits between consumers (Firn IDE, Flux ML, Quantum Trader) and the Provider interface. It transforms go-llm from "call a specific model" into "describe what you need, get the best available model."

**New files:**

| File | Responsibility |
|------|---------------|
| `routing_request.go` | RoutingRequest, Priority, RouteKind, StickyKey, budget class helpers |
| `router_errors.go` | Sentinel errors, BreakerState, BreakerInfo, HTTPStatusError, IsInfrastructureError |
| `circuit_breaker.go` | Three-state breaker (Closed/Open/HalfOpen) with failure decay |
| `warmth.go` | WarmthSource interface, WarmthInfo, WarmModel |
| `warmth_ollama.go` | OllamaWarmthSource — polls /api/ps for loaded models |
| `token_budget.go` | TokenBudgetValidator with per-use-case output budgets and HeadroomScore |
| `router_score.go` | Candidate scoring with active-signal normalization and configurable weight profiles |
| `router_sticky.go` | LRU-bounded sticky cache with touch-based expiry and hysteresis |
| `route_plan.go` | RoutePlan with bound-request execution, fallback chain, streaming pre-first-chunk rule |
| `router.go` | Router struct composing all subsystems, Route(), convenience methods, RouteRecorder |

**Modified files:**

| File | Change |
|------|--------|
| `model_profile.go` | Added QualityCtxCeiling field + EffectiveContextWindow() method |
| `types.go` | Added RouteOutcome struct + optional field on ChatResponse, GenerateResponse, EmbedResponse |

## Key Design Decisions

- **Nil-safe composition**: Optional subsystems (warmth, feedback, KV cache) can be nil. The scoring engine renormalizes weights across only the active signals, so adding subsystems in Phase 3 smoothly blends in without changing existing behavior.
- **Affinity-scoped sticky routing**: The sticky cache is keyed on AffinityKey + model selector + use case + capabilities + priority + budget class. Conversations maintain model stability without contaminating unrelated sessions.
- **Streaming fallback rule**: Fallback to alternate providers is only attempted before the first user-visible chunk is emitted. After content delivery begins, the Router returns the current provider's error rather than splicing streams.
- **Cancellation-aware execution**: context.Canceled does not trip circuit breakers or count as failures. Warmth is still recorded (the model IS loaded).
- **Read-only scoring**: scoreCandidate uses State() instead of Allow() to check breakers, preventing the Open-to-HalfOpen transition from being consumed during candidate evaluation.

## Review Findings Fixed

The per-task review chain (spec compliance, code quality, /code-review, /criticize-review) caught and fixed 8 issues before they could compound:

1. HTTPStatusError.Error() double-formatting the status code
2. ModelProfile struct field alignment after new field addition
3. Dead lastSuccess field on CircuitBreaker + missing concurrency test
4. mockWarmthSource.Snapshot() not filtering expired models
5. TokenBudgetValidator missing guard for zero context window
6. scoreCandidate calling Allow() (mutating) instead of State() (read-only) on breakers
7. Double failure recording for the last fallback provider in the chain
8. Router.Close() not closing WarmthSource + buildPlan returning nil-Provider plan

## Test plan

- [x] `go test -race ./...` passes (all 12 packages)
- [x] Router unit tests cover: qualified/unqualified/autopilot model resolution, breaker open, sticky routing, dry-run, all convenience methods, warmth integration, RAM filtering
- [x] Integration tests cover: full route-and-execute flow, fallback chain with 503 errors, budget adaptation/rejection, dry-run mode, sticky TTL expiry, breaker state queries, closed router rejection, multi-provider scoring
- [x] CircuitBreaker tests cover: all state transitions, failure decay, concurrent access with -race
- [x] RoutePlan tests cover: all 5 Execute methods, streaming pre-first-chunk fallback rule, cancellation handling, BudgetTruncate rejection
- [x] OllamaWarmthSource tests use httptest.Server mocking /api/ps — no external dependencies

Generated with [Claude Code](https://claude.com/claude-code)