### PR TITLE
Adopt 2026 model lineup (Gemma 4 / Qwen 3.6) + bench harness scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .claude
 docs/plans/
 docs/superpowers/
+docs/llm/traces/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to `go-llm` are documented here. Downstream consumers
+(Firn IDE, Flux ML, Quantum Trader) should consult this before any
+`go get -u github.com/kstruzzieri/go-llm`.
+
+## Unreleased
+
+### Breaking for consumers of `models.json` defaults
+
+The root `models.json` lineup has been retargeted for 2026 model releases.
+**Consumers that read `models.json` via `config.Load` and expect specific
+model names will observe different models at runtime.**
+
+| Role          | Was                    | Now                       |
+|---------------|------------------------|---------------------------|
+| `general`     | `qwen3.5:27b`          | `gemma4:31b`              |
+| `analysis`    | `qwen3.5:27b`          | `gemma4:31b`              |
+| `fast`        | `qwen3.5:35b-a3b`      | `qwen3.6:35b-a3b`         |
+| `agent` (new) | —                      | `gemma4:31b`              |
+| `coding`      | `qwen3-coder-next:latest` | unchanged              |
+| `lightweight` | `qwen3:8b`             | unchanged                 |
+| `embedding`   | `qwen3-embedding:8b`   | unchanged                 |
+
+**Before upgrading, consumers MUST:**
+
+1. `ollama pull gemma4:31b` and `ollama pull qwen3.6:35b-a3b` on every
+   deployment host. Absent pulls will produce 404s from Ollama at first
+   use (circuit breaker will trip and fall back per the `fallbacks`
+   chain, so behavior degrades rather than crashes — but quality will
+   drop).
+2. If you pinned to `qwen3.5:27b` or `qwen3.5:35b-a3b` in app-level
+   code, that pinning is unaffected by this change (the library only
+   reads from `models.json`). You can keep pinning explicitly.
+3. Review `docs/llm/recommendation.md` for the rationale and the
+   GLM-5.1 parallel experiment plan.
+
+### Added
+
+- **`agent` role** in `models.json` defaults, pointing at `gemma4:31b`.
+- **`agent` / `tool-use` weight profiles** in
+  `provider/router_score.go:defaultWeightProfiles` so the new role
+  gets meaningful scoring instead of falling back to `chat`.
+- **`ollama.ChatRequest.KeepAlive`** field exposing Ollama's
+  `keep_alive` directive. Useful for benchmark runs that want a model
+  to stay warm longer than the 5-minute default.
+- **`cmd/llm-bench`** — scaffold for model A/B comparison on captured
+  traces. See `docs/llm/benchmark-plan.md`.
+- **`qwen3.6`, `qwen3-coder-next`, `gemma4`** families in
+  `provider/catalog.json`.
+- **`docs/llm/`** — 2026 local-LLM analysis, three candidate setups,
+  recommendation, and benchmark plan.
+
+### Changed
+
+- Catalog: `qwen3-coder-next` gains a `latest` variant alias kept in
+  sync with `80b` (guarded by test).

