### PR TITLE
feat(rag): additive Router-aware constructors for Indexer and Retriever

### DIFF
--- a/mcp/embed_helper.go
+++ b/mcp/embed_helper.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/kstruzzieri/go-llm/provider"
+	"github.com/kstruzzieri/go-llm/rag"
 )
 
 // embedToolCategory enumerates the error-category strings used by the embed
@@ -91,4 +92,39 @@ func (s *Server) routedEmbed(ctx context.Context, model string, inputs []string,
 		}
 	}
 	return resp, nil
+}
+
+// ragEmbedder returns a rag.Embedder that routes through provider.Router via
+// s.routedEmbed at the supplied priority. Indexing should pass
+// provider.PriorityBackground; query retrieval should pass
+// provider.PriorityNormal so latency-sensitive user-facing paths take
+// precedence under contention.
+//
+// The closure refuses empty model strings to prevent vector-space drift:
+// RAG indexing and query embedding must always use the configured embedding
+// model, not chain fallback. If a real use case for empty-model + RAG
+// emerges, replace the inline error with a typed sentinel so callers can
+// errors.Is and consciously override.
+func (s *Server) ragEmbedder(priority provider.Priority) rag.Embedder {
+	return rag.EmbedderFunc(func(ctx context.Context, model string, inputs []string) (rag.EmbedResult, error) {
+		if model == "" {
+			return rag.EmbedResult{}, fmt.Errorf("rag: embedder requires explicit model to prevent vector-space drift across embedding-model boundaries")
+		}
+		resp, err := s.routedEmbed(ctx, model, inputs, priority)
+		if err != nil {
+			return rag.EmbedResult{}, err
+		}
+		result := rag.EmbedResult{
+			Embeddings: resp.Embeddings,
+			Model:      resp.Model,
+			Provider:   resp.Provider,
+		}
+		if resp.RouteOutcome != nil {
+			result.VectorSpaceID = resp.RouteOutcome.ActualModel.String()
+		}
+		if result.VectorSpaceID == "" && result.Provider != "" && result.Model != "" {
+			result.VectorSpaceID = result.Provider + "/" + result.Model
+		}
+		return result, nil
+	})
 }

--- a/mcp/embed_helper.go
+++ b/mcp/embed_helper.go
@@ -1,0 +1,94 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// embedToolCategory enumerates the error-category strings used by the embed
+// handlers. Centralised so callers can reason about categorisation without
+// string matching.
+type embedToolCategory string
+
+const (
+	embedToolConfig embedToolCategory = "config"
+	embedToolRouter embedToolCategory = "router"
+	embedToolOllama embedToolCategory = "ollama"
+)
+
+// routedEmbedError wraps a routing error with a category. Callers extract
+// the category via routedEmbedCategory; unwrapping yields the underlying
+// error for normal error inspection.
+type routedEmbedError struct {
+	category embedToolCategory
+	err      error
+}
+
+func (e routedEmbedError) Error() string { return e.err.Error() }
+func (e routedEmbedError) Unwrap() error { return e.err }
+
+// routedEmbedCategory extracts the embedToolCategory from any error returned
+// by routedEmbed. Errors not wrapping routedEmbedError are categorised as
+// "ollama" (the most conservative — assume backend execution failed).
+func routedEmbedCategory(err error) embedToolCategory {
+	var re routedEmbedError
+	if errors.As(err, &re) {
+		return re.category
+	}
+	return embedToolOllama
+}
+
+// routedEmbed is the single source of truth for embed routing in MCP.
+// All callers — handleEmbed, handleEmbedBatch, and s.ragEmbedder(priority) —
+// funnel through it. Returns the full *provider.EmbedResponse so callers can
+// preserve route metadata (e.g., RouteOutcome.ActualModel for vector-space
+// provenance).
+//
+// Empty inputs short-circuit and return an empty EmbedResponse without
+// invoking the router.
+//
+// model="" enables config-fallback-chain selection via s.chainFor("embedding").
+// RAG callers MUST NOT pass an empty model — see s.ragEmbedder for the
+// drift-prevention guard that enforces this for RAG indexing/retrieval.
+func (s *Server) routedEmbed(ctx context.Context, model string, inputs []string, priority provider.Priority) (*provider.EmbedResponse, error) {
+	if len(inputs) == 0 {
+		return &provider.EmbedResponse{}, nil
+	}
+	router := s.routerSnapshot()
+	if router == nil {
+		return nil, routedEmbedError{category: embedToolConfig, err: fmt.Errorf("router unavailable")}
+	}
+	rr := provider.RoutingRequest{
+		Model:          model,
+		UseCase:        "embedding",
+		RequiredCaps:   provider.CapEmbed,
+		Input:          inputs,
+		ExpectedOutput: provider.DefaultExpectedOutput("embedding"),
+		Priority:       priority,
+	}
+	if rr.Model == "" {
+		chain, err := s.chainFor("embedding")
+		if err != nil {
+			return nil, routedEmbedError{category: embedToolConfig, err: fmt.Errorf("chain: %w", err)}
+		}
+		rr.PreferredChain = chain
+	}
+	plan, err := router.Route(ctx, rr)
+	if err != nil {
+		return nil, routedEmbedError{category: embedToolRouter, err: fmt.Errorf("route: %w", err)}
+	}
+	resp, err := plan.ExecuteEmbed(ctx)
+	if err != nil {
+		return nil, routedEmbedError{category: embedToolOllama, err: err}
+	}
+	if len(resp.Embeddings) != len(inputs) {
+		return nil, routedEmbedError{
+			category: embedToolOllama,
+			err:      fmt.Errorf("embedding count mismatch: got %d for %d inputs", len(resp.Embeddings), len(inputs)),
+		}
+	}
+	return resp, nil
+}

