### PR TITLE
docs: update architecture and add MCP server documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,10 +11,16 @@
 ```
 go-llm/
 ├── ollama/          # Ollama REST API client (chat, generate, embeddings, models)
+├── config/          # Model configuration loader (models.json, resolve, fallback)
+├── provider/        # Intelligent model routing (Router, circuit breakers, warmth, scoring)
 ├── rag/             # RAG: chunking, SQLite vector store, indexing, retrieval
 ├── completion/      # IDE inline completion (Fill-in-the-Middle)
-├── analysis/        # Domain-specific analysis helpers
+├── analysis/        # Domain-specific analysis helpers (code review, ML metrics, trading)
 ├── mcp/             # MCP server: tools, prompts, resources over stdio/HTTP/2
+├── conversation/    # Persistent conversation storage with SQLite
+├── feedback/        # Implicit user behavioral signal collection
+├── fingerprint/     # Model profiling (latency benchmarks, capability detection)
+├── prefetch/        # Predictive cache-warming engine for RAG retrieval
 ├── cmd/go-llm-mcp/  # Standalone MCP server binary
 └── testdata/        # Test fixtures
 ```
@@ -61,7 +67,7 @@ Base URL: `http://localhost:11434`
 ### Chat Request
 ```json
 {
-  "model": "qwen2.5:72b",
+  "model": "qwen3.5:27b",
   "messages": [{"role": "user", "content": "hello"}],
   "stream": true,
   "options": {
@@ -75,7 +81,7 @@ Base URL: `http://localhost:11434`
 ### Embed Request
 ```json
 {
-  "model": "nomic-embed-text",
+  "model": "qwen3-embedding:8b",
   "input": "text to embed"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -268,13 +268,13 @@ Expose all go-llm capabilities over the [Model Context Protocol](https://modelco
 go build -o go-llm-mcp ./cmd/go-llm-mcp/
 
 # Stdio (Claude Desktop, IDE integration)
-go-llm-mcp --transport stdio
+./go-llm-mcp --transport stdio
 
 # HTTP/2 (local development)
-go-llm-mcp --transport http --addr 127.0.0.1:8080
+./go-llm-mcp --transport http --addr 127.0.0.1:8080
 
 # Custom Ollama URL
-go-llm-mcp --ollama-url http://gpu-server:11434
+./go-llm-mcp --ollama-url http://gpu-server:11434
 ```
 
 Claude Desktop configuration (`claude_desktop_config.json`):

--- a/README.md
+++ b/README.md
@@ -132,14 +132,18 @@ client := ollama.NewClient()
 store, _ := rag.NewSQLiteStore("vectors.db")
 defer store.Close()
 
-indexer := rag.NewIndexer(client, store)
+indexer := rag.NewIndexer(client, store,
+    rag.WithEmbeddingModel("qwen3-embedding:8b"),
+)
 indexer.IndexDirectory(ctx, "/path/to/project")
 ```
 
 ### Query with RAG context
 
 ```go
