### PR TITLE
docs: reframe LLM docs for current lineup and BYO-model support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Base URL: `http://localhost:11434`
 ### Chat Request
 ```json
 {
-  "model": "qwen3.5:27b",
+  "model": "gemma4:31b",
   "messages": [{"role": "user", "content": "hello"}],
   "stream": true,
   "options": {
@@ -77,6 +77,10 @@ Base URL: `http://localhost:11434`
   }
 }
 ```
+
+Model names in examples reflect the current `models.json` defaults but are
+not required by `go-llm` — any model the configured provider can load
+works. See `docs/llm/` for the reference lineup and BYO guidance.
 
 ### Embed Request
 ```json

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ func main() {
     client := ollama.NewClient()
 
     resp, err := client.Chat(context.Background(), ollama.ChatRequest{
-        Model: "qwen3.5:27b",
+        Model: "gemma4:31b",
         Messages: []ollama.ChatMessage{
             {Role: "user", Content: "Explain walk-forward validation for trading strategies"},
         },
@@ -75,7 +75,7 @@ func main() {
 
 ```go
 err := client.ChatStream(ctx, ollama.ChatRequest{
-    Model:    "qwen3.5:27b",
+    Model:    "gemma4:31b",
     Messages: []ollama.ChatMessage{{Role: "user", Content: "Hello"}},
 }, func(resp ollama.ChatResponse) error {
     fmt.Print(resp.Message.Content)
@@ -99,7 +99,7 @@ weatherTool := ollama.NewTool(
 
 // Send a chat request with tools
 resp, _ := client.Chat(ctx, ollama.ChatRequest{
-    Model:    "qwen3.5:27b",
+    Model:    "gemma4:31b",
     Messages: []ollama.ChatMessage{{Role: "user", Content: "What's the weather in NYC?"}},
     Tools:    []ollama.Tool{weatherTool},
 })
@@ -149,7 +149,7 @@ context := retriever.BuildContext(results, 4096)
 
 // Feed context into a chat completion
 resp, _ := client.Chat(ctx, ollama.ChatRequest{
-    Model: "qwen3.5:27b",
+    Model: "gemma4:31b",
     Messages: []ollama.ChatMessage{
         {Role: "system", Content: "Answer using the following code context:\n\n" + context},
         {Role: "user", Content: "How does the pairs trading strategy calculate hedge ratios?"},
@@ -212,7 +212,7 @@ client := ollama.NewClient(
 
 ```go
 models, _ := client.ListModels(ctx)
-info, _ := client.ShowModel(ctx, "qwen3.5:27b")
+info, _ := client.ShowModel(ctx, "gemma4:31b")
 client.PullModel(ctx, "qwen3:8b", func(status string, completed, total int64) {
     fmt.Printf("%s: %d/%d\n", status, completed, total)
 })
@@ -246,13 +246,15 @@ provider.CompleteStream(ctx, req, func(token string) error {
 
 Load model settings from `models.json` with provider configs, role-based defaults, and fallback chains that resolve against available Ollama models.
 
+`go-llm` does not hard-code a model roster — `models.json` is the sole source of truth. Substitute any model your configured provider can load by editing `models.json`; capabilities (chat / embedding / tool-call) are detected at runtime by `fingerprint/`. See [`docs/llm/`](docs/llm/) for the reference lineup shipped by default and the full BYO guide.
+
 ```go
 import "github.com/kstruzzieri/go-llm/config"
 
 cfg, _ := config.Default() // auto-discovers models.json
 
 // Simple lookup
-model := cfg.ModelFor("chat") // e.g., "qwen3.5:27b"
+model := cfg.ModelFor("chat") // e.g., "gemma4:31b"
 
 // Resolve with fallback chain (checks which models are actually available)
 resolved, _ := cfg.Resolve(ctx, client, "chat")
@@ -316,11 +318,11 @@ Domain-specific analysis helpers that leverage Ollama models.
 import "github.com/kstruzzieri/go-llm/analysis"
 
 // Code review (optionally backed by RAG context)
-reviewer, _ := analysis.NewCodeReviewer(client, retriever, "qwen3.5:27b")
+reviewer, _ := analysis.NewCodeReviewer(client, retriever, "gemma4:31b")
 review, _ := reviewer.Review(ctx, code, analysis.WithLanguage("go"))
 
 // ML training metrics analysis
-analyzer, _ := analysis.NewMetricsAnalyzer(client, "qwen3.5:27b")
+analyzer, _ := analysis.NewMetricsAnalyzer(client, "gemma4:31b")
 insight, _ := analyzer.AnalyzeTraining(ctx, analysis.TrainingMetrics{
     Epoch: 10, Loss: 0.42, LearningRate: 1e-4,
 })

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -536,7 +536,7 @@ type Service struct {
 
 func NewService() (*Service, error) {
     client := ollama.NewClient()
-    analyzer, err := analysis.NewMetricsAnalyzer(client, "qwen3.5:27b")
+    analyzer, err := analysis.NewMetricsAnalyzer(client, "gemma4:31b")
     if err != nil {
         return nil, err
     }

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -16,15 +16,17 @@ go get github.com/kstruzzieri/go-llm
 
 ## Pull Required Models
 
-```bash
-# General purpose (reasoning, vision, conversation)
-ollama pull qwen3.5:27b
+These pulls match the current reference lineup checked into `models.json`:
 
-# Fast MoE model (agents, tool use, high throughput)
-ollama pull qwen3.5:35b-a3b
+```bash
+# General / agent / analysis (reasoning, multimodal chat, tool use)
+ollama pull gemma4:31b
+
+# Fast fallback / lower-latency chat
+ollama pull qwen3.6:35b-a3b
 
 # Coding (code generation, review, FIM completion)
-ollama pull qwen3-coder-next
+ollama pull qwen3-coder-next:latest
 
 # Lightweight (simple/fast tasks)
 ollama pull qwen3:8b
@@ -32,6 +34,10 @@ ollama pull qwen3:8b
 # Embeddings (RAG vector search)
 ollama pull qwen3-embedding:8b
 ```
+
+If you customize `models.json`, pull the models you configured instead.
+See [llm/recommendation.md](llm/recommendation.md) for the current
+reference lineup and BYO-model guidance.
 
 ## Model Configuration
 
@@ -43,7 +49,7 @@ import "github.com/kstruzzieri/go-llm/config"
 cfg := config.MustLoad("models.json")
 
 // Resolve model names by use-case
-chatModel := cfg.MustModelFor("chat")           // "qwen3.5:27b"
+chatModel := cfg.MustModelFor("chat")            // "gemma4:31b"
 codeModel := cfg.MustModelFor("completion")      // "qwen3-coder-next:latest"
 embedModel := cfg.MustModelFor("embedding")      // "qwen3-embedding:8b"
 
@@ -68,11 +74,16 @@ Consumer applications (Firn IDE, Flux ML) can also use `config.Default()` to dis
 
 | Role | Model | When to Use |
 |------|-------|-------------|
-| `general` | qwen3.5:27b (17GB) | Complex reasoning, image analysis, long conversations |
-| `fast` | qwen3.5:35b-a3b (23GB) | Agent loops, tool calling, rapid iteration. MoE = only 3B params active per token |
-| `coding` | qwen3-coder-next (51GB) | Code generation, review, FIM completions |
-| `lightweight` | qwen3:8b (5GB) | Quick answers, classification, low-stakes tasks |
-| `embedding` | qwen3-embedding:8b (5GB) | Vector embeddings for RAG search |
+| `general` | `gemma4:31b` (~20GB) | Complex reasoning, multimodal chat, long conversations |
+| `agent` | `gemma4:31b` (~20GB) | Tool use, agent loops, function calling |
+| `fast` | `qwen3.6:35b-a3b` (~28GB) | Lower-latency chat and strong fallback path |
+| `coding` | `qwen3-coder-next:latest` (~46GB) | Code generation, review, FIM completions |
+| `lightweight` | `qwen3:8b` (~6GB) | Quick answers, classification, low-stakes tasks |
+| `embedding` | `qwen3-embedding:8b` (~5GB) | Vector embeddings for RAG search |
+
+The `analysis` use-case currently maps to the `general` role in
+`models.json`, so it also resolves to `gemma4:31b` unless you customize
+the defaults.
 
 ### Swapping Models
 
@@ -105,9 +116,9 @@ func main() {
     client := ollama.NewClient()
 
     resp, err := client.Chat(context.Background(), ollama.ChatRequest{
-        Model: "qwen3.5:27b",
+        Model: "gemma4:31b",
         Messages: []ollama.ChatMessage{
-            {Role: "user", Content: "Explain MoE architectures in neural networks"},
+            {Role: "user", Content: "Explain walk-forward validation for trading strategies"},
         },
     })
     if err != nil {
@@ -121,7 +132,7 @@ func main() {
 
 ```go
 err := client.ChatStream(ctx, ollama.ChatRequest{
-    Model:    "qwen3.5:35b-a3b",  // fast model for interactive use
+    Model:    "qwen3.6:35b-a3b",  // fast model for interactive use
     Messages: []ollama.ChatMessage{{Role: "user", Content: "Hello"}},
 }, func(resp ollama.ChatResponse) error {
     fmt.Print(resp.Message.Content)
@@ -133,7 +144,7 @@ err := client.ChatStream(ctx, ollama.ChatRequest{
 
 ```go
 resp, err := client.Generate(ctx, ollama.GenerateRequest{
-    Model:  "qwen3-coder-next",
+    Model:  "qwen3-coder-next:latest",
     Prompt: "Write a Go function that implements binary search on a sorted slice",
     Options: &ollama.ModelOptions{
         Temperature: 0.2,  // low temp for precise code
@@ -180,7 +191,7 @@ context := retriever.BuildContext(results, 4096)
 
 // Ask the LLM with retrieved context
 resp, _ := client.Chat(ctx, ollama.ChatRequest{
-    Model: "qwen3.5:27b",
+    Model: "gemma4:31b",
     Messages: []ollama.ChatMessage{
         {Role: "system", Content: "Answer using the provided code context.\n\n" + context},
         {Role: "user", Content: "How does authentication work in this project?"},
@@ -277,10 +288,10 @@ go-llm/
 
 | Setup | RAM | Recommended Models |
 |-------|-----|-------------------|
-| Minimal (8GB) | 8GB | qwen3:8b only |
-| Standard (16-32GB) | 16-32GB | qwen3.5:27b + qwen3:8b + embedding |
-| Full (64GB+) | 64GB+ | All models |
-| Power (128GB+) | 128GB+ | All models, can run 2+ simultaneously |
+| Minimal (8GB) | 8GB | `qwen3:8b` only |
+| Standard (16-32GB) | 16-32GB | `qwen3:8b` + `qwen3-embedding:8b` |
+| Large (32-64GB) | 32-64GB | One primary model at a time (`gemma4:31b` or `qwen3.6:35b-a3b`), adding smaller models only if memory allows |
+| Power (128GB+) | 128GB+ | Full reference lineup from `models.json` |
 
 ## Consumers
 

--- a/docs/llm/README.md
+++ b/docs/llm/README.md
@@ -1,8 +1,8 @@
-# go-llm: Local Model Strategy (April 2026)
+# go-llm: Local Model Strategy
 
-This directory documents the analysis and decisions behind the model lineup
-powering `go-llm` and its consumers (Firn IDE, Flux ML, Quantum Trader) on
-Apple Silicon workstations.
+This directory documents the analysis and decisions behind the reference
+model lineup shipped with `go-llm` and its consumers (Firn IDE, Flux ML,
+Quantum Trader) on Apple Silicon workstations.
 
 **Target hardware:** MacBook Pro M3 Max, 128GB unified memory (~97GB usable
 after OS overhead).
@@ -13,26 +13,46 @@ after OS overhead).
 |---|---|
 | [analysis.md](analysis.md) | 2026 open-weight landscape, benchmark summary, sources |
 | [setups.md](setups.md) | Three candidate setup combinations with tradeoffs |
-| [recommendation.md](recommendation.md) | Chosen lineup + migration steps |
+| [recommendation.md](recommendation.md) | Current reference lineup + how to customize |
 | [benchmark-plan.md](benchmark-plan.md) | Harness design for A/B'ing models on real traces |
 
-## TL;DR
+## Bring-your-own model
 
-- **Keep** `qwen3-coder-next` (primary code generation) and
-  `qwen3-embedding:8b` (embeddings).
-- **Add** `gemma4:31b` (dense) — agent / tool-use / reasoning specialist.
-  Fills the tool-calling gap; 86.4% τ2-bench, 80.0% LiveCodeBench.
-- **Add** `qwen3.6:35b-a3b` — MoE upgrade over `qwen3.5:35b-a3b` (73.4%
-  SWE-bench Verified with 3B active).
-- **Retire** `qwen3.5:27b` and `qwen3.5:35b-a3b` after validation.
-- **Stay on Ollama** — as of 0.19, it is backed by MLX on Apple Silicon,
-  so the historical MLX-vs-Ollama speed gap is closed.
-- **Defer** a llama.cpp / LM Studio backend abstraction until the
-  benchmark harness shows Gemma 4 or a frontier non-Ollama model
-  (GLM-5.1, MiniMax M2.7) produces a measurable quality delta on real
-  workloads.
+`go-llm` does **not** hard-code a model roster. `models.json` is the only
+source of truth for which models exist, what role each plays, and which
+provider serves them. You can substitute any model the provider can load:
+edit `models.json`, restart, and the router picks it up. See
+[recommendation.md#customizing-the-lineup](recommendation.md#customizing-the-lineup)
+for the full story.
 
-## Manual Smoke Test
+On first use, the `fingerprint/` package probes the model via the
+provider's `/api/show` (or equivalent) endpoint, captures capabilities
+(chat / embedding / tool-call) plus latency and throughput, and persists
+the profile to SQLite. No code changes are required to add a model — only
+config.
+
+The specific model IDs in this documentation describe the reference
+lineup checked into `models.json`. Treat them as "what ships by default",
+not "what `go-llm` requires."
+
+## TL;DR — Reference lineup (April 2026)
+
+- **`qwen3-coder-next`** — primary code generation (80B / 3.9B active MoE)
+- **`qwen3-embedding:8b`** — embeddings (#1 MTEB multilingual)
+- **`gemma4:31b`** (dense) — agent / tool-use / reasoning (86.4% τ2-bench,
+  80.0% LiveCodeBench, native function calling)
+- **`qwen3.6:35b-a3b`** — fast MoE (73.4% SWE-bench, 3B active)
+- **`qwen3:8b`** — lightweight / FIM
+
+The fleet co-resides in ~77GB with comfortable headroom. The architecture
+stays on Ollama (as of 0.19, Ollama is backed by MLX on Apple Silicon, so
+the historical MLX-vs-Ollama speed gap is closed). A second backend
+(llama.cpp, LM Studio, mlx-lm) is deferred until the benchmark harness
+shows a measurable quality delta on real workloads — see
+[setups.md](setups.md) for Setup 2/3 (GLM-5.1, MiniMax M2.7) as
+alternative paths.
+
+## Manual smoke test
 
 To smoke-test `cmd/llm-bench` without waiting for real captured traces,
 use the checked-in synthetic trace:
@@ -45,12 +65,14 @@ go run ./cmd/llm-bench \
   -report /tmp/llm-bench-smoke.md
 ```
 
-Success criteria: the command exits `0`, writes `/tmp/llm-bench-smoke.md`,
-and the report shows `Errors = 0` with `Mean Quality = 1.00` for each
-model on the `smoke-minimal-001` trace. This only verifies harness
-plumbing and basic model reachability, not real MCP-agent quality.
+Substitute whichever models are pulled on your machine. Success criteria:
+the command exits `0`, writes `/tmp/llm-bench-smoke.md`, and the report
+shows `Errors = 0` with `Mean Quality = 1.00` for each model on the
+`smoke-minimal-001` trace. This only verifies harness plumbing and basic
+model reachability, not real MCP-agent quality.
 
 ## Date stamp
 
-All research was conducted April 16, 2026. Benchmark numbers and release
-dates reflect that snapshot.
+Research was conducted April 16, 2026 and refreshed against the live
+`models.json` as of that date. Benchmark numbers and release dates
+reflect that snapshot.

--- a/docs/llm/analysis.md
+++ b/docs/llm/analysis.md
@@ -9,9 +9,18 @@ Keith runs an M3 Max, 128GB RAM, developing three apps that depend on
 - **Flux ML** — Wails ML dev environment, needs chat + analysis
 - **Quantum Trader** — Go+Python trading platform, needs agent loops + tool use
 
-The existing model lineup (`qwen3-coder-next`, `qwen3.5:35b-a3b`,
-`qwen3.5:27b`, `qwen3:8b`, `qwen3-embedding:8b`) was selected in late 2025.
-Several frontier open-weight releases in Q1 2026 warrant a re-evaluation.
+The late-2025 lineup was built around the Qwen 3.5 family. Frontier
+open-weight releases in Q1 2026 (Qwen 3.6, Gemma 4, GLM-5.1, MiniMax M2.7)
+triggered the re-evaluation captured in this document. The resulting
+reference lineup — shipped in `models.json` — supersedes Qwen 3.5 with
+Gemma 4 31B (agent/general/analysis), Qwen 3.6 35B-A3B (fast), and
+retains Qwen3-Coder-Next + Qwen3-Embedding. See
+[recommendation.md](recommendation.md) for role assignments.
+
+This analysis is **descriptive, not prescriptive**. `go-llm` does not
+hard-code any model. The IDs below are the reference lineup checked into
+`models.json`; edit that file to substitute your own. See
+[recommendation.md#customizing-the-lineup](recommendation.md#customizing-the-lineup).
 
 ## Hardware budget
 
@@ -29,8 +38,8 @@ dramatically faster than a dense 14B.
 
 | Model | Total / Active | SWE-bench Verified | Memory @ Q4 | Notes |
 |---|---|---|---|---|
-| **Qwen3-Coder-Next** | 80B / 3.9B | 70.6% | ~46GB | Already in use. Still top-tier agentic coding workhorse. |
-| **Qwen3.6-35B-A3B** | 35B / 3B | 73.4% | ~20GB | Direct drop-in for qwen3.5:35b-a3b. 86.0% GPQA, 92.7% AIME 2026. |
+| **Qwen3-Coder-Next** | 80B / 3.9B | 70.6% | ~46GB | `coding` role in the reference lineup. Top-tier agentic coding workhorse. |
+| **Qwen3.6-35B-A3B** | 35B / 3B | 73.4% | ~20GB | `fast` role in the reference lineup — superseded the legacy qwen3.5:35b-a3b. 86.0% GPQA, 92.7% AIME 2026. |
 | **Qwen3.6 Plus** | closed/cloud | 78.8% | — | Cloud-only, 1M context. Not applicable for local. |
 | **GLM-5.1** | 754B / 40B | 77.8% | ~95–110GB UD-Q2_K_XL | Tight fit, displaces everything else. |
 | **MiniMax M2.7** | 229B / 10B | ~80% | ~115GB Q4 | Best tool-calling (76.8% BFCL). Very tight. |
@@ -49,7 +58,7 @@ dramatically faster than a dense 14B.
 
 | Model | Params | MTEB | Strengths | Notes |
 |---|---|---|---|---|
-| **Qwen3-Embedding-8B** | 8B | 70.58 (multilingual #1 as of June 2025) | Multilingual + code | Already in use. Keep. |
+| **Qwen3-Embedding-8B** | 8B | 70.58 (multilingual #1 as of June 2025) | Multilingual + code | `embedding` role in the reference lineup. |
 | Nomic-Embed-Code | 7B | code-specialized | Beats Voyage Code 3, OpenAI Embed 3 Large on CodeSearchNet | Strong alternative if code retrieval becomes the bottleneck. |
 | Gemini Embedding 2 | API | 84.0 (MTEB Code) | Best code retrieval | Not local. |
 | Voyage code-3 | API | — | Strong for code/technical | Not local. |

--- a/docs/llm/benchmark-plan.md
+++ b/docs/llm/benchmark-plan.md
@@ -140,8 +140,15 @@ manual review because the "right answer" is domain-specific.
 
 ### Phase 4 — Live comparison runs
 
-- Qwen3-Coder-Next vs Gemma 4 31B on `agent` role traces
-- Qwen3-Coder-Next vs GLM-5.1 (Setup 2 experiment) on code-gen traces
+- **Currently-configured model vs candidate** on each role's captured
+  traces. The harness takes `-models <provider>/<name>,...` so any model
+  reachable through an existing `provider.Provider` can participate —
+  swap candidates without editing Go code.
+- Initial target comparisons against the reference lineup in `models.json`:
+  - `coding` — Qwen3-Coder-Next vs GLM-5.1 on code-gen traces (Setup 2
+    experiment; see [setups.md](setups.md))
+  - `agent` — Gemma 4 31B vs MiniMax M2.7 on MCP tool-use traces
+    (Setup 3 experiment)
 - Report in `docs/llm/benchmarks/YYYY-MM-DD-<name>.md`
 
 ## User decision required

--- a/docs/llm/recommendation.md
+++ b/docs/llm/recommendation.md
@@ -1,70 +1,132 @@
-# Recommended Lineup + Migration Plan
+# Current Lineup + Customization
 
-## Decision
+## Reference lineup (shipped in `models.json`)
 
-Adopt **Setup 1 — Balanced Daily Driver** as the production `go-llm`
-lineup. Run **Setup 2 (GLM-5.1 in LM Studio)** as a parallel off-Ollama
-experiment to gather evidence for whether second-backend work is
-justified.
+Adopted from the April 2026 analysis (see [analysis.md](analysis.md)).
+This is **Setup 1 — Balanced Daily Driver** from [setups.md](setups.md):
+drop-in upgrades, all-Ollama, full co-residency, zero architectural
+change to `go-llm`.
 
-## Target lineup
+| Role | Model | Source |
+|---|---|---|
+| `coding` | `qwen3-coder-next:latest` | Ollama |
+| `agent` | `gemma4:31b` | Ollama |
+| `general` | `gemma4:31b` | Ollama |
+| `analysis` | `gemma4:31b` | Ollama |
+| `fast` | `qwen3.6:35b-a3b` | Ollama |
+| `lightweight` | `qwen3:8b` | Ollama |
+| `embedding` | `qwen3-embedding:8b` | Ollama |
 
-| Role | Model | Source | Status |
-|---|---|---|---|
-| `coding` | `qwen3-coder-next:latest` | Ollama | **keep** |
-| `agent` | `gemma4:31b` | Ollama | **add** |
-| `general` | `gemma4:31b` | Ollama | **retarget** (was `qwen3.5:27b`) |
-| `analysis` | `gemma4:31b` | Ollama | **retarget** (was `qwen3.5:27b`) |
-| `fast` | `qwen3.6:35b-a3b` | Ollama | **add** (replaces `qwen3.5:35b-a3b`) |
-| `lightweight` | `qwen3:8b` | Ollama | **keep** |
-| `embedding` | `qwen3-embedding:8b` | Ollama | **keep** |
+These specific IDs are **the reference lineup**, not a contract. `go-llm`
+has no hard-coded model list: the router, registry, and every consumer
+read from `models.json`.
 
-## Migration steps
+## Customizing the lineup
 
-### Phase 1 — Pull new models (10 min)
+### The short story
 
-```bash
-ollama pull gemma4:31b          # ~20GB dense
-ollama pull gemma4:26b          # ~18GB MoE (optional, latency alternative)
-ollama pull qwen3.6:35b-a3b     # ~28GB MoE
+Edit `models.json`. Restart. Done.
+
+`go-llm` loads models at boot from a single config file and profiles each
+one on first use. There is no roster file to edit in Go, no build-time
+list to regenerate, and no capability list to keep in sync by hand —
+capabilities are discovered at runtime via the provider's model-info
+endpoint and cached in the fingerprint store (SQLite).
+
+### What a model entry looks like
+
+```json
+{
+  "models": {
+    "coding": {
+      "name": "llama-4-scout:q5_k_m",
+      "provider": "ollama",
+      "type": "dense",
+      "context_window": 131072,
+      "fallbacks": ["fast", "lightweight"]
+    }
+  }
+}
 ```
 
-### Phase 2 — Validate (1–2 days of normal use)
+| Field | Required | Notes |
+|---|---|---|
+| `name` | yes | Whatever the provider uses to load the model |
+| `provider` | no | Defaults to `"ollama"`; any key from the `providers` map |
+| `type` | yes | `"dense"`, `"moe"`, or `"embedding"` (validates fallback compatibility) |
+| `context_window` | no | Observed/overridden at runtime by fingerprint if wrong |
+| `dimensions` | no | For embedding models |
+| `fallbacks` | no | Role names to degrade to when the primary is unavailable |
+| `description`, `parameters` | no | Human-readable only |
 
-Run with both new and old models pulled. `models.json` updated to point
-to new models, but old models still available. Monitor:
+### Adding a new provider
 
-- `gemma4:31b` on agent workloads (Quantum Trader MCP loops, Firn code
-  actions)
-- `qwen3.6:35b-a3b` on general chat / analysis
-- Existing `qwen3-coder-next` workflows for regression (they should be
-  unchanged)
+`providers` is also config-driven:
 
-### Phase 3 — Retire legacy (5 min)
-
-Once Phase 2 passes:
-
-```bash
-ollama rm qwen3.5:27b
-ollama rm qwen3.5:35b-a3b
+```json
+{
+  "providers": {
+    "ollama": { "base_url": "http://localhost:11434", "timeout": "5m" },
+    "lm-studio": {
+      "base_url": "http://localhost:1234/v1",
+      "api_format": "openai",
+      "timeout": "5m"
+    }
+  }
+}
 ```
 
-### Phase 4 — Parallel GLM-5.1 experiment
+Then any model's `provider` field can reference the new key. This is how
+Setup 2 / Setup 3 from [setups.md](setups.md) land once they're
+justified — the abstraction seam already exists; the implementation (a
+second `provider.Provider`) is the only remaining work.
 
-Independent of the main migration:
+### Capability detection
 
-1. Install LM Studio (or `llama.cpp` server).
-2. Pull `glm-5.1-UD-Q2_K_XL` (via Unsloth).
-3. Run the benchmark harness (see [benchmark-plan.md](benchmark-plan.md))
-   comparing Qwen3-Coder-Next and GLM-5.1 on real captured traces.
-4. **Decision gate**: if GLM-5.1 shows ≥5% quality improvement on real
-   workloads (not synthetic benchmarks), invest in the second-backend
-   abstraction (Setup 2).
+The first time a model is used, `fingerprint/` queries the provider for
+model metadata and records:
 
-Expected outcome: in most cases the quality gain will not justify the
-integration cost. The experiment's real value is *evidence* that
-defending Setup 1 against speculative criticism ("but GLM-5.1 is better
-on SWE-bench!") is correct for this workload.
+- **Kind** — completion, embedding, tool-call, thinking-mode support
+- **Latency** — first-token and inter-token latency
+- **Throughput** — tokens per second under load
+- **Resources** — peak memory, cold-start time
+
+The catalog (`provider/catalog.json`) matches model **families** (e.g.
+`qwen3`, `gemma4`, `codellama`, `deepseek`) by name prefix and supplies
+FIM-policy and thinking-mode defaults. If a model's family isn't in the
+catalog, the system falls back to runtime-detected capabilities and a
+neutral default policy — it still works; it just won't get family-specific
+tuning until you add a catalog entry.
+
+### Router weight profiles
+
+`provider/router_score.go` ships default profiles for `fim`, `chat`,
+`embedding`, `reasoning`, `code-review`, `agent`, and `tool-use`
+(`agent` and `tool-use` are aliased to the same values). The profiles
+weigh generic traits — speed, quality, feedback — not specific models,
+so they apply unchanged to any lineup. If your own models have unusual
+speed/quality tradeoffs (e.g., a reasoner that's slow but very high
+quality), retune by constructing the router with
+`provider.WithWeightOverrides(map[string]*WeightProfile{...})`.
+
+### OpenAI-compat aliases
+
+The compat layer ships a `RecommendedAliases()` preset
+(`compat/aliases.go`) that maps OpenAI model names (`gpt-4`, `gpt-4o`,
+`text-embedding-3-large`, etc.) to the reference lineup for easy
+drop-in with Cursor / Continue / raw `openai` SDKs. **These aliases
+reference specific go-llm model IDs and will move as the reference
+lineup evolves.** For a custom lineup, pass your own map to
+`compat.WithAliases()`:
+
+```go
+srv := compat.New(router, registry, providers,
+    compat.WithAliases(map[string]string{
+        "gpt-4":                  "ollama/llama-4-scout:q5_k_m",
+        "text-embedding-3-large": "ollama/nomic-embed-code",
+    }),
+)
+```
 
 ## Unvalidated claims to verify on deploy
 
@@ -73,12 +135,13 @@ The `context_window` values in `models.json` (256000 for `gemma4:31b` /
 published model maxima and have **not** been validated at build time —
 the library does not boot Ollama in unit tests. First use on a given
 machine, the `fingerprint/` package will observe the real context
-window Ollama reports and cache it. If a published figure is wrong,
+window the provider reports and cache it. If a published figure is wrong,
 prompt-overflow bugs will surface at runtime, not at install.
 
-Mitigation: after pulling, run `ollama show <model>` once and compare
-the `num_ctx` figure with `models.json`. If they disagree, update
-`models.json` rather than trusting the source.
+Mitigation: after pulling, run `ollama show <model>` (or the equivalent
+for your provider) once and compare the `num_ctx` figure with
+`models.json`. If they disagree, update `models.json` rather than
+trusting the source.
 
 The catalog keeps both `qwen3-coder-next:latest` and `qwen3-coder-next:80b`
 variants with identical specs. `latest` tracks Ollama's floating tag and
@@ -86,32 +149,30 @@ is what `models.json` references; `80b` is retained so a consumer that
 pins explicitly still gets curated scoring data. `TestQwen3CoderNextVariantsInSync`
 enforces they stay identical.
 
-## Files touched in this migration
+## Alternate paths — GLM-5.1 and MiniMax experiments
 
-- `models.json` — role assignments
-- `provider/catalog.json` — add `qwen3.6`, `qwen3-coder-next`, `gemma4`
-  families
-- `docs/GETTING_STARTED.md` — update "Pull Required Models" section
-  *(follow-up PR, not blocking)*
-- `docs/llm/` — this directory
+Setup 2 (GLM-5.1 in LM Studio) and Setup 3 (MiniMax M2.7) from
+[setups.md](setups.md) remain candidate upgrades. They're deferred,
+not rejected. The benchmark harness
+([benchmark-plan.md](benchmark-plan.md)) is the decision gate: if a
+frontier non-Ollama model shows ≥5% quality improvement on real captured
+traces (not synthetic benchmarks), that's the evidence to invest in the
+second-backend abstraction. Until that evidence exists, Setup 1 wins on
+integration cost.
 
-No code changes required to `config/`, `provider/`, `ollama/`, `rag/`,
-`completion/`, `analysis/`, `mcp/`, `conversation/`, `feedback/`,
-`fingerprint/`, or `prefetch/` for Phase 1–3. The `provider.Router`
-signature is stable; new models get picked up automatically via
-`config.Load` and the catalog.
+## Files consulted when changing the lineup
 
-## Router weight profiles
+- `models.json` — role assignments (the only required edit for most
+  changes)
+- `provider/catalog.json` — family metadata (add a family entry if your
+  model belongs to a new family not already listed)
+- `docs/GETTING_STARTED.md` — "Pull Required Models" section, if you
+  ship a consumer-facing install guide
+- `docs/llm/` — this directory, if the change is significant enough to
+  warrant narrative updates
 
-`provider/router_score.go` ships default profiles for `fim`, `chat`,
-`embedding`, `reasoning`, `code-review`, `agent`, and `tool-use`
-(`agent` and `tool-use` are aliased to the same values). The agent
-profile prioritizes Speed and Feedback more heavily than chat, on the
-reasoning that tool-calling loops make many small calls and tool-call
-accuracy is directly observable as success/failure. If real traces
-suggest these weights are wrong, retune them — they are opinions, not
-benchmarked values, and the benchmark harness (`cmd/llm-bench`) is the
-right tool to validate them.
-
-Consumers can override any profile at construction via
-`provider.WithWeightOverrides(map[string]*WeightProfile{...})`.
+No code changes are required in `config/`, `provider/`, `ollama/`,
+`rag/`, `completion/`, `analysis/`, `mcp/`, `conversation/`,
+`feedback/`, `fingerprint/`, `prefetch/`, or `compat/` to add or swap
+models. The `provider.Router` signature is stable; new models get picked
+up automatically via `config.Load` and the catalog.

--- a/docs/llm/recommendation.md
+++ b/docs/llm/recommendation.md
@@ -111,22 +111,28 @@ quality), retune by constructing the router with
 
 ### OpenAI-compat aliases
 
-The compat layer ships a `RecommendedAliases()` preset
-(`compat/aliases.go`) that maps OpenAI model names (`gpt-4`, `gpt-4o`,
-`text-embedding-3-large`, etc.) to the reference lineup for easy
-drop-in with Cursor / Continue / raw `openai` SDKs. **These aliases
-reference specific go-llm model IDs and will move as the reference
-lineup evolves.** For a custom lineup, pass your own map to
-`compat.WithAliases()`:
+If you expose the optional `compat/` package's OpenAI-compatible HTTP
+façade, `compat.RecommendedAliases()` provides a conservative preset for
+tools that hardcode OpenAI model names (`gpt-4`, `gpt-4o`,
+`text-embedding-3-large`, etc.). The server default is an empty alias
+map; install aliases explicitly with `compat.WithAliases()`.
+
+For a custom lineup, start from the recommended preset and override the
+entries that should point somewhere else:
 
 ```go
+aliases := compat.RecommendedAliases()
+aliases["gpt-4"] = "ollama/llama-4-scout:q5_k_m"
+aliases["text-embedding-3-large"] = "ollama/nomic-embed-code"
+
 srv := compat.New(router, registry, providers,
-    compat.WithAliases(map[string]string{
-        "gpt-4":                  "ollama/llama-4-scout:q5_k_m",
-        "text-embedding-3-large": "ollama/nomic-embed-code",
-    }),
+    compat.WithAliases(aliases),
 )
 ```
+
+**These aliases reference specific go-llm model IDs and will move as the
+reference lineup evolves.** Treat the alias map as a view over
+`models.json`, not as a second source of truth.
 
 ## Unvalidated claims to verify on deploy
 

--- a/docs/llm/setups.md
+++ b/docs/llm/setups.md
@@ -3,21 +3,27 @@
 Each option is evaluated on co-residency (models that can stay warm
 simultaneously), `go-llm` integration cost, and quality ceiling.
 
+> **`models.json` is authoritative.** The model IDs below describe three
+> candidate configurations. Setup 1 is what's shipped by default. To
+> substitute your own models for any role (or add a new role), edit
+> `models.json` — no Go code changes are required. See
+> [recommendation.md#customizing-the-lineup](recommendation.md#customizing-the-lineup).
+
 ---
 
-## Setup 1 — Balanced Daily Driver (recommended)
+## Setup 1 — Balanced Daily Driver (current default)
 
-**Philosophy:** Drop-in upgrades, all-Ollama, full co-residency, zero
-architectural change to `go-llm`.
+**Philosophy:** All-Ollama, full co-residency, zero architectural change
+to `go-llm`. This is what `models.json` ships with.
 
 | Role | Model | Size on disk | Notes |
 |---|---|---|---|
-| `coding` | `qwen3-coder-next:latest` | ~46GB | 70.6% SWE-bench; unchanged |
-| `agent` | **`gemma4:31b`** (dense) | ~20GB | **NEW.** 86.4% τ2-bench, 80.0% LiveCodeBench, native function calling |
+| `coding` | `qwen3-coder-next:latest` | ~46GB | 70.6% SWE-bench |
+| `agent` | `gemma4:31b` (dense) | ~20GB | 86.4% τ2-bench, 80.0% LiveCodeBench, native function calling |
 | `general` / `analysis` | `gemma4:31b` (thinking mode on) | shared | Gemma 4 doubles as reasoner |
-| `fast` | **`qwen3.6:35b-a3b`** | ~28GB (Q6) | Upgrade over qwen3.5:35b-a3b; optional |
-| `lightweight` | `qwen3:8b` | ~6GB | Unchanged — FIM completion |
-| `embedding` | `qwen3-embedding:8b` | ~5GB | Unchanged |
+| `fast` | `qwen3.6:35b-a3b` | ~28GB (Q6) | Superseded the legacy qwen3.5:35b-a3b |
+| `lightweight` | `qwen3:8b` | ~6GB | FIM completion |
+| `embedding` | `qwen3-embedding:8b` | ~5GB | |
 
 **Resident memory:** ~77GB with the optional `qwen3.6:35b-a3b`, or ~57GB
 without. Comfortable headroom.
@@ -29,8 +35,8 @@ without. Comfortable headroom.
 
 **Cons:**
 - No GLM-5.1 / MiniMax ceiling — we cap at ~77% SWE-bench equivalent
-- Gemma 4 is 2 weeks old at the time of writing; long-term stability
-  unproven
+- Gemma 4 was ~2 weeks old at initial adoption; stability has held in
+  daily use but long-term trajectory still depends on upstream maintenance
 
 ---
 
@@ -106,8 +112,10 @@ workflows.
 | `go-llm` changes | Config only | Second backend | Second backend |
 | Time to deploy | ~30 min | ~1 week | ~1 week |
 | Incremental cost if wrong | Low | High | High |
-| Dependency on brand-new model | Yes (Gemma 4, 2 weeks old) | Moderate | Moderate |
 
-**Recommendation: Setup 1**, with a parallel experiment (LM Studio +
-GLM-5.1) to evaluate whether Setup 2's quality gain justifies the
-integration cost. See [recommendation.md](recommendation.md).
+**Current default: Setup 1** (see `models.json`). Setups 2 and 3 remain
+candidate upgrades; the benchmark harness
+([benchmark-plan.md](benchmark-plan.md)) is the decision gate for when
+second-backend work is justified. See
+[recommendation.md](recommendation.md) for how to evolve the lineup
+without touching Go code.


### PR DESCRIPTION
## Summary

- Retires the qwen3.5 migration framing. The lineup migration is done (`gemma4:31b`, `qwen3.6:35b-a3b`, `qwen3-coder-next:latest`, `qwen3-embedding:8b`, `qwen3:8b`) and `models.json` already reflects it, so the docs needed to describe the current state rather than a pending migration.
- Positions `models.json` as the single source of truth for the model roster and documents the BYO path (entry schema, provider additions, capability detection via `fingerprint/`, router weight overrides, OpenAI-compat alias overrides). No Go code changes are required to substitute a model.
- Aligns CLAUDE.md and root README.md with the same story: replaces eight stale `qwen3.5:27b` examples with `gemma4:31b` and adds short BYO pointers into `docs/llm/`.

## Scope

Documentation only. No code, no config, no tests touched.

| File | Change |
|---|---|
| `docs/llm/README.md` | Adds Bring-your-own section; reframes TL;DR from migration to current state |
| `docs/llm/recommendation.md` | Replaces Migration steps with Customizing the lineup (schema, providers, capability detection, router profiles, compat aliases) |
| `docs/llm/analysis.md` | Marks analysis as descriptive, not prescriptive; points at customization |
| `docs/llm/setups.md` | Adds authoritative-config preamble; Setup 1 now labeled current default |
| `docs/llm/benchmark-plan.md` | Generalizes Phase 4 to currently-configured vs candidate comparisons |
| `CLAUDE.md` | Ollama API example uses `gemma4:31b`; trailing BYO pointer added |
| `README.md` | Eight `qwen3.5:27b` to `gemma4:31b`; Model Configuration BYO paragraph added |

## Test plan

- [x] Skim `docs/llm/recommendation.md` on GitHub; confirm the Customizing the lineup section renders and the JSON schema block displays correctly
- [x] Confirm all inter-doc links still resolve (`analysis.md`, `setups.md`, `benchmark-plan.md`, `recommendation.md#customizing-the-lineup`)
- [x] Grep the tree for any surviving `qwen3.5` references outside of legitimate historical context: \`rg 'qwen3\\.5' --type md\`
- [x] Confirm CLAUDE.md Ollama API example aligns with the current default in \`models.json\`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>