### PR TITLE
feat(compat): Phase 4 OpenAI-compatible endpoint (#48)

### DIFF
--- a/compat/aliases.go
+++ b/compat/aliases.go
@@ -1,0 +1,73 @@
+package compat
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// resolveModel translates a wire model name into a provider.ModelKey. The
+// returned ModelKey has an empty Provider when the input (or its alias target)
+// is unqualified — the router resolves it across all providers advertising
+// that model.
+//
+// Alias lookup is intentionally single-level: if aliases["gpt-4"] = "gpt-4-turbo"
+// and aliases["gpt-4-turbo"] = "qwen3-coder-next", the result is "gpt-4-turbo",
+// not "qwen3-coder-next". This avoids accidental cycles and makes config
+// readable at a glance; callers who want chaining should flatten at config
+// time. Lookups are case-sensitive — OpenAI wire names are lowercase in
+// practice.
+func resolveModel(wire string, aliases map[string]string) (provider.ModelKey, error) {
+	wire = strings.TrimSpace(wire)
+	if wire == "" {
+		return provider.ModelKey{}, fmt.Errorf("compat: model field is required")
+	}
+	name := wire
+	if alias, ok := aliases[wire]; ok {
+		name = alias
+	}
+	key := parseKey(name)
+	// parseKey can return an empty Model for inputs like "/" or "ollama/" —
+	// catch these here so the router sees a clean 400 instead of an opaque
+	// "model not found" on a zero-width name.
+	if key.Model == "" {
+		return provider.ModelKey{}, fmt.Errorf("compat: malformed model %q", wire)
+	}
+	return key, nil
+}
+
+// parseKey splits "provider/model" into a ModelKey. No slash => unqualified.
+func parseKey(s string) provider.ModelKey {
+	if i := strings.IndexByte(s, '/'); i >= 0 {
+		return provider.ModelKey{Provider: s[:i], Model: s[i+1:]}
+	}
+	return provider.ModelKey{Model: s}
+}
+
+// RecommendedAliases returns a conservative preset suitable for IDE tools
+// that hardcode OpenAI model names. Callers pass the result to WithAliases;
+// the Server default is an empty map. Returned map is a fresh copy so
+// callers may mutate it without affecting future calls.
+//
+// Mappings reflect the go-llm role intent rather than identical capabilities:
+//   - "gpt-4" / "gpt-4-turbo"           -> coding role (qwen3-coder-next)
+//   - "gpt-4o"                          -> agent role (gemma4:31b)
+//   - "gpt-4o-mini" / "gpt-3.5-turbo"   -> fast role (qwen3.6:35b-a3b)
+//   - "text-embedding-3-large"          -> embedding role (qwen3-embedding:8b)
+//
+// These mappings are intentional best-effort and not a stability contract.
+// The models.json lineup may shift (see CHANGELOG.md); alias presets migrate
+// alongside it.
+func RecommendedAliases() map[string]string {
+	return map[string]string{
+		"gpt-4":                  "qwen3-coder-next:latest",
+		"gpt-4-turbo":            "qwen3-coder-next:latest",
+		"gpt-4o":                 "gemma4:31b",
+		"gpt-4o-mini":            "qwen3.6:35b-a3b",
+		"gpt-3.5-turbo":          "qwen3.6:35b-a3b",
+		"text-embedding-3-large": "qwen3-embedding:8b",
+		"text-embedding-3-small": "qwen3-embedding:8b",
+		"text-embedding-ada-002": "qwen3-embedding:8b",
+	}
+}

--- a/compat/aliases_test.go
+++ b/compat/aliases_test.go
@@ -1,0 +1,131 @@
+package compat
+
+import (
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+func TestResolveModel_PassThroughWhenNoAlias(t *testing.T) {
+	got, err := resolveModel("qwen3:8b", nil)
+	if err != nil {
+		t.Fatalf("resolveModel: %v", err)
+	}
+	if got.Provider != "" || got.Model != "qwen3:8b" {
+		t.Errorf("got %+v, want {Provider:'' Model:'qwen3:8b'}", got)
+	}
+}
+
+func TestResolveModel_QualifiedInput(t *testing.T) {
+	got, err := resolveModel("ollama/qwen3:8b", nil)
+	if err != nil {
+		t.Fatalf("resolveModel: %v", err)
+	}
+	if got.Provider != "ollama" || got.Model != "qwen3:8b" {
+		t.Errorf("got %+v, want ollama/qwen3:8b", got)
+	}
+}
+
+func TestResolveModel_UnqualifiedAlias(t *testing.T) {
+	aliases := map[string]string{"gpt-4": "qwen3-coder-next:latest"}
+	got, err := resolveModel("gpt-4", aliases)
+	if err != nil {
+		t.Fatalf("resolveModel: %v", err)
+	}
+	if got.Provider != "" || got.Model != "qwen3-coder-next:latest" {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestResolveModel_QualifiedAlias(t *testing.T) {
+	aliases := map[string]string{"gpt-4": "ollama/qwen3-coder-next:latest"}
+	got, err := resolveModel("gpt-4", aliases)
+	if err != nil {
+		t.Fatalf("resolveModel: %v", err)
+	}
+	if got.Provider != "ollama" || got.Model != "qwen3-coder-next:latest" {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestResolveModel_EmptyInput(t *testing.T) {
+	if _, err := resolveModel("", nil); err == nil {
+		t.Fatal("empty input must error")
+	}
+}
+
+func TestResolveModel_WhitespaceInput(t *testing.T) {
+	// Regression guard: clients (and OpenAI SDKs) occasionally send stray
+	// whitespace. Trim and reject rather than producing {Model:" "} which
+	// the router has no way to match.
+	for _, in := range []string{" ", "\t", "\n", "   "} {
+		if _, err := resolveModel(in, nil); err == nil {
+			t.Errorf("resolveModel(%q) = nil err, want error", in)
+		}
+	}
+}
+
+func TestResolveModel_MalformedSlash(t *testing.T) {
+	// Regression guard for the parseKey edges: inputs that produce an empty
+	// Model field must fail fast with a clear error, not get smuggled to the
+	// router and resurface as "model not found".
+	for _, in := range []string{"/", "ollama/", "  ollama/  "} {
+		if _, err := resolveModel(in, nil); err == nil {
+			t.Errorf("resolveModel(%q) = nil err, want malformed-model error", in)
+		}
+	}
+}
+
+func TestResolveModel_LeadingSlashIsUnqualified(t *testing.T) {
+	// "/qwen3:8b" is a typo of "qwen3:8b" — both should route the same way
+	// (empty Provider, Model preserved). Only empty Model is fatal.
+	got, err := resolveModel("/qwen3:8b", nil)
+	if err != nil {
+		t.Fatalf("resolveModel: %v", err)
+	}
+	if got.Provider != "" || got.Model != "qwen3:8b" {
+		t.Errorf("got %+v, want {Provider:'' Model:'qwen3:8b'}", got)
+	}
+}
+
+func TestResolveModel_AliasLookupIsSingleLevel(t *testing.T) {
+	// Locks in the documented contract: alias targets are NOT recursively
+	// resolved. If someone later adds a loop, this test fails and forces a
+	// conscious decision (plus cycle-detection) rather than silent breakage.
+	aliases := map[string]string{
+		"gpt-4":       "gpt-4-turbo",
+		"gpt-4-turbo": "qwen3-coder-next:latest",
+	}
+	got, err := resolveModel("gpt-4", aliases)
+	if err != nil {
+		t.Fatalf("resolveModel: %v", err)
+	}
+	if got.Model != "gpt-4-turbo" {
+		t.Errorf("got Model=%q, want %q (single-level lookup)", got.Model, "gpt-4-turbo")
+	}
+}
+
+func TestRecommendedAliases_ContainsCoreMappings(t *testing.T) {
+	m := RecommendedAliases()
+	for _, want := range []string{"gpt-4", "gpt-4o-mini", "gpt-3.5-turbo"} {
+		if _, ok := m[want]; !ok {
+			t.Errorf("RecommendedAliases missing %q", want)
+		}
+	}
+	// Must not be exported nil.
+	if m == nil {
+		t.Fatal("RecommendedAliases() returned nil")
+	}
+	// Mutation by caller must not affect future calls.
+	m["gpt-4"] = "evil"
+	if RecommendedAliases()["gpt-4"] == "evil" {
+		t.Error("RecommendedAliases() must return a fresh map each call")
+	}
+}
+
+func TestResolvedKey_String(t *testing.T) {
+	k := provider.ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+	if k.String() != "ollama/qwen3:8b" {
+		t.Errorf("got %q", k.String())
+	}
+}

--- a/compat/chat.go
+++ b/compat/chat.go
@@ -668,7 +668,10 @@ func fallbackRequestID() string {
 // toModelOptions maps the OpenAI sampling fields onto provider.ModelOptions.
 // Pointer inputs pass through unchanged. maxTokens is stored as NumPredict
 // (Ollama's convention); nil leaves NumPredict at zero so the provider picks
-// a default. Empty stop slices are normalized to nil.
+// a default. Empty stop slices are normalized to nil. Empty-string stop
+// entries are filtered out: Ollama treats "" as "stop immediately" which
+// would truncate generation to zero/one token with finish_reason="stop",
+// silently masking a caller mistake ({"stop": ""} or {"stop": [""]}).
 func toModelOptions(temperature, topP *float64, maxTokens *int, stop []string) provider.ModelOptions {
 	opts := provider.ModelOptions{
 		Temperature: temperature,
@@ -678,7 +681,15 @@ func toModelOptions(temperature, topP *float64, maxTokens *int, stop []string) p
 		opts.NumPredict = *maxTokens
 	}
 	if len(stop) > 0 {
-		opts.Stop = stop
+		filtered := make([]string, 0, len(stop))
+		for _, s := range stop {
+			if s != "" {
+				filtered = append(filtered, s)
+			}
+		}
+		if len(filtered) > 0 {
+			opts.Stop = filtered
+		}
 	}
 	return opts
 }

--- a/compat/chat.go
+++ b/compat/chat.go
@@ -1,0 +1,377 @@
+package compat
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// ---------------------------------------------------------------------------
+// Request / response wire types
+// ---------------------------------------------------------------------------
+
+// ChatCompletionRequest is the OpenAI-shape POST /v1/chat/completions body.
+// Fields prefixed with x_ are go-llm-specific extensions; standard OpenAI
+// SDKs ignore unknown fields so the wire remains compatible.
+type ChatCompletionRequest struct {
+	Model       string             `json:"model"`
+	Messages    []ChatMessageParam `json:"messages"`
+	Stream      bool               `json:"stream,omitempty"`
+	Temperature *float64           `json:"temperature,omitempty"`
+	TopP        *float64           `json:"top_p,omitempty"`
+	MaxTokens   *int               `json:"max_tokens,omitempty"`
+	Stop        StopSequences      `json:"stop,omitempty"` // string or []string
+	Tools       []OpenAIToolParam  `json:"tools,omitempty"`
+	ToolChoice  any                `json:"tool_choice,omitempty"`
+
+	// Extensions (amendments #6, #10). All optional.
+	UseCase     string `json:"x_use_case,omitempty"`
+	Priority    *int   `json:"x_priority,omitempty"`
+	AffinityKey string `json:"x_affinity_key,omitempty"`
+	DryRun      bool   `json:"x_dry_run,omitempty"`
+}
+
+// ChatMessageParam is a single message in an OpenAI chat request.
+// Role and Content are always populated; Name is optional and currently
+// dropped during conversion because provider.ChatMessage has no Name field.
+type ChatMessageParam struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+	Name    string `json:"name,omitempty"`
+}
+
+// ChatCompletionResponse is the OpenAI-shape response body. The x_ fields
+// extend it with go-llm routing metadata and extended reasoning output.
+type ChatCompletionResponse struct {
+	ID      string       `json:"id"`
+	Object  string       `json:"object"` // "chat.completion"
+	Created int64        `json:"created"`
+	Model   string       `json:"model"`
+	Choices []ChatChoice `json:"choices"`
+	Usage   UsageWire    `json:"usage"`
+
+	// Extensions.
+	Thinking  string        `json:"x_thinking,omitempty"`
+	RouteInfo *RouteInfoExt `json:"x_route_info,omitempty"`
+}
+
+// ChatChoice is one completion choice in an OpenAI chat response. The
+// non-streaming handler currently emits exactly one choice.
+type ChatChoice struct {
+	Index        int              `json:"index"`
+	Message      ChatMessageParam `json:"message"`
+	FinishReason string           `json:"finish_reason"`
+}
+
+// UsageWire is OpenAI's token accounting shape.
+type UsageWire struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+// RouteInfoExt surfaces the Router's decision metadata for a request. It is
+// populated from provider.RouteOutcome on executed requests and from
+// plan.Profile on dry-run requests.
+type RouteInfoExt struct {
+	ActualModel  string  `json:"actual_model"`
+	PlannedModel string  `json:"planned_model,omitempty"`
+	WasSticky    bool    `json:"was_sticky,omitempty"`
+	Score        float64 `json:"score,omitempty"`
+	Reason       string  `json:"reason,omitempty"`
+}
+
+// OpenAIToolParam mirrors OpenAI's function-calling tool descriptor.
+type OpenAIToolParam struct {
+	Type     string            `json:"type"` // "function"
+	Function OpenAIToolFnParam `json:"function"`
+}
+
+// OpenAIToolFnParam is the function descriptor nested under a tool entry.
+// Parameters is a raw JSON Schema document that go-llm forwards unmodified.
+type OpenAIToolFnParam struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+}
+
+// StopSequences accepts OpenAI's "stop" field as either a single string or a
+// list of strings. Both shapes unmarshal to []string internally so downstream
+// provider.ModelOptions can consume a single type.
+type StopSequences []string
+
+// UnmarshalJSON decodes either a JSON string or array of strings into s.
+// An empty string unmarshals to nil so downstream code sees no stop
+// sequences rather than a single empty sentinel.
+func (s *StopSequences) UnmarshalJSON(data []byte) error {
+	// Try array first — this is the OpenAI canonical shape.
+	var arr []string
+	if err := json.Unmarshal(data, &arr); err == nil {
+		*s = arr
+		return nil
+	}
+	// Fall back to single string.
+	var single string
+	if err := json.Unmarshal(data, &single); err != nil {
+		return fmt.Errorf("compat: stop must be string or []string: %w", err)
+	}
+	if single == "" {
+		*s = nil
+	} else {
+		*s = []string{single}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+// handleChatCompletions implements POST /v1/chat/completions (non-streaming).
+// Streaming requests return 501 until Task 10 wires in the SSE writer.
+//
+// Order of operations:
+//  1. Decode body and validate required fields.
+//  2. Resolve model alias -> provider.ModelKey.
+//  3. Build provider.RoutingRequest from wire fields + x_ extensions.
+//  4. If streaming, dispatch to the SSE branch (currently stubbed).
+//  5. Acquire a concurrency slot using the resolved priority — the slot is
+//     released when the handler returns. This is deliberately AFTER request
+//     parsing so x_priority influences admission control.
+//  6. Route via Router.Route. On error, map via writeCompatError.
+//  7. If DryRun, render route metadata with empty choices and return.
+//  8. Execute via RoutePlan.ExecuteChat and render the OpenAI response.
+func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
+	if s.router == nil {
+		writeError(w, http.StatusServiceUnavailable, "no_router", "server has no router")
+		return
+	}
+
+	var req ChatCompletionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "decode_error", err.Error())
+		return
+	}
+	key, err := resolveModel(req.Model, s.aliases)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "missing_model", err.Error())
+		return
+	}
+	if len(req.Messages) == 0 {
+		writeError(w, http.StatusBadRequest, "missing_messages", "messages is required")
+		return
+	}
+
+	rr := provider.RoutingRequest{
+		Model:        selectorFor(key),
+		UseCase:      firstNonEmpty(req.UseCase, "chat"),
+		Messages:     toProviderMessages(req.Messages),
+		Options:      toModelOptions(req.Temperature, req.TopP, req.MaxTokens, []string(req.Stop)),
+		RequiredCaps: provider.CapChat,
+		Priority:     resolvePriority(req.Priority, provider.PriorityNormal),
+		AffinityKey:  req.AffinityKey,
+		DryRun:       req.DryRun,
+	}
+	if len(req.Tools) > 0 {
+		rr.RequiredCaps |= provider.CapToolCall
+		rr.Tools = toProviderTools(req.Tools)
+	}
+	if req.Stream {
+		s.serveChatStream(w, r, rr)
+		return
+	}
+
+	// Acquire the HTTP concurrency slot only after body parsing so x_priority
+	// influences both admission control and routing.
+	release, ok := s.semaphore.acquire(rr.Priority)
+	if !ok {
+		w.Header().Set("Retry-After", "1")
+		writeError(w, http.StatusTooManyRequests, "capacity", "server is at capacity")
+		return
+	}
+	defer release()
+
+	plan, err := s.router.Route(r.Context(), rr)
+	if err != nil {
+		writeCompatError(w, err)
+		return
+	}
+	if req.DryRun {
+		writeChatDryRun(w, r, plan)
+		return
+	}
+	resp, err := plan.ExecuteChat(r.Context())
+	if err != nil {
+		writeCompatError(w, err)
+		return
+	}
+
+	out := ChatCompletionResponse{
+		ID:      "chatcmpl_" + requestIDFrom(r.Context()),
+		Object:  "chat.completion",
+		Created: time.Now().Unix(),
+		Model:   resp.Model,
+		Choices: []ChatChoice{{
+			Index: 0,
+			Message: ChatMessageParam{
+				Role:    "assistant",
+				Content: resp.Content,
+			},
+			FinishReason: "stop",
+		}},
+		Usage: UsageWire{
+			PromptTokens:     resp.Usage.PromptTokens,
+			CompletionTokens: resp.Usage.CompletionTokens,
+			TotalTokens:      resp.Usage.TotalTokens,
+		},
+		Thinking:  resp.Thinking,
+		RouteInfo: routeInfoFrom(resp.RouteOutcome),
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(out)
+}
+
+// serveChatStream handles the streaming branch. Task 10 replaces this stub
+// with a lazy-start SSE writer so pre-first-chunk failures still return a
+// JSON error envelope.
+func (s *Server) serveChatStream(w http.ResponseWriter, r *http.Request, rr provider.RoutingRequest) {
+	_ = rr // consumed by the SSE implementation in a follow-up task.
+	writeError(w, http.StatusNotImplemented, "not_implemented", "streaming arrives in a follow-up commit")
+}
+
+// writeChatDryRun renders the route decision without executing the request.
+// The response carries an empty Choices slice (nothing was generated) and a
+// populated x_route_info block so clients can observe the chosen model.
+//
+// On a dry-run the plan was not executed, so plan.Profile.Key is both the
+// planned and the actual model — we do not walk the fallback chain.
+func writeChatDryRun(w http.ResponseWriter, r *http.Request, plan *provider.RoutePlan) {
+	out := ChatCompletionResponse{
+		ID:      "chatcmpl_" + requestIDFrom(r.Context()),
+		Object:  "chat.completion",
+		Created: time.Now().Unix(),
+		Model:   plan.Profile.Key.String(),
+		Choices: []ChatChoice{}, // empty — nothing was executed
+		Usage:   UsageWire{},
+		RouteInfo: &RouteInfoExt{
+			ActualModel:  plan.Profile.Key.String(),
+			PlannedModel: plan.Profile.Key.String(),
+			Score:        plan.Score,
+			Reason:       plan.Reason,
+		},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(out)
+}
+
+// ---------------------------------------------------------------------------
+// Conversion helpers
+// ---------------------------------------------------------------------------
+
+// selectorFor formats a ModelKey for provider.RoutingRequest.Model. When the
+// key is qualified it returns "provider/model"; unqualified keys return just
+// the bare model name so the router performs a cross-provider lookup.
+func selectorFor(k provider.ModelKey) string {
+	if k.Provider == "" {
+		return k.Model
+	}
+	return k.String()
+}
+
+// firstNonEmpty returns the first non-empty string from its arguments.
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// resolvePriority maps the wire x_priority field (a *int) to a
+// provider.Priority. nil falls back to def. Values outside the
+// [PriorityBackground, PriorityCritical] range are clamped so callers sending
+// garbage integers do not bypass admission control.
+func resolvePriority(explicit *int, def provider.Priority) provider.Priority {
+	if explicit == nil {
+		return def
+	}
+	p := provider.Priority(*explicit)
+	if p < provider.PriorityBackground {
+		return provider.PriorityBackground
+	}
+	if p > provider.PriorityCritical {
+		return provider.PriorityCritical
+	}
+	return p
+}
+
+// toProviderMessages converts OpenAI chat messages to provider.ChatMessage.
+// Role/Content only — the Name field on ChatMessageParam is silently dropped
+// because provider.ChatMessage has no corresponding field today.
+func toProviderMessages(in []ChatMessageParam) []provider.ChatMessage {
+	out := make([]provider.ChatMessage, 0, len(in))
+	for _, m := range in {
+		out = append(out, provider.ChatMessage{
+			Role:    m.Role,
+			Content: m.Content,
+		})
+	}
+	return out
+}
+
+// toProviderTools converts OpenAI tool descriptors to provider.Tool entries.
+// Parameters is passed through as raw JSON so we do not canonicalize or
+// re-encode the schema.
+func toProviderTools(in []OpenAIToolParam) []provider.Tool {
+	out := make([]provider.Tool, 0, len(in))
+	for _, t := range in {
+		out = append(out, provider.Tool{
+			Type: firstNonEmpty(t.Type, "function"),
+			Function: provider.ToolFunction{
+				Name:        t.Function.Name,
+				Description: t.Function.Description,
+				Parameters:  t.Function.Parameters,
+			},
+		})
+	}
+	return out
+}
+
+// toModelOptions maps the OpenAI sampling fields onto provider.ModelOptions.
+// Pointer inputs pass through unchanged. maxTokens is stored as NumPredict
+// (Ollama's convention); nil leaves NumPredict at zero so the provider picks
+// a default. Empty stop slices are normalized to nil.
+func toModelOptions(temperature, topP *float64, maxTokens *int, stop []string) provider.ModelOptions {
+	opts := provider.ModelOptions{
+		Temperature: temperature,
+		TopP:        topP,
+	}
+	if maxTokens != nil {
+		opts.NumPredict = *maxTokens
+	}
+	if len(stop) > 0 {
+		opts.Stop = stop
+	}
+	return opts
+}
+
+// routeInfoFrom lifts a provider.RouteOutcome into the wire RouteInfoExt.
+// Returns nil when the outcome is nil so the x_route_info field omits
+// cleanly. ActualModel/PlannedModel use ModelKey.String() which always
+// includes the provider prefix for routed responses.
+func routeInfoFrom(outcome *provider.RouteOutcome) *RouteInfoExt {
+	if outcome == nil {
+		return nil
+	}
+	return &RouteInfoExt{
+		ActualModel:  outcome.ActualModel.String(),
+		PlannedModel: outcome.PlannedModel.String(),
+		WasSticky:    outcome.WasSticky,
+		Score:        outcome.Score,
+		Reason:       outcome.Reason,
+	}
+}

--- a/compat/chat.go
+++ b/compat/chat.go
@@ -1,6 +1,10 @@
 package compat
 
 import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -34,13 +38,47 @@ type ChatCompletionRequest struct {
 	DryRun      bool   `json:"x_dry_run,omitempty"`
 }
 
-// ChatMessageParam is a single message in an OpenAI chat request.
-// Role and Content are always populated; Name is optional and currently
-// dropped during conversion because provider.ChatMessage has no Name field.
+// ChatMessageParam is a single message in an OpenAI chat request or response.
+//
+// Fields:
+//   - Role / Content: always populated on the wire.
+//   - Name: honored only when Role=="tool" (it names the tool whose result
+//     this message carries). On any other role, Name is silently dropped
+//     during conversion because provider.ChatMessage has no general-purpose
+//     Name field. This is intentional — OpenAI's Name on non-tool roles is
+//     informational and has no provider-side effect today.
+//   - ToolCallID: correlates a role=="tool" result with the prior assistant
+//     tool_call that produced it. Required by the model to match the result
+//     to the invocation.
+//   - ToolCalls: populated on assistant turns (inbound when replaying a
+//     tool-calling history, outbound when the model emits a new invocation).
 type ChatMessageParam struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
-	Name    string `json:"name,omitempty"`
+	Role       string             `json:"role"`
+	Content    string             `json:"content"`
+	Name       string             `json:"name,omitempty"`
+	ToolCallID string             `json:"tool_call_id,omitempty"`
+	ToolCalls  []ChatToolCallWire `json:"tool_calls,omitempty"`
+}
+
+// ChatToolCallWire mirrors OpenAI's tool_calls[] entry on assistant messages.
+// It carries the call ID, the fixed "function" type, and the nested function
+// descriptor.
+type ChatToolCallWire struct {
+	ID       string                   `json:"id,omitempty"`
+	Type     string                   `json:"type"` // "function"
+	Function ChatToolCallFunctionWire `json:"function"`
+}
+
+// ChatToolCallFunctionWire is the function descriptor inside a tool_calls entry.
+// Arguments is forwarded from the provider verbatim as raw JSON. Note that
+// OpenAI's canonical API returns Arguments as a JSON-encoded string (a string
+// literal whose value is a serialized JSON object). go-llm preserves the
+// provider's own encoding instead of re-stringifying it; clients that compare
+// bytes strictly may notice the difference. This is an intentional transparency
+// tradeoff, not a lossy conversion — the semantic payload round-trips.
+type ChatToolCallFunctionWire struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
 }
 
 // ChatCompletionResponse is the OpenAI-shape response body. The x_ fields
@@ -104,13 +142,25 @@ type OpenAIToolFnParam struct {
 type StopSequences []string
 
 // UnmarshalJSON decodes either a JSON string or array of strings into s.
-// An empty string unmarshals to nil so downstream code sees no stop
-// sequences rather than a single empty sentinel.
+// Empty strings are filtered out in both shapes so downstream code sees a
+// clean list: [""] / "" become nil, ["", "b", ""] becomes []string{"b"}.
+// Providers treat an empty stop sequence as a no-op at best and an always-fire
+// sentinel at worst, so normalizing at the edge is strictly safer.
 func (s *StopSequences) UnmarshalJSON(data []byte) error {
 	// Try array first — this is the OpenAI canonical shape.
 	var arr []string
 	if err := json.Unmarshal(data, &arr); err == nil {
-		*s = arr
+		filtered := arr[:0]
+		for _, v := range arr {
+			if v != "" {
+				filtered = append(filtered, v)
+			}
+		}
+		if len(filtered) == 0 {
+			*s = nil
+		} else {
+			*s = filtered
+		}
 		return nil
 	}
 	// Fall back to single string.
@@ -176,8 +226,13 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		DryRun:       req.DryRun,
 	}
 	if len(req.Tools) > 0 {
+		tools, err := toProviderTools(req.Tools)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_tool_parameters", err.Error())
+			return
+		}
 		rr.RequiredCaps |= provider.CapToolCall
-		rr.Tools = toProviderTools(req.Tools)
+		rr.Tools = tools
 	}
 	if req.Stream {
 		s.serveChatStream(w, r, rr)
@@ -209,18 +264,33 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Derive finish_reason from response state. OpenAI's ordering is:
+	// "tool_calls" when the model emitted any function invocations; else
+	// "length" when MaxTokens was set and the response exhausted the budget;
+	// else "stop".
+	finish := "stop"
+	if len(resp.ToolCalls) > 0 {
+		finish = "tool_calls"
+	} else if req.MaxTokens != nil && *req.MaxTokens > 0 && resp.Usage.CompletionTokens >= *req.MaxTokens {
+		finish = "length"
+	}
+
 	out := ChatCompletionResponse{
-		ID:      "chatcmpl_" + requestIDFrom(r.Context()),
+		ID:      chatResponseID(r.Context()),
 		Object:  "chat.completion",
 		Created: time.Now().Unix(),
-		Model:   resp.Model,
+		// Model is the qualified "provider/model" form taken from the plan
+		// so success and dry-run responses have identical shape even when
+		// resp.Model (provider-reported) omits the provider prefix.
+		Model: plan.Profile.Key.String(),
 		Choices: []ChatChoice{{
 			Index: 0,
 			Message: ChatMessageParam{
-				Role:    "assistant",
-				Content: resp.Content,
+				Role:      "assistant",
+				Content:   resp.Content,
+				ToolCalls: toolCallsToWire(resp.ToolCalls),
 			},
-			FinishReason: "stop",
+			FinishReason: finish,
 		}},
 		Usage: UsageWire{
 			PromptTokens:     resp.Usage.PromptTokens,
@@ -250,7 +320,7 @@ func (s *Server) serveChatStream(w http.ResponseWriter, r *http.Request, rr prov
 // planned and the actual model — we do not walk the fallback chain.
 func writeChatDryRun(w http.ResponseWriter, r *http.Request, plan *provider.RoutePlan) {
 	out := ChatCompletionResponse{
-		ID:      "chatcmpl_" + requestIDFrom(r.Context()),
+		ID:      chatResponseID(r.Context()),
 		Object:  "chat.completion",
 		Created: time.Now().Unix(),
 		Model:   plan.Profile.Key.String(),
@@ -310,25 +380,52 @@ func resolvePriority(explicit *int, def provider.Priority) provider.Priority {
 }
 
 // toProviderMessages converts OpenAI chat messages to provider.ChatMessage.
-// Role/Content only — the Name field on ChatMessageParam is silently dropped
-// because provider.ChatMessage has no corresponding field today.
+//
+// Field handling:
+//   - Role=="tool": Name populates provider.ChatMessage.ToolName and
+//     ToolCallID populates provider.ChatMessage.ToolCallID. Both are
+//     required for the model to correlate a tool result with the assistant
+//     invocation that produced it; dropping them would break multi-turn
+//     tool use.
+//   - Role=="assistant" with inbound ToolCalls: converted to
+//     provider.ToolCall entries on the provider message so history replay
+//     carries the original invocations.
+//   - Other roles: Name is intentionally dropped. OpenAI allows Name on
+//     user/system messages for "human name" tagging, but provider.ChatMessage
+//     has no general-purpose Name field today and adding one would require
+//     provider-side changes outside the scope of the compat façade.
 func toProviderMessages(in []ChatMessageParam) []provider.ChatMessage {
 	out := make([]provider.ChatMessage, 0, len(in))
 	for _, m := range in {
-		out = append(out, provider.ChatMessage{
+		msg := provider.ChatMessage{
 			Role:    m.Role,
 			Content: m.Content,
-		})
+		}
+		if m.Role == "tool" {
+			msg.ToolName = m.Name
+			msg.ToolCallID = m.ToolCallID
+		}
+		if len(m.ToolCalls) > 0 {
+			msg.ToolCalls = toolCallsFromWire(m.ToolCalls)
+		}
+		out = append(out, msg)
 	}
 	return out
 }
 
 // toProviderTools converts OpenAI tool descriptors to provider.Tool entries.
 // Parameters is passed through as raw JSON so we do not canonicalize or
-// re-encode the schema.
-func toProviderTools(in []OpenAIToolParam) []provider.Tool {
+// re-encode the schema, but we reject payloads that are clearly not a JSON
+// object. Forwarding, e.g., a JSON string or array to the provider would
+// cause the upstream to return an opaque 400 that surfaces here as a 502.
+// Catching the mismatch at the edge gives the client a precise
+// invalid_tool_parameters signal instead.
+func toProviderTools(in []OpenAIToolParam) ([]provider.Tool, error) {
 	out := make([]provider.Tool, 0, len(in))
-	for _, t := range in {
+	for i, t := range in {
+		if err := validateToolParameters(t.Function.Parameters); err != nil {
+			return nil, fmt.Errorf("tools[%d].function.parameters: %w", i, err)
+		}
 		out = append(out, provider.Tool{
 			Type: firstNonEmpty(t.Type, "function"),
 			Function: provider.ToolFunction{
@@ -338,7 +435,93 @@ func toProviderTools(in []OpenAIToolParam) []provider.Tool {
 			},
 		})
 	}
+	return out, nil
+}
+
+// validateToolParameters checks that a tool-function parameters payload is
+// either empty (omitted) or a JSON object. We inspect the first
+// non-whitespace byte rather than fully unmarshaling — JSON Schema documents
+// can be arbitrarily nested and we do not want to pay the allocation cost on
+// every request. Rejecting obvious mismatches (strings, numbers, arrays) is
+// enough; malformed JSON inside a valid-looking object will still be caught
+// by the provider.
+func validateToolParameters(raw json.RawMessage) error {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil
+	}
+	if trimmed[0] != '{' {
+		return fmt.Errorf("must be a JSON object")
+	}
+	return nil
+}
+
+// toolCallsFromWire converts inbound ChatToolCallWire entries (replayed on
+// assistant messages) to provider.ToolCall. Arguments is forwarded as raw
+// JSON; provider.ToolCallFunction.Index defaults to zero which matches
+// OpenAI's behavior on non-streaming calls.
+func toolCallsFromWire(in []ChatToolCallWire) []provider.ToolCall {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]provider.ToolCall, 0, len(in))
+	for _, c := range in {
+		out = append(out, provider.ToolCall{
+			ID:   c.ID,
+			Type: firstNonEmpty(c.Type, "function"),
+			Function: provider.ToolCallFunction{
+				Name:      c.Function.Name,
+				Arguments: c.Function.Arguments,
+			},
+		})
+	}
 	return out
+}
+
+// toolCallsToWire converts outbound provider.ToolCall entries to
+// ChatToolCallWire for the response payload. Arguments is forwarded
+// verbatim — see the ChatToolCallFunctionWire godoc for the
+// OpenAI-canonical-string caveat.
+func toolCallsToWire(in []provider.ToolCall) []ChatToolCallWire {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]ChatToolCallWire, 0, len(in))
+	for _, c := range in {
+		out = append(out, ChatToolCallWire{
+			ID:   c.ID,
+			Type: firstNonEmpty(c.Type, "function"),
+			Function: ChatToolCallFunctionWire{
+				Name:      c.Function.Name,
+				Arguments: c.Function.Arguments,
+			},
+		})
+	}
+	return out
+}
+
+// chatResponseID builds the "chatcmpl_" response ID. It prefers the request
+// ID attached by requestIDMiddleware (so HTTP access logs and response
+// bodies correlate), but falls back to a freshly generated random suffix
+// when the context carries none — e.g. when handlers are invoked directly
+// via the mux for tests or embedded callers. Without the fallback, bypass
+// paths would return "chatcmpl_" verbatim, which is indistinguishable from
+// a bug.
+func chatResponseID(ctx context.Context) string {
+	rid := requestIDFrom(ctx)
+	if rid == "" {
+		rid = fallbackRequestID()
+	}
+	return "chatcmpl_" + rid
+}
+
+// fallbackRequestID generates a short, random hex suffix for use when no
+// request-ID middleware has run. 8 random bytes (16 hex chars) is well
+// beyond collision-hazard for response-body correlation.
+func fallbackRequestID() string {
+	var b [8]byte
+	_, _ = rand.Read(b[:])
+	return "cmpl_" + hex.EncodeToString(b[:])
 }
 
 // toModelOptions maps the OpenAI sampling fields onto provider.ModelOptions.

--- a/compat/chat.go
+++ b/compat/chat.go
@@ -658,11 +658,13 @@ func chatResponseID(ctx context.Context) string {
 
 // fallbackRequestID generates a short, random hex suffix for use when no
 // request-ID middleware has run. 8 random bytes (16 hex chars) is well
-// beyond collision-hazard for response-body correlation.
+// beyond collision-hazard for response-body correlation. Returns bare hex so
+// callers can compose their own family-specific prefix (e.g. "chatcmpl_" or
+// "cmpl_") without risking a double-prefix like "chatcmpl_cmpl_<hex>".
 func fallbackRequestID() string {
 	var b [8]byte
 	_, _ = rand.Read(b[:])
-	return "cmpl_" + hex.EncodeToString(b[:])
+	return hex.EncodeToString(b[:])
 }
 
 // toModelOptions maps the OpenAI sampling fields onto provider.ModelOptions.

--- a/compat/chat.go
+++ b/compat/chat.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -349,9 +350,12 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 //  5. For each chunk, emit a ChatCompletionChunk with the qualified model
 //     ID and, on the Done chunk, a derived finish_reason matching the
 //     non-streaming branch's logic (tool_calls > length > stop).
-//  6. After ExecuteChatStream returns, emit "data: [DONE]" if the stream
-//     has been committed. If the failure happened before the first chunk,
-//     surface a JSON error instead.
+//  6. After ExecuteChatStream returns, emit "data: [DONE]" only on clean
+//     completion. If the failure happened before the first chunk, surface
+//     a JSON error envelope. If the failure happened mid-stream, skip the
+//     [DONE] sentinel so clients can detect premature EOS via its absence;
+//     context.Canceled (client disconnect) is treated as normal and its
+//     log is suppressed to prevent spam.
 func (s *Server) serveChatStream(w http.ResponseWriter, r *http.Request, rr provider.RoutingRequest) {
 	rr.RequiredCaps |= provider.CapStream
 
@@ -412,13 +416,20 @@ func (s *Server) serveChatStream(w http.ResponseWriter, r *http.Request, rr prov
 		// If the failure happened BEFORE any chunk was delivered, the SSE
 		// writer never committed the 200 status — so we can still surface a
 		// JSON error envelope. Otherwise the stream is already live on the
-		// wire and the only correct action is to log and terminate with
-		// [DONE]. OpenAI SDKs tolerate a missing final event.
+		// wire and we must NOT emit "data: [DONE]" — that is OpenAI's
+		// success sentinel, and emitting it under error conditions silently
+		// signals success. Skipping it lets SDKs detect premature EOS via
+		// the missing terminator.
 		if !sw.started {
 			writeCompatError(w, streamErr)
 			return
 		}
-		log.Printf("compat: chat stream error rid=%s: %v", requestIDFrom(r.Context()), streamErr)
+		// Client disconnect is normal (e.g., IDE cancels completion on every
+		// keystroke) — suppress the log to prevent spam.
+		if !errors.Is(streamErr, context.Canceled) {
+			log.Printf("compat: chat stream error rid=%s: %v", requestIDFrom(r.Context()), streamErr)
+		}
+		return
 	}
 
 	_ = sw.writeDone()

--- a/compat/chat.go
+++ b/compat/chat.go
@@ -259,7 +259,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		rr.RequiredCaps |= provider.CapToolCall
 		rr.Tools = tools
 	}
-	if req.Stream {
+	if req.Stream && !req.DryRun {
 		s.serveChatStream(w, r, rr)
 		return
 	}

--- a/compat/chat.go
+++ b/compat/chat.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"time"
 
@@ -109,6 +110,30 @@ type UsageWire struct {
 	PromptTokens     int `json:"prompt_tokens"`
 	CompletionTokens int `json:"completion_tokens"`
 	TotalTokens      int `json:"total_tokens"`
+}
+
+// ChatCompletionChunk is one frame of an OpenAI-shape streaming response.
+// Each chunk carries exactly one ChatChunkChoice today. Usage is not included
+// on per-chunk frames — OpenAI emits usage only on the final frame when
+// stream_options.include_usage is set, which we don't yet expose.
+type ChatCompletionChunk struct {
+	ID      string            `json:"id"`
+	Object  string            `json:"object"` // "chat.completion.chunk"
+	Created int64             `json:"created"`
+	Model   string            `json:"model"`
+	Choices []ChatChunkChoice `json:"choices"`
+
+	// Extensions.
+	Thinking string `json:"x_thinking,omitempty"`
+}
+
+// ChatChunkChoice is one choice inside a streaming chunk. FinishReason is a
+// pointer so interim chunks serialize as "finish_reason":null and only the
+// final chunk carries a non-null reason, matching OpenAI's wire format.
+type ChatChunkChoice struct {
+	Index        int              `json:"index"`
+	Delta        ChatMessageParam `json:"delta"`
+	FinishReason *string          `json:"finish_reason"`
 }
 
 // RouteInfoExt surfaces the Router's decision metadata for a request. It is
@@ -304,12 +329,117 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(out)
 }
 
-// serveChatStream handles the streaming branch. Task 10 replaces this stub
-// with a lazy-start SSE writer so pre-first-chunk failures still return a
-// JSON error envelope.
+// serveChatStream handles the streaming branch of POST /v1/chat/completions.
+// It emits an SSE (text/event-stream) body whose events each carry a JSON
+// ChatCompletionChunk, terminated by a "data: [DONE]" sentinel.
+//
+// Order of operations:
+//  1. Broaden rr.RequiredCaps with CapStream so the router rejects any
+//     provider that cannot stream before any bytes are written.
+//  2. Acquire the HTTP concurrency slot using the resolved priority — the
+//     slot is released when the stream completes. Placement AFTER route
+//     parsing (already done by the caller) means x_priority influences
+//     admission control on streaming requests too.
+//  3. Route via Router.Route. On error, writeCompatError still works
+//     because no bytes have been written yet.
+//  4. Construct a lazy-start sseWriter — it does NOT commit the 200 status
+//     until the first chunk is written, so a pre-first-chunk
+//     ExecuteChatStream failure (e.g. provider returns 5xx before any chunk)
+//     can still be surfaced as a regular JSON error envelope.
+//  5. For each chunk, emit a ChatCompletionChunk with the qualified model
+//     ID and, on the Done chunk, a derived finish_reason matching the
+//     non-streaming branch's logic (tool_calls > length > stop).
+//  6. After ExecuteChatStream returns, emit "data: [DONE]" if the stream
+//     has been committed. If the failure happened before the first chunk,
+//     surface a JSON error instead.
 func (s *Server) serveChatStream(w http.ResponseWriter, r *http.Request, rr provider.RoutingRequest) {
-	_ = rr // consumed by the SSE implementation in a follow-up task.
-	writeError(w, http.StatusNotImplemented, "not_implemented", "streaming arrives in a follow-up commit")
+	rr.RequiredCaps |= provider.CapStream
+
+	release, ok := s.semaphore.acquire(rr.Priority)
+	if !ok {
+		w.Header().Set("Retry-After", "1")
+		writeError(w, http.StatusTooManyRequests, "capacity", "server is at capacity")
+		return
+	}
+	defer release()
+
+	plan, err := s.router.Route(r.Context(), rr)
+	if err != nil {
+		writeCompatError(w, err)
+		return
+	}
+
+	sw, err := newSSEWriter(w)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "no_flusher", err.Error())
+		return
+	}
+
+	// Capture the response ID and qualified model ID BEFORE invoking the
+	// provider so every chunk carries stable identifiers. chatResponseID
+	// falls back to a random suffix when no request-id middleware has run —
+	// this matches the non-streaming branch's fix (commit 9f04342).
+	id := chatResponseID(r.Context())
+	created := time.Now().Unix()
+	modelID := plan.Profile.Key.String()
+
+	streamErr := plan.ExecuteChatStream(r.Context(), func(chunk provider.ChatResponse) error {
+		delta := ChatMessageParam{
+			Role:      "assistant",
+			Content:   chunk.Content,
+			ToolCalls: toolCallsToWire(chunk.ToolCalls),
+		}
+		var finish *string
+		if chunk.Done {
+			reason := deriveStreamFinishReason(chunk, rr.Options.NumPredict)
+			finish = &reason
+		}
+		return sw.writeEvent(ChatCompletionChunk{
+			ID:      id,
+			Object:  "chat.completion.chunk",
+			Created: created,
+			Model:   modelID,
+			Choices: []ChatChunkChoice{{
+				Index:        0,
+				Delta:        delta,
+				FinishReason: finish,
+			}},
+			Thinking: chunk.Thinking,
+		})
+	})
+
+	if streamErr != nil {
+		// If the failure happened BEFORE any chunk was delivered, the SSE
+		// writer never committed the 200 status — so we can still surface a
+		// JSON error envelope. Otherwise the stream is already live on the
+		// wire and the only correct action is to log and terminate with
+		// [DONE]. OpenAI SDKs tolerate a missing final event.
+		if !sw.started {
+			writeCompatError(w, streamErr)
+			return
+		}
+		log.Printf("compat: chat stream error rid=%s: %v", requestIDFrom(r.Context()), streamErr)
+	}
+
+	_ = sw.writeDone()
+}
+
+// deriveStreamFinishReason mirrors the non-streaming branch's finish_reason
+// logic for the Done chunk of a stream. Priority:
+//   - "tool_calls" when the final chunk carried any tool invocations.
+//   - "length" when MaxTokens was set and usage reached the cap.
+//   - "stop" otherwise.
+//
+// numPredict is 0 when MaxTokens was unset, in which case we cannot infer a
+// length stop and default to "stop".
+func deriveStreamFinishReason(chunk provider.ChatResponse, numPredict int) string {
+	if len(chunk.ToolCalls) > 0 {
+		return "tool_calls"
+	}
+	if numPredict > 0 && chunk.Usage.CompletionTokens >= numPredict {
+		return "length"
+	}
+	return "stop"
 }
 
 // writeChatDryRun renders the route decision without executing the request.

--- a/compat/chat.go
+++ b/compat/chat.go
@@ -227,8 +227,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req ChatCompletionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "decode_error", err.Error())
+	if !decodeJSONBody(w, r, maxChatRequestBodyBytes, &req) {
 		return
 	}
 	key, err := resolveModel(req.Model, s.aliases)

--- a/compat/chat_test.go
+++ b/compat/chat_test.go
@@ -135,6 +135,32 @@ func TestChatCompletions_NonStreaming_Success(t *testing.T) {
 	}
 }
 
+func TestChatCompletions_BodyTooLarge(t *testing.T) {
+	srv, _, calls, teardown := newChatFixture(t, "unused")
+	defer teardown()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		oversizedJSONStringReader(
+			`{"model":"ollama/qwen3:8b","messages":[{"role":"user","content":"`,
+			maxChatRequestBodyBytes+1,
+			`"}]}`,
+		))
+	req.Header.Set("Content-Type", "application/json")
+	srv.buildHandler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if got := atomic.LoadInt32(calls); got != 0 {
+		t.Fatalf("provider Chat called %d times, want 0", got)
+	}
+	env := decodeErrorEnvelope(t, rec)
+	if env.Error.Code != "body_too_large" {
+		t.Errorf("error.code = %q, want body_too_large", env.Error.Code)
+	}
+}
+
 func TestChatCompletions_MissingMessages_400(t *testing.T) {
 	srv, _, _, teardown := newChatFixture(t, "n/a")
 	defer teardown()

--- a/compat/chat_test.go
+++ b/compat/chat_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -154,23 +155,290 @@ func TestChatCompletions_MissingMessages_400(t *testing.T) {
 	}
 }
 
-func TestChatCompletions_StreamReturns501(t *testing.T) {
-	srv, _, calls, teardown := newChatFixture(t, "n/a")
+// ---------------------------------------------------------------------------
+// Streaming path
+// ---------------------------------------------------------------------------
+
+// doChatRequest is doChat's streaming cousin — it keeps the raw recorder so
+// callers can inspect the SSE body for framing as well as individual chunks.
+func doChatRequest(t *testing.T, srv *Server, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	buf, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(buf))
+	req.Header.Set("Content-Type", "application/json")
+	srv.buildHandler().ServeHTTP(rec, req)
+	return rec
+}
+
+// decodeSSEChunks parses an SSE body into individual ChatCompletionChunk
+// payloads. It skips the [DONE] sentinel and any non-"data:" lines.
+func decodeSSEChunks(t *testing.T, body string) []ChatCompletionChunk {
+	t.Helper()
+	var chunks []ChatCompletionChunk
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		payload := strings.TrimPrefix(line, "data: ")
+		if payload == "[DONE]" {
+			continue
+		}
+		var c ChatCompletionChunk
+		if err := json.Unmarshal([]byte(payload), &c); err != nil {
+			t.Fatalf("decode chunk %q: %v", payload, err)
+		}
+		chunks = append(chunks, c)
+	}
+	return chunks
+}
+
+// newStreamingServer wires a server whose provider scripts ChatStream directly
+// — distinct from newChatFixture which scripts the non-streaming path. The
+// `build` callback lets each test drive its own chunk sequence.
+func newStreamingServer(
+	t *testing.T,
+	build func(ctx context.Context, req provider.ChatRequest, fn func(provider.ChatResponse) error) error,
+	opts ...Option,
+) (*Server, func()) {
+	t.Helper()
+	mp := &mockProvider{
+		name: "ollama",
+		caps: provider.CapChat | provider.CapStream | provider.CapToolCall,
+		models: []provider.ModelInfo{
+			{Name: "qwen3:8b", ContextWindow: 32768},
+		},
+		chatStreamFn: build,
+	}
+	return newTestServer(t, mp, opts...)
+}
+
+// TestChatCompletions_Streaming exercises the happy path: two chunks from the
+// provider, the final one with Done=true, produce two SSE events followed by
+// "data: [DONE]". The first chunk must carry role=assistant and content="hi ",
+// the second must carry finish_reason="stop".
+func TestChatCompletions_Streaming(t *testing.T) {
+	srv, teardown := newStreamingServer(t, func(ctx context.Context, req provider.ChatRequest, fn func(provider.ChatResponse) error) error {
+		if err := fn(provider.ChatResponse{Model: req.Model, Content: "hi "}); err != nil {
+			return err
+		}
+		return fn(provider.ChatResponse{Model: req.Model, Content: "there", Done: true})
+	})
 	defer teardown()
 
 	body := map[string]any{
-		"model": "ollama/qwen3:8b",
+		"model":  "ollama/qwen3:8b",
+		"stream": true,
 		"messages": []map[string]string{
 			{"role": "user", "content": "hi"},
 		},
+	}
+	rec := doChatRequest(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("content-type = %q, want text/event-stream", ct)
+	}
+	text := rec.Body.String()
+	if !strings.HasSuffix(text, "data: [DONE]\n\n") {
+		t.Errorf("missing DONE sentinel: %q", text)
+	}
+	chunks := decodeSSEChunks(t, text)
+	if len(chunks) != 2 {
+		t.Fatalf("got %d chunks, want 2: %q", len(chunks), text)
+	}
+	// First chunk: content delta, no finish_reason.
+	c0 := chunks[0]
+	if c0.Object != "chat.completion.chunk" {
+		t.Errorf("chunk[0].object = %q", c0.Object)
+	}
+	if !strings.HasPrefix(c0.ID, "chatcmpl_") {
+		t.Errorf("chunk[0].id = %q, want chatcmpl_ prefix", c0.ID)
+	}
+	if len(c0.Choices) != 1 {
+		t.Fatalf("chunk[0].choices = %d", len(c0.Choices))
+	}
+	if c0.Choices[0].Delta.Role != "assistant" {
+		t.Errorf("chunk[0].delta.role = %q", c0.Choices[0].Delta.Role)
+	}
+	if c0.Choices[0].Delta.Content != "hi " {
+		t.Errorf("chunk[0].delta.content = %q", c0.Choices[0].Delta.Content)
+	}
+	if c0.Choices[0].FinishReason != nil {
+		t.Errorf("chunk[0].finish_reason = %v, want nil", *c0.Choices[0].FinishReason)
+	}
+	// Second chunk: content delta, finish_reason=stop.
+	c1 := chunks[1]
+	if c1.Choices[0].Delta.Content != "there" {
+		t.Errorf("chunk[1].delta.content = %q", c1.Choices[0].Delta.Content)
+	}
+	if c1.Choices[0].FinishReason == nil || *c1.Choices[0].FinishReason != "stop" {
+		t.Errorf("chunk[1].finish_reason = %v, want stop", c1.Choices[0].FinishReason)
+	}
+}
+
+// TestChatCompletions_Streaming_ModelQualified verifies that every streaming
+// chunk carries the qualified "provider/model" form in the Model field,
+// matching the non-streaming branch's plan.Profile.Key.String() convention.
+func TestChatCompletions_Streaming_ModelQualified(t *testing.T) {
+	srv, teardown := newStreamingServer(t, func(ctx context.Context, req provider.ChatRequest, fn func(provider.ChatResponse) error) error {
+		// Provider returns bare model name (this is the realistic Ollama shape).
+		return fn(provider.ChatResponse{Model: req.Model, Content: "ok", Done: true})
+	})
+	defer teardown()
+
+	body := map[string]any{
+		"model":  "ollama/qwen3:8b",
 		"stream": true,
+		"messages": []map[string]string{
+			{"role": "user", "content": "hi"},
+		},
 	}
-	rec := doChat(t, srv, body)
-	if rec.Code != http.StatusNotImplemented {
-		t.Fatalf("status = %d, want 501, body=%s", rec.Code, rec.Body.String())
+	rec := doChatRequest(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
 	}
-	if got := atomic.LoadInt32(calls); got != 0 {
-		t.Errorf("provider Chat called %d times, want 0", got)
+	chunks := decodeSSEChunks(t, rec.Body.String())
+	if len(chunks) == 0 {
+		t.Fatalf("no chunks: %q", rec.Body.String())
+	}
+	for i, c := range chunks {
+		if c.Model != "ollama/qwen3:8b" {
+			t.Errorf("chunk[%d].model = %q, want ollama/qwen3:8b (qualified)", i, c.Model)
+		}
+	}
+}
+
+// TestChatCompletions_Streaming_FinishReasonFromToolCalls asserts that when
+// the provider emits tool_calls on the final chunk, the wire delta carries
+// them AND finish_reason is "tool_calls" — matching the non-streaming Task 9
+// fix's derivation rules.
+func TestChatCompletions_Streaming_FinishReasonFromToolCalls(t *testing.T) {
+	args := json.RawMessage(`{"city":"Paris"}`)
+	srv, teardown := newStreamingServer(t, func(ctx context.Context, req provider.ChatRequest, fn func(provider.ChatResponse) error) error {
+		return fn(provider.ChatResponse{
+			Model: req.Model,
+			Done:  true,
+			ToolCalls: []provider.ToolCall{{
+				ID:   "call_abc",
+				Type: "function",
+				Function: provider.ToolCallFunction{
+					Name:      "get_weather",
+					Arguments: args,
+				},
+			}},
+		})
+	})
+	defer teardown()
+
+	body := map[string]any{
+		"model":  "ollama/qwen3:8b",
+		"stream": true,
+		"messages": []map[string]string{
+			{"role": "user", "content": "weather in Paris?"},
+		},
+	}
+	rec := doChatRequest(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	chunks := decodeSSEChunks(t, rec.Body.String())
+	if len(chunks) != 1 {
+		t.Fatalf("got %d chunks, want 1", len(chunks))
+	}
+	final := chunks[0]
+	if final.Choices[0].FinishReason == nil || *final.Choices[0].FinishReason != "tool_calls" {
+		t.Errorf("finish_reason = %v, want tool_calls", final.Choices[0].FinishReason)
+	}
+	calls := final.Choices[0].Delta.ToolCalls
+	if len(calls) != 1 {
+		t.Fatalf("delta.tool_calls = %d, want 1", len(calls))
+	}
+	if calls[0].ID != "call_abc" {
+		t.Errorf("tool_call.id = %q, want call_abc", calls[0].ID)
+	}
+	if calls[0].Function.Name != "get_weather" {
+		t.Errorf("tool_call.function.name = %q, want get_weather", calls[0].Function.Name)
+	}
+	if !bytes.Equal(calls[0].Function.Arguments, args) {
+		t.Errorf("tool_call.function.arguments = %s, want %s", calls[0].Function.Arguments, args)
+	}
+}
+
+// TestChatCompletions_Streaming_FinishReasonLength covers the length-cap
+// branch of streaming finish_reason derivation: MaxTokens=5 and usage
+// reporting CompletionTokens=5 on the Done chunk must yield "length".
+func TestChatCompletions_Streaming_FinishReasonLength(t *testing.T) {
+	srv, teardown := newStreamingServer(t, func(ctx context.Context, req provider.ChatRequest, fn func(provider.ChatResponse) error) error {
+		return fn(provider.ChatResponse{
+			Model:   req.Model,
+			Content: "truncated",
+			Done:    true,
+			Usage:   provider.Usage{CompletionTokens: 5, TotalTokens: 8, PromptTokens: 3},
+		})
+	})
+	defer teardown()
+
+	body := map[string]any{
+		"model":      "ollama/qwen3:8b",
+		"stream":     true,
+		"max_tokens": 5,
+		"messages": []map[string]string{
+			{"role": "user", "content": "write a long essay"},
+		},
+	}
+	rec := doChatRequest(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	chunks := decodeSSEChunks(t, rec.Body.String())
+	if len(chunks) != 1 {
+		t.Fatalf("got %d chunks, want 1", len(chunks))
+	}
+	final := chunks[0]
+	if final.Choices[0].FinishReason == nil || *final.Choices[0].FinishReason != "length" {
+		t.Errorf("finish_reason = %v, want length", final.Choices[0].FinishReason)
+	}
+}
+
+// TestChatCompletions_Streaming_ErrorBeforeFirstChunk verifies the lazy-start
+// guarantee: when the provider's ChatStream fails before invoking fn even
+// once, the client sees a normal JSON error envelope (not a partial SSE
+// stream). The status is 502 because an unclassified provider error maps
+// through statusForCompatError to upstream_error.
+func TestChatCompletions_Streaming_ErrorBeforeFirstChunk(t *testing.T) {
+	wantErr := errors.New("synthetic upstream failure")
+	srv, teardown := newStreamingServer(t, func(ctx context.Context, req provider.ChatRequest, fn func(provider.ChatResponse) error) error {
+		// Never invoke fn — fail immediately. The SSE writer's lazy-start
+		// means no "data: ..." bytes have been committed yet.
+		return wantErr
+	})
+	defer teardown()
+
+	body := map[string]any{
+		"model":  "ollama/qwen3:8b",
+		"stream": true,
+		"messages": []map[string]string{
+			{"role": "user", "content": "hi"},
+		},
+	}
+	rec := doChatRequest(t, srv, body)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502, body=%s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("content-type = %q, want application/json (JSON error envelope)", ct)
+	}
+	var env errorEnvelope
+	if err := json.NewDecoder(rec.Body).Decode(&env); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+	if env.Error.Code != "upstream_error" {
+		t.Errorf("error.code = %q, want upstream_error", env.Error.Code)
 	}
 }
 

--- a/compat/chat_test.go
+++ b/compat/chat_test.go
@@ -118,6 +118,13 @@ func TestChatCompletions_NonStreaming_Success(t *testing.T) {
 	if out.Usage.TotalTokens != 8 {
 		t.Errorf("usage.total_tokens = %d, want 8", out.Usage.TotalTokens)
 	}
+	// Top-level "model" must be qualified (provider/model) to match the
+	// dry-run branch; see chat.go — we take it from plan.Profile.Key.String()
+	// rather than resp.Model so the wire is consistent even when the
+	// provider reports a bare model name.
+	if out.Model != "ollama/qwen3:8b" {
+		t.Errorf("response.model = %q, want ollama/qwen3:8b", out.Model)
+	}
 	if out.RouteInfo == nil {
 		t.Fatal("x_route_info missing; router should populate it")
 	}
@@ -289,6 +296,299 @@ func TestChatCompletions_DryRun(t *testing.T) {
 	}
 }
 
+// newChatFixtureWithResponse is like newChatFixture but lets the caller shape
+// the response returned by the mock provider. The builder receives the request
+// the provider observed and returns the desired ChatResponse — this is how
+// tests for finish_reason, tool_calls forwarding, etc. scriptedly inject
+// response state the mock would not otherwise produce.
+func newChatFixtureWithResponse(
+	t *testing.T,
+	build func(provider.ChatRequest) *provider.ChatResponse,
+	opts ...Option,
+) (*Server, *provider.ChatRequest, func()) {
+	t.Helper()
+	var last provider.ChatRequest
+	mp := &mockProvider{
+		name: "ollama",
+		caps: provider.CapChat | provider.CapGenerate | provider.CapStream | provider.CapToolCall,
+		models: []provider.ModelInfo{
+			{Name: "qwen3:8b", ContextWindow: 32768},
+		},
+		chatFn: func(_ context.Context, req provider.ChatRequest) (*provider.ChatResponse, error) {
+			last = req
+			return build(req), nil
+		},
+	}
+	srv, teardown := newTestServer(t, mp, opts...)
+	return srv, &last, teardown
+}
+
+// TestChatCompletions_ToolCallsPreserved verifies that a tool_calls response
+// from the provider surfaces in the response body's message.tool_calls array
+// AND drives finish_reason="tool_calls" — before this fix, tool_calls were
+// silently dropped and finish_reason was hard-coded to "stop".
+func TestChatCompletions_ToolCallsPreserved(t *testing.T) {
+	args := json.RawMessage(`{"city":"Paris"}`)
+	srv, _, teardown := newChatFixtureWithResponse(t, func(req provider.ChatRequest) *provider.ChatResponse {
+		return &provider.ChatResponse{
+			Model:    req.Model,
+			Provider: "ollama",
+			// Content may be empty when the model emits only tool calls;
+			// OpenAI SDK clients tolerate that.
+			Content: "",
+			Done:    true,
+			ToolCalls: []provider.ToolCall{{
+				ID:   "call_abc",
+				Type: "function",
+				Function: provider.ToolCallFunction{
+					Name:      "get_weather",
+					Arguments: args,
+				},
+			}},
+			Usage: provider.Usage{PromptTokens: 3, CompletionTokens: 5, TotalTokens: 8},
+		}
+	})
+	defer teardown()
+
+	body := map[string]any{
+		"model": "ollama/qwen3:8b",
+		"messages": []map[string]string{
+			{"role": "user", "content": "weather in Paris?"},
+		},
+	}
+	rec := doChat(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var out ChatCompletionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out.Choices) != 1 {
+		t.Fatalf("choices = %d, want 1", len(out.Choices))
+	}
+	if out.Choices[0].FinishReason != "tool_calls" {
+		t.Errorf("finish_reason = %q, want tool_calls", out.Choices[0].FinishReason)
+	}
+	calls := out.Choices[0].Message.ToolCalls
+	if len(calls) != 1 {
+		t.Fatalf("message.tool_calls = %d, want 1", len(calls))
+	}
+	if calls[0].ID != "call_abc" {
+		t.Errorf("tool_call.id = %q, want call_abc", calls[0].ID)
+	}
+	if calls[0].Type != "function" {
+		t.Errorf("tool_call.type = %q, want function", calls[0].Type)
+	}
+	if calls[0].Function.Name != "get_weather" {
+		t.Errorf("tool_call.function.name = %q, want get_weather", calls[0].Function.Name)
+	}
+	if !bytes.Equal(calls[0].Function.Arguments, args) {
+		t.Errorf("tool_call.function.arguments = %s, want %s", calls[0].Function.Arguments, args)
+	}
+}
+
+// TestChatCompletions_FinishReasonLength exercises the length-cap branch of
+// finish_reason derivation — when MaxTokens is set and the response hit the
+// cap, we return "length" instead of "stop".
+func TestChatCompletions_FinishReasonLength(t *testing.T) {
+	srv, _, teardown := newChatFixtureWithResponse(t, func(req provider.ChatRequest) *provider.ChatResponse {
+		return &provider.ChatResponse{
+			Model:    req.Model,
+			Provider: "ollama",
+			Content:  "truncated",
+			Done:     true,
+			Usage:    provider.Usage{PromptTokens: 3, CompletionTokens: 5, TotalTokens: 8},
+		}
+	})
+	defer teardown()
+
+	body := map[string]any{
+		"model": "ollama/qwen3:8b",
+		"messages": []map[string]string{
+			{"role": "user", "content": "write a long essay"},
+		},
+		"max_tokens": 5,
+	}
+	rec := doChat(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var out ChatCompletionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Choices[0].FinishReason != "length" {
+		t.Errorf("finish_reason = %q, want length", out.Choices[0].FinishReason)
+	}
+}
+
+// TestChatCompletions_ToolRoleMessageRoundTrip verifies that a tool-role
+// message's Name and ToolCallID flow through to the provider — they name the
+// tool whose result this message carries and correlate with the assistant's
+// prior invocation, so dropping them breaks multi-turn tool use.
+func TestChatCompletions_ToolRoleMessageRoundTrip(t *testing.T) {
+	srv, last, _, teardown := newChatFixture(t, "thanks")
+	defer teardown()
+
+	body := map[string]any{
+		"model": "ollama/qwen3:8b",
+		"messages": []map[string]any{
+			{"role": "user", "content": "weather?"},
+			{
+				"role":         "tool",
+				"name":         "search",
+				"tool_call_id": "call_1",
+				"content":      `{"results":[]}`,
+			},
+		},
+	}
+	rec := doChat(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if len(last.Messages) != 2 {
+		t.Fatalf("provider saw %d messages, want 2", len(last.Messages))
+	}
+	m := last.Messages[1]
+	if m.Role != "tool" {
+		t.Errorf("message[1].role = %q, want tool", m.Role)
+	}
+	if m.ToolName != "search" {
+		t.Errorf("message[1].ToolName = %q, want search", m.ToolName)
+	}
+	if m.ToolCallID != "call_1" {
+		t.Errorf("message[1].ToolCallID = %q, want call_1", m.ToolCallID)
+	}
+	if m.Content != `{"results":[]}` {
+		t.Errorf("message[1].Content = %q", m.Content)
+	}
+}
+
+// TestChatCompletions_InvalidToolParameters rejects non-object parameter
+// payloads at the edge rather than forwarding garbage to the provider.
+func TestChatCompletions_InvalidToolParameters(t *testing.T) {
+	srv, _, _, teardown := newChatFixture(t, "n/a")
+	defer teardown()
+
+	body := map[string]any{
+		"model": "ollama/qwen3:8b",
+		"messages": []map[string]string{
+			{"role": "user", "content": "hi"},
+		},
+		"tools": []map[string]any{
+			{
+				"type": "function",
+				"function": map[string]any{
+					"name":       "broken",
+					"parameters": "not an object",
+				},
+			},
+		},
+	}
+	rec := doChat(t, srv, body)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body=%s", rec.Code, rec.Body.String())
+	}
+	var env errorEnvelope
+	if err := json.NewDecoder(rec.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if env.Error.Code != "invalid_tool_parameters" {
+		t.Errorf("code = %q, want invalid_tool_parameters", env.Error.Code)
+	}
+}
+
+// TestChatCompletions_429WhenAtCapacity exercises the admission-control
+// boundary: once the semaphore is full, new requests receive 429 with
+// Retry-After: 1 and error code "capacity". Releasing the slot lets the
+// next request succeed.
+func TestChatCompletions_429WhenAtCapacity(t *testing.T) {
+	srv, _, _, teardown := newChatFixture(t, "ok", WithMaxConcurrency(1))
+	defer teardown()
+
+	// Manually fill the single slot so the handler's acquire() returns
+	// false. This mirrors what a real in-flight request would hold.
+	release, ok := srv.semaphore.acquire(provider.PriorityNormal)
+	if !ok {
+		t.Fatal("could not acquire semaphore slot for test setup")
+	}
+
+	body := map[string]any{
+		"model": "ollama/qwen3:8b",
+		"messages": []map[string]string{
+			{"role": "user", "content": "hi"},
+		},
+	}
+	rec := doChat(t, srv, body)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429, body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Retry-After"); got != "1" {
+		t.Errorf("Retry-After = %q, want 1", got)
+	}
+	var env errorEnvelope
+	if err := json.NewDecoder(rec.Body).Decode(&env); err != nil {
+		t.Fatalf("decode 429 body: %v", err)
+	}
+	if env.Error.Code != "capacity" {
+		t.Errorf("error.code = %q, want capacity", env.Error.Code)
+	}
+
+	// Release and retry — the next request should succeed.
+	release()
+	rec2 := doChat(t, srv, body)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("after release: status = %d, body=%s", rec2.Code, rec2.Body.String())
+	}
+}
+
+// TestChatCompletions_RequestIDFallback verifies that when the handler is
+// invoked through a path that bypasses requestIDMiddleware, the response ID
+// still gets a non-empty suffix. This guards against a bug where bypass
+// paths would emit "chatcmpl_" verbatim.
+func TestChatCompletions_RequestIDFallback(t *testing.T) {
+	srv, _, _, teardown := newChatFixture(t, "ok")
+	defer teardown()
+
+	// Build a mux directly (no middleware chain) so requestIDMiddleware
+	// never runs. This is the bypass path the fallback protects.
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST "+srv.basePath+"/chat/completions", srv.handleChatCompletions)
+
+	body := map[string]any{
+		"model": "ollama/qwen3:8b",
+		"messages": []map[string]string{
+			{"role": "user", "content": "hi"},
+		},
+	}
+	buf, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(buf))
+	req.Header.Set("Content-Type", "application/json")
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var out ChatCompletionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.ID == "chatcmpl_" {
+		t.Errorf("id = %q, want non-empty suffix via fallback", out.ID)
+	}
+	if !strings.HasPrefix(out.ID, "chatcmpl_") {
+		t.Errorf("id = %q, want chatcmpl_ prefix", out.ID)
+	}
+	if len(out.ID) <= len("chatcmpl_") {
+		t.Errorf("id = %q, want suffix longer than empty", out.ID)
+	}
+}
+
 // TestChatCompletions_AffinityKeyForwarded verifies that a request with
 // x_affinity_key set completes successfully. The provider.ChatRequest that
 // the mock receives does not carry AffinityKey (plumbing stays at the
@@ -330,6 +630,11 @@ func TestStopSequences_UnmarshalJSON(t *testing.T) {
 		{"single", `"END"`, []string{"END"}},
 		{"empty-string", `""`, nil},
 		{"null", `null`, nil},
+		// Array branch: empty strings are filtered out so providers never
+		// see a nil-like sentinel that would match at every token.
+		{"array-with-empties", `["", "b", ""]`, []string{"b"}},
+		{"array-all-empty", `[""]`, nil},
+		{"array-empty", `[]`, nil},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/compat/chat_test.go
+++ b/compat/chat_test.go
@@ -1,0 +1,426 @@
+package compat
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// ---------------------------------------------------------------------------
+// Shared fixture helpers
+// ---------------------------------------------------------------------------
+
+// newChatFixture returns a Server wired to a provider whose Chat handler
+// records the last request received and replies with the supplied content.
+// The returned pointer to the captured request is updated on every call.
+func newChatFixture(t *testing.T, content string, opts ...Option) (*Server, *provider.ChatRequest, *int32, func()) {
+	t.Helper()
+	var last provider.ChatRequest
+	var calls int32
+	mp := &mockProvider{
+		name: "ollama",
+		caps: provider.CapChat | provider.CapGenerate | provider.CapStream | provider.CapToolCall,
+		models: []provider.ModelInfo{
+			{Name: "qwen3:8b", ContextWindow: 32768},
+		},
+		chatFn: func(_ context.Context, req provider.ChatRequest) (*provider.ChatResponse, error) {
+			atomic.AddInt32(&calls, 1)
+			last = req
+			return &provider.ChatResponse{
+				Model:    req.Model,
+				Provider: "ollama",
+				Content:  content,
+				Done:     true,
+				Usage: provider.Usage{
+					PromptTokens:     3,
+					CompletionTokens: 5,
+					TotalTokens:      8,
+				},
+			}, nil
+		},
+	}
+	srv, teardown := newTestServer(t, mp, opts...)
+	return srv, &last, &calls, teardown
+}
+
+// doChat POSTs a JSON body to /v1/chat/completions and returns the recorder.
+func doChat(t *testing.T, srv *Server, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	buf, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(buf))
+	req.Header.Set("Content-Type", "application/json")
+	srv.buildHandler().ServeHTTP(rec, req)
+	return rec
+}
+
+// ---------------------------------------------------------------------------
+// Core non-streaming path
+// ---------------------------------------------------------------------------
+
+func TestChatCompletions_NonStreaming_Success(t *testing.T) {
+	srv, last, calls, teardown := newChatFixture(t, "hello from mock")
+	defer teardown()
+
+	body := map[string]any{
+		"model": "ollama/qwen3:8b",
+		"messages": []map[string]string{
+			{"role": "user", "content": "hi there"},
+		},
+	}
+	rec := doChat(t, srv, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if got := atomic.LoadInt32(calls); got != 1 {
+		t.Fatalf("provider Chat called %d times, want 1", got)
+	}
+	if last.Model != "qwen3:8b" {
+		t.Errorf("provider saw model = %q, want qwen3:8b", last.Model)
+	}
+	if len(last.Messages) != 1 || last.Messages[0].Content != "hi there" {
+		t.Errorf("provider saw messages = %+v", last.Messages)
+	}
+
+	var out ChatCompletionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Object != "chat.completion" {
+		t.Errorf("object = %q, want chat.completion", out.Object)
+	}
+	if !strings.HasPrefix(out.ID, "chatcmpl_") {
+		t.Errorf("id = %q, want chatcmpl_ prefix", out.ID)
+	}
+	if len(out.Choices) != 1 {
+		t.Fatalf("choices = %d, want 1", len(out.Choices))
+	}
+	if out.Choices[0].Message.Role != "assistant" {
+		t.Errorf("message role = %q, want assistant", out.Choices[0].Message.Role)
+	}
+	if out.Choices[0].Message.Content != "hello from mock" {
+		t.Errorf("message content = %q", out.Choices[0].Message.Content)
+	}
+	if out.Choices[0].FinishReason != "stop" {
+		t.Errorf("finish_reason = %q, want stop", out.Choices[0].FinishReason)
+	}
+	if out.Usage.TotalTokens != 8 {
+		t.Errorf("usage.total_tokens = %d, want 8", out.Usage.TotalTokens)
+	}
+	if out.RouteInfo == nil {
+		t.Fatal("x_route_info missing; router should populate it")
+	}
+	if out.RouteInfo.ActualModel != "ollama/qwen3:8b" {
+		t.Errorf("route.actual_model = %q", out.RouteInfo.ActualModel)
+	}
+}
+
+func TestChatCompletions_MissingMessages_400(t *testing.T) {
+	srv, _, _, teardown := newChatFixture(t, "n/a")
+	defer teardown()
+
+	body := map[string]any{
+		"model":    "ollama/qwen3:8b",
+		"messages": []any{},
+	}
+	rec := doChat(t, srv, body)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body=%s", rec.Code, rec.Body.String())
+	}
+	var env errorEnvelope
+	if err := json.NewDecoder(rec.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if env.Error.Code != "missing_messages" {
+		t.Errorf("code = %q, want missing_messages", env.Error.Code)
+	}
+}
+
+func TestChatCompletions_StreamReturns501(t *testing.T) {
+	srv, _, calls, teardown := newChatFixture(t, "n/a")
+	defer teardown()
+
+	body := map[string]any{
+		"model": "ollama/qwen3:8b",
+		"messages": []map[string]string{
+			{"role": "user", "content": "hi"},
+		},
+		"stream": true,
+	}
+	rec := doChat(t, srv, body)
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want 501, body=%s", rec.Code, rec.Body.String())
+	}
+	if got := atomic.LoadInt32(calls); got != 0 {
+		t.Errorf("provider Chat called %d times, want 0", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Compatibility tests
+// ---------------------------------------------------------------------------
+
+func TestChatCompletions_StopAsSingleString(t *testing.T) {
+	srv, last, _, teardown := newChatFixture(t, "ok")
+	defer teardown()
+
+	body := map[string]any{
+		"model": "ollama/qwen3:8b",
+		"messages": []map[string]string{
+			{"role": "user", "content": "hi"},
+		},
+		"stop": "END",
+	}
+	rec := doChat(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if len(last.Options.Stop) != 1 || last.Options.Stop[0] != "END" {
+		t.Errorf("provider saw Options.Stop = %v, want [END]", last.Options.Stop)
+	}
+}
+
+func TestChatCompletions_StopAsArray(t *testing.T) {
+	srv, last, _, teardown := newChatFixture(t, "ok")
+	defer teardown()
+
+	body := map[string]any{
+		"model": "ollama/qwen3:8b",
+		"messages": []map[string]string{
+			{"role": "user", "content": "hi"},
+		},
+		"stop": []string{"END1", "END2"},
+	}
+	rec := doChat(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if len(last.Options.Stop) != 2 || last.Options.Stop[0] != "END1" || last.Options.Stop[1] != "END2" {
+		t.Errorf("provider saw Options.Stop = %v, want [END1 END2]", last.Options.Stop)
+	}
+}
+
+func TestChatCompletions_ToolsForwarded(t *testing.T) {
+	srv, last, _, teardown := newChatFixture(t, "ok")
+	defer teardown()
+
+	body := map[string]any{
+		"model": "ollama/qwen3:8b",
+		"messages": []map[string]string{
+			{"role": "user", "content": "hi"},
+		},
+		"tools": []map[string]any{
+			{
+				"type": "function",
+				"function": map[string]any{
+					"name":        "get_time",
+					"description": "Return the current time",
+					"parameters":  map[string]any{"type": "object"},
+				},
+			},
+		},
+	}
+	rec := doChat(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if len(last.Tools) != 1 {
+		t.Fatalf("provider saw %d tools, want 1", len(last.Tools))
+	}
+	if last.Tools[0].Function.Name != "get_time" {
+		t.Errorf("tool name = %q, want get_time", last.Tools[0].Function.Name)
+	}
+	if last.Tools[0].Type != "function" {
+		t.Errorf("tool type = %q, want function", last.Tools[0].Type)
+	}
+	// Parameters should round-trip as JSON; we do not assert exact bytes
+	// because encoding/json map key order is stable but we only need the
+	// "type" field to show through.
+	if !bytes.Contains(last.Tools[0].Function.Parameters, []byte(`"type"`)) {
+		t.Errorf("tool parameters = %s, missing type field", last.Tools[0].Function.Parameters)
+	}
+}
+
+func TestChatCompletions_DryRun(t *testing.T) {
+	srv, _, calls, teardown := newChatFixture(t, "should-not-be-generated")
+	defer teardown()
+
+	body := map[string]any{
+		"model": "ollama/qwen3:8b",
+		"messages": []map[string]string{
+			{"role": "user", "content": "hi"},
+		},
+		"x_dry_run": true,
+	}
+	rec := doChat(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if got := atomic.LoadInt32(calls); got != 0 {
+		t.Errorf("provider Chat called %d times on dry-run, want 0", got)
+	}
+	var out ChatCompletionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out.Choices) != 0 {
+		t.Errorf("choices = %d, want 0 on dry-run", len(out.Choices))
+	}
+	if out.RouteInfo == nil {
+		t.Fatal("x_route_info missing on dry-run")
+	}
+	if out.RouteInfo.ActualModel == "" {
+		t.Errorf("route.actual_model is empty on dry-run")
+	}
+	if out.RouteInfo.PlannedModel != out.RouteInfo.ActualModel {
+		t.Errorf("dry-run planned=%q actual=%q, expected equal",
+			out.RouteInfo.PlannedModel, out.RouteInfo.ActualModel)
+	}
+}
+
+// TestChatCompletions_AffinityKeyForwarded verifies that a request with
+// x_affinity_key set completes successfully. The provider.ChatRequest that
+// the mock receives does not carry AffinityKey (plumbing stays at the
+// RoutingRequest layer) so we cannot assert the string directly at the HTTP
+// boundary; tests in package provider cover the AffinityKey -> sticky
+// cache plumbing. Here we assert only that the wire field is accepted and
+// the request executes end-to-end.
+func TestChatCompletions_AffinityKeyForwarded(t *testing.T) {
+	srv, _, calls, teardown := newChatFixture(t, "ok")
+	defer teardown()
+
+	body := map[string]any{
+		"model": "ollama/qwen3:8b",
+		"messages": []map[string]string{
+			{"role": "user", "content": "hi"},
+		},
+		"x_affinity_key": "session-42",
+	}
+	rec := doChat(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if got := atomic.LoadInt32(calls); got != 1 {
+		t.Errorf("provider Chat called %d times, want 1", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests for helpers
+// ---------------------------------------------------------------------------
+
+func TestStopSequences_UnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"array", `["a","b"]`, []string{"a", "b"}},
+		{"single", `"END"`, []string{"END"}},
+		{"empty-string", `""`, nil},
+		{"null", `null`, nil},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var s StopSequences
+			if err := json.Unmarshal([]byte(tc.in), &s); err != nil {
+				t.Fatalf("unmarshal %q: %v", tc.in, err)
+			}
+			if !equalStrings([]string(s), tc.want) {
+				t.Errorf("got %v, want %v", []string(s), tc.want)
+			}
+		})
+	}
+}
+
+func TestStopSequences_UnmarshalJSON_Invalid(t *testing.T) {
+	var s StopSequences
+	err := json.Unmarshal([]byte(`123`), &s)
+	if err == nil {
+		t.Fatal("want error on numeric input")
+	}
+	if !strings.Contains(err.Error(), "stop must be string or") {
+		t.Errorf("error = %v, want message about string or []string", err)
+	}
+}
+
+func TestResolvePriority(t *testing.T) {
+	cases := []struct {
+		name string
+		in   *int
+		def  provider.Priority
+		want provider.Priority
+	}{
+		{"nil uses default", nil, provider.PriorityNormal, provider.PriorityNormal},
+		{"explicit high", intPtr(int(provider.PriorityHigh)), provider.PriorityNormal, provider.PriorityHigh},
+		{"negative clamps to background", intPtr(-5), provider.PriorityNormal, provider.PriorityBackground},
+		{"overflow clamps to critical", intPtr(999), provider.PriorityNormal, provider.PriorityCritical},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolvePriority(tc.in, tc.def)
+			if got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSelectorFor(t *testing.T) {
+	cases := []struct {
+		in   provider.ModelKey
+		want string
+	}{
+		{provider.ModelKey{Provider: "ollama", Model: "qwen3:8b"}, "ollama/qwen3:8b"},
+		{provider.ModelKey{Provider: "", Model: "qwen3:8b"}, "qwen3:8b"},
+	}
+	for _, tc := range cases {
+		got := selectorFor(tc.in)
+		if got != tc.want {
+			t.Errorf("selectorFor(%+v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestFirstNonEmpty(t *testing.T) {
+	if got := firstNonEmpty("", "", "c"); got != "c" {
+		t.Errorf("got %q, want c", got)
+	}
+	if got := firstNonEmpty("a", "b"); got != "a" {
+		t.Errorf("got %q, want a", got)
+	}
+	if got := firstNonEmpty(); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// small utilities
+// ---------------------------------------------------------------------------
+
+func intPtr(v int) *int { return &v }
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/compat/chat_test.go
+++ b/compat/chat_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -1010,14 +1011,12 @@ func TestChatCompletions_RequestIDFallback(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if out.ID == "chatcmpl_" {
-		t.Errorf("id = %q, want non-empty suffix via fallback", out.ID)
-	}
-	if !strings.HasPrefix(out.ID, "chatcmpl_") {
-		t.Errorf("id = %q, want chatcmpl_ prefix", out.ID)
-	}
-	if len(out.ID) <= len("chatcmpl_") {
-		t.Errorf("id = %q, want suffix longer than empty", out.ID)
+	// Exact shape: "chatcmpl_" + 16 hex chars (8 random bytes). The regex
+	// rejects the historical "chatcmpl_cmpl_<hex>" double-prefix bug that
+	// arose when fallbackRequestID returned its own "cmpl_" prefix.
+	idRE := regexp.MustCompile(`^chatcmpl_[0-9a-f]{16}$`)
+	if !idRE.MatchString(out.ID) {
+		t.Errorf("id = %q, want match %s", out.ID, idRE)
 	}
 }
 

--- a/compat/chat_test.go
+++ b/compat/chat_test.go
@@ -755,6 +755,37 @@ func TestChatCompletions_DryRun(t *testing.T) {
 	}
 }
 
+func TestChatCompletions_DryRunWinsOverStream(t *testing.T) {
+	srv, _, calls, teardown := newChatFixture(t, "should-not-be-generated")
+	defer teardown()
+
+	body := map[string]any{
+		"model": "ollama/qwen3:8b",
+		"messages": []map[string]string{
+			{"role": "user", "content": "hi"},
+		},
+		"stream":    true,
+		"x_dry_run": true,
+	}
+	rec := doChat(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if got := atomic.LoadInt32(calls); got != 0 {
+		t.Errorf("provider Chat called %d times on stream dry-run, want 0", got)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("content-type = %q, want application/json", got)
+	}
+	var out ChatCompletionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.RouteInfo == nil {
+		t.Fatal("x_route_info missing on stream dry-run")
+	}
+}
+
 // newChatFixtureWithResponse is like newChatFixture but lets the caller shape
 // the response returned by the mock provider. The builder receives the request
 // the provider observed and returns the desired ChatResponse — this is how

--- a/compat/chat_test.go
+++ b/compat/chat_test.go
@@ -442,6 +442,170 @@ func TestChatCompletions_Streaming_ErrorBeforeFirstChunk(t *testing.T) {
 	}
 }
 
+// TestChatCompletions_Streaming_ErrorAfterFirstChunk guards the HIGH-severity
+// silent-truncation fix: when the provider emits one chunk successfully then
+// fails mid-stream (non-cancellation error), the handler MUST NOT emit
+// "data: [DONE]". The [DONE] sentinel is OpenAI's success signal — emitting
+// it under error conditions silently masks the truncation. Its absence lets
+// OpenAI SDKs detect premature EOS.
+func TestChatCompletions_Streaming_ErrorAfterFirstChunk(t *testing.T) {
+	srv, teardown := newStreamingServer(t, func(ctx context.Context, req provider.ChatRequest, fn func(provider.ChatResponse) error) error {
+		if err := fn(provider.ChatResponse{Model: req.Model, Content: "partial"}); err != nil {
+			return err
+		}
+		return errors.New("upstream collapsed")
+	})
+	defer teardown()
+
+	body := map[string]any{
+		"model":  "ollama/qwen3:8b",
+		"stream": true,
+		"messages": []map[string]string{
+			{"role": "user", "content": "hi"},
+		},
+	}
+	rec := doChatRequest(t, srv, body)
+
+	// Status 200 + event-stream headers are committed because the first chunk
+	// was written successfully. The error occurs after commit.
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (headers committed on first chunk), body=%s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("content-type = %q, want text/event-stream", ct)
+	}
+
+	text := rec.Body.String()
+	// First chunk was delivered before the failure.
+	if !strings.Contains(text, `"content":"partial"`) {
+		t.Errorf("body missing first chunk payload %q: %q", `"content":"partial"`, text)
+	}
+	// Critical assertion: no [DONE] sentinel. Its absence is the wire-level
+	// signal of premature EOS that clients rely on.
+	if strings.Contains(text, "data: [DONE]") {
+		t.Errorf("body unexpectedly contains data: [DONE] after mid-stream error: %q", text)
+	}
+}
+
+// TestChatCompletions_Streaming_ClientDisconnect verifies the handler returns
+// cleanly when the caller's context is canceled mid-stream (IDE closing the
+// completion, e.g., on the next keystroke). The semaphore slot must be
+// released so subsequent requests are not blocked — we probe this by
+// acquiring all slots after the handler returns.
+func TestChatCompletions_Streaming_ClientDisconnect(t *testing.T) {
+	// Use a single-slot semaphore so we can prove the slot was released by
+	// re-acquiring it after the handler returns.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv, teardown := newStreamingServer(t, func(streamCtx context.Context, req provider.ChatRequest, fn func(provider.ChatResponse) error) error {
+		// Emit one chunk, then cancel the request context and return the
+		// cancellation error — simulating a client disconnect detected by the
+		// provider after it had already pushed a chunk.
+		if err := fn(provider.ChatResponse{Model: req.Model, Content: "tick"}); err != nil {
+			return err
+		}
+		cancel()
+		return context.Canceled
+	}, WithMaxConcurrency(1))
+	defer teardown()
+
+	buf, err := json.Marshal(map[string]any{
+		"model":  "ollama/qwen3:8b",
+		"stream": true,
+		"messages": []map[string]string{
+			{"role": "user", "content": "hi"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(buf)).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+
+	// Should not panic and should return (not hang).
+	srv.buildHandler().ServeHTTP(rec, req)
+
+	// The first chunk made it onto the wire; no [DONE] should follow because
+	// the stream was aborted.
+	text := rec.Body.String()
+	if !strings.Contains(text, `"content":"tick"`) {
+		t.Errorf("body missing first chunk: %q", text)
+	}
+	if strings.Contains(text, "data: [DONE]") {
+		t.Errorf("body contains data: [DONE] after cancellation: %q", text)
+	}
+
+	// Probe semaphore release: with max concurrency 1, we must be able to
+	// acquire a fresh slot now that the handler has returned.
+	release, ok := srv.semaphore.acquire(provider.PriorityNormal)
+	if !ok {
+		t.Fatal("semaphore slot not released after client-disconnect — handler leaked a slot")
+	}
+	release()
+}
+
+// TestChatCompletions_Streaming_ProviderWithoutCapStream verifies that a
+// streaming request routed through a model that lacks CapStream is rejected
+// cleanly — the router's capability gate eliminates the candidate BEFORE
+// newSSEWriter is called, so the client sees a JSON error envelope (not a
+// partial SSE stream). This proves the capability gate closes before any SSE
+// bytes are committed.
+//
+// The model profile's Caps come from the static catalog or runtime
+// ModelInfo.Capabilities (merged in model_registry.go). Using a model that is
+// NOT in the catalog and providing no runtime Capabilities yields profile.Caps
+// == 0, which fails the gate when RequiredCaps includes CapChat | CapStream.
+func TestChatCompletions_Streaming_ProviderWithoutCapStream(t *testing.T) {
+	mp := &mockProvider{
+		name: "ollama",
+		caps: provider.CapChat,
+		models: []provider.ModelInfo{
+			// No Capabilities set, no catalog match for this family — so
+			// profile.Caps stays 0 and the capability gate rejects when the
+			// router requires CapStream.
+			{Name: "unlisted-model:1b", ContextWindow: 32768},
+		},
+	}
+	srv, teardown := newTestServer(t, mp)
+	defer teardown()
+
+	body := map[string]any{
+		"model":  "ollama/unlisted-model:1b",
+		"stream": true,
+		"messages": []map[string]string{
+			{"role": "user", "content": "hi"},
+		},
+	}
+	rec := doChatRequest(t, srv, body)
+
+	if rec.Code == http.StatusOK {
+		t.Fatalf("status = 200, want non-200 (router should reject before SSE headers): body=%s", rec.Body.String())
+	}
+	// JSON envelope, not text/event-stream — the lazy-start SSE writer was
+	// never constructed because Route returned an error first.
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("content-type = %q, want application/json (JSON error envelope, not partial SSE)", ct)
+	}
+	var env errorEnvelope
+	if err := json.NewDecoder(rec.Body).Decode(&env); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+	if env.Error.Code == "" {
+		t.Errorf("error.code is empty, want non-empty")
+	}
+	// Pin the specific code: the router returns ErrNoViableCandidate for
+	// capability-gated rejections, which statusForCompatError maps to
+	// "no_viable_candidate" with status 400.
+	if env.Error.Code != "no_viable_candidate" {
+		t.Errorf("error.code = %q, want no_viable_candidate", env.Error.Code)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 (ErrNoViableCandidate)", rec.Code)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Compatibility tests
 // ---------------------------------------------------------------------------

--- a/compat/completion_store.go
+++ b/compat/completion_store.go
@@ -1,0 +1,75 @@
+package compat
+
+import (
+	"container/list"
+	"sync"
+	"time"
+)
+
+// CompletionRecord holds the minimum metadata needed to attribute a feedback
+// signal back to the provider/model that served the original completion.
+type CompletionRecord struct {
+	ID        string
+	Provider  string
+	Model     string
+	UseCase   string
+	FilePath  string
+	RouteInfo string
+	CreatedAt time.Time
+}
+
+// completionRecordStore is an in-memory, bounded, TTL-expiring LRU.
+type completionRecordStore struct {
+	mu    sync.Mutex
+	ttl   time.Duration
+	max   int
+	list  *list.List
+	index map[string]*list.Element
+}
+
+func newCompletionRecordStore(ttl time.Duration, max int) *completionRecordStore {
+	return &completionRecordStore{
+		ttl:   ttl,
+		max:   max,
+		list:  list.New(),
+		index: make(map[string]*list.Element, max),
+	}
+}
+
+func (s *completionRecordStore) put(rec CompletionRecord) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if rec.CreatedAt.IsZero() {
+		rec.CreatedAt = time.Now()
+	}
+	if elem, ok := s.index[rec.ID]; ok {
+		elem.Value = rec
+		s.list.MoveToFront(elem)
+		return
+	}
+	s.index[rec.ID] = s.list.PushFront(rec)
+	for s.list.Len() > s.max {
+		oldest := s.list.Back()
+		if oldest != nil {
+			s.list.Remove(oldest)
+			delete(s.index, oldest.Value.(CompletionRecord).ID)
+		}
+	}
+}
+
+func (s *completionRecordStore) get(id string) (CompletionRecord, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	elem, ok := s.index[id]
+	if !ok {
+		return CompletionRecord{}, false
+	}
+	rec := elem.Value.(CompletionRecord)
+	if time.Since(rec.CreatedAt) > s.ttl {
+		s.list.Remove(elem)
+		delete(s.index, id)
+		return CompletionRecord{}, false
+	}
+	s.list.MoveToFront(elem)
+	return rec, true
+}

--- a/compat/completion_store.go
+++ b/compat/completion_store.go
@@ -90,3 +90,27 @@ func (s *completionRecordStore) get(id string) (CompletionRecord, bool) {
 	s.list.MoveToFront(elem)
 	return rec, true
 }
+
+// consume returns the record and deletes it atomically so subsequent calls
+// miss. Used by the feedback endpoint to enforce a single-shot contract:
+// the first POST for a given completion_id records it; subsequent POSTs
+// return 404 (unknown_completion). Expired entries are also removed and
+// reported as a miss.
+func (s *completionRecordStore) consume(id string) (CompletionRecord, bool) {
+	if id == "" {
+		return CompletionRecord{}, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	elem, ok := s.index[id]
+	if !ok {
+		return CompletionRecord{}, false
+	}
+	rec := elem.Value.(CompletionRecord)
+	s.list.Remove(elem)
+	delete(s.index, id)
+	if time.Since(rec.CreatedAt) > s.ttl {
+		return CompletionRecord{}, false
+	}
+	return rec, true
+}

--- a/compat/completion_store.go
+++ b/compat/completion_store.go
@@ -19,6 +19,12 @@ type CompletionRecord struct {
 }
 
 // completionRecordStore is an in-memory, bounded, TTL-expiring LRU.
+//
+// ID must be non-empty; empty IDs are silently ignored (both on put and get)
+// as defense-in-depth against caller bugs. Callers never construct empty IDs
+// in practice (completionResponseID always returns "cmpl_"+suffix), so the
+// short-circuit is purely to prevent a single "" key from overwriting itself
+// and colliding across unrelated requests.
 type completionRecordStore struct {
 	mu    sync.Mutex
 	ttl   time.Duration
@@ -36,7 +42,15 @@ func newCompletionRecordStore(ttl time.Duration, max int) *completionRecordStore
 	}
 }
 
+// put stores rec under rec.ID. An empty rec.ID is silently ignored — see the
+// type-level doc for rationale. Re-put of an existing ID refreshes CreatedAt
+// when the caller's CreatedAt is zero, otherwise preserves the caller-provided
+// CreatedAt. Callers should generally not re-put — completion IDs are unique
+// per request.
 func (s *completionRecordStore) put(rec CompletionRecord) {
+	if rec.ID == "" {
+		return
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if rec.CreatedAt.IsZero() {
@@ -58,6 +72,9 @@ func (s *completionRecordStore) put(rec CompletionRecord) {
 }
 
 func (s *completionRecordStore) get(id string) (CompletionRecord, bool) {
+	if id == "" {
+		return CompletionRecord{}, false
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	elem, ok := s.index[id]

--- a/compat/completion_store_test.go
+++ b/compat/completion_store_test.go
@@ -1,0 +1,40 @@
+package compat
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCompletionRecordStore_PutGet(t *testing.T) {
+	store := newCompletionRecordStore(time.Minute, 10)
+	store.put(CompletionRecord{ID: "a", Provider: "ollama", Model: "qwen3:8b"})
+	rec, ok := store.get("a")
+	if !ok {
+		t.Fatal("expected hit")
+	}
+	if rec.Provider != "ollama" {
+		t.Errorf("provider = %q", rec.Provider)
+	}
+}
+
+func TestCompletionRecordStore_Expiration(t *testing.T) {
+	store := newCompletionRecordStore(10*time.Millisecond, 10)
+	store.put(CompletionRecord{ID: "a"})
+	time.Sleep(20 * time.Millisecond)
+	if _, ok := store.get("a"); ok {
+		t.Error("expected expired miss")
+	}
+}
+
+func TestCompletionRecordStore_CapacityEviction(t *testing.T) {
+	store := newCompletionRecordStore(time.Minute, 2)
+	store.put(CompletionRecord{ID: "a"})
+	store.put(CompletionRecord{ID: "b"})
+	store.put(CompletionRecord{ID: "c"})
+	if _, ok := store.get("a"); ok {
+		t.Error("oldest entry must be evicted at capacity")
+	}
+	if _, ok := store.get("c"); !ok {
+		t.Error("newest entry should survive")
+	}
+}

--- a/compat/completion_store_test.go
+++ b/compat/completion_store_test.go
@@ -1,6 +1,8 @@
 package compat
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 )
@@ -37,4 +39,53 @@ func TestCompletionRecordStore_CapacityEviction(t *testing.T) {
 	if _, ok := store.get("c"); !ok {
 		t.Error("newest entry should survive")
 	}
+}
+
+// TestCompletionRecordStore_EmptyIDRejected guards the defense-in-depth empty
+// ID short-circuit in both put and get. Without the guard, a caller bug that
+// constructed an empty ID would let the first empty-ID record "stick" and
+// collide across unrelated requests.
+func TestCompletionRecordStore_EmptyIDRejected(t *testing.T) {
+	store := newCompletionRecordStore(time.Minute, 10)
+	store.put(CompletionRecord{ID: "", Provider: "ollama"})
+	rec, ok := store.get("")
+	if ok {
+		t.Errorf("get(\"\") returned ok; want (zero, false)")
+	}
+	if rec != (CompletionRecord{}) {
+		t.Errorf("get(\"\") returned %+v; want zero value", rec)
+	}
+	if got := len(store.index); got != 0 {
+		t.Errorf("store index length = %d; want 0 (empty-ID put must be silently ignored)", got)
+	}
+}
+
+// TestCompletionRecordStore_ConcurrentAccess feeds the race detector: 8
+// goroutines each put 100 unique records and read them back. The assertion is
+// weak (no goroutine loses data), but "go test -race" is what this test
+// really exercises.
+func TestCompletionRecordStore_ConcurrentAccess(t *testing.T) {
+	const (
+		goroutines = 8
+		perG       = 100
+	)
+	store := newCompletionRecordStore(time.Minute, goroutines*perG)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		g := g
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perG; i++ {
+				id := fmt.Sprintf("g%d-i%d", g, i)
+				store.put(CompletionRecord{ID: id, Provider: "ollama"})
+				if _, ok := store.get(id); !ok {
+					t.Errorf("get(%q) miss immediately after put", id)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
 }

--- a/compat/completions.go
+++ b/compat/completions.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"time"
 
@@ -149,9 +150,12 @@ func (p PromptUnion) String() string {
 //  5. Acquire a concurrency slot using the resolved priority — AFTER the
 //     FIM/generate branch sets rr.Priority so FIM gets its elevated slot.
 //  6. Route via Router.Route. On error, map via writeCompatError.
-//  7. FIM branch: apply the adaptive FIM budget to the routing request IN
+//  7. If DryRun, render route metadata with empty choice text and return.
+//     This runs BEFORE applyFIMBudget so the metadata describes the plan
+//     as it would actually be routed, not a budget-mutated copy that never
+//     executes.
+//  8. FIM branch: apply the adaptive FIM budget to the routing request IN
 //     PLACE before execution so the provider receives trimmed prefix/suffix.
-//  8. If DryRun, render route metadata with empty choice text and return.
 //  9. Execute via RoutePlan.ExecuteGenerate and render the OpenAI response.
 func (s *Server) handleCompletions(w http.ResponseWriter, r *http.Request) {
 	if s.router == nil {
@@ -220,6 +224,15 @@ func (s *Server) handleCompletions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Dry-run short-circuits BEFORE applyFIMBudget so the returned route
+	// metadata reflects the plan that would actually be routed (unmutated
+	// prefix/suffix). Reporting a budget-mutated plan that never executes
+	// would be phantom state.
+	if req.DryRun {
+		writeCompletionDryRun(w, r, plan)
+		return
+	}
+
 	// Apply the adaptive FIM budget in place on the plan's request snapshot so
 	// buildGenerateRequest picks up the trimmed prefix/suffix. No-op for the
 	// generate branch (suffix is empty).
@@ -227,10 +240,6 @@ func (s *Server) handleCompletions(w http.ResponseWriter, r *http.Request) {
 		applyFIMBudget(plan, req.Language, prompt, req.Suffix, req.MaxTokens)
 	}
 
-	if req.DryRun {
-		writeCompletionDryRun(w, r, plan)
-		return
-	}
 	resp, err := plan.ExecuteGenerate(r.Context())
 	if err != nil {
 		writeCompatError(w, err)
@@ -240,6 +249,8 @@ func (s *Server) handleCompletions(w http.ResponseWriter, r *http.Request) {
 	// Derive finish_reason from usage: "length" when MaxTokens was set and the
 	// response exhausted the budget, else "stop". We do not emit "tool_calls"
 	// here — the completions endpoint is not tool-aware.
+	// TODO(#48): Ollama's done_reason isn't surfaced by provider — finish_reason
+	// may misreport "stop" when the upstream actually hit num_predict.
 	finish := "stop"
 	if req.MaxTokens != nil && *req.MaxTokens > 0 && resp.Usage.CompletionTokens >= *req.MaxTokens {
 		finish = "length"
@@ -307,6 +318,7 @@ func writeCompletionDryRun(w http.ResponseWriter, r *http.Request, plan *provide
 		RouteInfo: &RouteInfoExt{
 			ActualModel:  plan.Profile.Key.String(),
 			PlannedModel: plan.Profile.Key.String(),
+			WasSticky:    plan.WasSticky(),
 			Score:        plan.Score,
 			Reason:       plan.Reason,
 		},
@@ -340,15 +352,26 @@ func applyFIMBudget(plan *provider.RoutePlan, language, prompt, suffix string, m
 	prefixTok := (len(prompt) / 4) + 1
 	suffixTok := (len(suffix) / 4) + 1
 	b := budgetForProfile(plan.Profile.Family, language, overridePct, prefixTok, suffixTok, *maxTokens)
-	if b.Prefix < prefixTok {
+	// Guard against zero/negative budgets (e.g. max_tokens=1): without this,
+	// keepChars=0 would silently set Prompt/Suffix to "" and the provider
+	// would see an empty FIM request. Preserve the original content instead
+	// and log one breadcrumb per occurrence so the misconfiguration is
+	// observable.
+	if b.Prefix <= 0 {
+		log.Printf("compat: applyFIMBudget: zero prefix budget (max_tokens=%d, family=%s, lang=%s); preserving original prefix",
+			*maxTokens, plan.Profile.Family, language)
+	} else if b.Prefix < prefixTok {
 		keepChars := b.Prefix * 4
-		if keepChars < len(prompt) {
+		if keepChars > 0 && keepChars < len(prompt) {
 			plan.Request.Prompt = prompt[len(prompt)-keepChars:]
 		}
 	}
-	if b.Suffix < suffixTok {
+	if b.Suffix <= 0 {
+		log.Printf("compat: applyFIMBudget: zero suffix budget (max_tokens=%d, family=%s, lang=%s); preserving original suffix",
+			*maxTokens, plan.Profile.Family, language)
+	} else if b.Suffix < suffixTok {
 		keepChars := b.Suffix * 4
-		if keepChars < len(suffix) {
+		if keepChars > 0 && keepChars < len(suffix) {
 			plan.Request.Suffix = suffix[:keepChars]
 		}
 	}

--- a/compat/completions.go
+++ b/compat/completions.go
@@ -1,0 +1,375 @@
+package compat
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// ---------------------------------------------------------------------------
+// Request / response wire types
+// ---------------------------------------------------------------------------
+
+// CompletionRequest is the OpenAI-shape POST /v1/completions body. Fields
+// prefixed with x_ are go-llm-specific extensions; OpenAI SDKs ignore unknown
+// fields so the wire remains compatible.
+//
+// The Prompt field accepts either a single JSON string or a JSON array of
+// strings; see PromptUnion for the array-form policy. Suffix is optional and,
+// when non-empty, triggers the Fill-in-the-Middle routing branch
+// (CapGenerate|CapInsert required, priority elevated to PriorityHigh).
+type CompletionRequest struct {
+	Model       string        `json:"model"`
+	Prompt      PromptUnion   `json:"prompt"`
+	Suffix      string        `json:"suffix,omitempty"`
+	Stream      bool          `json:"stream,omitempty"`
+	MaxTokens   *int          `json:"max_tokens,omitempty"`
+	Temperature *float64      `json:"temperature,omitempty"`
+	TopP        *float64      `json:"top_p,omitempty"`
+	Stop        StopSequences `json:"stop,omitempty"`
+
+	// Extensions. All optional.
+	Language    string `json:"x_language,omitempty"`
+	FilePath    string `json:"x_file_path,omitempty"`
+	UseCase     string `json:"x_use_case,omitempty"`
+	Priority    *int   `json:"x_priority,omitempty"`
+	AffinityKey string `json:"x_affinity_key,omitempty"`
+	DryRun      bool   `json:"x_dry_run,omitempty"`
+}
+
+// CompletionResponse is the OpenAI-shape response body. The x_ fields extend
+// it with go-llm routing metadata and confidence scoring.
+type CompletionResponse struct {
+	ID      string             `json:"id"`
+	Object  string             `json:"object"` // "text_completion"
+	Created int64              `json:"created"`
+	Model   string             `json:"model"`
+	Choices []CompletionChoice `json:"choices"`
+	Usage   UsageWire          `json:"usage"`
+
+	// Extensions.
+	CompletionID string        `json:"x_completion_id,omitempty"`
+	Confidence   *float64      `json:"x_confidence,omitempty"`
+	RouteInfo    *RouteInfoExt `json:"x_route_info,omitempty"`
+}
+
+// CompletionChoice is one completion in an OpenAI /v1/completions response.
+type CompletionChoice struct {
+	Index        int    `json:"index"`
+	Text         string `json:"text"`
+	FinishReason string `json:"finish_reason"`
+}
+
+// PromptUnion decodes OpenAI's "prompt" field which may be either a single
+// string or a JSON array of strings. Both shapes unmarshal to []string so the
+// handler can treat the payload uniformly.
+//
+// Array form: OpenAI treats each element as an independent completion and
+// returns a multi-choice response. go-llm returns a single-choice response,
+// so the array form here is reduced to its first non-empty element — see
+// String(). Joining the elements would silently reshape the prompt; picking
+// the first non-empty element is unambiguous and matches typical IDE usage
+// where clients pass a single string anyway.
+type PromptUnion []string
+
+// UnmarshalJSON accepts JSON null, a single string, or a []string. In the
+// array form, empty strings are filtered out to match StopSequences semantics
+// (an empty element is always a caller mistake). An unrecognized JSON kind
+// (object, number, bool) is rejected so the client gets a precise 400 rather
+// than a silent empty-prompt error downstream.
+func (p *PromptUnion) UnmarshalJSON(data []byte) error {
+	// JSON null → empty slice (same as an empty string).
+	if string(data) == "null" {
+		*p = nil
+		return nil
+	}
+	// Try array first — canonical multi-prompt shape.
+	var arr []string
+	if err := json.Unmarshal(data, &arr); err == nil {
+		filtered := arr[:0]
+		for _, v := range arr {
+			if v != "" {
+				filtered = append(filtered, v)
+			}
+		}
+		if len(filtered) == 0 {
+			*p = nil
+		} else {
+			*p = filtered
+		}
+		return nil
+	}
+	// Fall back to single string.
+	var single string
+	if err := json.Unmarshal(data, &single); err != nil {
+		return fmt.Errorf("compat: prompt must be string or []string: %w", err)
+	}
+	if single == "" {
+		*p = nil
+	} else {
+		*p = []string{single}
+	}
+	return nil
+}
+
+// String returns the first non-empty element of the prompt, or "" if none.
+// This collapses the array form to a single completion prompt; see the
+// PromptUnion godoc for the rationale.
+func (p PromptUnion) String() string {
+	for _, v := range p {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+// handleCompletions implements POST /v1/completions (non-streaming). Streaming
+// requests currently return 501; Task 13 replaces the stub with the real SSE
+// writer.
+//
+// Order of operations:
+//  1. Decode body and validate required fields.
+//  2. Resolve model alias -> provider.ModelKey.
+//  3. Build provider.RoutingRequest:
+//     - When Suffix is non-empty, take the FIM branch (CapGenerate|CapInsert,
+//     PriorityHigh, UseCase="fim") regardless of caller-supplied x_priority.
+//     - Otherwise take the generate branch (CapGenerate, default priority).
+//  4. If streaming, dispatch to the 501 stub.
+//  5. Acquire a concurrency slot using the resolved priority — AFTER the
+//     FIM/generate branch sets rr.Priority so FIM gets its elevated slot.
+//  6. Route via Router.Route. On error, map via writeCompatError.
+//  7. FIM branch: apply the adaptive FIM budget to the routing request IN
+//     PLACE before execution so the provider receives trimmed prefix/suffix.
+//  8. If DryRun, render route metadata with empty choice text and return.
+//  9. Execute via RoutePlan.ExecuteGenerate and render the OpenAI response.
+func (s *Server) handleCompletions(w http.ResponseWriter, r *http.Request) {
+	if s.router == nil {
+		writeError(w, http.StatusServiceUnavailable, "no_router", "server has no router")
+		return
+	}
+
+	var req CompletionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "decode_error", err.Error())
+		return
+	}
+	key, err := resolveModel(req.Model, s.aliases)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "missing_model", err.Error())
+		return
+	}
+	// A request with no prompt and no suffix has nothing to complete. An empty
+	// prompt with a non-empty suffix is a valid FIM pattern (completing at the
+	// very start of a file), so we only reject when both are empty.
+	prompt := req.Prompt.String()
+	if prompt == "" && req.Suffix == "" {
+		writeError(w, http.StatusBadRequest, "empty_prompt", "prompt and suffix are both empty")
+		return
+	}
+
+	rr := provider.RoutingRequest{
+		Model:       selectorFor(key),
+		Prompt:      prompt,
+		Suffix:      req.Suffix,
+		Options:     toModelOptions(req.Temperature, req.TopP, req.MaxTokens, []string(req.Stop)),
+		AffinityKey: req.AffinityKey,
+		DryRun:      req.DryRun,
+	}
+	if req.Suffix != "" {
+		// FIM branch: Router.Generate mirrors these fields when Suffix is
+		// non-empty, so we match them exactly for consistency.
+		rr.UseCase = "fim"
+		rr.RequiredCaps = provider.CapGenerate | provider.CapInsert
+		rr.Priority = provider.PriorityHigh
+	} else {
+		rr.UseCase = firstNonEmpty(req.UseCase, "generate")
+		rr.RequiredCaps = provider.CapGenerate
+		rr.Priority = resolvePriority(req.Priority, provider.PriorityNormal)
+	}
+
+	if req.Stream {
+		s.serveCompletionsStream(w, r, rr)
+		return
+	}
+
+	// Acquire the HTTP concurrency slot AFTER FIM/generate branching so the
+	// resolved priority (PriorityHigh for FIM, default for generate) drives
+	// admission control.
+	release, ok := s.semaphore.acquire(rr.Priority)
+	if !ok {
+		w.Header().Set("Retry-After", "1")
+		writeError(w, http.StatusTooManyRequests, "capacity", "server is at capacity")
+		return
+	}
+	defer release()
+
+	plan, err := s.router.Route(r.Context(), rr)
+	if err != nil {
+		writeCompatError(w, err)
+		return
+	}
+
+	// Apply the adaptive FIM budget in place on the plan's request snapshot so
+	// buildGenerateRequest picks up the trimmed prefix/suffix. No-op for the
+	// generate branch (suffix is empty).
+	if req.Suffix != "" {
+		applyFIMBudget(plan, req.Language, prompt, req.Suffix, req.MaxTokens)
+	}
+
+	if req.DryRun {
+		writeCompletionDryRun(w, r, plan)
+		return
+	}
+	resp, err := plan.ExecuteGenerate(r.Context())
+	if err != nil {
+		writeCompatError(w, err)
+		return
+	}
+
+	// Derive finish_reason from usage: "length" when MaxTokens was set and the
+	// response exhausted the budget, else "stop". We do not emit "tool_calls"
+	// here — the completions endpoint is not tool-aware.
+	finish := "stop"
+	if req.MaxTokens != nil && *req.MaxTokens > 0 && resp.Usage.CompletionTokens >= *req.MaxTokens {
+		finish = "length"
+	}
+
+	id := completionResponseID(r.Context())
+	out := CompletionResponse{
+		ID:      id,
+		Object:  "text_completion",
+		Created: time.Now().Unix(),
+		// Qualified "provider/model" form taken from the plan so success and
+		// dry-run responses have identical shape even when resp.Model omits
+		// the provider prefix.
+		Model: plan.Profile.Key.String(),
+		Choices: []CompletionChoice{{
+			Index:        0,
+			Text:         resp.Response,
+			FinishReason: finish,
+		}},
+		Usage: UsageWire{
+			PromptTokens:     resp.Usage.PromptTokens,
+			CompletionTokens: resp.Usage.CompletionTokens,
+			TotalTokens:      resp.Usage.TotalTokens,
+		},
+		CompletionID: id,
+		RouteInfo:    routeInfoFrom(resp.RouteOutcome),
+	}
+	if resp.Confidence != nil {
+		score := resp.Confidence.Score
+		out.Confidence = &score
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(out)
+}
+
+// serveCompletionsStream is the streaming branch stub. Task 13 replaces it
+// with the real SSE writer; today it returns 501 so clients get a clear
+// signal rather than a silent fallthrough. The non-streaming handler still
+// honors every other feature (FIM budget, dry-run, route metadata).
+func (s *Server) serveCompletionsStream(w http.ResponseWriter, _ *http.Request, _ provider.RoutingRequest) {
+	writeError(w, http.StatusNotImplemented, "not_implemented", "streaming completions not yet implemented")
+}
+
+// writeCompletionDryRun renders the route decision without executing the
+// request. The response carries a single empty-text choice and a populated
+// x_route_info block so clients can observe the chosen model.
+//
+// Unlike the chat dry-run (which uses an empty Choices slice), the completions
+// endpoint always emits one choice so OpenAI SDKs that iterate resp.choices[0]
+// do not index out of bounds on dry-run responses. Text is empty — clients
+// should treat dry-run as metadata-only.
+func writeCompletionDryRun(w http.ResponseWriter, r *http.Request, plan *provider.RoutePlan) {
+	id := completionResponseID(r.Context())
+	out := CompletionResponse{
+		ID:      id,
+		Object:  "text_completion",
+		Created: time.Now().Unix(),
+		Model:   plan.Profile.Key.String(),
+		Choices: []CompletionChoice{{
+			Index:        0,
+			Text:         "",
+			FinishReason: "stop",
+		}},
+		CompletionID: id,
+		RouteInfo: &RouteInfoExt{
+			ActualModel:  plan.Profile.Key.String(),
+			PlannedModel: plan.Profile.Key.String(),
+			Score:        plan.Score,
+			Reason:       plan.Reason,
+		},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(out)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// applyFIMBudget mutates plan.Request.Prompt and plan.Request.Suffix to stay
+// within the computed prefix/suffix token budget. It uses a 4-chars-per-token
+// approximation — good enough for the edge-trimming policy below, and avoids
+// pulling in a tokenizer. When maxTokens is nil or <= 0 the step is skipped
+// (no caller-supplied budget to enforce).
+//
+// Truncation policy: preserve the TAIL of the prefix (the text closest to the
+// cursor) and the HEAD of the suffix (the text immediately after the cursor).
+// That keeps the span most meaningful to the model; the opposite end is the
+// natural candidate for truncation.
+func applyFIMBudget(plan *provider.RoutePlan, language, prompt, suffix string, maxTokens *int) {
+	if maxTokens == nil || *maxTokens <= 0 || plan == nil || plan.Profile == nil {
+		return
+	}
+	var overridePct int
+	if plan.Profile.FIM != nil {
+		overridePct = plan.Profile.FIM.PrefixBudgetPct
+	}
+	prefixTok := (len(prompt) / 4) + 1
+	suffixTok := (len(suffix) / 4) + 1
+	b := budgetForProfile(plan.Profile.Family, language, overridePct, prefixTok, suffixTok, *maxTokens)
+	if b.Prefix < prefixTok {
+		keepChars := b.Prefix * 4
+		if keepChars < len(prompt) {
+			plan.Request.Prompt = prompt[len(prompt)-keepChars:]
+		}
+	}
+	if b.Suffix < suffixTok {
+		keepChars := b.Suffix * 4
+		if keepChars < len(suffix) {
+			plan.Request.Suffix = suffix[:keepChars]
+		}
+	}
+}
+
+// completionResponseID builds the "cmpl_<suffix>" response ID. It prefers the
+// request ID attached by requestIDMiddleware (so HTTP access logs and response
+// bodies correlate), but falls back to a freshly generated random suffix when
+// the context carries none — e.g. when handlers are invoked directly via the
+// mux for tests or embedded callers. Without the fallback, bypass paths would
+// return "cmpl_" verbatim, which is indistinguishable from a bug.
+//
+// NOTE: we deliberately do NOT reuse fallbackRequestID() from chat.go — that
+// helper prepends its own "cmpl_" prefix, which would yield "cmpl_cmpl_<hex>"
+// when composed here.
+func completionResponseID(ctx context.Context) string {
+	rid := requestIDFrom(ctx)
+	if rid == "" {
+		var b [8]byte
+		_, _ = rand.Read(b[:])
+		rid = hex.EncodeToString(b[:])
+	}
+	return "cmpl_" + rid
+}

--- a/compat/completions.go
+++ b/compat/completions.go
@@ -2,8 +2,6 @@ package compat
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -600,16 +598,10 @@ func applyFIMBudget(plan *provider.RoutePlan, language, prompt, suffix string, m
 // the context carries none — e.g. when handlers are invoked directly via the
 // mux for tests or embedded callers. Without the fallback, bypass paths would
 // return "cmpl_" verbatim, which is indistinguishable from a bug.
-//
-// NOTE: we deliberately do NOT reuse fallbackRequestID() from chat.go — that
-// helper prepends its own "cmpl_" prefix, which would yield "cmpl_cmpl_<hex>"
-// when composed here.
 func completionResponseID(ctx context.Context) string {
 	rid := requestIDFrom(ctx)
 	if rid == "" {
-		var b [8]byte
-		_, _ = rand.Read(b[:])
-		rid = hex.EncodeToString(b[:])
+		rid = fallbackRequestID()
 	}
 	return "cmpl_" + rid
 }

--- a/compat/completions.go
+++ b/compat/completions.go
@@ -230,7 +230,7 @@ func (s *Server) handleCompletions(w http.ResponseWriter, r *http.Request) {
 		rr.Priority = resolvePriority(req.Priority, provider.PriorityNormal)
 	}
 
-	if req.Stream {
+	if req.Stream && !req.DryRun {
 		s.serveCompletionsStream(w, r, rr, req.FilePath, fim)
 		return
 	}

--- a/compat/completions.go
+++ b/compat/completions.go
@@ -292,6 +292,11 @@ func (s *Server) handleCompletions(w http.ResponseWriter, r *http.Request) {
 	if resp.RouteOutcome != nil {
 		routeReason = resp.RouteOutcome.Reason
 	}
+	// Non-streaming: the put happens before the JSON encode. If the encoder
+	// fails mid-write the record is technically orphan, but the response body
+	// is a single JSON object (not a multi-frame stream) and encode failures
+	// here are vanishingly rare — the streaming orphan case is the one that
+	// actually warrants deferred persistence.
 	s.completionStore.put(CompletionRecord{
 		ID:        id,
 		Provider:  resp.Provider,
@@ -397,6 +402,13 @@ func (s *Server) serveCompletionsStream(w http.ResponseWriter, r *http.Request, 
 
 	var lastConfidence *float64
 	var sawDone bool
+	// Captured on the Done chunk and used AFTER the stream loop returns
+	// cleanly, so we only persist attribution for completions the client
+	// actually received. Writing the record inside the callback (before the
+	// Done frame is flushed) risks storing a record for a completion the
+	// client never saw if writeEvent fails on the final frame.
+	var lastProvider string
+	var lastRouteReason string
 
 	streamErr := plan.ExecuteGenerateStream(r.Context(), func(chunk provider.GenerateResponse) error {
 		// Derive finish_reason on the Done chunk. Completions are not
@@ -418,18 +430,13 @@ func (s *Server) serveCompletionsStream(w http.ResponseWriter, r *http.Request, 
 				v := chunk.Confidence.Score
 				lastConfidence = &v
 			}
-			routeReason := ""
+			// Capture attribution for the post-stream put. See the
+			// success-path put below for why we defer until after the
+			// Done frame has been flushed successfully.
+			lastProvider = chunk.Provider
 			if chunk.RouteOutcome != nil {
-				routeReason = chunk.RouteOutcome.Reason
+				lastRouteReason = chunk.RouteOutcome.Reason
 			}
-			s.completionStore.put(CompletionRecord{
-				ID:        id,
-				Provider:  chunk.Provider,
-				Model:     modelID,
-				UseCase:   rr.UseCase,
-				FilePath:  filePath,
-				RouteInfo: routeReason,
-			})
 		}
 		out := CompletionChunk{
 			ID:      id,
@@ -482,6 +489,23 @@ func (s *Server) serveCompletionsStream(w http.ResponseWriter, r *http.Request, 
 	if !sawDone {
 		log.Printf("compat: generate stream ended without Done chunk rid=%s", requestIDFrom(r.Context()))
 		return
+	}
+
+	// Persist attribution only after the stream completed cleanly AND the
+	// provider sent a terminal Done chunk. This avoids orphan records for
+	// streams that errored mid-flight or silently ended without [DONE]: Task
+	// 15 feedback keyed on a lost completion should miss, not hit. At this
+	// point streamErr is nil and sawDone is true (both guarded above), so
+	// the put is unconditional — the explicit if is kept for readability.
+	if sawDone {
+		s.completionStore.put(CompletionRecord{
+			ID:        id,
+			Provider:  lastProvider,
+			Model:     modelID,
+			UseCase:   rr.UseCase,
+			FilePath:  filePath,
+			RouteInfo: lastRouteReason,
+		})
 	}
 
 	_ = sw.writeDone()

--- a/compat/completions.go
+++ b/compat/completions.go
@@ -288,6 +288,18 @@ func (s *Server) handleCompletions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	id := completionResponseID(r.Context())
+	routeReason := ""
+	if resp.RouteOutcome != nil {
+		routeReason = resp.RouteOutcome.Reason
+	}
+	s.completionStore.put(CompletionRecord{
+		ID:        id,
+		Provider:  resp.Provider,
+		Model:     plan.Profile.Key.String(),
+		UseCase:   rr.UseCase,
+		FilePath:  req.FilePath,
+		RouteInfo: routeReason,
+	})
 	out := CompletionResponse{
 		ID:      id,
 		Object:  "text_completion",
@@ -352,8 +364,7 @@ func (s *Server) handleCompletions(w http.ResponseWriter, r *http.Request) {
 // If maintainers later want streaming-FIM budgeting, they can wire
 // req.MaxTokens through rr.Options.NumPredict.
 func (s *Server) serveCompletionsStream(w http.ResponseWriter, r *http.Request, rr provider.RoutingRequest, filePath string, fim bool) {
-	_ = filePath // reserved for Task 14's completion store; currently unused
-	_ = fim      // reserved for Task 14's completion store; currently unused
+	_ = fim // reserved for Task 14's completion store; currently unused
 
 	rr.RequiredCaps |= provider.CapStream
 
@@ -407,10 +418,18 @@ func (s *Server) serveCompletionsStream(w http.ResponseWriter, r *http.Request, 
 				v := chunk.Confidence.Score
 				lastConfidence = &v
 			}
-			// Task 14 wires s.completionStore.put here once the
-			// CompletionRecord type and LRU store land. Leaving a hook
-			// point (local identifiers populated above) so Task 14 is a
-			// pure additive diff.
+			routeReason := ""
+			if chunk.RouteOutcome != nil {
+				routeReason = chunk.RouteOutcome.Reason
+			}
+			s.completionStore.put(CompletionRecord{
+				ID:        id,
+				Provider:  chunk.Provider,
+				Model:     modelID,
+				UseCase:   rr.UseCase,
+				FilePath:  filePath,
+				RouteInfo: routeReason,
+			})
 		}
 		out := CompletionChunk{
 			ID:      id,

--- a/compat/completions.go
+++ b/compat/completions.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -65,6 +66,28 @@ type CompletionChoice struct {
 	Index        int    `json:"index"`
 	Text         string `json:"text"`
 	FinishReason string `json:"finish_reason"`
+}
+
+// CompletionChunk is one frame of an OpenAI-shape streaming /v1/completions
+// response. Each chunk carries exactly one CompletionChunkChoice today. Usage
+// is not included on per-chunk frames — OpenAI emits usage only on the final
+// frame when stream_options.include_usage is set, which we don't yet expose.
+type CompletionChunk struct {
+	ID      string                  `json:"id"`
+	Object  string                  `json:"object"` // "text_completion"
+	Created int64                   `json:"created"`
+	Model   string                  `json:"model"`
+	Choices []CompletionChunkChoice `json:"choices"`
+}
+
+// CompletionChunkChoice is one choice inside a streaming completion chunk.
+// FinishReason is a pointer so interim chunks serialize as
+// "finish_reason":null and only the final chunk carries a non-null reason,
+// matching OpenAI's wire format.
+type CompletionChunkChoice struct {
+	Index        int     `json:"index"`
+	Text         string  `json:"text"`
+	FinishReason *string `json:"finish_reason"`
 }
 
 // PromptUnion decodes OpenAI's "prompt" field which may be either a single
@@ -190,7 +213,8 @@ func (s *Server) handleCompletions(w http.ResponseWriter, r *http.Request) {
 		AffinityKey: req.AffinityKey,
 		DryRun:      req.DryRun,
 	}
-	if req.Suffix != "" {
+	fim := req.Suffix != ""
+	if fim {
 		// FIM branch: Router.Generate mirrors these fields when Suffix is
 		// non-empty, so we match them exactly for consistency.
 		rr.UseCase = "fim"
@@ -203,7 +227,7 @@ func (s *Server) handleCompletions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.Stream {
-		s.serveCompletionsStream(w, r, rr)
+		s.serveCompletionsStream(w, r, rr, req.FilePath, fim)
 		return
 	}
 
@@ -286,12 +310,134 @@ func (s *Server) handleCompletions(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(out)
 }
 
-// serveCompletionsStream is the streaming branch stub. Task 13 replaces it
-// with the real SSE writer; today it returns 501 so clients get a clear
-// signal rather than a silent fallthrough. The non-streaming handler still
-// honors every other feature (FIM budget, dry-run, route metadata).
-func (s *Server) serveCompletionsStream(w http.ResponseWriter, _ *http.Request, _ provider.RoutingRequest) {
-	writeError(w, http.StatusNotImplemented, "not_implemented", "streaming completions not yet implemented")
+// serveCompletionsStream handles the streaming branch of POST /v1/completions.
+// It emits an SSE (text/event-stream) body whose events each carry a JSON
+// CompletionChunk, terminated by a "data: [DONE]" sentinel.
+//
+// Order of operations:
+//  1. Broaden rr.RequiredCaps with CapStream so the router rejects any
+//     provider that cannot stream before any bytes are written.
+//  2. Acquire the HTTP concurrency slot using the resolved priority — the
+//     slot is released when the stream completes.
+//  3. Route via Router.Route. On error, writeCompatError still works
+//     because no bytes have been written yet.
+//  4. Construct a lazy-start sseWriter — it does NOT commit the 200 status
+//     until the first chunk is written, so a pre-first-chunk
+//     ExecuteGenerateStream failure can still be surfaced as a regular JSON
+//     error envelope. Without this guard a failure that happens before the
+//     first chunk is written as an empty 200 response, which is
+//     indistinguishable from a successful zero-token stream.
+//  5. For each chunk, emit a CompletionChunk with the qualified model ID and,
+//     on the Done chunk, a derived finish_reason matching the non-streaming
+//     branch's logic ("length" when NumPredict was set and usage reached the
+//     cap, "stop" otherwise — completions don't emit tool_calls).
+//  6. After ExecuteGenerateStream returns, emit "data: [DONE]" only on clean
+//     completion. If the failure happened before the first chunk, surface a
+//     JSON error envelope. If the failure happened mid-stream, skip the
+//     [DONE] sentinel so clients can detect premature EOS via its absence;
+//     context.Canceled (client disconnect — e.g. IDE cancels completion on
+//     every keystroke) is treated as normal and its log is suppressed to
+//     prevent spam.
+//
+// FIM budget is not applied on the streaming path — a streaming client
+// selects num_predict via the provider's live back-pressure rather than a
+// pre-truncation budget. Non-streaming callers still get applyFIMBudget.
+// If maintainers later want streaming-FIM budgeting, they can wire
+// req.MaxTokens through rr.Options.NumPredict.
+func (s *Server) serveCompletionsStream(w http.ResponseWriter, r *http.Request, rr provider.RoutingRequest, filePath string, fim bool) {
+	_ = filePath // reserved for Task 14's completion store; currently unused
+	_ = fim      // reserved for Task 14's completion store; currently unused
+
+	rr.RequiredCaps |= provider.CapStream
+
+	release, ok := s.semaphore.acquire(rr.Priority)
+	if !ok {
+		w.Header().Set("Retry-After", "1")
+		writeError(w, http.StatusTooManyRequests, "capacity", "server is at capacity")
+		return
+	}
+	defer release()
+
+	plan, err := s.router.Route(r.Context(), rr)
+	if err != nil {
+		writeCompatError(w, err)
+		return
+	}
+
+	sw, err := newSSEWriter(w)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "no_flusher", err.Error())
+		return
+	}
+
+	// Capture the response ID and qualified model ID BEFORE invoking the
+	// provider so every chunk carries stable identifiers. completionResponseID
+	// falls back to a random suffix when no request-id middleware has run.
+	id := completionResponseID(r.Context())
+	created := time.Now().Unix()
+	modelID := plan.Profile.Key.String()
+
+	var lastConfidence *float64
+	_ = lastConfidence // reserved hook point for Task 14's completion store
+
+	streamErr := plan.ExecuteGenerateStream(r.Context(), func(chunk provider.GenerateResponse) error {
+		// Derive finish_reason on the Done chunk. Completions are not
+		// tool-aware, so the rule collapses to "length" vs "stop".
+		// TODO(#48): Ollama's done_reason isn't surfaced by provider —
+		// finish_reason may misreport "stop" when the upstream actually hit
+		// num_predict but arrived with CompletionTokens==0. Same caveat as
+		// the non-streaming branch; a future DoneReason plumbing will fix
+		// both sites.
+		var finish *string
+		if chunk.Done {
+			reason := "stop"
+			if rr.Options.NumPredict > 0 && chunk.Usage.CompletionTokens >= rr.Options.NumPredict {
+				reason = "length"
+			}
+			finish = &reason
+			if chunk.Confidence != nil {
+				v := chunk.Confidence.Score
+				lastConfidence = &v
+			}
+			// Task 14 wires s.completionStore.put here once the
+			// CompletionRecord type and LRU store land. Leaving a hook
+			// point (local identifiers populated above) so Task 14 is a
+			// pure additive diff.
+		}
+		return sw.writeEvent(CompletionChunk{
+			ID:      id,
+			Object:  "text_completion",
+			Created: created,
+			Model:   modelID,
+			Choices: []CompletionChunkChoice{{
+				Index:        0,
+				Text:         chunk.Response,
+				FinishReason: finish,
+			}},
+		})
+	})
+
+	if streamErr != nil {
+		// If the failure happened BEFORE any chunk was delivered, the SSE
+		// writer never committed the 200 status — so we can still surface a
+		// JSON error envelope. Otherwise the stream is already live on the
+		// wire and we must NOT emit "data: [DONE]" — that is OpenAI's
+		// success sentinel, and emitting it under error conditions silently
+		// signals success. Skipping it lets SDKs detect premature EOS via
+		// the missing terminator.
+		if !sw.started {
+			writeCompatError(w, streamErr)
+			return
+		}
+		// Client disconnect is normal (e.g., IDE cancels completion on every
+		// keystroke) — suppress the log to prevent spam.
+		if !errors.Is(streamErr, context.Canceled) {
+			log.Printf("compat: generate stream error rid=%s: %v", requestIDFrom(r.Context()), streamErr)
+		}
+		return
+	}
+
+	_ = sw.writeDone()
 }
 
 // writeCompletionDryRun renders the route decision without executing the

--- a/compat/completions.go
+++ b/compat/completions.go
@@ -78,6 +78,13 @@ type CompletionChunk struct {
 	Created int64                   `json:"created"`
 	Model   string                  `json:"model"`
 	Choices []CompletionChunkChoice `json:"choices"`
+
+	// Extensions. Populated only on the final (Done) chunk so interim frames
+	// stay minimal; omitempty + nil pointer keep the wire unchanged for
+	// non-final chunks. Mirrors CompletionResponse.CompletionID / Confidence
+	// so clients that toggle stream:true see the same extension fields.
+	CompletionID string   `json:"x_completion_id,omitempty"`
+	Confidence   *float64 `json:"x_confidence,omitempty"`
 }
 
 // CompletionChunkChoice is one choice inside a streaming completion chunk.
@@ -378,7 +385,7 @@ func (s *Server) serveCompletionsStream(w http.ResponseWriter, r *http.Request, 
 	modelID := plan.Profile.Key.String()
 
 	var lastConfidence *float64
-	_ = lastConfidence // reserved hook point for Task 14's completion store
+	var sawDone bool
 
 	streamErr := plan.ExecuteGenerateStream(r.Context(), func(chunk provider.GenerateResponse) error {
 		// Derive finish_reason on the Done chunk. Completions are not
@@ -390,6 +397,7 @@ func (s *Server) serveCompletionsStream(w http.ResponseWriter, r *http.Request, 
 		// both sites.
 		var finish *string
 		if chunk.Done {
+			sawDone = true
 			reason := "stop"
 			if rr.Options.NumPredict > 0 && chunk.Usage.CompletionTokens >= rr.Options.NumPredict {
 				reason = "length"
@@ -404,7 +412,7 @@ func (s *Server) serveCompletionsStream(w http.ResponseWriter, r *http.Request, 
 			// point (local identifiers populated above) so Task 14 is a
 			// pure additive diff.
 		}
-		return sw.writeEvent(CompletionChunk{
+		out := CompletionChunk{
 			ID:      id,
 			Object:  "text_completion",
 			Created: created,
@@ -414,7 +422,16 @@ func (s *Server) serveCompletionsStream(w http.ResponseWriter, r *http.Request, 
 				Text:         chunk.Response,
 				FinishReason: finish,
 			}},
-		})
+		}
+		// Surface x_completion_id / x_confidence only on the final frame so
+		// interim chunks stay minimal (omitempty + nil pointer). This mirrors
+		// the non-streaming CompletionResponse shape — toggling stream:true
+		// must not silently drop those extensions.
+		if chunk.Done {
+			out.CompletionID = id
+			out.Confidence = lastConfidence
+		}
+		return sw.writeEvent(out)
 	})
 
 	if streamErr != nil {
@@ -434,6 +451,17 @@ func (s *Server) serveCompletionsStream(w http.ResponseWriter, r *http.Request, 
 		if !errors.Is(streamErr, context.Canceled) {
 			log.Printf("compat: generate stream error rid=%s: %v", requestIDFrom(r.Context()), streamErr)
 		}
+		return
+	}
+
+	// A nil streamErr with no terminal Done chunk is a misbehaving provider
+	// (or upstream wrapper that swallowed the terminator). Emitting [DONE]
+	// here would tell the SDK the stream completed successfully even though
+	// we never saw a Done frame. Skip the sentinel so clients detect the
+	// premature EOS, and log one breadcrumb with the request ID so the
+	// misbehavior is observable in logs.
+	if !sawDone {
+		log.Printf("compat: generate stream ended without Done chunk rid=%s", requestIDFrom(r.Context()))
 		return
 	}
 

--- a/compat/completions.go
+++ b/compat/completions.go
@@ -192,8 +192,7 @@ func (s *Server) handleCompletions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req CompletionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "decode_error", err.Error())
+	if !decodeJSONBody(w, r, maxCompletionRequestBodyBytes, &req) {
 		return
 	}
 	key, err := resolveModel(req.Model, s.aliases)
@@ -592,16 +591,15 @@ func applyFIMBudget(plan *provider.RoutePlan, language, prompt, suffix string, m
 	}
 }
 
-// completionResponseID builds the "cmpl_<suffix>" response ID. It prefers the
-// request ID attached by requestIDMiddleware (so HTTP access logs and response
-// bodies correlate), but falls back to a freshly generated random suffix when
-// the context carries none — e.g. when handlers are invoked directly via the
-// mux for tests or embedded callers. Without the fallback, bypass paths would
-// return "cmpl_" verbatim, which is indistinguishable from a bug.
+// completionResponseID builds the "cmpl_<suffix>" response ID. When an inbound
+// request ID exists, we keep it as a correlation prefix but always append a
+// server-generated random suffix so callers cannot force duplicate completion
+// IDs by reusing X-Request-Id across requests. Without the fallback, bypass
+// paths would return "cmpl_" verbatim, which is indistinguishable from a bug.
 func completionResponseID(ctx context.Context) string {
 	rid := requestIDFrom(ctx)
 	if rid == "" {
-		rid = fallbackRequestID()
+		return "cmpl_" + fallbackRequestID()
 	}
-	return "cmpl_" + rid
+	return "cmpl_" + rid + "_" + fallbackRequestID()
 }

--- a/compat/completions_test.go
+++ b/compat/completions_test.go
@@ -129,6 +129,32 @@ func TestCompletions_GenerateMode(t *testing.T) {
 	}
 }
 
+func TestCompletions_BodyTooLarge(t *testing.T) {
+	srv, _, calls, teardown := newCompletionFixture(t, "unused")
+	defer teardown()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/completions",
+		oversizedJSONStringReader(
+			`{"model":"ollama/qwen3:8b","prompt":"`,
+			maxCompletionRequestBodyBytes+1,
+			`"}`,
+		))
+	req.Header.Set("Content-Type", "application/json")
+	srv.buildHandler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if got := atomic.LoadInt32(calls); got != 0 {
+		t.Fatalf("provider Generate called %d times, want 0", got)
+	}
+	env := decodeErrorEnvelope(t, rec)
+	if env.Error.Code != "body_too_large" {
+		t.Errorf("error.code = %q, want body_too_large", env.Error.Code)
+	}
+}
+
 // TestCompletions_FIMMode verifies that a non-empty Suffix triggers the FIM
 // branch: UseCase="fim" and CapGenerate|CapInsert required (we prove the
 // latter indirectly by successful routing to a model that only satisfies
@@ -492,6 +518,55 @@ func TestCompletions_RequestIDFallback(t *testing.T) {
 	idRE := regexp.MustCompile(`^cmpl_[0-9a-f]{16}$`)
 	if !idRE.MatchString(out.ID) {
 		t.Errorf("id = %q, want match %s", out.ID, idRE)
+	}
+}
+
+func TestCompletions_RequestIDDoesNotForceDuplicateCompletionIDs(t *testing.T) {
+	srv, _, _, teardown := newCompletionFixture(t, "ok")
+	defer teardown()
+
+	body := map[string]any{
+		"model":  "ollama/qwen3:8b",
+		"prompt": "hi",
+	}
+	buf, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	doReq := func() CompletionResponse {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/v1/completions", bytes.NewReader(buf))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Request-Id", "caller-id")
+		srv.buildHandler().ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+		}
+		var out CompletionResponse
+		if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return out
+	}
+
+	first := doReq()
+	second := doReq()
+
+	if first.ID != first.CompletionID {
+		t.Fatalf("id = %q, x_completion_id = %q; want identical IDs", first.ID, first.CompletionID)
+	}
+	if second.ID != second.CompletionID {
+		t.Fatalf("id = %q, x_completion_id = %q; want identical IDs", second.ID, second.CompletionID)
+	}
+	if first.CompletionID == second.CompletionID {
+		t.Fatalf("duplicate completion IDs for reused X-Request-Id: %q", first.CompletionID)
+	}
+	if !strings.HasPrefix(first.CompletionID, "cmpl_caller-id_") {
+		t.Errorf("first completion id = %q, want caller-id correlation prefix", first.CompletionID)
+	}
+	if !strings.HasPrefix(second.CompletionID, "cmpl_caller-id_") {
+		t.Errorf("second completion id = %q, want caller-id correlation prefix", second.CompletionID)
 	}
 }
 

--- a/compat/completions_test.go
+++ b/compat/completions_test.go
@@ -845,6 +845,73 @@ func TestCompletions_Streaming_NoDoneChunkSkipsDONE(t *testing.T) {
 	}
 }
 
+// TestCompletions_Streaming_StoreRecordOnCleanDone verifies that after a clean
+// streaming completion (interim chunk + terminal Done chunk) the completion
+// record store has a hit for the response's x_completion_id. This is the
+// orphan-avoidance positive test.
+func TestCompletions_Streaming_StoreRecordOnCleanDone(t *testing.T) {
+	srv, teardown := newStreamingCompletionServer(t, func(_ context.Context, req provider.GenerateRequest, fn func(provider.GenerateResponse) error) error {
+		if err := fn(provider.GenerateResponse{Model: req.Model, Response: "a"}); err != nil {
+			return err
+		}
+		return fn(provider.GenerateResponse{Model: req.Model, Response: "b", Done: true})
+	})
+	defer teardown()
+
+	body := map[string]any{
+		"model":  "ollama/qwen3:8b",
+		"prompt": "p",
+		"stream": true,
+	}
+	rec := doCompletion(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	chunks := decodeCompletionSSEChunks(t, rec.Body.String())
+	if len(chunks) == 0 {
+		t.Fatalf("no chunks: %q", rec.Body.String())
+	}
+	last := chunks[len(chunks)-1]
+	if last.CompletionID == "" {
+		t.Fatalf("final chunk missing x_completion_id:\n%s", rec.Body.String())
+	}
+	rec2, ok := srv.completionStore.get(last.CompletionID)
+	if !ok {
+		t.Fatalf("completionStore.get(%q) miss; want hit after clean Done", last.CompletionID)
+	}
+	if rec2.Model != "ollama/qwen3:8b" {
+		t.Errorf("record.Model = %q, want ollama/qwen3:8b", rec2.Model)
+	}
+}
+
+// TestCompletions_Streaming_NoStoreRecordWithoutDone verifies that when the
+// provider returns nil without ever sending a Done chunk, no completion
+// record is written. The Task 15 feedback flow depends on a miss in this
+// case (the stream was incomplete — feedback on a lost completion should
+// not find an attribution record).
+func TestCompletions_Streaming_NoStoreRecordWithoutDone(t *testing.T) {
+	srv, teardown := newStreamingCompletionServer(t, func(_ context.Context, req provider.GenerateRequest, fn func(provider.GenerateResponse) error) error {
+		_ = fn(provider.GenerateResponse{Model: req.Model, Response: "partial"})
+		return nil
+	})
+	defer teardown()
+
+	body := map[string]any{
+		"model":  "ollama/qwen3:8b",
+		"prompt": "p",
+		"stream": true,
+	}
+	rec := doCompletion(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	// The handler doesn't expose the generated id on this path, so we assert
+	// the store remained empty — equivalent and stricter.
+	if got := srv.completionStore.list.Len(); got != 0 {
+		t.Errorf("completionStore.list.Len() = %d; want 0 (no Done chunk = no record)", got)
+	}
+}
+
 // TestCompletions_Streaming_ConfidenceOnDoneChunk guards Fix 2 for the Task 13
 // skeptic findings: the streaming CompletionChunk must surface
 // x_completion_id and x_confidence on the final (Done) frame, matching the

--- a/compat/completions_test.go
+++ b/compat/completions_test.go
@@ -1,0 +1,589 @@
+package compat
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// ---------------------------------------------------------------------------
+// Shared fixture helpers
+// ---------------------------------------------------------------------------
+
+// newCompletionFixture returns a Server wired to a provider whose Generate
+// handler records the last request received and replies with the supplied
+// text. The returned pointer to the captured request is updated on every
+// call. Registered model grants CapGenerate|CapInsert via the "insert" runtime
+// capability label so both the generate and FIM branches route successfully.
+func newCompletionFixture(t *testing.T, text string, opts ...Option) (*Server, *provider.GenerateRequest, *int32, func()) {
+	t.Helper()
+	var last provider.GenerateRequest
+	var calls int32
+	mp := &mockProvider{
+		name: "ollama",
+		caps: provider.CapGenerate | provider.CapInsert | provider.CapStream,
+		models: []provider.ModelInfo{
+			// "insert" grants CapGenerate|CapStream|CapInsert; combined with
+			// the catalog entry for qwen3 (completion+tools) the merged
+			// profile satisfies FIM routing requirements.
+			{Name: "qwen3:8b", ContextWindow: 32768, Capabilities: []string{"insert"}},
+		},
+		genFn: func(_ context.Context, req provider.GenerateRequest) (*provider.GenerateResponse, error) {
+			atomic.AddInt32(&calls, 1)
+			last = req
+			return &provider.GenerateResponse{
+				Model:    req.Model,
+				Provider: "ollama",
+				Response: text,
+				Done:     true,
+				Usage: provider.Usage{
+					PromptTokens:     3,
+					CompletionTokens: 5,
+					TotalTokens:      8,
+				},
+			}, nil
+		},
+	}
+	srv, teardown := newTestServer(t, mp, opts...)
+	return srv, &last, &calls, teardown
+}
+
+// doCompletion POSTs a JSON body to /v1/completions and returns the recorder.
+func doCompletion(t *testing.T, srv *Server, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	buf, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/completions", bytes.NewReader(buf))
+	req.Header.Set("Content-Type", "application/json")
+	srv.buildHandler().ServeHTTP(rec, req)
+	return rec
+}
+
+// ---------------------------------------------------------------------------
+// Core paths
+// ---------------------------------------------------------------------------
+
+// TestCompletions_GenerateMode exercises the non-FIM branch: a plain prompt
+// with no suffix yields a "generate" use case and CapGenerate-only required
+// caps. The response must carry the qualified provider/model identifier and
+// a "cmpl_" ID prefix.
+func TestCompletions_GenerateMode(t *testing.T) {
+	srv, last, calls, teardown := newCompletionFixture(t, "hello from mock")
+	defer teardown()
+
+	body := map[string]any{
+		"model":  "ollama/qwen3:8b",
+		"prompt": "finish this",
+	}
+	rec := doCompletion(t, srv, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if got := atomic.LoadInt32(calls); got != 1 {
+		t.Fatalf("provider Generate called %d times, want 1", got)
+	}
+	if last.Prompt != "finish this" {
+		t.Errorf("provider saw prompt = %q, want %q", last.Prompt, "finish this")
+	}
+	if last.Suffix != "" {
+		t.Errorf("provider saw suffix = %q, want empty (generate branch)", last.Suffix)
+	}
+
+	var out CompletionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Object != "text_completion" {
+		t.Errorf("object = %q, want text_completion", out.Object)
+	}
+	if !strings.HasPrefix(out.ID, "cmpl_") {
+		t.Errorf("id = %q, want cmpl_ prefix", out.ID)
+	}
+	if !strings.HasPrefix(out.CompletionID, "cmpl_") {
+		t.Errorf("x_completion_id = %q, want cmpl_ prefix", out.CompletionID)
+	}
+	if out.Model != "ollama/qwen3:8b" {
+		t.Errorf("response.model = %q, want ollama/qwen3:8b (qualified)", out.Model)
+	}
+	if len(out.Choices) != 1 {
+		t.Fatalf("choices = %d, want 1", len(out.Choices))
+	}
+	if out.Choices[0].Text != "hello from mock" {
+		t.Errorf("choices[0].text = %q", out.Choices[0].Text)
+	}
+	if out.Choices[0].FinishReason != "stop" {
+		t.Errorf("choices[0].finish_reason = %q, want stop", out.Choices[0].FinishReason)
+	}
+}
+
+// TestCompletions_FIMMode verifies that a non-empty Suffix triggers the FIM
+// branch: UseCase="fim" and CapGenerate|CapInsert required (we prove the
+// latter indirectly by successful routing to a model that only satisfies
+// the gate when CapInsert is granted). The provider must see the suffix.
+func TestCompletions_FIMMode(t *testing.T) {
+	srv, last, calls, teardown := newCompletionFixture(t, "def foo(): pass")
+	defer teardown()
+
+	body := map[string]any{
+		"model":  "ollama/qwen3:8b",
+		"prompt": "def foo(",
+		"suffix": "\n    return None",
+	}
+	rec := doCompletion(t, srv, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if got := atomic.LoadInt32(calls); got != 1 {
+		t.Fatalf("provider Generate called %d times, want 1", got)
+	}
+	if last.Prompt != "def foo(" {
+		t.Errorf("provider saw prompt = %q", last.Prompt)
+	}
+	if last.Suffix != "\n    return None" {
+		t.Errorf("provider saw suffix = %q, want FIM suffix forwarded", last.Suffix)
+	}
+}
+
+// TestCompletions_FIMBudgetTruncatesBeforeProvider verifies that applyFIMBudget
+// shrinks the prompt BEFORE the provider is invoked when max_tokens is set.
+// Using a 2000-char prompt, a short suffix, and max_tokens=16, the computed
+// budget for qwen3+python is 75% prefix − 10% lang = 65%, so the prefix
+// budget is ~10 tokens (~40 chars). The provider must see a trimmed prompt.
+func TestCompletions_FIMBudgetTruncatesBeforeProvider(t *testing.T) {
+	srv, last, _, teardown := newCompletionFixture(t, "ok")
+	defer teardown()
+
+	longPrompt := strings.Repeat("abcd", 500) // 2000 chars, tail-preserving truncation
+	shortSuffix := "short"
+	body := map[string]any{
+		"model":      "ollama/qwen3:8b",
+		"prompt":     longPrompt,
+		"suffix":     shortSuffix,
+		"max_tokens": 16,
+		"x_language": "python",
+	}
+	rec := doCompletion(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	// Provider should have received a truncated prompt. Exact length depends
+	// on budgetForProfile's rounding; we only assert strictly less than the
+	// original so the test is robust to small budget-policy tweaks.
+	if len(last.Prompt) >= len(longPrompt) {
+		t.Errorf("provider saw prompt of len %d, expected < %d (budget truncation didn't fire)",
+			len(last.Prompt), len(longPrompt))
+	}
+	// Tail-preserving: the LAST character of the original prompt must still
+	// be present after truncation.
+	if !strings.HasSuffix(last.Prompt, "abcd") {
+		t.Errorf("provider saw prompt tail = %q, want tail preserved", last.Prompt[len(last.Prompt)-4:])
+	}
+	// Suffix is shorter than its budget share so it is preserved intact.
+	if last.Suffix != shortSuffix {
+		t.Errorf("provider saw suffix = %q, want %q (short enough to preserve)", last.Suffix, shortSuffix)
+	}
+}
+
+// TestCompletions_PromptAsArray exercises the array-form prompt decoder: the
+// handler must collapse ["first","second"] to its first non-empty element.
+func TestCompletions_PromptAsArray(t *testing.T) {
+	srv, last, _, teardown := newCompletionFixture(t, "ok")
+	defer teardown()
+
+	body := map[string]any{
+		"model":  "ollama/qwen3:8b",
+		"prompt": []string{"first", "second"},
+	}
+	rec := doCompletion(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if last.Prompt != "first" {
+		t.Errorf("provider saw prompt = %q, want first", last.Prompt)
+	}
+}
+
+// TestCompletions_PromptAsString exercises the single-string prompt decoder.
+func TestCompletions_PromptAsString(t *testing.T) {
+	srv, last, _, teardown := newCompletionFixture(t, "ok")
+	defer teardown()
+
+	body := map[string]any{
+		"model":  "ollama/qwen3:8b",
+		"prompt": "solo",
+	}
+	rec := doCompletion(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if last.Prompt != "solo" {
+		t.Errorf("provider saw prompt = %q, want solo", last.Prompt)
+	}
+}
+
+// TestCompletions_StopAsSingleString verifies the shared StopSequences decoder
+// accepts a bare string.
+func TestCompletions_StopAsSingleString(t *testing.T) {
+	srv, last, _, teardown := newCompletionFixture(t, "ok")
+	defer teardown()
+
+	body := map[string]any{
+		"model":  "ollama/qwen3:8b",
+		"prompt": "hi",
+		"stop":   "END",
+	}
+	rec := doCompletion(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if len(last.Options.Stop) != 1 || last.Options.Stop[0] != "END" {
+		t.Errorf("provider saw Options.Stop = %v, want [END]", last.Options.Stop)
+	}
+}
+
+// TestCompletions_DryRunReturnsRouteMetadata verifies that x_dry_run=true
+// short-circuits before the provider is invoked: the handler returns route
+// metadata with empty choice text and the Generate mock is never called.
+func TestCompletions_DryRunReturnsRouteMetadata(t *testing.T) {
+	var calls int32
+	mp := &mockProvider{
+		name: "ollama",
+		caps: provider.CapGenerate | provider.CapInsert | provider.CapStream,
+		models: []provider.ModelInfo{
+			{Name: "qwen3:8b", ContextWindow: 32768, Capabilities: []string{"insert"}},
+		},
+		genFn: func(_ context.Context, _ provider.GenerateRequest) (*provider.GenerateResponse, error) {
+			atomic.AddInt32(&calls, 1)
+			// If this ever runs on a dry-run, we want the test to see it as
+			// a failed assertion — panicking here surfaces cleanly via the
+			// recovery middleware as a 500, making the wrong-behavior loud.
+			panic("provider.Generate called on dry-run path")
+		},
+	}
+	srv, teardown := newTestServer(t, mp)
+	defer teardown()
+
+	body := map[string]any{
+		"model":     "ollama/qwen3:8b",
+		"prompt":    "should not execute",
+		"x_dry_run": true,
+	}
+	rec := doCompletion(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if got := atomic.LoadInt32(&calls); got != 0 {
+		t.Errorf("provider Generate called %d times on dry-run, want 0", got)
+	}
+	var out CompletionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out.Choices) != 1 {
+		t.Fatalf("choices = %d, want 1 (dry-run single empty choice)", len(out.Choices))
+	}
+	if out.Choices[0].Text != "" {
+		t.Errorf("choices[0].text = %q, want empty on dry-run", out.Choices[0].Text)
+	}
+	if out.RouteInfo == nil {
+		t.Fatal("x_route_info missing on dry-run")
+	}
+	if out.RouteInfo.ActualModel != "ollama/qwen3:8b" {
+		t.Errorf("route.actual_model = %q, want ollama/qwen3:8b", out.RouteInfo.ActualModel)
+	}
+	if out.RouteInfo.PlannedModel != out.RouteInfo.ActualModel {
+		t.Errorf("dry-run planned=%q actual=%q, expected equal",
+			out.RouteInfo.PlannedModel, out.RouteInfo.ActualModel)
+	}
+}
+
+// TestCompletions_AffinityKeyForwarded verifies that a request carrying
+// x_affinity_key executes successfully and produces a populated x_route_info
+// block — proving the field was accepted by the handler and the request
+// reached the router. Exact sticky-cache behavior is covered by provider-
+// package tests.
+func TestCompletions_AffinityKeyForwarded(t *testing.T) {
+	srv, _, calls, teardown := newCompletionFixture(t, "ok")
+	defer teardown()
+
+	body := map[string]any{
+		"model":          "ollama/qwen3:8b",
+		"prompt":         "hi",
+		"x_affinity_key": "file.py",
+	}
+	rec := doCompletion(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if got := atomic.LoadInt32(calls); got != 1 {
+		t.Errorf("provider Generate called %d times, want 1", got)
+	}
+	var out CompletionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.RouteInfo == nil {
+		t.Fatal("x_route_info missing; affinity key request should still populate it")
+	}
+}
+
+// TestCompletions_EmptyPromptAndSuffixRejected guards the empty-input
+// validation: a request with no prompt and no suffix is meaningless (nothing
+// to complete) and must fail with a clear 400 rather than propagating to the
+// provider.
+func TestCompletions_EmptyPromptAndSuffixRejected(t *testing.T) {
+	srv, _, _, teardown := newCompletionFixture(t, "n/a")
+	defer teardown()
+
+	body := map[string]any{
+		"model":  "ollama/qwen3:8b",
+		"prompt": "",
+	}
+	rec := doCompletion(t, srv, body)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body=%s", rec.Code, rec.Body.String())
+	}
+	var env errorEnvelope
+	if err := json.NewDecoder(rec.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if env.Error.Code != "empty_prompt" {
+		t.Errorf("error.code = %q, want empty_prompt", env.Error.Code)
+	}
+}
+
+// newCompletionFixtureWithResponse lets the caller shape the GenerateResponse
+// returned by the mock provider. Used for finish_reason tests that need
+// specific usage counts.
+func newCompletionFixtureWithResponse(
+	t *testing.T,
+	build func(provider.GenerateRequest) *provider.GenerateResponse,
+	opts ...Option,
+) (*Server, func()) {
+	t.Helper()
+	mp := &mockProvider{
+		name: "ollama",
+		caps: provider.CapGenerate | provider.CapInsert | provider.CapStream,
+		models: []provider.ModelInfo{
+			{Name: "qwen3:8b", ContextWindow: 32768, Capabilities: []string{"insert"}},
+		},
+		genFn: func(_ context.Context, req provider.GenerateRequest) (*provider.GenerateResponse, error) {
+			return build(req), nil
+		},
+	}
+	srv, teardown := newTestServer(t, mp, opts...)
+	return srv, teardown
+}
+
+// TestCompletions_FinishReasonLength exercises the length-cap branch: when
+// max_tokens was set and the mock's reported CompletionTokens meets the cap,
+// finish_reason must be "length" rather than the default "stop".
+func TestCompletions_FinishReasonLength(t *testing.T) {
+	srv, teardown := newCompletionFixtureWithResponse(t, func(req provider.GenerateRequest) *provider.GenerateResponse {
+		return &provider.GenerateResponse{
+			Model:    req.Model,
+			Provider: "ollama",
+			Response: "truncated",
+			Done:     true,
+			Usage:    provider.Usage{PromptTokens: 3, CompletionTokens: 8, TotalTokens: 11},
+		}
+	})
+	defer teardown()
+
+	body := map[string]any{
+		"model":      "ollama/qwen3:8b",
+		"prompt":     "write a long essay",
+		"max_tokens": 8,
+	}
+	rec := doCompletion(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var out CompletionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Choices[0].FinishReason != "length" {
+		t.Errorf("finish_reason = %q, want length", out.Choices[0].FinishReason)
+	}
+}
+
+// TestCompletions_FinishReasonStop covers the default: usage well under the
+// cap yields finish_reason="stop".
+func TestCompletions_FinishReasonStop(t *testing.T) {
+	srv, teardown := newCompletionFixtureWithResponse(t, func(req provider.GenerateRequest) *provider.GenerateResponse {
+		return &provider.GenerateResponse{
+			Model:    req.Model,
+			Provider: "ollama",
+			Response: "done",
+			Done:     true,
+			Usage:    provider.Usage{PromptTokens: 3, CompletionTokens: 5, TotalTokens: 8},
+		}
+	})
+	defer teardown()
+
+	body := map[string]any{
+		"model":      "ollama/qwen3:8b",
+		"prompt":     "short",
+		"max_tokens": 100,
+	}
+	rec := doCompletion(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var out CompletionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Choices[0].FinishReason != "stop" {
+		t.Errorf("finish_reason = %q, want stop", out.Choices[0].FinishReason)
+	}
+}
+
+// TestCompletions_RequestIDFallback verifies that when the handler is invoked
+// through a path that bypasses requestIDMiddleware, the response ID gets a
+// generated random-hex suffix rather than the bare "cmpl_" string. This also
+// guards against the accidental "cmpl_cmpl_<hex>" double-prefix regression
+// that would arise from reusing fallbackRequestID() (which has its own cmpl_
+// prefix).
+func TestCompletions_RequestIDFallback(t *testing.T) {
+	srv, _, _, teardown := newCompletionFixture(t, "ok")
+	defer teardown()
+
+	// Build a mux directly (no middleware chain) so requestIDMiddleware
+	// never runs.
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST "+srv.basePath+"/completions", srv.handleCompletions)
+
+	body := map[string]any{
+		"model":  "ollama/qwen3:8b",
+		"prompt": "hi",
+	}
+	buf, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/completions", bytes.NewReader(buf))
+	req.Header.Set("Content-Type", "application/json")
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var out CompletionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Exact shape: "cmpl_" + 16 hex chars (8 random bytes).
+	idRE := regexp.MustCompile(`^cmpl_[0-9a-f]{16}$`)
+	if !idRE.MatchString(out.ID) {
+		t.Errorf("id = %q, want match %s", out.ID, idRE)
+	}
+}
+
+// TestCompletions_StreamStubReturns501 pins the current streaming behavior:
+// stream=true yields 501 not_implemented until Task 13 replaces the stub with
+// the real SSE writer. Task 13 will delete this test as it wires in the real
+// streaming path.
+func TestCompletions_StreamStubReturns501(t *testing.T) {
+	srv, _, calls, teardown := newCompletionFixture(t, "ok")
+	defer teardown()
+
+	body := map[string]any{
+		"model":  "ollama/qwen3:8b",
+		"prompt": "hi",
+		"stream": true,
+	}
+	rec := doCompletion(t, srv, body)
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want 501, body=%s", rec.Code, rec.Body.String())
+	}
+	if got := atomic.LoadInt32(calls); got != 0 {
+		t.Errorf("provider Generate called %d times for stream stub, want 0", got)
+	}
+	var env errorEnvelope
+	if err := json.NewDecoder(rec.Body).Decode(&env); err != nil {
+		t.Fatalf("decode 501 body: %v", err)
+	}
+	if env.Error.Code != "not_implemented" {
+		t.Errorf("error.code = %q, want not_implemented", env.Error.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests for helpers
+// ---------------------------------------------------------------------------
+
+func TestPromptUnion_UnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"array", `["a","b"]`, []string{"a", "b"}},
+		{"single", `"solo"`, []string{"solo"}},
+		{"empty-string", `""`, nil},
+		{"null", `null`, nil},
+		{"array-with-empties", `["", "b", ""]`, []string{"b"}},
+		{"array-all-empty", `[""]`, nil},
+		{"array-empty", `[]`, nil},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var p PromptUnion
+			if err := json.Unmarshal([]byte(tc.in), &p); err != nil {
+				t.Fatalf("unmarshal %q: %v", tc.in, err)
+			}
+			if !equalStrings([]string(p), tc.want) {
+				t.Errorf("got %v, want %v", []string(p), tc.want)
+			}
+		})
+	}
+}
+
+func TestPromptUnion_UnmarshalJSON_Invalid(t *testing.T) {
+	var p PromptUnion
+	err := json.Unmarshal([]byte(`123`), &p)
+	if err == nil {
+		t.Fatal("want error on numeric input")
+	}
+	if !strings.Contains(err.Error(), "prompt must be string or") {
+		t.Errorf("error = %v, want message about string or []string", err)
+	}
+}
+
+func TestPromptUnion_String(t *testing.T) {
+	cases := []struct {
+		name string
+		p    PromptUnion
+		want string
+	}{
+		{"empty", nil, ""},
+		{"single", PromptUnion{"solo"}, "solo"},
+		{"first non-empty", PromptUnion{"", "", "third"}, "third"},
+		{"all empty", PromptUnion{"", ""}, ""},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.p.String(); got != tc.want {
+				t.Errorf("String() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/compat/completions_test.go
+++ b/compat/completions_test.go
@@ -812,6 +812,92 @@ func TestCompletions_Streaming_ModelQualified(t *testing.T) {
 	}
 }
 
+// TestCompletions_Streaming_NoDoneChunkSkipsDONE guards Fix 1 for the Task 13
+// skeptic findings: when ExecuteGenerateStream returns nil (no error) but the
+// provider never sent a chunk with Done=true, the handler must NOT emit
+// "data: [DONE]". The sentinel is OpenAI's success signal — emitting it when
+// the stream was never cleanly terminated makes SDKs silently report success
+// on a truncated response. Withholding the sentinel preserves the wire-level
+// premature-EOS signal clients depend on.
+func TestCompletions_Streaming_NoDoneChunkSkipsDONE(t *testing.T) {
+	srv, teardown := newStreamingCompletionServer(t, func(_ context.Context, req provider.GenerateRequest, fn func(provider.GenerateResponse) error) error {
+		// Clean return but the provider never set Done=true.
+		_ = fn(provider.GenerateResponse{Model: req.Model, Response: "partial"})
+		return nil
+	})
+	defer teardown()
+
+	body := map[string]any{
+		"model":  "ollama/qwen3:8b",
+		"prompt": "p",
+		"stream": true,
+	}
+	rec := doCompletion(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	text := rec.Body.String()
+	if !strings.Contains(text, `"text":"partial"`) {
+		t.Errorf("body missing first chunk payload: %q", text)
+	}
+	if strings.Contains(text, "data: [DONE]") {
+		t.Errorf("emitted [DONE] despite provider never sending Done chunk:\n%s", text)
+	}
+}
+
+// TestCompletions_Streaming_ConfidenceOnDoneChunk guards Fix 2 for the Task 13
+// skeptic findings: the streaming CompletionChunk must surface
+// x_completion_id and x_confidence on the final (Done) frame, matching the
+// non-streaming CompletionResponse. Interim frames must not carry either
+// (omitempty + nil pointer).
+func TestCompletions_Streaming_ConfidenceOnDoneChunk(t *testing.T) {
+	score := 0.87
+	srv, teardown := newStreamingCompletionServer(t, func(_ context.Context, req provider.GenerateRequest, fn func(provider.GenerateResponse) error) error {
+		if err := fn(provider.GenerateResponse{Model: req.Model, Response: "a"}); err != nil {
+			return err
+		}
+		return fn(provider.GenerateResponse{
+			Model:      req.Model,
+			Response:   "b",
+			Done:       true,
+			Confidence: &provider.CompletionConfidence{Score: score},
+		})
+	})
+	defer teardown()
+
+	body := map[string]any{
+		"model":  "ollama/qwen3:8b",
+		"prompt": "p",
+		"stream": true,
+	}
+	rec := doCompletion(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	chunks := decodeCompletionSSEChunks(t, rec.Body.String())
+	if len(chunks) < 2 {
+		t.Fatalf("want >=2 chunks, got %d: %q", len(chunks), rec.Body.String())
+	}
+	// Interim chunk must NOT carry extensions — omitempty + nil pointer keeps
+	// the wire frame minimal.
+	if chunks[0].Confidence != nil {
+		t.Errorf("interim chunk carried confidence: %v", *chunks[0].Confidence)
+	}
+	if chunks[0].CompletionID != "" {
+		t.Errorf("interim chunk carried x_completion_id: %q", chunks[0].CompletionID)
+	}
+	last := chunks[len(chunks)-1]
+	if last.Confidence == nil {
+		t.Fatalf("done chunk missing x_confidence:\n%s", rec.Body.String())
+	}
+	if *last.Confidence != score {
+		t.Errorf("confidence = %v, want %v", *last.Confidence, score)
+	}
+	if last.CompletionID == "" {
+		t.Error("done chunk missing x_completion_id")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Unit tests for helpers
 // ---------------------------------------------------------------------------

--- a/compat/completions_test.go
+++ b/compat/completions_test.go
@@ -567,6 +567,163 @@ func TestPromptUnion_UnmarshalJSON_Invalid(t *testing.T) {
 	}
 }
 
+// TestCompletions_FIMBudgetZeroPrefixPreservesOriginal guards against a
+// regression where applyFIMBudget silently emptied the FIM prefix when
+// budgetForProfile returned a zero prefix budget (e.g. max_tokens=1): the old
+// code computed keepChars=0 and sliced prompt[len(prompt)-0:] -> "". The fix
+// preserves the original prefix and logs a breadcrumb.
+func TestCompletions_FIMBudgetZeroPrefixPreservesOriginal(t *testing.T) {
+	var seenPrompt, seenSuffix string
+	mp := &mockProvider{
+		name: "ollama",
+		caps: provider.CapGenerate | provider.CapInsert | provider.CapStream,
+		models: []provider.ModelInfo{
+			{Name: "qwen3:8b", ContextWindow: 32768, Capabilities: []string{"insert"}},
+		},
+		genFn: func(_ context.Context, req provider.GenerateRequest) (*provider.GenerateResponse, error) {
+			seenPrompt = req.Prompt
+			seenSuffix = req.Suffix
+			return &provider.GenerateResponse{Model: req.Model, Provider: "ollama", Response: "ok", Done: true}, nil
+		},
+	}
+	srv, teardown := newTestServer(t, mp)
+	defer teardown()
+
+	longPrefix := strings.Repeat("A", 400)
+	body := `{"model":"ollama/qwen3:8b","prompt":"` + longPrefix + `","suffix":"B","max_tokens":1,"x_language":"python"}`
+	rec := httptest.NewRecorder()
+	srv.buildHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/completions", strings.NewReader(body)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if seenPrompt == "" {
+		t.Fatal("provider received empty prompt — budget truncated to zero silently")
+	}
+	if seenSuffix == "" {
+		t.Fatal("provider received empty suffix")
+	}
+}
+
+// TestCompletions_StopFiltersEmptyStrings covers the toModelOptions fix:
+// {"stop": ""} and {"stop": ["",""]} must not forward "" to the provider,
+// which Ollama interprets as "stop immediately" and silently truncates
+// generation.
+func TestCompletions_StopFiltersEmptyStrings(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"stop_as_empty_string", `{"model":"ollama/qwen3:8b","prompt":"p","stop":""}`},
+		{"stop_as_array_of_empty", `{"model":"ollama/qwen3:8b","prompt":"p","stop":["",""]}`},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var seenStop []string
+			mp := &mockProvider{
+				name: "ollama",
+				caps: provider.CapGenerate | provider.CapStream,
+				models: []provider.ModelInfo{
+					{Name: "qwen3:8b", ContextWindow: 32768},
+				},
+				genFn: func(_ context.Context, req provider.GenerateRequest) (*provider.GenerateResponse, error) {
+					seenStop = req.Options.Stop
+					return &provider.GenerateResponse{Model: req.Model, Provider: "ollama", Response: "x", Done: true}, nil
+				},
+			}
+			srv, teardown := newTestServer(t, mp)
+			defer teardown()
+			rec := httptest.NewRecorder()
+			srv.buildHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/completions", strings.NewReader(tc.body)))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+			}
+			if len(seenStop) != 0 {
+				t.Errorf("provider received non-empty Stop after empty-only filter: %+v", seenStop)
+			}
+		})
+	}
+}
+
+// TestCompletions_FIMDryRunDoesNotTruncate verifies that applyFIMBudget runs
+// AFTER the dry-run short-circuit: on a dry-run, the mutation is skipped
+// entirely (the provider never executes) and the metadata-only response
+// carries an empty choice.
+func TestCompletions_FIMDryRunDoesNotTruncate(t *testing.T) {
+	var called int32
+	mp := &mockProvider{
+		name: "ollama",
+		caps: provider.CapGenerate | provider.CapInsert | provider.CapStream,
+		models: []provider.ModelInfo{
+			{Name: "qwen3:8b", ContextWindow: 32768, Capabilities: []string{"insert"}},
+		},
+		genFn: func(context.Context, provider.GenerateRequest) (*provider.GenerateResponse, error) {
+			atomic.AddInt32(&called, 1)
+			return nil, nil
+		},
+	}
+	srv, teardown := newTestServer(t, mp)
+	defer teardown()
+	long := strings.Repeat("A", 2000)
+	body := `{"model":"ollama/qwen3:8b","prompt":"` + long + `","suffix":"x","max_tokens":4,"x_dry_run":true}`
+	rec := httptest.NewRecorder()
+	srv.buildHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/completions", strings.NewReader(body)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if got := atomic.LoadInt32(&called); got != 0 {
+		t.Fatalf("provider invoked on dry-run (calls=%d)", got)
+	}
+	var resp CompletionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.RouteInfo == nil {
+		t.Fatal("dry-run missing route info")
+	}
+	// Sanity: dry-run should not itself write generated text.
+	if len(resp.Choices) != 1 || resp.Choices[0].Text != "" {
+		t.Errorf("dry-run emitted non-empty text: %+v", resp.Choices)
+	}
+}
+
+// TestCompletions_DryRunReportsWasSticky verifies that writeCompletionDryRun
+// surfaces RoutePlan.WasSticky() on the wire. The handler-level integration
+// path (Router.Route with req.DryRun=true) deliberately bypasses the sticky
+// cache in the Router (see router.go step 6: `req.AffinityKey != "" && !req.DryRun`),
+// so integration testing is not possible today. We test the wire-shape
+// responsibility of the compat layer directly: given a plan whose
+// SetWasSticky(true) was called, writeCompletionDryRun must populate
+// RouteInfo.WasSticky. Without the accessor+field wiring this fix added,
+// RouteInfo.WasSticky would always be false regardless of plan state.
+func TestCompletions_DryRunReportsWasSticky(t *testing.T) {
+	key := provider.ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+	plan := &provider.RoutePlan{
+		Profile: &provider.ModelProfile{Key: key, Family: "qwen3"},
+		Score:   0.75,
+		Reason:  "test",
+	}
+	plan.SetWasSticky(true)
+
+	rec := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/v1/completions", nil)
+	writeCompletionDryRun(rec, r, plan)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp CompletionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.RouteInfo == nil {
+		t.Fatal("dry-run missing route info")
+	}
+	if !resp.RouteInfo.WasSticky {
+		t.Errorf("expected WasSticky=true, got RouteInfo=%+v", resp.RouteInfo)
+	}
+}
+
 func TestPromptUnion_String(t *testing.T) {
 	cases := []struct {
 		name string

--- a/compat/completions_test.go
+++ b/compat/completions_test.go
@@ -337,6 +337,47 @@ func TestCompletions_DryRunReturnsRouteMetadata(t *testing.T) {
 	}
 }
 
+func TestCompletions_DryRunWinsOverStream(t *testing.T) {
+	var calls int32
+	mp := &mockProvider{
+		name: "ollama",
+		caps: provider.CapGenerate | provider.CapInsert | provider.CapStream,
+		models: []provider.ModelInfo{
+			{Name: "qwen3:8b", ContextWindow: 32768, Capabilities: []string{"insert"}},
+		},
+		genFn: func(_ context.Context, _ provider.GenerateRequest) (*provider.GenerateResponse, error) {
+			atomic.AddInt32(&calls, 1)
+			panic("provider.Generate called on stream dry-run path")
+		},
+	}
+	srv, teardown := newTestServer(t, mp)
+	defer teardown()
+
+	body := map[string]any{
+		"model":     "ollama/qwen3:8b",
+		"prompt":    "should not execute",
+		"stream":    true,
+		"x_dry_run": true,
+	}
+	rec := doCompletion(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if got := atomic.LoadInt32(&calls); got != 0 {
+		t.Errorf("provider Generate called %d times on stream dry-run, want 0", got)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("content-type = %q, want application/json", got)
+	}
+	var out CompletionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.RouteInfo == nil {
+		t.Fatal("x_route_info missing on stream dry-run")
+	}
+}
+
 // TestCompletions_AffinityKeyForwarded verifies that a request carrying
 // x_affinity_key executes successfully and produces a populated x_route_info
 // block — proving the field was accepted by the handler and the request

--- a/compat/completions_test.go
+++ b/compat/completions_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -495,12 +496,170 @@ func TestCompletions_RequestIDFallback(t *testing.T) {
 	}
 }
 
-// TestCompletions_StreamStubReturns501 pins the current streaming behavior:
-// stream=true yields 501 not_implemented until Task 13 replaces the stub with
-// the real SSE writer. Task 13 will delete this test as it wires in the real
-// streaming path.
-func TestCompletions_StreamStubReturns501(t *testing.T) {
-	srv, _, calls, teardown := newCompletionFixture(t, "ok")
+// ---------------------------------------------------------------------------
+// Streaming path
+// ---------------------------------------------------------------------------
+
+// newStreamingCompletionServer wires a server whose provider scripts
+// GenerateStream directly. The `build` callback lets each test drive its own
+// chunk sequence. The registered model grants CapGenerate|CapInsert|CapStream
+// so both generate and FIM streaming routes resolve.
+func newStreamingCompletionServer(
+	t *testing.T,
+	build func(ctx context.Context, req provider.GenerateRequest, fn func(provider.GenerateResponse) error) error,
+	opts ...Option,
+) (*Server, func()) {
+	t.Helper()
+	mp := &mockProvider{
+		name: "ollama",
+		caps: provider.CapGenerate | provider.CapInsert | provider.CapStream,
+		models: []provider.ModelInfo{
+			{Name: "qwen3:8b", ContextWindow: 32768, Capabilities: []string{"insert"}},
+		},
+		genStreamFn: build,
+	}
+	return newTestServer(t, mp, opts...)
+}
+
+// decodeCompletionSSEChunks parses an SSE body into individual CompletionChunk
+// payloads. It skips the [DONE] sentinel and any non-"data:" lines.
+func decodeCompletionSSEChunks(t *testing.T, body string) []CompletionChunk {
+	t.Helper()
+	var chunks []CompletionChunk
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		payload := strings.TrimPrefix(line, "data: ")
+		if payload == "[DONE]" {
+			continue
+		}
+		var c CompletionChunk
+		if err := json.Unmarshal([]byte(payload), &c); err != nil {
+			t.Fatalf("decode chunk %q: %v", payload, err)
+		}
+		chunks = append(chunks, c)
+	}
+	return chunks
+}
+
+// TestCompletions_Streaming exercises the happy path: two chunks "4" then "2"
+// from the provider (the second with Done=true) produce two SSE events
+// followed by "data: [DONE]". The first chunk must carry text="4" with no
+// finish_reason, the second must carry text="2" and finish_reason="stop".
+func TestCompletions_Streaming(t *testing.T) {
+	srv, teardown := newStreamingCompletionServer(t, func(_ context.Context, req provider.GenerateRequest, fn func(provider.GenerateResponse) error) error {
+		if err := fn(provider.GenerateResponse{Model: req.Model, Response: "4"}); err != nil {
+			return err
+		}
+		return fn(provider.GenerateResponse{Model: req.Model, Response: "2", Done: true})
+	})
+	defer teardown()
+
+	body := map[string]any{
+		"model":  "ollama/qwen3:8b",
+		"prompt": "what is 4+38?",
+		"stream": true,
+	}
+	rec := doCompletion(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("content-type = %q, want text/event-stream", ct)
+	}
+	text := rec.Body.String()
+	if !strings.HasSuffix(text, "data: [DONE]\n\n") {
+		t.Errorf("missing DONE sentinel: %q", text)
+	}
+	if !strings.Contains(text, `"text":"4"`) {
+		t.Errorf("first chunk text %q not found in body: %q", "4", text)
+	}
+	if !strings.Contains(text, `"text":"2"`) {
+		t.Errorf("second chunk text %q not found in body: %q", "2", text)
+	}
+
+	chunks := decodeCompletionSSEChunks(t, text)
+	if len(chunks) != 2 {
+		t.Fatalf("got %d chunks, want 2: %q", len(chunks), text)
+	}
+	c0 := chunks[0]
+	if c0.Object != "text_completion" {
+		t.Errorf("chunk[0].object = %q, want text_completion", c0.Object)
+	}
+	if !strings.HasPrefix(c0.ID, "cmpl_") {
+		t.Errorf("chunk[0].id = %q, want cmpl_ prefix", c0.ID)
+	}
+	if c0.Model != "ollama/qwen3:8b" {
+		t.Errorf("chunk[0].model = %q, want ollama/qwen3:8b (qualified)", c0.Model)
+	}
+	if len(c0.Choices) != 1 {
+		t.Fatalf("chunk[0].choices = %d", len(c0.Choices))
+	}
+	if c0.Choices[0].Text != "4" {
+		t.Errorf("chunk[0].text = %q, want 4", c0.Choices[0].Text)
+	}
+	if c0.Choices[0].FinishReason != nil {
+		t.Errorf("chunk[0].finish_reason = %v, want nil", *c0.Choices[0].FinishReason)
+	}
+	c1 := chunks[1]
+	if c1.Choices[0].Text != "2" {
+		t.Errorf("chunk[1].text = %q, want 2", c1.Choices[0].Text)
+	}
+	if c1.Choices[0].FinishReason == nil || *c1.Choices[0].FinishReason != "stop" {
+		t.Errorf("chunk[1].finish_reason = %v, want stop", c1.Choices[0].FinishReason)
+	}
+	if c1.Model != "ollama/qwen3:8b" {
+		t.Errorf("chunk[1].model = %q, want ollama/qwen3:8b (qualified)", c1.Model)
+	}
+}
+
+// TestCompletions_Streaming_FinishReasonLength covers the length-cap branch of
+// streaming finish_reason derivation: max_tokens=8 and usage reporting
+// CompletionTokens=8 on the Done chunk must yield "length".
+func TestCompletions_Streaming_FinishReasonLength(t *testing.T) {
+	srv, teardown := newStreamingCompletionServer(t, func(_ context.Context, req provider.GenerateRequest, fn func(provider.GenerateResponse) error) error {
+		return fn(provider.GenerateResponse{
+			Model:    req.Model,
+			Response: "truncated",
+			Done:     true,
+			Usage:    provider.Usage{PromptTokens: 3, CompletionTokens: 8, TotalTokens: 11},
+		})
+	})
+	defer teardown()
+
+	body := map[string]any{
+		"model":      "ollama/qwen3:8b",
+		"prompt":     "write a long essay",
+		"stream":     true,
+		"max_tokens": 8,
+	}
+	rec := doCompletion(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	chunks := decodeCompletionSSEChunks(t, rec.Body.String())
+	if len(chunks) != 1 {
+		t.Fatalf("got %d chunks, want 1", len(chunks))
+	}
+	final := chunks[0]
+	if final.Choices[0].FinishReason == nil || *final.Choices[0].FinishReason != "length" {
+		t.Errorf("finish_reason = %v, want length", final.Choices[0].FinishReason)
+	}
+}
+
+// TestCompletions_Streaming_ErrorBeforeFirstChunk verifies the lazy-start
+// guarantee: when the provider's GenerateStream fails before invoking fn even
+// once, the client sees a normal JSON error envelope (not a partial SSE
+// stream). The status is 502 because an unclassified provider error maps
+// through statusForCompatError to upstream_error.
+func TestCompletions_Streaming_ErrorBeforeFirstChunk(t *testing.T) {
+	wantErr := errors.New("synthetic upstream failure")
+	srv, teardown := newStreamingCompletionServer(t, func(_ context.Context, _ provider.GenerateRequest, _ func(provider.GenerateResponse) error) error {
+		// Never invoke fn — fail immediately. The SSE writer's lazy-start
+		// means no "data: ..." bytes have been committed yet.
+		return wantErr
+	})
 	defer teardown()
 
 	body := map[string]any{
@@ -509,18 +668,147 @@ func TestCompletions_StreamStubReturns501(t *testing.T) {
 		"stream": true,
 	}
 	rec := doCompletion(t, srv, body)
-	if rec.Code != http.StatusNotImplemented {
-		t.Fatalf("status = %d, want 501, body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502, body=%s", rec.Code, rec.Body.String())
 	}
-	if got := atomic.LoadInt32(calls); got != 0 {
-		t.Errorf("provider Generate called %d times for stream stub, want 0", got)
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("content-type = %q, want application/json (JSON error envelope)", ct)
+	}
+	if strings.Contains(rec.Body.String(), "data:") {
+		t.Errorf("body unexpectedly contains SSE data line: %q", rec.Body.String())
 	}
 	var env errorEnvelope
 	if err := json.NewDecoder(rec.Body).Decode(&env); err != nil {
-		t.Fatalf("decode 501 body: %v", err)
+		t.Fatalf("decode error envelope: %v", err)
 	}
-	if env.Error.Code != "not_implemented" {
-		t.Errorf("error.code = %q, want not_implemented", env.Error.Code)
+	if env.Error.Code != "upstream_error" {
+		t.Errorf("error.code = %q, want upstream_error", env.Error.Code)
+	}
+}
+
+// TestCompletions_Streaming_ErrorAfterFirstChunk guards the HIGH-severity
+// silent-truncation fix: when the provider emits one chunk successfully then
+// fails mid-stream (non-cancellation error), the handler MUST NOT emit
+// "data: [DONE]". The [DONE] sentinel is OpenAI's success signal — emitting
+// it under error conditions silently masks the truncation. Its absence lets
+// OpenAI SDKs detect premature EOS.
+func TestCompletions_Streaming_ErrorAfterFirstChunk(t *testing.T) {
+	srv, teardown := newStreamingCompletionServer(t, func(_ context.Context, req provider.GenerateRequest, fn func(provider.GenerateResponse) error) error {
+		if err := fn(provider.GenerateResponse{Model: req.Model, Response: "partial"}); err != nil {
+			return err
+		}
+		return errors.New("upstream collapsed")
+	})
+	defer teardown()
+
+	body := map[string]any{
+		"model":  "ollama/qwen3:8b",
+		"prompt": "hi",
+		"stream": true,
+	}
+	rec := doCompletion(t, srv, body)
+
+	// Status 200 + event-stream headers are committed because the first chunk
+	// was written successfully. The error occurs after commit.
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (headers committed on first chunk), body=%s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("content-type = %q, want text/event-stream", ct)
+	}
+
+	text := rec.Body.String()
+	if !strings.Contains(text, `"text":"partial"`) {
+		t.Errorf("body missing first chunk payload: %q", text)
+	}
+	// Critical assertion: no [DONE] sentinel. Its absence is the wire-level
+	// signal of premature EOS that clients rely on.
+	if strings.Contains(text, "data: [DONE]") {
+		t.Errorf("body unexpectedly contains data: [DONE] after mid-stream error: %q", text)
+	}
+}
+
+// TestCompletions_Streaming_ClientDisconnect verifies the handler returns
+// cleanly when the caller's context is canceled mid-stream (IDE closing the
+// completion, e.g., on the next keystroke). The semaphore slot must be
+// released so subsequent requests are not blocked — we probe this by
+// acquiring a fresh slot after the handler returns with MaxConcurrency=1.
+func TestCompletions_Streaming_ClientDisconnect(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv, teardown := newStreamingCompletionServer(t, func(_ context.Context, req provider.GenerateRequest, fn func(provider.GenerateResponse) error) error {
+		// Emit one chunk, then cancel the request context and return the
+		// cancellation error — simulating a client disconnect detected by the
+		// provider after it had already pushed a chunk.
+		if err := fn(provider.GenerateResponse{Model: req.Model, Response: "tick"}); err != nil {
+			return err
+		}
+		cancel()
+		return context.Canceled
+	}, WithMaxConcurrency(1))
+	defer teardown()
+
+	buf, err := json.Marshal(map[string]any{
+		"model":  "ollama/qwen3:8b",
+		"prompt": "hi",
+		"stream": true,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/completions", bytes.NewReader(buf)).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+
+	// Should not panic and should return (not hang).
+	srv.buildHandler().ServeHTTP(rec, req)
+
+	text := rec.Body.String()
+	if !strings.Contains(text, `"text":"tick"`) {
+		t.Errorf("body missing first chunk: %q", text)
+	}
+	if strings.Contains(text, "data: [DONE]") {
+		t.Errorf("body contains data: [DONE] after cancellation: %q", text)
+	}
+
+	// Probe semaphore release: with max concurrency 1, we must be able to
+	// acquire a fresh slot now that the handler has returned.
+	release, ok := srv.semaphore.acquire(provider.PriorityNormal)
+	if !ok {
+		t.Fatal("semaphore slot not released after client-disconnect — handler leaked a slot")
+	}
+	release()
+}
+
+// TestCompletions_Streaming_ModelQualified verifies that every streaming
+// chunk carries the qualified "provider/model" form in the Model field,
+// matching the non-streaming branch's plan.Profile.Key.String() convention.
+// The provider returns a bare model name (the realistic Ollama shape); the
+// compat layer must upgrade it to the qualified form.
+func TestCompletions_Streaming_ModelQualified(t *testing.T) {
+	srv, teardown := newStreamingCompletionServer(t, func(_ context.Context, req provider.GenerateRequest, fn func(provider.GenerateResponse) error) error {
+		return fn(provider.GenerateResponse{Model: req.Model, Response: "ok", Done: true})
+	})
+	defer teardown()
+
+	body := map[string]any{
+		"model":  "ollama/qwen3:8b",
+		"prompt": "hi",
+		"stream": true,
+	}
+	rec := doCompletion(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	chunks := decodeCompletionSSEChunks(t, rec.Body.String())
+	if len(chunks) == 0 {
+		t.Fatalf("no chunks: %q", rec.Body.String())
+	}
+	for i, c := range chunks {
+		if c.Model != "ollama/qwen3:8b" {
+			t.Errorf("chunk[%d].model = %q, want ollama/qwen3:8b (qualified)", i, c.Model)
+		}
 	}
 }
 

--- a/compat/completions_test.go
+++ b/compat/completions_test.go
@@ -456,10 +456,9 @@ func TestCompletions_FinishReasonStop(t *testing.T) {
 
 // TestCompletions_RequestIDFallback verifies that when the handler is invoked
 // through a path that bypasses requestIDMiddleware, the response ID gets a
-// generated random-hex suffix rather than the bare "cmpl_" string. This also
-// guards against the accidental "cmpl_cmpl_<hex>" double-prefix regression
-// that would arise from reusing fallbackRequestID() (which has its own cmpl_
-// prefix).
+// generated random-hex suffix rather than the bare "cmpl_" string. The regex
+// also pins the exact "cmpl_<16 hex>" shape so a future change to
+// fallbackRequestID that reintroduces a prefix would break the assertion.
 func TestCompletions_RequestIDFallback(t *testing.T) {
 	srv, _, _, teardown := newCompletionFixture(t, "ok")
 	defer teardown()

--- a/compat/concurrency.go
+++ b/compat/concurrency.go
@@ -1,0 +1,60 @@
+package compat
+
+import "github.com/kstruzzieri/go-llm/provider"
+
+// reserveFor returns the general-pool size and the high-priority reserve size
+// for a requested max concurrency. The total is always equal to the input
+// (clamped to >= 1) so the global cap stays honest.
+//
+//	n <= 1:  (1, 0)      minimum viable concurrency, no reserve
+//	2 <= n <= 3: (n, 0)  small caps do not reserve (reserve would starve general)
+//	n >= 4:  (n-1, 1)    one slot reserved for PriorityHigh/PriorityCritical
+func reserveFor(n int) (general, reserved int) {
+	if n < 1 {
+		n = 1
+	}
+	switch {
+	case n == 1:
+		return 1, 0
+	case n < 4:
+		return n, 0
+	default:
+		return n - 1, 1
+	}
+}
+
+// semaphore bounds concurrent request execution. It keeps a general pool for
+// all requests and an optional reserve pool only usable by PriorityHigh and
+// PriorityCritical. High-priority requests try the general pool first and
+// only tap the reserve when the general pool is full.
+type semaphore struct {
+	general chan struct{}
+	reserve chan struct{}
+}
+
+func newSemaphore(max int) *semaphore {
+	gen, res := reserveFor(max)
+	return &semaphore{
+		general: make(chan struct{}, gen),
+		reserve: make(chan struct{}, res),
+	}
+}
+
+// acquire reserves a slot for the given priority. Returns a release func
+// and true on success; if the pool is full it returns nil, false immediately
+// without blocking. Callers convert false into 429 Too Many Requests.
+func (s *semaphore) acquire(p provider.Priority) (release func(), ok bool) {
+	select {
+	case s.general <- struct{}{}:
+		return func() { <-s.general }, true
+	default:
+	}
+	if p >= provider.PriorityHigh && cap(s.reserve) > 0 {
+		select {
+		case s.reserve <- struct{}{}:
+			return func() { <-s.reserve }, true
+		default:
+		}
+	}
+	return nil, false
+}

--- a/compat/concurrency_test.go
+++ b/compat/concurrency_test.go
@@ -1,0 +1,125 @@
+package compat
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+func TestReserveFor(t *testing.T) {
+	cases := []struct {
+		in                   int
+		wantGen, wantReserve int
+	}{
+		{0, 1, 0},
+		{1, 1, 0},
+		{2, 2, 0},
+		{3, 3, 0},
+		{4, 3, 1},
+		{8, 7, 1},
+		{100, 99, 1},
+	}
+	for _, tc := range cases {
+		gen, res := reserveFor(tc.in)
+		if gen != tc.wantGen || res != tc.wantReserve {
+			t.Errorf("reserveFor(%d) = (%d, %d), want (%d, %d)",
+				tc.in, gen, res, tc.wantGen, tc.wantReserve)
+		}
+	}
+}
+
+func TestSemaphore_AcquireRelease(t *testing.T) {
+	sem := newSemaphore(2)
+	r1, ok := sem.acquire(provider.PriorityNormal)
+	if !ok {
+		t.Fatal("acquire 1 failed")
+	}
+	r2, ok := sem.acquire(provider.PriorityNormal)
+	if !ok {
+		t.Fatal("acquire 2 failed")
+	}
+	if _, ok := sem.acquire(provider.PriorityNormal); ok {
+		t.Fatal("acquire 3 must fail (cap=2)")
+	}
+	r1()
+	if _, ok := sem.acquire(provider.PriorityNormal); !ok {
+		t.Fatal("acquire after release must succeed")
+	}
+	r2()
+}
+
+func TestSemaphore_HighPriorityUsesReserve(t *testing.T) {
+	// cap=4 -> general=3, reserve=1.
+	sem := newSemaphore(4)
+
+	// Fill the general pool with normal requests.
+	releases := make([]func(), 0, 3)
+	for i := 0; i < 3; i++ {
+		r, ok := sem.acquire(provider.PriorityNormal)
+		if !ok {
+			t.Fatalf("acquire normal %d failed", i)
+		}
+		releases = append(releases, r)
+	}
+	// Normal request blocks.
+	if _, ok := sem.acquire(provider.PriorityNormal); ok {
+		t.Fatal("normal must be blocked once general pool is full")
+	}
+	// High-priority still fits in the reserve.
+	rHigh, ok := sem.acquire(provider.PriorityHigh)
+	if !ok {
+		t.Fatal("PriorityHigh must use reserve lane")
+	}
+	// Now every slot is taken.
+	if _, ok := sem.acquire(provider.PriorityHigh); ok {
+		t.Fatal("second high must be blocked (reserve=1)")
+	}
+	rHigh()
+	for _, r := range releases {
+		r()
+	}
+}
+
+func TestSemaphore_HighPriorityFallsBackToGeneralWhenReserveZero(t *testing.T) {
+	// cap=2 -> general=2, reserve=0.
+	sem := newSemaphore(2)
+	r1, ok := sem.acquire(provider.PriorityHigh)
+	if !ok {
+		t.Fatal("high must acquire general slot when reserve=0")
+	}
+	r2, ok := sem.acquire(provider.PriorityHigh)
+	if !ok {
+		t.Fatal("high must acquire second general slot when reserve=0")
+	}
+	if _, ok := sem.acquire(provider.PriorityHigh); ok {
+		t.Fatal("third high must fail (cap=2)")
+	}
+	r1()
+	r2()
+}
+
+func TestSemaphore_Concurrent(t *testing.T) {
+	sem := newSemaphore(4)
+	var wg sync.WaitGroup
+	var acquired int
+	var mu sync.Mutex
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if release, ok := sem.acquire(provider.PriorityNormal); ok {
+				mu.Lock()
+				acquired++
+				mu.Unlock()
+				time.Sleep(10 * time.Millisecond)
+				release()
+			}
+		}()
+	}
+	wg.Wait()
+	if acquired == 0 {
+		t.Fatal("no acquisitions succeeded")
+	}
+}

--- a/compat/doc.go
+++ b/compat/doc.go
@@ -2,11 +2,14 @@
 // API. Consumers such as Cursor, Continue.dev, Aider, and llama.cpp clients
 // can point at a compat.Server instance and use it as a drop-in OpenAI
 // backend. Request/response wire format matches OpenAI; go-llm-specific
-// metadata is carried on x_ prefixed extension fields that standard OpenAI
+// metadata is carried on x_-prefixed extension fields that standard OpenAI
 // SDKs ignore.
 //
 // Usage:
 //
+//	// provReg is a *provider.Registry holding registered providers; modelReg
+//	// is a *provider.ModelRegistry built from models.json. See package
+//	// provider for construction.
 //	router := provider.NewRouter(modelReg, provReg)
 //	srv := compat.New(router, modelReg, provReg,
 //	    compat.WithAddr("127.0.0.1:18741"),

--- a/compat/doc.go
+++ b/compat/doc.go
@@ -1,0 +1,17 @@
+// Package compat exposes provider.Router over an OpenAI-compatible HTTP REST
+// API. Consumers such as Cursor, Continue.dev, Aider, and llama.cpp clients
+// can point at a compat.Server instance and use it as a drop-in OpenAI
+// backend. Request/response wire format matches OpenAI; go-llm-specific
+// metadata is carried on x_ prefixed extension fields that standard OpenAI
+// SDKs ignore.
+//
+// Usage:
+//
+//	router := provider.NewRouter(modelReg, provReg)
+//	srv := compat.New(router, modelReg, provReg,
+//	    compat.WithAddr("127.0.0.1:18741"),
+//	    compat.WithMaxConcurrency(8),
+//	)
+//	defer srv.Close()
+//	go srv.ListenAndServe(ctx)
+package compat

--- a/compat/embeddings.go
+++ b/compat/embeddings.go
@@ -4,13 +4,27 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
+	"strings"
 
 	"github.com/kstruzzieri/go-llm/provider"
 )
 
+// maxEmbeddingInputs caps the number of per-request inputs we accept. The
+// router's token-budget path fans out across every element, so an unbounded
+// array lets a single caller monopolize provider capacity. 2048 matches the
+// OpenAI embeddings batch limit and is well below any reasonable memory
+// threshold for the collected vector slice.
+const maxEmbeddingInputs = 2048
+
 // EmbeddingRequest is the OpenAI-shape embedding request. Input accepts either
 // a single string or a string array.
+//
+// The target embedding model MUST be registered with a non-zero ContextWindow;
+// otherwise the router's token-budget check rejects every request with
+// "budget_exceeded". This is a Phase-3 router artifact — embeddings are per-
+// input and don't conceptually need a window, but the budget path is shared.
 type EmbeddingRequest struct {
 	Model string         `json:"model"`
 	Input EmbeddingInput `json:"input"`
@@ -58,12 +72,24 @@ func (e *EmbeddingInput) UnmarshalJSON(data []byte) error {
 	return fmt.Errorf("embedding input must be string or string array")
 }
 
+// embeddingUsageWire mirrors OpenAI's embedding usage shape, which omits
+// completion_tokens entirely (embeddings produce no completion). Reusing the
+// shared UsageWire would surface "completion_tokens":0 on every response and
+// diverge from the reference wire.
+type embeddingUsageWire struct {
+	PromptTokens int `json:"prompt_tokens"`
+	TotalTokens  int `json:"total_tokens"`
+}
+
 // EmbeddingResponse is the OpenAI-shape response.
 type EmbeddingResponse struct {
-	Object string          `json:"object"` // "list"
-	Data   []EmbeddingData `json:"data"`
-	Model  string          `json:"model"`
-	Usage  UsageWire       `json:"usage"`
+	Object string             `json:"object"` // "list"
+	Data   []EmbeddingData    `json:"data"`
+	Model  string             `json:"model"`
+	Usage  embeddingUsageWire `json:"usage"`
+
+	// Extensions.
+	RouteInfo *RouteInfoExt `json:"x_route_info,omitempty"`
 }
 
 // EmbeddingData is one vector with its source index.
@@ -74,6 +100,11 @@ type EmbeddingData struct {
 }
 
 func (s *Server) handleEmbeddings(w http.ResponseWriter, r *http.Request) {
+	if s.router == nil {
+		writeError(w, http.StatusServiceUnavailable, "no_router", "server has no router")
+		return
+	}
+
 	var req EmbeddingRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "decode_error", err.Error())
@@ -86,6 +117,18 @@ func (s *Server) handleEmbeddings(w http.ResponseWriter, r *http.Request) {
 	}
 	if len(req.Input.Values) == 0 {
 		writeError(w, http.StatusBadRequest, "missing_input", "input is required")
+		return
+	}
+	for i, v := range req.Input.Values {
+		if strings.TrimSpace(v) == "" {
+			writeError(w, http.StatusBadRequest, "invalid_input",
+				fmt.Sprintf("input[%d] is empty or whitespace-only", i))
+			return
+		}
+	}
+	if len(req.Input.Values) > maxEmbeddingInputs {
+		writeError(w, http.StatusBadRequest, "input_too_large",
+			fmt.Sprintf("input array length %d exceeds maximum %d", len(req.Input.Values), maxEmbeddingInputs))
 		return
 	}
 
@@ -114,6 +157,12 @@ func (s *Server) handleEmbeddings(w http.ResponseWriter, r *http.Request) {
 		writeCompatError(w, err)
 		return
 	}
+	log.Printf("compat: embed rid=%s model=%s inputs=%d prompt_tokens=%d",
+		requestIDFrom(r.Context()),
+		plan.Profile.Key.String(),
+		len(req.Input.Values),
+		resp.Usage.PromptTokens,
+	)
 
 	// Use the qualified "provider/model" form for wire consistency with
 	// /v1/completions and /v1/chat/completions, which also report
@@ -122,15 +171,15 @@ func (s *Server) handleEmbeddings(w http.ResponseWriter, r *http.Request) {
 		Object: "list",
 		Model:  plan.Profile.Key.String(),
 		Data:   make([]EmbeddingData, 0, len(resp.Embeddings)),
-		Usage: UsageWire{
-			PromptTokens:     resp.Usage.PromptTokens,
-			CompletionTokens: resp.Usage.CompletionTokens,
-			TotalTokens:      resp.Usage.TotalTokens,
+		Usage: embeddingUsageWire{
+			PromptTokens: resp.Usage.PromptTokens,
+			TotalTokens:  resp.Usage.TotalTokens,
 		},
 	}
 	for i, vec := range resp.Embeddings {
 		out.Data = append(out.Data, EmbeddingData{Object: "embedding", Embedding: vec, Index: i})
 	}
+	out.RouteInfo = routeInfoFrom(resp.RouteOutcome)
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(out)
 }

--- a/compat/embeddings.go
+++ b/compat/embeddings.go
@@ -106,8 +106,7 @@ func (s *Server) handleEmbeddings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req EmbeddingRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "decode_error", err.Error())
+	if !decodeJSONBody(w, r, maxEmbeddingRequestBodyBytes, &req) {
 		return
 	}
 	key, err := resolveModel(req.Model, s.aliases)

--- a/compat/embeddings.go
+++ b/compat/embeddings.go
@@ -1,0 +1,136 @@
+package compat
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// EmbeddingRequest is the OpenAI-shape embedding request. Input accepts either
+// a single string or a string array.
+type EmbeddingRequest struct {
+	Model string         `json:"model"`
+	Input EmbeddingInput `json:"input"`
+}
+
+// EmbeddingInput unmarshals either "hello" or ["hello", "world"]. OpenAI's
+// SDKs serialize both shapes; rejecting the scalar form would break every
+// client that passes a single document.
+type EmbeddingInput struct {
+	Values []string
+}
+
+// MarshalJSON writes the array form for outbound payloads (tests). We never
+// produce this shape on the response wire, so the single-string branch is
+// only relevant to inbound Decode.
+func (e EmbeddingInput) MarshalJSON() ([]byte, error) {
+	return json.Marshal(e.Values)
+}
+
+// UnmarshalJSON accepts null, a single JSON string, or a JSON string array.
+// Any other shape (number, object, mixed array) yields a typed error so the
+// handler can surface a 400 with a useful code.
+func (e *EmbeddingInput) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		e.Values = nil
+		return nil
+	}
+	if trimmed[0] == '"' {
+		var s string
+		if err := json.Unmarshal(trimmed, &s); err != nil {
+			return fmt.Errorf("embedding input string: %w", err)
+		}
+		e.Values = []string{s}
+		return nil
+	}
+	if trimmed[0] == '[' {
+		var arr []string
+		if err := json.Unmarshal(trimmed, &arr); err != nil {
+			return fmt.Errorf("embedding input array: %w", err)
+		}
+		e.Values = arr
+		return nil
+	}
+	return fmt.Errorf("embedding input must be string or string array")
+}
+
+// EmbeddingResponse is the OpenAI-shape response.
+type EmbeddingResponse struct {
+	Object string          `json:"object"` // "list"
+	Data   []EmbeddingData `json:"data"`
+	Model  string          `json:"model"`
+	Usage  UsageWire       `json:"usage"`
+}
+
+// EmbeddingData is one vector with its source index.
+type EmbeddingData struct {
+	Object    string    `json:"object"` // "embedding"
+	Embedding []float64 `json:"embedding"`
+	Index     int       `json:"index"`
+}
+
+func (s *Server) handleEmbeddings(w http.ResponseWriter, r *http.Request) {
+	var req EmbeddingRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "decode_error", err.Error())
+		return
+	}
+	key, err := resolveModel(req.Model, s.aliases)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "missing_model", err.Error())
+		return
+	}
+	if len(req.Input.Values) == 0 {
+		writeError(w, http.StatusBadRequest, "missing_input", "input is required")
+		return
+	}
+
+	rr := provider.RoutingRequest{
+		Model:        selectorFor(key),
+		UseCase:      "embedding",
+		Input:        req.Input.Values,
+		RequiredCaps: provider.CapEmbed,
+		Priority:     provider.PriorityNormal,
+	}
+	release, ok := s.semaphore.acquire(rr.Priority)
+	if !ok {
+		w.Header().Set("Retry-After", "1")
+		writeError(w, http.StatusTooManyRequests, "capacity", "server is at capacity")
+		return
+	}
+	defer release()
+
+	plan, err := s.router.Route(r.Context(), rr)
+	if err != nil {
+		writeCompatError(w, err)
+		return
+	}
+	resp, err := plan.ExecuteEmbed(r.Context())
+	if err != nil {
+		writeCompatError(w, err)
+		return
+	}
+
+	// Use the qualified "provider/model" form for wire consistency with
+	// /v1/completions and /v1/chat/completions, which also report
+	// plan.Profile.Key.String() rather than resp.Model.
+	out := EmbeddingResponse{
+		Object: "list",
+		Model:  plan.Profile.Key.String(),
+		Data:   make([]EmbeddingData, 0, len(resp.Embeddings)),
+		Usage: UsageWire{
+			PromptTokens:     resp.Usage.PromptTokens,
+			CompletionTokens: resp.Usage.CompletionTokens,
+			TotalTokens:      resp.Usage.TotalTokens,
+		},
+	}
+	for i, vec := range resp.Embeddings {
+		out.Data = append(out.Data, EmbeddingData{Object: "embedding", Embedding: vec, Index: i})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(out)
+}

--- a/compat/embeddings_test.go
+++ b/compat/embeddings_test.go
@@ -1,0 +1,83 @@
+package compat
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+func TestEmbeddings_DisabledByDefault(t *testing.T) {
+	srv, teardown := newTestServer(t, &mockProvider{name: "ollama", caps: provider.CapEmbed})
+	defer teardown()
+	raw, _ := json.Marshal(EmbeddingRequest{Model: "qwen3-embedding:8b", Input: EmbeddingInput{Values: []string{"hi"}}})
+	rec := httptest.NewRecorder()
+	srv.buildHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/embeddings", bytes.NewReader(raw)))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d want 404 (route not registered)", rec.Code)
+	}
+}
+
+func TestEmbeddings_EnabledReturnsVectors(t *testing.T) {
+	mp := &mockProvider{
+		name: "ollama", caps: provider.CapEmbed,
+		models: []provider.ModelInfo{{Name: "qwen3-embedding:8b", ContextWindow: 32768, Capabilities: []string{"embedding"}}},
+		embedFn: func(ctx context.Context, req provider.EmbedRequest) (*provider.EmbedResponse, error) {
+			return &provider.EmbedResponse{
+				Model:      req.Model,
+				Embeddings: [][]float64{{0.1, 0.2}},
+				Usage:      provider.Usage{PromptTokens: 1, TotalTokens: 1},
+			}, nil
+		},
+	}
+	srv, teardown := newTestServer(t, mp, WithEmbeddings(true))
+	defer teardown()
+
+	raw, _ := json.Marshal(EmbeddingRequest{Model: "qwen3-embedding:8b", Input: EmbeddingInput{Values: []string{"hi"}}})
+	rec := httptest.NewRecorder()
+	srv.buildHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/embeddings", bytes.NewReader(raw)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp EmbeddingResponse
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	if len(resp.Data) != 1 || len(resp.Data[0].Embedding) != 2 {
+		t.Errorf("bad data: %+v", resp.Data)
+	}
+}
+
+func TestEmbeddings_EnabledAcceptsSingleStringInput(t *testing.T) {
+	mp := &mockProvider{
+		name: "ollama", caps: provider.CapEmbed,
+		models: []provider.ModelInfo{{Name: "qwen3-embedding:8b", ContextWindow: 32768, Capabilities: []string{"embedding"}}},
+		embedFn: func(ctx context.Context, req provider.EmbedRequest) (*provider.EmbedResponse, error) {
+			if len(req.Input) != 1 || req.Input[0] != "hi" {
+				t.Errorf("expected Input=[\"hi\"], got %v", req.Input)
+			}
+			return &provider.EmbedResponse{
+				Model:      req.Model,
+				Embeddings: [][]float64{{0.3, 0.4}},
+				Usage:      provider.Usage{PromptTokens: 1, TotalTokens: 1},
+			}, nil
+		},
+	}
+	srv, teardown := newTestServer(t, mp, WithEmbeddings(true))
+	defer teardown()
+
+	// Marshal the raw OpenAI shape directly: input as a single string.
+	raw := []byte(`{"model":"qwen3-embedding:8b","input":"hi"}`)
+	rec := httptest.NewRecorder()
+	srv.buildHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/embeddings", bytes.NewReader(raw)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp EmbeddingResponse
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	if len(resp.Data) != 1 || len(resp.Data[0].Embedding) != 2 || resp.Data[0].Embedding[0] != 0.3 {
+		t.Errorf("bad data: %+v", resp.Data)
+	}
+}

--- a/compat/embeddings_test.go
+++ b/compat/embeddings_test.go
@@ -82,6 +82,37 @@ func TestEmbeddings_EnabledAcceptsSingleStringInput(t *testing.T) {
 	}
 }
 
+func TestEmbeddings_BodyTooLarge(t *testing.T) {
+	mp := &mockProvider{
+		name: "ollama", caps: provider.CapEmbed,
+		models: []provider.ModelInfo{{Name: "qwen3-embedding:8b", ContextWindow: 32768, Capabilities: []string{"embedding"}}},
+		embedFn: func(context.Context, provider.EmbedRequest) (*provider.EmbedResponse, error) {
+			t.Fatal("provider should not be called for oversized body")
+			return nil, nil
+		},
+	}
+	srv, teardown := newTestServer(t, mp, WithEmbeddings(true))
+	defer teardown()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/embeddings",
+		oversizedJSONStringReader(
+			`{"model":"qwen3-embedding:8b","input":"`,
+			maxEmbeddingRequestBodyBytes+1,
+			`"}`,
+		))
+	req.Header.Set("Content-Type", "application/json")
+	srv.buildHandler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	env := decodeErrorEnvelope(t, rec)
+	if env.Error.Code != "body_too_large" {
+		t.Errorf("error.code = %q, want body_too_large", env.Error.Code)
+	}
+}
+
 func TestEmbeddings_ResponseOmitsCompletionTokens(t *testing.T) {
 	mp := &mockProvider{
 		name: "ollama", caps: provider.CapEmbed,

--- a/compat/embeddings_test.go
+++ b/compat/embeddings_test.go
@@ -81,3 +81,30 @@ func TestEmbeddings_EnabledAcceptsSingleStringInput(t *testing.T) {
 		t.Errorf("bad data: %+v", resp.Data)
 	}
 }
+
+func TestEmbeddings_ResponseOmitsCompletionTokens(t *testing.T) {
+	mp := &mockProvider{
+		name: "ollama", caps: provider.CapEmbed,
+		models: []provider.ModelInfo{{Name: "qwen3-embedding:8b", ContextWindow: 32768, Capabilities: []string{"embedding"}}},
+		embedFn: func(ctx context.Context, req provider.EmbedRequest) (*provider.EmbedResponse, error) {
+			return &provider.EmbedResponse{
+				Model:      req.Model,
+				Embeddings: [][]float64{{0.1}},
+				Usage:      provider.Usage{PromptTokens: 1, TotalTokens: 1},
+			}, nil
+		},
+	}
+	srv, teardown := newTestServer(t, mp, WithEmbeddings(true))
+	defer teardown()
+
+	raw, _ := json.Marshal(EmbeddingRequest{Model: "qwen3-embedding:8b", Input: EmbeddingInput{Values: []string{"hi"}}})
+	rec := httptest.NewRecorder()
+	srv.buildHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/embeddings", bytes.NewReader(raw)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if bytes.Contains(rec.Body.Bytes(), []byte("completion_tokens")) {
+		t.Errorf("response should omit completion_tokens, got: %s", rec.Body.String())
+	}
+}

--- a/compat/errors.go
+++ b/compat/errors.go
@@ -1,0 +1,86 @@
+package compat
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// errorEnvelope is the OpenAI-shape error body.
+type errorEnvelope struct {
+	Error errorBody `json:"error"`
+}
+
+// errorBody mirrors OpenAI's error shape. "type" is OpenAI's vocabulary:
+// invalid_request_error (4xx client), api_error (5xx/infra).
+type errorBody struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+	Code    string `json:"code,omitempty"`
+}
+
+// writeError sends a JSON error using OpenAI's shape. The "type" field is
+// derived from the status: 4xx -> invalid_request_error, else api_error.
+func writeError(w http.ResponseWriter, status int, code, message string) {
+	kind := "api_error"
+	if status >= 400 && status < 500 {
+		kind = "invalid_request_error"
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errorEnvelope{
+		Error: errorBody{Message: message, Type: kind, Code: code},
+	})
+}
+
+// writeCompatError classifies a router/provider error per amendment #4 of the
+// plan and writes the corresponding OpenAI-shape error body. Never flattens
+// everything to 502 — preserves retry semantics for 429/timeouts/budget.
+func writeCompatError(w http.ResponseWriter, err error) {
+	status, code, message := statusForCompatError(err)
+	writeError(w, status, code, message)
+}
+
+// statusForCompatError maps a provider/router error to an HTTP status, a short
+// machine-readable code, and a human-readable message. See the amendment #4
+// table in docs/superpowers/plans/2026-04-20-openai-compat.md for the full
+// rationale of each mapping.
+func statusForCompatError(err error) (status int, code, message string) {
+	switch {
+	case errors.Is(err, provider.ErrNoViableCandidate):
+		return http.StatusBadRequest, "no_viable_candidate", err.Error()
+	case errors.Is(err, provider.ErrBudgetExceeded):
+		return http.StatusBadRequest, "budget_exceeded", err.Error()
+	case errors.Is(err, provider.ErrBudgetAdaptationRequired):
+		return http.StatusBadRequest, "budget_adaptation_required", err.Error()
+	case errors.Is(err, provider.ErrAllBreakersOpen):
+		return http.StatusServiceUnavailable, "all_breakers_open", err.Error()
+	case errors.Is(err, context.DeadlineExceeded):
+		return http.StatusGatewayTimeout, "timeout", "request timed out"
+	case errors.Is(err, context.Canceled):
+		// 499 follows nginx's "client closed request" convention — there is no
+		// stdlib StatusCode constant for it.
+		return 499, "canceled", "request canceled"
+	}
+	var httpErr *provider.HTTPStatusError
+	if errors.As(err, &httpErr) && httpErr != nil {
+		switch {
+		case httpErr.StatusCode == http.StatusTooManyRequests:
+			return http.StatusTooManyRequests, "rate_limited", httpErr.Error()
+		case httpErr.StatusCode >= 500:
+			return http.StatusBadGateway, "upstream_error", httpErr.Error()
+		case httpErr.StatusCode >= 400:
+			// Upstream 4xx (e.g. Ollama "model not found" 404, bad-request 400)
+			// is almost always caused by a malformed client request. Pass the
+			// status through so clients do not retry a deterministic failure
+			// as if it were a transient upstream fault.
+			return httpErr.StatusCode, "upstream_client_error", httpErr.Error()
+		}
+	}
+	// Unknown infrastructure / unclassified failure: return a generic 502
+	// without leaking provider-specific internals.
+	return http.StatusBadGateway, "upstream_error", "upstream error"
+}

--- a/compat/feedback.go
+++ b/compat/feedback.go
@@ -2,6 +2,8 @@ package compat
 
 import (
 	"encoding/json"
+	"errors"
+	"io"
 	"log"
 	"net/http"
 )
@@ -24,9 +26,20 @@ var validFeedbackActions = map[string]bool{
 	"edited":   true,
 }
 
+// handleFeedback records an IDE-side acceptance/rejection/edit signal for a
+// previously issued completion. The contract is single-shot: the completion
+// record is consumed on first successful call, so any subsequent POST with the
+// same completion_id returns 404.
+//
+// Admission control is applied by Task 17 at handler registration time if
+// needed; feedback is cheap enough that exemption may be appropriate.
 func (s *Server) handleFeedback(w http.ResponseWriter, r *http.Request) {
 	var req FeedbackRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if errors.Is(err, io.EOF) {
+			writeError(w, http.StatusBadRequest, "empty_body", "request body is required")
+			return
+		}
 		writeError(w, http.StatusBadRequest, "decode_error", err.Error())
 		return
 	}
@@ -39,13 +52,19 @@ func (s *Server) handleFeedback(w http.ResponseWriter, r *http.Request) {
 			"action must be one of: accepted, rejected, edited")
 		return
 	}
-	rec, ok := s.completionStore.get(req.CompletionID)
+	rec, ok := s.completionStore.consume(req.CompletionID)
 	if !ok {
-		writeError(w, http.StatusNotFound, "unknown_completion", "completion_id not found or expired")
+		writeError(w, http.StatusNotFound, "unknown_completion",
+			"completion_id not found, expired, or already consumed")
 		return
 	}
-	log.Printf("compat: feedback rid=%s id=%s provider=%s model=%s action=%s",
-		requestIDFrom(r.Context()), rec.ID, rec.Provider, rec.Model, req.Action)
+	if req.EditDistance != nil {
+		log.Printf("compat: feedback rid=%s id=%s provider=%s model=%s action=%s edit_distance=%d",
+			requestIDFrom(r.Context()), rec.ID, rec.Provider, rec.Model, req.Action, *req.EditDistance)
+	} else {
+		log.Printf("compat: feedback rid=%s id=%s provider=%s model=%s action=%s",
+			requestIDFrom(r.Context()), rec.ID, rec.Provider, rec.Model, req.Action)
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(FeedbackResponse{Recorded: true})

--- a/compat/feedback.go
+++ b/compat/feedback.go
@@ -36,7 +36,13 @@ var validFeedbackActions = map[string]bool{
 // user-facing work.
 func (s *Server) handleFeedback(w http.ResponseWriter, r *http.Request) {
 	var req FeedbackRequest
+	r.Body = http.MaxBytesReader(w, r.Body, maxFeedbackRequestBodyBytes)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeBodyTooLarge(w, maxErr.Limit)
+			return
+		}
 		if errors.Is(err, io.EOF) {
 			writeError(w, http.StatusBadRequest, "empty_body", "request body is required")
 			return

--- a/compat/feedback.go
+++ b/compat/feedback.go
@@ -31,8 +31,9 @@ var validFeedbackActions = map[string]bool{
 // record is consumed on first successful call, so any subsequent POST with the
 // same completion_id returns 404.
 //
-// Admission control is applied by Task 17 at handler registration time if
-// needed; feedback is cheap enough that exemption may be appropriate.
+// Admission control is applied at route registration (see buildHandler in
+// server.go) using PriorityBackground so feedback never crowds out
+// user-facing work.
 func (s *Server) handleFeedback(w http.ResponseWriter, r *http.Request) {
 	var req FeedbackRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {

--- a/compat/feedback.go
+++ b/compat/feedback.go
@@ -1,0 +1,52 @@
+package compat
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+// FeedbackRequest is the non-standard signal from IDE tools.
+type FeedbackRequest struct {
+	CompletionID string `json:"completion_id"`
+	Action       string `json:"action"` // "accepted" | "rejected" | "edited"
+	EditDistance *int   `json:"edit_distance,omitempty"`
+}
+
+// FeedbackResponse acknowledges the signal.
+type FeedbackResponse struct {
+	Recorded bool `json:"recorded"`
+}
+
+var validFeedbackActions = map[string]bool{
+	"accepted": true,
+	"rejected": true,
+	"edited":   true,
+}
+
+func (s *Server) handleFeedback(w http.ResponseWriter, r *http.Request) {
+	var req FeedbackRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "decode_error", err.Error())
+		return
+	}
+	if req.CompletionID == "" {
+		writeError(w, http.StatusBadRequest, "missing_id", "completion_id is required")
+		return
+	}
+	if !validFeedbackActions[req.Action] {
+		writeError(w, http.StatusBadRequest, "bad_action",
+			"action must be one of: accepted, rejected, edited")
+		return
+	}
+	rec, ok := s.completionStore.get(req.CompletionID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "unknown_completion", "completion_id not found or expired")
+		return
+	}
+	log.Printf("compat: feedback rid=%s id=%s provider=%s model=%s action=%s",
+		requestIDFrom(r.Context()), rec.ID, rec.Provider, rec.Model, req.Action)
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(FeedbackResponse{Recorded: true})
+}

--- a/compat/feedback_test.go
+++ b/compat/feedback_test.go
@@ -1,0 +1,55 @@
+package compat
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+func TestFeedback_AcceptsKnownID(t *testing.T) {
+	srv, teardown := newTestServer(t, &mockProvider{name: "ollama", caps: provider.CapGenerate})
+	defer teardown()
+	srv.completionStore.put(CompletionRecord{ID: "cmpl_abc", Provider: "ollama", Model: "qwen3:8b"})
+
+	body := FeedbackRequest{CompletionID: "cmpl_abc", Action: "accepted"}
+	raw, _ := json.Marshal(body)
+	rec := httptest.NewRecorder()
+	srv.buildHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/completions/feedback", bytes.NewReader(raw)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp FeedbackResponse
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	if !resp.Recorded {
+		t.Error("recorded=false for valid id")
+	}
+}
+
+func TestFeedback_UnknownID404(t *testing.T) {
+	srv, teardown := newTestServer(t, &mockProvider{name: "ollama", caps: provider.CapGenerate})
+	defer teardown()
+	body := FeedbackRequest{CompletionID: "nope", Action: "accepted"}
+	raw, _ := json.Marshal(body)
+	rec := httptest.NewRecorder()
+	srv.buildHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/completions/feedback", bytes.NewReader(raw)))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d want 404", rec.Code)
+	}
+}
+
+func TestFeedback_InvalidAction(t *testing.T) {
+	srv, teardown := newTestServer(t, &mockProvider{name: "ollama", caps: provider.CapGenerate})
+	defer teardown()
+	srv.completionStore.put(CompletionRecord{ID: "cmpl_abc"})
+	body := FeedbackRequest{CompletionID: "cmpl_abc", Action: "weird"}
+	raw, _ := json.Marshal(body)
+	rec := httptest.NewRecorder()
+	srv.buildHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/completions/feedback", bytes.NewReader(raw)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d want 400", rec.Code)
+	}
+}

--- a/compat/feedback_test.go
+++ b/compat/feedback_test.go
@@ -53,3 +53,40 @@ func TestFeedback_InvalidAction(t *testing.T) {
 		t.Fatalf("status=%d want 400", rec.Code)
 	}
 }
+
+func TestFeedback_SecondCallReturns404(t *testing.T) {
+	srv, teardown := newTestServer(t, &mockProvider{name: "ollama", caps: provider.CapGenerate})
+	defer teardown()
+	srv.completionStore.put(CompletionRecord{ID: "cmpl_once", Provider: "ollama", Model: "qwen3:8b"})
+
+	body := FeedbackRequest{CompletionID: "cmpl_once", Action: "accepted"}
+	raw, _ := json.Marshal(body)
+
+	rec1 := httptest.NewRecorder()
+	srv.buildHandler().ServeHTTP(rec1, httptest.NewRequest(http.MethodPost, "/v1/completions/feedback", bytes.NewReader(raw)))
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first call: status=%d want 200 body=%s", rec1.Code, rec1.Body.String())
+	}
+
+	rec2 := httptest.NewRecorder()
+	srv.buildHandler().ServeHTTP(rec2, httptest.NewRequest(http.MethodPost, "/v1/completions/feedback", bytes.NewReader(raw)))
+	if rec2.Code != http.StatusNotFound {
+		t.Fatalf("second call: status=%d want 404 body=%s", rec2.Code, rec2.Body.String())
+	}
+	if !bytes.Contains(rec2.Body.Bytes(), []byte("already consumed")) {
+		t.Errorf("expected 'already consumed' in error message, got %s", rec2.Body.String())
+	}
+}
+
+func TestFeedback_EmptyBodyReturns400(t *testing.T) {
+	srv, teardown := newTestServer(t, &mockProvider{name: "ollama", caps: provider.CapGenerate})
+	defer teardown()
+	rec := httptest.NewRecorder()
+	srv.buildHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/completions/feedback", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d want 400", rec.Code)
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte("empty_body")) {
+		t.Errorf("expected empty_body error code, got %s", rec.Body.String())
+	}
+}

--- a/compat/feedback_test.go
+++ b/compat/feedback_test.go
@@ -90,3 +90,25 @@ func TestFeedback_EmptyBodyReturns400(t *testing.T) {
 		t.Errorf("expected empty_body error code, got %s", rec.Body.String())
 	}
 }
+
+func TestFeedback_BodyTooLargeReturns413(t *testing.T) {
+	srv, teardown := newTestServer(t, &mockProvider{name: "ollama", caps: provider.CapGenerate})
+	defer teardown()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/completions/feedback",
+		oversizedJSONStringReader(
+			`{"completion_id":"`,
+			maxFeedbackRequestBodyBytes+1,
+			`","action":"accepted"}`,
+		))
+	req.Header.Set("Content-Type", "application/json")
+	srv.buildHandler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte("body_too_large")) {
+		t.Errorf("expected body_too_large error code, got %s", rec.Body.String())
+	}
+}

--- a/compat/fim_budget.go
+++ b/compat/fim_budget.go
@@ -1,0 +1,118 @@
+// Package-local file implementing Section 6 of the provider-intelligence
+// design: four-layer adaptive FIM context budgeting.
+//
+// Layer 1: family base split (prefix percentage)
+// Layer 2: language adjustment (additive modifier)
+// Layer 3: position-aware rebalancing when one side is shorter than budget
+// Layer 4: learned splits — not implemented here; a FIMBenchmarkSource
+//
+//	interface is reserved for a later phase.
+package compat
+
+import "strings"
+
+// BudgetResult reports how many tokens of prefix and suffix to send.
+type BudgetResult struct {
+	Prefix int
+	Suffix int
+}
+
+// familyBase maps normalized family to base prefix percentage.
+var familyBase = map[string]int{
+	"qwen3":     75,
+	"qwen2.5":   75,
+	"qwen3.5":   75,
+	"codellama": 65,
+	"deepseek":  70,
+	"starcoder": 70,
+	"phi-4":     75,
+}
+
+// languageDelta maps language to additive modifier.
+var languageDelta = map[string]int{
+	"python":     -10,
+	"yaml":       -10,
+	"go":         +5,
+	"rust":       +5,
+	"typescript": -5,
+	"sql":        -5,
+}
+
+// fimFamily normalizes a family string to the familyBase key.
+func fimFamily(family string) string {
+	f := strings.ToLower(strings.TrimSpace(family))
+	if f == "" {
+		return "unknown"
+	}
+	for key := range familyBase {
+		if strings.HasPrefix(f, key) {
+			return key
+		}
+	}
+	return "unknown"
+}
+
+// baseSplit returns the family base prefix pct, defaulting to 70.
+func baseSplit(family string) int {
+	if pct, ok := familyBase[family]; ok {
+		return pct
+	}
+	return 70
+}
+
+// languageAdjust returns the additive modifier for a language, 0 if unknown.
+func languageAdjust(lang string) int {
+	return languageDelta[strings.ToLower(strings.TrimSpace(lang))]
+}
+
+// clampPct keeps the prefix percentage in [40, 90] so neither side drops below 10%.
+func clampPct(pct int) int {
+	if pct < 40 {
+		return 40
+	}
+	if pct > 90 {
+		return 90
+	}
+	return pct
+}
+
+// adaptiveSplit allocates the maxTokens budget between prefix and suffix
+// based on the configured prefix percentage, then rebalances when one side's
+// actual content is shorter than its budget share.
+func adaptiveSplit(prefixLen, suffixLen, prefixPct, maxTokens int) BudgetResult {
+	prefixBudget := (maxTokens * prefixPct) / 100
+	suffixBudget := maxTokens - prefixBudget
+
+	// Layer 3: surplus transfer.
+	result := BudgetResult{}
+	if prefixLen <= prefixBudget {
+		surplus := prefixBudget - prefixLen
+		result.Prefix = prefixLen
+		suffixBudget += surplus
+	} else {
+		result.Prefix = prefixBudget
+	}
+	if suffixLen <= suffixBudget {
+		result.Suffix = suffixLen
+	} else {
+		result.Suffix = suffixBudget
+	}
+	return result
+}
+
+// budgetForProfile is the single entry point used by the completions handler.
+// It combines Layer 1 (family) and Layer 2 (language) into a prefix pct, then
+// delegates to adaptiveSplit. PrefixBudgetPct from the profile's FIMConfig
+// overrides the family default when non-zero.
+//
+// Compose order: when overridePrefixPct > 0, it REPLACES the family default
+// BEFORE the language adjustment is applied. The final percentage is then
+// passed through clampPct so it stays in [40, 90].
+func budgetForProfile(family, language string, overridePrefixPct int, prefixLen, suffixLen, maxTokens int) BudgetResult {
+	pct := baseSplit(fimFamily(family))
+	if overridePrefixPct > 0 {
+		pct = overridePrefixPct
+	}
+	pct = clampPct(pct + languageAdjust(language))
+	return adaptiveSplit(prefixLen, suffixLen, pct, maxTokens)
+}

--- a/compat/fim_budget_test.go
+++ b/compat/fim_budget_test.go
@@ -1,0 +1,90 @@
+package compat
+
+import "testing"
+
+func TestFIMBudget_QwenPythonPrefixReduced(t *testing.T) {
+	split := baseSplit(fimFamily("qwen3"))
+	adj := languageAdjust("python")
+	got := clampPct(split + adj)
+	if got != 65 {
+		t.Errorf("Qwen+Python prefix pct = %d, want 65", got)
+	}
+}
+
+func TestFIMBudget_UnknownFamilyConservative(t *testing.T) {
+	if baseSplit("unknown") != 70 {
+		t.Errorf("unknown family default = %d, want 70", baseSplit("unknown"))
+	}
+}
+
+func TestFIMBudget_Clamped(t *testing.T) {
+	if clampPct(5) != 40 {
+		t.Errorf("clamp low = %d, want 40", clampPct(5))
+	}
+	if clampPct(99) != 90 {
+		t.Errorf("clamp high = %d, want 90", clampPct(99))
+	}
+}
+
+func TestAdaptiveSplit_ShortPrefixTransfersBudgetToSuffix(t *testing.T) {
+	result := adaptiveSplit(100, 1000, 70, 1000)
+	if result.Prefix != 100 {
+		t.Errorf("prefix = %d, want 100 (short prefix)", result.Prefix)
+	}
+	if result.Suffix < 600 {
+		t.Errorf("suffix = %d, want >= 600 (surplus transferred)", result.Suffix)
+	}
+}
+
+func TestAdaptiveSplit_BothFitWithinBudget(t *testing.T) {
+	result := adaptiveSplit(200, 100, 70, 1000)
+	if result.Prefix != 200 || result.Suffix != 100 {
+		t.Errorf("both-fit: got prefix=%d suffix=%d, want 200/100", result.Prefix, result.Suffix)
+	}
+}
+
+func TestAdaptiveSplit_BothExceedBudget(t *testing.T) {
+	result := adaptiveSplit(5000, 5000, 70, 1000)
+	if result.Prefix != 700 || result.Suffix != 300 {
+		t.Errorf("both-exceed: got prefix=%d suffix=%d, want 700/300", result.Prefix, result.Suffix)
+	}
+}
+
+func TestBudgetForProfile_EndToEnd(t *testing.T) {
+	// Qwen3 (75) + Python (-10) = 65 — below family default, reasonable for a
+	// language where suffix context tends to matter more.
+	result := budgetForProfile("qwen3-coder", "python", 0, 200, 200, 1000)
+	// pct = 65, so prefixBudget = 650, suffixBudget = 350.
+	// Both fit; surplus from prefix (650-200=450) goes to suffix, giving suffix
+	// budget 800. Both shorter than their budgets: prefix=200, suffix=200.
+	if result.Prefix != 200 || result.Suffix != 200 {
+		t.Errorf("end-to-end short: got %+v, want {200,200}", result)
+	}
+}
+
+func TestBudgetForProfile_OverrideBeatsFamilyDefault(t *testing.T) {
+	// Override of 50 replaces the family default (75) before language adjust.
+	// Go delta = +5, so final pct = clamp(50+5) = 55.
+	// Max 1000 -> prefixBudget 550, suffixBudget 450.
+	result := budgetForProfile("qwen3", "go", 50, 5000, 5000, 1000)
+	if result.Prefix != 550 || result.Suffix != 450 {
+		t.Errorf("override: got %+v, want {550,450}", result)
+	}
+}
+
+func TestBudgetForProfile_OverrideClampedHigh(t *testing.T) {
+	// Override of 95 would exceed the 90 ceiling; clampPct should enforce it.
+	// Language=rust (+5) would push it to 100; final clamp = 90.
+	result := budgetForProfile("deepseek", "rust", 95, 5000, 5000, 1000)
+	if result.Prefix != 900 || result.Suffix != 100 {
+		t.Errorf("override clamped high: got %+v, want {900,100}", result)
+	}
+}
+
+func TestBudgetForProfile_UnknownFamilyAndLanguage(t *testing.T) {
+	// Unknown family -> 70 base, unknown language -> 0 delta, so pct = 70.
+	result := budgetForProfile("made-up-model", "klingon", 0, 5000, 5000, 1000)
+	if result.Prefix != 700 || result.Suffix != 300 {
+		t.Errorf("unknown: got %+v, want {700,300}", result)
+	}
+}

--- a/compat/integration_test.go
+++ b/compat/integration_test.go
@@ -42,7 +42,7 @@ func TestIntegration_ChatRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer closeBody(t, resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		raw, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
@@ -93,7 +93,7 @@ func TestIntegration_FeedbackRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cResp.Body.Close()
+	defer closeBody(t, cResp.Body)
 	var cOut CompletionResponse
 	if err := json.NewDecoder(cResp.Body).Decode(&cOut); err != nil {
 		t.Fatalf("decode response: %v", err)
@@ -107,7 +107,7 @@ func TestIntegration_FeedbackRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer fResp.Body.Close()
+	defer closeBody(t, fResp.Body)
 	if fResp.StatusCode != http.StatusOK {
 		raw, _ := io.ReadAll(fResp.Body)
 		t.Fatalf("feedback status=%d body=%s", fResp.StatusCode, raw)
@@ -127,7 +127,7 @@ func TestIntegration_FeedbackRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer dupResp.Body.Close()
+	defer closeBody(t, dupResp.Body)
 	if dupResp.StatusCode != http.StatusNotFound {
 		raw, _ := io.ReadAll(dupResp.Body)
 		t.Fatalf("duplicate feedback status=%d, want 404; body=%s", dupResp.StatusCode, raw)
@@ -156,7 +156,7 @@ func TestIntegration_StatusReportsLiveUptime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer closeBody(t, resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status=%d", resp.StatusCode)
 	}
@@ -242,7 +242,7 @@ func TestIntegration_ModelsAliasAndWarmOrder(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer closeBody(t, resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		raw, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
@@ -318,7 +318,7 @@ func TestIntegration_EmbeddingsScalarInput(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer closeBody(t, resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		raw, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
@@ -340,7 +340,7 @@ func TestIntegration_EmbeddingsScalarInput(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer emptyResp.Body.Close()
+	defer closeBody(t, emptyResp.Body)
 	if emptyResp.StatusCode != http.StatusBadRequest {
 		raw, _ := io.ReadAll(emptyResp.Body)
 		t.Fatalf("empty-array status=%d, want 400; body=%s", emptyResp.StatusCode, raw)
@@ -378,7 +378,7 @@ func TestIntegration_ChatDryRun(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer closeBody(t, resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		raw, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
@@ -430,7 +430,7 @@ func TestIntegration_StreamPreFirstChunkError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer closeBody(t, resp.Body)
 	if resp.StatusCode < 400 {
 		raw, _ := io.ReadAll(resp.Body)
 		t.Fatalf("expected error status, got %d body=%s", resp.StatusCode, raw)
@@ -478,7 +478,7 @@ func TestIntegration_SSEFraming(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer closeBody(t, resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		raw, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)

--- a/compat/integration_test.go
+++ b/compat/integration_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -47,7 +48,26 @@ func TestIntegration_ChatRoundTrip(t *testing.T) {
 		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
 	}
 	var out ChatCompletionResponse
-	_ = json.NewDecoder(resp.Body).Decode(&out)
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if out.Object != "chat.completion" {
+		t.Errorf("object = %q, want chat.completion", out.Object)
+	}
+	// ChatCompletionResponse has no separate CompletionID field (that exists
+	// only on CompletionResponse/CompletionChunk). The equivalent assertion
+	// for chat is that the top-level ID is non-empty and carries the
+	// "chatcmpl_" prefix — which is the chat counterpart of "cmpl_" from
+	// M5 — so this covers the plan's "ID has cmpl_ prefix" intent.
+	if out.ID == "" {
+		t.Error("id is empty")
+	}
+	if !strings.HasPrefix(out.ID, "chatcmpl_") {
+		t.Errorf("id = %q, want chatcmpl_ prefix", out.ID)
+	}
+	if out.Model == "" {
+		t.Error("model is empty")
+	}
 	if len(out.Choices) == 0 || out.Choices[0].Message.Content != "pong" {
 		t.Errorf("content mismatch: %+v", out.Choices)
 	}
@@ -75,13 +95,15 @@ func TestIntegration_FeedbackRoundTrip(t *testing.T) {
 	}
 	defer cResp.Body.Close()
 	var cOut CompletionResponse
-	_ = json.NewDecoder(cResp.Body).Decode(&cOut)
+	if err := json.NewDecoder(cResp.Body).Decode(&cOut); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
 	if cOut.CompletionID == "" {
 		t.Fatal("no completion id returned")
 	}
 
-	fbBody := strings.NewReader(`{"completion_id":"` + cOut.CompletionID + `","action":"accepted"}`)
-	fResp, err := http.Post(ts.URL+"/v1/completions/feedback", "application/json", fbBody)
+	fbPayload := `{"completion_id":"` + cOut.CompletionID + `","action":"accepted"}`
+	fResp, err := http.Post(ts.URL+"/v1/completions/feedback", "application/json", strings.NewReader(fbPayload))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,6 +111,33 @@ func TestIntegration_FeedbackRoundTrip(t *testing.T) {
 	if fResp.StatusCode != http.StatusOK {
 		raw, _ := io.ReadAll(fResp.Body)
 		t.Fatalf("feedback status=%d body=%s", fResp.StatusCode, raw)
+	}
+	var fbOut FeedbackResponse
+	if err := json.NewDecoder(fResp.Body).Decode(&fbOut); err != nil {
+		t.Fatalf("decode feedback response: %v", err)
+	}
+	if !fbOut.Recorded {
+		t.Errorf("recorded = false on first POST, want true")
+	}
+
+	// Duplicate POST: the completion store is consume-once, so a second
+	// feedback for the same id must 404 with "unknown_completion" (matches
+	// feedback.go's sentinel code for the consume miss).
+	dupResp, err := http.Post(ts.URL+"/v1/completions/feedback", "application/json", strings.NewReader(fbPayload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dupResp.Body.Close()
+	if dupResp.StatusCode != http.StatusNotFound {
+		raw, _ := io.ReadAll(dupResp.Body)
+		t.Fatalf("duplicate feedback status=%d, want 404; body=%s", dupResp.StatusCode, raw)
+	}
+	var dupEnv errorEnvelope
+	if err := json.NewDecoder(dupResp.Body).Decode(&dupEnv); err != nil {
+		t.Fatalf("decode duplicate error envelope: %v", err)
+	}
+	if dupEnv.Error.Code != "unknown_completion" {
+		t.Errorf("duplicate error code = %q, want unknown_completion", dupEnv.Error.Code)
 	}
 }
 
@@ -111,19 +160,81 @@ func TestIntegration_StatusReportsLiveUptime(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status=%d", resp.StatusCode)
 	}
+	var out StatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	// Handler emits "ready" when every registered provider reports healthy
+	// (see status.go handleStatus). The mock provider has no health error so
+	// we expect the happy-path string rather than "degraded"/"unavailable".
+	if out.Status != "ready" {
+		t.Errorf("status = %q, want ready", out.Status)
+	}
+	if out.Uptime == "" {
+		t.Fatal("uptime is empty")
+	}
+	d, err := time.ParseDuration(out.Uptime)
+	if err != nil {
+		t.Fatalf("uptime %q not parseable: %v", out.Uptime, err)
+	}
+	// startedAt was pinned to time.Now() immediately before the request; the
+	// reported uptime must be well under a minute. This guards against a
+	// regression that silently reports a stale or zero duration.
+	if d >= time.Minute {
+		t.Errorf("uptime %s >= 1m; expected recent start", d)
+	}
 }
 
 // TestIntegration_ModelsAliasAndWarmOrder verifies GET /v1/models emits
 // alias entries and orders warm models first.
+//
+// newTestServer does not expose a WithWarmthSource hook, so this test wires
+// its own provider.Registry/ModelRegistry/Router using a fakeWarmthSource
+// (defined in models_test.go) so warmth can be forced deterministically.
+// Two canonical models are registered (qwen3:8b warm, qwen3:14b cold) plus
+// one alias; we assert the alias maps exactly to the qualified target and
+// at least one warm entry precedes any cold entry in the Data slice.
 func TestIntegration_ModelsAliasAndWarmOrder(t *testing.T) {
 	mp := &mockProvider{
 		name: "ollama", caps: provider.CapChat,
 		models: []provider.ModelInfo{
 			{Name: "qwen3:8b", ContextWindow: 32768, Capabilities: []string{"chat"}},
+			{Name: "qwen3:14b", ContextWindow: 32768, Capabilities: []string{"chat"}},
 		},
 	}
-	srv, teardown := newTestServer(t, mp, WithAliases(map[string]string{"gpt-3.5-turbo": "ollama/qwen3:8b"}))
-	defer teardown()
+	provReg := provider.NewRegistry()
+	if err := provReg.Register(mp); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	if err := provReg.RefreshModels(context.Background(), mp.Name()); err != nil {
+		t.Fatalf("refresh models: %v", err)
+	}
+	modelReg, err := provider.NewModelRegistry(provReg, nil)
+	if err != nil {
+		t.Fatalf("NewModelRegistry: %v", err)
+	}
+	// Force qwen3:8b warm; qwen3:14b stays cold.
+	warmKey := provider.ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+	ws := &fakeWarmthSource{
+		models: []provider.WarmModel{{
+			Key: warmKey,
+			Info: provider.WarmthInfo{
+				Loaded:    true,
+				Since:     time.Now().Add(-1 * time.Minute),
+				ExpiresAt: time.Now().Add(5 * time.Minute),
+				VRAM:      6.0,
+			},
+		}},
+	}
+	router := provider.NewRouter(modelReg, provReg,
+		provider.WithStickyTTL(time.Second),
+		provider.WithAvailableRAM(256),
+		provider.WithWarmthSource(ws),
+	)
+	defer func() { _ = router.Close() }()
+	srv := New(router, modelReg, provReg,
+		WithAliases(map[string]string{"gpt-3.5-turbo": "ollama/qwen3:8b"}),
+	)
 	ts := httptest.NewServer(srv.buildHandler())
 	defer ts.Close()
 
@@ -137,19 +248,49 @@ func TestIntegration_ModelsAliasAndWarmOrder(t *testing.T) {
 		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
 	}
 	var out ModelsListResponse
-	_ = json.NewDecoder(resp.Body).Decode(&out)
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
 
 	var sawAlias bool
 	for _, m := range out.Data {
 		if m.ID == "gpt-3.5-turbo" {
 			sawAlias = true
-			if m.AliasFor == "" {
-				t.Errorf("alias entry missing x_alias_for")
+			if m.AliasFor != "ollama/qwen3:8b" {
+				t.Errorf("alias x_alias_for = %q, want ollama/qwen3:8b", m.AliasFor)
 			}
 		}
 	}
 	if !sawAlias {
 		t.Errorf("expected alias entry in /v1/models; got %d entries", len(out.Data))
+	}
+
+	// Warm-first ordering: at least one warm=true entry must precede any
+	// warm=false entry. sortModelsWarmFirst is the canonical policy; we
+	// assert the observable wire-level effect here.
+	firstCold := -1
+	for i, m := range out.Data {
+		if !m.Warm {
+			firstCold = i
+			break
+		}
+	}
+	if firstCold < 0 {
+		t.Fatalf("expected at least one cold entry in Data; got %d entries, all warm", len(out.Data))
+	}
+	sawWarmBeforeCold := false
+	for i := 0; i < firstCold; i++ {
+		if out.Data[i].Warm {
+			sawWarmBeforeCold = true
+			break
+		}
+	}
+	if !sawWarmBeforeCold {
+		ids := make([]string, 0, len(out.Data))
+		for _, m := range out.Data {
+			ids = append(ids, m.ID)
+		}
+		t.Errorf("no warm entry precedes first cold entry; order=%v", ids)
 	}
 }
 
@@ -183,21 +324,47 @@ func TestIntegration_EmbeddingsScalarInput(t *testing.T) {
 		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
 	}
 	var out EmbeddingResponse
-	_ = json.NewDecoder(resp.Body).Decode(&out)
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
 	if len(out.Data) != 1 || len(out.Data[0].Embedding) != 2 {
 		t.Errorf("bad embedding: %+v", out.Data)
+	}
+
+	// Negative path: an explicit empty input array is rejected with 400 and
+	// the "missing_input" code (see embeddings.go: len(req.Input.Values)==0
+	// branch). Guards against a regression where UnmarshalJSON silently
+	// accepts [] and the handler falls through to a zero-vector response.
+	emptyResp, err := http.Post(ts.URL+"/v1/embeddings", "application/json",
+		bytes.NewBufferString(`{"model":"qwen3-embedding:8b","input":[]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer emptyResp.Body.Close()
+	if emptyResp.StatusCode != http.StatusBadRequest {
+		raw, _ := io.ReadAll(emptyResp.Body)
+		t.Fatalf("empty-array status=%d, want 400; body=%s", emptyResp.StatusCode, raw)
+	}
+	var emptyEnv errorEnvelope
+	if err := json.NewDecoder(emptyResp.Body).Decode(&emptyEnv); err != nil {
+		t.Fatalf("decode empty-array error: %v", err)
+	}
+	if emptyEnv.Error.Code != "missing_input" {
+		t.Errorf("empty-array error code = %q, want missing_input", emptyEnv.Error.Code)
 	}
 }
 
 // TestIntegration_ChatDryRun verifies chat dry_run short-circuits the
 // request without executing the provider call.
 func TestIntegration_ChatDryRun(t *testing.T) {
-	var called bool
+	// atomic.Bool so a stray provider invocation from an unrelated goroutine
+	// (e.g. future background refresh) cannot race the assertion.
+	var called atomic.Bool
 	mp := &mockProvider{
 		name: "ollama", caps: provider.CapChat,
 		models: []provider.ModelInfo{{Name: "qwen3:8b", ContextWindow: 32768, Capabilities: []string{"chat"}}},
 		chatFn: func(ctx context.Context, req provider.ChatRequest) (*provider.ChatResponse, error) {
-			called = true
+			called.Store(true)
 			return &provider.ChatResponse{Model: req.Model, Content: "should not be emitted", Done: true}, nil
 		},
 	}
@@ -216,8 +383,29 @@ func TestIntegration_ChatDryRun(t *testing.T) {
 		raw, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
 	}
-	if called {
+	if called.Load() {
 		t.Errorf("dry_run must not invoke provider")
+	}
+
+	// Decode the body so we can assert the handler surfaced route metadata
+	// rather than silently returning a 200 with no x_route_info. Dry-run is
+	// metadata-only; ActualModel must identify the model the handler would
+	// have routed to.
+	var out ChatCompletionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if out.RouteInfo == nil {
+		t.Fatal("x_route_info missing on dry-run")
+	}
+	if out.RouteInfo.ActualModel == "" {
+		t.Error("x_route_info.actual_model is empty on dry-run")
+	}
+	// The qualified form from plan.Profile.Key.String() is the convention
+	// shared with /v1/completions; confirm the handler is on the same wire
+	// shape here.
+	if !strings.Contains(out.RouteInfo.ActualModel, "qwen3:8b") {
+		t.Errorf("x_route_info.actual_model = %q, want to reference qwen3:8b", out.RouteInfo.ActualModel)
 	}
 }
 
@@ -249,6 +437,20 @@ func TestIntegration_StreamPreFirstChunkError(t *testing.T) {
 	}
 	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "application/json") {
 		t.Errorf("expected JSON error, got Content-Type=%q", ct)
+	}
+	// Wire-level shape: OpenAI error envelope with a populated code/message.
+	// A silent 4xx/5xx without a decodable envelope would indicate the lazy-
+	// start SSE writer leaked a committed 200 or the error handler wrote a
+	// bare status without a body.
+	var env errorEnvelope
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+	if env.Error.Code == "" {
+		t.Error("error.code is empty")
+	}
+	if env.Error.Message == "" {
+		t.Error("error.message is empty")
 	}
 }
 
@@ -285,21 +487,37 @@ func TestIntegration_SSEFraming(t *testing.T) {
 		t.Errorf("Content-Type = %q, want text/event-stream", ct)
 	}
 
-	var sawData, sawDone bool
+	// Collect all "data: " frames so we can assert ordering, not just
+	// presence. The final frame must be "[DONE]" and at least one earlier
+	// frame must be a non-sentinel payload.
+	var frames []string
 	scanner := bufio.NewScanner(resp.Body)
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.HasPrefix(line, "data: ") {
-			sawData = true
-			if strings.TrimSpace(strings.TrimPrefix(line, "data: ")) == "[DONE]" {
-				sawDone = true
-			}
+			frames = append(frames, strings.TrimPrefix(line, "data: "))
 		}
 	}
-	if !sawData {
-		t.Errorf("no `data: ` frames seen")
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("sse scan: %v", err)
 	}
-	if !sawDone {
-		t.Errorf("no `[DONE]` sentinel seen")
+	if len(frames) < 2 {
+		t.Fatalf("got %d frames, want >=2 (at least one payload + [DONE])", len(frames))
+	}
+	if frames[len(frames)-1] != "[DONE]" {
+		t.Errorf("last frame = %q, want [DONE]", frames[len(frames)-1])
+	}
+	// Require at least one earlier payload frame that is not [DONE] — this
+	// is the wire-level guarantee that the provider emitted real chunks
+	// before terminating, not just a bare sentinel.
+	sawPayload := false
+	for _, f := range frames[:len(frames)-1] {
+		if f != "[DONE]" {
+			sawPayload = true
+			break
+		}
+	}
+	if !sawPayload {
+		t.Errorf("no non-sentinel payload frame before [DONE]; frames=%v", frames)
 	}
 }

--- a/compat/integration_test.go
+++ b/compat/integration_test.go
@@ -1,0 +1,305 @@
+package compat
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// TestIntegration_ChatRoundTrip verifies a real OpenAI-shape POST over a
+// real socket returns a real JSON body.
+func TestIntegration_ChatRoundTrip(t *testing.T) {
+	mp := &mockProvider{
+		name: "ollama", caps: provider.CapChat,
+		models: []provider.ModelInfo{{Name: "qwen3:8b", ContextWindow: 32768, Capabilities: []string{"chat"}}},
+		chatFn: func(ctx context.Context, req provider.ChatRequest) (*provider.ChatResponse, error) {
+			return &provider.ChatResponse{
+				Model:   req.Model,
+				Content: "pong",
+				Done:    true,
+			}, nil
+		},
+	}
+	srv, teardown := newTestServer(t, mp)
+	defer teardown()
+
+	ts := httptest.NewServer(srv.buildHandler())
+	defer ts.Close()
+
+	body := bytes.NewBufferString(`{"model":"qwen3:8b","messages":[{"role":"user","content":"ping"}]}`)
+	resp, err := http.Post(ts.URL+"/v1/chat/completions", "application/json", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
+	}
+	var out ChatCompletionResponse
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+	if len(out.Choices) == 0 || out.Choices[0].Message.Content != "pong" {
+		t.Errorf("content mismatch: %+v", out.Choices)
+	}
+}
+
+// TestIntegration_FeedbackRoundTrip exercises the completion->feedback loop
+// over a real socket, confirming x_completion_id attribution works.
+func TestIntegration_FeedbackRoundTrip(t *testing.T) {
+	mp := &mockProvider{
+		name: "ollama", caps: provider.CapGenerate,
+		models: []provider.ModelInfo{{Name: "qwen3:8b", ContextWindow: 32768, Capabilities: []string{"generate"}}},
+		genFn: func(ctx context.Context, req provider.GenerateRequest) (*provider.GenerateResponse, error) {
+			return &provider.GenerateResponse{Model: req.Model, Response: "x", Done: true}, nil
+		},
+	}
+	srv, teardown := newTestServer(t, mp)
+	defer teardown()
+	ts := httptest.NewServer(srv.buildHandler())
+	defer ts.Close()
+
+	completeBody := bytes.NewBufferString(`{"model":"qwen3:8b","prompt":"hi"}`)
+	cResp, err := http.Post(ts.URL+"/v1/completions", "application/json", completeBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cResp.Body.Close()
+	var cOut CompletionResponse
+	_ = json.NewDecoder(cResp.Body).Decode(&cOut)
+	if cOut.CompletionID == "" {
+		t.Fatal("no completion id returned")
+	}
+
+	fbBody := strings.NewReader(`{"completion_id":"` + cOut.CompletionID + `","action":"accepted"}`)
+	fResp, err := http.Post(ts.URL+"/v1/completions/feedback", "application/json", fbBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fResp.Body.Close()
+	if fResp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(fResp.Body)
+		t.Fatalf("feedback status=%d body=%s", fResp.StatusCode, raw)
+	}
+}
+
+// TestIntegration_StatusReportsLiveUptime smoke-tests GET /v1/status over
+// a real socket. startedAt is written in New, but we refresh it here to
+// pin the read against a recent time for hermeticity.
+func TestIntegration_StatusReportsLiveUptime(t *testing.T) {
+	mp := &mockProvider{name: "ollama", caps: provider.CapChat}
+	srv, teardown := newTestServer(t, mp)
+	defer teardown()
+	srv.startedAt = time.Now()
+	ts := httptest.NewServer(srv.buildHandler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/status")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+}
+
+// TestIntegration_ModelsAliasAndWarmOrder verifies GET /v1/models emits
+// alias entries and orders warm models first.
+func TestIntegration_ModelsAliasAndWarmOrder(t *testing.T) {
+	mp := &mockProvider{
+		name: "ollama", caps: provider.CapChat,
+		models: []provider.ModelInfo{
+			{Name: "qwen3:8b", ContextWindow: 32768, Capabilities: []string{"chat"}},
+		},
+	}
+	srv, teardown := newTestServer(t, mp, WithAliases(map[string]string{"gpt-3.5-turbo": "ollama/qwen3:8b"}))
+	defer teardown()
+	ts := httptest.NewServer(srv.buildHandler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/models")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
+	}
+	var out ModelsListResponse
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+
+	var sawAlias bool
+	for _, m := range out.Data {
+		if m.ID == "gpt-3.5-turbo" {
+			sawAlias = true
+			if m.AliasFor == "" {
+				t.Errorf("alias entry missing x_alias_for")
+			}
+		}
+	}
+	if !sawAlias {
+		t.Errorf("expected alias entry in /v1/models; got %d entries", len(out.Data))
+	}
+}
+
+// TestIntegration_EmbeddingsScalarInput confirms the OpenAI scalar input
+// shape round-trips over a real socket.
+func TestIntegration_EmbeddingsScalarInput(t *testing.T) {
+	mp := &mockProvider{
+		name: "ollama", caps: provider.CapEmbed,
+		models: []provider.ModelInfo{{Name: "qwen3-embedding:8b", ContextWindow: 32768, Capabilities: []string{"embedding"}}},
+		embedFn: func(ctx context.Context, req provider.EmbedRequest) (*provider.EmbedResponse, error) {
+			return &provider.EmbedResponse{
+				Model:      req.Model,
+				Embeddings: [][]float64{{0.1, 0.2}},
+				Usage:      provider.Usage{PromptTokens: 1, TotalTokens: 1},
+			}, nil
+		},
+	}
+	srv, teardown := newTestServer(t, mp, WithEmbeddings(true))
+	defer teardown()
+	ts := httptest.NewServer(srv.buildHandler())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/embeddings", "application/json",
+		bytes.NewBufferString(`{"model":"qwen3-embedding:8b","input":"hi"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
+	}
+	var out EmbeddingResponse
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+	if len(out.Data) != 1 || len(out.Data[0].Embedding) != 2 {
+		t.Errorf("bad embedding: %+v", out.Data)
+	}
+}
+
+// TestIntegration_ChatDryRun verifies chat dry_run short-circuits the
+// request without executing the provider call.
+func TestIntegration_ChatDryRun(t *testing.T) {
+	var called bool
+	mp := &mockProvider{
+		name: "ollama", caps: provider.CapChat,
+		models: []provider.ModelInfo{{Name: "qwen3:8b", ContextWindow: 32768, Capabilities: []string{"chat"}}},
+		chatFn: func(ctx context.Context, req provider.ChatRequest) (*provider.ChatResponse, error) {
+			called = true
+			return &provider.ChatResponse{Model: req.Model, Content: "should not be emitted", Done: true}, nil
+		},
+	}
+	srv, teardown := newTestServer(t, mp)
+	defer teardown()
+	ts := httptest.NewServer(srv.buildHandler())
+	defer ts.Close()
+
+	body := bytes.NewBufferString(`{"model":"qwen3:8b","messages":[{"role":"user","content":"ping"}],"x_dry_run":true}`)
+	resp, err := http.Post(ts.URL+"/v1/chat/completions", "application/json", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
+	}
+	if called {
+		t.Errorf("dry_run must not invoke provider")
+	}
+}
+
+// TestIntegration_StreamPreFirstChunkError verifies that if the stream
+// fails BEFORE emitting any chunk, the wire response is a JSON error
+// (not a false-positive 200 SSE stream).
+func TestIntegration_StreamPreFirstChunkError(t *testing.T) {
+	mp := &mockProvider{
+		name: "ollama", caps: provider.CapChat | provider.CapStream,
+		models: []provider.ModelInfo{{Name: "qwen3:8b", ContextWindow: 32768, Capabilities: []string{"chat", "stream"}}},
+		chatStreamFn: func(ctx context.Context, req provider.ChatRequest, cb func(provider.ChatResponse) error) error {
+			return errors.New("provider failed before first chunk")
+		},
+	}
+	srv, teardown := newTestServer(t, mp)
+	defer teardown()
+	ts := httptest.NewServer(srv.buildHandler())
+	defer ts.Close()
+
+	body := bytes.NewBufferString(`{"model":"qwen3:8b","messages":[{"role":"user","content":"ping"}],"stream":true}`)
+	resp, err := http.Post(ts.URL+"/v1/chat/completions", "application/json", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 400 {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected error status, got %d body=%s", resp.StatusCode, raw)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Errorf("expected JSON error, got Content-Type=%q", ct)
+	}
+}
+
+// TestIntegration_SSEFraming verifies a successful streaming chat over a
+// real socket produces well-formed SSE: `data:` prefixed events, a final
+// `[DONE]` sentinel, and blank-line separators.
+func TestIntegration_SSEFraming(t *testing.T) {
+	mp := &mockProvider{
+		name: "ollama", caps: provider.CapChat | provider.CapStream,
+		models: []provider.ModelInfo{{Name: "qwen3:8b", ContextWindow: 32768, Capabilities: []string{"chat", "stream"}}},
+		chatStreamFn: func(ctx context.Context, req provider.ChatRequest, cb func(provider.ChatResponse) error) error {
+			if err := cb(provider.ChatResponse{Model: req.Model, Content: "p"}); err != nil {
+				return err
+			}
+			return cb(provider.ChatResponse{Model: req.Model, Content: "ong", Done: true})
+		},
+	}
+	srv, teardown := newTestServer(t, mp)
+	defer teardown()
+	ts := httptest.NewServer(srv.buildHandler())
+	defer ts.Close()
+
+	body := bytes.NewBufferString(`{"model":"qwen3:8b","messages":[{"role":"user","content":"ping"}],"stream":true}`)
+	resp, err := http.Post(ts.URL+"/v1/chat/completions", "application/json", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, raw)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Errorf("Content-Type = %q, want text/event-stream", ct)
+	}
+
+	var sawData, sawDone bool
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "data: ") {
+			sawData = true
+			if strings.TrimSpace(strings.TrimPrefix(line, "data: ")) == "[DONE]" {
+				sawDone = true
+			}
+		}
+	}
+	if !sawData {
+		t.Errorf("no `data: ` frames seen")
+	}
+	if !sawDone {
+		t.Errorf("no `[DONE]` sentinel seen")
+	}
+}

--- a/compat/loopback.go
+++ b/compat/loopback.go
@@ -1,0 +1,23 @@
+package compat
+
+import "net"
+
+// isLoopback reports whether the host part of addr is a loopback address.
+// An empty host (e.g. ":8080") is NOT considered loopback because Go's
+// net/http binds to 0.0.0.0 (all interfaces) in that case.
+//
+// Mirrors mcp/transport.go:71-84.
+func isLoopback(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	if host == "" {
+		return false
+	}
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/compat/loopback_test.go
+++ b/compat/loopback_test.go
@@ -8,8 +8,12 @@ func TestIsLoopback(t *testing.T) {
 		want bool
 	}{
 		{"127.0.0.1:18741", true},
+		{"127.0.0.2:18741", true}, // entire 127.0.0.0/8 is loopback
 		{"[::1]:18741", true},
+		{"[0:0:0:0:0:0:0:1]:18741", true},  // uncompressed IPv6 loopback
+		{"[::ffff:127.0.0.1]:18741", true}, // IPv4-mapped IPv6 loopback
 		{"localhost:18741", true},
+		{"[::ffff:192.168.1.5]:18741", false}, // IPv4-mapped IPv6 non-loopback
 		{"0.0.0.0:18741", false},
 		{":18741", false},
 		{"192.168.1.5:18741", false},

--- a/compat/loopback_test.go
+++ b/compat/loopback_test.go
@@ -1,0 +1,26 @@
+package compat
+
+import "testing"
+
+func TestIsLoopback(t *testing.T) {
+	cases := []struct {
+		addr string
+		want bool
+	}{
+		{"127.0.0.1:18741", true},
+		{"[::1]:18741", true},
+		{"localhost:18741", true},
+		{"0.0.0.0:18741", false},
+		{":18741", false},
+		{"192.168.1.5:18741", false},
+		{"example.com:18741", false},
+		{"not-an-address", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.addr, func(t *testing.T) {
+			if got := isLoopback(tc.addr); got != tc.want {
+				t.Errorf("isLoopback(%q) = %v, want %v", tc.addr, got, tc.want)
+			}
+		})
+	}
+}

--- a/compat/middleware.go
+++ b/compat/middleware.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"net/http"
 	"time"
+
+	"github.com/kstruzzieri/go-llm/provider"
 )
 
 type ctxKey int
@@ -126,5 +128,24 @@ func loggingMiddleware(next http.Handler) http.Handler {
 			r.Method, r.URL.Path, rec.status,
 			time.Since(start).Round(time.Millisecond),
 			requestIDFrom(r.Context()))
+	})
+}
+
+// withSemaphore wraps next with admission control at the handler boundary.
+// This helper is for routes that do NOT need body-parse-before-acquire
+// (e.g. GET endpoints, or fixed-priority POSTs like /feedback). Body-bearing
+// endpoints that resolve priority from `x_priority` MUST acquire the
+// semaphore inline AFTER parsing so the resolved priority is honored —
+// wrapping them here would acquire before the priority is known.
+func withSemaphore(sem *semaphore, p provider.Priority, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		release, ok := sem.acquire(p)
+		if !ok {
+			w.Header().Set("Retry-After", "1")
+			writeError(w, http.StatusTooManyRequests, "capacity", "server is at capacity")
+			return
+		}
+		defer release()
+		next.ServeHTTP(w, r)
 	})
 }

--- a/compat/middleware.go
+++ b/compat/middleware.go
@@ -1,0 +1,130 @@
+package compat
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"log"
+	"net/http"
+	"time"
+)
+
+type ctxKey int
+
+const (
+	ctxRequestID ctxKey = iota + 1
+)
+
+// requestIDFrom returns the request ID attached by requestIDMiddleware, or "".
+func requestIDFrom(ctx context.Context) string {
+	v, _ := ctx.Value(ctxRequestID).(string)
+	return v
+}
+
+// corsMiddleware applies a simple CORS policy. An empty origin disables CORS.
+func corsMiddleware(next http.Handler, origin string) http.Handler {
+	if origin == "" {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Request-Id")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// recoveryMiddleware turns handler panics into 500 JSON errors. If the handler
+// panics after response headers have already been committed (e.g. mid-stream
+// in SSE), writing a fresh 500 would corrupt the body and produce Go's
+// "superfluous response.WriteHeader" warning. In that case we re-panic with
+// http.ErrAbortHandler, which is the stdlib's signal to drop the connection
+// without logging.
+func recoveryMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			p := recover()
+			if p == nil {
+				return
+			}
+			log.Printf("compat: panic serving %s %s: %v", r.Method, r.URL.Path, p)
+			if rec, ok := w.(*statusRecorder); ok && rec.wroteHeader {
+				panic(http.ErrAbortHandler)
+			}
+			writeError(w, http.StatusInternalServerError, "internal_error", "internal server error")
+		}()
+		next.ServeHTTP(w, r)
+	})
+}
+
+// requestIDMiddleware ensures every request has a correlation ID. If the
+// caller sent X-Request-Id, it is reused; otherwise a fresh 128-bit hex ID
+// is generated. The ID is reflected on the response header.
+func requestIDMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.Header.Get("X-Request-Id")
+		if id == "" {
+			id = newRequestID()
+		}
+		w.Header().Set("X-Request-Id", id)
+		ctx := context.WithValue(r.Context(), ctxRequestID, id)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func newRequestID() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	return hex.EncodeToString(b[:])
+}
+
+// statusRecorder captures the status code for logging and tracks whether
+// headers have been committed so recoveryMiddleware knows when a panic is
+// mid-stream. It also forwards http.Flusher so SSE handlers wrapped by
+// loggingMiddleware can still flush per chunk — without this, w.(http.Flusher)
+// would fail against the recorder and the outbound stream would be silently
+// buffered.
+type statusRecorder struct {
+	http.ResponseWriter
+	status      int
+	wroteHeader bool
+}
+
+func (s *statusRecorder) WriteHeader(code int) {
+	if !s.wroteHeader {
+		s.status = code
+		s.wroteHeader = true
+	}
+	s.ResponseWriter.WriteHeader(code)
+}
+
+// Write marks headers as committed — stdlib auto-calls WriteHeader(200) on the
+// first Write, and recoveryMiddleware needs to see that commit to avoid
+// double-writing headers after a mid-stream panic.
+func (s *statusRecorder) Write(b []byte) (int, error) {
+	s.wroteHeader = true
+	return s.ResponseWriter.Write(b)
+}
+
+func (s *statusRecorder) Flush() {
+	if f, ok := s.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// loggingMiddleware writes one line per request.
+func loggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(rec, r)
+		log.Printf("compat: %s %s %d %s rid=%s",
+			r.Method, r.URL.Path, rec.status,
+			time.Since(start).Round(time.Millisecond),
+			requestIDFrom(r.Context()))
+	})
+}

--- a/compat/middleware_test.go
+++ b/compat/middleware_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kstruzzieri/go-llm/provider"
 )
@@ -229,6 +230,35 @@ func TestStatusForCompatError_WrappedErrorsStillClassified(t *testing.T) {
 	if status != 429 || code != "rate_limited" {
 		t.Errorf("wrapped HTTP 429 = (%d, %q), want (429, rate_limited)", status, code)
 	}
+}
+
+func TestConcurrencyMiddleware_429WhenFull(t *testing.T) {
+	sem := newSemaphore(1)
+	blocker := make(chan struct{})
+	h := withSemaphore(sem, provider.PriorityNormal, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-blocker
+	}))
+
+	// First request takes the only slot.
+	done := make(chan struct{})
+	go func() {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+		close(done)
+	}()
+	time.Sleep(10 * time.Millisecond)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rec.Code != http.StatusTooManyRequests {
+		t.Errorf("status=%d want 429", rec.Code)
+	}
+	if rec.Header().Get("Retry-After") == "" {
+		t.Error("missing Retry-After header")
+	}
+
+	close(blocker)
+	<-done
 }
 
 func TestWriteCompatError_EndToEnd(t *testing.T) {

--- a/compat/middleware_test.go
+++ b/compat/middleware_test.go
@@ -1,0 +1,251 @@
+package compat
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+func TestCORSMiddleware_SetsHeaders(t *testing.T) {
+	h := corsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), "*")
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("CORS origin = %q, want *", got)
+	}
+}
+
+func TestCORSMiddleware_EmptyOriginDisables(t *testing.T) {
+	h := corsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), "")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("want no CORS header, got %q", got)
+	}
+}
+
+func TestCORSMiddleware_OptionsReturns204(t *testing.T) {
+	h := corsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("next should not run for OPTIONS")
+	}), "*")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodOptions, "/v1/models", nil))
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("OPTIONS status = %d, want 204", rec.Code)
+	}
+}
+
+func TestRecoveryMiddleware_ConvertsPanicTo500(t *testing.T) {
+	h := recoveryMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("boom")
+	}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", rec.Code)
+	}
+	var env errorEnvelope
+	if err := json.NewDecoder(rec.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if env.Error.Type != "api_error" {
+		t.Errorf("error type = %q, want api_error", env.Error.Type)
+	}
+}
+
+func TestRecoveryMiddleware_PanicAfterHeadersAborts(t *testing.T) {
+	// Regression guard: a handler panic after headers are committed (i.e.
+	// mid-stream in SSE) must NOT try to write a fresh 500 header on top of
+	// the already-sent 200. Writing twice would corrupt the stream and
+	// trigger Go's "superfluous response.WriteHeader" warning. The correct
+	// response is panic(http.ErrAbortHandler), which drops the connection.
+	h := loggingMiddleware(recoveryMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: chunk 1\n\n"))
+		panic("boom mid-stream")
+	})))
+	rec := httptest.NewRecorder()
+	defer func() {
+		p := recover()
+		if p != http.ErrAbortHandler {
+			t.Fatalf("expected panic with http.ErrAbortHandler, got %v", p)
+		}
+	}()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/chat/completions", nil))
+	t.Fatal("ServeHTTP returned without re-panicking on mid-stream panic")
+}
+
+func TestLoggingMiddleware_RecordsPanicStatus(t *testing.T) {
+	// Regression guard for middleware order: when recoveryMiddleware is
+	// INSIDE loggingMiddleware, a handler panic is converted to a 500 by
+	// recovery and then observed as status=500 by logging. If the order is
+	// inverted, logging's next.ServeHTTP re-panics before the log line runs,
+	// and the 500 goes unrecorded.
+	chain := loggingMiddleware(recoveryMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("boom")
+	})))
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", rec.Code)
+	}
+}
+
+func TestRequestIDMiddleware_ReusesIncoming(t *testing.T) {
+	h := requestIDMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requestIDFrom(r.Context()) != "caller-id" {
+			t.Errorf("context rid = %q, want caller-id", requestIDFrom(r.Context()))
+		}
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req.Header.Set("X-Request-Id", "caller-id")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Header().Get("X-Request-Id") != "caller-id" {
+		t.Errorf("response rid = %q, want caller-id", rec.Header().Get("X-Request-Id"))
+	}
+}
+
+func TestRequestIDMiddleware_GeneratesWhenAbsent(t *testing.T) {
+	h := requestIDMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+	id := rec.Header().Get("X-Request-Id")
+	if len(id) != 32 || strings.TrimLeft(id, "0123456789abcdef") != "" {
+		t.Errorf("generated rid = %q, want 32 hex chars", id)
+	}
+}
+
+// flushableRecorder is httptest.ResponseRecorder plus an http.Flusher. The
+// stdlib recorder does not implement Flusher, so without this stub the
+// regression test below could not distinguish "Flush passthrough works" from
+// "no Flusher on the chain at all".
+type flushableRecorder struct {
+	*httptest.ResponseRecorder
+	flushed int
+}
+
+func (f *flushableRecorder) Flush() { f.flushed++ }
+
+func TestLoggingMiddleware_ForwardsFlusher(t *testing.T) {
+	// Regression guard for SSE: statusRecorder must forward Flush to the
+	// underlying writer, otherwise streaming handlers (chat/completions)
+	// silently buffer their chunks when wrapped by loggingMiddleware.
+	var reachedHandler bool
+	h := loggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reachedHandler = true
+		f, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("wrapped ResponseWriter does not implement http.Flusher")
+		}
+		f.Flush()
+	}))
+	rec := &flushableRecorder{ResponseRecorder: httptest.NewRecorder()}
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/chat/completions", nil))
+	if !reachedHandler {
+		t.Fatal("handler did not run")
+	}
+	if rec.flushed != 1 {
+		t.Errorf("underlying Flush calls = %d, want 1", rec.flushed)
+	}
+}
+
+func TestWriteError_OpenAIShape(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeError(rec, http.StatusBadRequest, "bad_model", "unknown model")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+	body, _ := io.ReadAll(rec.Body)
+	var env errorEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if env.Error.Type != "invalid_request_error" ||
+		env.Error.Code != "bad_model" ||
+		env.Error.Message != "unknown model" {
+		t.Errorf("bad error body: %+v", env)
+	}
+}
+
+func TestStatusForCompatError_KnownSentinels(t *testing.T) {
+	cases := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   string
+	}{
+		{"no_viable_candidate", provider.ErrNoViableCandidate, 400, "no_viable_candidate"},
+		{"budget_exceeded", provider.ErrBudgetExceeded, 400, "budget_exceeded"},
+		{"budget_adaptation_required", provider.ErrBudgetAdaptationRequired, 400, "budget_adaptation_required"},
+		{"all_breakers_open", provider.ErrAllBreakersOpen, 503, "all_breakers_open"},
+		{"deadline", context.DeadlineExceeded, 504, "timeout"},
+		{"canceled", context.Canceled, 499, "canceled"},
+		{"http_400", &provider.HTTPStatusError{StatusCode: 400, Status: "400 Bad Request"}, 400, "upstream_client_error"},
+		{"http_404", &provider.HTTPStatusError{StatusCode: 404, Status: "404 Not Found"}, 404, "upstream_client_error"},
+		{"http_429", &provider.HTTPStatusError{StatusCode: 429, Status: "429 Too Many Requests"}, 429, "rate_limited"},
+		{"http_500", &provider.HTTPStatusError{StatusCode: 500, Status: "500 Internal Server Error"}, 502, "upstream_error"},
+		{"http_502", &provider.HTTPStatusError{StatusCode: 502, Status: "502 Bad Gateway"}, 502, "upstream_error"},
+		{"http_503", &provider.HTTPStatusError{StatusCode: 503, Status: "503 Service Unavailable"}, 502, "upstream_error"},
+		{"unknown", errors.New("some random failure"), 502, "upstream_error"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, code, _ := statusForCompatError(tc.err)
+			if status != tc.wantStatus || code != tc.wantCode {
+				t.Errorf("statusForCompatError(%v) = (%d, %q), want (%d, %q)",
+					tc.err, status, code, tc.wantStatus, tc.wantCode)
+			}
+		})
+	}
+}
+
+func TestStatusForCompatError_WrappedErrorsStillClassified(t *testing.T) {
+	// Regression guard: handlers call fmt.Errorf("route: %w", err). The mapper
+	// must unwrap and still classify correctly.
+	wrapped := fmt.Errorf("route: %w", provider.ErrNoViableCandidate)
+	status, code, _ := statusForCompatError(wrapped)
+	if status != 400 || code != "no_viable_candidate" {
+		t.Errorf("wrapped sentinel = (%d, %q), want (400, no_viable_candidate)", status, code)
+	}
+
+	wrappedHTTP := fmt.Errorf("provider: %w", &provider.HTTPStatusError{StatusCode: 429, Status: "429"})
+	status, code, _ = statusForCompatError(wrappedHTTP)
+	if status != 429 || code != "rate_limited" {
+		t.Errorf("wrapped HTTP 429 = (%d, %q), want (429, rate_limited)", status, code)
+	}
+}
+
+func TestWriteCompatError_EndToEnd(t *testing.T) {
+	// Verify writeCompatError glues statusForCompatError + writeError correctly.
+	rec := httptest.NewRecorder()
+	writeCompatError(rec, provider.ErrAllBreakersOpen)
+	if rec.Code != 503 {
+		t.Errorf("status = %d, want 503", rec.Code)
+	}
+	var env errorEnvelope
+	if err := json.NewDecoder(rec.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if env.Error.Code != "all_breakers_open" {
+		t.Errorf("code = %q, want all_breakers_open", env.Error.Code)
+	}
+	if env.Error.Type != "api_error" {
+		t.Errorf("type = %q, want api_error", env.Error.Type)
+	}
+}

--- a/compat/models.go
+++ b/compat/models.go
@@ -1,0 +1,168 @@
+package compat
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// ModelsListResponse is the OpenAI-shape response for GET /v1/models.
+type ModelsListResponse struct {
+	Object string        `json:"object"` // always "list"
+	Data   []ModelObject `json:"data"`
+}
+
+// ModelObject is the OpenAI-shape model descriptor, extended with go-llm
+// specific fields under the x_ prefix. Standard OpenAI SDKs ignore unknown
+// fields, so these extensions are safe for mixed clients.
+//
+// Canonical entries (real provider/model pairs) populate Capabilities,
+// ContextWindow, Quality, Resources, and Warm. Alias entries populate
+// AliasFor only; clients should follow x_alias_for to look up the
+// canonical entry for capability details.
+type ModelObject struct {
+	ID      string `json:"id"` // canonical provider/model selector, or alias name
+	Object  string `json:"object"`
+	Created int64  `json:"created"`
+	OwnedBy string `json:"owned_by"`
+
+	Capabilities  []string           `json:"x_capabilities,omitempty"`
+	ContextWindow int                `json:"x_context_window,omitempty"`
+	Quality       string             `json:"x_quality,omitempty"`
+	Resources     *ModelResourcesExt `json:"x_resources,omitempty"`
+	Warm          bool               `json:"x_warm,omitempty"`
+	AliasFor      string             `json:"x_alias_for,omitempty"`
+}
+
+// ModelResourcesExt reports resource requirements for a canonical model. All
+// sizes are in gigabytes. Fields are omitted when zero; Resources itself is
+// set to nil by handleModels when every field is zero so omitempty suppresses
+// the whole object.
+type ModelResourcesExt struct {
+	RAMRequired     float64 `json:"ram_required_gb,omitempty"`
+	RAMRecommended  float64 `json:"ram_recommended_gb,omitempty"`
+	VRAMRecommended float64 `json:"vram_recommended_gb,omitempty"`
+}
+
+// handleModels implements GET /v1/models. It enumerates every model the
+// server can route to (canonical provider/model pairs) plus every configured
+// alias, and emits them in OpenAI's list-of-models shape with go-llm x_*
+// extensions. Warm entries sort first so clients that enumerate models see
+// the fastest ready-to-serve options before cold ones.
+func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
+	if s.registry == nil {
+		writeError(w, http.StatusServiceUnavailable, "no_registry", "server has no model registry")
+		return
+	}
+
+	profiles, err := s.registry.All(r.Context())
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "registry_error", err.Error())
+		return
+	}
+
+	// Pre-size generously (canonical + aliases) and ensure the slice is
+	// non-nil so an empty registry serializes as "data": [] not "data": null.
+	out := make([]ModelObject, 0, len(profiles)+len(s.aliases))
+
+	// Warmth lookup keyed by ModelKey. A model is warm when its entry
+	// reports Loaded == true.
+	warm := make(map[provider.ModelKey]bool)
+	if s.router != nil {
+		for _, wm := range s.router.WarmthSnapshot() {
+			if wm.Info.Loaded {
+				warm[wm.Key] = true
+			}
+		}
+	}
+
+	// Track canonical IDs and UpdatedAt so alias entries can reuse the
+	// target's UpdatedAt instead of falling back to zero.
+	canonicalUpdatedAt := make(map[string]time.Time, len(profiles))
+
+	for _, p := range profiles {
+		id := p.Key.String()
+		canonicalUpdatedAt[id] = p.UpdatedAt
+
+		obj := ModelObject{
+			ID:            id,
+			Object:        "model",
+			Created:       p.UpdatedAt.Unix(),
+			OwnedBy:       p.Provider,
+			Capabilities:  splitCapabilities(p.Caps),
+			ContextWindow: p.ContextWindow,
+			Quality:       p.Quality.String(),
+			Warm:          warm[p.Key],
+		}
+		if p.Resources.RAMRequired != 0 || p.Resources.RAMRecommended != 0 || p.Resources.VRAMRecommended != 0 {
+			obj.Resources = &ModelResourcesExt{
+				RAMRequired:     p.Resources.RAMRequired,
+				RAMRecommended:  p.Resources.RAMRecommended,
+				VRAMRecommended: p.Resources.VRAMRecommended,
+			}
+		}
+		out = append(out, obj)
+	}
+
+	// Deterministic alias ordering: Go map iteration is randomized, so sort
+	// alias keys alphabetically before emitting.
+	aliasKeys := make([]string, 0, len(s.aliases))
+	for k := range s.aliases {
+		aliasKeys = append(aliasKeys, k)
+	}
+	sort.Strings(aliasKeys)
+
+	for _, aliasKey := range aliasKeys {
+		target := s.aliases[aliasKey]
+		// Normalize the target the same way resolveModel does: parse the
+		// "provider/model" form when present; carry the bare model name
+		// through otherwise. parseKey does not synthesize a provider for
+		// unqualified inputs, so we do not invent one here either.
+		tk := parseKey(target)
+		var aliasFor string
+		if tk.Provider != "" {
+			aliasFor = tk.String()
+		} else {
+			aliasFor = tk.Model
+		}
+
+		// Use the canonical target's UpdatedAt when we can resolve it; fall
+		// back to 0 otherwise. The plan does not require a specific semantic
+		// for alias Created, so linking the alias's timestamp to the profile
+		// it points at keeps clients' staleness checks coherent when they
+		// follow x_alias_for.
+		var created int64
+		if ts, ok := canonicalUpdatedAt[aliasFor]; ok {
+			created = ts.Unix()
+		}
+
+		out = append(out, ModelObject{
+			ID:       aliasKey,
+			Object:   "model",
+			Created:  created,
+			OwnedBy:  "alias",
+			AliasFor: aliasFor,
+		})
+	}
+
+	sortModelsWarmFirst(out)
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(ModelsListResponse{Object: "list", Data: out})
+}
+
+// sortModelsWarmFirst orders entries so warm models come before cold ones and
+// IDs ascend within each group. The sort is stable-by-construction because
+// the keying function is total. Extracted as a named helper so the ordering
+// policy can be unit-tested without threading warmth through the router.
+func sortModelsWarmFirst(models []ModelObject) {
+	sort.Slice(models, func(i, j int) bool {
+		if models[i].Warm != models[j].Warm {
+			return models[i].Warm
+		}
+		return models[i].ID < models[j].ID
+	})
+}

--- a/compat/models.go
+++ b/compat/models.go
@@ -2,6 +2,7 @@ package compat
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"sort"
 	"time"
@@ -60,6 +61,19 @@ func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 
 	profiles, err := s.registry.All(r.Context())
 	if err != nil {
+		// ModelRegistry.All does not wrap the underlying cancellation with %w
+		// when every provider fails, so errors.Is(err, context.Canceled) on
+		// the aggregate "all N providers failed" string returns false. Detect
+		// cancellation directly via the request context and route through
+		// writeCompatError so it maps to 499 (client closed) or 504 (deadline)
+		// instead of a misleading 502. For genuine registry failures, keep the
+		// specific registry_error code and log the cause so operators can see
+		// why the list endpoint is flapping.
+		if ctxErr := r.Context().Err(); ctxErr != nil {
+			writeCompatError(w, ctxErr)
+			return
+		}
+		log.Printf("compat: /v1/models registry error: %v", err)
 		writeError(w, http.StatusBadGateway, "registry_error", err.Error())
 		return
 	}
@@ -80,12 +94,21 @@ func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Track canonical IDs and UpdatedAt so alias entries can reuse the
-	// target's UpdatedAt instead of falling back to zero.
+	// target's UpdatedAt instead of falling back to zero. We also keep a
+	// secondary index keyed by bare model name so unqualified alias targets
+	// (e.g. "gpt-3.5-turbo" -> "qwen3:8b") can still find a canonical
+	// timestamp. Ambiguous bare names — the same model served by more than one
+	// provider — are dropped below so we do not arbitrarily pick one
+	// provider's UpdatedAt.
 	canonicalUpdatedAt := make(map[string]time.Time, len(profiles))
+	bareCount := make(map[string]int, len(profiles))
+	bareUpdatedAt := make(map[string]time.Time, len(profiles))
 
 	for _, p := range profiles {
 		id := p.Key.String()
 		canonicalUpdatedAt[id] = p.UpdatedAt
+		bareCount[p.Key.Model]++
+		bareUpdatedAt[p.Key.Model] = p.UpdatedAt
 
 		obj := ModelObject{
 			ID:            id,
@@ -105,6 +128,17 @@ func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		out = append(out, obj)
+	}
+
+	// Drop ambiguous bare-name entries: when a bare model name is advertised
+	// by more than one provider, we cannot pick a single canonical UpdatedAt
+	// without silently privileging one provider over another. Deleting the
+	// key here makes unqualified alias Created fall back to 0, which is more
+	// honest than an arbitrary choice.
+	for model, n := range bareCount {
+		if n > 1 {
+			delete(bareUpdatedAt, model)
+		}
 	}
 
 	// Deterministic alias ordering: Go map iteration is randomized, so sort
@@ -130,13 +164,23 @@ func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Use the canonical target's UpdatedAt when we can resolve it; fall
-		// back to 0 otherwise. The plan does not require a specific semantic
-		// for alias Created, so linking the alias's timestamp to the profile
-		// it points at keeps clients' staleness checks coherent when they
-		// follow x_alias_for.
+		// back to 0 otherwise. Disambiguation rules:
+		//   1. Qualified target (provider/model): look up the canonical entry
+		//      directly and use its UpdatedAt.
+		//   2. Unqualified target (bare model) with exactly one canonical
+		//      provider advertising that model: use that canonical's
+		//      UpdatedAt.
+		//   3. Unqualified target whose bare name is advertised by multiple
+		//      providers: Created stays 0. Picking one provider's timestamp
+		//      arbitrarily would mislead clients that follow x_alias_for to a
+		//      different provider's canonical entry.
 		var created int64
 		if ts, ok := canonicalUpdatedAt[aliasFor]; ok {
 			created = ts.Unix()
+		} else if tk.Provider == "" {
+			if ts, ok := bareUpdatedAt[tk.Model]; ok {
+				created = ts.Unix()
+			}
 		}
 
 		out = append(out, ModelObject{
@@ -155,11 +199,13 @@ func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 }
 
 // sortModelsWarmFirst orders entries so warm models come before cold ones and
-// IDs ascend within each group. The sort is stable-by-construction because
-// the keying function is total. Extracted as a named helper so the ordering
-// policy can be unit-tested without threading warmth through the router.
+// IDs ascend within each group. Uses a stable sort so any future refactor that
+// introduces tied keys (e.g. multiple alias entries sharing an ID shape)
+// preserves input order rather than flipping entries between calls. Extracted
+// as a named helper so the ordering policy can be unit-tested without threading
+// warmth through the router.
 func sortModelsWarmFirst(models []ModelObject) {
-	sort.Slice(models, func(i, j int) bool {
+	sort.SliceStable(models, func(i, j int) bool {
 		if models[i].Warm != models[j].Warm {
 			return models[i].Warm
 		}

--- a/compat/models_test.go
+++ b/compat/models_test.go
@@ -1,10 +1,13 @@
 package compat
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/kstruzzieri/go-llm/provider"
 )
@@ -182,7 +185,7 @@ func TestModelsHandler_EmptyRegistryReturnsEmptyList(t *testing.T) {
 	}
 	// The raw body must contain "data":[] not "data":null.
 	body := rec.Body.String()
-	if !contains(body, `"data":[]`) {
+	if !strings.Contains(body, `"data":[]`) {
 		t.Errorf("body = %q, want Data to serialize as []", body)
 	}
 }
@@ -214,19 +217,124 @@ func TestSortModelsWarmFirst_WarmBeforeCold(t *testing.T) {
 	}
 }
 
-// contains is a tiny helper so the test file does not pull in strings just for
-// one substring check.
-func contains(haystack, needle string) bool {
-	return len(haystack) >= len(needle) && indexOf(haystack, needle) >= 0
+// fakeWarmthSource is a minimal WarmthSource that always reports the same
+// snapshot. It is used to drive x_warm through a real Router for
+// TestModelsHandler_WarmModelsGetXWarmTrue. Only Snapshot/Close are exercised
+// by the models handler; the other interface methods are stubbed to satisfy
+// the compile-time assertion.
+type fakeWarmthSource struct {
+	models []provider.WarmModel
 }
 
-func indexOf(haystack, needle string) int {
-	for i := 0; i+len(needle) <= len(haystack); i++ {
-		if haystack[i:i+len(needle)] == needle {
-			return i
+func (f *fakeWarmthSource) IsWarm(key provider.ModelKey) bool {
+	for _, wm := range f.models {
+		if wm.Key == key && wm.Info.Loaded {
+			return true
 		}
 	}
-	return -1
+	return false
+}
+
+func (f *fakeWarmthSource) WarmthState(key provider.ModelKey) *provider.WarmthInfo {
+	for _, wm := range f.models {
+		if wm.Key == key {
+			info := wm.Info
+			return &info
+		}
+	}
+	return nil
+}
+
+func (f *fakeWarmthSource) RecordUse(provider.ModelKey)    {}
+func (f *fakeWarmthSource) Snapshot() []provider.WarmModel { return f.models }
+func (f *fakeWarmthSource) Close() error                   { return nil }
+
+// TestModelsHandler_WarmModelsGetXWarmTrue plugs a fake WarmthSource into a
+// real Router and verifies x_warm propagates end-to-end through the handler.
+// This guards against a future refactor where ModelKey formatting drift (e.g.
+// provider-name capitalization) could silently mark every canonical entry cold
+// with no HTTP-level test to catch it. TestSortModelsWarmFirst_WarmBeforeCold
+// only exercises the sort helper in isolation, so the warm map lookup would be
+// untested otherwise.
+func TestModelsHandler_WarmModelsGetXWarmTrue(t *testing.T) {
+	warmModel := &mockProvider{
+		name: "ollama",
+		caps: provider.CapChat | provider.CapGenerate,
+		models: []provider.ModelInfo{
+			{Name: "qwen3:8b", ContextWindow: 32768},
+			{Name: "qwen3-embedding:8b", ContextWindow: 8192},
+		},
+	}
+
+	provReg := provider.NewRegistry()
+	if err := provReg.Register(warmModel); err != nil {
+		t.Fatalf("provider registry register: %v", err)
+	}
+	if err := provReg.RefreshModels(context.Background(), warmModel.Name()); err != nil {
+		t.Fatalf("provider registry refresh models: %v", err)
+	}
+	modelReg, err := provider.NewModelRegistry(provReg, nil)
+	if err != nil {
+		t.Fatalf("NewModelRegistry: %v", err)
+	}
+
+	// Mark qwen3:8b warm, leave qwen3-embedding:8b cold. The handler's warmth
+	// lookup keys on provider.ModelKey, so the fake's entry must match the
+	// canonical key exactly.
+	warmKey := provider.ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+	ws := &fakeWarmthSource{
+		models: []provider.WarmModel{
+			{
+				Key: warmKey,
+				Info: provider.WarmthInfo{
+					Loaded:    true,
+					Since:     time.Now().Add(-1 * time.Minute),
+					ExpiresAt: time.Now().Add(5 * time.Minute),
+					VRAM:      6.0,
+				},
+			},
+		},
+	}
+	router := provider.NewRouter(modelReg, provReg,
+		provider.WithStickyTTL(time.Second),
+		provider.WithAvailableRAM(256),
+		provider.WithWarmthSource(ws),
+	)
+	defer func() { _ = router.Close() }()
+	srv := New(router, modelReg, provReg)
+
+	rec := httptest.NewRecorder()
+	srv.buildHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp ModelsListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	byID := make(map[string]ModelObject, len(resp.Data))
+	for _, m := range resp.Data {
+		byID[m.ID] = m
+	}
+
+	hot, ok := byID["ollama/qwen3:8b"]
+	if !ok {
+		t.Fatalf("missing canonical entry ollama/qwen3:8b; got IDs=%v", idsOf(resp.Data))
+	}
+	if !hot.Warm {
+		t.Errorf("ollama/qwen3:8b x_warm = false, want true (warmth snapshot did not propagate)")
+	}
+
+	cold, ok := byID["ollama/qwen3-embedding:8b"]
+	if !ok {
+		t.Fatalf("missing canonical entry ollama/qwen3-embedding:8b; got IDs=%v", idsOf(resp.Data))
+	}
+	if cold.Warm {
+		t.Errorf("ollama/qwen3-embedding:8b x_warm = true, want false (cold model reported warm)")
+	}
 }
 
 func idsOf(models []ModelObject) []string {

--- a/compat/models_test.go
+++ b/compat/models_test.go
@@ -1,0 +1,238 @@
+package compat
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+func TestModelsHandler_ListsRegisteredModels(t *testing.T) {
+	mp := &mockProvider{
+		name: "ollama",
+		caps: provider.CapChat | provider.CapGenerate,
+		models: []provider.ModelInfo{
+			{Name: "qwen3:8b", ContextWindow: 32768},
+			{Name: "qwen3-embedding:8b", ContextWindow: 8192},
+		},
+	}
+	srv, teardown := newTestServer(t, mp)
+	defer teardown()
+
+	rec := httptest.NewRecorder()
+	srv.buildHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp ModelsListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Object != "list" {
+		t.Errorf("object = %q, want list", resp.Object)
+	}
+	if len(resp.Data) == 0 {
+		t.Fatal("expected at least one model")
+	}
+	for _, m := range resp.Data {
+		if m.Object != "model" {
+			t.Errorf("model object = %q", m.Object)
+		}
+		if m.ID == "" {
+			t.Error("empty ID")
+		}
+		if m.OwnedBy == "" {
+			t.Error("empty OwnedBy")
+		}
+	}
+}
+
+// TestModelsHandler_ListsAliasEntriesAndXResources exercises Amendment #7:
+// canonical entries must carry go-llm-specific extension fields (x_capabilities,
+// x_context_window, x_resources) and configured aliases must be listed with
+// x_alias_for pointing at the canonical provider/model selector.
+//
+// Note: warm-first ordering is exercised in TestSortModelsWarmFirst_WarmBeforeCold
+// directly against the sort helper. Driving the router's warmth source through
+// this HTTP-level test would require running real requests through the router,
+// which is more ceremony than the assertion warrants.
+func TestModelsHandler_ListsAliasEntriesAndXResources(t *testing.T) {
+	mp := &mockProvider{
+		name: "ollama",
+		caps: provider.CapChat | provider.CapGenerate,
+		models: []provider.ModelInfo{
+			{Name: "qwen3:8b", ContextWindow: 32768},
+		},
+	}
+	aliases := map[string]string{
+		"gpt-4":         "ollama/qwen3:8b",
+		"gpt-3.5-turbo": "qwen3:8b",
+	}
+	srv, teardown := newTestServer(t, mp, WithAliases(aliases))
+	defer teardown()
+
+	rec := httptest.NewRecorder()
+	srv.buildHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp ModelsListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	byID := make(map[string]ModelObject, len(resp.Data))
+	for _, m := range resp.Data {
+		byID[m.ID] = m
+	}
+
+	canonical, ok := byID["ollama/qwen3:8b"]
+	if !ok {
+		t.Fatalf("missing canonical entry ollama/qwen3:8b; got IDs=%v", idsOf(resp.Data))
+	}
+	if canonical.OwnedBy != "ollama" {
+		t.Errorf("canonical OwnedBy = %q, want ollama", canonical.OwnedBy)
+	}
+	if len(canonical.Capabilities) == 0 {
+		t.Error("canonical x_capabilities is empty; want at least chat/generate")
+	}
+	// Quality tier should serialize as a known string ("basic"/.../"unknown").
+	if canonical.Quality == "" {
+		t.Error("canonical x_quality is empty; want a tier string")
+	}
+	if canonical.AliasFor != "" {
+		t.Errorf("canonical entry must not have x_alias_for, got %q", canonical.AliasFor)
+	}
+
+	// Alias with qualified target: "gpt-4" -> "ollama/qwen3:8b".
+	gpt4, ok := byID["gpt-4"]
+	if !ok {
+		t.Fatalf("missing alias entry gpt-4; got IDs=%v", idsOf(resp.Data))
+	}
+	if gpt4.OwnedBy != "alias" {
+		t.Errorf("alias OwnedBy = %q, want alias", gpt4.OwnedBy)
+	}
+	if gpt4.AliasFor != "ollama/qwen3:8b" {
+		t.Errorf("alias x_alias_for = %q, want ollama/qwen3:8b", gpt4.AliasFor)
+	}
+	// Alias entries should be pointers only — no duplicated capability/context fields.
+	if len(gpt4.Capabilities) != 0 {
+		t.Errorf("alias x_capabilities = %v, want empty", gpt4.Capabilities)
+	}
+	if gpt4.ContextWindow != 0 {
+		t.Errorf("alias x_context_window = %d, want 0", gpt4.ContextWindow)
+	}
+	if gpt4.Quality != "" {
+		t.Errorf("alias x_quality = %q, want empty", gpt4.Quality)
+	}
+	if gpt4.Resources != nil {
+		t.Errorf("alias x_resources = %+v, want nil", gpt4.Resources)
+	}
+	if gpt4.Warm {
+		t.Error("alias x_warm = true, want false")
+	}
+
+	// Alias with unqualified target: "gpt-3.5-turbo" -> "qwen3:8b" (bare model).
+	// Per implementation guidance step 5, when an alias target carries no provider
+	// segment we do NOT synthesize one, so the raw model name is carried through.
+	turbo, ok := byID["gpt-3.5-turbo"]
+	if !ok {
+		t.Fatalf("missing alias entry gpt-3.5-turbo; got IDs=%v", idsOf(resp.Data))
+	}
+	if turbo.AliasFor != "qwen3:8b" {
+		t.Errorf("unqualified alias x_alias_for = %q, want qwen3:8b", turbo.AliasFor)
+	}
+}
+
+func TestModelsHandler_NoRegistry(t *testing.T) {
+	srv := New(nil, nil, nil)
+
+	rec := httptest.NewRecorder()
+	srv.buildHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+}
+
+func TestModelsHandler_EmptyRegistryReturnsEmptyList(t *testing.T) {
+	// Regression guard: All() returns (nil, nil) when no providers are
+	// registered. The handler must emit an empty list with Data=[] (never
+	// null) so JavaScript clients can safely access .length.
+	provReg := provider.NewRegistry()
+	modelReg, err := provider.NewModelRegistry(provReg, nil)
+	if err != nil {
+		t.Fatalf("NewModelRegistry: %v", err)
+	}
+	router := provider.NewRouter(modelReg, provReg)
+	defer func() { _ = router.Close() }()
+	srv := New(router, modelReg, provReg)
+
+	rec := httptest.NewRecorder()
+	srv.buildHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	// The raw body must contain "data":[] not "data":null.
+	body := rec.Body.String()
+	if !contains(body, `"data":[]`) {
+		t.Errorf("body = %q, want Data to serialize as []", body)
+	}
+}
+
+func TestSortModelsWarmFirst_WarmBeforeCold(t *testing.T) {
+	// Synthesize a mixed slice and verify sortModelsWarmFirst:
+	//   1. moves warm entries ahead of cold
+	//   2. sorts within each group by ID ascending
+	in := []ModelObject{
+		{ID: "ollama/zebra:8b", Warm: false},
+		{ID: "ollama/apple:8b", Warm: true},
+		{ID: "gpt-4", Warm: false}, // alias, cold
+		{ID: "ollama/banana:8b", Warm: true},
+		{ID: "ollama/cherry:8b", Warm: false},
+	}
+	sortModelsWarmFirst(in)
+
+	wantIDs := []string{
+		"ollama/apple:8b",  // warm
+		"ollama/banana:8b", // warm
+		"gpt-4",            // cold
+		"ollama/cherry:8b", // cold
+		"ollama/zebra:8b",  // cold
+	}
+	for i, want := range wantIDs {
+		if in[i].ID != want {
+			t.Errorf("sorted[%d].ID = %q, want %q (full=%v)", i, in[i].ID, want, idsOf(in))
+		}
+	}
+}
+
+// contains is a tiny helper so the test file does not pull in strings just for
+// one substring check.
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && indexOf(haystack, needle) >= 0
+}
+
+func indexOf(haystack, needle string) int {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}
+
+func idsOf(models []ModelObject) []string {
+	out := make([]string, 0, len(models))
+	for _, m := range models {
+		out = append(out, m.ID)
+	}
+	return out
+}

--- a/compat/options.go
+++ b/compat/options.go
@@ -1,0 +1,94 @@
+package compat
+
+import "time"
+
+// Option configures a Server at construction time.
+type Option func(*Server)
+
+// WithAddr sets the TCP listen address. Default "127.0.0.1:18741".
+// Non-loopback addresses require WithTLS.
+func WithAddr(addr string) Option {
+	return func(s *Server) { s.addr = addr }
+}
+
+// WithBasePath sets the HTTP path prefix under which endpoints are mounted.
+// Default "/v1". A trailing slash is normalized away.
+func WithBasePath(prefix string) Option {
+	return func(s *Server) { s.basePath = normalizeBase(prefix) }
+}
+
+// WithCORS sets the Access-Control-Allow-Origin value. Default "*".
+// Pass the empty string to disable CORS headers entirely.
+func WithCORS(origin string) Option {
+	return func(s *Server) { s.corsOrigin = origin }
+}
+
+// WithTLS enables HTTPS using the given certificate and private key paths.
+// Required when binding to a non-loopback address.
+func WithTLS(certFile, keyFile string) Option {
+	return func(s *Server) {
+		s.tlsCert = certFile
+		s.tlsKey = keyFile
+	}
+}
+
+// WithAliases installs a model-name translation map. Keys are the names
+// clients send on the wire (e.g. "gpt-4"); values are canonical provider-
+// qualified selectors (e.g. "ollama/qwen3-coder-next:latest") or unqualified
+// model names (e.g. "qwen3:8b"). Unqualified values constrain the request by
+// model name across providers; qualified values pin the backend.
+//
+// Passing nil clears any previously configured aliases. The default is empty.
+func WithAliases(aliases map[string]string) Option {
+	return func(s *Server) {
+		if aliases == nil {
+			s.aliases = map[string]string{}
+			return
+		}
+		m := make(map[string]string, len(aliases))
+		for k, v := range aliases {
+			m[k] = v
+		}
+		s.aliases = m
+	}
+}
+
+// WithMaxConcurrency caps simultaneous in-flight requests. Default 4.
+// The reserve for PriorityHigh requests is derived internally; see
+// reserveFor. Values <= 0 are treated as 1.
+func WithMaxConcurrency(n int) Option {
+	return func(s *Server) {
+		if n < 1 {
+			n = 1
+		}
+		s.maxConcurrency = n
+	}
+}
+
+// WithEmbeddings enables the POST /v1/embeddings endpoint. Default false.
+// Opt-in only — embedding requests can trigger surprise model loads.
+func WithEmbeddings(enabled bool) Option {
+	return func(s *Server) { s.embeddingsEnabled = enabled }
+}
+
+// WithShutdownTimeout sets how long Close waits for in-flight requests.
+// Default 30 seconds.
+func WithShutdownTimeout(d time.Duration) Option {
+	return func(s *Server) {
+		if d > 0 {
+			s.shutdownTimeout = d
+		}
+	}
+}
+
+// normalizeBase trims trailing slashes, forces a leading slash when non-empty,
+// and maps empty or "/" to "".
+func normalizeBase(prefix string) string {
+	if prefix != "" && prefix[0] != '/' {
+		prefix = "/" + prefix
+	}
+	for len(prefix) > 0 && prefix[len(prefix)-1] == '/' {
+		prefix = prefix[:len(prefix)-1]
+	}
+	return prefix
+}

--- a/compat/options.go
+++ b/compat/options.go
@@ -72,7 +72,9 @@ func WithEmbeddings(enabled bool) Option {
 }
 
 // WithShutdownTimeout sets how long Close waits for in-flight requests.
-// Default 30 seconds.
+// Default 30 seconds. Values <= 0 are ignored (the default is preserved);
+// this matches the zero-value semantics of time.Duration so callers can pass
+// a configured duration without a conditional wrap.
 func WithShutdownTimeout(d time.Duration) Option {
 	return func(s *Server) {
 		if d > 0 {

--- a/compat/options.go
+++ b/compat/options.go
@@ -1,6 +1,9 @@
 package compat
 
-import "time"
+import (
+	"path"
+	"time"
+)
 
 // Option configures a Server at construction time.
 type Option func(*Server)
@@ -72,9 +75,8 @@ func WithEmbeddings(enabled bool) Option {
 }
 
 // WithShutdownTimeout sets how long Close waits for in-flight requests.
-// Default 30 seconds. Values <= 0 are ignored (the default is preserved);
-// this matches the zero-value semantics of time.Duration so callers can pass
-// a configured duration without a conditional wrap.
+// Default 30 seconds. Values <= 0 are treated as no-op so the default set by
+// New survives (callers can wire up optional configuration without a branch).
 func WithShutdownTimeout(d time.Duration) Option {
 	return func(s *Server) {
 		if d > 0 {
@@ -83,14 +85,22 @@ func WithShutdownTimeout(d time.Duration) Option {
 	}
 }
 
-// normalizeBase trims trailing slashes, forces a leading slash when non-empty,
-// and maps empty or "/" to "".
+// normalizeBase canonicalizes an HTTP base path prefix:
+//   - empty input returns ""
+//   - a leading slash is added when missing
+//   - consecutive slashes anywhere in the path are collapsed (path.Clean)
+//   - a trailing slash (and "/" or "//..." that collapses to "/") is mapped to ""
+//     so callers can join "basePath + /route" unambiguously
 func normalizeBase(prefix string) string {
-	if prefix != "" && prefix[0] != '/' {
+	if prefix == "" {
+		return ""
+	}
+	if prefix[0] != '/' {
 		prefix = "/" + prefix
 	}
-	for len(prefix) > 0 && prefix[len(prefix)-1] == '/' {
-		prefix = prefix[:len(prefix)-1]
+	prefix = path.Clean(prefix)
+	if prefix == "/" {
+		return ""
 	}
 	return prefix
 }

--- a/compat/options_test.go
+++ b/compat/options_test.go
@@ -1,0 +1,49 @@
+package compat
+
+import "testing"
+
+func TestNormalizeBase(t *testing.T) {
+	cases := map[string]string{
+		"/v1":      "/v1",
+		"/v1/":     "/v1",
+		"v1":       "/v1",
+		"/":        "",
+		"":         "",
+		"/api/v1/": "/api/v1",
+	}
+	for in, want := range cases {
+		if got := normalizeBase(in); got != want {
+			t.Errorf("normalizeBase(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestWithAliases_CopiesInput(t *testing.T) {
+	src := map[string]string{"gpt-4": "qwen3-coder-next:latest"}
+	s := &Server{}
+	WithAliases(src)(s)
+	src["gpt-4"] = "evil"
+	if s.aliases["gpt-4"] != "qwen3-coder-next:latest" {
+		t.Fatalf("aliases map aliased caller input: got %q", s.aliases["gpt-4"])
+	}
+}
+
+func TestWithAliases_Nil(t *testing.T) {
+	s := &Server{aliases: map[string]string{"x": "y"}}
+	WithAliases(nil)(s)
+	if len(s.aliases) != 0 {
+		t.Fatalf("WithAliases(nil) did not clear aliases: %v", s.aliases)
+	}
+}
+
+func TestWithMaxConcurrency_ClampBelowOne(t *testing.T) {
+	s := &Server{}
+	WithMaxConcurrency(0)(s)
+	if s.maxConcurrency != 1 {
+		t.Fatalf("got %d, want 1", s.maxConcurrency)
+	}
+	WithMaxConcurrency(-5)(s)
+	if s.maxConcurrency != 1 {
+		t.Fatalf("got %d, want 1", s.maxConcurrency)
+	}
+}

--- a/compat/options_test.go
+++ b/compat/options_test.go
@@ -1,6 +1,9 @@
 package compat
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestNormalizeBase(t *testing.T) {
 	cases := map[string]string{
@@ -10,11 +13,52 @@ func TestNormalizeBase(t *testing.T) {
 		"/":        "",
 		"":         "",
 		"/api/v1/": "/api/v1",
+		"//":       "",
+		"///":      "",
+		"/v1//":    "/v1",
+		"api/v1":   "/api/v1",
 	}
 	for in, want := range cases {
 		if got := normalizeBase(in); got != want {
 			t.Errorf("normalizeBase(%q) = %q, want %q", in, got, want)
 		}
+	}
+}
+
+func TestWithAddr(t *testing.T) {
+	s := &Server{}
+	WithAddr("127.0.0.1:12345")(s)
+	if s.addr != "127.0.0.1:12345" {
+		t.Fatalf("addr = %q, want %q", s.addr, "127.0.0.1:12345")
+	}
+}
+
+func TestWithBasePath_Normalizes(t *testing.T) {
+	s := &Server{}
+	WithBasePath("/openai/v1/")(s)
+	if s.basePath != "/openai/v1" {
+		t.Fatalf("basePath = %q, want %q", s.basePath, "/openai/v1")
+	}
+}
+
+func TestWithCORS(t *testing.T) {
+	s := &Server{}
+	WithCORS("https://example.com")(s)
+	if s.corsOrigin != "https://example.com" {
+		t.Fatalf("corsOrigin = %q, want %q", s.corsOrigin, "https://example.com")
+	}
+	WithCORS("")(s)
+	if s.corsOrigin != "" {
+		t.Fatalf("corsOrigin = %q, want empty (disabled)", s.corsOrigin)
+	}
+}
+
+func TestWithTLS(t *testing.T) {
+	s := &Server{}
+	WithTLS("/etc/tls/cert.pem", "/etc/tls/key.pem")(s)
+	if s.tlsCert != "/etc/tls/cert.pem" || s.tlsKey != "/etc/tls/key.pem" {
+		t.Fatalf("tlsCert=%q tlsKey=%q, want (cert.pem, key.pem) paths",
+			s.tlsCert, s.tlsKey)
 	}
 }
 
@@ -45,5 +89,51 @@ func TestWithMaxConcurrency_ClampBelowOne(t *testing.T) {
 	WithMaxConcurrency(-5)(s)
 	if s.maxConcurrency != 1 {
 		t.Fatalf("got %d, want 1", s.maxConcurrency)
+	}
+}
+
+func TestWithMaxConcurrency_Positive(t *testing.T) {
+	s := &Server{}
+	WithMaxConcurrency(16)(s)
+	if s.maxConcurrency != 16 {
+		t.Fatalf("got %d, want 16", s.maxConcurrency)
+	}
+}
+
+func TestWithEmbeddings(t *testing.T) {
+	s := &Server{}
+	if s.embeddingsEnabled {
+		t.Fatal("embeddingsEnabled should default to false before options apply")
+	}
+	WithEmbeddings(true)(s)
+	if !s.embeddingsEnabled {
+		t.Fatal("WithEmbeddings(true) did not set embeddingsEnabled")
+	}
+	WithEmbeddings(false)(s)
+	if s.embeddingsEnabled {
+		t.Fatal("WithEmbeddings(false) did not clear embeddingsEnabled")
+	}
+}
+
+func TestWithShutdownTimeout_Positive(t *testing.T) {
+	s := &Server{shutdownTimeout: 30 * time.Second}
+	WithShutdownTimeout(5 * time.Second)(s)
+	if s.shutdownTimeout != 5*time.Second {
+		t.Fatalf("got %s, want 5s", s.shutdownTimeout)
+	}
+}
+
+func TestWithShutdownTimeout_ZeroOrNegativeIgnored(t *testing.T) {
+	// Documented contract: values <= 0 leave the existing value untouched so
+	// the default set by New() survives. Guard against regressions that
+	// accidentally zero the field.
+	baseline := 30 * time.Second
+	for _, bad := range []time.Duration{0, -1, -500 * time.Millisecond} {
+		s := &Server{shutdownTimeout: baseline}
+		WithShutdownTimeout(bad)(s)
+		if s.shutdownTimeout != baseline {
+			t.Fatalf("WithShutdownTimeout(%s) mutated field to %s, want %s",
+				bad, s.shutdownTimeout, baseline)
+		}
 	}
 }

--- a/compat/options_test.go
+++ b/compat/options_test.go
@@ -17,6 +17,12 @@ func TestNormalizeBase(t *testing.T) {
 		"///":      "",
 		"/v1//":    "/v1",
 		"api/v1":   "/api/v1",
+		// Regression guard: consecutive slashes anywhere must be collapsed,
+		// not just trailing. Previous hand-rolled trim left these uncleaned.
+		"//foo":       "/foo",
+		"///api":      "/api",
+		"/a//b":       "/a/b",
+		"//foo/bar//": "/foo/bar",
 	}
 	for in, want := range cases {
 		if got := normalizeBase(in); got != want {
@@ -34,10 +40,24 @@ func TestWithAddr(t *testing.T) {
 }
 
 func TestWithBasePath_Normalizes(t *testing.T) {
-	s := &Server{}
-	WithBasePath("/openai/v1/")(s)
-	if s.basePath != "/openai/v1" {
-		t.Fatalf("basePath = %q, want %q", s.basePath, "/openai/v1")
+	cases := []struct {
+		in, want string
+	}{
+		{"/openai/v1/", "/openai/v1"},
+		{"openai/v1", "/openai/v1"},
+		{"//foo", "/foo"},
+		{"/a//b", "/a/b"},
+		{"", ""},
+		{"/", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			s := &Server{}
+			WithBasePath(tc.in)(s)
+			if s.basePath != tc.want {
+				t.Fatalf("basePath = %q, want %q", s.basePath, tc.want)
+			}
+		})
 	}
 }
 
@@ -129,11 +149,13 @@ func TestWithShutdownTimeout_ZeroOrNegativeIgnored(t *testing.T) {
 	// accidentally zero the field.
 	baseline := 30 * time.Second
 	for _, bad := range []time.Duration{0, -1, -500 * time.Millisecond} {
-		s := &Server{shutdownTimeout: baseline}
-		WithShutdownTimeout(bad)(s)
-		if s.shutdownTimeout != baseline {
-			t.Fatalf("WithShutdownTimeout(%s) mutated field to %s, want %s",
-				bad, s.shutdownTimeout, baseline)
-		}
+		t.Run(bad.String(), func(t *testing.T) {
+			s := &Server{shutdownTimeout: baseline}
+			WithShutdownTimeout(bad)(s)
+			if s.shutdownTimeout != baseline {
+				t.Fatalf("WithShutdownTimeout(%s) mutated field to %s, want %s",
+					bad, s.shutdownTimeout, baseline)
+			}
+		})
 	}
 }

--- a/compat/request_body.go
+++ b/compat/request_body.go
@@ -11,6 +11,7 @@ const (
 	maxChatRequestBodyBytes       int64 = 8 << 20
 	maxCompletionRequestBodyBytes int64 = 4 << 20
 	maxEmbeddingRequestBodyBytes  int64 = 4 << 20
+	maxFeedbackRequestBodyBytes   int64 = 64 << 10
 )
 
 // decodeJSONBody caps the inbound body before decoding so oversized POSTs fail
@@ -21,12 +22,16 @@ func decodeJSONBody(w http.ResponseWriter, r *http.Request, limit int64, dst any
 	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
 		var maxErr *http.MaxBytesError
 		if errors.As(err, &maxErr) {
-			writeError(w, http.StatusRequestEntityTooLarge, "body_too_large",
-				fmt.Sprintf("request body exceeds maximum %d bytes", maxErr.Limit))
+			writeBodyTooLarge(w, maxErr.Limit)
 			return false
 		}
 		writeError(w, http.StatusBadRequest, "decode_error", err.Error())
 		return false
 	}
 	return true
+}
+
+func writeBodyTooLarge(w http.ResponseWriter, limit int64) {
+	writeError(w, http.StatusRequestEntityTooLarge, "body_too_large",
+		fmt.Sprintf("request body exceeds maximum %d bytes", limit))
 }

--- a/compat/request_body.go
+++ b/compat/request_body.go
@@ -1,0 +1,32 @@
+package compat
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+const (
+	maxChatRequestBodyBytes       int64 = 8 << 20
+	maxCompletionRequestBodyBytes int64 = 4 << 20
+	maxEmbeddingRequestBodyBytes  int64 = 4 << 20
+)
+
+// decodeJSONBody caps the inbound body before decoding so oversized POSTs fail
+// with a bounded client error instead of consuming unbounded memory/CPU ahead
+// of the handler's semaphore gate.
+func decodeJSONBody(w http.ResponseWriter, r *http.Request, limit int64, dst any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, limit)
+	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "body_too_large",
+				fmt.Sprintf("request body exceeds maximum %d bytes", maxErr.Limit))
+			return false
+		}
+		writeError(w, http.StatusBadRequest, "decode_error", err.Error())
+		return false
+	}
+	return true
+}

--- a/compat/server.go
+++ b/compat/server.go
@@ -1,0 +1,32 @@
+package compat
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// Server is the OpenAI-compatible HTTP façade over a provider.Router.
+type Server struct {
+	router    *provider.Router
+	registry  *provider.ModelRegistry
+	providers *provider.Registry
+
+	addr              string
+	basePath          string
+	corsOrigin        string
+	tlsCert           string
+	tlsKey            string
+	aliases           map[string]string
+	maxConcurrency    int
+	embeddingsEnabled bool
+	shutdownTimeout   time.Duration
+
+	httpServer *http.Server
+	startedAt  time.Time
+	mu         sync.Mutex
+	closed     bool
+	closeOnce  sync.Once
+}

--- a/compat/server.go
+++ b/compat/server.go
@@ -99,7 +99,17 @@ func (s *Server) ListenAndServe(ctx context.Context) error {
 		return fmt.Errorf("%w: addr=%q", ErrNonLoopbackRequiresTLS, s.addr)
 	}
 
-	httpServer := &http.Server{Addr: s.addr, Handler: s.buildHandler()}
+	// ReadHeaderTimeout bounds the header-read phase so a slow-header attack
+	// (Slowloris) cannot pin a handler slot — and burn a semaphore lane —
+	// indefinitely when the server is exposed beyond loopback via WithTLS.
+	// Body reads are bounded per-endpoint by json.Decode against a MaxBytes
+	// reader. WriteTimeout is deliberately unset because SSE streams run
+	// open-ended.
+	httpServer := &http.Server{
+		Addr:              s.addr,
+		Handler:           s.buildHandler(),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
 
 	s.mu.Lock()
 	if s.closed {

--- a/compat/server.go
+++ b/compat/server.go
@@ -161,6 +161,7 @@ func (s *Server) buildHandler() http.Handler {
 	mux.HandleFunc("GET "+s.basePath+"/status", s.handleStatus)
 	mux.HandleFunc("GET "+s.basePath+"/models", s.handleModels)
 	mux.HandleFunc("POST "+s.basePath+"/chat/completions", s.handleChatCompletions)
+	mux.HandleFunc("POST "+s.basePath+"/completions", s.handleCompletions)
 
 	var handler http.Handler = mux
 	handler = recoveryMiddleware(handler)

--- a/compat/server.go
+++ b/compat/server.go
@@ -37,6 +37,11 @@ type Server struct {
 	embeddingsEnabled bool
 	shutdownTimeout   time.Duration
 
+	// semaphore bounds concurrent in-flight requests and reserves a lane for
+	// PriorityHigh+ traffic. Initialized in New after options apply so that
+	// WithMaxConcurrency has already been observed.
+	semaphore *semaphore
+
 	httpServer *http.Server
 	startedAt  time.Time
 
@@ -72,6 +77,8 @@ func New(router *provider.Router, registry *provider.ModelRegistry, providers *p
 	for _, opt := range opts {
 		opt(s)
 	}
+	// newSemaphore normalizes max < 1 to 1 so we do not need a guard here.
+	s.semaphore = newSemaphore(s.maxConcurrency)
 	return s
 }
 
@@ -153,6 +160,7 @@ func (s *Server) buildHandler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET "+s.basePath+"/status", s.handleStatus)
 	mux.HandleFunc("GET "+s.basePath+"/models", s.handleModels)
+	mux.HandleFunc("POST "+s.basePath+"/chat/completions", s.handleChatCompletions)
 
 	var handler http.Handler = mux
 	handler = recoveryMiddleware(handler)

--- a/compat/server.go
+++ b/compat/server.go
@@ -172,7 +172,12 @@ func (s *Server) buildHandler() http.Handler {
 	mux.HandleFunc("GET "+s.basePath+"/models", s.handleModels)
 	mux.HandleFunc("POST "+s.basePath+"/chat/completions", s.handleChatCompletions)
 	mux.HandleFunc("POST "+s.basePath+"/completions", s.handleCompletions)
-	mux.HandleFunc("POST "+s.basePath+"/completions/feedback", s.handleFeedback)
+	// Feedback is cheap but unauthenticated; gate at background priority so
+	// it never crowds out user-facing work when the server is saturated.
+	mux.Handle(
+		"POST "+s.basePath+"/completions/feedback",
+		withSemaphore(s.semaphore, provider.PriorityBackground, http.HandlerFunc(s.handleFeedback)),
+	)
 	if s.embeddingsEnabled {
 		mux.HandleFunc("POST "+s.basePath+"/embeddings", s.handleEmbeddings)
 	}

--- a/compat/server.go
+++ b/compat/server.go
@@ -9,6 +9,12 @@ import (
 )
 
 // Server is the OpenAI-compatible HTTP façade over a provider.Router.
+//
+// After New returns, Server is safe for concurrent use: ListenAndServe runs
+// the HTTP server, handler goroutines read Router/Registry/config fields
+// concurrently, and Close performs idempotent shutdown from any goroutine.
+// Options must be applied at construction time only; applying an Option to
+// a Server that is already serving is not safe.
 type Server struct {
 	router    *provider.Router
 	registry  *provider.ModelRegistry
@@ -27,9 +33,12 @@ type Server struct {
 	httpServer *http.Server
 	startedAt  time.Time
 
-	// mu guards closed. closeOnce enforces single-shot Close semantics;
-	// startedAt is written once at server start and is read-only thereafter,
-	// so it does not require mu.
+	// mu guards closed, which request handlers read to reject work that
+	// arrives after shutdown begins. closeOnce is a separate primitive that
+	// makes the Close body itself idempotent; it cannot replace closed because
+	// handlers need a cheap readable flag, not a run-once action. startedAt is
+	// written once at server start and is read-only thereafter, so it does not
+	// require mu.
 	mu        sync.Mutex
 	closed    bool
 	closeOnce sync.Once

--- a/compat/server.go
+++ b/compat/server.go
@@ -173,6 +173,9 @@ func (s *Server) buildHandler() http.Handler {
 	mux.HandleFunc("POST "+s.basePath+"/chat/completions", s.handleChatCompletions)
 	mux.HandleFunc("POST "+s.basePath+"/completions", s.handleCompletions)
 	mux.HandleFunc("POST "+s.basePath+"/completions/feedback", s.handleFeedback)
+	if s.embeddingsEnabled {
+		mux.HandleFunc("POST "+s.basePath+"/embeddings", s.handleEmbeddings)
+	}
 
 	var handler http.Handler = mux
 	handler = recoveryMiddleware(handler)

--- a/compat/server.go
+++ b/compat/server.go
@@ -152,6 +152,7 @@ func (s *Server) Close() error {
 func (s *Server) buildHandler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET "+s.basePath+"/status", s.handleStatus)
+	mux.HandleFunc("GET "+s.basePath+"/models", s.handleModels)
 
 	var handler http.Handler = mux
 	handler = recoveryMiddleware(handler)

--- a/compat/server.go
+++ b/compat/server.go
@@ -42,6 +42,11 @@ type Server struct {
 	// WithMaxConcurrency has already been observed.
 	semaphore *semaphore
 
+	// completionStore attributes x_completion_id back to the provider/model
+	// that served the original completion, so the feedback endpoint can route
+	// signals to the canonical entry. Initialized in New.
+	completionStore *completionRecordStore
+
 	httpServer *http.Server
 	startedAt  time.Time
 
@@ -79,6 +84,11 @@ func New(router *provider.Router, registry *provider.ModelRegistry, providers *p
 	}
 	// newSemaphore normalizes max < 1 to 1 so we do not need a guard here.
 	s.semaphore = newSemaphore(s.maxConcurrency)
+	// completionStore attributes x_completion_id → (provider, model) so
+	// feedback requests can be routed back to the canonical entry that
+	// served the original completion. 15-minute TTL matches Phase 4's
+	// feedback SLA; 4096 entries bound memory (~1MB worst case).
+	s.completionStore = newCompletionRecordStore(15*time.Minute, 4096)
 	return s
 }
 

--- a/compat/server.go
+++ b/compat/server.go
@@ -44,8 +44,9 @@ type Server struct {
 	// arrives after shutdown begins. closeOnce is a separate primitive that
 	// makes the Close body itself idempotent; it cannot replace closed because
 	// handlers need a cheap readable flag, not a run-once action. startedAt is
-	// written once at server start and is read-only thereafter, so it does not
-	// require mu.
+	// written once in New so handlers invoked via buildHandler (tests,
+	// embedded callers) see a meaningful uptime even when ListenAndServe has
+	// not run; it is read-only thereafter and does not require mu.
 	mu        sync.Mutex
 	closed    bool
 	closeOnce sync.Once
@@ -66,6 +67,7 @@ func New(router *provider.Router, registry *provider.ModelRegistry, providers *p
 		maxConcurrency:    4,
 		embeddingsEnabled: false,
 		shutdownTimeout:   30 * time.Second,
+		startedAt:         time.Now(),
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -88,7 +90,6 @@ func (s *Server) ListenAndServe(ctx context.Context) error {
 		return http.ErrServerClosed
 	}
 	s.httpServer = httpServer
-	s.startedAt = time.Now()
 	s.mu.Unlock()
 
 	// The shutdown goroutine must exit when EITHER ctx is canceled OR the
@@ -150,6 +151,7 @@ func (s *Server) Close() error {
 //     mid-stream panics) sees the same *statusRecorder that logging installed.
 func (s *Server) buildHandler() http.Handler {
 	mux := http.NewServeMux()
+	mux.HandleFunc("GET "+s.basePath+"/status", s.handleStatus)
 
 	var handler http.Handler = mux
 	handler = recoveryMiddleware(handler)

--- a/compat/server.go
+++ b/compat/server.go
@@ -172,6 +172,7 @@ func (s *Server) buildHandler() http.Handler {
 	mux.HandleFunc("GET "+s.basePath+"/models", s.handleModels)
 	mux.HandleFunc("POST "+s.basePath+"/chat/completions", s.handleChatCompletions)
 	mux.HandleFunc("POST "+s.basePath+"/completions", s.handleCompletions)
+	mux.HandleFunc("POST "+s.basePath+"/completions/feedback", s.handleFeedback)
 
 	var handler http.Handler = mux
 	handler = recoveryMiddleware(handler)

--- a/compat/server.go
+++ b/compat/server.go
@@ -1,12 +1,19 @@
 package compat
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"sync"
 	"time"
 
 	"github.com/kstruzzieri/go-llm/provider"
 )
+
+// ErrNonLoopbackRequiresTLS is returned from ListenAndServe when the bind
+// address is not a loopback and WithTLS was not configured.
+var ErrNonLoopbackRequiresTLS = errors.New("compat: non-loopback address requires TLS (use WithTLS)")
 
 // Server is the OpenAI-compatible HTTP façade over a provider.Router.
 //
@@ -42,4 +49,97 @@ type Server struct {
 	mu        sync.Mutex
 	closed    bool
 	closeOnce sync.Once
+}
+
+// New constructs a Server with the given router, model registry, and provider
+// registry. These may be nil in tests that exercise only the bare HTTP
+// lifecycle; real callers must supply all three. Options override defaults.
+func New(router *provider.Router, registry *provider.ModelRegistry, providers *provider.Registry, opts ...Option) *Server {
+	s := &Server{
+		router:            router,
+		registry:          registry,
+		providers:         providers,
+		addr:              "127.0.0.1:18741",
+		basePath:          "/v1",
+		corsOrigin:        "*",
+		aliases:           map[string]string{},
+		maxConcurrency:    4,
+		embeddingsEnabled: false,
+		shutdownTimeout:   30 * time.Second,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// ListenAndServe starts the HTTP server and blocks until ctx is cancelled or
+// an unrecoverable error occurs. Non-loopback bind requires TLS.
+func (s *Server) ListenAndServe(ctx context.Context) error {
+	if s.tlsCert == "" && !isLoopback(s.addr) {
+		return fmt.Errorf("%w: addr=%q", ErrNonLoopbackRequiresTLS, s.addr)
+	}
+
+	httpServer := &http.Server{Addr: s.addr, Handler: s.buildHandler()}
+
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return http.ErrServerClosed
+	}
+	s.httpServer = httpServer
+	s.startedAt = time.Now()
+	s.mu.Unlock()
+
+	// The shutdown goroutine must exit when EITHER ctx is canceled OR the
+	// serve call returns early (e.g. port already in use). Without the served
+	// channel, an early error leaks the goroutine for the lifetime of ctx.
+	served := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), s.shutdownTimeout)
+			defer cancel()
+			_ = httpServer.Shutdown(shutdownCtx)
+		case <-served:
+		}
+	}()
+
+	var err error
+	if s.tlsCert != "" {
+		err = httpServer.ListenAndServeTLS(s.tlsCert, s.tlsKey)
+	} else {
+		err = httpServer.ListenAndServe()
+	}
+	close(served)
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
+}
+
+// Close shuts down the server. Idempotent. Subsequent ListenAndServe calls
+// after Close return http.ErrServerClosed.
+func (s *Server) Close() error {
+	var err error
+	s.closeOnce.Do(func() {
+		s.mu.Lock()
+		s.closed = true
+		srv := s.httpServer
+		s.mu.Unlock()
+		if srv == nil {
+			return
+		}
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), s.shutdownTimeout)
+		defer cancel()
+		err = srv.Shutdown(shutdownCtx)
+	})
+	return err
+}
+
+// buildHandler constructs the HTTP handler. Task 2 mounts a 404-only mux so
+// the lifecycle tests pass; later tasks replace this with real routes.
+func (s *Server) buildHandler() http.Handler {
+	mux := http.NewServeMux()
+	return mux
 }

--- a/compat/server.go
+++ b/compat/server.go
@@ -137,9 +137,24 @@ func (s *Server) Close() error {
 	return err
 }
 
-// buildHandler constructs the HTTP handler. Task 2 mounts a 404-only mux so
-// the lifecycle tests pass; later tasks replace this with real routes.
+// buildHandler constructs the HTTP handler. Routes are registered on the mux
+// in later tasks; the returned handler wraps the mux in (outermost first)
+// CORS → request-ID → logging → recovery → mux. Empty corsOrigin disables CORS.
+//
+// Order matters:
+//   - request-ID is outside CORS-preflight short-circuit so OPTIONS responses
+//     still carry X-Request-Id for correlation.
+//   - logging wraps recovery so panics (converted to 500s by recovery) are
+//     still recorded in the access log with the correct status.
+//   - recovery is innermost so its statusRecorder-aware writer check (for
+//     mid-stream panics) sees the same *statusRecorder that logging installed.
 func (s *Server) buildHandler() http.Handler {
 	mux := http.NewServeMux()
-	return mux
+
+	var handler http.Handler = mux
+	handler = recoveryMiddleware(handler)
+	handler = loggingMiddleware(handler)
+	handler = requestIDMiddleware(handler)
+	handler = corsMiddleware(handler, s.corsOrigin)
+	return handler
 }

--- a/compat/server.go
+++ b/compat/server.go
@@ -26,7 +26,11 @@ type Server struct {
 
 	httpServer *http.Server
 	startedAt  time.Time
-	mu         sync.Mutex
-	closed     bool
-	closeOnce  sync.Once
+
+	// mu guards closed. closeOnce enforces single-shot Close semantics;
+	// startedAt is written once at server start and is read-only thereafter,
+	// so it does not require mu.
+	mu        sync.Mutex
+	closed    bool
+	closeOnce sync.Once
 }

--- a/compat/server_test.go
+++ b/compat/server_test.go
@@ -1,0 +1,144 @@
+package compat
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestNew_DefaultsAreLoopbackAndV1(t *testing.T) {
+	s := New(nil, nil, nil)
+	if s.addr != "127.0.0.1:18741" {
+		t.Errorf("default addr = %q, want 127.0.0.1:18741", s.addr)
+	}
+	if s.basePath != "/v1" {
+		t.Errorf("default basePath = %q, want /v1", s.basePath)
+	}
+	if s.corsOrigin != "*" {
+		t.Errorf("default corsOrigin = %q, want *", s.corsOrigin)
+	}
+	if s.maxConcurrency != 4 {
+		t.Errorf("default maxConcurrency = %d, want 4", s.maxConcurrency)
+	}
+	if s.embeddingsEnabled {
+		t.Errorf("embeddings must be off by default")
+	}
+	if s.shutdownTimeout != 30*time.Second {
+		t.Errorf("default shutdownTimeout = %v, want 30s", s.shutdownTimeout)
+	}
+}
+
+func TestListenAndServe_NonLoopbackWithoutTLSErrors(t *testing.T) {
+	s := New(nil, nil, nil, WithAddr("0.0.0.0:0"))
+	err := s.ListenAndServe(context.Background())
+	if err == nil {
+		t.Fatal("expected error for non-loopback without TLS")
+	}
+	if !errors.Is(err, ErrNonLoopbackRequiresTLS) {
+		t.Fatalf("want ErrNonLoopbackRequiresTLS, got %v", err)
+	}
+}
+
+func TestListenAndServe_LoopbackServesThenCloses(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+
+	s := New(nil, nil, nil, WithAddr(addr))
+	errCh := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() { errCh <- s.ListenAndServe(ctx) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get("http://" + addr + "/v1/does-not-exist")
+		if err == nil {
+			_ = resp.Body.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	select {
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			t.Fatalf("ListenAndServe returned %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ListenAndServe did not return after Close")
+	}
+}
+
+func TestClose_Idempotent(t *testing.T) {
+	s := New(nil, nil, nil)
+	if err := s.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}
+
+// Regression guard for the shutdown-goroutine leak. If ListenAndServe returns
+// early (e.g. because the address is already bound), the shutdown goroutine
+// must not remain parked on ctx.Done for the lifetime of a long-lived ctx.
+// We detect the leak by checking goroutine count returns to baseline after a
+// serve failure, with ctx still live.
+func TestListenAndServe_EarlyFailureDoesNotLeakGoroutines(t *testing.T) {
+	// Occupy a loopback port so the server's bind fails.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ln.Close() }()
+	addr := ln.Addr().String()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	baseline := runtime.NumGoroutine()
+
+	s := New(nil, nil, nil, WithAddr(addr))
+	if err := s.ListenAndServe(ctx); err == nil {
+		t.Fatal("expected bind error on occupied port")
+	}
+
+	// Give the scheduler a beat to reap the goroutine if it exited cleanly.
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= baseline+1 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("goroutine count did not return to baseline: got %d, want <= %d (leak)",
+		runtime.NumGoroutine(), baseline+1)
+}
+
+// Regression guard: Close's contract is that subsequent ListenAndServe calls
+// return http.ErrServerClosed. Without the closed-flag check under s.mu, a
+// Close that races ahead of ListenAndServe would be silently defeated — the
+// second call would start a fresh server even though the caller asked to shut
+// down.
+func TestListenAndServe_AfterCloseReturnsErrServerClosed(t *testing.T) {
+	s := New(nil, nil, nil)
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	err := s.ListenAndServe(context.Background())
+	if !errors.Is(err, http.ErrServerClosed) {
+		t.Fatalf("ListenAndServe after Close = %v, want http.ErrServerClosed", err)
+	}
+}

--- a/compat/sse.go
+++ b/compat/sse.go
@@ -1,0 +1,94 @@
+// Package compat — sse.go wires a minimal Server-Sent Events writer used by
+// the streaming branch of POST /v1/chat/completions. The writer serializes
+// one event per call as a "data: <json>\n\n" block and terminates the stream
+// with "data: [DONE]\n\n", matching OpenAI's chat.completion.chunk wire
+// format so stock OpenAI SDKs consume it without customization.
+package compat
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// sseWriter serializes one SSE event per call. Each event is a JSON payload
+// on a single "data:" line, followed by a blank line. A trailing "data: [DONE]"
+// event signals the end of the stream, matching OpenAI's wire format.
+//
+// Important: this writer is lazy-start. It does not commit the HTTP status
+// code until the first event or keepalive comment is written. This is what
+// allows the streaming chat handler to fall back to a normal JSON error
+// envelope when routing, admission, or the provider fails before any chunk
+// has been delivered to the client.
+type sseWriter struct {
+	w       http.ResponseWriter
+	flusher http.Flusher
+	started bool
+}
+
+// newSSEWriter prepares SSE response headers and returns a writer bound to w.
+// The HTTP status is NOT yet committed — subsequent writeEvent / writeComment
+// / writeDone calls are the first bytes of the response body.
+//
+// Returns an error when w does not implement http.Flusher, which in net/http
+// only happens for exotic response writers (e.g. gzip wrappers that do not
+// forward Flush). In that case the caller should fall back to a JSON error.
+func newSSEWriter(w http.ResponseWriter) (*sseWriter, error) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		return nil, fmt.Errorf("compat: response writer does not support flushing")
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no") // disable proxy buffering
+	return &sseWriter{w: w, flusher: flusher}, nil
+}
+
+// writeEvent marshals payload as JSON and emits it as a single "data: <json>"
+// event, flushing afterward so intermediary proxies do not buffer. On the
+// first call it also commits the HTTP 200 status.
+func (s *sseWriter) writeEvent(payload any) error {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	if !s.started {
+		s.w.WriteHeader(http.StatusOK)
+		s.started = true
+	}
+	if _, err := fmt.Fprintf(s.w, "data: %s\n\n", raw); err != nil {
+		return err
+	}
+	s.flusher.Flush()
+	return nil
+}
+
+// writeComment emits an SSE comment line (": <text>\n\n") and flushes. SSE
+// comments are opaque to OpenAI SDKs but keep the connection alive across
+// long provider stalls. This helper is intended for future keepalive wiring
+// (Task 17 or later); the current streaming handler does not call it yet.
+func (s *sseWriter) writeComment(text string) error {
+	if !s.started {
+		s.w.WriteHeader(http.StatusOK)
+		s.started = true
+	}
+	if _, err := fmt.Fprintf(s.w, ": %s\n\n", text); err != nil {
+		return err
+	}
+	s.flusher.Flush()
+	return nil
+}
+
+// writeDone emits the "data: [DONE]\n\n" terminator that OpenAI SDKs
+// recognize as the end of a chat.completion.chunk stream. It does not
+// commit the status code — callers must have already written at least one
+// event (otherwise the stream is empty, which OpenAI SDKs tolerate as long
+// as the DONE sentinel is present).
+func (s *sseWriter) writeDone() error {
+	if _, err := fmt.Fprint(s.w, "data: [DONE]\n\n"); err != nil {
+		return err
+	}
+	s.flusher.Flush()
+	return nil
+}

--- a/compat/sse_test.go
+++ b/compat/sse_test.go
@@ -1,0 +1,56 @@
+package compat
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestSSEWriter_EventAndDone verifies the basic event -> DONE sequence lands
+// on the wire with the expected "data: ..." framing and the SSE content-type
+// header is set. This exercises the lazy-start path (headers written before
+// WriteHeader, status committed on first event).
+func TestSSEWriter_EventAndDone(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sw, err := newSSEWriter(rec)
+	if err != nil {
+		t.Fatalf("newSSEWriter: %v", err)
+	}
+	if err := sw.writeEvent(map[string]string{"hello": "world"}); err != nil {
+		t.Fatalf("writeEvent: %v", err)
+	}
+	if err := sw.writeDone(); err != nil {
+		t.Fatalf("writeDone: %v", err)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `data: {"hello":"world"}`) {
+		t.Errorf("missing data line: %q", body)
+	}
+	if !strings.HasSuffix(body, "data: [DONE]\n\n") {
+		t.Errorf("missing DONE sentinel: %q", body)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("content-type = %q", ct)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "no-cache" {
+		t.Errorf("cache-control = %q, want no-cache", cc)
+	}
+}
+
+// TestSSEWriter_Comment exercises the keepalive-comment path. The helper is
+// not wired into the streaming chat handler yet (Task 17 territory), but it
+// is exported to the test package so the code path stays live and the "data:"
+// vs ": " framing difference is asserted here rather than regressing silently.
+func TestSSEWriter_Comment(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sw, err := newSSEWriter(rec)
+	if err != nil {
+		t.Fatalf("newSSEWriter: %v", err)
+	}
+	if err := sw.writeComment("keepalive"); err != nil {
+		t.Fatalf("writeComment: %v", err)
+	}
+	if !strings.Contains(rec.Body.String(), ": keepalive\n\n") {
+		t.Errorf("missing comment: %q", rec.Body.String())
+	}
+}

--- a/compat/status.go
+++ b/compat/status.go
@@ -1,0 +1,134 @@
+package compat
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// healthCheckTimeout bounds how long a single provider.Health call is allowed
+// to run from the status handler. The check context is detached from the
+// request so a client disconnect does not surface as a phantom degraded
+// provider on the next poll. 2s is enough for a local TCP probe and short
+// enough that a single hung provider cannot freeze the endpoint.
+const healthCheckTimeout = 2 * time.Second
+
+// StatusResponse is the payload for GET /v1/status. Non-standard extension;
+// modeled loosely on OpenAI's health endpoints but carries go-llm-specific
+// provider and warmth detail.
+type StatusResponse struct {
+	Status    string            `json:"status"` // "ready" | "degraded" | "unavailable"
+	Providers []ProviderStatus  `json:"providers"`
+	Warm      []WarmModelStatus `json:"warm,omitempty"`
+	Uptime    string            `json:"uptime"`
+}
+
+// ProviderStatus describes one registered backend.
+type ProviderStatus struct {
+	Name         string   `json:"name"`
+	Healthy      bool     `json:"healthy"`
+	Capabilities []string `json:"capabilities"`
+	Error        string   `json:"error,omitempty"`
+}
+
+// WarmModelStatus describes one model currently resident in a provider's memory.
+type WarmModelStatus struct {
+	Provider  string  `json:"provider"`
+	Model     string  `json:"model"`
+	Loaded    bool    `json:"loaded"`
+	VRAMGB    float64 `json:"vram_gb,omitempty"`
+	ExpiresAt string  `json:"expires_at,omitempty"`
+}
+
+// handleStatus implements GET /v1/status. It is a non-standard extension that
+// surfaces provider health and warmth snapshots for operators. Status is
+// "ready" when every provider reports healthy, "degraded" when at least one
+// is unhealthy, "unavailable" when no providers are registered.
+func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
+	if s.providers == nil {
+		writeError(w, http.StatusServiceUnavailable, "no_providers", "server has no provider registry")
+		return
+	}
+
+	providers := s.providers.All()
+	out := StatusResponse{
+		Providers: make([]ProviderStatus, 0, len(providers)),
+		Uptime:    time.Since(s.startedAt).Round(time.Second).String(),
+	}
+	healthy := 0
+	for _, p := range providers {
+		ps := ProviderStatus{
+			Name:         p.Name(),
+			Capabilities: splitCapabilities(p.Capabilities()),
+		}
+		hctx, hcancel := context.WithTimeout(context.Background(), healthCheckTimeout)
+		err := p.Health(hctx)
+		hcancel()
+		if err != nil {
+			ps.Error = err.Error()
+		} else {
+			ps.Healthy = true
+			healthy++
+		}
+		out.Providers = append(out.Providers, ps)
+	}
+	switch {
+	case len(providers) == 0:
+		out.Status = "unavailable"
+	case healthy == len(providers):
+		out.Status = "ready"
+	default:
+		out.Status = "degraded"
+	}
+
+	if s.router != nil {
+		for _, wm := range s.router.WarmthSnapshot() {
+			ws := WarmModelStatus{
+				Provider: wm.Key.Provider,
+				Model:    wm.Key.Model,
+				Loaded:   wm.Info.Loaded,
+				VRAMGB:   wm.Info.VRAM,
+			}
+			if !wm.Info.ExpiresAt.IsZero() {
+				ws.ExpiresAt = wm.Info.ExpiresAt.Format(time.RFC3339)
+			}
+			out.Warm = append(out.Warm, ws)
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(out)
+}
+
+// splitCapabilities converts a Capability bitmask into ordered names. The
+// returned slice is always non-nil (possibly empty) so JSON clients see
+// "capabilities": [] rather than "capabilities": null — the latter breaks
+// JavaScript callers that access .length.
+//
+// NOTE: keep this list in sync with provider.Capability in provider/types.go.
+// A new bit added there is silently dropped from /v1/status output without
+// this update.
+func splitCapabilities(c provider.Capability) []string {
+	all := []struct {
+		bit  provider.Capability
+		name string
+	}{
+		{provider.CapChat, "chat"},
+		{provider.CapGenerate, "generate"},
+		{provider.CapInsert, "insert"},
+		{provider.CapEmbed, "embed"},
+		{provider.CapStream, "stream"},
+		{provider.CapToolCall, "tool_call"},
+		{provider.CapThinking, "thinking"},
+	}
+	out := make([]string, 0, len(all))
+	for _, a := range all {
+		if c.Has(a.bit) {
+			out = append(out, a.name)
+		}
+	}
+	return out
+}

--- a/compat/status_test.go
+++ b/compat/status_test.go
@@ -1,0 +1,112 @@
+package compat
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+func TestStatusHandler_ReadyWithProviders(t *testing.T) {
+	mp := &mockProvider{name: "ollama", caps: provider.CapChat | provider.CapGenerate}
+	srv, teardown := newTestServer(t, mp)
+	defer teardown()
+
+	rec := httptest.NewRecorder()
+	srv.buildHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/status", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	var resp StatusResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Status != "ready" {
+		t.Errorf("status = %q, want ready", resp.Status)
+	}
+	if len(resp.Providers) != 1 || resp.Providers[0].Name != "ollama" {
+		t.Errorf("providers = %+v", resp.Providers)
+	}
+	// Regression guard: capabilities must JSON-encode as [] not null, so
+	// JavaScript clients can safely call .length on it.
+	if resp.Providers[0].Capabilities == nil {
+		t.Error("Capabilities is nil; want non-nil slice (JSON [] not null)")
+	}
+	// Regression guard: uptime must be meaningful even when handler runs
+	// via buildHandler without ListenAndServe. Parse and sanity-check.
+	if resp.Uptime == "" {
+		t.Error("Uptime is empty")
+	}
+	if strings.Contains(resp.Uptime, "h") && strings.HasPrefix(resp.Uptime, "17") {
+		t.Errorf("Uptime looks like time.Since(zero): %q", resp.Uptime)
+	}
+	if d, err := time.ParseDuration(resp.Uptime); err != nil {
+		t.Errorf("Uptime not parseable: %q (%v)", resp.Uptime, err)
+	} else if d > time.Hour {
+		t.Errorf("Uptime unreasonably large: %v", d)
+	}
+}
+
+func TestStatusHandler_UnavailableWithNoProviders(t *testing.T) {
+	// Regression guard for the switch ordering in handleStatus: empty
+	// registry must produce "unavailable", not "ready" (healthy==0==len).
+	provReg := provider.NewRegistry()
+	modelReg, err := provider.NewModelRegistry(provReg, nil)
+	if err != nil {
+		t.Fatalf("NewModelRegistry: %v", err)
+	}
+	router := provider.NewRouter(modelReg, provReg)
+	defer func() { _ = router.Close() }()
+	srv := New(router, modelReg, provReg)
+
+	rec := httptest.NewRecorder()
+	srv.buildHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/status", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp StatusResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Status != "unavailable" {
+		t.Errorf("Status = %q, want unavailable", resp.Status)
+	}
+	if len(resp.Providers) != 0 {
+		t.Errorf("Providers = %+v, want empty", resp.Providers)
+	}
+}
+
+func TestStatusHandler_DegradedWhenHealthFails(t *testing.T) {
+	mp := &mockProvider{
+		name:   "ollama",
+		caps:   provider.CapChat,
+		health: errExpected,
+	}
+	srv, teardown := newTestServer(t, mp)
+	defer teardown()
+
+	rec := httptest.NewRecorder()
+	srv.buildHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/status", nil))
+
+	var resp StatusResponse
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	if resp.Status != "degraded" {
+		t.Errorf("status = %q, want degraded", resp.Status)
+	}
+	if resp.Providers[0].Healthy {
+		t.Error("provider healthy=true despite health() error")
+	}
+}
+
+var errExpected = fakeErr("expected")
+
+type fakeErr string
+
+func (e fakeErr) Error() string { return string(e) }

--- a/compat/test_helpers_test.go
+++ b/compat/test_helpers_test.go
@@ -1,0 +1,44 @@
+package compat
+
+import (
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func closeBody(t testing.TB, c io.Closer) {
+	t.Helper()
+	if err := c.Close(); err != nil {
+		t.Errorf("close body: %v", err)
+	}
+}
+
+type repeatByteReader struct {
+	b byte
+}
+
+func (r repeatByteReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = r.b
+	}
+	return len(p), nil
+}
+
+func oversizedJSONStringReader(prefix string, n int64, suffix string) io.Reader {
+	return io.MultiReader(
+		strings.NewReader(prefix),
+		io.LimitReader(repeatByteReader{b: 'a'}, n),
+		strings.NewReader(suffix),
+	)
+}
+
+func decodeErrorEnvelope(t testing.TB, rec *httptest.ResponseRecorder) errorEnvelope {
+	t.Helper()
+	var env errorEnvelope
+	if err := json.NewDecoder(rec.Body).Decode(&env); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+	return env
+}

--- a/compat/testutil_test.go
+++ b/compat/testutil_test.go
@@ -1,0 +1,87 @@
+package compat
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// mockProvider is a scriptable provider.Provider for handler tests.
+type mockProvider struct {
+	name string
+	caps provider.Capability
+
+	models []provider.ModelInfo
+	health error
+
+	chatFn       func(context.Context, provider.ChatRequest) (*provider.ChatResponse, error)
+	chatStreamFn func(context.Context, provider.ChatRequest, func(provider.ChatResponse) error) error
+	genFn        func(context.Context, provider.GenerateRequest) (*provider.GenerateResponse, error)
+	genStreamFn  func(context.Context, provider.GenerateRequest, func(provider.GenerateResponse) error) error
+	embedFn      func(context.Context, provider.EmbedRequest) (*provider.EmbedResponse, error)
+}
+
+func (m *mockProvider) Name() string                      { return m.name }
+func (m *mockProvider) Capabilities() provider.Capability { return m.caps }
+func (m *mockProvider) Health(ctx context.Context) error  { return m.health }
+func (m *mockProvider) Models(ctx context.Context) ([]provider.ModelInfo, error) {
+	return m.models, nil
+}
+func (m *mockProvider) Chat(ctx context.Context, req provider.ChatRequest) (*provider.ChatResponse, error) {
+	if m.chatFn == nil {
+		return nil, errors.New("mock: chat not scripted")
+	}
+	return m.chatFn(ctx, req)
+}
+func (m *mockProvider) ChatStream(ctx context.Context, req provider.ChatRequest, fn func(provider.ChatResponse) error) error {
+	if m.chatStreamFn == nil {
+		return errors.New("mock: chat-stream not scripted")
+	}
+	return m.chatStreamFn(ctx, req, fn)
+}
+func (m *mockProvider) Generate(ctx context.Context, req provider.GenerateRequest) (*provider.GenerateResponse, error) {
+	if m.genFn == nil {
+		return nil, errors.New("mock: generate not scripted")
+	}
+	return m.genFn(ctx, req)
+}
+func (m *mockProvider) GenerateStream(ctx context.Context, req provider.GenerateRequest, fn func(provider.GenerateResponse) error) error {
+	if m.genStreamFn == nil {
+		return errors.New("mock: generate-stream not scripted")
+	}
+	return m.genStreamFn(ctx, req, fn)
+}
+func (m *mockProvider) Embed(ctx context.Context, req provider.EmbedRequest) (*provider.EmbedResponse, error) {
+	if m.embedFn == nil {
+		return nil, errors.New("mock: embed not scripted")
+	}
+	return m.embedFn(ctx, req)
+}
+
+// newTestServer builds a Server wired to a real Router backed by the given
+// scripted mock provider. The returned teardown closes the Router.
+func newTestServer(t *testing.T, mp *mockProvider, opts ...Option) (*Server, func()) {
+	t.Helper()
+	provReg := provider.NewRegistry()
+	if err := provReg.Register(mp); err != nil {
+		t.Fatalf("provider registry register: %v", err)
+	}
+	if err := provReg.RefreshModels(context.Background(), mp.Name()); err != nil {
+		t.Fatalf("provider registry refresh models: %v", err)
+	}
+	modelReg, err := provider.NewModelRegistry(provReg, nil)
+	if err != nil {
+		t.Fatalf("model registry: %v", err)
+	}
+	router := provider.NewRouter(modelReg, provReg,
+		provider.WithStickyTTL(time.Second),
+		provider.WithAvailableRAM(256),
+	)
+	srv := New(router, modelReg, provReg, opts...)
+	return srv, func() {
+		_ = router.Close()
+	}
+}

--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -65,6 +65,13 @@ func (rp *RoutePlan) SetWasSticky(v bool) {
 	rp.wasSticky = v
 }
 
+// WasSticky reports whether the plan was selected via sticky routing. This
+// mirrors the RouteOutcome field of the same name but is available before
+// execution, which is what dry-run callers want.
+func (rp *RoutePlan) WasSticky() bool {
+	return rp.wasSticky
+}
+
 // ---------------------------------------------------------------------------
 // Execute — Chat (non-streaming)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase 4 of Epic #48: ships a first-class OpenAI-compatible HTTP façade (`compat/`) on top of the existing provider router. Drop-in for clients that speak the OpenAI REST/SSE wire format (Cursor, Continue, raw `openai` SDKs) while preserving go-llm's intelligent routing, capability filters, FIM context budgeting, and warmth-aware selection.

- 19 source files + full unit/integration test suite; 30 commits on the branch
- Defaults to loopback bind (`127.0.0.1:18741`); `WithTLS` required to bind non-loopback
- Handler-level concurrency gating (amendment #3) with a reserved high-priority lane
- SSE streaming (chat + completions) with pre-first-chunk JSON-envelope error handling
- Adaptive FIM budget (family base × language delta × position rebalance)
- Completion record store (LRU+TTL) with single-shot `consume` for `/completions/feedback`
- Opt-in `/v1/embeddings` via `WithEmbeddings` (off by default for resource safety)

## Endpoints (under `/v1/`, default base path)

- `GET /status` — liveness + uptime
- `GET /models` — canonical pairs + aliases, warm-first sort, `x_*` capability extensions
- `POST /chat/completions` — non-stream + SSE (`data:` frames, `[DONE]` terminator)
- `POST /completions` — non-stream + SSE; FIM branch when `suffix` is present
- `POST /completions/feedback` — single-shot `accepted`/`rejected`/`edited` attribution
- `POST /embeddings` — opt-in; scalar or array `input`, OpenAI-shape `embedding` wire

## Scope checklist (plan §19)

- [x] Package scaffold + options + loopback+TLS gate
- [x] Server lifecycle (New / ListenAndServe / Close) with idempotent shutdown
- [x] Bounded-concurrency primitive + handler-level gating with priority reserve
- [x] Middleware stack (CORS, request-id, logging, recovery) + provider-sentinel → HTTP mapping
- [x] Model alias resolver + `RecommendedAliases` preset
- [x] Mock-provider test fixture (`newTestServer`)
- [x] `GET /v1/status` + `GET /v1/models` (capability extensions + warm ordering)
- [x] `POST /v1/chat/completions` non-stream + SSE (clean error semantics before first chunk)
- [x] 4-layer adaptive FIM budgeting
- [x] `POST /v1/completions` non-stream + SSE (FIM branch + adaptive budget in-place)
- [x] Completion record store (LRU + TTL) + streaming-path defer-on-done
- [x] `POST /v1/completions/feedback` (single-shot via `consume`, 404 on duplicate)
- [x] `POST /v1/embeddings` (opt-in) with `maxEmbeddingInputs` cap
- [x] E2E integration tests (httptest.Server) — 8 tests including warm-order, dry-run, pre-first-chunk error, SSE framing, duplicate-feedback 404

## Test plan

- [x] `go build ./...`
- [x] `gofmt -l compat/` (clean)
- [x] `go vet ./...`
- [x] `go test ./...` (16 packages green)
- [x] `go test ./compat/... -race` (green)
- [x] `go test ./compat/... -run TestIntegration -v` (8/8 pass)

## Review trail

Every task went through an implement → skeptic (silent-failure-hunter) → fix → re-verify cycle; 12 fix commits address the findings. The final code-reviewer sweep surfaced three more issues (double-prefix chat ID bug, `ReadHeaderTimeout`) which are fixed in `9ea0aa7`.

Generated with [Claude Code](https://claude.com/claude-code)