--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -1,0 +1,90 @@
+// Command llm-bench replays captured MCP/chat traces against one or more
+// candidate models and produces a comparative quality + latency report.
+//
+// See docs/llm/benchmark-plan.md for design rationale and metrics.
+//
+// Example:
+//
+//	llm-bench \
+//	  -traces docs/llm/traces/*.json \
+//	  -models "ollama/qwen3-coder-next:latest,ollama/gemma4:31b" \
+//	  -scorer exact-match \
+//	  -report ./bench-report.md
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+)
+
+func main() {
+	tracesGlob := flag.String("traces", "", "Glob pattern for trace JSON files (required)")
+	modelsArg := flag.String("models", "", "Comma-separated provider/model identifiers (required)")
+	scorerName := flag.String("scorer", "exact-match", "Scoring strategy: exact-match, llm-judge, manual")
+	reportPath := flag.String("report", "", "Output report path (default: stdout)")
+	ollamaURL := flag.String("ollama-url", "http://localhost:11434", "Ollama base URL")
+	timeout := flag.Duration("timeout", 5*time.Minute, "Per-trace timeout")
+	flag.Parse()
+
+	if *tracesGlob == "" || *modelsArg == "" {
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	tracePaths, err := filepath.Glob(*tracesGlob)
+	if err != nil {
+		log.Fatalf("llm-bench: glob %q: %v", *tracesGlob, err)
+	}
+	if len(tracePaths) == 0 {
+		log.Fatalf("llm-bench: no traces matched %q", *tracesGlob)
+	}
+
+	models := strings.Split(*modelsArg, ",")
+	for i, m := range models {
+		models[i] = strings.TrimSpace(m)
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	traces, err := loadTraces(tracePaths)
+	if err != nil {
+		log.Fatalf("llm-bench: load traces: %v", err)
+	}
+
+	scorer, err := newScorer(*scorerName)
+	if err != nil {
+		log.Fatalf("llm-bench: scorer: %v", err)
+	}
+
+	runner := &Runner{
+		OllamaURL: *ollamaURL,
+		Timeout:   *timeout,
+		Scorer:    scorer,
+	}
+
+	results, err := runner.RunAll(ctx, models, traces)
+	if err != nil {
+		log.Fatalf("llm-bench: run: %v", err)
+	}
+
+	report := formatReport(models, results)
+
+	if *reportPath == "" {
+		fmt.Print(report)
+		return
+	}
+
+	if err := os.WriteFile(*reportPath, []byte(report), 0o644); err != nil {
+		log.Fatalf("llm-bench: write report: %v", err)
+	}
+	fmt.Fprintf(os.Stderr, "llm-bench: report written to %s\n", *reportPath)
+}

--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -20,14 +20,13 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"time"
 )
 
 func main() {
 	tracesGlob := flag.String("traces", "", "Glob pattern for trace JSON files (required)")
-	modelsArg := flag.String("models", "", "Comma-separated provider/model identifiers (required)")
+	modelsArg := flag.String("models", "", "Comma-separated model selectors (provider/model or bare model name; required)")
 	scorerName := flag.String("scorer", "exact-match", "Scoring strategy: exact-match, llm-judge, manual")
 	reportPath := flag.String("report", "", "Output report path (default: stdout)")
 	ollamaURL := flag.String("ollama-url", "http://localhost:11434", "Ollama base URL")
@@ -47,9 +46,9 @@ func main() {
 		log.Fatalf("llm-bench: no traces matched %q", *tracesGlob)
 	}
 
-	models := strings.Split(*modelsArg, ",")
-	for i, m := range models {
-		models[i] = strings.TrimSpace(m)
+	targets, err := parseModelTargets(*modelsArg)
+	if err != nil {
+		log.Fatalf("llm-bench: parse models: %v", err)
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -71,12 +70,17 @@ func main() {
 		Scorer:    scorer,
 	}
 
-	results, err := runner.RunAll(ctx, models, traces)
+	results, err := runner.RunAll(ctx, targets, traces)
 	if err != nil {
 		log.Fatalf("llm-bench: run: %v", err)
 	}
 
-	report := formatReport(models, results)
+	modelNames := make([]string, 0, len(targets))
+	for _, target := range targets {
+		modelNames = append(modelNames, target.Display)
+	}
+
+	report := formatReport(modelNames, results)
 
 	if *reportPath == "" {
 		fmt.Print(report)

--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -87,7 +87,7 @@ func main() {
 		return
 	}
 
-	if err := os.WriteFile(*reportPath, []byte(report), 0o644); err != nil {
+	if err := os.WriteFile(*reportPath, []byte(report), 0o600); err != nil {
 		log.Fatalf("llm-bench: write report: %v", err)
 	}
 	fmt.Fprintf(os.Stderr, "llm-bench: report written to %s\n", *reportPath)

--- a/cmd/llm-bench/replay_test.go
+++ b/cmd/llm-bench/replay_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -59,5 +60,81 @@ func TestReplayRefusesTraceWithoutUserTurn(t *testing.T) {
 	}
 	if *called {
 		t.Error("replay reached Ollama despite refusing the trace")
+	}
+}
+
+func TestReplayForwardsTraceTools(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollama.ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if len(req.Tools) != 1 {
+			t.Fatalf("expected 1 tool, got %d", len(req.Tools))
+		}
+		if req.Tools[0].Type != "function" {
+			t.Fatalf("tool type = %q, want function", req.Tools[0].Type)
+		}
+		if req.Tools[0].Function.Name != "read_file" {
+			t.Fatalf("tool name = %q, want read_file", req.Tools[0].Function.Name)
+		}
+
+		var schema map[string]any
+		if err := json.Unmarshal(req.Tools[0].Function.Parameters, &schema); err != nil {
+			t.Fatalf("unmarshal schema: %v", err)
+		}
+		if schema["type"] != "object" {
+			t.Fatalf("schema type = %v, want object", schema["type"])
+		}
+
+		resp := ollama.ChatResponse{
+			Model:   "test-model",
+			Message: ollama.ChatMessage{Role: "assistant", Content: "done"},
+			Done:    true,
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	trace := Trace{
+		ID:     "tool-trace",
+		System: "sys",
+		Tools: []json.RawMessage{
+			json.RawMessage(`{"name":"read_file","description":"Read a file from disk","inputSchema":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}}`),
+		},
+		Turns: []Turn{{Role: "user", Content: "Read provider/router.go"}},
+	}
+
+	transcript, err := replay(context.Background(), client, "test-model", trace)
+	if err != nil {
+		t.Fatalf("replay() error: %v", err)
+	}
+	if len(transcript) != 1 || transcript[0].Content != "done" {
+		t.Fatalf("transcript = %#v, want single assistant turn with content", transcript)
+	}
+}
+
+func TestReplayRejectsInvalidTraceTool(t *testing.T) {
+	srv, called := newBlockedServer(t)
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+
+	trace := Trace{
+		ID:     "bad-tool",
+		System: "sys",
+		Tools: []json.RawMessage{
+			json.RawMessage(`{"name":"read_file","description":"Read a file","inputSchema":123}`),
+		},
+		Turns: []Turn{{Role: "user", Content: "hi"}},
+	}
+
+	_, err := replay(context.Background(), client, "m", trace)
+	if !errors.Is(err, errInvalidTraceTool) {
+		t.Fatalf("err = %v, want errInvalidTraceTool", err)
+	}
+	if *called {
+		t.Error("replay reached Ollama despite invalid tool definition")
 	}
 }

--- a/cmd/llm-bench/replay_test.go
+++ b/cmd/llm-bench/replay_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+func TestReplayRefusesMultipleUserTurns(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	trace := Trace{
+		ID:     "multi-turn",
+		System: "sys",
+		Turns: []Turn{
+			{Role: "user", Content: "first"},
+			{Role: "assistant", Content: "ack"},
+			{Role: "user", Content: "second"},
+		},
+	}
+
+	_, err := replay(context.Background(), client, "some-model", trace)
+	if err == nil {
+		t.Fatal("expected error for multi-user-turn trace, got nil")
+	}
+	if !strings.Contains(err.Error(), "multi-turn replay not yet supported") {
+		t.Errorf("error = %v, want multi-turn guard message", err)
+	}
+	if called {
+		t.Error("replay reached Ollama despite refusing the trace")
+	}
+}
+
+func TestReplayRefusesTraceWithoutUserTurn(t *testing.T) {
+	client := ollama.NewClient(ollama.WithBaseURL("http://127.0.0.1:1"))
+	trace := Trace{ID: "no-user", Turns: []Turn{{Role: "assistant", Content: "hi"}}}
+
+	_, err := replay(context.Background(), client, "m", trace)
+	if err == nil {
+		t.Fatal("expected error for trace with no user turn, got nil")
+	}
+	if !strings.Contains(err.Error(), "no user turn") {
+		t.Errorf("error = %v, want no-user-turn guard message", err)
+	}
+}

--- a/cmd/llm-bench/replay_test.go
+++ b/cmd/llm-bench/replay_test.go
@@ -48,6 +48,30 @@ func TestReplayRefusesMultipleUserTurns(t *testing.T) {
 	}
 }
 
+func TestReplayRefusesTraceWithUnsupportedExtraTurns(t *testing.T) {
+	srv, called := newBlockedServer(t)
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+
+	trace := Trace{
+		ID:     "tool-loop-trace",
+		System: "sys",
+		Turns: []Turn{
+			{Role: "user", Content: "first"},
+			{Role: "assistant", ToolCalls: []ToolCall{{Name: "read_file"}}},
+			{Role: "tool", Name: "read_file", Content: "contents"},
+			{Role: "assistant", Content: "final"},
+		},
+	}
+
+	_, err := replay(context.Background(), client, "some-model", trace)
+	if !errors.Is(err, errUnsupportedTurns) {
+		t.Fatalf("err = %v, want errUnsupportedTurns", err)
+	}
+	if *called {
+		t.Error("replay reached Ollama despite refusing the trace")
+	}
+}
+
 func TestReplayRefusesTraceWithoutUserTurn(t *testing.T) {
 	srv, called := newBlockedServer(t)
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))

--- a/cmd/llm-bench/replay_test.go
+++ b/cmd/llm-bench/replay_test.go
@@ -2,23 +2,32 @@ package main
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/kstruzzieri/go-llm/ollama"
 )
 
-func TestReplayRefusesMultipleUserTurns(t *testing.T) {
+// newBlockedServer returns a test server that flags any received request.
+// Callers assert !called to prove replay refused the trace before reaching
+// the network.
+func newBlockedServer(t *testing.T) (*httptest.Server, *bool) {
+	t.Helper()
 	called := false
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
 		w.WriteHeader(http.StatusOK)
 	}))
-	defer srv.Close()
+	t.Cleanup(srv.Close)
+	return srv, &called
+}
 
+func TestReplayRefusesMultipleUserTurns(t *testing.T) {
+	srv, called := newBlockedServer(t)
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+
 	trace := Trace{
 		ID:     "multi-turn",
 		System: "sys",
@@ -30,26 +39,25 @@ func TestReplayRefusesMultipleUserTurns(t *testing.T) {
 	}
 
 	_, err := replay(context.Background(), client, "some-model", trace)
-	if err == nil {
-		t.Fatal("expected error for multi-user-turn trace, got nil")
+	if !errors.Is(err, errMultiUserTurn) {
+		t.Fatalf("err = %v, want errMultiUserTurn", err)
 	}
-	if !strings.Contains(err.Error(), "multi-turn replay not yet supported") {
-		t.Errorf("error = %v, want multi-turn guard message", err)
-	}
-	if called {
+	if *called {
 		t.Error("replay reached Ollama despite refusing the trace")
 	}
 }
 
 func TestReplayRefusesTraceWithoutUserTurn(t *testing.T) {
-	client := ollama.NewClient(ollama.WithBaseURL("http://127.0.0.1:1"))
+	srv, called := newBlockedServer(t)
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+
 	trace := Trace{ID: "no-user", Turns: []Turn{{Role: "assistant", Content: "hi"}}}
 
 	_, err := replay(context.Background(), client, "m", trace)
-	if err == nil {
-		t.Fatal("expected error for trace with no user turn, got nil")
+	if !errors.Is(err, errNoUserTurn) {
+		t.Fatalf("err = %v, want errNoUserTurn", err)
 	}
-	if !strings.Contains(err.Error(), "no user turn") {
-		t.Errorf("error = %v, want no-user-turn guard message", err)
+	if *called {
+		t.Error("replay reached Ollama despite refusing the trace")
 	}
 }

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -36,12 +36,14 @@ func formatReport(models []string, results []Result) string {
 		rs := byModel[m]
 		sort.Slice(rs, func(i, j int) bool { return rs[i].TraceID < rs[j].TraceID })
 		for _, r := range rs {
-			errCell := ""
 			if r.Err != nil {
-				errCell = r.Err.Error()
+				// Errored runs: render em-dash in metric cells so a reader
+				// never confuses an error with a genuine zero score.
+				fmt.Fprintf(&b, "| %s | — | — | — | %s |\n", r.TraceID, r.Err.Error())
+				continue
 			}
-			fmt.Fprintf(&b, "| %s | %.2f | %.2f | %d | %s |\n",
-				r.TraceID, r.Score.AnswerQuality, r.Score.ToolSequenceMatch, r.Score.LatencyMs, errCell)
+			fmt.Fprintf(&b, "| %s | %.2f | %.2f | %d | |\n",
+				r.TraceID, r.Score.AnswerQuality, r.Score.ToolSequenceMatch, r.Score.LatencyMs)
 		}
 		fmt.Fprintln(&b)
 	}

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// formatReport renders per-model aggregates as a Markdown table.
+func formatReport(models []string, results []Result) string {
+	byModel := make(map[string][]Result, len(models))
+	for _, r := range results {
+		byModel[r.Model] = append(byModel[r.Model], r)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "# llm-bench report\n\n")
+	fmt.Fprintf(&b, "Generated: %s\n\n", time.Now().UTC().Format(time.RFC3339))
+
+	fmt.Fprintf(&b, "## Summary\n\n")
+	fmt.Fprintf(&b, "| Model | Traces | Errors | Mean Quality | Mean ToolSeq | Mean Latency (ms) |\n")
+	fmt.Fprintf(&b, "|---|---|---|---|---|---|\n")
+	for _, m := range models {
+		rs := byModel[m]
+		agg := aggregate(rs)
+		fmt.Fprintf(&b, "| %s | %d | %d | %.2f | %.2f | %d |\n",
+			m, len(rs), agg.errors, agg.meanQuality, agg.meanToolSeq, agg.meanLatencyMs)
+	}
+
+	fmt.Fprintf(&b, "\n## Per-trace detail\n\n")
+	for _, m := range models {
+		fmt.Fprintf(&b, "### %s\n\n", m)
+		fmt.Fprintf(&b, "| Trace | Quality | ToolSeq | Latency (ms) | Error |\n")
+		fmt.Fprintf(&b, "|---|---|---|---|---|\n")
+		rs := byModel[m]
+		sort.Slice(rs, func(i, j int) bool { return rs[i].TraceID < rs[j].TraceID })
+		for _, r := range rs {
+			errCell := ""
+			if r.Err != nil {
+				errCell = r.Err.Error()
+			}
+			fmt.Fprintf(&b, "| %s | %.2f | %.2f | %d | %s |\n",
+				r.TraceID, r.Score.AnswerQuality, r.Score.ToolSequenceMatch, r.Score.LatencyMs, errCell)
+		}
+		fmt.Fprintln(&b)
+	}
+
+	return b.String()
+}
+
+type modelAggregate struct {
+	errors         int
+	meanQuality    float64
+	meanToolSeq    float64
+	meanLatencyMs  int64
+}
+
+func aggregate(rs []Result) modelAggregate {
+	if len(rs) == 0 {
+		return modelAggregate{}
+	}
+	var a modelAggregate
+	var qSum, tsSum float64
+	var latSum int64
+	var scored int
+	for _, r := range rs {
+		if r.Err != nil {
+			a.errors++
+			continue
+		}
+		qSum += r.Score.AnswerQuality
+		tsSum += r.Score.ToolSequenceMatch
+		latSum += r.Score.LatencyMs
+		scored++
+	}
+	if scored > 0 {
+		a.meanQuality = qSum / float64(scored)
+		a.meanToolSeq = tsSum / float64(scored)
+		a.meanLatencyMs = latSum / int64(scored)
+	}
+	return a
+}

--- a/cmd/llm-bench/run_all_test.go
+++ b/cmd/llm-bench/run_all_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newFakeChatServer responds to /api/chat with a fixed assistant reply.
+func newFakeChatServer(t *testing.T, reply string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/api/chat") {
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"model":"m","done":true,"message":{"role":"assistant","content":"` + reply + `"}}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestRunAllReturnsPartialResultsOnCtxCancel(t *testing.T) {
+	srv := newFakeChatServer(t, "answer with needle inside")
+	runner := &Runner{
+		OllamaURL: srv.URL,
+		Timeout:   5 * time.Second,
+		Scorer:    &ExactMatchScorer{},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel up front
+
+	targets := []ModelTarget{{Display: "m1", Provider: "ollama", Model: "m1"}}
+	traces := []Trace{{
+		ID:     "t1",
+		System: "sys",
+		Turns:  []Turn{{Role: "user", Content: "q"}},
+		Golden: Golden{FinalAnswerSubstring: "needle"},
+	}}
+
+	results, err := runner.RunAll(ctx, targets, traces)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("got %d results on pre-cancelled ctx, want 0", len(results))
+	}
+}
+
+func TestRunAllRecordsClientConstructionFailureAsResults(t *testing.T) {
+	runner := &Runner{
+		OllamaURL: "   ", // whitespace triggers errEmptyBaseURL
+		Timeout:   time.Second,
+		Scorer:    &ExactMatchScorer{},
+	}
+
+	targets := []ModelTarget{{Display: "m1", Provider: "ollama", Model: "m1"}}
+	traces := []Trace{
+		{ID: "t1", System: "s", Turns: []Turn{{Role: "user", Content: "q"}}, Golden: Golden{FinalAnswerSubstring: "x"}},
+		{ID: "t2", System: "s", Turns: []Turn{{Role: "user", Content: "q"}}, Golden: Golden{FinalAnswerSubstring: "x"}},
+	}
+
+	results, err := runner.RunAll(context.Background(), targets, traces)
+	if err != nil {
+		t.Fatalf("RunAll() error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2 (one per trace, all errored)", len(results))
+	}
+	for _, r := range results {
+		if !errors.Is(r.Err, errEmptyBaseURL) {
+			t.Errorf("result %q: err = %v, want errEmptyBaseURL", r.TraceID, r.Err)
+		}
+	}
+}
+
+func TestRunAllSucceedsEndToEnd(t *testing.T) {
+	srv := newFakeChatServer(t, "answer with needle inside")
+	runner := &Runner{
+		OllamaURL: srv.URL,
+		Timeout:   5 * time.Second,
+		Scorer:    &ExactMatchScorer{},
+	}
+
+	targets := []ModelTarget{{Display: "m1", Provider: "ollama", Model: "m1"}}
+	traces := []Trace{{
+		ID:     "t1",
+		System: "sys",
+		Turns:  []Turn{{Role: "user", Content: "q"}},
+		Golden: Golden{FinalAnswerSubstring: "needle"},
+	}}
+
+	results, err := runner.RunAll(context.Background(), targets, traces)
+	if err != nil {
+		t.Fatalf("RunAll() error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	r := results[0]
+	if r.Err != nil {
+		t.Fatalf("unexpected err: %v", r.Err)
+	}
+	if r.Score.AnswerQuality != 1.0 {
+		t.Errorf("AnswerQuality = %f, want 1.0", r.Score.AnswerQuality)
+	}
+}

--- a/cmd/llm-bench/run_all_test.go
+++ b/cmd/llm-bench/run_all_test.go
@@ -19,7 +19,9 @@ func newFakeChatServer(t *testing.T, reply string) *httptest.Server {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"model":"m","done":true,"message":{"role":"assistant","content":"` + reply + `"}}`))
+		if _, err := w.Write([]byte(`{"model":"m","done":true,"message":{"role":"assistant","content":"` + reply + `"}}`)); err != nil {
+			t.Errorf("fake server write: %v", err)
+		}
 	}))
 	t.Cleanup(srv.Close)
 	return srv

--- a/cmd/llm-bench/runner.go
+++ b/cmd/llm-bench/runner.go
@@ -18,13 +18,14 @@ const benchKeepAlive = "30m"
 
 // Sentinel errors so tests assert on identity rather than message text.
 var (
-	errNoUserTurn      = errors.New("trace has no user turn")
-	errMultiUserTurn   = errors.New("multi-turn replay not yet supported")
-	errEmptyBaseURL    = errors.New("empty ollama base URL")
-	errMissingGolden   = errors.New("scorer requires golden.final_answer_substring")
-	errEmptySystem     = errors.New("trace has empty system prompt")
-	errNoTurns         = errors.New("trace has no turns")
-	errUnsupportedProv = errors.New("unsupported provider")
+	errNoUserTurn       = errors.New("trace has no user turn")
+	errMultiUserTurn    = errors.New("multi-turn replay not yet supported")
+	errEmptyBaseURL     = errors.New("empty ollama base URL")
+	errMissingGolden    = errors.New("scorer requires golden.final_answer_substring")
+	errEmptySystem      = errors.New("trace has empty system prompt")
+	errNoTurns          = errors.New("trace has no turns")
+	errInvalidTraceTool = errors.New("trace has invalid tool definition")
+	errUnsupportedProv  = errors.New("unsupported provider")
 )
 
 // Runner executes traces against a list of candidate models and collects
@@ -139,10 +140,15 @@ func replay(ctx context.Context, client *ollama.Client, model string, trace Trac
 		{Role: "system", Content: trace.System},
 		{Role: "user", Content: firstUser.Content},
 	}
+	tools, err := decodeTraceTools(trace.Tools)
+	if err != nil {
+		return nil, fmt.Errorf("trace %q: %w", trace.ID, err)
+	}
 
 	resp, err := client.Chat(ctx, ollama.ChatRequest{
 		Model:     model,
 		Messages:  messages,
+		Tools:     tools,
 		KeepAlive: benchKeepAlive,
 	})
 	if err != nil {
@@ -155,6 +161,74 @@ func replay(ctx context.Context, client *ollama.Client, model string, trace Trac
 	}
 
 	return []Turn{turn}, nil
+}
+
+func decodeTraceTools(rawTools []json.RawMessage) ([]ollama.Tool, error) {
+	if len(rawTools) == 0 {
+		return nil, nil
+	}
+
+	tools := make([]ollama.Tool, 0, len(rawTools))
+	for i, raw := range rawTools {
+		tool, err := decodeTraceTool(raw)
+		if err != nil {
+			return nil, fmt.Errorf("tool[%d]: %w", i, err)
+		}
+		tools = append(tools, tool)
+	}
+	return tools, nil
+}
+
+func decodeTraceTool(raw json.RawMessage) (ollama.Tool, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil || fields == nil {
+		if err != nil {
+			return ollama.Tool{}, fmt.Errorf("%w: invalid JSON object: %v", errInvalidTraceTool, err)
+		}
+		return ollama.Tool{}, fmt.Errorf("%w: invalid JSON object", errInvalidTraceTool)
+	}
+
+	if _, ok := fields["function"]; ok {
+		var tool ollama.Tool
+		if err := json.Unmarshal(raw, &tool); err != nil {
+			return ollama.Tool{}, fmt.Errorf("%w: decode provider tool: %v", errInvalidTraceTool, err)
+		}
+		if tool.Type != "" && tool.Type != "function" {
+			return ollama.Tool{}, fmt.Errorf("%w: unsupported type %q", errInvalidTraceTool, tool.Type)
+		}
+		if strings.TrimSpace(tool.Function.Name) == "" {
+			return ollama.Tool{}, fmt.Errorf("%w: missing function.name", errInvalidTraceTool)
+		}
+		normalized, err := ollama.NewToolRaw(tool.Function.Name, tool.Function.Description, tool.Function.Parameters)
+		if err != nil {
+			return ollama.Tool{}, fmt.Errorf("%w: %v", errInvalidTraceTool, err)
+		}
+		return normalized, nil
+	}
+
+	if _, ok := fields["name"]; ok {
+		var tool struct {
+			Name        string          `json:"name"`
+			Description string          `json:"description"`
+			InputSchema json.RawMessage `json:"inputSchema"`
+		}
+		if err := json.Unmarshal(raw, &tool); err != nil {
+			return ollama.Tool{}, fmt.Errorf("%w: decode MCP tool: %v", errInvalidTraceTool, err)
+		}
+		if len(tool.InputSchema) == 0 {
+			tool.InputSchema = fields["input_schema"]
+		}
+		if strings.TrimSpace(tool.Name) == "" {
+			return ollama.Tool{}, fmt.Errorf("%w: missing name", errInvalidTraceTool)
+		}
+		normalized, err := ollama.NewToolRaw(tool.Name, tool.Description, tool.InputSchema)
+		if err != nil {
+			return ollama.Tool{}, fmt.Errorf("%w: %v", errInvalidTraceTool, err)
+		}
+		return normalized, nil
+	}
+
+	return ollama.Tool{}, fmt.Errorf("%w: expected provider tool or MCP tool shape", errInvalidTraceTool)
 }
 
 func assistantTurnFromMessage(msg ollama.ChatMessage) (Turn, error) {

--- a/cmd/llm-bench/runner.go
+++ b/cmd/llm-bench/runner.go
@@ -25,6 +25,7 @@ var (
 	errEmptySystem      = errors.New("trace has empty system prompt")
 	errNoTurns          = errors.New("trace has no turns")
 	errInvalidTraceTool = errors.New("trace has invalid tool definition")
+	errUnsupportedTurns = errors.New("trace has unsupported extra turns")
 	errUnsupportedProv  = errors.New("unsupported provider")
 )
 
@@ -115,9 +116,10 @@ func (r *Runner) runOne(ctx context.Context, client *ollama.Client, target Model
 // Feeding tool results back to the model and extracting real ToolCalls
 // from the Ollama response requires more plumbing than this scaffold.
 //
-// Until the tool loop lands, replay refuses multi-user-turn traces rather
-// than silently scoring only the first turn, which would produce
-// misleading aggregates.
+// Until the tool loop lands, replay only supports the minimal trace shape:
+// a single user turn plus the top-level system prompt. Any additional
+// assistant/tool turns would be silently truncated by this scaffold, so
+// replay refuses them rather than producing misleading aggregates.
 func replay(ctx context.Context, client *ollama.Client, model string, trace Trace) ([]Turn, error) {
 	var firstUser *Turn
 	userTurns := 0
@@ -134,6 +136,9 @@ func replay(ctx context.Context, client *ollama.Client, model string, trace Trac
 	}
 	if userTurns > 1 {
 		return nil, fmt.Errorf("trace %q has %d user turns: %w", trace.ID, userTurns, errMultiUserTurn)
+	}
+	if len(trace.Turns) != 1 {
+		return nil, fmt.Errorf("trace %q has %d turns: %w", trace.ID, len(trace.Turns), errUnsupportedTurns)
 	}
 
 	messages := []ollama.ChatMessage{

--- a/cmd/llm-bench/runner.go
+++ b/cmd/llm-bench/runner.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -19,52 +20,52 @@ type Runner struct {
 
 // Result is a single (model, trace) evaluation.
 type Result struct {
-	Model     string
-	TraceID   string
-	Score     Score
-	Err       error
+	Model      string
+	TraceID    string
+	Score      Score
+	Err        error
 	Transcript []Turn
 }
 
 // RunAll replays every trace against every model. Iterates models in the
 // outer loop so a warm model stays warm across its traces.
-func (r *Runner) RunAll(ctx context.Context, models []string, traces []Trace) ([]Result, error) {
-	results := make([]Result, 0, len(models)*len(traces))
-	for _, model := range models {
-		client, err := newOllamaClient(model, r.OllamaURL)
+func (r *Runner) RunAll(ctx context.Context, targets []ModelTarget, traces []Trace) ([]Result, error) {
+	results := make([]Result, 0, len(targets)*len(traces))
+	for _, target := range targets {
+		client, err := newOllamaClient(target.Model, r.OllamaURL)
 		if err != nil {
-			return nil, fmt.Errorf("client for %q: %w", model, err)
+			return nil, fmt.Errorf("client for %q: %w", target.Display, err)
 		}
 		for _, trace := range traces {
-			res := r.runOne(ctx, client, model, trace)
+			res := r.runOne(ctx, client, target, trace)
 			results = append(results, res)
 		}
 	}
 	return results, nil
 }
 
-func (r *Runner) runOne(ctx context.Context, client *ollama.Client, model string, trace Trace) Result {
+func (r *Runner) runOne(ctx context.Context, client *ollama.Client, target ModelTarget, trace Trace) Result {
 	runCtx, cancel := context.WithTimeout(ctx, r.Timeout)
 	defer cancel()
 
 	start := time.Now()
-	transcript, err := replay(runCtx, client, model, trace)
+	transcript, err := replay(runCtx, client, target.Model, trace)
 	if err != nil {
-		return Result{Model: model, TraceID: trace.ID, Err: err}
+		return Result{Model: target.Display, TraceID: trace.ID, Err: err}
 	}
 
 	score, err := r.Scorer.Score(runCtx, trace, Result{
-		Model:      model,
+		Model:      target.Display,
 		TraceID:    trace.ID,
 		Transcript: transcript,
 	})
 	if err != nil {
-		return Result{Model: model, TraceID: trace.ID, Err: err, Transcript: transcript}
+		return Result{Model: target.Display, TraceID: trace.ID, Err: err, Transcript: transcript}
 	}
 	score.LatencyMs = time.Since(start).Milliseconds()
 
 	return Result{
-		Model:      model,
+		Model:      target.Display,
 		TraceID:    trace.ID,
 		Score:      score,
 		Transcript: transcript,
@@ -92,7 +93,37 @@ func replay(ctx context.Context, client *ollama.Client, model string, trace Trac
 		return nil, err
 	}
 
-	return []Turn{{Role: "assistant", Content: resp.Message.Content}}, nil
+	turn, err := assistantTurnFromMessage(resp.Message)
+	if err != nil {
+		return nil, err
+	}
+
+	return []Turn{turn}, nil
+}
+
+func assistantTurnFromMessage(msg ollama.ChatMessage) (Turn, error) {
+	role := msg.Role
+	if role == "" {
+		role = "assistant"
+	}
+
+	toolCalls := make([]ToolCall, 0, len(msg.ToolCalls))
+	for _, tc := range msg.ToolCalls {
+		args, err := json.Marshal(tc.Function.Arguments)
+		if err != nil {
+			return Turn{}, fmt.Errorf("marshal tool call arguments for %q: %w", tc.Function.Name, err)
+		}
+		toolCalls = append(toolCalls, ToolCall{
+			Name:      tc.Function.Name,
+			Arguments: json.RawMessage(args),
+		})
+	}
+
+	return Turn{
+		Role:      role,
+		Content:   msg.Content,
+		ToolCalls: toolCalls,
+	}, nil
 }
 
 // newOllamaClient constructs an ollama.Client targeting the configured URL.

--- a/cmd/llm-bench/runner.go
+++ b/cmd/llm-bench/runner.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+// Runner executes traces against a list of candidate models and collects
+// per-trace, per-model Results.
+type Runner struct {
+	OllamaURL string
+	Timeout   time.Duration
+	Scorer    Scorer
+}
+
+// Result is a single (model, trace) evaluation.
+type Result struct {
+	Model     string
+	TraceID   string
+	Score     Score
+	Err       error
+	Transcript []Turn
+}
+
+// RunAll replays every trace against every model. Iterates models in the
+// outer loop so a warm model stays warm across its traces.
+func (r *Runner) RunAll(ctx context.Context, models []string, traces []Trace) ([]Result, error) {
+	results := make([]Result, 0, len(models)*len(traces))
+	for _, model := range models {
+		client, err := newOllamaClient(model, r.OllamaURL)
+		if err != nil {
+			return nil, fmt.Errorf("client for %q: %w", model, err)
+		}
+		for _, trace := range traces {
+			res := r.runOne(ctx, client, model, trace)
+			results = append(results, res)
+		}
+	}
+	return results, nil
+}
+
+func (r *Runner) runOne(ctx context.Context, client *ollama.Client, model string, trace Trace) Result {
+	runCtx, cancel := context.WithTimeout(ctx, r.Timeout)
+	defer cancel()
+
+	start := time.Now()
+	transcript, err := replay(runCtx, client, model, trace)
+	if err != nil {
+		return Result{Model: model, TraceID: trace.ID, Err: err}
+	}
+
+	score, err := r.Scorer.Score(runCtx, trace, Result{
+		Model:      model,
+		TraceID:    trace.ID,
+		Transcript: transcript,
+	})
+	if err != nil {
+		return Result{Model: model, TraceID: trace.ID, Err: err, Transcript: transcript}
+	}
+	score.LatencyMs = time.Since(start).Milliseconds()
+
+	return Result{
+		Model:      model,
+		TraceID:    trace.ID,
+		Score:      score,
+		Transcript: transcript,
+	}
+}
+
+// replay sends the trace's turns to the model and captures the assistant's
+// responses. This is a SKELETON — the tool-call loop is not yet wired up.
+// Feeding tool results back to the model and extracting real ToolCalls
+// from the Ollama response requires more plumbing than this scaffold.
+func replay(ctx context.Context, client *ollama.Client, model string, trace Trace) ([]Turn, error) {
+	messages := []ollama.ChatMessage{{Role: "system", Content: trace.System}}
+	for _, t := range trace.Turns {
+		if t.Role == "user" {
+			messages = append(messages, ollama.ChatMessage{Role: "user", Content: t.Content})
+			break // replay only first user turn for now; tool loop is TODO
+		}
+	}
+
+	resp, err := client.Chat(ctx, ollama.ChatRequest{
+		Model:    model,
+		Messages: messages,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return []Turn{{Role: "assistant", Content: resp.Message.Content}}, nil
+}
+
+// newOllamaClient constructs an ollama.Client targeting the configured URL.
+// The model argument is unused today but will matter when we route to
+// different endpoints per provider (e.g. LM Studio at a different port).
+func newOllamaClient(model, baseURL string) (*ollama.Client, error) {
+	if strings.TrimSpace(model) == "" {
+		return nil, fmt.Errorf("empty model")
+	}
+	return ollama.NewClient(ollama.WithBaseURL(baseURL)), nil
+}

--- a/cmd/llm-bench/runner.go
+++ b/cmd/llm-bench/runner.go
@@ -3,11 +3,28 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+// benchKeepAlive is the Ollama keep_alive directive used for benchmark runs.
+// Explicitly overrides Ollama's 5-minute default so the outer-loop ordering
+// in RunAll actually keeps the model warm across all of a target's traces.
+const benchKeepAlive = "30m"
+
+// Sentinel errors so tests assert on identity rather than message text.
+var (
+	errNoUserTurn      = errors.New("trace has no user turn")
+	errMultiUserTurn   = errors.New("multi-turn replay not yet supported")
+	errEmptyBaseURL    = errors.New("empty ollama base URL")
+	errMissingGolden   = errors.New("scorer requires golden.final_answer_substring")
+	errEmptySystem     = errors.New("trace has empty system prompt")
+	errNoTurns         = errors.New("trace has no turns")
+	errUnsupportedProv = errors.New("unsupported provider")
 )
 
 // Runner executes traces against a list of candidate models and collects
@@ -28,17 +45,34 @@ type Result struct {
 }
 
 // RunAll replays every trace against every model. Iterates models in the
-// outer loop so a warm model stays warm across its traces.
+// outer loop plus an explicit keep_alive directive so the model stays
+// warm across all of its traces. Per-target client-construction failures
+// and per-trace errors are recorded as Result rows rather than aborting
+// the whole run, so partial progress is never discarded.
 func (r *Runner) RunAll(ctx context.Context, targets []ModelTarget, traces []Trace) ([]Result, error) {
 	results := make([]Result, 0, len(targets)*len(traces))
 	for _, target := range targets {
+		if err := ctx.Err(); err != nil {
+			return results, err
+		}
+
 		client, err := newOllamaClient(r.OllamaURL)
 		if err != nil {
-			return nil, fmt.Errorf("client for %q: %w", target.Display, err)
+			for _, trace := range traces {
+				results = append(results, Result{
+					Model:   target.Display,
+					TraceID: trace.ID,
+					Err:     fmt.Errorf("client for %q: %w", target.Display, err),
+				})
+			}
+			continue
 		}
+
 		for _, trace := range traces {
-			res := r.runOne(ctx, client, target, trace)
-			results = append(results, res)
+			if err := ctx.Err(); err != nil {
+				return results, err
+			}
+			results = append(results, r.runOne(ctx, client, target, trace))
 		}
 	}
 	return results, nil
@@ -48,8 +82,9 @@ func (r *Runner) runOne(ctx context.Context, client *ollama.Client, target Model
 	runCtx, cancel := context.WithTimeout(ctx, r.Timeout)
 	defer cancel()
 
-	start := time.Now()
+	replayStart := time.Now()
 	transcript, err := replay(runCtx, client, target.Model, trace)
+	replayMs := time.Since(replayStart).Milliseconds()
 	if err != nil {
 		return Result{Model: target.Display, TraceID: trace.ID, Err: err}
 	}
@@ -62,7 +97,9 @@ func (r *Runner) runOne(ctx context.Context, client *ollama.Client, target Model
 	if err != nil {
 		return Result{Model: target.Display, TraceID: trace.ID, Err: err, Transcript: transcript}
 	}
-	score.LatencyMs = time.Since(start).Milliseconds()
+	// Latency reflects replay only, not scorer work. When llm-judge lands,
+	// the judge round-trip must not pollute the model-latency metric.
+	score.LatencyMs = replayMs
 
 	return Result{
 		Model:      target.Display,
@@ -92,10 +129,10 @@ func replay(ctx context.Context, client *ollama.Client, model string, trace Trac
 		}
 	}
 	if firstUser == nil {
-		return nil, fmt.Errorf("trace %q has no user turn", trace.ID)
+		return nil, fmt.Errorf("trace %q: %w", trace.ID, errNoUserTurn)
 	}
 	if userTurns > 1 {
-		return nil, fmt.Errorf("trace %q has %d user turns; multi-turn replay not yet supported", trace.ID, userTurns)
+		return nil, fmt.Errorf("trace %q has %d user turns: %w", trace.ID, userTurns, errMultiUserTurn)
 	}
 
 	messages := []ollama.ChatMessage{
@@ -104,8 +141,9 @@ func replay(ctx context.Context, client *ollama.Client, model string, trace Trac
 	}
 
 	resp, err := client.Chat(ctx, ollama.ChatRequest{
-		Model:    model,
-		Messages: messages,
+		Model:     model,
+		Messages:  messages,
+		KeepAlive: benchKeepAlive,
 	})
 	if err != nil {
 		return nil, err
@@ -149,7 +187,7 @@ func assistantTurnFromMessage(msg ollama.ChatMessage) (Turn, error) {
 // follow-up that will introduce a client factory keyed by target.Provider.
 func newOllamaClient(baseURL string) (*ollama.Client, error) {
 	if strings.TrimSpace(baseURL) == "" {
-		return nil, fmt.Errorf("empty ollama base URL")
+		return nil, errEmptyBaseURL
 	}
 	return ollama.NewClient(ollama.WithBaseURL(baseURL)), nil
 }

--- a/cmd/llm-bench/runner.go
+++ b/cmd/llm-bench/runner.go
@@ -32,7 +32,7 @@ type Result struct {
 func (r *Runner) RunAll(ctx context.Context, targets []ModelTarget, traces []Trace) ([]Result, error) {
 	results := make([]Result, 0, len(targets)*len(traces))
 	for _, target := range targets {
-		client, err := newOllamaClient(target.Model, r.OllamaURL)
+		client, err := newOllamaClient(r.OllamaURL)
 		if err != nil {
 			return nil, fmt.Errorf("client for %q: %w", target.Display, err)
 		}
@@ -76,13 +76,31 @@ func (r *Runner) runOne(ctx context.Context, client *ollama.Client, target Model
 // responses. This is a SKELETON — the tool-call loop is not yet wired up.
 // Feeding tool results back to the model and extracting real ToolCalls
 // from the Ollama response requires more plumbing than this scaffold.
+//
+// Until the tool loop lands, replay refuses multi-user-turn traces rather
+// than silently scoring only the first turn, which would produce
+// misleading aggregates.
 func replay(ctx context.Context, client *ollama.Client, model string, trace Trace) ([]Turn, error) {
-	messages := []ollama.ChatMessage{{Role: "system", Content: trace.System}}
-	for _, t := range trace.Turns {
-		if t.Role == "user" {
-			messages = append(messages, ollama.ChatMessage{Role: "user", Content: t.Content})
-			break // replay only first user turn for now; tool loop is TODO
+	var firstUser *Turn
+	userTurns := 0
+	for i := range trace.Turns {
+		if trace.Turns[i].Role == "user" {
+			userTurns++
+			if firstUser == nil {
+				firstUser = &trace.Turns[i]
+			}
 		}
+	}
+	if firstUser == nil {
+		return nil, fmt.Errorf("trace %q has no user turn", trace.ID)
+	}
+	if userTurns > 1 {
+		return nil, fmt.Errorf("trace %q has %d user turns; multi-turn replay not yet supported", trace.ID, userTurns)
+	}
+
+	messages := []ollama.ChatMessage{
+		{Role: "system", Content: trace.System},
+		{Role: "user", Content: firstUser.Content},
 	}
 
 	resp, err := client.Chat(ctx, ollama.ChatRequest{
@@ -127,11 +145,11 @@ func assistantTurnFromMessage(msg ollama.ChatMessage) (Turn, error) {
 }
 
 // newOllamaClient constructs an ollama.Client targeting the configured URL.
-// The model argument is unused today but will matter when we route to
-// different endpoints per provider (e.g. LM Studio at a different port).
-func newOllamaClient(model, baseURL string) (*ollama.Client, error) {
-	if strings.TrimSpace(model) == "" {
-		return nil, fmt.Errorf("empty model")
+// Multi-provider routing (e.g. LM Studio at a different port) is a
+// follow-up that will introduce a client factory keyed by target.Provider.
+func newOllamaClient(baseURL string) (*ollama.Client, error) {
+	if strings.TrimSpace(baseURL) == "" {
+		return nil, fmt.Errorf("empty ollama base URL")
 	}
 	return ollama.NewClient(ollama.WithBaseURL(baseURL)), nil
 }

--- a/cmd/llm-bench/runner_test.go
+++ b/cmd/llm-bench/runner_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+func TestAssistantTurnFromMessagePreservesToolCalls(t *testing.T) {
+	msg := ollama.ChatMessage{
+		Role:    "assistant",
+		Content: "Calling a tool",
+		ToolCalls: []ollama.ToolCall{
+			{
+				Type: "function",
+				Function: ollama.ToolCallFunction{
+					Name: "read_file",
+					Arguments: map[string]any{
+						"path": "provider/router.go",
+					},
+				},
+			},
+		},
+	}
+
+	turn, err := assistantTurnFromMessage(msg)
+	if err != nil {
+		t.Fatalf("assistantTurnFromMessage() error: %v", err)
+	}
+
+	if turn.Role != "assistant" {
+		t.Fatalf("Role = %q, want assistant", turn.Role)
+	}
+	if got := extractToolNames([]Turn{turn}); !reflect.DeepEqual(got, []string{"read_file"}) {
+		t.Fatalf("extractToolNames() = %v, want [read_file]", got)
+	}
+
+	var args map[string]any
+	if err := json.Unmarshal(turn.ToolCalls[0].Arguments, &args); err != nil {
+		t.Fatalf("unmarshal tool call args: %v", err)
+	}
+	if got := args["path"]; got != "provider/router.go" {
+		t.Fatalf("tool arg path = %v, want provider/router.go", got)
+	}
+}

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -55,7 +55,7 @@ type ExactMatchScorer struct{}
 func (s *ExactMatchScorer) Score(_ context.Context, trace Trace, actual Result) (Score, error) {
 	needle := strings.TrimSpace(trace.Golden.FinalAnswerSubstring)
 	if needle == "" {
-		return Score{}, fmt.Errorf("exact-match scorer requires golden.final_answer_substring for trace %q", trace.ID)
+		return Score{}, fmt.Errorf("trace %q: %w", trace.ID, errMissingGolden)
 	}
 
 	score := Score{
@@ -115,9 +115,15 @@ func extractToolNames(turns []Turn) []string {
 	return names
 }
 
+// lastAssistantContent returns the content of the final assistant turn, or
+// "" if there is no assistant turn. It does NOT walk backward past an
+// empty-content assistant turn to find a prior non-empty one — doing so
+// would return stale content if the last action was a tool call with no
+// final answer. Callers can distinguish "no final answer" from "answer
+// didn't match" via an empty return.
 func lastAssistantContent(turns []Turn) string {
 	for i := len(turns) - 1; i >= 0; i-- {
-		if turns[i].Role == "assistant" && turns[i].Content != "" {
+		if turns[i].Role == "assistant" {
 			return turns[i].Content
 		}
 	}

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Score captures the evaluation dimensions for a single (model, trace) run.
+// See docs/llm/benchmark-plan.md for the scoring rationale.
+type Score struct {
+	ToolSequenceMatch float64 // [0,1] — how close actual tool calls were to the golden sequence
+	ToolArgsValid     float64 // [0,1] — fraction of tool calls with valid arguments
+	AnswerQuality     float64 // [0,1] — final-answer quality per the active Scorer
+	LatencyMs         int64
+	TotalTokens       int
+	Notes             string
+}
+
+// Scorer is the pluggable strategy for evaluating a replay result.
+//
+// The AnswerQuality dimension is load-bearing: how it's computed
+// determines whether the harness is trustworthy enough to override public
+// benchmark narratives. The three shipped strategies trade cost, quality
+// of judgment, and reproducibility differently — see benchmark-plan.md.
+type Scorer interface {
+	Score(ctx context.Context, trace Trace, actual Result) (Score, error)
+}
+
+// newScorer returns the Scorer matching the given name.
+func newScorer(name string) (Scorer, error) {
+	switch name {
+	case "exact-match":
+		return &ExactMatchScorer{}, nil
+	case "llm-judge":
+		return nil, fmt.Errorf("llm-judge scorer not yet implemented (see docs/llm/benchmark-plan.md Phase 3)")
+	case "manual":
+		return nil, fmt.Errorf("manual scorer not yet implemented")
+	default:
+		return nil, fmt.Errorf("unknown scorer %q", name)
+	}
+}
+
+// ExactMatchScorer is a dependency-free baseline. Answer quality is scored
+// as 1.0 iff the golden substring appears in the assistant's response,
+// 0.0 otherwise. Use it to bootstrap the harness; graduate to `llm-judge`
+// before drawing conclusions.
+type ExactMatchScorer struct{}
+
+// Score implements Scorer.
+func (s *ExactMatchScorer) Score(_ context.Context, trace Trace, actual Result) (Score, error) {
+	score := Score{
+		ToolSequenceMatch: toolSequenceScore(trace.Golden.ToolCalls, extractToolNames(actual.Transcript)),
+		ToolArgsValid:     1.0, // TODO: validate against trace.Tools JSON schemas once the tool loop is wired
+	}
+
+	finalText := lastAssistantContent(actual.Transcript)
+	needle := strings.TrimSpace(trace.Golden.FinalAnswerSubstring)
+	if needle == "" {
+		score.AnswerQuality = 0.5
+		score.Notes = "no FinalAnswerSubstring in golden; defaulting AnswerQuality=0.5"
+	} else if strings.Contains(finalText, needle) {
+		score.AnswerQuality = 1.0
+	} else {
+		score.AnswerQuality = 0.0
+	}
+
+	return score, nil
+}
+
+// toolSequenceScore computes a simple Jaccard overlap between the expected
+// and actual tool-call sequences, ignoring order for now. A Levenshtein-
+// based sequence comparison is a follow-up once the tool loop records real
+// ordered calls.
+func toolSequenceScore(expected, actual []string) float64 {
+	if len(expected) == 0 && len(actual) == 0 {
+		return 1.0
+	}
+	if len(expected) == 0 || len(actual) == 0 {
+		return 0.0
+	}
+	expSet := make(map[string]struct{}, len(expected))
+	for _, e := range expected {
+		expSet[e] = struct{}{}
+	}
+	union := make(map[string]struct{}, len(expected)+len(actual))
+	for k := range expSet {
+		union[k] = struct{}{}
+	}
+	intersect := 0
+	for _, a := range actual {
+		union[a] = struct{}{}
+		if _, ok := expSet[a]; ok {
+			intersect++
+		}
+	}
+	if len(union) == 0 {
+		return 0.0
+	}
+	return float64(intersect) / float64(len(union))
+}
+
+func extractToolNames(turns []Turn) []string {
+	var names []string
+	for _, t := range turns {
+		for _, tc := range t.ToolCalls {
+			names = append(names, tc.Name)
+		}
+	}
+	return names
+}
+
+func lastAssistantContent(turns []Turn) string {
+	for i := len(turns) - 1; i >= 0; i-- {
+		if turns[i].Role == "assistant" && turns[i].Content != "" {
+			return turns[i].Content
+		}
+	}
+	return ""
+}

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -88,12 +88,16 @@ func toolSequenceScore(expected, actual []string) float64 {
 	for _, e := range expected {
 		expSet[e] = struct{}{}
 	}
+	actSet := make(map[string]struct{}, len(actual))
+	for _, a := range actual {
+		actSet[a] = struct{}{}
+	}
 	union := make(map[string]struct{}, len(expected)+len(actual))
 	for k := range expSet {
 		union[k] = struct{}{}
 	}
 	intersect := 0
-	for _, a := range actual {
+	for a := range actSet {
 		union[a] = struct{}{}
 		if _, ok := expSet[a]; ok {
 			intersect++

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -47,19 +47,24 @@ func newScorer(name string) (Scorer, error) {
 // before drawing conclusions.
 type ExactMatchScorer struct{}
 
-// Score implements Scorer.
+// Score implements Scorer. ToolArgsValid is left unset (zero) because the
+// tool loop has not yet been wired in Phase 1, so per-call argument
+// validation against trace.Tools schemas is not computable. The Notes
+// field records this so aggregate consumers can distinguish "not scored"
+// from "scored zero".
 func (s *ExactMatchScorer) Score(_ context.Context, trace Trace, actual Result) (Score, error) {
+	needle := strings.TrimSpace(trace.Golden.FinalAnswerSubstring)
+	if needle == "" {
+		return Score{}, fmt.Errorf("exact-match scorer requires golden.final_answer_substring for trace %q", trace.ID)
+	}
+
 	score := Score{
 		ToolSequenceMatch: toolSequenceScore(trace.Golden.ToolCalls, extractToolNames(actual.Transcript)),
-		ToolArgsValid:     1.0, // TODO: validate against trace.Tools JSON schemas once the tool loop is wired
+		Notes:             "ToolArgsValid not computed (tool loop pending; see benchmark-plan.md Phase 2)",
 	}
 
 	finalText := lastAssistantContent(actual.Transcript)
-	needle := strings.TrimSpace(trace.Golden.FinalAnswerSubstring)
-	if needle == "" {
-		score.AnswerQuality = 0.5
-		score.Notes = "no FinalAnswerSubstring in golden; defaulting AnswerQuality=0.5"
-	} else if strings.Contains(finalText, needle) {
+	if strings.Contains(finalText, needle) {
 		score.AnswerQuality = 1.0
 	} else {
 		score.AnswerQuality = 0.0

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -59,3 +59,10 @@ func TestExactMatchScorerSubstringMiss(t *testing.T) {
 		t.Errorf("AnswerQuality = %f, want 0.0", score.AnswerQuality)
 	}
 }
+
+func TestToolSequenceScoreDeduplicatesActualToolNames(t *testing.T) {
+	score := toolSequenceScore([]string{"read_file"}, []string{"read_file", "read_file"})
+	if score != 1.0 {
+		t.Fatalf("toolSequenceScore() = %f, want 1.0", score)
+	}
+}

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestExactMatchScorerRequiresGoldenSubstring(t *testing.T) {
+	s := &ExactMatchScorer{}
+	trace := Trace{ID: "t1", Golden: Golden{FinalAnswerCriteria: "describe the bug"}}
+	actual := Result{Transcript: []Turn{{Role: "assistant", Content: "some answer"}}}
+
+	_, err := s.Score(context.Background(), trace, actual)
+	if err == nil {
+		t.Fatal("expected error when golden.final_answer_substring is missing, got nil")
+	}
+	if !strings.Contains(err.Error(), "final_answer_substring") {
+		t.Errorf("error = %v, want mention of final_answer_substring", err)
+	}
+}
+
+func TestExactMatchScorerSubstringHit(t *testing.T) {
+	s := &ExactMatchScorer{}
+	trace := Trace{
+		ID: "t2",
+		Golden: Golden{
+			ToolCalls:            []string{"read_file"},
+			FinalAnswerSubstring: "circular fallback",
+		},
+	}
+	actual := Result{Transcript: []Turn{
+		{Role: "assistant", Content: "the bug is a circular fallback between routers",
+			ToolCalls: []ToolCall{{Name: "read_file"}}},
+	}}
+
+	score, err := s.Score(context.Background(), trace, actual)
+	if err != nil {
+		t.Fatalf("Score() error: %v", err)
+	}
+	if score.AnswerQuality != 1.0 {
+		t.Errorf("AnswerQuality = %f, want 1.0", score.AnswerQuality)
+	}
+	if score.ToolSequenceMatch != 1.0 {
+		t.Errorf("ToolSequenceMatch = %f, want 1.0", score.ToolSequenceMatch)
+	}
+}
+
+func TestExactMatchScorerSubstringMiss(t *testing.T) {
+	s := &ExactMatchScorer{}
+	trace := Trace{
+		ID:     "t3",
+		Golden: Golden{FinalAnswerSubstring: "circular fallback"},
+	}
+	actual := Result{Transcript: []Turn{{Role: "assistant", Content: "looks fine"}}}
+
+	score, err := s.Score(context.Background(), trace, actual)
+	if err != nil {
+		t.Fatalf("Score() error: %v", err)
+	}
+	if score.AnswerQuality != 0.0 {
+		t.Errorf("AnswerQuality = %f, want 0.0", score.AnswerQuality)
+	}
+}

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"strings"
+	"errors"
 	"testing"
 )
 
@@ -12,11 +12,8 @@ func TestExactMatchScorerRequiresGoldenSubstring(t *testing.T) {
 	actual := Result{Transcript: []Turn{{Role: "assistant", Content: "some answer"}}}
 
 	_, err := s.Score(context.Background(), trace, actual)
-	if err == nil {
-		t.Fatal("expected error when golden.final_answer_substring is missing, got nil")
-	}
-	if !strings.Contains(err.Error(), "final_answer_substring") {
-		t.Errorf("error = %v, want mention of final_answer_substring", err)
+	if !errors.Is(err, errMissingGolden) {
+		t.Fatalf("err = %v, want errMissingGolden", err)
 	}
 }
 

--- a/cmd/llm-bench/target.go
+++ b/cmd/llm-bench/target.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+const defaultBenchProvider = "ollama"
+
+// ModelTarget is a benchmark candidate model selector. Display preserves the
+// user-facing identifier while Model is the provider-native model name.
+type ModelTarget struct {
+	Display  string
+	Provider string
+	Model    string
+}
+
+func parseModelTargets(csv string) ([]ModelTarget, error) {
+	parts := strings.Split(csv, ",")
+	targets := make([]ModelTarget, 0, len(parts))
+	for _, part := range parts {
+		target, err := parseModelTarget(part)
+		if err != nil {
+			return nil, err
+		}
+		targets = append(targets, target)
+	}
+	return targets, nil
+}
+
+func parseModelTarget(raw string) (ModelTarget, error) {
+	selector := strings.TrimSpace(raw)
+	if selector == "" {
+		return ModelTarget{}, fmt.Errorf("empty model selector")
+	}
+
+	target := ModelTarget{
+		Display:  selector,
+		Provider: defaultBenchProvider,
+		Model:    selector,
+	}
+
+	if strings.Contains(selector, "/") {
+		parts := strings.SplitN(selector, "/", 2)
+		target.Provider = strings.TrimSpace(parts[0])
+		target.Model = strings.TrimSpace(parts[1])
+		if target.Provider == "" || target.Model == "" {
+			return ModelTarget{}, fmt.Errorf("invalid model selector %q", selector)
+		}
+	}
+
+	if target.Provider != defaultBenchProvider {
+		return ModelTarget{}, fmt.Errorf("unsupported provider %q", target.Provider)
+	}
+
+	return target, nil
+}

--- a/cmd/llm-bench/target.go
+++ b/cmd/llm-bench/target.go
@@ -50,7 +50,7 @@ func parseModelTarget(raw string) (ModelTarget, error) {
 	}
 
 	if target.Provider != defaultBenchProvider {
-		return ModelTarget{}, fmt.Errorf("unsupported provider %q", target.Provider)
+		return ModelTarget{}, fmt.Errorf("%w: %q", errUnsupportedProv, target.Provider)
 	}
 
 	return target, nil

--- a/cmd/llm-bench/target_test.go
+++ b/cmd/llm-bench/target_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseModelTargets(t *testing.T) {
+	got, err := parseModelTargets("ollama/qwen3-coder-next:latest, gemma4:31b")
+	if err != nil {
+		t.Fatalf("parseModelTargets() error: %v", err)
+	}
+
+	want := []ModelTarget{
+		{
+			Display:  "ollama/qwen3-coder-next:latest",
+			Provider: "ollama",
+			Model:    "qwen3-coder-next:latest",
+		},
+		{
+			Display:  "gemma4:31b",
+			Provider: "ollama",
+			Model:    "gemma4:31b",
+		},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseModelTargets() = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseModelTargetRejectsInvalidSelectors(t *testing.T) {
+	tests := []string{
+		"",
+		"   ",
+		"/gemma4:31b",
+		"ollama/",
+		"anthropic/claude-sonnet",
+	}
+
+	for _, input := range tests {
+		t.Run(strings.ReplaceAll(input, " ", "_"), func(t *testing.T) {
+			if _, err := parseModelTarget(input); err == nil {
+				t.Fatalf("parseModelTarget(%q) returned nil error", input)
+			}
+		})
+	}
+}

--- a/cmd/llm-bench/testdata/smoke/minimal.json
+++ b/cmd/llm-bench/testdata/smoke/minimal.json
@@ -1,0 +1,18 @@
+{
+  "id": "smoke-minimal-001",
+  "source": "repo-smoke-test",
+  "captured_at": "2026-04-18T00:00:00Z",
+  "system": "You are a precise test assistant. Follow the user's output instructions exactly.",
+  "tools": [],
+  "turns": [
+    {
+      "role": "user",
+      "content": "Reply with exactly: smoke-ok"
+    }
+  ],
+  "golden": {
+    "tool_calls": [],
+    "final_answer_criteria": "Assistant returns the literal token smoke-ok.",
+    "final_answer_substring": "smoke-ok"
+  }
+}

--- a/cmd/llm-bench/trace.go
+++ b/cmd/llm-bench/trace.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+)
+
+// Trace is a replayable conversation captured from a real MCP / chat session.
+// See docs/llm/benchmark-plan.md for the format and capture strategy.
+type Trace struct {
+	ID         string            `json:"id"`
+	Source     string            `json:"source"`
+	CapturedAt time.Time         `json:"captured_at"`
+	System     string            `json:"system"`
+	Tools      []json.RawMessage `json:"tools"`
+	Turns      []Turn            `json:"turns"`
+	Golden     Golden            `json:"golden"`
+}
+
+// Turn represents a single role/content pair, optionally with tool calls or
+// tool results. Preserved verbatim so the replay is deterministic.
+type Turn struct {
+	Role       string          `json:"role"`
+	Content    string          `json:"content,omitempty"`
+	ToolCalls  []ToolCall      `json:"tool_calls,omitempty"`
+	ToolCallID string          `json:"tool_call_id,omitempty"`
+	Name       string          `json:"name,omitempty"`
+	Raw        json.RawMessage `json:"raw,omitempty"`
+}
+
+// ToolCall is a minimal representation of a tool invocation.
+type ToolCall struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+// Golden is the rubric the replay is scored against.
+type Golden struct {
+	ToolCalls            []string `json:"tool_calls"`
+	FinalAnswerCriteria  string   `json:"final_answer_criteria"`
+	FinalAnswerSubstring string   `json:"final_answer_substring,omitempty"`
+}
+
+// loadTraces reads each path as a JSON Trace and returns the full set.
+func loadTraces(paths []string) ([]Trace, error) {
+	traces := make([]Trace, 0, len(paths))
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %q: %w", path, err)
+		}
+		var t Trace
+		if err := json.Unmarshal(data, &t); err != nil {
+			return nil, fmt.Errorf("parse %q: %w", path, err)
+		}
+		if t.ID == "" {
+			return nil, fmt.Errorf("trace %q: missing id", path)
+		}
+		traces = append(traces, t)
+	}
+	return traces, nil
+}

--- a/cmd/llm-bench/trace.go
+++ b/cmd/llm-bench/trace.go
@@ -44,6 +44,8 @@ type Golden struct {
 }
 
 // loadTraces reads each path as a JSON Trace and returns the full set.
+// Validates structural minimums up front so malformed traces surface at
+// load time, not deep in the replay loop.
 func loadTraces(paths []string) ([]Trace, error) {
 	traces := make([]Trace, 0, len(paths))
 	for _, path := range paths {
@@ -55,10 +57,23 @@ func loadTraces(paths []string) ([]Trace, error) {
 		if err := json.Unmarshal(data, &t); err != nil {
 			return nil, fmt.Errorf("parse %q: %w", path, err)
 		}
-		if t.ID == "" {
-			return nil, fmt.Errorf("trace %q: missing id", path)
+		if err := validateTrace(t); err != nil {
+			return nil, fmt.Errorf("trace %q (%s): %w", path, t.ID, err)
 		}
 		traces = append(traces, t)
 	}
 	return traces, nil
+}
+
+func validateTrace(t Trace) error {
+	if t.ID == "" {
+		return fmt.Errorf("missing id")
+	}
+	if t.System == "" {
+		return errEmptySystem
+	}
+	if len(t.Turns) == 0 {
+		return errNoTurns
+	}
+	return nil
 }

--- a/cmd/llm-bench/trace_test.go
+++ b/cmd/llm-bench/trace_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestValidateTrace(t *testing.T) {
+	tests := []struct {
+		name    string
+		trace   Trace
+		wantErr error
+	}{
+		{
+			name:    "ok",
+			trace:   Trace{ID: "t1", System: "sys", Turns: []Turn{{Role: "user", Content: "q"}}},
+			wantErr: nil,
+		},
+		{
+			name:    "missing id",
+			trace:   Trace{System: "sys", Turns: []Turn{{Role: "user"}}},
+			wantErr: nil, // validateTrace returns fmt.Errorf, not a sentinel, for missing id — covered by substring
+		},
+		{
+			name:    "empty system",
+			trace:   Trace{ID: "t2", Turns: []Turn{{Role: "user"}}},
+			wantErr: errEmptySystem,
+		},
+		{
+			name:    "no turns",
+			trace:   Trace{ID: "t3", System: "sys"},
+			wantErr: errNoTurns,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTrace(tt.trace)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("err = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			// nil wantErr cases: ok case must pass, missing-id case must error.
+			if tt.name == "ok" && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.name == "missing id" && err == nil {
+				t.Fatal("expected error for missing id, got nil")
+			}
+		})
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -536,7 +536,7 @@ func TestLoad_RootModelsJSON(t *testing.T) {
 	if cfg.ModelFor("chat") == "" {
 		t.Error("expected chat model from root models.json")
 	}
-	if len(cfg.Models) != 5 {
-		t.Errorf("expected 5 models, got %d", len(cfg.Models))
+	if len(cfg.Models) != 6 {
+		t.Errorf("expected 6 models, got %d", len(cfg.Models))
 	}
 }

--- a/docs/llm/README.md
+++ b/docs/llm/README.md
@@ -1,0 +1,38 @@
+# go-llm: Local Model Strategy (April 2026)
+
+This directory documents the analysis and decisions behind the model lineup
+powering `go-llm` and its consumers (Firn IDE, Flux ML, Quantum Trader) on
+Apple Silicon workstations.
+
+**Target hardware:** MacBook Pro M3 Max, 128GB unified memory (~97GB usable
+after OS overhead).
+
+## Documents
+
+| File | Purpose |
+|---|---|
+| [analysis.md](analysis.md) | 2026 open-weight landscape, benchmark summary, sources |
+| [setups.md](setups.md) | Three candidate setup combinations with tradeoffs |
+| [recommendation.md](recommendation.md) | Chosen lineup + migration steps |
+| [benchmark-plan.md](benchmark-plan.md) | Harness design for A/B'ing models on real traces |
+
+## TL;DR
+
+- **Keep** `qwen3-coder-next` (primary code generation) and
+  `qwen3-embedding:8b` (embeddings).
+- **Add** `gemma4:31b` (dense) — agent / tool-use / reasoning specialist.
+  Fills the tool-calling gap; 86.4% τ2-bench, 80.0% LiveCodeBench.
+- **Add** `qwen3.6:35b-a3b` — MoE upgrade over `qwen3.5:35b-a3b` (73.4%
+  SWE-bench Verified with 3B active).
+- **Retire** `qwen3.5:27b` and `qwen3.5:35b-a3b` after validation.
+- **Stay on Ollama** — as of 0.19, it is backed by MLX on Apple Silicon,
+  so the historical MLX-vs-Ollama speed gap is closed.
+- **Defer** a llama.cpp / LM Studio backend abstraction until the
+  benchmark harness shows Gemma 4 or a frontier non-Ollama model
+  (GLM-5.1, MiniMax M2.7) produces a measurable quality delta on real
+  workloads.
+
+## Date stamp
+
+All research was conducted April 16, 2026. Benchmark numbers and release
+dates reflect that snapshot.

--- a/docs/llm/README.md
+++ b/docs/llm/README.md
@@ -32,6 +32,24 @@ after OS overhead).
   (GLM-5.1, MiniMax M2.7) produces a measurable quality delta on real
   workloads.
 
+## Manual Smoke Test
+
+To smoke-test `cmd/llm-bench` without waiting for real captured traces,
+use the checked-in synthetic trace:
+
+```bash
+go run ./cmd/llm-bench \
+  -traces 'cmd/llm-bench/testdata/smoke/*.json' \
+  -models 'ollama/gemma4:31b,ollama/qwen3.6:35b-a3b' \
+  -scorer exact-match \
+  -report /tmp/llm-bench-smoke.md
+```
+
+Success criteria: the command exits `0`, writes `/tmp/llm-bench-smoke.md`,
+and the report shows `Errors = 0` with `Mean Quality = 1.00` for each
+model on the `smoke-minimal-001` trace. This only verifies harness
+plumbing and basic model reachability, not real MCP-agent quality.
+
 ## Date stamp
 
 All research was conducted April 16, 2026. Benchmark numbers and release

--- a/docs/llm/analysis.md
+++ b/docs/llm/analysis.md
@@ -1,0 +1,114 @@
+# LLM Landscape Analysis — April 2026
+
+## Context
+
+Keith runs an M3 Max, 128GB RAM, developing three apps that depend on
+`go-llm`:
+
+- **Firn IDE** — custom Wails IDE, needs FIM / inline completion + RAG
+- **Flux ML** — Wails ML dev environment, needs chat + analysis
+- **Quantum Trader** — Go+Python trading platform, needs agent loops + tool use
+
+The existing model lineup (`qwen3-coder-next`, `qwen3.5:35b-a3b`,
+`qwen3.5:27b`, `qwen3:8b`, `qwen3-embedding:8b`) was selected in late 2025.
+Several frontier open-weight releases in Q1 2026 warrant a re-evaluation.
+
+## Hardware budget
+
+- Total unified memory: 128GB
+- Usable for models (after OS, IDEs, build toolchains): **~97GB**
+- Memory bandwidth: 400 GB/s (40-core GPU M3 Max)
+
+MoE (Mixture of Experts) models are preferred: total params dictate memory,
+active params dictate latency. At 400 GB/s, a 3B-active MoE feels
+dramatically faster than a dense 14B.
+
+## 2026 model landscape — relevant candidates
+
+### Coding-focused
+
+| Model | Total / Active | SWE-bench Verified | Memory @ Q4 | Notes |
+|---|---|---|---|---|
+| **Qwen3-Coder-Next** | 80B / 3.9B | 70.6% | ~46GB | Already in use. Still top-tier agentic coding workhorse. |
+| **Qwen3.6-35B-A3B** | 35B / 3B | 73.4% | ~20GB | Direct drop-in for qwen3.5:35b-a3b. 86.0% GPQA, 92.7% AIME 2026. |
+| **Qwen3.6 Plus** | closed/cloud | 78.8% | — | Cloud-only, 1M context. Not applicable for local. |
+| **GLM-5.1** | 754B / 40B | 77.8% | ~95–110GB UD-Q2_K_XL | Tight fit, displaces everything else. |
+| **MiniMax M2.7** | 229B / 10B | ~80% | ~115GB Q4 | Best tool-calling (76.8% BFCL). Very tight. |
+| **Kimi K2.5** | 1T / 32B | 76.8% | ~500GB+ | Out of budget. |
+
+### Agent / tool-use / reasoning
+
+| Model | Params | τ2-bench (agentic) | LiveCodeBench v6 | Memory | Notes |
+|---|---|---|---|---|---|
+| **Gemma 4 31B Dense** | 30.7B | **86.4%** | **80.0%** | ~20GB | Released 2026-04-02. #3 Arena AI open. Native function calling + thinking modes. |
+| **Gemma 4 26B A4B MoE** | 25.2B / 3.8B | — | high | ~18GB | Latency-optimized. #6 Arena AI open. |
+| Llama 4 (frontier variant) | varies | 85.5% | 77.1% | — | No local-friendly variant at the time of writing. |
+| DeepSeek V4 | varies | 57.5% | 52.0% | — | Dramatically weaker on agentic tasks. |
+
+### Embedding
+
+| Model | Params | MTEB | Strengths | Notes |
+|---|---|---|---|---|
+| **Qwen3-Embedding-8B** | 8B | 70.58 (multilingual #1 as of June 2025) | Multilingual + code | Already in use. Keep. |
+| Nomic-Embed-Code | 7B | code-specialized | Beats Voyage Code 3, OpenAI Embed 3 Large on CodeSearchNet | Strong alternative if code retrieval becomes the bottleneck. |
+| Gemini Embedding 2 | API | 84.0 (MTEB Code) | Best code retrieval | Not local. |
+| Voyage code-3 | API | — | Strong for code/technical | Not local. |
+
+## Framework: Ollama vs llama.cpp vs MLX
+
+As of Ollama 0.19 (Feb 2026), **Ollama is built on MLX on Apple Silicon**.
+The prior narrative ("MLX is 20–30% faster than Ollama") is largely obsolete
+— Ollama now inherits MLX's unified-memory throughput advantages.
+
+Practical implication: **keep `go-llm` pointed at Ollama**. Adding a second
+backend (llama.cpp, LM Studio, mlx-lm) should be a deliberate decision
+justified by measurable workload improvement, not speculative performance
+optimization. See [benchmark-plan.md](benchmark-plan.md).
+
+When a second backend does become justified:
+- LM Studio exposes an OpenAI-compatible HTTP API → minimal adapter work
+- llama.cpp's `server` binary exposes OpenAI-compatible + native APIs
+- mlx-lm has a `server` but lacks the stability of the above
+
+Either way, the existing `provider.Provider` interface is the right seam.
+The `ollama.Client` is not — it's wire-format specific.
+
+## Why not Kimi K2.5, GLM-5.1, MiniMax M2.7?
+
+All three are frontier-tier but misaligned with a **simultaneous
+multi-role fleet**:
+
+- **Kimi K2.5** — 1T params; does not fit at any usable quantization.
+- **GLM-5.1** — best SWE-bench among open, but UD-Q2_K_XL (~100GB)
+  displaces every other model. You'd load it, use it, unload it, reload
+  the fleet. Viable for a "heavy task" escape hatch; not viable as the
+  daily driver.
+- **MiniMax M2.7** — best BFCL (tool calling), but at Q4 occupies ~115GB.
+  Same displacement problem as GLM-5.1.
+
+Gemma 4 31B achieves comparable tool-calling quality (86.4% τ2-bench vs
+MiniMax's 76.8% BFCL — different benchmarks, but Gemma's is broader and
+more recent) in **one-fifth the memory footprint**. That makes it the
+correct choice for a co-resident fleet.
+
+## Sources
+
+- [Best Open-Source Coding Model 2026 — Morph](https://www.morphllm.com/best-open-source-coding-model-2026)
+- [Qwen vs DeepSeek vs GLM Benchmark Comparison](https://blog.easecloud.io/ai-cloud/qwen-vs-deepseek-vs-glm/)
+- [Qwen 3.6 Developer Guide — Lushbinary](https://lushbinary.com/blog/qwen-3-6-developer-guide-benchmarks-architecture-api-self-hosting/)
+- [Qwen3.6-35B-A3B — Hugging Face](https://huggingface.co/Qwen/Qwen3.6-35B-A3B)
+- [Gemma 4 — Google DeepMind](https://deepmind.google/models/gemma/gemma-4/)
+- [Welcome Gemma 4 — Hugging Face](https://huggingface.co/blog/gemma4)
+- [Gemma 4 Coding Benchmarks 2026 — Gemma 4 Wiki](https://www.gemma4.wiki/benchmark/gemma-4-coding-performance-benchmarks-2026)
+- [Google Gemma 4 Review — StartupHub](https://www.startuphub.ai/ai-news/technology/2026/google-gemma-4-review-2026)
+- [Gemma 4 Family Guide — aimadetools](https://www.aimadetools.com/blog/gemma-4-family-guide/)
+- [Gemma 4 releases — Google AI for Developers](https://ai.google.dev/gemma/docs/releases)
+- [GLM-5.1 How to Run Locally — Unsloth](https://unsloth.ai/docs/models/glm-5.1)
+- [Ollama is now powered by MLX on Apple Silicon](https://ollama.com/blog/mlx)
+- [2026 Mac Inference Framework Comparison — MACGPU](https://macgpu.com/en/blog/2026-mac-inference-framework-vllm-mlx-ollama-llamacpp-benchmark.html)
+- [Qwen3-Embedding-8B — Hugging Face](https://huggingface.co/Qwen/Qwen3-Embedding-8B)
+- [Nomic Embed Code — Hugging Face](https://huggingface.co/nomic-ai/nomic-embed-code)
+- [Qwen3-Coder-Next Local Guide 2026 — DEV](https://dev.to/sienna/qwen3-coder-next-the-complete-2026-guide-to-running-powerful-ai-coding-agents-locally-1k95)
+- [VRAM Calculator — apxml](https://apxml.com/tools/vram-calculator)
+- [Ollama Search](https://ollama.com/search)
+- [Hugging Face Ollama-compatible trending](https://huggingface.co/models?apps=ollama&sort=trending)

--- a/docs/llm/benchmark-plan.md
+++ b/docs/llm/benchmark-plan.md
@@ -74,8 +74,10 @@ the existing `feedback/` and `conversation/` SQLite stores.
 
 ### Per-trace
 
-1. **Tool call sequence match** — Levenshtein distance between actual and
-   golden tool-call sequence, normalized to [0,1].
+1. **Tool call sequence match** — Jaccard set overlap between actual and
+   golden tool-call names, normalized to [0,1]. Order-agnostic in Phase 1
+   (`toolSequenceScore` in `scorer.go`); ordered Levenshtein comparison is
+   a Phase 2 follow-up once the tool loop records real per-turn calls.
 2. **Tool argument validity** — JSON schema validation against the
    declared tool schemas. Binary pass/fail per call, averaged.
 3. **Final answer quality** — *User-selected scoring strategy*:

--- a/docs/llm/benchmark-plan.md
+++ b/docs/llm/benchmark-plan.md
@@ -1,0 +1,164 @@
+# Benchmark Harness Plan
+
+## Goal
+
+Replace speculative leaderboard comparisons with **evidence from real
+workloads**. Given a set of captured MCP tool-use traces, compare
+candidate models (e.g. Qwen3-Coder-Next vs Gemma 4 31B vs GLM-5.1) on
+metrics that actually correlate with user value.
+
+## Why not just use SWE-bench / τ2-bench?
+
+Public benchmarks answer "which model is best on this benchmark." That's
+not the question. The question is **"which model is best on
+Keith's workloads"** — MCP tool calls for code review, ML metrics
+analysis, trading signal generation, and RAG-backed Q&A.
+
+A 3-point SWE-bench advantage means nothing if the model fumbles the
+MCP protocol handshake or picks the wrong tool 10% of the time.
+
+## Architecture
+
+```
+cmd/llm-bench/
+├── main.go           # CLI entry point
+├── trace.go          # Trace loading + validation
+├── runner.go         # Per-model replay loop
+├── scorer.go         # Pluggable scoring strategies
+└── report.go         # Output formatting
+
+docs/llm/
+└── traces/           # Captured traces (gitignored; sensitive)
+    ├── mcp-review-*.json
+    ├── mcp-rag-*.json
+    └── ...
+```
+
+## Trace format
+
+Each trace is a replayable conversation:
+
+```jsonc
+{
+  "id": "mcp-review-2026-04-10-a3f",
+  "source": "firn-ide",
+  "captured_at": "2026-04-10T14:23:11Z",
+  "system": "You are a code review assistant...",
+  "tools": [ /* MCP tool schemas */ ],
+  "turns": [
+    {
+      "role": "user",
+      "content": "Review the diff in provider/router.go"
+    },
+    {
+      "role": "assistant",
+      "content": "...",
+      "tool_calls": [
+        {"name": "read_file", "arguments": {"path": "provider/router.go"}}
+      ]
+    },
+    // tool response, more turns, etc.
+  ],
+  "golden": {
+    "tool_calls": ["read_file", "git_diff"],
+    "final_answer_criteria": "Identifies the circular fallback bug"
+  }
+}
+```
+
+The `golden` field is the rubric: what tools *should* have been called,
+and what the final answer *should* contain. Traces can be seeded from
+the existing `feedback/` and `conversation/` SQLite stores.
+
+## Metrics
+
+### Per-trace
+
+1. **Tool call sequence match** — Levenshtein distance between actual and
+   golden tool-call sequence, normalized to [0,1].
+2. **Tool argument validity** — JSON schema validation against the
+   declared tool schemas. Binary pass/fail per call, averaged.
+3. **Final answer quality** — *User-selected scoring strategy*:
+   - `llm-judge` — Claude API scores response against
+     `final_answer_criteria` on a 0–1 rubric.
+   - `exact-match` — substring match (cheap, brittle).
+   - `manual` — dump to CSV for human rating.
+4. **Latency** — end-to-end wall time + per-token throughput.
+5. **Token cost** — input + output tokens (for context-window
+   pressure analysis).
+
+### Aggregate (per model across all traces)
+
+- Mean + p50 / p95 of each metric
+- Win rate: % of traces where this model's quality score exceeds the
+  baseline by >5%
+- Cost of failure: when this model failed a trace, how did it fail?
+  (wrong tool / malformed args / bad answer / timeout)
+
+## Scoring strategy is a pluggable interface
+
+```go
+type Scorer interface {
+    Score(ctx context.Context, trace Trace, actual Result) (Score, error)
+}
+
+type Score struct {
+    ToolSequenceMatch   float64 // [0,1]
+    ToolArgsValid       float64 // [0,1]
+    AnswerQuality       float64 // [0,1]
+    LatencyMs           int64
+    TotalTokens         int
+    Notes               string
+}
+```
+
+**Why pluggable:** the `AnswerQuality` dimension has no one-size-fits-all
+answer. Some tasks (code review) need LLM-as-judge. Some (RAG retrieval)
+need exact-match on citations. Some (trading signal analysis) need
+manual review because the "right answer" is domain-specific.
+
+## Implementation phases
+
+### Phase 1 — Skeleton + synthetic traces (this PR)
+
+- `cmd/llm-bench/main.go` with CLI args, trace loader, runner loop
+- Synthetic traces in `testdata/` so the harness is testable
+- `Scorer` interface with an `exact-match` implementation as a baseline
+
+### Phase 2 — Real trace capture (follow-up PR)
+
+- Extend `feedback/` or `conversation/` store to export replayable traces
+- Redaction pass for sensitive data (paths, tokens, customer info)
+- Initial capture target: 20–30 traces spanning all three consumer apps
+
+### Phase 3 — LLM-as-judge scorer (follow-up PR)
+
+- Optional integration with Claude API for `AnswerQuality`
+- Careful prompt engineering + cache the judgments
+
+### Phase 4 — Live comparison runs
+
+- Qwen3-Coder-Next vs Gemma 4 31B on `agent` role traces
+- Qwen3-Coder-Next vs GLM-5.1 (Setup 2 experiment) on code-gen traces
+- Report in `docs/llm/benchmarks/YYYY-MM-DD-<name>.md`
+
+## User decision required
+
+The `AnswerQuality` scorer is the load-bearing piece. Three choices with
+distinct tradeoffs:
+
+| Strategy | Cost per trace | Quality of judgment | Reproducibility |
+|---|---|---|---|
+| `exact-match` | ~0 | Low (brittle) | High |
+| `llm-judge` (Claude) | $0.01–0.05 | High | Moderate (varies with Claude updates) |
+| `manual` | ~5 min of human time | Highest | Low (rater variance) |
+
+**TODO for Keith**: decide which Scorer ships in Phase 1. The skeleton
+assumes `exact-match` because it has no external dependencies, but for
+the actual comparison runs (Phase 4) we likely want `llm-judge` as the
+primary with `manual` spot-checks.
+
+This is a real decision point, not busywork — the scorer choice
+determines whether the harness is trustworthy enough to override the
+public benchmark narrative. A wrong choice here makes the whole exercise
+advisory rather than authoritative.

--- a/docs/llm/recommendation.md
+++ b/docs/llm/recommendation.md
@@ -66,6 +66,26 @@ integration cost. The experiment's real value is *evidence* that
 defending Setup 1 against speculative criticism ("but GLM-5.1 is better
 on SWE-bench!") is correct for this workload.
 
+## Unvalidated claims to verify on deploy
+
+The `context_window` values in `models.json` (256000 for `gemma4:31b` /
+`qwen3.6:35b-a3b`, 262144 for `qwen3-coder-next:latest`) are the
+published model maxima and have **not** been validated at build time —
+the library does not boot Ollama in unit tests. First use on a given
+machine, the `fingerprint/` package will observe the real context
+window Ollama reports and cache it. If a published figure is wrong,
+prompt-overflow bugs will surface at runtime, not at install.
+
+Mitigation: after pulling, run `ollama show <model>` once and compare
+the `num_ctx` figure with `models.json`. If they disagree, update
+`models.json` rather than trusting the source.
+
+The catalog keeps both `qwen3-coder-next:latest` and `qwen3-coder-next:80b`
+variants with identical specs. `latest` tracks Ollama's floating tag and
+is what `models.json` references; `80b` is retained so a consumer that
+pins explicitly still gets curated scoring data. `TestQwen3CoderNextVariantsInSync`
+enforces they stay identical.
+
 ## Files touched in this migration
 
 - `models.json` — role assignments
@@ -81,30 +101,17 @@ No code changes required to `config/`, `provider/`, `ollama/`, `rag/`,
 signature is stable; new models get picked up automatically via
 `config.Load` and the catalog.
 
-## User decision required
+## Router weight profiles
 
-The router has default weight profiles (`provider/router_score.go`) for
-`fim`, `chat`, `embedding`, `reasoning`, and `code-review`. It does
-**not** have a profile for `agent` or `tool-use`. Adding Gemma 4 as the
-`agent` role surfaces this gap.
+`provider/router_score.go` ships default profiles for `fim`, `chat`,
+`embedding`, `reasoning`, `code-review`, `agent`, and `tool-use`
+(`agent` and `tool-use` are aliased to the same values). The agent
+profile prioritizes Speed and Feedback more heavily than chat, on the
+reasoning that tool-calling loops make many small calls and tool-call
+accuracy is directly observable as success/failure. If real traces
+suggest these weights are wrong, retune them — they are opinions, not
+benchmarked values, and the benchmark harness (`cmd/llm-bench`) is the
+right tool to validate them.
 
-**TODO (requires Keith's input):** Define a `tool-use` weight profile.
-Candidate starting values:
-
-```go
-"tool-use": {Warmth: 2, Headroom: 2, Feedback: 4, Quality: 4, Speed: 3, KVCache: 1, Cost: 1},
-```
-
-vs. reasoning (`{Warmth: 1, Headroom: 3, Feedback: 3, Quality: 5, Speed: 0, KVCache: 0, Cost: 1}`).
-
-The meaningful tradeoffs:
-- `Speed` — agents make many small calls; speed per call matters more
-  than it does for reasoning (which is latency-tolerant)
-- `Feedback` — tool-call accuracy is directly observable; heavier
-  weighting on historical success is appropriate
-- `Headroom` — tool traces accumulate (system prompt + tool schemas + N
-  turns); but each individual call is small
-
-Whether this belongs as a new profile or as a parameterization of
-existing profiles is a design call that depends on how often agent
-loops blend with chat/reasoning in practice.
+Consumers can override any profile at construction via
+`provider.WithWeightOverrides(map[string]*WeightProfile{...})`.

--- a/docs/llm/recommendation.md
+++ b/docs/llm/recommendation.md
@@ -1,0 +1,110 @@
+# Recommended Lineup + Migration Plan
+
+## Decision
+
+Adopt **Setup 1 — Balanced Daily Driver** as the production `go-llm`
+lineup. Run **Setup 2 (GLM-5.1 in LM Studio)** as a parallel off-Ollama
+experiment to gather evidence for whether second-backend work is
+justified.
+
+## Target lineup
+
+| Role | Model | Source | Status |
+|---|---|---|---|
+| `coding` | `qwen3-coder-next:latest` | Ollama | **keep** |
+| `agent` | `gemma4:31b` | Ollama | **add** |
+| `general` | `gemma4:31b` | Ollama | **retarget** (was `qwen3.5:27b`) |
+| `analysis` | `gemma4:31b` | Ollama | **retarget** (was `qwen3.5:27b`) |
+| `fast` | `qwen3.6:35b-a3b` | Ollama | **add** (replaces `qwen3.5:35b-a3b`) |
+| `lightweight` | `qwen3:8b` | Ollama | **keep** |
+| `embedding` | `qwen3-embedding:8b` | Ollama | **keep** |
+
+## Migration steps
+
+### Phase 1 — Pull new models (10 min)
+
+```bash
+ollama pull gemma4:31b          # ~20GB dense
+ollama pull gemma4:26b          # ~18GB MoE (optional, latency alternative)
+ollama pull qwen3.6:35b-a3b     # ~28GB MoE
+```
+
+### Phase 2 — Validate (1–2 days of normal use)
+
+Run with both new and old models pulled. `models.json` updated to point
+to new models, but old models still available. Monitor:
+
+- `gemma4:31b` on agent workloads (Quantum Trader MCP loops, Firn code
+  actions)
+- `qwen3.6:35b-a3b` on general chat / analysis
+- Existing `qwen3-coder-next` workflows for regression (they should be
+  unchanged)
+
+### Phase 3 — Retire legacy (5 min)
+
+Once Phase 2 passes:
+
+```bash
+ollama rm qwen3.5:27b
+ollama rm qwen3.5:35b-a3b
+```
+
+### Phase 4 — Parallel GLM-5.1 experiment
+
+Independent of the main migration:
+
+1. Install LM Studio (or `llama.cpp` server).
+2. Pull `glm-5.1-UD-Q2_K_XL` (via Unsloth).
+3. Run the benchmark harness (see [benchmark-plan.md](benchmark-plan.md))
+   comparing Qwen3-Coder-Next and GLM-5.1 on real captured traces.
+4. **Decision gate**: if GLM-5.1 shows ≥5% quality improvement on real
+   workloads (not synthetic benchmarks), invest in the second-backend
+   abstraction (Setup 2).
+
+Expected outcome: in most cases the quality gain will not justify the
+integration cost. The experiment's real value is *evidence* that
+defending Setup 1 against speculative criticism ("but GLM-5.1 is better
+on SWE-bench!") is correct for this workload.
+
+## Files touched in this migration
+
+- `models.json` — role assignments
+- `provider/catalog.json` — add `qwen3.6`, `qwen3-coder-next`, `gemma4`
+  families
+- `docs/GETTING_STARTED.md` — update "Pull Required Models" section
+  *(follow-up PR, not blocking)*
+- `docs/llm/` — this directory
+
+No code changes required to `config/`, `provider/`, `ollama/`, `rag/`,
+`completion/`, `analysis/`, `mcp/`, `conversation/`, `feedback/`,
+`fingerprint/`, or `prefetch/` for Phase 1–3. The `provider.Router`
+signature is stable; new models get picked up automatically via
+`config.Load` and the catalog.
+
+## User decision required
+
+The router has default weight profiles (`provider/router_score.go`) for
+`fim`, `chat`, `embedding`, `reasoning`, and `code-review`. It does
+**not** have a profile for `agent` or `tool-use`. Adding Gemma 4 as the
+`agent` role surfaces this gap.
+
+**TODO (requires Keith's input):** Define a `tool-use` weight profile.
+Candidate starting values:
+
+```go
+"tool-use": {Warmth: 2, Headroom: 2, Feedback: 4, Quality: 4, Speed: 3, KVCache: 1, Cost: 1},
+```
+
+vs. reasoning (`{Warmth: 1, Headroom: 3, Feedback: 3, Quality: 5, Speed: 0, KVCache: 0, Cost: 1}`).
+
+The meaningful tradeoffs:
+- `Speed` — agents make many small calls; speed per call matters more
+  than it does for reasoning (which is latency-tolerant)
+- `Feedback` — tool-call accuracy is directly observable; heavier
+  weighting on historical success is appropriate
+- `Headroom` — tool traces accumulate (system prompt + tool schemas + N
+  turns); but each individual call is small
+
+Whether this belongs as a new profile or as a parameterization of
+existing profiles is a design call that depends on how often agent
+loops blend with chat/reasoning in practice.

--- a/docs/llm/setups.md
+++ b/docs/llm/setups.md
@@ -1,0 +1,113 @@
+# Three Candidate Setups
+
+Each option is evaluated on co-residency (models that can stay warm
+simultaneously), `go-llm` integration cost, and quality ceiling.
+
+---
+
+## Setup 1 — Balanced Daily Driver (recommended)
+
+**Philosophy:** Drop-in upgrades, all-Ollama, full co-residency, zero
+architectural change to `go-llm`.
+
+| Role | Model | Size on disk | Notes |
+|---|---|---|---|
+| `coding` | `qwen3-coder-next:latest` | ~46GB | 70.6% SWE-bench; unchanged |
+| `agent` | **`gemma4:31b`** (dense) | ~20GB | **NEW.** 86.4% τ2-bench, 80.0% LiveCodeBench, native function calling |
+| `general` / `analysis` | `gemma4:31b` (thinking mode on) | shared | Gemma 4 doubles as reasoner |
+| `fast` | **`qwen3.6:35b-a3b`** | ~28GB (Q6) | Upgrade over qwen3.5:35b-a3b; optional |
+| `lightweight` | `qwen3:8b` | ~6GB | Unchanged — FIM completion |
+| `embedding` | `qwen3-embedding:8b` | ~5GB | Unchanged |
+
+**Resident memory:** ~77GB with the optional `qwen3.6:35b-a3b`, or ~57GB
+without. Comfortable headroom.
+
+**Pros:**
+- No backend-abstraction work in `go-llm`
+- Every gap filled: coding, agent/tool-use, reasoning, fast chat, FIM, embeddings
+- Qwen3-Coder-Next stays as the specialist code generator
+
+**Cons:**
+- No GLM-5.1 / MiniMax ceiling — we cap at ~77% SWE-bench equivalent
+- Gemma 4 is 2 weeks old at the time of writing; long-term stability
+  unproven
+
+---
+
+## Setup 2 — SWE-Bench Maximalist
+
+**Philosophy:** Accept model-swapping for best-in-class agentic coding
+ceiling.
+
+| Role | Model | Runtime | Mem |
+|---|---|---|---|
+| `heavy-code` | **GLM-5.1** | LM Studio (MLX) or llama.cpp | ~95–110GB |
+| `coding` (fallback) | `qwen3-coder-next` | Ollama | ~46GB |
+| `agent` | `gemma4:31b` | Ollama | ~20GB |
+| `general` | `qwen3.6:35b-a3b` | Ollama | ~28GB |
+| `embedding` | Nomic-Embed-Code or Qwen3-Embedding-8B | Ollama | ~5GB |
+
+**Pros:**
+- 77.8% SWE-bench ceiling (close to Claude Opus 4.6's 80.8%)
+- Nomic-Embed-Code is state-of-the-art for code retrieval
+
+**Cons:**
+- Requires a second inference backend in `go-llm` (~500–1000 LoC + tests)
+- Cold-load of GLM-5.1 is ~60s; router must encode this in warmth score
+- GLM-5.1 displaces everything while loaded — swap-in/swap-out UX
+
+**Backend abstraction shape:**
+
+```
+provider/
+├── ollama.go         (existing)
+├── openai_compat.go  (NEW — LM Studio, llama.cpp server, vLLM)
+└── mlx_lm.go         (NEW — optional native mlx-lm integration)
+```
+
+All routed through the existing `provider.Provider` interface.
+
+---
+
+## Setup 3 — Agentic Tool-Use Specialist
+
+**Philosophy:** Optimize for MCP server + multi-step tool-calling
+workflows.
+
+| Role | Model | Runtime | Mem |
+|---|---|---|---|
+| `agent` | **MiniMax M2.7** | LM Studio (MLX) Q4 | ~115GB |
+| `coding` (swap) | `qwen3-coder-next` | Ollama | ~46GB |
+| `general` | `gemma4:31b` | Ollama | ~20GB |
+| `fast` | `qwen3.6:35b-a3b` | Ollama | ~28GB |
+| `embedding` | `qwen3-embedding:8b` | Ollama | ~5GB |
+
+**Pros:**
+- 76.8% BFCL (tool calling) — best in class among open-weight models
+- Strong on multi-step planning and orchestration
+- Good for MCP-heavy workloads (Quantum Trader live trading loops)
+
+**Cons:**
+- Same backend-abstraction cost as Setup 2
+- M2.7 at Q4 dominates memory; displaces the Ollama fleet when loaded
+- **BFCL vs τ2-bench** — BFCL is synthetic; τ2-bench (where Gemma 4 31B
+  leads) is realistic retail-task agents. For Keith's MCP workload, the
+  Gemma 4 advantage may matter more. This needs empirical validation —
+  see [benchmark-plan.md](benchmark-plan.md).
+
+---
+
+## Decision matrix
+
+| Criterion | Setup 1 | Setup 2 | Setup 3 |
+|---|---|---|---|
+| Quality ceiling | Good | Best | Best-for-tools |
+| Co-residency | Full | Partial | Partial |
+| `go-llm` changes | Config only | Second backend | Second backend |
+| Time to deploy | ~30 min | ~1 week | ~1 week |
+| Incremental cost if wrong | Low | High | High |
+| Dependency on brand-new model | Yes (Gemma 4, 2 weeks old) | Moderate | Moderate |
+
+**Recommendation: Setup 1**, with a parallel experiment (LM Studio +
+GLM-5.1) to evaluate whether Setup 2's quality gain justifies the
+integration cost. See [recommendation.md](recommendation.md).

--- a/models.json
+++ b/models.json
@@ -7,18 +7,27 @@
   },
   "models": {
     "general": {
-      "name": "qwen3.5:27b",
+      "name": "gemma4:31b",
       "provider": "ollama",
-      "description": "General purpose — reasoning, conversation, multimodal (vision)",
+      "description": "Gemma 4 31B dense — reasoning, analysis, multimodal; configurable thinking mode",
       "type": "dense",
-      "parameters": "27B",
+      "parameters": "31B",
       "context_window": 256000,
-      "fallbacks": ["lightweight"]
+      "fallbacks": ["fast", "lightweight"]
+    },
+    "agent": {
+      "name": "gemma4:31b",
+      "provider": "ollama",
+      "description": "Agent / tool-use — 86.4% τ2-bench, native function calling, 80.0% LiveCodeBench",
+      "type": "dense",
+      "parameters": "31B",
+      "context_window": 256000,
+      "fallbacks": ["fast", "lightweight"]
     },
     "fast": {
-      "name": "qwen3.5:35b-a3b",
+      "name": "qwen3.6:35b-a3b",
       "provider": "ollama",
-      "description": "MoE model — fast inference, agent/tool use, multimodal",
+      "description": "Qwen 3.6 MoE — 73.4% SWE-bench, 3B active for fast inference, tool use",
       "type": "moe",
       "parameters": "35B total / 3B active",
       "context_window": 256000,
@@ -27,24 +36,24 @@
     "coding": {
       "name": "qwen3-coder-next:latest",
       "provider": "ollama",
-      "description": "Dedicated coding model — code generation, review, completion",
-      "type": "dense",
-      "parameters": "~32B",
-      "context_window": 131072,
-      "fallbacks": ["general", "lightweight"]
+      "description": "Qwen3-Coder-Next MoE — 70.6% SWE-bench, dedicated agentic coding",
+      "type": "moe",
+      "parameters": "80B total / 3.9B active",
+      "context_window": 262144,
+      "fallbacks": ["fast", "lightweight"]
     },
     "lightweight": {
       "name": "qwen3:8b",
       "provider": "ollama",
-      "description": "Small and fast — simple tasks, low resource usage",
+      "description": "Small and fast — FIM / inline completion, simple tasks",
       "type": "dense",
       "parameters": "8B",
-      "context_window": 32768
+      "context_window": 40960
     },
     "embedding": {
       "name": "qwen3-embedding:8b",
       "provider": "ollama",
-      "description": "Embedding model for RAG vector search",
+      "description": "Qwen3 embedding — #1 MTEB multilingual, strong code retrieval",
       "type": "embedding",
       "parameters": "8B",
       "dimensions": 4096
@@ -54,7 +63,7 @@
     "chat": "general",
     "completion": "coding",
     "embedding": "embedding",
-    "agent": "fast",
+    "agent": "agent",
     "analysis": "general"
   }
 }

--- a/ollama/types.go
+++ b/ollama/types.go
@@ -47,11 +47,12 @@ type ChatMessage struct {
 
 // ChatRequest is the request body for the /api/chat endpoint.
 type ChatRequest struct {
-	Model    string        `json:"model"`
-	Messages []ChatMessage `json:"messages"`
-	Stream   bool          `json:"stream"`
-	Options  *ModelOptions `json:"options,omitempty"`
-	Tools    []Tool        `json:"tools,omitempty"` // available tools
+	Model     string        `json:"model"`
+	Messages  []ChatMessage `json:"messages"`
+	Stream    bool          `json:"stream"`
+	Options   *ModelOptions `json:"options,omitempty"`
+	Tools     []Tool        `json:"tools,omitempty"`      // available tools
+	KeepAlive string        `json:"keep_alive,omitempty"` // e.g. "5m", "30m", "-1" (keep forever); empty = Ollama default
 }
 
 // ChatResponse is the response from the /api/chat endpoint.

--- a/provider/catalog.json
+++ b/provider/catalog.json
@@ -87,6 +87,7 @@
       "caps": ["completion", "tools"],
       "context_window": 262144,
       "variants": {
+        "latest": { "ram_required": 46.0, "ram_recommended": 56.0, "vram_recommended": 46.0, "quality": "best", "speed": "fast" },
         "80b": { "ram_required": 46.0, "ram_recommended": 56.0, "vram_recommended": 46.0, "quality": "best", "speed": "fast" }
       }
     },

--- a/provider/catalog.json
+++ b/provider/catalog.json
@@ -60,6 +60,49 @@
         "35b": { "ram_required": 22.0, "ram_recommended": 28.0, "vram_recommended": 22.0, "quality": "great", "speed": "medium" }
       }
     },
+    "qwen3.6": {
+      "fim": {
+        "prefix": "<|fim_prefix|>",
+        "suffix": "<|fim_suffix|>",
+        "middle": "<|fim_middle|>",
+        "prefix_budget_pct": 75
+      },
+      "think_mode": "toggle",
+      "think_tags": { "open": "<think>", "close": "</think>" },
+      "caps": ["completion", "tools"],
+      "context_window": 256000,
+      "variants": {
+        "35b": { "ram_required": 20.0, "ram_recommended": 28.0, "vram_recommended": 20.0, "quality": "best", "speed": "fast" }
+      }
+    },
+    "qwen3-coder-next": {
+      "fim": {
+        "prefix": "<|fim_prefix|>",
+        "suffix": "<|fim_suffix|>",
+        "middle": "<|fim_middle|>",
+        "prefix_budget_pct": 75
+      },
+      "think_mode": "toggle",
+      "think_tags": { "open": "<think>", "close": "</think>" },
+      "caps": ["completion", "tools"],
+      "context_window": 262144,
+      "variants": {
+        "80b": { "ram_required": 46.0, "ram_recommended": 56.0, "vram_recommended": 46.0, "quality": "best", "speed": "fast" }
+      }
+    },
+    "gemma4": {
+      "fim": null,
+      "think_mode": "toggle",
+      "think_tags": { "open": "<think>", "close": "</think>" },
+      "caps": ["completion", "tools"],
+      "context_window": 256000,
+      "variants": {
+        "e2b": { "ram_required": 2.5, "ram_recommended": 4.0, "vram_recommended": 2.5, "quality": "basic", "speed": "fast" },
+        "e4b": { "ram_required": 4.5, "ram_recommended": 6.5, "vram_recommended": 4.5, "quality": "good", "speed": "fast" },
+        "26b": { "ram_required": 16.0, "ram_recommended": 20.0, "vram_recommended": 16.0, "quality": "great", "speed": "fast" },
+        "31b": { "ram_required": 19.0, "ram_recommended": 24.0, "vram_recommended": 19.0, "quality": "best", "speed": "medium" }
+      }
+    },
     "deepseek-r1": {
       "fim": null,
       "think_mode": "always",

--- a/provider/catalog_test.go
+++ b/provider/catalog_test.go
@@ -13,11 +13,11 @@ func TestCatalogLoad(t *testing.T) {
 
 	// Spot-check that all required families are present.
 	families := []string{
-		"qwen2.5", "qwen3", "qwen3.5",
+		"qwen2.5", "qwen3", "qwen3.5", "qwen3.6", "qwen3-coder-next",
 		"deepseek-r1", "deepseek-coder-v2",
 		"codellama", "starcoder", "starcoder2",
 		"llama3", "llama3.1", "llama3.2", "llama3.3",
-		"gemma2", "gemma3",
+		"gemma2", "gemma3", "gemma4",
 		"phi3", "phi4",
 		"mistral", "mixtral",
 		"nomic-embed-text", "mxbai-embed-large",
@@ -124,6 +124,14 @@ func TestCatalogLookupExact(t *testing.T) {
 			wantFIM:    true,
 			wantThink:  ThinkNone,
 			wantRAMMin: 10.0,
+		},
+		{
+			name:       "qwen3-coder-next latest retains scoring data",
+			family:     "qwen3-coder-next",
+			paramSize:  "latest",
+			wantFIM:    true,
+			wantThink:  ThinkToggle,
+			wantRAMMin: 46.0,
 		},
 	}
 	for _, tt := range tests {

--- a/provider/catalog_test.go
+++ b/provider/catalog_test.go
@@ -1,6 +1,33 @@
 package provider
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
+
+// TestQwen3CoderNextVariantsInSync guards against drift between the
+// "latest" alias and the canonical "80b" variant. If 80b's profile is
+// retuned, latest must track — or this test must be updated deliberately.
+func TestQwen3CoderNextVariantsInSync(t *testing.T) {
+	cat, err := loadCatalog()
+	if err != nil {
+		t.Fatalf("loadCatalog() error: %v", err)
+	}
+
+	fam, ok := cat.Families["qwen3-coder-next"]
+	if !ok {
+		t.Fatal("catalog missing qwen3-coder-next family")
+	}
+
+	latest, hasLatest := fam.Variants["latest"]
+	canonical, hasCanonical := fam.Variants["80b"]
+	if !hasLatest || !hasCanonical {
+		t.Fatalf("qwen3-coder-next variants: latest=%v 80b=%v", hasLatest, hasCanonical)
+	}
+	if !reflect.DeepEqual(latest, canonical) {
+		t.Errorf("qwen3-coder-next latest != 80b — variants drifted\nlatest: %+v\n80b:    %+v", latest, canonical)
+	}
+}
 
 func TestCatalogLoad(t *testing.T) {
 	cat, err := loadCatalog()

--- a/provider/model_registry_test.go
+++ b/provider/model_registry_test.go
@@ -265,6 +265,55 @@ func TestModelRegistry_Lookup_LatestVariantCatalogMatch(t *testing.T) {
 	}
 }
 
+func TestModelRegistry_Lookup_Qwen3CoderNextLatestCatalogMatch(t *testing.T) {
+	ctx := context.Background()
+
+	prov := &mrMockProvider{
+		name: "ollama",
+		caps: CapChat | CapGenerate | CapStream,
+		models: []ModelInfo{
+			{
+				Name:          "qwen3-coder-next:latest",
+				Family:        "qwen3-coder-next",
+				ParameterSize: "80B",
+				ContextWindow: 262144,
+				Digest:        "coder123",
+				Capabilities:  []string{"completion", "tools"},
+			},
+		},
+	}
+
+	reg := &mrMockProviderRegistry{
+		providers: map[string]Provider{"ollama": prov},
+	}
+
+	mr, err := NewModelRegistry(reg, newMrMockFingerprintStore())
+	if err != nil {
+		t.Fatalf("NewModelRegistry() error: %v", err)
+	}
+
+	profile, err := mr.Lookup(ctx, ModelKey{Provider: "ollama", Model: "qwen3-coder-next:latest"})
+	if err != nil {
+		t.Fatalf("Lookup() error: %v", err)
+	}
+
+	if profile.Resources.RAMRequired != 46.0 {
+		t.Errorf("RAMRequired = %f, want 46.0", profile.Resources.RAMRequired)
+	}
+	if profile.Resources.RAMRecommended != 56.0 {
+		t.Errorf("RAMRecommended = %f, want 56.0", profile.Resources.RAMRecommended)
+	}
+	if profile.Quality != TierBest {
+		t.Errorf("Quality = %v, want %v", profile.Quality, TierBest)
+	}
+	if profile.Speed != TierGreat {
+		t.Errorf("Speed = %v, want %v", profile.Speed, TierGreat)
+	}
+	if profile.FIM == nil {
+		t.Fatal("expected FIM config from catalog, got nil")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // TestModelRegistry_Lookup_UnknownModel
 // ---------------------------------------------------------------------------

--- a/provider/router_score.go
+++ b/provider/router_score.go
@@ -36,13 +36,18 @@ type WeightProfile struct {
 // FIM heavily favors KV cache (prefix reuse) and speed. Chat favors quality
 // and feedback. Embedding cares about quality and speed, not warmth/headroom.
 // Reasoning maximizes quality with headroom for long outputs. Code-review
-// balances quality and feedback.
+// balances quality and feedback. Agent (tool-calling) loops need speed per
+// call (many small calls), headroom (accumulating tool trace), and feedback
+// (tool-call accuracy is directly observable). "tool-use" is an alias for
+// "agent" kept so callers can pick whichever name reads better locally.
 var defaultWeightProfiles = map[string]*WeightProfile{
 	"fim":         {Warmth: 2, Headroom: 1, Feedback: 1, Quality: 1, Speed: 2, KVCache: 3, Cost: 1},
 	"chat":        {Warmth: 1, Headroom: 2, Feedback: 3, Quality: 4, Speed: 1, KVCache: 0, Cost: 1},
 	"embedding":   {Warmth: 0, Headroom: 0, Feedback: 1, Quality: 3, Speed: 2, KVCache: 0, Cost: 2},
 	"reasoning":   {Warmth: 1, Headroom: 3, Feedback: 3, Quality: 5, Speed: 0, KVCache: 0, Cost: 1},
 	"code-review": {Warmth: 1, Headroom: 3, Feedback: 4, Quality: 3, Speed: 1, KVCache: 0, Cost: 1},
+	"agent":       {Warmth: 2, Headroom: 2, Feedback: 4, Quality: 4, Speed: 3, KVCache: 1, Cost: 1},
+	"tool-use":    {Warmth: 2, Headroom: 2, Feedback: 4, Quality: 4, Speed: 3, KVCache: 1, Cost: 1},
 }
 
 // defaultWeightProfile returns the weight profile for the given use case.

--- a/provider/router_score_test.go
+++ b/provider/router_score_test.go
@@ -37,7 +37,7 @@ func TestTierToFloat(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDefaultWeightProfile(t *testing.T) {
-	useCases := []string{"fim", "chat", "embedding", "reasoning", "code-review"}
+	useCases := []string{"fim", "chat", "embedding", "reasoning", "code-review", "agent", "tool-use"}
 
 	for _, uc := range useCases {
 		t.Run(uc, func(t *testing.T) {
@@ -74,6 +74,22 @@ func TestDefaultWeightProfile(t *testing.T) {
 		}
 		if *unknown != *chat {
 			t.Errorf("unknown profile = %+v, want chat profile %+v", unknown, chat)
+		}
+	})
+
+	t.Run("agent and tool-use are aliased", func(t *testing.T) {
+		agent := defaultWeightProfile("agent")
+		toolUse := defaultWeightProfile("tool-use")
+		if *agent != *toolUse {
+			t.Errorf("agent (%+v) and tool-use (%+v) should share a profile", agent, toolUse)
+		}
+		// Agent workloads must weight Speed and Feedback higher than chat.
+		chat := defaultWeightProfile("chat")
+		if agent.Speed <= chat.Speed {
+			t.Errorf("agent Speed (%d) should exceed chat Speed (%d)", agent.Speed, chat.Speed)
+		}
+		if agent.Feedback <= chat.Feedback {
+			t.Errorf("agent Feedback (%d) should exceed chat Feedback (%d)", agent.Feedback, chat.Feedback)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Retargets `models.json` to the 2026 lineup: `gemma4:31b` for `general`/`analysis`/`agent`, `qwen3.6:35b-a3b` for `fast`, `qwen3-coder-next:latest` retained for `coding`.
- Adds `agent` and `tool-use` weight profiles to `provider/router_score.go` so the new `agent` role gets meaningful routing instead of falling through to `chat`.
- Introduces `cmd/llm-bench`, a skeleton harness that replays captured MCP/chat traces against multiple candidate models and scores them. Phase 1 ships an `exact-match` scorer; `llm-judge` and `manual` are declared but return errors until Phase 3.
- Adds `cmd/llm-bench/testdata/smoke/minimal.json` plus a documented smoke-test command in `docs/llm/README.md` so the harness can be manually exercised before Phase 2 trace capture lands.
- Exposes `ollama.ChatRequest.KeepAlive` so callers can override Ollama's 5-minute keep-alive default (used by the bench to hold models warm across traces).
- Documents the research and rationale in `docs/llm/` (analysis, three setups, recommendation, benchmark plan).
- Adds `CHANGELOG.md` documenting the breaking retarget of `general`/`analysis` roles for downstream consumers (Firn IDE, Flux ML, Quantum Trader).

## Breaking change notice

`models.json` roles `general` and `analysis` now resolve to `gemma4:31b` instead of `qwen3.5:27b`, and `fast` resolves to `qwen3.6:35b-a3b` instead of `qwen3.5:35b-a3b`. Consumers that read `models.json` via `config.Load` will talk to different models after `go get -u`. Pull the new models (`ollama pull gemma4:31b`, `ollama pull qwen3.6:35b-a3b`) on every deployment host before upgrading. See `CHANGELOG.md` for the full migration table.

## Review history

Eight commits separated for staged review:
1. `docs(llm): add 2026 local-LLM analysis and recommendation` — research docs only
2. `config: adopt Gemma 4 and Qwen 3.6 lineup` — `models.json` + catalog additions
3. `cmd/llm-bench: skeleton harness for model A/B comparison` — initial harness
4. `Fix llm-bench review findings` — first review-cycle fixes (target parsing, tool-call extraction, `qwen3-coder-next:latest` catalog entry)
5. `cmd/llm-bench: tighten scaffolding to remove silent-failure surfaces` — second cycle: killed 0.5 placeholder, multi-turn silent truncation, 0o644 report, unused param
6. `Address critique findings across benchmark, router, and docs` — self-critique pass fixing 15 items: latency measurement, agent profile, keep_alive, partial-failure resilience, ctx cancellation, sentinel errors, error-row rendering, variant drift guard, docs/impl alignment, context-window disclaimer
7. `cmd/llm-bench: address PR review findings` — forwards trace tools during replay and fixes duplicate-counted Jaccard overlap
8. `docs(llm): add llm-bench smoke test instructions` — checked-in synthetic smoke trace plus manual smoke-test command

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes (all 15+ package test suites)
- [x] New tests cover: partial-failure recording, ctx cancellation, trace validation, scorer guardrails, `agent`/`tool-use` profile semantics, `latest`/`80b` catalog drift
- [x] Manual: `ollama pull gemma4:31b && ollama pull qwen3.6:35b-a3b` on local M3 Max
- [x] Manual: `go run ./cmd/llm-bench -traces 'cmd/llm-bench/testdata/smoke/*.json' -models 'ollama/gemma4:31b,ollama/qwen3.6:35b-a3b' -scorer exact-match -report /tmp/llm-bench-smoke.md` and verify `/tmp/llm-bench-smoke.md` shows `Errors = 0` and `Mean Quality = 1.00` for both models

Generated with [Claude Code](https://claude.com/claude-code)