--- a/mcp/embed_helper.go
+++ b/mcp/embed_helper.go
@@ -73,13 +73,13 @@ func (s *Server) routedEmbed(ctx context.Context, model string, inputs []string,
 	if rr.Model == "" {
 		chain, err := s.chainFor("embedding")
 		if err != nil {
-			return nil, routedEmbedError{category: embedToolConfig, err: fmt.Errorf("chain: %w", err)}
+			return nil, routedEmbedError{category: embedToolConfig, err: err}
 		}
 		rr.PreferredChain = chain
 	}
 	plan, err := router.Route(ctx, rr)
 	if err != nil {
-		return nil, routedEmbedError{category: embedToolRouter, err: fmt.Errorf("route: %w", err)}
+		return nil, routedEmbedError{category: embedToolRouter, err: err}
 	}
 	resp, err := plan.ExecuteEmbed(ctx)
 	if err != nil {
@@ -110,6 +110,12 @@ func (s *Server) ragEmbedder(priority provider.Priority) rag.Embedder {
 		if model == "" {
 			return rag.EmbedResult{}, fmt.Errorf("rag: embedder requires explicit model to prevent vector-space drift across embedding-model boundaries")
 		}
+		if len(inputs) == 0 {
+			// Short-circuit before routing. Provider/VectorSpaceID are
+			// undetermined without a routing decision; preserve the requested
+			// model so callers see the model they asked for.
+			return rag.EmbedResult{Model: model}, nil
+		}
 		resp, err := s.routedEmbed(ctx, model, inputs, priority)
 		if err != nil {
 			return rag.EmbedResult{}, err
@@ -120,7 +126,10 @@ func (s *Server) ragEmbedder(priority provider.Priority) rag.Embedder {
 			Provider:   resp.Provider,
 		}
 		if resp.RouteOutcome != nil {
-			result.VectorSpaceID = resp.RouteOutcome.ActualModel.String()
+			am := resp.RouteOutcome.ActualModel
+			if am.Provider != "" && am.Model != "" {
+				result.VectorSpaceID = am.String()
+			}
 		}
 		if result.VectorSpaceID == "" && result.Provider != "" && result.Model != "" {
 			result.VectorSpaceID = result.Provider + "/" + result.Model

--- a/mcp/embed_helper_test.go
+++ b/mcp/embed_helper_test.go
@@ -1,0 +1,191 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/config"
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// newEmbedHelperServer mirrors the direct Server fixture pattern used by
+// mcp/tools_embed_test.go: install the recording route engine on Server.router
+// and provide just enough config for chainFor("embedding") to succeed.
+func newEmbedHelperServer(t *testing.T, eng routeEngine) *Server {
+	t.Helper()
+	return &Server{
+		cfg: &config.Config{
+			Defaults: map[string]string{"embedding": "embedder"},
+			Models: map[string]config.ModelConfig{
+				"embedder": {Name: "qwen3-embedding:8b", Provider: "ollama"},
+			},
+		},
+		router: eng,
+	}
+}
+
+func TestRoutedEmbed_EmptyInputsShortCircuits(t *testing.T) {
+	eng := newRecordingRouteEngine("")
+	s := newEmbedHelperServer(t, eng)
+
+	resp, err := s.routedEmbed(context.Background(), "m", nil, provider.PriorityNormal)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+	if eng.called {
+		t.Error("router was contacted for empty inputs; want short-circuit")
+	}
+}
+
+func TestRoutedEmbed_ExplicitModelLeavesPreferredChainEmpty(t *testing.T) {
+	eng := newRecordingRouteEngine("")
+	s := newEmbedHelperServer(t, eng)
+
+	_, err := s.routedEmbed(context.Background(), "m-explicit", []string{"x"}, provider.PriorityBackground)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if !eng.called {
+		t.Fatal("router was not contacted")
+	}
+	if len(eng.last.PreferredChain) != 0 {
+		t.Errorf("PreferredChain = %v, want empty for explicit model", eng.last.PreferredChain)
+	}
+	if eng.last.Model != "m-explicit" {
+		t.Errorf("Model = %q, want %q", eng.last.Model, "m-explicit")
+	}
+	if eng.last.Priority != provider.PriorityBackground {
+		t.Errorf("Priority = %v, want %v", eng.last.Priority, provider.PriorityBackground)
+	}
+	if eng.last.RequiredCaps != provider.CapEmbed {
+		t.Errorf("RequiredCaps = %v, want CapEmbed", eng.last.RequiredCaps)
+	}
+	if eng.last.UseCase != "embedding" {
+		t.Errorf("UseCase = %q, want %q", eng.last.UseCase, "embedding")
+	}
+}
+
+func TestRoutedEmbed_EmptyModelSetsPreferredChain(t *testing.T) {
+	eng := newRecordingRouteEngine("")
+	s := newEmbedHelperServer(t, eng)
+
+	_, err := s.routedEmbed(context.Background(), "", []string{"x"}, provider.PriorityNormal)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(eng.last.PreferredChain) == 0 {
+		t.Error("PreferredChain is empty; want s.chainFor(\"embedding\") result")
+	}
+}
+
+func TestRoutedEmbed_LengthMismatchIsCategorisedOllama(t *testing.T) {
+	// Engine returns a single embedding for a 2-input batch.
+	eng := newRecordingRouteEngine("")
+	eng.embedVectors = [][]float64{{1, 2, 3}}
+	s := newEmbedHelperServer(t, eng)
+
+	_, err := s.routedEmbed(context.Background(), "m", []string{"a", "b"}, provider.PriorityNormal)
+	if err == nil {
+		t.Fatal("expected length-mismatch error, got nil")
+	}
+	if got := routedEmbedCategory(err); got != embedToolOllama {
+		t.Errorf("category = %q, want %q", got, embedToolOllama)
+	}
+	if !strings.Contains(err.Error(), "count mismatch") {
+		t.Errorf("error = %q, want it to mention %q", err.Error(), "count mismatch")
+	}
+}
+
+func TestRoutedEmbed_RouterErrorIsCategorisedRouter(t *testing.T) {
+	eng := newRecordingRouteEngine("")
+	eng.routeErr = errors.New("simulated route failure")
+	s := newEmbedHelperServer(t, eng)
+
+	_, err := s.routedEmbed(context.Background(), "m", []string{"x"}, provider.PriorityNormal)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if got := routedEmbedCategory(err); got != embedToolRouter {
+		t.Errorf("category = %q, want %q", got, embedToolRouter)
+	}
+}
+
+func TestRoutedEmbed_NilRouterIsCategorisedConfig(t *testing.T) {
+	s := newEmbedHelperServer(t, nil) // explicitly nil engine
+
+	_, err := s.routedEmbed(context.Background(), "m", []string{"x"}, provider.PriorityNormal)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if got := routedEmbedCategory(err); got != embedToolConfig {
+		t.Errorf("category = %q, want %q", got, embedToolConfig)
+	}
+}
+
+func TestRagEmbedder_EmptyModelRejected(t *testing.T) {
+	eng := newRecordingRouteEngine("")
+	s := newEmbedHelperServer(t, eng)
+	emb := s.ragEmbedder(provider.PriorityNormal)
+
+	_, err := emb.Embed(context.Background(), "", []string{"x"})
+	if err == nil {
+		t.Fatal("expected drift-guard error, got nil")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "drift") {
+		t.Errorf("error = %q, want it to mention %q", err.Error(), "drift")
+	}
+	if eng.called {
+		t.Error("router was contacted for empty-model RAG call; want fail-closed before routing")
+	}
+}
+
+func TestRagEmbedder_ForwardsPriorityBackground(t *testing.T) {
+	eng := newRecordingRouteEngine("")
+	s := newEmbedHelperServer(t, eng)
+
+	emb := s.ragEmbedder(provider.PriorityBackground)
+	_, err := emb.Embed(context.Background(), "m", []string{"x"})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if eng.last.Priority != provider.PriorityBackground {
+		t.Errorf("Priority = %v, want %v", eng.last.Priority, provider.PriorityBackground)
+	}
+}
+
+func TestRagEmbedder_ForwardsPriorityNormal(t *testing.T) {
+	eng := newRecordingRouteEngine("")
+	s := newEmbedHelperServer(t, eng)
+
+	emb := s.ragEmbedder(provider.PriorityNormal)
+	_, err := emb.Embed(context.Background(), "m", []string{"x"})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if eng.last.Priority != provider.PriorityNormal {
+		t.Errorf("Priority = %v, want %v", eng.last.Priority, provider.PriorityNormal)
+	}
+}
+
+func TestRagEmbedder_ExtractsProvenance(t *testing.T) {
+	eng := newRecordingRouteEngine("")
+	eng.embedVectors = [][]float64{{1, 2, 3}}
+	s := newEmbedHelperServer(t, eng)
+
+	emb := s.ragEmbedder(provider.PriorityNormal)
+	res, err := emb.Embed(context.Background(), "m", []string{"x"})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if res.Provider == "" || res.Model == "" {
+		t.Errorf("expected populated Provider/Model in EmbedResult, got %+v", res)
+	}
+	if res.VectorSpaceID == "" {
+		t.Errorf("expected populated VectorSpaceID in EmbedResult, got %+v", res)
+	}
+}

--- a/mcp/embed_helper_test.go
+++ b/mcp/embed_helper_test.go
@@ -125,6 +125,23 @@ func TestRoutedEmbed_NilRouterIsCategorisedConfig(t *testing.T) {
 	if got := routedEmbedCategory(err); got != embedToolConfig {
 		t.Errorf("category = %q, want %q", got, embedToolConfig)
 	}
+	if !strings.Contains(err.Error(), "router unavailable") {
+		t.Errorf("error = %q, want it to mention %q", err.Error(), "router unavailable")
+	}
+}
+
+// TestRoutedEmbedCategory_UnwrappedErrorDefaultsToOllama documents the
+// conservative default for errors that are not routedEmbedError-wrapped:
+// they categorise as "ollama" (assume backend execution failed). This
+// guards the fallback at routedEmbedCategory against silent recategorisation
+// if a future refactor leaks an unwrapped error from routedEmbed.
+func TestRoutedEmbedCategory_UnwrappedErrorDefaultsToOllama(t *testing.T) {
+	if got := routedEmbedCategory(errors.New("plain error")); got != embedToolOllama {
+		t.Errorf("category = %q, want %q", got, embedToolOllama)
+	}
+	if got := routedEmbedCategory(nil); got != embedToolOllama {
+		t.Errorf("category for nil = %q, want %q", got, embedToolOllama)
+	}
 }
 
 func TestRagEmbedder_EmptyModelRejected(t *testing.T) {
@@ -182,10 +199,37 @@ func TestRagEmbedder_ExtractsProvenance(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
-	if res.Provider == "" || res.Model == "" {
-		t.Errorf("expected populated Provider/Model in EmbedResult, got %+v", res)
+	if res.Provider != "fake" {
+		t.Errorf("Provider = %q, want %q", res.Provider, "fake")
 	}
-	if res.VectorSpaceID == "" {
-		t.Errorf("expected populated VectorSpaceID in EmbedResult, got %+v", res)
+	if res.Model != "m" {
+		t.Errorf("Model = %q, want %q", res.Model, "m")
+	}
+	if res.VectorSpaceID != "fake/m" {
+		t.Errorf("VectorSpaceID = %q, want %q", res.VectorSpaceID, "fake/m")
+	}
+}
+
+// TestRagEmbedder_EmptyInputsPropagatesModel verifies that empty-input RAG
+// calls short-circuit before routing AND preserve the requested model in the
+// result, so callers see the model they asked for even when no embeddings
+// were produced.
+func TestRagEmbedder_EmptyInputsPropagatesModel(t *testing.T) {
+	eng := newRecordingRouteEngine("")
+	s := newEmbedHelperServer(t, eng)
+
+	emb := s.ragEmbedder(provider.PriorityNormal)
+	res, err := emb.Embed(context.Background(), "embed-model", nil)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if eng.called {
+		t.Error("router was contacted for empty inputs; want short-circuit before routing")
+	}
+	if res.Model != "embed-model" {
+		t.Errorf("Model = %q, want %q (caller-supplied model must surface even on empty-input short-circuit)", res.Model, "embed-model")
+	}
+	if len(res.Embeddings) != 0 {
+		t.Errorf("Embeddings = %v, want empty", res.Embeddings)
 	}
 }

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -275,8 +275,22 @@ func (s *Server) rebuildDerivedClients(ctx context.Context) {
 	var indexer *rag.Indexer
 	var retriever *rag.Retriever
 	if store != nil && embeddingModel != "" {
-		indexer = rag.NewIndexer(s.client, store, rag.WithEmbeddingModel(embeddingModel))
-		retriever = rag.NewRetriever(s.client, store, rag.WithRetrieverModel(embeddingModel))
+		// Indexing is best-effort batch traffic — yield to user-facing routes.
+		if idx, err := rag.NewIndexerWithEmbedder(
+			s.ragEmbedder(provider.PriorityBackground),
+			store,
+			rag.WithEmbeddingModel(embeddingModel),
+		); err == nil {
+			indexer = idx
+		}
+		// Retrieval is in the user-facing latency path.
+		if ret, err := rag.NewRetrieverWithEmbedder(
+			s.ragEmbedder(provider.PriorityNormal),
+			store,
+			rag.WithRetrieverModel(embeddingModel),
+		); err == nil {
+			retriever = ret
+		}
 	}
 
 	s.mu.Lock()

--- a/mcp/tools_embed.go
+++ b/mcp/tools_embed.go
@@ -64,34 +64,10 @@ func (s *Server) handleEmbed(ctx context.Context, req *gomcp.CallToolRequest) (*
 	if args.Text == "" {
 		return toolError("validation", "text must not be empty"), nil
 	}
-	router := s.routerSnapshot()
-	if router == nil {
-		return toolError("config", "router unavailable"), nil
-	}
 
-	rr := provider.RoutingRequest{
-		Model:          args.Model,
-		UseCase:        "embedding",
-		RequiredCaps:   provider.CapEmbed,
-		Input:          []string{args.Text},
-		ExpectedOutput: provider.DefaultExpectedOutput("embedding"),
-		Priority:       provider.PriorityNormal,
-	}
-	if rr.Model == "" {
-		chain, err := s.chainFor("embedding")
-		if err != nil {
-			return toolError("config", "%v", err), nil
-		}
-		rr.PreferredChain = chain
-	}
-
-	plan, err := router.Route(ctx, rr)
+	resp, err := s.routedEmbed(ctx, args.Model, []string{args.Text}, provider.PriorityNormal)
 	if err != nil {
-		return toolError("router", "%v", err), nil
-	}
-	resp, err := plan.ExecuteEmbed(ctx)
-	if err != nil {
-		return toolError("ollama", "%v", err), nil
+		return toolError(string(routedEmbedCategory(err)), "%v", err), nil
 	}
 	if len(resp.Embeddings) == 0 {
 		return toolError("ollama", "no embedding returned"), nil
@@ -114,34 +90,10 @@ func (s *Server) handleEmbedBatch(ctx context.Context, req *gomcp.CallToolReques
 	if len(args.Texts) > maxBatchSize {
 		return toolError("validation", "texts exceeds maximum batch size of %d (got %d)", maxBatchSize, len(args.Texts)), nil
 	}
-	router := s.routerSnapshot()
-	if router == nil {
-		return toolError("config", "router unavailable"), nil
-	}
 
-	rr := provider.RoutingRequest{
-		Model:          args.Model,
-		UseCase:        "embedding",
-		RequiredCaps:   provider.CapEmbed,
-		Input:          args.Texts,
-		ExpectedOutput: provider.DefaultExpectedOutput("embedding"),
-		Priority:       provider.PriorityNormal,
-	}
-	if rr.Model == "" {
-		chain, err := s.chainFor("embedding")
-		if err != nil {
-			return toolError("config", "%v", err), nil
-		}
-		rr.PreferredChain = chain
-	}
-
-	plan, err := router.Route(ctx, rr)
+	resp, err := s.routedEmbed(ctx, args.Model, args.Texts, provider.PriorityNormal)
 	if err != nil {
-		return toolError("router", "%v", err), nil
-	}
-	resp, err := plan.ExecuteEmbed(ctx)
-	if err != nil {
-		return toolError("ollama", "%v", err), nil
+		return toolError(string(routedEmbedCategory(err)), "%v", err), nil
 	}
 	data, mErr := json.Marshal(resp.Embeddings)
 	if mErr != nil {

--- a/rag/embedder.go
+++ b/rag/embedder.go
@@ -1,15 +1,7 @@
-// Embedder seam for rag.
-//
-// The Embedder interface is rag's narrow embedding dependency: batch-shaped,
-// returning generic provenance instead of importing provider response types
-// into rag. Router-backed implementations are supplied by callers (see
-// mcp.Server.ragEmbedder); the legacy *ollama.Client path is preserved via
-// the private embedderFromOllamaClient adapter used by NewIndexer / NewRetriever.
 package rag
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/kstruzzieri/go-llm/ollama"
 )
@@ -71,7 +63,7 @@ func embedderFromOllamaClient(c *ollama.Client) Embedder {
 		}
 		embeddings, err := c.EmbedBatch(ctx, model, inputs)
 		if err != nil {
-			return EmbedResult{}, fmt.Errorf("rag: ollama embedder: %w", err)
+			return EmbedResult{}, err
 		}
 		return EmbedResult{
 			Embeddings:    embeddings,

--- a/rag/embedder.go
+++ b/rag/embedder.go
@@ -1,0 +1,83 @@
+// Package rag — Embedder seam.
+//
+// The Embedder interface is rag's narrow embedding dependency: batch-shaped,
+// returning generic provenance instead of importing provider response types
+// into rag. Router-backed implementations are supplied by callers (see
+// mcp.Server.ragEmbedder); the legacy *ollama.Client path is preserved via
+// the private embedderFromOllamaClient adapter used by NewIndexer / NewRetriever.
+package rag
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+// EmbedResult is the embedding payload plus enough provenance for RAG to
+// validate vector-space identity. VectorSpaceID is implementation-defined
+// but should be stable for all embeddings that can be compared safely; for
+// the Ollama path it is "ollama/<model>".
+type EmbedResult struct {
+	Embeddings    [][]float64
+	Model         string
+	Provider      string
+	VectorSpaceID string
+}
+
+// Embedder is the narrow embedding dependency rag needs. Batch-shaped, like
+// provider.Provider.Embed, but returning generic provenance instead of
+// importing provider response types into rag.
+//
+// An empty model string is implementation-defined. The *ollama.Client compat
+// shim will fail because Ollama requires a model. Router-backed
+// implementations may invoke chain fallback; RAG callers MUST pass a
+// non-empty model unless they intentionally own vector-space drift policy.
+//
+// Implementations must be safe for concurrent use; Indexer.IndexDirectory
+// runs files in parallel and may issue Embed calls from multiple goroutines.
+//
+// Empty inputs (nil or zero-length slice) MUST short-circuit and return
+// (EmbedResult{}, nil) without invoking the backend.
+type Embedder interface {
+	Embed(ctx context.Context, model string, inputs []string) (EmbedResult, error)
+}
+
+// EmbedderFunc is a closure adapter mirroring http.HandlerFunc. Lets MCP
+// (and any other consumer) supply an Embedder from a closure without
+// declaring a named type.
+type EmbedderFunc func(ctx context.Context, model string, inputs []string) (EmbedResult, error)
+
+// Embed calls f(ctx, model, inputs).
+func (f EmbedderFunc) Embed(ctx context.Context, model string, inputs []string) (EmbedResult, error) {
+	return f(ctx, model, inputs)
+}
+
+// embedderFromOllamaClient adapts *ollama.Client to Embedder. Private —
+// used only by the legacy NewIndexer / NewRetriever compat shims. External
+// consumers wiring router-aware embedding switch to NewIndexerWithEmbedder
+// and supply their own Embedder.
+//
+// Returns nil when client is nil so the legacy nil-passthrough behaviour of
+// NewIndexer / NewRetriever is preserved (a nil-deref on first embed call,
+// not at construction time).
+func embedderFromOllamaClient(c *ollama.Client) Embedder {
+	if c == nil {
+		return nil
+	}
+	return EmbedderFunc(func(ctx context.Context, model string, inputs []string) (EmbedResult, error) {
+		if len(inputs) == 0 {
+			return EmbedResult{}, nil
+		}
+		embeddings, err := c.EmbedBatch(ctx, model, inputs)
+		if err != nil {
+			return EmbedResult{}, fmt.Errorf("rag: ollama embedder: %w", err)
+		}
+		return EmbedResult{
+			Embeddings:    embeddings,
+			Model:         model,
+			Provider:      "ollama",
+			VectorSpaceID: "ollama/" + model,
+		}, nil
+	})
+}

--- a/rag/embedder.go
+++ b/rag/embedder.go
@@ -29,8 +29,10 @@ type EmbedResult struct {
 // Implementations must be safe for concurrent use; Indexer.IndexDirectory
 // runs files in parallel and may issue Embed calls from multiple goroutines.
 //
-// Empty inputs (nil or zero-length slice) MUST short-circuit and return
-// (EmbedResult{}, nil) without invoking the backend.
+// Empty inputs (nil or zero-length slice) MUST short-circuit without invoking
+// the backend and return nil error with zero embeddings. Implementations MAY
+// populate provenance fields such as Model when they can do so without routing
+// or execution.
 type Embedder interface {
 	Embed(ctx context.Context, model string, inputs []string) (EmbedResult, error)
 }

--- a/rag/embedder.go
+++ b/rag/embedder.go
@@ -1,4 +1,4 @@
-// Package rag — Embedder seam.
+// Embedder seam for rag.
 //
 // The Embedder interface is rag's narrow embedding dependency: batch-shaped,
 // returning generic provenance instead of importing provider response types

--- a/rag/embedder_test.go
+++ b/rag/embedder_test.go
@@ -173,6 +173,87 @@ func TestIndexer_LengthMismatchSurfacesError(t *testing.T) {
 	}
 }
 
+// TestIndexer_CountMismatchPreservesExistingData guards Indexer.IndexFile's
+// "existing data is preserved on embedding failure" doc invariant for the
+// count-mismatch failure path specifically. If a future refactor moves the
+// length check below replaceSourceWithHash, prior chunks would be wiped
+// silently; this test catches that regression.
+func TestIndexer_CountMismatchPreservesExistingData(t *testing.T) {
+	store, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	twoChunks := chunkerFunc(func(path string, content string) ([]Chunk, error) {
+		return []Chunk{
+			{ID: "a", Content: content, Source: path, StartLine: 1, EndLine: 1},
+			{ID: "b", Content: content, Source: path, StartLine: 2, EndLine: 2},
+		}, nil
+	})
+
+	goodEmb := EmbedderFunc(func(_ context.Context, _ string, inputs []string) (EmbedResult, error) {
+		out := make([][]float64, len(inputs))
+		for i := range out {
+			out[i] = []float64{1, 2, 3}
+		}
+		return EmbedResult{Embeddings: out, Model: "m", Provider: "fake"}, nil
+	})
+	idx, err := NewIndexerWithEmbedder(goodEmb, store)
+	if err != nil {
+		t.Fatalf("ctor: %v", err)
+	}
+	idx.chunker = twoChunks
+
+	tmp := t.TempDir()
+	path := tmp + "/f.go"
+	if err := writeFileImpl(path, "v1"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := idx.IndexFile(context.Background(), path); err != nil {
+		t.Fatalf("first IndexFile: %v", err)
+	}
+
+	pre, err := store.Search(context.Background(), []float64{1, 2, 3}, 5)
+	if err != nil {
+		t.Fatalf("pre-Search: %v", err)
+	}
+	if len(pre) != 2 {
+		t.Fatalf("pre-Search: got %d results, want 2 (seed phase failed)", len(pre))
+	}
+
+	// Second pass: rewrite content, return one fewer embedding than chunks.
+	if err := writeFileImpl(path, "v2"); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	badEmb := EmbedderFunc(func(_ context.Context, _ string, inputs []string) (EmbedResult, error) {
+		out := make([][]float64, len(inputs)-1)
+		for i := range out {
+			out[i] = []float64{4, 5, 6}
+		}
+		return EmbedResult{Embeddings: out, Model: "m", Provider: "fake"}, nil
+	})
+	idxBad, err := NewIndexerWithEmbedder(badEmb, store)
+	if err != nil {
+		t.Fatalf("ctor: %v", err)
+	}
+	idxBad.chunker = twoChunks
+
+	if err := idxBad.IndexFile(context.Background(), path); err == nil {
+		t.Fatal("expected count-mismatch error, got nil")
+	} else if !strings.Contains(err.Error(), "count mismatch") {
+		t.Errorf("error = %q, want it to mention %q", err.Error(), "count mismatch")
+	}
+
+	post, err := store.Search(context.Background(), []float64{1, 2, 3}, 5)
+	if err != nil {
+		t.Fatalf("post-Search: %v", err)
+	}
+	if len(post) != 2 {
+		t.Errorf("post-Search: got %d results, want 2 — count-mismatch path wiped or partially overwrote prior data", len(post))
+	}
+}
+
 func TestRetriever_LengthMismatchSurfacesError(t *testing.T) {
 	store, err := NewSQLiteStore(":memory:")
 	if err != nil {

--- a/rag/embedder_test.go
+++ b/rag/embedder_test.go
@@ -1,0 +1,211 @@
+package rag
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+// recordingEmbedder is the canonical mock for rag tests that need to inspect
+// how callers invoke an Embedder. Use this pattern in new tests rather than
+// spinning up an httptest mock Ollama unless the test specifically exercises
+// the ollama compat shim.
+type recordingEmbedder struct {
+	model      string
+	inputs     []string
+	calls      int
+	result     EmbedResult
+	err        error
+	beforeFunc func(ctx context.Context)
+}
+
+func (r *recordingEmbedder) Embed(ctx context.Context, model string, inputs []string) (EmbedResult, error) {
+	if r.beforeFunc != nil {
+		r.beforeFunc(ctx)
+	}
+	r.calls++
+	r.model = model
+	r.inputs = append([]string(nil), inputs...)
+	if r.err != nil {
+		return EmbedResult{}, r.err
+	}
+	return r.result, nil
+}
+
+func TestEmbedderFunc_Delegates(t *testing.T) {
+	called := 0
+	var gotModel string
+	var gotInputs []string
+	want := EmbedResult{Embeddings: [][]float64{{1, 2, 3}}, Model: "m", Provider: "fake", VectorSpaceID: "fake/m"}
+	e := EmbedderFunc(func(_ context.Context, model string, inputs []string) (EmbedResult, error) {
+		called++
+		gotModel = model
+		gotInputs = inputs
+		return want, nil
+	})
+	got, err := e.Embed(context.Background(), "m", []string{"a"})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if called != 1 || gotModel != "m" || len(gotInputs) != 1 || gotInputs[0] != "a" {
+		t.Errorf("delegation incorrect: calls=%d model=%q inputs=%v", called, gotModel, gotInputs)
+	}
+	if got.VectorSpaceID != want.VectorSpaceID {
+		t.Errorf("got %+v want %+v", got, want)
+	}
+}
+
+func TestEmbedderFromOllamaClient_NilReturnsNil(t *testing.T) {
+	if got := embedderFromOllamaClient(nil); got != nil {
+		t.Errorf("expected nil, got %T", got)
+	}
+}
+
+func TestEmbedderFromOllamaClient_EmptyInputShortCircuits(t *testing.T) {
+	// Server that fails the test if hit — proves we did not call Ollama.
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	emb := embedderFromOllamaClient(c)
+	if emb == nil {
+		t.Fatal("expected non-nil embedder")
+	}
+
+	res, err := emb.Embed(context.Background(), "m", nil)
+	if err != nil {
+		t.Errorf("nil inputs: err = %v, want nil", err)
+	}
+	if len(res.Embeddings) != 0 {
+		t.Errorf("nil inputs: got %d embeddings, want 0", len(res.Embeddings))
+	}
+
+	res, err = emb.Embed(context.Background(), "m", []string{})
+	if err != nil {
+		t.Errorf("empty inputs: err = %v, want nil", err)
+	}
+	if len(res.Embeddings) != 0 {
+		t.Errorf("empty inputs: got %d embeddings, want 0", len(res.Embeddings))
+	}
+
+	if hits != 0 {
+		t.Errorf("Ollama was contacted %d times for empty inputs; want 0", hits)
+	}
+}
+
+func TestEmbedderFromOllamaClient_PopulatesProvenance(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"embeddings":[[0.1,0.2]]}`))
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	emb := embedderFromOllamaClient(c)
+	res, err := emb.Embed(context.Background(), "test-model", []string{"hello"})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if res.Model != "test-model" {
+		t.Errorf("Model = %q, want %q", res.Model, "test-model")
+	}
+	if res.Provider != "ollama" {
+		t.Errorf("Provider = %q, want %q", res.Provider, "ollama")
+	}
+	if res.VectorSpaceID != "ollama/test-model" {
+		t.Errorf("VectorSpaceID = %q, want %q", res.VectorSpaceID, "ollama/test-model")
+	}
+	if len(res.Embeddings) != 1 || len(res.Embeddings[0]) != 2 {
+		t.Errorf("Embeddings shape = %v, want [[_,_]]", res.Embeddings)
+	}
+}
+
+func TestIndexer_LengthMismatchSurfacesError(t *testing.T) {
+	store, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// Embedder returns one fewer embedding than chunks. Indexer must error.
+	emb := EmbedderFunc(func(_ context.Context, _ string, inputs []string) (EmbedResult, error) {
+		out := make([][]float64, len(inputs)-1)
+		for i := range out {
+			out[i] = []float64{1, 2, 3}
+		}
+		return EmbedResult{Embeddings: out, Model: "m", Provider: "fake"}, nil
+	})
+
+	idx, err := NewIndexerWithEmbedder(emb, store)
+	if err != nil {
+		t.Fatalf("ctor: %v", err)
+	}
+	// Use a chunker that yields >=2 chunks for any non-empty content; the
+	// default code chunker may yield 1, so override with a deterministic mock.
+	idx.chunker = chunkerFunc(func(_ string, content string) ([]Chunk, error) {
+		return []Chunk{
+			{ID: "a", Content: content, Source: "f.go", StartLine: 1, EndLine: 1},
+			{ID: "b", Content: content, Source: "f.go", StartLine: 2, EndLine: 2},
+		}, nil
+	})
+
+	tmp := t.TempDir()
+	path := tmp + "/f.go"
+	if err := writeFileImpl(path, "package x"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	err = idx.IndexFile(context.Background(), path)
+	if err == nil {
+		t.Fatal("expected count-mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "count mismatch") {
+		t.Errorf("error = %q, want it to mention %q", err.Error(), "count mismatch")
+	}
+}
+
+func TestRetriever_LengthMismatchSurfacesError(t *testing.T) {
+	store, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// Embedder returns 0 embeddings for a 1-input batch.
+	emb := EmbedderFunc(func(_ context.Context, _ string, _ []string) (EmbedResult, error) {
+		return EmbedResult{Embeddings: nil, Model: "m"}, nil
+	})
+
+	r, err := NewRetrieverWithEmbedder(emb, store)
+	if err != nil {
+		t.Fatalf("ctor: %v", err)
+	}
+	_, err = r.Retrieve(context.Background(), "query", 5)
+	if err == nil {
+		t.Fatal("expected length-1 mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "expected 1 embedding") {
+		t.Errorf("error = %q, want it to mention %q", err.Error(), "expected 1 embedding")
+	}
+}
+
+// chunkerFunc adapts a closure to the Chunker interface for tests.
+type chunkerFunc func(path string, content string) ([]Chunk, error)
+
+func (f chunkerFunc) Chunk(path string, content string) ([]Chunk, error) {
+	return f(path, content)
+}
+
+func writeFileImpl(path string, content string) error {
+	// 0o644 matches stdlib Go's convention for source files.
+	return os.WriteFile(path, []byte(content), 0o644)
+}

--- a/rag/indexer.go
+++ b/rag/indexer.go
@@ -17,7 +17,7 @@ import (
 // may call IndexFile concurrently provided the injected Chunker and
 // VectorStore implementations are themselves safe for concurrent use.
 type Indexer struct {
-	client        *ollama.Client
+	embedder      Embedder
 	model         string
 	store         VectorStore
 	chunker       Chunker
@@ -67,18 +67,31 @@ func WithWorkspaceRoot(root string) IndexerOption {
 	}
 }
 
-// NewIndexer creates an indexer that coordinates chunking, embedding, and storing.
-func NewIndexer(client *ollama.Client, store VectorStore, opts ...IndexerOption) *Indexer {
+// buildIndexer is the single private path constructing an Indexer; both the
+// legacy ollama-backed shim NewIndexer and the new NewIndexerWithEmbedder
+// route through it so option-application order and defaults match exactly.
+func buildIndexer(emb Embedder, store VectorStore, opts ...IndexerOption) *Indexer {
 	idx := &Indexer{
-		client:  client,
-		model:   "nomic-embed-text",
-		store:   store,
-		chunker: NewCodeChunker(),
+		embedder: emb,
+		model:    "nomic-embed-text",
+		store:    store,
+		chunker:  NewCodeChunker(),
 	}
 	for _, opt := range opts {
 		opt(idx)
 	}
 	return idx
+}
+
+// NewIndexer is the *ollama.Client-backed compat shim. Existing consumers
+// (Firn IDE, Flux ML, Quantum Trader) continue to use this constructor
+// unchanged; new code should prefer NewIndexerWithEmbedder.
+//
+// Nil-passthrough is preserved: passing a nil client yields an Indexer
+// whose embedder is nil and which will nil-deref on first embed call,
+// matching the pre-Embedder behaviour.
+func NewIndexer(client *ollama.Client, store VectorStore, opts ...IndexerOption) *Indexer {
+	return buildIndexer(embedderFromOllamaClient(client), store, opts...)
 }
 
 func (idx *Indexer) replaceSource(ctx context.Context, path string, chunks []Chunk, embeddings [][]float64) error {
@@ -160,11 +173,15 @@ func (idx *Indexer) IndexFile(ctx context.Context, path string) error {
 		texts[i] = c.Content
 	}
 
-	embeddings, err := idx.client.EmbedBatch(ctx, idx.model, texts)
+	res, err := idx.embedder.Embed(ctx, idx.model, texts)
 	if err != nil {
 		// Embedding failed — preserve existing indexed data for this file
 		return fmt.Errorf("rag: embed chunks for %q: %w", path, err)
 	}
+	if len(res.Embeddings) != len(texts) {
+		return fmt.Errorf("rag: embed chunks for %q: count mismatch (got %d for %d chunks)", path, len(res.Embeddings), len(texts))
+	}
+	embeddings := res.Embeddings
 
 	// Step 3: Replace old chunks with new ones. Store the source signature so
 	// subsequent IndexFileIncremental calls can safely use the fast path.

--- a/rag/indexer.go
+++ b/rag/indexer.go
@@ -112,6 +112,9 @@ func NewIndexerWithEmbedder(embedder Embedder, store VectorStore, opts ...Indexe
 	if embedder == nil {
 		return nil, fmt.Errorf("rag: NewIndexerWithEmbedder: embedder is required")
 	}
+	if isNilVectorStore(store) {
+		return nil, fmt.Errorf("rag: NewIndexerWithEmbedder: store is required")
+	}
 	return buildIndexer(embedder, store, opts...), nil
 }
 

--- a/rag/indexer.go
+++ b/rag/indexer.go
@@ -94,6 +94,21 @@ func NewIndexer(client *ollama.Client, store VectorStore, opts ...IndexerOption)
 	return buildIndexer(embedderFromOllamaClient(client), store, opts...)
 }
 
+// NewIndexerWithEmbedder is the router-aware constructor. The supplied
+// Embedder mediates all embedding calls, so callers can route through
+// provider.Router (circuit breakers, warmth, token-budget validation) by
+// supplying a Router-backed Embedder.
+//
+// Returns an error if embedder is nil — distinct from NewIndexer's
+// no-validation contract, since callers picking the new shape are
+// expected to supply a real Embedder.
+func NewIndexerWithEmbedder(embedder Embedder, store VectorStore, opts ...IndexerOption) (*Indexer, error) {
+	if embedder == nil {
+		return nil, fmt.Errorf("rag: embedder is required")
+	}
+	return buildIndexer(embedder, store, opts...), nil
+}
+
 func (idx *Indexer) replaceSource(ctx context.Context, path string, chunks []Chunk, embeddings [][]float64) error {
 	return idx.replaceSourceWithHash(ctx, path, chunks, embeddings, "")
 }

--- a/rag/indexer.go
+++ b/rag/indexer.go
@@ -42,12 +42,11 @@ type IndexerOption func(*Indexer)
 
 // WithEmbeddingModel sets the embedding model name (default: "nomic-embed-text").
 //
-// An empty model defers selection to the Embedder. For Router-backed
-// embedders this can enable chain fallback, which can substitute embedding
-// models and corrupt the SQLite vector store by mixing incompatible vector
-// spaces. Only pass an empty string when the Embedder is known not to fall
-// back across embedding-model boundaries — the MCP server's ragEmbedder
-// rejects empty-model RAG calls precisely to prevent this drift.
+// An empty model defers selection to the Embedder. Router-backed embedders
+// that allow chain fallback (the MCP server's ragEmbedder does not) can
+// substitute embedding models, corrupting the SQLite vector store by mixing
+// incompatible vector spaces. Only pass an empty string when the Embedder
+// is known not to fall back across embedding-model boundaries.
 func WithEmbeddingModel(model string) IndexerOption {
 	return func(idx *Indexer) {
 		idx.model = model
@@ -111,7 +110,7 @@ func NewIndexer(client *ollama.Client, store VectorStore, opts ...IndexerOption)
 // expected to supply a real Embedder.
 func NewIndexerWithEmbedder(embedder Embedder, store VectorStore, opts ...IndexerOption) (*Indexer, error) {
 	if embedder == nil {
-		return nil, fmt.Errorf("rag: embedder is required")
+		return nil, fmt.Errorf("rag: NewIndexerWithEmbedder: embedder is required")
 	}
 	return buildIndexer(embedder, store, opts...), nil
 }

--- a/rag/indexer.go
+++ b/rag/indexer.go
@@ -41,6 +41,13 @@ type atomicSourceReplacerWithHash interface {
 type IndexerOption func(*Indexer)
 
 // WithEmbeddingModel sets the embedding model name (default: "nomic-embed-text").
+//
+// An empty model defers selection to the Embedder. For Router-backed
+// embedders this can enable chain fallback, which can substitute embedding
+// models and corrupt the SQLite vector store by mixing incompatible vector
+// spaces. Only pass an empty string when the Embedder is known not to fall
+// back across embedding-model boundaries — the MCP server's ragEmbedder
+// rejects empty-model RAG calls precisely to prevent this drift.
 func WithEmbeddingModel(model string) IndexerOption {
 	return func(idx *Indexer) {
 		idx.model = model

--- a/rag/indexer_embedder_test.go
+++ b/rag/indexer_embedder_test.go
@@ -25,6 +25,32 @@ func TestNewIndexerWithEmbedder_NilEmbedderRejected(t *testing.T) {
 	}
 }
 
+func TestNewIndexerWithEmbedder_NilStoreRejected(t *testing.T) {
+	emb := &recordingEmbedder{}
+
+	tests := []struct {
+		name  string
+		store VectorStore
+	}{
+		{name: "nil interface", store: nil},
+		{name: "typed nil", store: (*SQLiteStore)(nil)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx, err := NewIndexerWithEmbedder(emb, tt.store)
+			if err == nil {
+				t.Fatal("expected error for nil store, got nil")
+			}
+			if idx != nil {
+				t.Errorf("expected nil indexer on error, got %v", idx)
+			}
+			if !strings.Contains(err.Error(), "store") {
+				t.Errorf("error = %q, want it to mention store", err.Error())
+			}
+		})
+	}
+}
+
 // TestNewIndexerWithEmbedder_AppliesEmbeddingModel verifies WithEmbeddingModel
 // surfaces the configured model in the embedder call (observable via
 // recordingEmbedder), rather than asserting on private struct fields.

--- a/rag/indexer_embedder_test.go
+++ b/rag/indexer_embedder_test.go
@@ -1,0 +1,47 @@
+package rag
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewIndexerWithEmbedder_NilEmbedderRejected(t *testing.T) {
+	store, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	idx, err := NewIndexerWithEmbedder(nil, store)
+	if err == nil {
+		t.Fatal("expected error for nil embedder, got nil")
+	}
+	if idx != nil {
+		t.Errorf("expected nil indexer on error, got %v", idx)
+	}
+	if err.Error() == "" {
+		t.Errorf("expected non-empty error, got %q", err)
+	}
+}
+
+func TestNewIndexerWithEmbedder_AppliesOptions(t *testing.T) {
+	store, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	emb := EmbedderFunc(func(_ context.Context, _ string, _ []string) (EmbedResult, error) {
+		return EmbedResult{}, nil
+	})
+	idx, err := NewIndexerWithEmbedder(emb, store, WithEmbeddingModel("test-model"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if idx == nil {
+		t.Fatal("expected non-nil indexer")
+	}
+	if idx.model != "test-model" {
+		t.Errorf("model = %q, want %q", idx.model, "test-model")
+	}
+}

--- a/rag/indexer_embedder_test.go
+++ b/rag/indexer_embedder_test.go
@@ -2,6 +2,7 @@ package rag
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -19,29 +20,44 @@ func TestNewIndexerWithEmbedder_NilEmbedderRejected(t *testing.T) {
 	if idx != nil {
 		t.Errorf("expected nil indexer on error, got %v", idx)
 	}
-	if err.Error() == "" {
-		t.Errorf("expected non-empty error, got %q", err)
+	if !strings.Contains(err.Error(), "NewIndexerWithEmbedder") {
+		t.Errorf("error = %q, want it to identify the constructor", err.Error())
 	}
 }
 
-func TestNewIndexerWithEmbedder_AppliesOptions(t *testing.T) {
+// TestNewIndexerWithEmbedder_AppliesEmbeddingModel verifies WithEmbeddingModel
+// surfaces the configured model in the embedder call (observable via
+// recordingEmbedder), rather than asserting on private struct fields.
+func TestNewIndexerWithEmbedder_AppliesEmbeddingModel(t *testing.T) {
 	store, err := NewSQLiteStore(":memory:")
 	if err != nil {
 		t.Fatalf("open store: %v", err)
 	}
 	defer func() { _ = store.Close() }()
 
-	emb := EmbedderFunc(func(_ context.Context, _ string, _ []string) (EmbedResult, error) {
-		return EmbedResult{}, nil
-	})
+	emb := &recordingEmbedder{result: EmbedResult{
+		Embeddings: [][]float64{{1, 2, 3}},
+	}}
 	idx, err := NewIndexerWithEmbedder(emb, store, WithEmbeddingModel("test-model"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if idx == nil {
-		t.Fatal("expected non-nil indexer")
+	idx.chunker = chunkerFunc(func(path string, content string) ([]Chunk, error) {
+		return []Chunk{{ID: "c", Content: content, Source: path, StartLine: 1, EndLine: 1}}, nil
+	})
+	tmp := t.TempDir()
+	path := tmp + "/f.go"
+	if err := writeFileImpl(path, "package x"); err != nil {
+		t.Fatalf("write: %v", err)
 	}
-	if idx.model != "test-model" {
-		t.Errorf("model = %q, want %q", idx.model, "test-model")
+	if err := idx.IndexFile(context.Background(), path); err != nil {
+		t.Fatalf("IndexFile: %v", err)
+	}
+
+	if emb.calls != 1 {
+		t.Errorf("embedder calls = %d, want 1", emb.calls)
+	}
+	if emb.model != "test-model" {
+		t.Errorf("embedder saw model = %q, want %q", emb.model, "test-model")
 	}
 }

--- a/rag/indexer_incremental.go
+++ b/rag/indexer_incremental.go
@@ -123,11 +123,15 @@ func (idx *Indexer) IndexFileIncremental(ctx context.Context, path string) error
 		texts[i] = c.Content
 	}
 
-	embeddings, err := idx.client.EmbedBatch(ctx, idx.model, texts)
+	res, err := idx.embedder.Embed(ctx, idx.model, texts)
 	if err != nil {
 		// Embedding failed -- preserve existing indexed data for this file.
 		return fmt.Errorf("rag: embed chunks for %q: %w", path, err)
 	}
+	if len(res.Embeddings) != len(texts) {
+		return fmt.Errorf("rag: embed chunks for %q: count mismatch (got %d for %d chunks)", path, len(res.Embeddings), len(texts))
+	}
+	embeddings := res.Embeddings
 
 	if err := idx.replaceSourceWithHash(ctx, path, chunks, embeddings, sourceHash); err != nil {
 		return fmt.Errorf("rag: replace chunks for %q: %w", path, err)
@@ -196,10 +200,14 @@ func (idx *Indexer) indexIncremental(ctx context.Context, path string, newChunks
 	// Embed only changed chunks.
 	var freshEmbeddings [][]float64
 	if len(textsToEmbed) > 0 {
-		freshEmbeddings, err = idx.client.EmbedBatch(ctx, idx.model, textsToEmbed)
-		if err != nil {
-			return fmt.Errorf("rag: embed changed chunks for %q: %w", path, err)
+		res, embedErr := idx.embedder.Embed(ctx, idx.model, textsToEmbed)
+		if embedErr != nil {
+			return fmt.Errorf("rag: embed changed chunks for %q: %w", path, embedErr)
 		}
+		if len(res.Embeddings) != len(textsToEmbed) {
+			return fmt.Errorf("rag: embed changed chunks for %q: count mismatch (got %d for %d chunks)", path, len(res.Embeddings), len(textsToEmbed))
+		}
+		freshEmbeddings = res.Embeddings
 	}
 
 	// Assemble final embeddings aligned 1:1 with newChunks.

--- a/rag/retriever.go
+++ b/rag/retriever.go
@@ -62,6 +62,9 @@ func NewRetrieverWithEmbedder(embedder Embedder, store VectorStore, opts ...Retr
 	if embedder == nil {
 		return nil, fmt.Errorf("rag: NewRetrieverWithEmbedder: embedder is required")
 	}
+	if isNilVectorStore(store) {
+		return nil, fmt.Errorf("rag: NewRetrieverWithEmbedder: store is required")
+	}
 	return buildRetriever(embedder, store, opts...), nil
 }
 

--- a/rag/retriever.go
+++ b/rag/retriever.go
@@ -51,6 +51,17 @@ func NewRetriever(client *ollama.Client, store VectorStore, opts ...RetrieverOpt
 	return buildRetriever(embedderFromOllamaClient(client), store, opts...)
 }
 
+// NewRetrieverWithEmbedder is the router-aware constructor. See
+// NewIndexerWithEmbedder for the design rationale.
+//
+// Returns an error if embedder is nil.
+func NewRetrieverWithEmbedder(embedder Embedder, store VectorStore, opts ...RetrieverOption) (*Retriever, error) {
+	if embedder == nil {
+		return nil, fmt.Errorf("rag: embedder is required")
+	}
+	return buildRetriever(embedder, store, opts...), nil
+}
+
 // Retrieve finds the top-k most relevant chunks for a query.
 func (r *Retriever) Retrieve(ctx context.Context, query string, k int) ([]SearchResult, error) {
 	res, err := r.embedder.Embed(ctx, r.model, []string{query})

--- a/rag/retriever.go
+++ b/rag/retriever.go
@@ -18,7 +18,10 @@ type Retriever struct {
 // RetrieverOption configures a Retriever.
 type RetrieverOption func(*Retriever)
 
-// WithRetrieverModel sets the embedding model for query embedding (default: "nomic-embed-text").
+// WithRetrieverModel sets the embedding model for query embedding (default:
+// "nomic-embed-text"). The retriever model must match the model used when
+// the corpus was indexed; mismatches surface as SQLiteStore.Search dimension
+// errors at query time rather than silent zero-score results.
 func WithRetrieverModel(model string) RetrieverOption {
 	return func(r *Retriever) {
 		r.model = model
@@ -57,7 +60,7 @@ func NewRetriever(client *ollama.Client, store VectorStore, opts ...RetrieverOpt
 // Returns an error if embedder is nil.
 func NewRetrieverWithEmbedder(embedder Embedder, store VectorStore, opts ...RetrieverOption) (*Retriever, error) {
 	if embedder == nil {
-		return nil, fmt.Errorf("rag: embedder is required")
+		return nil, fmt.Errorf("rag: NewRetrieverWithEmbedder: embedder is required")
 	}
 	return buildRetriever(embedder, store, opts...), nil
 }

--- a/rag/retriever.go
+++ b/rag/retriever.go
@@ -10,9 +10,9 @@ import (
 
 // Retriever queries the vector store and builds augmented prompts.
 type Retriever struct {
-	client *ollama.Client
-	model  string
-	store  VectorStore
+	embedder Embedder
+	model    string
+	store    VectorStore
 }
 
 // RetrieverOption configures a Retriever.
@@ -25,12 +25,14 @@ func WithRetrieverModel(model string) RetrieverOption {
 	}
 }
 
-// NewRetriever creates a retriever that queries the vector store.
-func NewRetriever(client *ollama.Client, store VectorStore, opts ...RetrieverOption) *Retriever {
+// buildRetriever is the single private path constructing a Retriever; both
+// the legacy ollama-backed shim NewRetriever and the new
+// NewRetrieverWithEmbedder route through it.
+func buildRetriever(emb Embedder, store VectorStore, opts ...RetrieverOption) *Retriever {
 	r := &Retriever{
-		client: client,
-		model:  "nomic-embed-text",
-		store:  store,
+		embedder: emb,
+		model:    "nomic-embed-text",
+		store:    store,
 	}
 	for _, opt := range opts {
 		opt(r)
@@ -38,12 +40,27 @@ func NewRetriever(client *ollama.Client, store VectorStore, opts ...RetrieverOpt
 	return r
 }
 
+// NewRetriever is the *ollama.Client-backed compat shim. Existing consumers
+// continue to use this constructor unchanged; new code should prefer
+// NewRetrieverWithEmbedder.
+//
+// Nil-passthrough is preserved: passing a nil client yields a Retriever
+// whose embedder is nil and which will nil-deref on first Retrieve call,
+// matching the pre-Embedder behaviour.
+func NewRetriever(client *ollama.Client, store VectorStore, opts ...RetrieverOption) *Retriever {
+	return buildRetriever(embedderFromOllamaClient(client), store, opts...)
+}
+
 // Retrieve finds the top-k most relevant chunks for a query.
 func (r *Retriever) Retrieve(ctx context.Context, query string, k int) ([]SearchResult, error) {
-	embedding, err := r.client.Embed(ctx, r.model, query)
+	res, err := r.embedder.Embed(ctx, r.model, []string{query})
 	if err != nil {
 		return nil, fmt.Errorf("rag: embed query: %w", err)
 	}
+	if len(res.Embeddings) != 1 {
+		return nil, fmt.Errorf("rag: embed query: expected 1 embedding, got %d", len(res.Embeddings))
+	}
+	embedding := res.Embeddings[0]
 
 	results, err := r.store.Search(ctx, embedding, k)
 	if err != nil {

--- a/rag/retriever_embedder_test.go
+++ b/rag/retriever_embedder_test.go
@@ -2,6 +2,7 @@ package rag
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -19,26 +20,36 @@ func TestNewRetrieverWithEmbedder_NilEmbedderRejected(t *testing.T) {
 	if r != nil {
 		t.Errorf("expected nil retriever on error, got %v", r)
 	}
+	if !strings.Contains(err.Error(), "NewRetrieverWithEmbedder") {
+		t.Errorf("error = %q, want it to identify the constructor", err.Error())
+	}
 }
 
-func TestNewRetrieverWithEmbedder_AppliesOptions(t *testing.T) {
+// TestNewRetrieverWithEmbedder_AppliesRetrieverModel verifies WithRetrieverModel
+// surfaces the configured model in the embedder call (observable via
+// recordingEmbedder), rather than asserting on private struct fields.
+func TestNewRetrieverWithEmbedder_AppliesRetrieverModel(t *testing.T) {
 	store, err := NewSQLiteStore(":memory:")
 	if err != nil {
 		t.Fatalf("open store: %v", err)
 	}
 	defer func() { _ = store.Close() }()
 
-	emb := EmbedderFunc(func(_ context.Context, _ string, _ []string) (EmbedResult, error) {
-		return EmbedResult{}, nil
-	})
+	emb := &recordingEmbedder{result: EmbedResult{
+		Embeddings: [][]float64{{1, 2, 3}},
+	}}
 	r, err := NewRetrieverWithEmbedder(emb, store, WithRetrieverModel("test-model"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if r == nil {
-		t.Fatal("expected non-nil retriever")
+	if _, err := r.Retrieve(context.Background(), "query", 5); err != nil {
+		t.Fatalf("Retrieve: %v", err)
 	}
-	if r.model != "test-model" {
-		t.Errorf("model = %q, want %q", r.model, "test-model")
+
+	if emb.calls != 1 {
+		t.Errorf("embedder calls = %d, want 1", emb.calls)
+	}
+	if emb.model != "test-model" {
+		t.Errorf("embedder saw model = %q, want %q", emb.model, "test-model")
 	}
 }

--- a/rag/retriever_embedder_test.go
+++ b/rag/retriever_embedder_test.go
@@ -25,6 +25,32 @@ func TestNewRetrieverWithEmbedder_NilEmbedderRejected(t *testing.T) {
 	}
 }
 
+func TestNewRetrieverWithEmbedder_NilStoreRejected(t *testing.T) {
+	emb := &recordingEmbedder{}
+
+	tests := []struct {
+		name  string
+		store VectorStore
+	}{
+		{name: "nil interface", store: nil},
+		{name: "typed nil", store: (*SQLiteStore)(nil)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := NewRetrieverWithEmbedder(emb, tt.store)
+			if err == nil {
+				t.Fatal("expected error for nil store, got nil")
+			}
+			if r != nil {
+				t.Errorf("expected nil retriever on error, got %v", r)
+			}
+			if !strings.Contains(err.Error(), "store") {
+				t.Errorf("error = %q, want it to mention store", err.Error())
+			}
+		})
+	}
+}
+
 // TestNewRetrieverWithEmbedder_AppliesRetrieverModel verifies WithRetrieverModel
 // surfaces the configured model in the embedder call (observable via
 // recordingEmbedder), rather than asserting on private struct fields.

--- a/rag/retriever_embedder_test.go
+++ b/rag/retriever_embedder_test.go
@@ -1,0 +1,44 @@
+package rag
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewRetrieverWithEmbedder_NilEmbedderRejected(t *testing.T) {
+	store, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	r, err := NewRetrieverWithEmbedder(nil, store)
+	if err == nil {
+		t.Fatal("expected error for nil embedder, got nil")
+	}
+	if r != nil {
+		t.Errorf("expected nil retriever on error, got %v", r)
+	}
+}
+
+func TestNewRetrieverWithEmbedder_AppliesOptions(t *testing.T) {
+	store, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	emb := EmbedderFunc(func(_ context.Context, _ string, _ []string) (EmbedResult, error) {
+		return EmbedResult{}, nil
+	})
+	r, err := NewRetrieverWithEmbedder(emb, store, WithRetrieverModel("test-model"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r == nil {
+		t.Fatal("expected non-nil retriever")
+	}
+	if r.model != "test-model" {
+		t.Errorf("model = %q, want %q", r.model, "test-model")
+	}
+}

--- a/rag/search_multi.go
+++ b/rag/search_multi.go
@@ -43,6 +43,9 @@ func (s *SQLiteStore) SearchMulti(ctx context.Context, queryEmbedding []float64,
 	// Build embedding map for the semantic scorer.
 	embMap := make(map[string][]float64, len(chunks))
 	for i, chunk := range chunks {
+		if err := validateSearchEmbeddingDimension(chunk.ID, queryEmbedding, embeddings[i]); err != nil {
+			return nil, err
+		}
 		embMap[chunk.ID] = embeddings[i]
 	}
 
@@ -156,6 +159,14 @@ func (s *SQLiteStore) loadChunksWithEmbeddings(ctx context.Context) ([]Chunk, []
 		return nil, nil, fmt.Errorf("rag: iterate chunks: %w", err)
 	}
 	return chunks, embeddings, nil
+}
+
+func validateSearchEmbeddingDimension(chunkID string, queryEmbedding, storedEmbedding []float64) error {
+	if len(storedEmbedding) != len(queryEmbedding) {
+		return fmt.Errorf("rag: search: embedding dimension mismatch for chunk %q (query=%d stored=%d)",
+			chunkID, len(queryEmbedding), len(storedEmbedding))
+	}
+	return nil
 }
 
 // computeRanks returns 1-based ranks for a score slice (highest score = rank 1).

--- a/rag/search_multi_test.go
+++ b/rag/search_multi_test.go
@@ -2,6 +2,7 @@ package rag
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 )
@@ -77,6 +78,26 @@ func TestSearchMultiEmptyStore(t *testing.T) {
 	}
 	if len(results) != 0 {
 		t.Errorf("expected 0 results from empty store, got %d", len(results))
+	}
+}
+
+func TestSearchMultiRejectsDimensionMismatch(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	chunks := []Chunk{
+		{ID: "c1", Content: "test content", Source: "test.go", StartLine: 1, EndLine: 1, Metadata: map[string]string{}},
+	}
+	if err := store.Store(ctx, chunks, [][]float64{{0.1, 0.2, 0.3, 0.4}}); err != nil {
+		t.Fatalf("Store() error: %v", err)
+	}
+
+	_, err := store.SearchMulti(ctx, []float64{0.1, 0.2, 0.3}, "test", 5, QueryContext{})
+	if err == nil {
+		t.Fatal("expected dimension-mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "dimension mismatch") {
+		t.Errorf("error = %q, want it to mention %q", err.Error(), "dimension mismatch")
 	}
 }
 

--- a/rag/sqlite_store.go
+++ b/rag/sqlite_store.go
@@ -222,6 +222,9 @@ func (s *SQLiteStore) Search(ctx context.Context, queryEmbedding []float64, k in
 		if err := json.Unmarshal([]byte(embJSON), &embedding); err != nil {
 			return nil, fmt.Errorf("rag: unmarshal embedding: %w", err)
 		}
+		if len(embedding) != len(queryEmbedding) {
+			return nil, fmt.Errorf("rag: search: embedding dimension mismatch for chunk %q (query=%d stored=%d)", chunk.ID, len(queryEmbedding), len(embedding))
+		}
 
 		score := cosineSimilarity(queryEmbedding, embedding)
 		results = append(results, SearchResult{

--- a/rag/sqlite_store.go
+++ b/rag/sqlite_store.go
@@ -222,8 +222,8 @@ func (s *SQLiteStore) Search(ctx context.Context, queryEmbedding []float64, k in
 		if err := json.Unmarshal([]byte(embJSON), &embedding); err != nil {
 			return nil, fmt.Errorf("rag: unmarshal embedding: %w", err)
 		}
-		if len(embedding) != len(queryEmbedding) {
-			return nil, fmt.Errorf("rag: search: embedding dimension mismatch for chunk %q (query=%d stored=%d)", chunk.ID, len(queryEmbedding), len(embedding))
+		if err := validateSearchEmbeddingDimension(chunk.ID, queryEmbedding, embedding); err != nil {
+			return nil, err
 		}
 
 		score := cosineSimilarity(queryEmbedding, embedding)

--- a/rag/sqlite_store_dimension_test.go
+++ b/rag/sqlite_store_dimension_test.go
@@ -1,0 +1,33 @@
+package rag
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestSQLiteStore_Search_RejectsDimensionMismatch(t *testing.T) {
+	store, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	ctx := context.Background()
+
+	// Seed a chunk with a 4-dimensional embedding.
+	chunks := []Chunk{{ID: "c1", Content: "x", Source: "f.go", StartLine: 1, EndLine: 1}}
+	embeddings := [][]float64{{0.1, 0.2, 0.3, 0.4}}
+	if err := store.Store(ctx, chunks, embeddings); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+
+	// Query with a 3-dimensional vector — must error, not silently return zero score.
+	_, err = store.Search(ctx, []float64{0.1, 0.2, 0.3}, 5)
+	if err == nil {
+		t.Fatal("expected dimension-mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "dimension mismatch") {
+		t.Errorf("error = %q, want it to mention %q", err.Error(), "dimension mismatch")
+	}
+}

--- a/rag/store.go
+++ b/rag/store.go
@@ -1,6 +1,9 @@
 package rag
 
-import "context"
+import (
+	"context"
+	"reflect"
+)
 
 // VectorStore persists and searches embeddings.
 type VectorStore interface {
@@ -33,4 +36,17 @@ type StoreStats struct {
 	TotalSources int
 	EmbeddingDim int
 	StorageBytes int64
+}
+
+func isNilVectorStore(store VectorStore) bool {
+	if store == nil {
+		return true
+	}
+	v := reflect.ValueOf(store)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
Closes #74.

## Summary

- Adds `rag.Embedder` interface, `rag.EmbedResult` provenance struct, and `rag.EmbedderFunc` adapter (`rag/embedder.go`) — narrow batch-shaped seam consumer-owned in `rag/`, provider-agnostic by design.
- Adds `rag.NewIndexerWithEmbedder` and `rag.NewRetrieverWithEmbedder` additive constructors with explicit nil-embedder rejection. Legacy `NewIndexer(*ollama.Client, ...)` and `NewRetriever(*ollama.Client, ...)` retained as compat shims via private `embedderFromOllamaClient` adapter — Firn IDE / Flux ML / Quantum Trader compile and run unchanged.
- `Indexer.IndexFile`, `IndexFileIncremental`, and `Retriever.Retrieve` now route embedding calls through the `Embedder` seam with response-length validation; mismatches surface as descriptive errors before storing.
- Adds `SQLiteStore.Search` query/stored embedding dimension guard so vector-space drift surfaces as a hard error rather than silent zero-score (`rag/sqlite_store.go`).
- Centralises MCP embed routing in a single `s.routedEmbed` helper (`mcp/embed_helper.go`); `handleEmbed`, `handleEmbedBatch`, and the new `s.ragEmbedder(priority)` closure all funnel through it. Typed `routedEmbedError` preserves the existing `validation` / `config` / `router` / `ollama` categorisation without string matching.
- `s.ragEmbedder(priority)` adds a fail-closed empty-model drift guard so a misconfigured `WithEmbeddingModel(\"\")` cannot trigger embedding-chain fallback that corrupts the SQLite vector store; pre-routing short-circuit on empty inputs preserves the caller-supplied model in the result.
- MCP RAG construction (`mcp/server.go`) switches to the new constructors with `PriorityBackground` for indexing and `PriorityNormal` for retrieval. After this change, `s.client` is no longer threaded into RAG construction.

## Scope

| Path | Action |
|---|---|
| `rag/embedder.go` | Create — Embedder interface, EmbedResult, EmbedderFunc, private ollama adapter |
| `rag/indexer.go`, `rag/indexer_incremental.go`, `rag/retriever.go` | Modify — `client *ollama.Client` → `embedder Embedder` via private builder; new `*WithEmbedder` constructors; length validation on every embed call site |
| `rag/sqlite_store.go` | Modify — add per-row dimension guard inside `Search` |
| `rag/embedder_test.go`, `rag/indexer_embedder_test.go`, `rag/retriever_embedder_test.go`, `rag/sqlite_store_dimension_test.go` | Create — Embedder contract, constructor option behavior, count-mismatch preserves prior data, dimension-guard regression |
| `mcp/embed_helper.go`, `mcp/embed_helper_test.go` | Create — `routedEmbed`, `ragEmbedder`, typed error category, drift-guard + provenance + categorisation tests |
| `mcp/tools_embed.go` | Modify — handlers shrink to validate-args → `routedEmbed` → categorise → marshal; inline `RoutingRequest{...}` blocks deleted |
| `mcp/server.go` | Modify — `rebuildDerivedClients` wires RAG via `s.ragEmbedder(...)` |

`rag/indexer_test.go` and `rag/retriever_test.go` are untouched — their httptest-mock-Ollama tests pass without modification, satisfying AC#5's bug-for-bug compat invariant for the legacy shim.

## Test plan

- [x] `go test ./...` — 16 packages green
- [x] `go test -race ./rag/ ./mcp/` — race-detector clean
- [x] `go vet ./...` — no findings
- [x] `go build ./...` — all packages compile
- [x] `rag/indexer_test.go` and `rag/retriever_test.go` pass without modification (AC#5)
- [x] Refactored `handleEmbed` / `handleEmbedBatch` produce identical `RoutingRequest` shape and category strings as pre-refactor (AC#12)

## Acceptance criteria coverage

Per spec §8 (`docs/superpowers/specs/2026-05-01-rag-via-router-design.md`, local-only):

- [x] AC#1 `go test ./...` passes
- [x] AC#3 `rag.Embedder`, `rag.EmbedderFunc`, `rag.EmbedResult` exported
- [x] AC#4 `rag.NewIndexerWithEmbedder` / `NewRetrieverWithEmbedder` exist; both reject nil embedder; signatures `(*T, error)`
- [x] AC#5 Existing `rag/indexer_test.go` and `rag/retriever_test.go` pass without modification
- [x] AC#6 `rag.NewIndexer` / `NewRetriever` keep `(*ollama.Client, VectorStore, ...) *T` signatures
- [x] AC#7 `mcp.Server.routedEmbed` exists; `handleEmbed`, `handleEmbedBatch`, `s.ragEmbedder(priority)` funnel through it
- [x] AC#8 `len(resp.Embeddings) != len(inputs)` returns error before reaching callers
- [x] AC#9 `s.ragEmbedder(priority)` returns drift error on empty model
- [x] AC#10 `SQLiteStore.Search` errors on dimension mismatch
- [x] AC#11 `mcp/server.go` constructs RAG via `NewIndexerWithEmbedder` / `NewRetrieverWithEmbedder`; `s.client` no longer threaded
- [x] AC#12 Error categories `validation` / `config` / `router` / `ollama` preserved

AC#2 (integration tests against running Ollama) verified via existing `provider/router_chain_integration_test.go` patterns; not required for this PR's CI green-bar.

## Review trail

13 staged commits implement the spec; 4 follow-up commits address findings from per-task `/code-review` + `/criticize-review` cycles:

- `b55ee86` fix(rag): drop redundant `fmt.Errorf` wrap in ollama adapter to match spec §5.1 raw-error passthrough; distinct constructor error messages; tightened `WithEmbeddingModel` doc; added parallel `WithRetrieverModel` drift warning
- `4e14f44` fix(mcp): zero-`ActualModel` guard on `VectorSpaceID` derivation; drop redundant `chain:` / `route:` prefixes (categories already convey the layer); empty-input ragEmbedder short-circuits before routing while preserving requested model
- `f204313` test(rag): observable-behavior tests via `recordingEmbedder` instead of white-box `idx.model` / `r.model`; `TestIndexer_CountMismatchPreservesExistingData` regression
- `d36542d` test(mcp): pin error message body and provenance values; cover unwrapped-error categorisation fallback; verify empty-input model propagation

## Out of scope (tracked separately)

Spec §8 AC#13 follow-ups, all filed before merge:

- #80 `feat(rag): document ingestion layer for managed RAG sources` (already open, pre-existing)
- #81 `feat(provider): add OpenAI-compatible local provider backend` — informs the eventual strict-chain drift fix
- #82 `feat(rag): record actual embedding model in source signature for drift detection` — extends the in-memory drift guard with persistent vector-space identity per spec §6 last paragraph
- #83 `refactor(mcp): unify embed tool with s.ragEmbedder behind single Embedder instance` — Approach 3 follow-up; revisit after #73

Specs and plans live in `docs/superpowers/` (local-only, gitignored).

Generated with [Claude Code](https://claude.com/claude-code)