-retriever := rag.NewRetriever(client, store)
+retriever := rag.NewRetriever(client, store,
+    rag.WithRetrieverModel("qwen3-embedding:8b"),
+)
 results, _ := retriever.Retrieve(ctx, "how does the pairs trading strategy work?", 5)
 context := retriever.BuildContext(results, 4096)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A batteries-included Go module for building local-first AI features on top of [Ollama](https://ollama.com). Provides a complete pipeline from model management and configuration through RAG-powered retrieval to domain-specific analysis — all running locally with no cloud dependencies or API keys.
 
-Designed for embedding into Go applications that need LLM capabilities: chat, tool calling, code completion, retrieval-augmented generation, and more. A standalone MCP server mode is [on the roadmap](#roadmap) for use as a local AI service without embedding. Pure Go with minimal dependencies (no CGo).
+Designed for embedding into Go applications that need LLM capabilities: chat, tool calling, code completion, retrieval-augmented generation, and more. Also runs as a standalone [MCP server](#mcp-server) for use as a local AI service without embedding. Pure Go with minimal dependencies (no CGo).
 
 ### What's included
 
@@ -18,11 +18,18 @@ Designed for embedding into Go applications that need LLM capabilities: chat, to
 | Package | Description |
 |---------|-------------|
 | `ollama/` | HTTP client for the Ollama REST API — chat, text generation, embeddings, model management, tool calling. Streaming support via callbacks. |
-| `rag/` | Code-aware text chunking, SQLite vector store with cosine similarity search, concurrent file/directory indexer with `.gitignore` support, and context-building retriever. |
+| `config/` | Model configuration loader (`models.json`) with provider settings, role-based defaults, and fallback chain resolution against available models. |
+| `provider/` | Intelligent model routing — Router with circuit breakers, warmth tracking, token budget, sticky routing, and multi-model scoring. |
+| `rag/` | Code-aware text chunking, SQLite vector store with cosine similarity and FTS5 hybrid search, concurrent file/directory indexer with `.gitignore` support, diff-aware incremental reindexing, and context-building retriever. |
 | `rag/parquet/` | Parquet dataset exporter for ML pipeline interop — exports vector store contents with quality metrics and configurable precision. |
 | `completion/` | IDE inline completion via Fill-in-the-Middle (FIM) with context window management. Sync and streaming APIs. |
 | `analysis/` | Domain-specific analysis helpers — code review (with optional RAG context), ML training metrics, and trading strategy analysis. |
-| `config/` | Model configuration loader (`models.json`) with provider settings, role-based defaults, and fallback chain resolution against available models. |
+| `mcp/` | MCP server exposing go-llm as tools, prompts, and resources over stdio and HTTP/2 transports. |
+| `conversation/` | Persistent conversation storage with SQLite. |
+| `feedback/` | Implicit user behavioral signal collection for retrieval quality improvement. |
+| `fingerprint/` | Model profiling — latency benchmarks and capability detection. |
+| `prefetch/` | Predictive cache-warming engine for RAG retrieval. |
+| `cmd/go-llm-mcp/` | Standalone MCP server binary with stdio and HTTP/2 support. |
 
 ## Requirements
 
@@ -52,7 +59,7 @@ func main() {
     client := ollama.NewClient()
 
     resp, err := client.Chat(context.Background(), ollama.ChatRequest{
-        Model: "qwen2.5:72b",
+        Model: "qwen3.5:27b",
         Messages: []ollama.ChatMessage{
             {Role: "user", Content: "Explain walk-forward validation for trading strategies"},
         },
@@ -68,7 +75,7 @@ func main() {
 
 ```go
 err := client.ChatStream(ctx, ollama.ChatRequest{
-    Model:    "qwen2.5:72b",
+    Model:    "qwen3.5:27b",
     Messages: []ollama.ChatMessage{{Role: "user", Content: "Hello"}},
 }, func(resp ollama.ChatResponse) error {
     fmt.Print(resp.Message.Content)
@@ -92,7 +99,7 @@ weatherTool := ollama.NewTool(
 
 // Send a chat request with tools
 resp, _ := client.Chat(ctx, ollama.ChatRequest{
-    Model:    "qwen2.5:72b",
+    Model:    "qwen3.5:27b",
     Messages: []ollama.ChatMessage{{Role: "user", Content: "What's the weather in NYC?"}},
     Tools:    []ollama.Tool{weatherTool},
 })
@@ -109,8 +116,8 @@ if len(resp.Message.ToolCalls) > 0 {
 ### Generate embeddings
 
 ```go
-embedding, err := client.Embed(ctx, "nomic-embed-text", "mean reversion strategy")
-// embedding is []float64 with 768 dimensions
+embedding, err := client.Embed(ctx, "qwen3-embedding:8b", "mean reversion strategy")
+// embedding is []float64 with 4096 dimensions
 ```
 
 ### Index a codebase for RAG
@@ -138,7 +145,7 @@ context := retriever.BuildContext(results, 4096)
 
 // Feed context into a chat completion
 resp, _ := client.Chat(ctx, ollama.ChatRequest{
-    Model: "qwen2.5:72b",
+    Model: "qwen3.5:27b",
     Messages: []ollama.ChatMessage{
         {Role: "system", Content: "Answer using the following code context:\n\n" + context},
         {Role: "user", Content: "How does the pairs trading strategy calculate hedge ratios?"},
@@ -201,8 +208,8 @@ client := ollama.NewClient(
 
 ```go
 models, _ := client.ListModels(ctx)
-info, _ := client.ShowModel(ctx, "qwen2.5:72b")
-client.PullModel(ctx, "nomic-embed-text", func(status string, completed, total int64) {
+info, _ := client.ShowModel(ctx, "qwen3.5:27b")
+client.PullModel(ctx, "qwen3:8b", func(status string, completed, total int64) {
     fmt.Printf("%s: %d/%d\n", status, completed, total)
 })
 ```
@@ -214,7 +221,7 @@ Fill-in-the-Middle completion for IDE integration with automatic context window 
 ```go
 import "github.com/kstruzzieri/go-llm/completion"
 
-provider := completion.NewProvider(client, "qwen2.5-coder:7b")
+provider := completion.NewProvider(client, "qwen3-coder-next")
 
 resp, _ := provider.Complete(ctx, completion.FIMRequest{
     Prefix:    "func fibonacci(n int) int {\n\t",
@@ -241,12 +248,45 @@ import "github.com/kstruzzieri/go-llm/config"
 cfg, _ := config.Default() // auto-discovers models.json
 
 // Simple lookup
-model := cfg.ModelFor("chat") // e.g., "qwen2.5:72b"
+model := cfg.ModelFor("chat") // e.g., "qwen3.5:27b"
 
 // Resolve with fallback chain (checks which models are actually available)
 resolved, _ := cfg.Resolve(ctx, client, "chat")
 fmt.Printf("Using %s (fallback: %v)\n", resolved.Name, resolved.IsFallback)
 ```
+
+## MCP Server
+
+Expose all go-llm capabilities over the [Model Context Protocol](https://modelcontextprotocol.io/) for use with Claude Desktop, IDE extensions, or any MCP client.
+
+```bash
+# Build
+go build -o go-llm-mcp ./cmd/go-llm-mcp/
+
+# Stdio (Claude Desktop, IDE integration)
+go-llm-mcp --transport stdio
+
+# HTTP/2 (local development)
+go-llm-mcp --transport http --addr 127.0.0.1:8080
+
+# Custom Ollama URL
+go-llm-mcp --ollama-url http://gpu-server:11434
+```
+
+Claude Desktop configuration (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "go-llm": {
+      "command": "/path/to/go-llm-mcp",
+      "args": ["--transport", "stdio"]
+    }
+  }
+}
+```
+
+The server exposes 19 tools (chat, generate, code completion, embeddings, RAG, model management, analysis), 4 prompt templates, and 5 resources. Chat, generate, completion, embedding, and analysis tools accept an optional `model` parameter; when omitted, the configured default for that use-case is used.
 
 ## Parquet Export
 
@@ -258,7 +298,7 @@ import "github.com/kstruzzieri/go-llm/rag/parquet"
 info, _ := parquet.ExportVectorStore(ctx, store, "dataset.parquet",
     parquet.WithDType(parquet.Float32),
     parquet.WithSourcePattern("*.go"),
-    parquet.WithModel("nomic-embed-text"),
+    parquet.WithModel("qwen3-embedding:8b"),
 )
 fmt.Printf("Exported %d rows (%d clean, %d flagged)\n",
     info.RowCount, info.Quality.CleanRows, info.Quality.FlaggedRows)
@@ -272,11 +312,11 @@ Domain-specific analysis helpers that leverage Ollama models.
 import "github.com/kstruzzieri/go-llm/analysis"
 
 // Code review (optionally backed by RAG context)
-reviewer, _ := analysis.NewCodeReviewer(client, retriever, "qwen2.5:72b")
+reviewer, _ := analysis.NewCodeReviewer(client, retriever, "qwen3.5:27b")
 review, _ := reviewer.Review(ctx, code, analysis.WithLanguage("go"))
 
 // ML training metrics analysis
-analyzer, _ := analysis.NewMetricsAnalyzer(client, "qwen2.5:72b")
+analyzer, _ := analysis.NewMetricsAnalyzer(client, "qwen3.5:27b")
 insight, _ := analyzer.AnalyzeTraining(ctx, analysis.TrainingMetrics{
     Epoch: 10, Loss: 0.42, LearningRate: 1e-4,
 })
@@ -284,27 +324,12 @@ insight, _ := analyzer.AnalyzeTraining(ctx, analysis.TrainingMetrics{
 
 ## Roadmap
 
-### Up next
-
 | Feature | Description |
 |---------|-------------|
-| Hybrid retrieval | FTS5 full-text search alongside vector similarity for keyword+semantic search |
-| Conversation store | Persistent conversation history with lossless tool-call round-trips |
-| Candidate resolution | Ordered model fallback chains resolved against what's actually running |
-| Fingerprint profiles | Backend-scoped identity profiles for per-deployment configuration |
-
-### Planned
-
-| Feature | Description |
-|---------|-------------|
-| MCP server | Expose go-llm as a standalone [Model Context Protocol](https://modelcontextprotocol.io) server — use it as a local AI service without embedding |
-| Stable chunk identity | Content-addressed chunk keys for feedback-safe reindexing |
-| Behavioral feedback | Collect and aggregate implicit quality signals to improve retrieval over time |
-| Prefetch engine | Warm-cache retrieval for predictable access patterns |
-| Orchestration pipeline | Multi-model orchestration with enriched model selection |
-| Diff-aware indexing | Incremental reindexing that only re-embeds changed content |
+| Router-MCP integration | Wire provider.Router into MCP server for intelligent model selection with circuit breakers and fallback chains |
+| FIM intelligence | Adaptive token budgets and multi-family stop tokens for completion |
+| OpenAI-compatible endpoint | `compat/` package exposing an OpenAI-compatible API over local Ollama models |
 | Vision support | Image inputs in chat messages |
-| Batch embeddings | True batch embedding via Ollama's array API |
 | ANN search | Approximate nearest neighbor search for large vector stores |
 
 ## Dependencies
@@ -313,6 +338,8 @@ Minimal by design:
 
 - `modernc.org/sqlite` — pure Go SQLite driver (no CGo)
 - `golang.org/x/sync` — concurrency primitives (bounded worker pools for indexing)
+- `golang.org/x/net` — h2c HTTP/2 cleartext transport (only imported by `mcp/`)
+- `github.com/modelcontextprotocol/go-sdk` — official MCP Go SDK (only imported by `mcp/`)
 - `github.com/parquet-go/parquet-go` — Parquet file writer (only imported by `rag/parquet/`)
 
 ## Testing

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -12,55 +12,20 @@ A shared Go module providing Ollama integration (chat, completions, embeddings) 
 ## Repository Structure
 
 ```
-projects/
-├── go-llm/                              # NEW: shared module
-│   ├── go.mod                           # module github.com/kstruzzieri/go-llm
-│   ├── go.sum
-│   ├── README.md
-│   │
-│   ├── ollama/                          # Ollama API client
-│   │   ├── client.go                    # HTTP client, connection management
-│   │   ├── client_test.go
-│   │   ├── types.go                     # Request/response types
-│   │   ├── chat.go                      # Chat completions (streaming + non-streaming)
-│   │   ├── chat_test.go
-│   │   ├── generate.go                  # Raw text generation
-│   │   ├── generate_test.go
-│   │   ├── embed.go                     # Embedding generation
-│   │   ├── embed_test.go
-│   │   ├── models.go                    # Model listing, info, pull, delete
-│   │   └── models_test.go
-│   │
-│   ├── config/                          # Model configuration loader
-│   │   ├── config.go                    # Types, Load, ModelFor, Provider lookups
-│   │   ├── config_test.go
-│   │   ├── resolve.go                   # ModelChecker interface, Resolve, ResolveAll
-│   │   └── resolve_test.go
-│   │
-│   ├── rag/                             # RAG (Retrieval Augmented Generation)
-│   │   ├── chunker.go                   # Text chunking strategies
-│   │   ├── chunker_test.go
-│   │   ├── chunker_code.go             # Code-aware chunking (by function/class)
-│   │   ├── store.go                     # VectorStore interface
-│   │   ├── store_test.go
-│   │   ├── sqlite_store.go             # SQLite + brute-force cosine similarity
-│   │   ├── sqlite_store_test.go
-│   │   ├── indexer.go                   # Index files → chunks → embeddings → store
-│   │   ├── indexer_test.go
-│   │   ├── retriever.go                # Query → embed → search → rank → return
-│   │   └── retriever_test.go
-│   │
-│   ├── completion/                      # IDE completion helpers
-│   │   ├── inline.go                    # FIM (Fill-in-the-Middle) completion
-│   │   ├── inline_test.go
-│   │   ├── context.go                   # Context window management
-│   │   └── context_test.go
-│   │
-│   └── analysis/                        # Higher-level analysis helpers
-│       ├── code_review.go               # Code review prompt construction
-│       ├── explain.go                   # Code explanation
-│       ├── metrics.go                   # ML metrics analysis (for Flux)
-│       └── trading.go                   # Trading strategy analysis (for QT)
+go-llm/
+├── ollama/          # Ollama REST API client (chat, generate, embeddings, models)
+├── config/          # Model configuration loader (models.json, resolve, fallback)
+├── provider/        # Intelligent model routing (Router, circuit breakers, warmth, scoring)
+├── rag/             # RAG: chunking, SQLite vector store, indexing, retrieval
+├── completion/      # IDE inline completion (Fill-in-the-Middle)
+├── analysis/        # Domain-specific analysis (code review, ML metrics, trading)
+├── mcp/             # MCP server: tools, prompts, resources over stdio/HTTP/2
+├── conversation/    # Persistent conversation storage with SQLite
+├── feedback/        # Implicit user behavioral signal collection
+├── fingerprint/     # Model profiling (latency benchmarks, capability detection)
+├── prefetch/        # Predictive cache-warming engine for RAG retrieval
+├── cmd/go-llm-mcp/  # Standalone MCP server binary
+└── testdata/        # Test fixtures
 ```
 
 ## Module Path
@@ -271,7 +236,7 @@ type Indexer struct {
 func NewIndexer(client *ollama.Client, store VectorStore, opts ...IndexerOption) *Indexer
 
 type IndexerOption func(*Indexer)
-func WithEmbeddingModel(model string) IndexerOption  // default: "nomic-embed-text"
+func WithEmbeddingModel(model string) IndexerOption  // default: from config or "qwen3-embedding:8b"
 func WithChunker(c Chunker) IndexerOption
 
 // IndexFile indexes a single file.
@@ -402,6 +367,74 @@ type AnomalyInfo struct {
 }
 ```
 
+### `mcp/` — MCP Server
+
+Exposes all go-llm capabilities over the [Model Context Protocol](https://modelcontextprotocol.io/), allowing any MCP-compatible client (Claude Desktop, IDE extensions, custom tools) to use them without writing Go.
+
+```go
+package mcp
+
+// Server wraps go-llm functionality as an MCP server.
+// Initializes in degraded mode when Ollama is unavailable.
+type Server struct { /* ... */ }
+
+func NewServer(ctx context.Context, opts ...Option) (*Server, error)
+
+// Options
+func WithOllamaURL(url string) Option
+func WithConfig(path string) Option    // models.json path
+func WithRAGPath(path string) Option   // SQLite vector store
+func WithRAGDisabled() Option
+func WithTLS(cert, key string) Option
+
+// Transports
+func (s *Server) ListenStdio(ctx context.Context) error
+func (s *Server) ListenHTTP(ctx context.Context, addr string) error
+
+// Lifecycle
+func (s *Server) Shutdown(ctx context.Context) error
+func (s *Server) Close() error
+```
+
+**19 tools** organized by domain:
+
+| Domain | Tools |
+|--------|-------|
+| Chat | `chat` (with optional RAG context) |
+| Generate | `generate` (raw text) |
+| Completion | `complete_code` (FIM) |
+| Embeddings | `embed`, `embed_batch` |
+| Models | `list_models`, `show_model`, `pull_model` |
+| RAG | `rag_index_file`, `rag_index_directory`, `rag_search`, `rag_stats`, `rag_delete` |
+| Analysis | `code_review`, `explain_code`, `analyze_training`, `explain_anomaly`, `analyze_strategy`, `compare_strategies` |
+
+**4 prompt templates:** `code-review`, `explain`, `rag-query`, `refactor`
+
+**5 resources:** `go-llm://health`, `go-llm://models`, `go-llm://models/{name}`, `go-llm://rag/stats`, `go-llm://config`
+
+**Key design decisions:**
+- Stateful `Server` struct wraps `ollama.Client` + optional `rag.VectorStore`/`rag.Indexer`/`rag.Retriever`
+- Model resolution: explicit model param > config defaults > error. Uses `config.ResolveAll` with cached results, refreshed on `list_models` / `pull_model`
+- Transport: stdio for client integration, HTTP/2 for network. h2c (cleartext HTTP/2) for local, TLS for remote — `isLoopback()` prevents accidental plaintext exposure on non-loopback addresses
+- Graceful shutdown: `Shutdown` stops HTTP listener, waits for in-flight requests, then closes RAG store and derived clients
+- RAG tools trust caller-provided paths (matches MCP trust model: server trusts its client)
+
+### `cmd/go-llm-mcp/` — Standalone Binary
+
+```bash
+# Stdio (for Claude Desktop, IDE integration)
+go-llm-mcp --transport stdio
+
+# HTTP/2 (local development)
+go-llm-mcp --transport http --addr 127.0.0.1:8080
+
+# HTTP/2 with TLS (remote deployment)
+go-llm-mcp --transport http --addr 0.0.0.0:443 --tls-cert cert.pem --tls-key key.pem
+
+# Custom config
+go-llm-mcp --ollama-url http://gpu-server:11434 --config /etc/go-llm/models.json
+```
+
 ---
 
 ## Integration Points
@@ -432,7 +465,7 @@ func NewService(dbPath string) (*Service, error) {
     store, _ := rag.NewSQLiteStore(dbPath)
     indexer := rag.NewIndexer(client, store)
     retriever := rag.NewRetriever(client, store)
-    completer := completion.NewProvider(client, "qwen2.5-coder:32b")
+    completer := completion.NewProvider(client, "qwen3-coder-next")
 
     return &Service{
         client:    client,
@@ -505,7 +538,7 @@ func NewService() *Service {
     client := ollama.NewClient()
     return &Service{
         client:   client,
-        analyzer: analysis.NewMetricsAnalyzer(client, "qwen2.5:72b"),
+        analyzer: analysis.NewMetricsAnalyzer(client, "qwen3.5:27b"),
     }
 }
 
@@ -534,14 +567,18 @@ Minimal external dependencies:
 // go.mod
 module github.com/kstruzzieri/go-llm
 
-go 1.23
+go 1.25
 
 require (
-    modernc.org/sqlite v1.44.3   // SQLite for vector store (pure Go, no CGo)
+    modernc.org/sqlite                      // SQLite for vector store (pure Go, no CGo)
+    golang.org/x/sync                       // errgroup for bounded worker pools
+    golang.org/x/net                        // h2c HTTP/2 cleartext (mcp/ only)
+    github.com/modelcontextprotocol/go-sdk  // Official MCP Go SDK (mcp/ only)
+    github.com/parquet-go/parquet-go         // Parquet file writer (rag/parquet/ only)
 )
 ```
 
-That's it. The Ollama client is pure `net/http`. Embeddings math is `math` stdlib. SQLite is already used by Flux ML (same driver: `modernc.org/sqlite`).
+The Ollama client is pure `net/http`. Embeddings math is `math` stdlib. SQLite is already used by Flux ML (same driver: `modernc.org/sqlite`).
 
 ---
 
@@ -582,7 +619,7 @@ That's it. The Ollama client is pure `net/http`. Embeddings math is `math` stdli
 
 ## Performance Considerations
 
-- **Embedding batch size:** nomic-embed-text handles ~32 texts per batch efficiently. The indexer should batch.
+- **Embedding batch size:** Embedding models handle ~32 texts per batch efficiently. The indexer should batch.
 - **Vector search:** For < 50k chunks (typical codebase), brute-force cosine similarity in SQLite is < 50ms. No ANN index needed yet.
 - **Completion latency:** FIM completion should target < 500ms for inline suggestions. Use small context windows (2048 tokens) and `num_predict: 128`.
 - **Memory:** The go-llm module itself uses negligible memory. Ollama manages model memory independently.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -236,7 +236,7 @@ type Indexer struct {
 func NewIndexer(client *ollama.Client, store VectorStore, opts ...IndexerOption) *Indexer
 
 type IndexerOption func(*Indexer)
-func WithEmbeddingModel(model string) IndexerOption  // default: from config or "qwen3-embedding:8b"
+func WithEmbeddingModel(model string) IndexerOption  // default: "nomic-embed-text"
 func WithChunker(c Chunker) IndexerOption
 
 // IndexFile indexes a single file.
@@ -534,12 +534,16 @@ type Service struct {
     analyzer *analysis.MetricsAnalyzer
 }
 
-func NewService() *Service {
+func NewService() (*Service, error) {
     client := ollama.NewClient()
+    analyzer, err := analysis.NewMetricsAnalyzer(client, "qwen3.5:27b")
+    if err != nil {
+        return nil, err
+    }
     return &Service{
         client:   client,
-        analyzer: analysis.NewMetricsAnalyzer(client, "qwen3.5:27b"),
-    }
+        analyzer: analyzer,
+    }, nil
 }
 
 // --- Wails-exposed methods ---

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -4,7 +4,7 @@ A guide to setting up and using go-llm with your local Ollama models.
 
 ## Prerequisites
 
-1. **Go 1.24+** installed
+1. **Go 1.25+** installed
 2. **Ollama** running locally — [install](https://ollama.com/download)
 3. Required models pulled (see [Model Configuration](#model-configuration))
 
@@ -188,29 +188,89 @@ resp, _ := client.Chat(ctx, ollama.ChatRequest{
 })
 ```
 
+### MCP Server
+
+The MCP server exposes all go-llm capabilities over the [Model Context Protocol](https://modelcontextprotocol.io/) for use with Claude Desktop, IDE extensions, or any MCP client.
+
+#### Standalone Binary
+
+```bash
+# Build
+go build -o go-llm-mcp ./cmd/go-llm-mcp/
+
+# Stdio transport (for Claude Desktop / IDE integration)
+go-llm-mcp --transport stdio
+
+# HTTP/2 transport (local development)
+go-llm-mcp --transport http --addr 127.0.0.1:8080
+
+# With custom Ollama URL and config
+go-llm-mcp --ollama-url http://gpu-server:11434 --config /path/to/models.json
+
+# Disable RAG tools
+go-llm-mcp --no-rag
+
+# HTTP/2 with TLS (remote deployment)
+go-llm-mcp --transport http --addr 0.0.0.0:443 --tls-cert cert.pem --tls-key key.pem
+```
+
+#### Claude Desktop Configuration
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "go-llm": {
+      "command": "/path/to/go-llm-mcp",
+      "args": ["--transport", "stdio"]
+    }
+  }
+}
+```
+
+#### Embedded in a Go Application
+
+```go
+import "github.com/kstruzzieri/go-llm/mcp"
+
+srv, err := mcp.NewServer(ctx,
+    mcp.WithOllamaURL("http://localhost:11434"),
+    mcp.WithConfig("models.json"),
+    mcp.WithRAGPath("./vectors.db"),
+)
+if err != nil {
+    log.Fatal(err)
+}
+defer srv.Shutdown(ctx)
+
+// Stdio (connects to parent process)
+srv.ListenStdio(ctx)
+
+// Or HTTP/2 (network)
+srv.ListenHTTP(ctx, "127.0.0.1:8080")
+```
+
+The server provides 19 tools (chat, generate, code completion, embeddings, RAG, model management, analysis), 4 prompt templates, and 5 resources. Chat, generate, completion, embedding, and analysis tools accept an optional `model` parameter; when omitted, the configured default for that use-case is used.
+
 ## Architecture
 
 ```
 go-llm/
-├── ollama/        # Ollama REST API client
-│   ├── client.go  # HTTP client with functional options
-│   ├── chat.go    # Chat completions (streaming + sync)
-│   ├── generate.go# Text generation (streaming + sync)
-│   ├── embed.go   # Embedding generation (single + batch)
-│   ├── models.go  # Model management (list, show, pull)
-│   └── types.go   # Request/response types
-├── rag/           # Retrieval Augmented Generation
-│   ├── store.go       # VectorStore interface
-│   ├── sqlite_store.go# SQLite implementation (cosine similarity)
-│   ├── chunker.go     # Text chunking interface + sliding window
-│   ├── chunker_code.go# Code-aware chunking (Go, Python, TS, etc.)
-│   ├── indexer.go     # File/directory indexing coordinator
-│   └── retriever.go   # Query embedding + context building
-├── completion/    # IDE inline completions (planned)
-├── analysis/      # Domain analysis helpers (planned)
-├── config/        # Model configuration loader (models.json)
-├── models.json    # Model configuration (loaded by config package)
-└── docs/          # Documentation
+├── ollama/          # Ollama REST API client (chat, generate, embeddings, models)
+├── config/          # Model configuration loader (models.json, resolve, fallback)
+├── provider/        # Intelligent model routing (Router, circuit breakers, warmth, scoring)
+├── rag/             # RAG: chunking, SQLite vector store, indexing, retrieval
+├── completion/      # IDE inline completion (Fill-in-the-Middle)
+├── analysis/        # Domain-specific analysis (code review, ML metrics, trading)
+├── mcp/             # MCP server: tools, prompts, resources over stdio/HTTP/2
+├── conversation/    # Persistent conversation storage with SQLite
+├── feedback/        # Implicit user behavioral signal collection
+├── fingerprint/     # Model profiling (latency benchmarks, capability detection)
+├── prefetch/        # Predictive cache-warming engine for RAG retrieval
+├── cmd/go-llm-mcp/  # Standalone MCP server binary
+├── models.json      # Model configuration (loaded by config package)
+└── testdata/        # Test fixtures
 ```
 
 ## Hardware Requirements

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -199,19 +199,19 @@ The MCP server exposes all go-llm capabilities over the [Model Context Protocol]
 go build -o go-llm-mcp ./cmd/go-llm-mcp/
 
 # Stdio transport (for Claude Desktop / IDE integration)
-go-llm-mcp --transport stdio
+./go-llm-mcp --transport stdio
 
 # HTTP/2 transport (local development)
-go-llm-mcp --transport http --addr 127.0.0.1:8080
+./go-llm-mcp --transport http --addr 127.0.0.1:8080
 
 # With custom Ollama URL and config
-go-llm-mcp --ollama-url http://gpu-server:11434 --config /path/to/models.json
+./go-llm-mcp --ollama-url http://gpu-server:11434 --config /path/to/models.json
 
 # Disable RAG tools
-go-llm-mcp --no-rag
+./go-llm-mcp --no-rag
 
 # HTTP/2 with TLS (remote deployment)
-go-llm-mcp --transport http --addr 0.0.0.0:443 --tls-cert cert.pem --tls-key key.pem
+./go-llm-mcp --transport http --addr 0.0.0.0:443 --tls-cert cert.pem --tls-key key.pem
 ```
 
 #### Claude Desktop Configuration


### PR DESCRIPTION
## Summary

- Update all docs to reflect current codebase state after MCP server (#53), Router (#52), and other shipped features
- Add MCP server sections to DESIGN.md, GETTING_STARTED.md, and README.md
- Fix stale model names throughout (qwen2.5 -> qwen3.5, nomic-embed-text -> qwen3-embedding:8b)

### Changes by file

- **CLAUDE.md**: Add config/, provider/, conversation/, feedback/, fingerprint/, prefetch/ to architecture tree; update API reference model names
- **README.md**: Add MCP server section, add 7 shipped packages to table, rewrite roadmap (removed 9 shipped items), update model names and embedding dimensions, update dependencies
- **DESIGN.md**: Add MCP server package section with tool/prompt/resource inventory and CLI usage, update repo structure, fix `rag.Engine` to actual types (`VectorStore`/`Indexer`/`Retriever`), correct tool count (22 -> 19), update dependencies, fix integration examples
- **GETTING_STARTED.md**: Add MCP server usage (standalone, Claude Desktop, embedded), update architecture tree, fix Go version to 1.25+, correct tool count and model param description

## Test plan

- [x] Docs-only change, no code modified
- [x] Verified no stale model names remain in active docs
- [x] Tool count (19) verified against `grep -c AddTool mcp/tools_*.go`

Generated with [Claude Code](https://claude.com/claude-code)