### PR TITLE
feat(completion): additive Router-aware constructor and MCP FIM pin policy

### DIFF
--- a/completion/generator.go
+++ b/completion/generator.go
@@ -62,14 +62,23 @@ type GenerateResult struct {
 // RouteHint is human-readable provenance suitable for logs and telemetry
 // (typically the underlying provider.RouteOutcome.Reason; falls back to
 // ActualModel.String() if Reason is empty). PlannedModel records the
-// router's first-choice candidate; differs from the top-level
-// GenerateResult.Model when chain fallback occurred. The expression
-// `result.Outcome != nil && result.Outcome.PlannedModel != result.Model`
-// is the canonical drift detector for #82. Score is the composite ranking
-// score the resolved candidate received. FallbacksUsed is the number of
-// chain fallbacks consumed before success (0 = first candidate answered).
-// WasSticky is true if the resolved model came from the sticky-cache
-// rather than fresh scoring.
+// router's first-choice candidate as a provider-qualified identity in
+// "provider/model" form (e.g. "ollama/qwen3:8b"); it preserves the
+// provider component so provider-level fallback is observable even when
+// the model name happens to coincide across providers.
+//
+// The canonical drift detector for #82 is therefore the qualified
+// comparison:
+//
+//	result.Outcome != nil && result.Outcome.PlannedModel != result.Provider+"/"+result.Model
+//
+// Comparing PlannedModel against the unqualified GenerateResult.Model
+// alone would report false drift on every routed success because the
+// formats differ. Score is the composite ranking score the resolved
+// candidate received. FallbacksUsed is the number of chain fallbacks
+// consumed before success (0 = first candidate answered). WasSticky is
+// true if the resolved model came from the sticky-cache rather than
+// fresh scoring.
 type RouteOutcome struct {
 	RouteHint     string
 	PlannedModel  string

--- a/completion/generator.go
+++ b/completion/generator.go
@@ -108,13 +108,24 @@ type GenerateChunk struct {
 // stop-token suppression buffer without external synchronization; a
 // Generator that fans chunks out across goroutines would break it.
 //
-// Implementations MUST reject requests where Prompt AND Suffix are both
-// empty, matching ollama.Client.Generate's contract. The Generator
-// interface itself does not enforce this: the completion package's
-// Provider.planRequest can produce trivially-empty prompts on edge cases
-// (cursor at file start with empty suffix), and a defensive
-// implementation may catch them before issuing a backend call. Callers
-// should treat such requests as invalid.
+// Empty-Prompt-AND-empty-Suffix requests are not rejected by the
+// interface itself: ollama.Client.Generate already rejects such requests
+// at the backend layer (the bundled ollamaGenerator surfaces the same
+// rejection at the seam), and Provider.planRequest does not produce them
+// for current FIM call sites. Implementations MAY add their own
+// defensive validation; callers should treat such requests as invalid
+// regardless.
+//
+// Suffix being non-empty implies FIM mode and requires the backing
+// implementation to honour CapInsert at the provider level. The
+// implementation MUST NOT substitute across FIM-family template
+// compatibility boundaries within a single call: families differ in
+// their native prompt+suffix marker tokens (qwen3-coder, codellama,
+// codestral, etc. each use distinct templates), so cross-family
+// fallback can produce malformed prompts and incorrect completions.
+// The MCP server's s.fimGenerator pins the resolved model end-to-end
+// to enforce this; other Generator implementations should follow the
+// same policy or document the deviation.
 //
 // On success, GenerateResult.Response is the complete, non-stop-stripped
 // backend payload; Provider.Complete owns stop-token stripping.

--- a/completion/generator.go
+++ b/completion/generator.go
@@ -99,8 +99,14 @@ type GenerateChunk struct {
 // silently degrading to Generate (callers may interpret a one-chunk
 // stream as the final answer).
 //
-// Implementations MUST be safe for concurrent use. The IDE invokes FIM
-// completions on every keystroke and may have multiple in flight.
+// Implementations MUST be safe for concurrent use across separate
+// Generate / GenerateStream calls — the IDE invokes FIM completions on
+// every keystroke and may have multiple in flight. Within a single
+// GenerateStream call, however, fn MUST be invoked serially from a
+// single goroutine and MUST NOT be called concurrently. Provider.
+// CompleteStream relies on this serial-fn contract to maintain its
+// stop-token suppression buffer without external synchronization; a
+// Generator that fans chunks out across goroutines would break it.
 //
 // Implementations MUST reject requests where Prompt AND Suffix are both
 // empty, matching ollama.Client.Generate's contract. The Generator

--- a/completion/generator.go
+++ b/completion/generator.go
@@ -1,0 +1,232 @@
+// Generator seam for completion.
+//
+// The Generator interface is completion's narrow generation dependency:
+// two-method (Generate + GenerateStream), returning generic provenance
+// instead of importing provider response types into completion. Router-
+// backed implementations are supplied by callers (see mcp.Server.fimGenerator);
+// the legacy *ollama.Client path is preserved via the private
+// generatorFromOllamaClient adapter used by NewProvider.
+package completion
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+// providerNameOllama is the canonical provider identifier surfaced in
+// GenerateResult.Provider when the ollama adapter answers. Mirrors the
+// string returned by provider.OllamaProvider.Name() (provider/ollama.go).
+// Single source of truth within completion/ so the two adapter call sites
+// stay in lockstep.
+const providerNameOllama = "ollama"
+
+// GenerateRequest is the generation request shape the completion package
+// hands to the Generator seam. Suffix being non-empty implies FIM mode and
+// requires the backing implementation to honour CapInsert at the provider
+// level. NumCtx, NumPredict, Temperature, and Stop reflect the resolved
+// budget computed by Provider.planRequest and must be passed through
+// unchanged.
+type GenerateRequest struct {
+	Model       string
+	Prompt      string
+	Suffix      string
+	Temperature float64
+	NumPredict  int
+	NumCtx      int
+	Stop        []string
+}
+
+// GenerateResult is the non-streaming generation payload plus enough
+// provenance for completion (and future #82 drift telemetry) to identify
+// the model that actually answered. Top-level Model and Provider are the
+// source of truth post-routing; Outcome carries supplementary route-side
+// signals (planned model, score, fallback count, sticky-cache hit) when
+// the backing implementation has them. The legacy ollama adapter leaves
+// Outcome nil.
+type GenerateResult struct {
+	Response string
+	Tokens   int
+	Model    string        // model that actually answered (post-routing)
+	Provider string        // provider that actually answered
+	Outcome  *RouteOutcome // nil when no router-side metadata is available
+}
+
+// RouteOutcome carries router-side decision metadata for a generation
+// response. Populated by Router-backed Generator implementations (see
+// mcp.Server.fimGenerator); the legacy ollama adapter leaves
+// GenerateResult.Outcome nil.
+//
+// RouteHint is human-readable provenance suitable for logs and telemetry
+// (typically the underlying provider.RouteOutcome.Reason; falls back to
+// ActualModel.String() if Reason is empty). PlannedModel records the
+// router's first-choice candidate; differs from the top-level
+// GenerateResult.Model when chain fallback occurred. The expression
+// `result.Outcome != nil && result.Outcome.PlannedModel != result.Model`
+// is the canonical drift detector for #82. Score is the composite ranking
+// score the resolved candidate received. FallbacksUsed is the number of
+// chain fallbacks consumed before success (0 = first candidate answered).
+// WasSticky is true if the resolved model came from the sticky-cache
+// rather than fresh scoring.
+type RouteOutcome struct {
+	RouteHint     string
+	PlannedModel  string
+	Score         float64
+	FallbacksUsed int
+	WasSticky     bool
+}
+
+// GenerateChunk is a streaming chunk's payload. The completion package's
+// CompleteStream owns stop-token suppression on top of these raw chunks.
+//
+// Done MUST be true on exactly the last chunk emitted by a successful
+// GenerateStream call (matching ollama.GenerateResponse.Done semantics);
+// callers rely on this to flush trailing stop-token-suppression buffers.
+// Implementations that cannot guarantee a final Done=true chunk on
+// success must return an error from GenerateStream rather than emit a
+// stream that never terminates cleanly.
+type GenerateChunk struct {
+	Response string
+	Done     bool
+}
+
+// Generator is the narrow generation dependency completion needs.
+//
+// Both methods MUST be implemented; a generator that does not support
+// streaming should return an error from GenerateStream rather than
+// silently degrading to Generate (callers may interpret a one-chunk
+// stream as the final answer).
+//
+// Implementations MUST be safe for concurrent use. The IDE invokes FIM
+// completions on every keystroke and may have multiple in flight.
+//
+// Implementations MUST reject requests where Prompt AND Suffix are both
+// empty, matching ollama.Client.Generate's contract. The Generator
+// interface itself does not enforce this: the completion package's
+// Provider.planRequest can produce trivially-empty prompts on edge cases
+// (cursor at file start with empty suffix), and a defensive
+// implementation may catch them before issuing a backend call. Callers
+// should treat such requests as invalid.
+//
+// On success, GenerateResult.Response is the complete, non-stop-stripped
+// backend payload; Provider.Complete owns stop-token stripping.
+// GenerateStream returns the final aggregated GenerateResult (Response =
+// full concatenation) for symmetry with Generate and to expose route
+// metadata uniformly.
+type Generator interface {
+	Generate(ctx context.Context, req GenerateRequest) (GenerateResult, error)
+	GenerateStream(ctx context.Context, req GenerateRequest, fn func(GenerateChunk) error) (GenerateResult, error)
+}
+
+// generatorFromOllamaClient adapts *ollama.Client to Generator. Private —
+// used only by the legacy NewProvider compat shim. External consumers
+// wiring router-aware generation switch to NewProviderWithGenerator and
+// supply their own Generator.
+//
+// Returns nil when client is nil so the legacy nil-client behaviour of
+// NewProvider is preserved (existing code rejects a nil client with an
+// error from Complete/CompleteStream; the adapter preserves that path).
+func generatorFromOllamaClient(c *ollama.Client) Generator {
+	if c == nil {
+		return nil
+	}
+	return &ollamaGenerator{client: c}
+}
+
+// ollamaGenerator wraps *ollama.Client to satisfy Generator. It is the
+// only place in completion/ that imports ollama types; consumers wiring
+// router-aware generation never touch this struct.
+//
+// Safe for concurrent use: *ollama.Client is a stateless HTTP wrapper
+// (each Generate / GenerateStream call issues its own request), and this
+// struct adds no mutable state on top of it.
+type ollamaGenerator struct {
+	client *ollama.Client
+}
+
+func (g *ollamaGenerator) Generate(ctx context.Context, req GenerateRequest) (GenerateResult, error) {
+	if err := validateOllamaGenerateRequest(req); err != nil {
+		return GenerateResult{}, err
+	}
+	resp, err := g.client.Generate(ctx, ollamaGenerateRequest(req))
+	if err != nil {
+		return GenerateResult{}, err
+	}
+	return GenerateResult{
+		Response: resp.Response,
+		Tokens:   resp.EvalCount,
+		Model:    req.Model,
+		Provider: providerNameOllama,
+	}, nil
+}
+
+func (g *ollamaGenerator) GenerateStream(ctx context.Context, req GenerateRequest, fn func(GenerateChunk) error) (GenerateResult, error) {
+	if err := validateOllamaGenerateRequest(req); err != nil {
+		return GenerateResult{}, err
+	}
+	if fn == nil {
+		return GenerateResult{}, fmt.Errorf("completion: GenerateStream callback is required")
+	}
+	var (
+		full   strings.Builder
+		tokens int
+	)
+	err := g.client.GenerateStream(ctx, ollamaGenerateRequest(req), func(resp ollama.GenerateResponse) error {
+		full.WriteString(resp.Response)
+		if resp.EvalCount > 0 {
+			tokens = resp.EvalCount
+		}
+		return fn(GenerateChunk{Response: resp.Response, Done: resp.Done})
+	})
+	if err != nil {
+		return GenerateResult{}, err
+	}
+	return GenerateResult{
+		Response: full.String(),
+		Tokens:   tokens,
+		Model:    req.Model,
+		Provider: providerNameOllama,
+	}, nil
+}
+
+// validateOllamaGenerateRequest enforces upfront defense-in-depth on the
+// fields Provider.Generate / *ollama.Client.Generate would reject anyway.
+// Catching at the seam yields a clearer error message tagged with
+// "completion:" rather than "ollama: generate: ..." surfacing from the
+// network layer, and matches the validation surface of the future
+// Router-backed Generator (mcp.Server.fimGenerator) so callers can write
+// uniform error handling regardless of which Generator is wired in.
+func validateOllamaGenerateRequest(req GenerateRequest) error {
+	if req.Model == "" {
+		return fmt.Errorf("completion: model is required")
+	}
+	if req.Prompt == "" && req.Suffix == "" {
+		return fmt.Errorf("completion: prompt or suffix is required")
+	}
+	return nil
+}
+
+// ollamaGenerateRequest converts the seam-shaped GenerateRequest into the
+// ollama.GenerateRequest the underlying client expects. The Stop slice is
+// copied (not aliased) so the in-flight goroutine cannot observe caller
+// mutation; concurrent FIM workloads that reuse request structs from a
+// pool would otherwise be exposed to data races on Stop.
+func ollamaGenerateRequest(req GenerateRequest) ollama.GenerateRequest {
+	var stop []string
+	if len(req.Stop) > 0 {
+		stop = append(make([]string, 0, len(req.Stop)), req.Stop...)
+	}
+	return ollama.GenerateRequest{
+		Model:  req.Model,
+		Prompt: req.Prompt,
+		Suffix: req.Suffix,
+		Options: &ollama.ModelOptions{
+			NumPredict:  req.NumPredict,
+			NumCtx:      req.NumCtx,
+			Temperature: req.Temperature,
+			Stop:        stop,
+		},
+	}
+}

--- a/completion/generator_test.go
+++ b/completion/generator_test.go
@@ -183,15 +183,15 @@ func TestNewProviderNilClientCompatibility(t *testing.T) {
 	if err == nil {
 		t.Fatal("Complete with nil client must error")
 	}
-	if !strings.Contains(err.Error(), "client is required") {
-		t.Fatalf("Complete error = %v, want substring %q", err, "client is required")
+	if !strings.Contains(err.Error(), "generator is required") {
+		t.Fatalf("Complete error = %v, want substring %q", err, "generator is required")
 	}
 	err = p.CompleteStream(context.Background(), FIMRequest{Prefix: "x", Suffix: "y"}, func(string) error { return nil })
 	if err == nil {
 		t.Fatal("CompleteStream with nil client must error")
 	}
-	if !strings.Contains(err.Error(), "client is required") {
-		t.Fatalf("CompleteStream error = %v, want substring %q", err, "client is required")
+	if !strings.Contains(err.Error(), "generator is required") {
+		t.Fatalf("CompleteStream error = %v, want substring %q", err, "generator is required")
 	}
 }
 

--- a/completion/generator_test.go
+++ b/completion/generator_test.go
@@ -3,7 +3,6 @@ package completion
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,23 +11,84 @@ import (
 	"github.com/kstruzzieri/go-llm/ollama"
 )
 
+// fakeGenerator is the canonical test fake for the Generator seam. It
+// supports two usage styles, in priority order:
+//
+//  1. Function override via generate / stream — preferred for tests that
+//     need to capture/inspect the request arg or drive custom chunk
+//     sequences.
+//  2. Struct-field recording via result / chunks / genErr / streamErr —
+//     preferred for happy-path tests where the test only cares about the
+//     return value and the request/called-flag fields are inspected after.
+//
+// Both Generate and GenerateStream record called/streamCalled and lastReq
+// regardless of which path runs, so tests can assert "the seam was
+// invoked" without driving the function path.
+//
+// Concurrency: fakeGenerator is intended for SERIAL test invocation. The
+// recording fields (called, streamCalled, lastReq) are written without a
+// mutex; concurrent calls would race. This matches the typical Generator
+// caller pattern (Provider.Complete / completeStream invoke the seam
+// from a single goroutine), but tests that exercise concurrent use must
+// add their own synchronization or use a different fake.
+//
+// Default behaviour: when no function override AND no struct-field path
+// is configured, Generate / GenerateStream return (GenerateResult{}, nil)
+// — a SILENT success. Tests that must catch unexpected invocations
+// should assert !gen.called / !gen.streamCalled explicitly. This
+// trade-off was made deliberately so the struct-field happy-path tests
+// don't have to set up an unused function override; the cost is the
+// loss of the prior "unexpected Generate call" loud-failure default.
 type fakeGenerator struct {
+	// Function overrides — when non-nil, take precedence over the
+	// struct-field path.
 	generate func(context.Context, GenerateRequest) (GenerateResult, error)
 	stream   func(context.Context, GenerateRequest, func(GenerateChunk) error) (GenerateResult, error)
+
+	// Struct-field path — used when the corresponding function override
+	// is nil. result is returned from both Generate and GenerateStream;
+	// chunks is fed to fn (in order) by GenerateStream before returning
+	// result; genErr / streamErr force the corresponding error path.
+	result    GenerateResult
+	chunks    []GenerateChunk
+	genErr    error
+	streamErr error
+
+	// Recording — populated on every invocation regardless of path.
+	called       bool
+	streamCalled bool
+	lastReq      GenerateRequest
 }
 
 func (g *fakeGenerator) Generate(ctx context.Context, req GenerateRequest) (GenerateResult, error) {
-	if g.generate == nil {
-		return GenerateResult{}, errors.New("unexpected Generate call")
+	g.called = true
+	g.lastReq = req
+	if g.generate != nil {
+		return g.generate(ctx, req)
 	}
-	return g.generate(ctx, req)
+	if g.genErr != nil {
+		return GenerateResult{}, g.genErr
+	}
+	return g.result, nil
 }
 
 func (g *fakeGenerator) GenerateStream(ctx context.Context, req GenerateRequest, fn func(GenerateChunk) error) (GenerateResult, error) {
-	if g.stream == nil {
-		return GenerateResult{}, errors.New("unexpected GenerateStream call")
+	g.streamCalled = true
+	g.lastReq = req
+	if g.stream != nil {
+		return g.stream(ctx, req, fn)
 	}
-	return g.stream(ctx, req, fn)
+	if g.streamErr != nil {
+		return GenerateResult{}, g.streamErr
+	}
+	if fn != nil {
+		for _, ch := range g.chunks {
+			if err := fn(ch); err != nil {
+				return GenerateResult{}, err
+			}
+		}
+	}
+	return g.result, nil
 }
 
 func TestNewProviderWithGeneratorValidation(t *testing.T) {

--- a/completion/generator_test.go
+++ b/completion/generator_test.go
@@ -1,0 +1,357 @@
+package completion
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+type fakeGenerator struct {
+	generate func(context.Context, GenerateRequest) (GenerateResult, error)
+	stream   func(context.Context, GenerateRequest, func(GenerateChunk) error) (GenerateResult, error)
+}
+
+func (g *fakeGenerator) Generate(ctx context.Context, req GenerateRequest) (GenerateResult, error) {
+	if g.generate == nil {
+		return GenerateResult{}, errors.New("unexpected Generate call")
+	}
+	return g.generate(ctx, req)
+}
+
+func (g *fakeGenerator) GenerateStream(ctx context.Context, req GenerateRequest, fn func(GenerateChunk) error) (GenerateResult, error) {
+	if g.stream == nil {
+		return GenerateResult{}, errors.New("unexpected GenerateStream call")
+	}
+	return g.stream(ctx, req, fn)
+}
+
+func TestNewProviderWithGeneratorValidation(t *testing.T) {
+	if _, err := NewProviderWithGenerator(nil, "test-model", testProviderConfig()); err == nil {
+		t.Fatal("expected nil generator to be rejected")
+	}
+
+	p, err := NewProviderWithGenerator(&fakeGenerator{}, "", testProviderConfig())
+	if err != nil {
+		t.Fatalf("empty model should be rejected at call time, not construction: %v", err)
+	}
+	if _, err := p.Complete(context.Background(), FIMRequest{Prefix: "code"}); err == nil {
+		t.Fatal("expected empty model to be rejected at call time")
+	}
+}
+
+func TestCompleteUsesGeneratorRequestPlan(t *testing.T) {
+	cfg := testProviderConfig()
+	prefix := "func main() {\n\t"
+	suffix := "\n}"
+	var got GenerateRequest
+
+	gen := &fakeGenerator{
+		generate: func(_ context.Context, req GenerateRequest) (GenerateResult, error) {
+			got = req
+			return GenerateResult{
+				Response: "fmt.Println()<|endoftext|>",
+				Tokens:   5,
+				Model:    req.Model,
+				Provider: "fake",
+			}, nil
+		},
+	}
+
+	p, err := NewProviderWithGenerator(gen, "test-model", cfg)
+	if err != nil {
+		t.Fatalf("NewProviderWithGenerator: %v", err)
+	}
+
+	resp, err := p.Complete(context.Background(), FIMRequest{
+		Prefix:    prefix,
+		Suffix:    suffix,
+		FilePath:  "main.go",
+		MaxTokens: 17,
+		Trace:     true,
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	if got.Model != "test-model" {
+		t.Errorf("Model = %q, want test-model", got.Model)
+	}
+	if got.Prompt != prefix {
+		t.Errorf("Prompt = %q, want %q", got.Prompt, prefix)
+	}
+	if got.Suffix != suffix {
+		t.Errorf("Suffix = %q, want %q", got.Suffix, suffix)
+	}
+	if got.NumPredict != 17 {
+		t.Errorf("NumPredict = %d, want 17", got.NumPredict)
+	}
+	if got.NumCtx != cfg.ContextWindow {
+		t.Errorf("NumCtx = %d, want %d", got.NumCtx, cfg.ContextWindow)
+	}
+	if resp.BudgetTrace == nil {
+		t.Fatal("BudgetTrace is nil")
+	}
+	if got.Temperature != resp.BudgetTrace.Temperature {
+		t.Errorf("Temperature = %v, want trace temperature %v", got.Temperature, resp.BudgetTrace.Temperature)
+	}
+	if len(got.Stop) == 0 || got.Stop[0] != "<|endoftext|>" {
+		t.Fatalf("Stop = %v, want first stop token <|endoftext|>", got.Stop)
+	}
+	if resp.Completion != "fmt.Println()" {
+		t.Errorf("Completion = %q, want stop-stripped response", resp.Completion)
+	}
+	if resp.Tokens != 5 {
+		t.Errorf("Tokens = %d, want 5", resp.Tokens)
+	}
+}
+
+func TestCompleteStreamUsesGeneratorRequestPlan(t *testing.T) {
+	var got GenerateRequest
+	gen := &fakeGenerator{
+		stream: func(_ context.Context, req GenerateRequest, fn func(GenerateChunk) error) (GenerateResult, error) {
+			got = req
+			chunks := []GenerateChunk{
+				{Response: "fmt.", Done: false},
+				{Response: "Println()", Done: false},
+				{Response: "<|endoftext|>", Done: true},
+			}
+			for _, chunk := range chunks {
+				if err := fn(chunk); err != nil {
+					return GenerateResult{}, err
+				}
+			}
+			return GenerateResult{
+				Response: "fmt.Println()<|endoftext|>",
+				Tokens:   3,
+				Model:    req.Model,
+				Provider: "fake",
+			}, nil
+		},
+	}
+
+	p, err := NewProviderWithGenerator(gen, "test-model", testProviderConfig())
+	if err != nil {
+		t.Fatalf("NewProviderWithGenerator: %v", err)
+	}
+
+	var tokens []string
+	err = p.CompleteStream(context.Background(), FIMRequest{
+		Prefix:    "func main() {\n\t",
+		Suffix:    "\n}",
+		MaxTokens: 11,
+	}, func(token string) error {
+		tokens = append(tokens, token)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("CompleteStream: %v", err)
+	}
+
+	if got.Model != "test-model" {
+		t.Errorf("Model = %q, want test-model", got.Model)
+	}
+	if got.NumPredict != 11 {
+		t.Errorf("NumPredict = %d, want 11", got.NumPredict)
+	}
+	joined := strings.Join(tokens, "")
+	if joined != "fmt.Println()" {
+		t.Errorf("stream output = %q, want stop-stripped response", joined)
+	}
+	if strings.Contains(joined, "<|endoftext|>") {
+		t.Errorf("stop token leaked to stream callback: %q", joined)
+	}
+}
+
+func TestGeneratorFromOllamaClientNilPassthrough(t *testing.T) {
+	if got := generatorFromOllamaClient(nil); got != nil {
+		t.Fatalf("generatorFromOllamaClient(nil) = %v, want nil", got)
+	}
+}
+
+func TestNewProviderNilClientCompatibility(t *testing.T) {
+	p, err := NewProvider(nil, "test-model", testProviderConfig())
+	if err != nil {
+		t.Fatalf("NewProvider(nil, ...) construction must succeed for legacy compat, got: %v", err)
+	}
+	_, err = p.Complete(context.Background(), FIMRequest{Prefix: "x", Suffix: "y"})
+	if err == nil {
+		t.Fatal("Complete with nil client must error")
+	}
+	if !strings.Contains(err.Error(), "client is required") {
+		t.Fatalf("Complete error = %v, want substring %q", err, "client is required")
+	}
+	err = p.CompleteStream(context.Background(), FIMRequest{Prefix: "x", Suffix: "y"}, func(string) error { return nil })
+	if err == nil {
+		t.Fatal("CompleteStream with nil client must error")
+	}
+	if !strings.Contains(err.Error(), "client is required") {
+		t.Fatalf("CompleteStream error = %v, want substring %q", err, "client is required")
+	}
+}
+
+func TestOllamaGeneratorDelegation(t *testing.T) {
+	t.Run("Generate", func(t *testing.T) {
+		var captured ollama.GenerateRequest
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/generate" {
+				t.Errorf("path = %q, want /api/generate", r.URL.Path)
+			}
+			if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(ollama.GenerateResponse{
+				Model:     "qwen3:8b",
+				Response:  "delegated",
+				Done:      true,
+				EvalCount: 7,
+			})
+		}))
+		defer srv.Close()
+
+		gen := generatorFromOllamaClient(ollama.NewClient(ollama.WithBaseURL(srv.URL)))
+		if gen == nil {
+			t.Fatal("generatorFromOllamaClient returned nil for non-nil client")
+		}
+
+		got, err := gen.Generate(context.Background(), GenerateRequest{
+			Model:      "qwen3:8b",
+			Prompt:     "func main() {",
+			Suffix:     "}",
+			NumPredict: 32,
+			NumCtx:     2048,
+			Stop:       []string{"<|endoftext|>"},
+		})
+		if err != nil {
+			t.Fatalf("Generate: %v", err)
+		}
+		if got.Response != "delegated" {
+			t.Errorf("Response = %q, want delegated", got.Response)
+		}
+		if got.Tokens != 7 {
+			t.Errorf("Tokens = %d, want 7 (from EvalCount)", got.Tokens)
+		}
+		if got.Model != "qwen3:8b" {
+			t.Errorf("Model = %q, want qwen3:8b (from request)", got.Model)
+		}
+		if got.Provider != "ollama" {
+			t.Errorf("Provider = %q, want ollama", got.Provider)
+		}
+		if got.Outcome != nil {
+			t.Errorf("Outcome = %v, want nil for ollama adapter", got.Outcome)
+		}
+		if captured.Model != "qwen3:8b" {
+			t.Errorf("forwarded Model = %q, want qwen3:8b", captured.Model)
+		}
+		if captured.Suffix != "}" {
+			t.Errorf("forwarded Suffix = %q, want }", captured.Suffix)
+		}
+	})
+
+	t.Run("GenerateStream", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/generate" {
+				t.Errorf("path = %q, want /api/generate", r.URL.Path)
+			}
+			enc := json.NewEncoder(w)
+			_ = enc.Encode(ollama.GenerateResponse{Response: "hel", Done: false})
+			_ = enc.Encode(ollama.GenerateResponse{Response: "lo", Done: false})
+			_ = enc.Encode(ollama.GenerateResponse{Response: "", Done: true, EvalCount: 3})
+		}))
+		defer srv.Close()
+
+		gen := generatorFromOllamaClient(ollama.NewClient(ollama.WithBaseURL(srv.URL)))
+
+		var chunks []GenerateChunk
+		got, err := gen.GenerateStream(
+			context.Background(),
+			GenerateRequest{Model: "qwen3:8b", Prompt: "say hi"},
+			func(c GenerateChunk) error {
+				chunks = append(chunks, c)
+				return nil
+			},
+		)
+		if err != nil {
+			t.Fatalf("GenerateStream: %v", err)
+		}
+		if len(chunks) != 3 {
+			t.Fatalf("chunks = %d, want 3", len(chunks))
+		}
+		if !chunks[len(chunks)-1].Done {
+			t.Error("last chunk Done = false, want true")
+		}
+		if got.Response != "hello" {
+			t.Errorf("aggregated Response = %q, want hello", got.Response)
+		}
+		if got.Tokens != 3 {
+			t.Errorf("Tokens = %d, want 3 (from final EvalCount)", got.Tokens)
+		}
+		if got.Provider != "ollama" {
+			t.Errorf("Provider = %q, want ollama", got.Provider)
+		}
+	})
+}
+
+func TestOllamaGeneratorValidation(t *testing.T) {
+	// Use a real client wired to a server that should never be hit — validation
+	// must reject before any HTTP call. If a request escapes validation the
+	// handler fails the test loudly.
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("HTTP handler called; validation should have rejected the request")
+	}))
+	defer srv.Close()
+
+	gen := generatorFromOllamaClient(ollama.NewClient(ollama.WithBaseURL(srv.URL)))
+
+	cases := []struct {
+		name    string
+		req     GenerateRequest
+		wantErr string
+	}{
+		{
+			name:    "empty model",
+			req:     GenerateRequest{Prompt: "x", Suffix: "y"},
+			wantErr: "model is required",
+		},
+		{
+			name:    "empty prompt and suffix",
+			req:     GenerateRequest{Model: "qwen3:8b"},
+			wantErr: "prompt or suffix is required",
+		},
+	}
+	for _, tc := range cases {
+		t.Run("Generate/"+tc.name, func(t *testing.T) {
+			_, err := gen.Generate(context.Background(), tc.req)
+			if err == nil {
+				t.Fatalf("Generate did not reject %+v", tc.req)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Generate err = %v, want substring %q", err, tc.wantErr)
+			}
+		})
+		t.Run("GenerateStream/"+tc.name, func(t *testing.T) {
+			_, err := gen.GenerateStream(context.Background(), tc.req, func(GenerateChunk) error { return nil })
+			if err == nil {
+				t.Fatalf("GenerateStream did not reject %+v", tc.req)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("GenerateStream err = %v, want substring %q", err, tc.wantErr)
+			}
+		})
+	}
+
+	t.Run("GenerateStream/nil callback", func(t *testing.T) {
+		_, err := gen.GenerateStream(context.Background(), GenerateRequest{Model: "qwen3:8b", Prompt: "x"}, nil)
+		if err == nil {
+			t.Fatal("GenerateStream with nil callback must error")
+		}
+		if !strings.Contains(err.Error(), "callback is required") {
+			t.Fatalf("err = %v, want substring %q", err, "callback is required")
+		}
+	})
+}

--- a/completion/inline.go
+++ b/completion/inline.go
@@ -38,16 +38,39 @@ type FIMResponse struct {
 	BudgetTrace     *BudgetTrace    // populated when FIMRequest.Trace is true
 }
 
-// Provider performs FIM (Fill-in-the-Middle) completions against an Ollama backend.
+// Provider performs FIM (Fill-in-the-Middle) completions against a generation backend.
 type Provider struct {
-	client *ollama.Client
-	model  string
-	cfg    ProviderConfig
+	generator Generator
+	model     string
+	cfg       ProviderConfig
 }
 
-// NewProvider creates a completion Provider for the given model.
+// NewProvider creates a completion Provider for the given model using an
+// Ollama client-backed compatibility shim.
+//
+// A nil client is accepted for backwards compatibility with the legacy
+// constructor contract, but Complete and CompleteStream will reject it at call
+// time with "completion: client is required".
 // Returns an error if cfg is invalid or cfg.FIM is nil.
 func NewProvider(client *ollama.Client, model string, cfg ProviderConfig) (*Provider, error) {
+	return buildProvider(generatorFromOllamaClient(client), model, cfg)
+}
+
+// NewProviderWithGenerator creates a completion Provider backed by the given
+// Generator. It is additive to NewProvider so existing callers can keep the
+// Ollama client-shaped constructor while router-aware callers supply their own
+// generation implementation.
+//
+// Unlike NewProvider's legacy nil-client compatibility path, a nil generator
+// is rejected at construction time.
+func NewProviderWithGenerator(generator Generator, model string, cfg ProviderConfig) (*Provider, error) {
+	if generator == nil {
+		return nil, fmt.Errorf("completion: NewProviderWithGenerator: generator is required")
+	}
+	return buildProvider(generator, model, cfg)
+}
+
+func buildProvider(generator Generator, model string, cfg ProviderConfig) (*Provider, error) {
 	if cfg.FIM == nil {
 		return nil, fmt.Errorf("completion: FIM config is required")
 	}
@@ -58,9 +81,9 @@ func NewProvider(client *ollama.Client, model string, cfg ProviderConfig) (*Prov
 		return nil, fmt.Errorf("completion: context window must be positive, got %d", cfg.ContextWindow)
 	}
 	return &Provider{
-		client: client,
-		model:  model,
-		cfg:    cfg,
+		generator: generator,
+		model:     model,
+		cfg:       cfg,
 	}, nil
 }
 
@@ -81,7 +104,7 @@ func (p *Provider) effectiveNumCtx(inputTokens int) int {
 
 // plannedRequest carries the fully-resolved plan for a single FIM round-trip.
 type plannedRequest struct {
-	genReq   ollama.GenerateRequest
+	genReq   GenerateRequest
 	analysis CursorAnalysis
 	budget   ComputedBudget
 	language string
@@ -135,16 +158,14 @@ func (p *Provider) planRequest(req FIMRequest) plannedRequest {
 	prefix := TruncateToTokens(req.Prefix, prefixBudget)
 	suffix := TruncateSuffixToTokens(req.Suffix, suffixBudget)
 
-	genReq := ollama.GenerateRequest{
-		Model:  p.model,
-		Prompt: prefix,
-		Suffix: suffix,
-		Options: &ollama.ModelOptions{
-			NumPredict:  maxTokens,
-			NumCtx:      numCtx,
-			Temperature: budget.Temperature,
-			Stop:        budget.StopTokens,
-		},
+	genReq := GenerateRequest{
+		Model:       p.model,
+		Prompt:      prefix,
+		Suffix:      suffix,
+		NumPredict:  maxTokens,
+		NumCtx:      numCtx,
+		Temperature: budget.Temperature,
+		Stop:        budget.StopTokens,
 	}
 
 	return plannedRequest{
@@ -176,7 +197,7 @@ func buildTrace(pr plannedRequest) *BudgetTrace {
 
 // Complete generates an inline completion synchronously.
 func (p *Provider) Complete(ctx context.Context, req FIMRequest) (*FIMResponse, error) {
-	if p.client == nil {
+	if p.generator == nil {
 		return nil, fmt.Errorf("completion: client is required")
 	}
 	if p.model == "" {
@@ -186,7 +207,7 @@ func (p *Provider) Complete(ctx context.Context, req FIMRequest) (*FIMResponse, 
 	pr := p.planRequest(req)
 	start := time.Now()
 
-	resp, err := p.client.Generate(ctx, pr.genReq)
+	resp, err := p.generator.Generate(ctx, pr.genReq)
 	if err != nil {
 		return nil, fmt.Errorf("completion: %w", err)
 	}
@@ -195,7 +216,7 @@ func (p *Provider) Complete(ctx context.Context, req FIMRequest) (*FIMResponse, 
 
 	result := &FIMResponse{
 		Completion:      completion,
-		Tokens:          resp.EvalCount,
+		Tokens:          resp.Tokens,
 		LatencyMs:       time.Since(start).Milliseconds(),
 		CursorContext:   pr.analysis.Context,
 		CompletionShape: pr.analysis.Shape,
@@ -213,7 +234,7 @@ func (p *Provider) Complete(ctx context.Context, req FIMRequest) (*FIMResponse, 
 // flushed (with any tail stop token stripped) on the final chunk.
 // If fn returns an error, streaming stops and that error is returned.
 func (p *Provider) CompleteStream(ctx context.Context, req FIMRequest, fn func(token string) error) error {
-	if p.client == nil {
+	if p.generator == nil {
 		return fmt.Errorf("completion: client is required")
 	}
 	if p.model == "" {
@@ -245,7 +266,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req FIMRequest, fn func(t
 		return nil
 	}
 
-	streamErr := p.client.GenerateStream(ctx, pr.genReq, func(resp ollama.GenerateResponse) error {
+	_, streamErr := p.generator.GenerateStream(ctx, pr.genReq, func(resp GenerateChunk) error {
 		if maxStopLen == 0 {
 			return emit(resp.Response)
 		}

--- a/completion/inline.go
+++ b/completion/inline.go
@@ -234,15 +234,50 @@ func (p *Provider) Complete(ctx context.Context, req FIMRequest) (*FIMResponse, 
 // to the longest effective stop token is held back on every write and only
 // flushed (with any tail stop token stripped) on the final chunk.
 // If fn returns an error, streaming stops and that error is returned.
+//
+// Code that needs the aggregated GenerateResult (route metadata, final
+// model/provider, token count) should prefer CompleteStreamWithResult.
+// The two methods produce byte-identical chunk sequences to fn; they
+// differ only in what is returned after the stream terminates.
 func (p *Provider) CompleteStream(ctx context.Context, req FIMRequest, fn func(token string) error) error {
+	_, err := p.completeStream(ctx, req, fn)
+	return err
+}
+
+// CompleteStreamWithResult is the router-aware streaming entry point. It
+// behaves identically to CompleteStream except it returns the aggregated
+// GenerateResult (final Response, Tokens, Model, Provider, and Outcome
+// route metadata) on success.
+//
+// CompleteStream(...) error remains unchanged for backwards compatibility
+// with Firn IDE / Flux ML / Quantum Trader; new code that needs route
+// provenance (e.g. for #82 drift telemetry or FIM acceptance/cancel
+// feedback) should prefer CompleteStreamWithResult.
+//
+// When the underlying Generator is the Router-backed mcpFIMGenerator, the
+// returned GenerateResult.Outcome is populated by translateRouteOutcome.
+// When the Generator is the legacy ollama adapter, Outcome is nil but
+// Model and Provider are still populated from the request and adapter
+// respectively.
+func (p *Provider) CompleteStreamWithResult(ctx context.Context, req FIMRequest, fn func(token string) error) (GenerateResult, error) {
+	return p.completeStream(ctx, req, fn)
+}
+
+// completeStream is the shared implementation for CompleteStream and
+// CompleteStreamWithResult. It performs the full streaming flow with
+// stop-token suppression and returns the aggregated GenerateResult
+// (final Response, Tokens, Model, Provider, Outcome) along with any
+// error. Both public methods delegate here so the streaming-buffer and
+// stop-suppression logic exists in exactly one place.
+func (p *Provider) completeStream(ctx context.Context, req FIMRequest, fn func(token string) error) (GenerateResult, error) {
 	if p.generator == nil {
-		return fmt.Errorf("completion: generator is required")
+		return GenerateResult{}, fmt.Errorf("completion: generator is required")
 	}
 	if p.model == "" {
-		return fmt.Errorf("completion: model is required")
+		return GenerateResult{}, fmt.Errorf("completion: model is required")
 	}
 	if fn == nil {
-		return fmt.Errorf("completion: callback function is required")
+		return GenerateResult{}, fmt.Errorf("completion: callback function is required")
 	}
 
 	pr := p.planRequest(req)
@@ -267,7 +302,7 @@ func (p *Provider) CompleteStream(ctx context.Context, req FIMRequest, fn func(t
 		return nil
 	}
 
-	_, streamErr := p.generator.GenerateStream(ctx, pr.genReq, func(resp GenerateChunk) error {
+	result, streamErr := p.generator.GenerateStream(ctx, pr.genReq, func(resp GenerateChunk) error {
 		if maxStopLen == 0 {
 			return emit(resp.Response)
 		}
@@ -294,8 +329,8 @@ func (p *Provider) CompleteStream(ctx context.Context, req FIMRequest, fn func(t
 		cleaned := stripStopTokens(buffer, pr.budget.StopTokens)
 		buffer = ""
 		if err := emit(cleaned); err != nil {
-			return errors.Join(streamErr, err)
+			return result, errors.Join(streamErr, err)
 		}
 	}
-	return streamErr
+	return result, streamErr
 }

--- a/completion/inline.go
+++ b/completion/inline.go
@@ -64,6 +64,13 @@ func NewProvider(client *ollama.Client, model string, cfg ProviderConfig) (*Prov
 //
 // Unlike NewProvider's legacy nil-client compatibility path, a nil generator
 // is rejected at construction time.
+//
+// FIM request shaping remains caller-resolved: cfg.FIM is read from the
+// resolved ModelProfile by the caller (typically via
+// ProviderConfigFromProfile), and the chosen Generator must not substitute
+// across FIM-family boundaries within a single call. The MCP server's
+// s.fimGenerator pins the resolved model in the routing request to enforce
+// this; other Generator implementations should follow the same policy.
 func NewProviderWithGenerator(generator Generator, model string, cfg ProviderConfig) (*Provider, error) {
 	if generator == nil {
 		return nil, fmt.Errorf("completion: NewProviderWithGenerator: generator is required")

--- a/completion/inline.go
+++ b/completion/inline.go
@@ -48,9 +48,10 @@ type Provider struct {
 // NewProvider creates a completion Provider for the given model using an
 // Ollama client-backed compatibility shim.
 //
-// A nil client is accepted for backwards compatibility with the legacy
-// constructor contract, but Complete and CompleteStream will reject it at call
-// time with "completion: client is required".
+// A nil client is accepted only for backwards compatibility with the legacy
+// constructor contract; new code should always pass a real *ollama.Client or
+// migrate to NewProviderWithGenerator. When client is nil, Complete and
+// CompleteStream reject the call with "completion: generator is required".
 // Returns an error if cfg is invalid or cfg.FIM is nil.
 func NewProvider(client *ollama.Client, model string, cfg ProviderConfig) (*Provider, error) {
 	return buildProvider(generatorFromOllamaClient(client), model, cfg)
@@ -198,7 +199,7 @@ func buildTrace(pr plannedRequest) *BudgetTrace {
 // Complete generates an inline completion synchronously.
 func (p *Provider) Complete(ctx context.Context, req FIMRequest) (*FIMResponse, error) {
 	if p.generator == nil {
-		return nil, fmt.Errorf("completion: client is required")
+		return nil, fmt.Errorf("completion: generator is required")
 	}
 	if p.model == "" {
 		return nil, fmt.Errorf("completion: model is required")
@@ -235,7 +236,7 @@ func (p *Provider) Complete(ctx context.Context, req FIMRequest) (*FIMResponse, 
 // If fn returns an error, streaming stops and that error is returned.
 func (p *Provider) CompleteStream(ctx context.Context, req FIMRequest, fn func(token string) error) error {
 	if p.generator == nil {
-		return fmt.Errorf("completion: client is required")
+		return fmt.Errorf("completion: generator is required")
 	}
 	if p.model == "" {
 		return fmt.Errorf("completion: model is required")

--- a/completion/inline.go
+++ b/completion/inline.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/kstruzzieri/go-llm/ollama"
@@ -266,6 +267,15 @@ func (p *Provider) CompleteStream(ctx context.Context, req FIMRequest, fn func(t
 // When the Generator is the legacy ollama adapter, Outcome is nil but
 // Model and Provider are still populated from the request and adapter
 // respectively.
+//
+// On success, GenerateResult.Response is the stop-token-stripped completion
+// text — the byte concatenation of tokens fn observed, matching the
+// semantics of FIMResponse.Completion from Provider.Complete. The raw
+// non-stop-stripped backend payload returned by the underlying Generator's
+// GenerateStream is replaced with this cleaned aggregate so the two views
+// (chunks-via-fn and Response-via-return) cannot diverge. On error, the
+// Response field carries whatever the underlying Generator returned (the
+// bundled implementations return GenerateResult{} on error).
 func (p *Provider) CompleteStreamWithResult(ctx context.Context, req FIMRequest, fn func(token string) error) (GenerateResult, error) {
 	return p.completeStream(ctx, req, fn)
 }
@@ -298,6 +308,13 @@ func (p *Provider) completeStream(ctx context.Context, req FIMRequest, fn func(t
 
 	var buffer string
 	var callbackErr error
+	// cleanedStream accumulates the stop-stripped tokens fn actually saw,
+	// so the returned GenerateResult.Response can be overwritten with the
+	// cleaned aggregate. Without this, CompleteStreamWithResult callers
+	// would see the underlying Generator's raw (non-stop-stripped) payload
+	// in Response while their fn callback received clean tokens — two
+	// inconsistent views of the same stream.
+	var cleanedStream strings.Builder
 	emit := func(token string) error {
 		if token == "" {
 			return nil
@@ -306,6 +323,7 @@ func (p *Provider) completeStream(ctx context.Context, req FIMRequest, fn func(t
 			callbackErr = err
 			return err
 		}
+		cleanedStream.WriteString(token)
 		return nil
 	}
 
@@ -338,6 +356,14 @@ func (p *Provider) completeStream(ctx context.Context, req FIMRequest, fn func(t
 		if err := emit(cleaned); err != nil {
 			return result, errors.Join(streamErr, err)
 		}
+	}
+	if streamErr == nil {
+		// Overwrite Response with the cleaned aggregate so
+		// CompleteStreamWithResult callers see semantically the same text
+		// as fn observed. On error we leave whatever the Generator
+		// returned (typically GenerateResult{} for the bundled
+		// implementations) so error-path provenance is unchanged.
+		result.Response = cleanedStream.String()
 	}
 	return result, streamErr
 }

--- a/completion/provider_generator_test.go
+++ b/completion/provider_generator_test.go
@@ -1,0 +1,300 @@
+package completion
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestProvider_CompleteRoutesThroughGenerator(t *testing.T) {
+	gen := &fakeGenerator{
+		result: GenerateResult{Response: "return a + b", Tokens: 4, Model: "qwen3:8b", Provider: "ollama"},
+	}
+	p, err := NewProviderWithGenerator(gen, "qwen3:8b", testProviderConfig())
+	if err != nil {
+		t.Fatalf("NewProviderWithGenerator: %v", err)
+	}
+	resp, err := p.Complete(context.Background(), FIMRequest{
+		Prefix:   "func add(a, b int) int {\n\t",
+		Suffix:   "\n}",
+		FilePath: "math.go",
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if !gen.called {
+		t.Fatal("Generator.Generate was not invoked")
+	}
+	if got := gen.lastReq.Model; got != "qwen3:8b" {
+		t.Errorf("GenerateRequest.Model = %q, want %q", got, "qwen3:8b")
+	}
+	if gen.lastReq.Suffix != "\n}" {
+		t.Errorf("GenerateRequest.Suffix = %q, want %q", gen.lastReq.Suffix, "\n}")
+	}
+	if gen.lastReq.NumCtx <= 0 {
+		t.Errorf("GenerateRequest.NumCtx = %d, want > 0 (planRequest must populate)", gen.lastReq.NumCtx)
+	}
+	if gen.lastReq.NumPredict <= 0 {
+		t.Errorf("GenerateRequest.NumPredict = %d, want > 0", gen.lastReq.NumPredict)
+	}
+	if resp.Completion != "return a + b" {
+		t.Errorf("Completion = %q, want %q", resp.Completion, "return a + b")
+	}
+	if resp.Tokens != 4 {
+		t.Errorf("Tokens = %d, want 4", resp.Tokens)
+	}
+}
+
+// TestProvider_CompleteStreamSuppressesStopTokensAcrossChunks proves the
+// trailing-buffer logic surfaces stop-stripped tokens to fn even when the
+// upstream stream splits a stop token across chunk boundaries — the
+// existing TestCompleteStreamUsesGeneratorRequestPlan covers the "stop
+// token arrives in a single chunk" case; this test covers the harder
+// "stop token straddles two chunks" case.
+func TestProvider_CompleteStreamSuppressesStopTokensAcrossChunks(t *testing.T) {
+	gen := &fakeGenerator{
+		chunks: []GenerateChunk{
+			{Response: "return ", Done: false},
+			{Response: "1<|", Done: false},
+			{Response: "endoftext|>", Done: true},
+		},
+		result: GenerateResult{Response: "return 1<|endoftext|>", Tokens: 4, Model: "qwen3:8b", Provider: "ollama"},
+	}
+	cfg := testProviderConfig()
+	p, err := NewProviderWithGenerator(gen, "qwen3:8b", cfg)
+	if err != nil {
+		t.Fatalf("NewProviderWithGenerator: %v", err)
+	}
+	var emitted []string
+	if err := p.CompleteStream(context.Background(), FIMRequest{
+		Prefix:   "func add(a, b int) int {\n\t",
+		Suffix:   "\n}",
+		FilePath: "math.go",
+	}, func(token string) error {
+		emitted = append(emitted, token)
+		return nil
+	}); err != nil {
+		t.Fatalf("CompleteStream: %v", err)
+	}
+	joined := strings.Join(emitted, "")
+	if strings.Contains(joined, "<|endoftext|>") {
+		t.Fatalf("emitted contained literal stop token: %q", joined)
+	}
+	if !strings.Contains(joined, "return 1") {
+		t.Errorf("emitted = %q, want substring %q", joined, "return 1")
+	}
+}
+
+func TestProvider_CompleteWithGeneratorRejectsNilGenerator(t *testing.T) {
+	// NewProvider(nil, ...) preserves the legacy nil-client compat path
+	// (generatorFromOllamaClient(nil) returns a nil Generator); Complete
+	// must reject with "generator is required" when the field is nil.
+	p, err := NewProvider(nil, "qwen3:8b", testProviderConfig())
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	_, err = p.Complete(context.Background(), FIMRequest{Prefix: "x", Suffix: "y"})
+	if err == nil || !strings.Contains(err.Error(), "generator is required") {
+		t.Fatalf("Complete error = %v, want substring %q", err, "generator is required")
+	}
+}
+
+func TestProvider_CompleteStreamWithGeneratorRejectsNilCallback(t *testing.T) {
+	gen := &fakeGenerator{}
+	p, err := NewProviderWithGenerator(gen, "qwen3:8b", testProviderConfig())
+	if err != nil {
+		t.Fatalf("NewProviderWithGenerator: %v", err)
+	}
+	if err := p.CompleteStream(context.Background(), FIMRequest{Prefix: "x", Suffix: "y"}, nil); err == nil {
+		t.Fatal("CompleteStream with nil callback error = nil, want non-nil")
+	}
+	if gen.streamCalled {
+		t.Error("Generator.GenerateStream invoked despite nil callback")
+	}
+}
+
+// TestProvider_CompleteStreamWithResult_ReturnsAggregatedResult proves the
+// additive entry point captures and returns the underlying Generator's
+// aggregated GenerateResult — Tokens, Model, Provider, and the route
+// metadata (Outcome) on success. CompleteStream(...) error preserves
+// backwards compatibility but discards this; CompleteStreamWithResult
+// surfaces it for #82 drift telemetry consumers.
+func TestProvider_CompleteStreamWithResult_ReturnsAggregatedResult(t *testing.T) {
+	wantResult := GenerateResult{
+		Response: "fmt.Println()",
+		Tokens:   5,
+		Model:    "qwen3:8b",
+		Provider: "ollama",
+	}
+	gen := &fakeGenerator{
+		chunks: []GenerateChunk{
+			{Response: "fmt.", Done: false},
+			{Response: "Println()", Done: true},
+		},
+		result: wantResult,
+	}
+	p, err := NewProviderWithGenerator(gen, "qwen3:8b", testProviderConfig())
+	if err != nil {
+		t.Fatalf("NewProviderWithGenerator: %v", err)
+	}
+	var emitted []string
+	got, err := p.CompleteStreamWithResult(context.Background(), FIMRequest{
+		Prefix: "func main() {\n\t",
+		Suffix: "\n}",
+	}, func(token string) error {
+		emitted = append(emitted, token)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("CompleteStreamWithResult: %v", err)
+	}
+	if got.Response != wantResult.Response {
+		t.Errorf("Response = %q, want %q", got.Response, wantResult.Response)
+	}
+	if got.Tokens != wantResult.Tokens {
+		t.Errorf("Tokens = %d, want %d", got.Tokens, wantResult.Tokens)
+	}
+	if got.Model != wantResult.Model {
+		t.Errorf("Model = %q, want %q", got.Model, wantResult.Model)
+	}
+	if got.Provider != wantResult.Provider {
+		t.Errorf("Provider = %q, want %q", got.Provider, wantResult.Provider)
+	}
+	// The aggregated chunk content the user fn observed should match the
+	// chunks the fake fed in (no stop-token suppression in this test
+	// because the fake's chunks contain none).
+	if want := "fmt.Println()"; strings.Join(emitted, "") != want {
+		t.Errorf("emitted joined = %q, want %q", strings.Join(emitted, ""), want)
+	}
+}
+
+// TestProvider_CompleteStreamWithResult_PropagatesOutcomeVerbatim asserts
+// the structured RouteOutcome the underlying Generator places on its
+// GenerateResult reaches the CompleteStreamWithResult caller unmodified.
+// This is the seam #82 drift telemetry consumes.
+func TestProvider_CompleteStreamWithResult_PropagatesOutcomeVerbatim(t *testing.T) {
+	wantOutcome := &RouteOutcome{
+		RouteHint:     "fake/qwen3:8b",
+		PlannedModel:  "fake/qwen3:8b",
+		Score:         1.5,
+		FallbacksUsed: 2,
+		WasSticky:     true,
+	}
+	gen := &fakeGenerator{
+		chunks: []GenerateChunk{{Response: "ok", Done: true}},
+		result: GenerateResult{
+			Response: "ok",
+			Tokens:   1,
+			Model:    "qwen3:8b",
+			Provider: "fake",
+			Outcome:  wantOutcome,
+		},
+	}
+	p, err := NewProviderWithGenerator(gen, "qwen3:8b", testProviderConfig())
+	if err != nil {
+		t.Fatalf("NewProviderWithGenerator: %v", err)
+	}
+	got, err := p.CompleteStreamWithResult(context.Background(), FIMRequest{
+		Prefix: "x",
+		Suffix: "y",
+	}, func(string) error { return nil })
+	if err != nil {
+		t.Fatalf("CompleteStreamWithResult: %v", err)
+	}
+	if got.Outcome == nil {
+		t.Fatal("got.Outcome is nil; CompleteStreamWithResult must propagate Outcome verbatim")
+	}
+	if got.Outcome != wantOutcome {
+		t.Errorf("got.Outcome = %+v, want pointer-equal to %+v (must be verbatim, no copy/translate)", got.Outcome, wantOutcome)
+	}
+}
+
+// TestProvider_CompleteStreamWithResult_NilOutcomeWhenGeneratorOmitsIt
+// asserts the legacy ollama-adapter shape (Outcome nil) round-trips
+// unchanged — CompleteStreamWithResult does NOT synthesize a placeholder
+// Outcome from Model/Provider when the underlying Generator returns nil.
+// Keeping nil-as-nil is the explicit signal "no router-side metadata
+// available" that downstream telemetry consumers (#82) rely on.
+func TestProvider_CompleteStreamWithResult_NilOutcomeWhenGeneratorOmitsIt(t *testing.T) {
+	gen := &fakeGenerator{
+		chunks: []GenerateChunk{{Response: "ok", Done: true}},
+		result: GenerateResult{
+			Response: "ok",
+			Tokens:   1,
+			Model:    "qwen3:8b",
+			Provider: "ollama",
+			// Outcome intentionally nil — the legacy adapter shape.
+		},
+	}
+	p, err := NewProviderWithGenerator(gen, "qwen3:8b", testProviderConfig())
+	if err != nil {
+		t.Fatalf("NewProviderWithGenerator: %v", err)
+	}
+	got, err := p.CompleteStreamWithResult(context.Background(), FIMRequest{
+		Prefix: "x",
+		Suffix: "y",
+	}, func(string) error { return nil })
+	if err != nil {
+		t.Fatalf("CompleteStreamWithResult: %v", err)
+	}
+	if got.Outcome != nil {
+		t.Errorf("got.Outcome = %+v, want nil (legacy ollama-adapter shape must round-trip unchanged)", got.Outcome)
+	}
+	if got.Model != "qwen3:8b" {
+		t.Errorf("got.Model = %q, want qwen3:8b (Model must still be populated even when Outcome is nil)", got.Model)
+	}
+}
+
+// TestProvider_CompleteStream_ChunkParityWithCompleteStreamWithResult
+// proves the two streaming entry points produce byte-identical fn-observed
+// chunk sequences for the same fake-Generator input. This is the
+// structural guarantee that legacy callers and Outcome-aware callers see
+// identical streams; only the post-stream return value differs.
+func TestProvider_CompleteStream_ChunkParityWithCompleteStreamWithResult(t *testing.T) {
+	chunks := []GenerateChunk{
+		{Response: "fmt.", Done: false},
+		{Response: "Println(\"hi\")", Done: false},
+		{Response: "<|endoftext|>", Done: true},
+	}
+	result := GenerateResult{Response: "fmt.Println(\"hi\")<|endoftext|>", Tokens: 3, Model: "qwen3:8b", Provider: "ollama"}
+
+	collect := func(t *testing.T, run func(p *Provider, fn func(token string) error) error) []string {
+		t.Helper()
+		gen := &fakeGenerator{
+			chunks: append([]GenerateChunk(nil), chunks...), // fresh per run; stop-suppression mutates buffer
+			result: result,
+		}
+		p, err := NewProviderWithGenerator(gen, "qwen3:8b", testProviderConfig())
+		if err != nil {
+			t.Fatalf("NewProviderWithGenerator: %v", err)
+		}
+		var got []string
+		if err := run(p, func(token string) error {
+			got = append(got, token)
+			return nil
+		}); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		return got
+	}
+
+	gotLegacy := collect(t, func(p *Provider, fn func(token string) error) error {
+		return p.CompleteStream(context.Background(), FIMRequest{Prefix: "x", Suffix: "y"}, fn)
+	})
+	gotResult := collect(t, func(p *Provider, fn func(token string) error) error {
+		_, err := p.CompleteStreamWithResult(context.Background(), FIMRequest{Prefix: "x", Suffix: "y"}, fn)
+		return err
+	})
+
+	if strings.Join(gotLegacy, "") != strings.Join(gotResult, "") {
+		t.Errorf("chunk-byte parity violated:\n  CompleteStream           emitted = %q\n  CompleteStreamWithResult emitted = %q",
+			strings.Join(gotLegacy, ""), strings.Join(gotResult, ""))
+	}
+	// Both must also produce stop-stripped output (no leak across the
+	// buffer boundary).
+	for _, joined := range []string{strings.Join(gotLegacy, ""), strings.Join(gotResult, "")} {
+		if strings.Contains(joined, "<|endoftext|>") {
+			t.Errorf("emitted contained literal stop token: %q", joined)
+		}
+	}
+}

--- a/completion/provider_generator_test.go
+++ b/completion/provider_generator_test.go
@@ -245,6 +245,61 @@ func TestProvider_CompleteStreamWithResult_NilOutcomeWhenGeneratorOmitsIt(t *tes
 	}
 }
 
+// TestProvider_CompleteStreamWithResult_ResponseStopsStripped proves that
+// CompleteStreamWithResult.Response is the byte concatenation of the
+// stop-stripped tokens fn observed, NOT the raw backend payload the
+// underlying Generator returned. Without this guarantee, callers would
+// see a Response containing literal stop tokens (e.g. "<|endoftext|>")
+// even though fn was correctly stripped — two inconsistent views of the
+// same stream. This is the post-fix invariant for the P2 review finding
+// on inline.go's completeStream.
+func TestProvider_CompleteStreamWithResult_ResponseStopsStripped(t *testing.T) {
+	cfg := testProviderConfig()
+	// Sanity: the fixture must declare a stop token, otherwise the
+	// stripping path is never exercised and this test would tautologically
+	// pass.
+	if len(cfg.FIM.StopTokens) == 0 {
+		t.Fatal("testProviderConfig().FIM.StopTokens must be non-empty for this test to be meaningful")
+	}
+	stop := cfg.FIM.StopTokens[0]
+
+	gen := &fakeGenerator{
+		// Chunks split the stop token across boundaries to also exercise
+		// the trailing-buffer logic.
+		chunks: []GenerateChunk{
+			{Response: "fmt.", Done: false},
+			{Response: "Println()" + stop[:2], Done: false},
+			{Response: stop[2:], Done: true},
+		},
+		// The fake's raw result.Response carries the stop token exactly
+		// like Ollama would; if completeStream returned this verbatim,
+		// callers would observe a leak.
+		result: GenerateResult{
+			Response: "fmt.Println()" + stop,
+			Tokens:   3,
+			Model:    "qwen3:8b",
+			Provider: "ollama",
+		},
+	}
+	p, err := NewProviderWithGenerator(gen, "qwen3:8b", cfg)
+	if err != nil {
+		t.Fatalf("NewProviderWithGenerator: %v", err)
+	}
+	got, err := p.CompleteStreamWithResult(context.Background(), FIMRequest{
+		Prefix: "func main() {\n\t",
+		Suffix: "\n}",
+	}, func(string) error { return nil })
+	if err != nil {
+		t.Fatalf("CompleteStreamWithResult: %v", err)
+	}
+	if strings.Contains(got.Response, stop) {
+		t.Errorf("Response = %q contains literal stop token %q; CompleteStreamWithResult must return the stop-stripped aggregate", got.Response, stop)
+	}
+	if want := "fmt.Println()"; got.Response != want {
+		t.Errorf("Response = %q, want %q (cleaned aggregate matching fn-observed bytes)", got.Response, want)
+	}
+}
+
 // TestProvider_CompleteStream_ChunkParityWithCompleteStreamWithResult
 // proves the two streaming entry points produce byte-identical fn-observed
 // chunk sequences for the same fake-Generator input. This is the

--- a/mcp/fim_via_router_integration_test.go
+++ b/mcp/fim_via_router_integration_test.go
@@ -1,0 +1,143 @@
+//go:build integration
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/completion"
+	"github.com/kstruzzieri/go-llm/ollama"
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// TestFIMViaRouter_Smoke is the end-to-end falsifiable smoke test for the
+// FIM-via-Router wiring: it constructs a real *Server, wraps the live
+// router engine in a recording shim, drives newCompletionProvider through
+// to Complete against a real Ollama instance, and asserts the routing
+// trail (UseCase = "fim", RequiredCaps include CapInsert, Model pinned
+// per the FIM-pin policy, Priority forwarded as PriorityHigh).
+//
+// Skip semantics:
+//   - OLLAMA_FIM_INTEGRATION_MODEL unset → skip with explicit reason.
+//   - Ollama unreachable at OLLAMA_URL (or default) → skip with explicit
+//     reachability message.
+//   - Server lacks a router (e.g., NewServer fell back to single-provider
+//     mode due to an unusual config) → skip with explicit unavailability
+//     message.
+//
+// No unconditional skip is allowed: every skip path documents WHY.
+func TestFIMViaRouter_Smoke(t *testing.T) {
+	ctx := context.Background()
+	url := os.Getenv("OLLAMA_URL")
+	if url == "" {
+		url = defaultOllamaURL
+	}
+	model := os.Getenv("OLLAMA_FIM_INTEGRATION_MODEL")
+	if model == "" {
+		t.Skip("OLLAMA_FIM_INTEGRATION_MODEL not set; skip (set to a native-FIM model such as qwen3-coder-next:latest)")
+	}
+
+	client := ollama.NewClient(ollama.WithBaseURL(url), ollama.WithTimeout(30*time.Second))
+	if !client.IsAvailable(ctx) {
+		t.Skipf("Ollama not reachable at %s; skip", url)
+	}
+
+	cfgPath := writeFIMIntegrationConfig(t, t.TempDir(), url, model)
+	s, err := NewServer(ctx, WithConfig(cfgPath), WithRAGDisabled())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	inner := s.routerSnapshot()
+	if inner == nil {
+		t.Skip("router unavailable; skip (NewServer did not wire a routeEngine — likely a single-provider degraded mode)")
+	}
+	rec := &recordingRealRouteEngine{inner: inner}
+	s.mu.Lock()
+	s.router = rec
+	s.mu.Unlock()
+
+	p, err := s.newCompletionProvider(ctx, model)
+	if err != nil {
+		t.Fatalf("newCompletionProvider: %v", err)
+	}
+	// MaxTokens=8 is intentionally small — the smoke test only needs the
+	// routing path to fire and stamp rec.last; we don't assert anything
+	// about completion content. A small budget keeps the test fast even
+	// when the integration model has a slow cold-start.
+	if _, err := p.Complete(ctx, completion.FIMRequest{
+		Prefix:    "func add(a, b int) int {\n\treturn ",
+		Suffix:    "\n}",
+		FilePath:  "math.go",
+		MaxTokens: 8,
+	}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if !rec.called {
+		t.Fatal("router was not invoked")
+	}
+	if rec.last.UseCase != "fim" {
+		t.Errorf("UseCase = %q, want fim", rec.last.UseCase)
+	}
+	wantCaps := provider.CapGenerate | provider.CapInsert
+	if rec.last.RequiredCaps != wantCaps {
+		t.Errorf("RequiredCaps = %v, want %v", rec.last.RequiredCaps, wantCaps)
+	}
+	if rec.last.Model != model {
+		t.Errorf("Model = %q, want %q", rec.last.Model, model)
+	}
+	if rec.last.Priority != provider.PriorityHigh {
+		t.Errorf("Priority = %v, want %v", rec.last.Priority, provider.PriorityHigh)
+	}
+}
+
+// recordingRealRouteEngine wraps a real routeEngine and captures the
+// last RoutingRequest it observed, while still delegating execution to
+// the wrapped engine. Used to assert routing-shape invariants
+// end-to-end without bypassing the real Router's plan construction.
+//
+// Single-call fixture: last and called are written without a mutex.
+// The current smoke test issues exactly one Complete call. A future
+// test that exercises concurrent FIM completions through this wrapper
+// must add its own synchronization or use a different fixture.
+type recordingRealRouteEngine struct {
+	inner  routeEngine
+	last   provider.RoutingRequest
+	called bool
+}
+
+func (r *recordingRealRouteEngine) Route(ctx context.Context, req provider.RoutingRequest) (*provider.RoutePlan, error) {
+	r.last = req
+	r.called = true
+	return r.inner.Route(ctx, req)
+}
+func (r *recordingRealRouteEngine) Close() error { return r.inner.Close() }
+func (r *recordingRealRouteEngine) BreakerInfo(name string) (provider.BreakerInfo, bool) {
+	return r.inner.BreakerInfo(name)
+}
+func (r *recordingRealRouteEngine) WarmthSnapshot() []provider.WarmModel {
+	return r.inner.WarmthSnapshot()
+}
+func (r *recordingRealRouteEngine) StickyRoutes() map[string]provider.StickyRouteInfo {
+	return r.inner.StickyRoutes()
+}
+
+func writeFIMIntegrationConfig(t *testing.T, dir, baseURL, model string) string {
+	t.Helper()
+	path := filepath.Join(dir, "models.json")
+	data := fmt.Sprintf(`{
+  "providers": {"ollama": {"base_url": %q, "timeout": "30s"}},
+  "models": {"completion": {"name": %q, "provider": "ollama", "type": "dense"}},
+  "defaults": {"completion": "completion"}
+}`, baseURL, model)
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+	return path
+}

--- a/mcp/generate_helper.go
+++ b/mcp/generate_helper.go
@@ -74,6 +74,18 @@ func (s *Server) routedGenerate(ctx context.Context, req completion.GenerateRequ
 		return nil, routedGenerateError{category: generateToolConfig, err: fmt.Errorf("router unavailable")}
 	}
 	requiredCaps := provider.CapGenerate | provider.CapInsert | extraCaps
+	// ExpectedOutput tracks the actual planned NumPredict so Router scoring
+	// and budget gating reflect this request's real output budget, not the
+	// generic 200-token "fim" default. Provider.planRequest already trims
+	// NumPredict for tight contexts; passing the static default would
+	// cause Router to over-reserve and either mis-score or reject requests
+	// that would otherwise fit. Falls back to the use-case default only
+	// when NumPredict is unset (zero) — primarily a defensive case since
+	// the empty-model rejection above already covers most malformed input.
+	expectedOutput := req.NumPredict
+	if expectedOutput <= 0 {
+		expectedOutput = provider.DefaultExpectedOutput("fim")
+	}
 	rr := provider.RoutingRequest{
 		Model:        req.Model,
 		UseCase:      "fim",
@@ -90,7 +102,7 @@ func (s *Server) routedGenerate(ctx context.Context, req completion.GenerateRequ
 			NumCtx:      req.NumCtx,
 			Stop:        req.Stop,
 		},
-		ExpectedOutput: provider.DefaultExpectedOutput("fim"),
+		ExpectedOutput: expectedOutput,
 		Priority:       priority,
 		// PreferredChain intentionally left empty — see FIM pinning policy.
 	}

--- a/mcp/generate_helper.go
+++ b/mcp/generate_helper.go
@@ -221,6 +221,15 @@ func (g *mcpFIMGenerator) Generate(ctx context.Context, req completion.GenerateR
 	if err != nil {
 		return completion.GenerateResult{}, routedGenerateError{category: generateToolOllama, err: err}
 	}
+	// Defensive nil-check: provider contract requires non-nil resp on nil err,
+	// but a buggy provider implementation could violate it; surface a clear
+	// error rather than letting resultFromGenerateResponse nil-deref.
+	if resp == nil {
+		return completion.GenerateResult{}, routedGenerateError{
+			category: generateToolOllama,
+			err:      fmt.Errorf("fim: provider returned nil response with no error"),
+		}
+	}
 	return resultFromGenerateResponse(resp, req), nil
 }
 

--- a/mcp/generate_helper.go
+++ b/mcp/generate_helper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/kstruzzieri/go-llm/completion"
 	"github.com/kstruzzieri/go-llm/provider"
@@ -180,4 +181,80 @@ func translateRouteOutcome(o *provider.RouteOutcome) *completion.RouteOutcome {
 		FallbacksUsed: o.FallbacksUsed,
 		WasSticky:     o.WasSticky,
 	}
+}
+
+// fimGenerator returns a completion.Generator that routes FIM completions
+// through provider.Router via s.routedGenerate at the supplied priority. FIM
+// completions are user-facing keystroke-driven traffic; production wiring
+// (newCompletionProvider in mcp/server.go) supplies s.fimPriority() which
+// defaults to provider.PriorityHigh.
+//
+// Both Generator methods pin the resolved model end-to-end (no
+// PreferredChain), so Router cannot substitute across FIM-family boundaries.
+// Cross-family fallback is deferred to a future ticket.
+func (s *Server) fimGenerator(priority provider.Priority) completion.Generator {
+	return &mcpFIMGenerator{server: s, priority: priority}
+}
+
+// mcpFIMGenerator is the concrete completion.Generator wired into the MCP
+// server. Unexported because external consumers wanting a router-aware
+// generator should construct their own implementation against the
+// completion.Generator interface; this type is an MCP wiring detail.
+//
+// Safe for concurrent use: routedGenerate snapshots the router under a read
+// lock per call, RoutePlan execution is itself concurrent-safe, and the
+// closure holds no mutable per-instance state beyond the immutable Server
+// pointer and priority. Within a single GenerateStream call, fn is invoked
+// serially from a single goroutine — Provider.completeStream's stop-token
+// suppression buffer relies on this contract (see Generator interface).
+type mcpFIMGenerator struct {
+	server   *Server
+	priority provider.Priority
+}
+
+func (g *mcpFIMGenerator) Generate(ctx context.Context, req completion.GenerateRequest) (completion.GenerateResult, error) {
+	plan, err := g.server.routedGenerate(ctx, req, g.priority, 0)
+	if err != nil {
+		return completion.GenerateResult{}, err
+	}
+	resp, err := plan.ExecuteGenerate(ctx)
+	if err != nil {
+		return completion.GenerateResult{}, routedGenerateError{category: generateToolOllama, err: err}
+	}
+	return resultFromGenerateResponse(resp, req), nil
+}
+
+func (g *mcpFIMGenerator) GenerateStream(ctx context.Context, req completion.GenerateRequest, fn func(completion.GenerateChunk) error) (completion.GenerateResult, error) {
+	if fn == nil {
+		return completion.GenerateResult{}, routedGenerateError{
+			category: generateToolConfig,
+			err:      fmt.Errorf("fim: GenerateStream callback is required"),
+		}
+	}
+	plan, err := g.server.routedGenerate(ctx, req, g.priority, provider.CapStream)
+	if err != nil {
+		return completion.GenerateResult{}, err
+	}
+	var (
+		full    strings.Builder
+		tokens  int
+		outcome *provider.RouteOutcome
+	)
+	streamErr := plan.ExecuteGenerateStream(ctx, func(chunk provider.GenerateResponse) error {
+		full.WriteString(chunk.Response)
+		// Cumulative max: providers (notably Ollama) only stamp Usage on the
+		// terminal chunk, but a future provider could stream incremental
+		// Usage updates — taking the max preserves correctness either way.
+		if chunk.Usage.CompletionTokens > tokens {
+			tokens = chunk.Usage.CompletionTokens
+		}
+		if chunk.RouteOutcome != nil {
+			outcome = chunk.RouteOutcome
+		}
+		return fn(completion.GenerateChunk{Response: chunk.Response, Done: chunk.Done})
+	})
+	if streamErr != nil {
+		return completion.GenerateResult{}, routedGenerateError{category: generateToolOllama, err: streamErr}
+	}
+	return resultFromAggregatedStream(full.String(), tokens, outcome, req), nil
 }

--- a/mcp/generate_helper.go
+++ b/mcp/generate_helper.go
@@ -1,0 +1,183 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/kstruzzieri/go-llm/completion"
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// generateToolCategory enumerates the error-category strings used by the
+// FIM-via-Router helper. Centralised so callers can reason about
+// categorisation without string matching.
+type generateToolCategory string
+
+const (
+	generateToolConfig generateToolCategory = "config"
+	generateToolRouter generateToolCategory = "router"
+	generateToolOllama generateToolCategory = "ollama"
+)
+
+// routedGenerateError wraps a routing or execution error with a category.
+// Callers extract the category via routedGenerateCategory; unwrapping yields
+// the underlying error for normal error inspection (errors.Is / errors.As
+// against the wrapped cause).
+type routedGenerateError struct {
+	category generateToolCategory
+	err      error
+}
+
+func (e routedGenerateError) Error() string { return e.err.Error() }
+func (e routedGenerateError) Unwrap() error { return e.err }
+
+// routedGenerateCategory extracts the generateToolCategory from any error
+// returned by the FIM-via-Router helper or fimGenerator. Errors not wrapping
+// routedGenerateError are categorised as "ollama" (the most conservative —
+// assume backend execution failed).
+func routedGenerateCategory(err error) generateToolCategory {
+	var re routedGenerateError
+	if errors.As(err, &re) {
+		return re.category
+	}
+	return generateToolOllama
+}
+
+// routedGenerate plans a FIM-shaped generate routing request and returns the
+// executable RoutePlan. It does not execute the plan — callers branch on
+// streaming vs non-streaming via plan.ExecuteGenerate or
+// plan.ExecuteGenerateStream so request shaping stays shared while each
+// branch can supply its required capability mask.
+//
+// FIM pinning policy: the resolved model is mandatory and PreferredChain is
+// intentionally never set, so Router cannot substitute across FIM-family
+// boundaries. Native prompt+suffix insert uses provider/model template
+// semantics rather than client-side marker assembly, but compatibility is
+// still model-family-specific; cross-family fallback therefore requires
+// route-after-template or compatibility-class routing and is deferred to a
+// future ticket.
+//
+// extraCaps lets callers layer transport-specific requirements onto the
+// common FIM gate. Non-streaming calls pass 0; streaming calls pass
+// provider.CapStream.
+func (s *Server) routedGenerate(ctx context.Context, req completion.GenerateRequest, priority provider.Priority, extraCaps provider.Capability) (*provider.RoutePlan, error) {
+	if req.Model == "" {
+		return nil, routedGenerateError{
+			category: generateToolConfig,
+			err:      fmt.Errorf("fim: generator requires explicit model to prevent FIM-family token-template mismatch"),
+		}
+	}
+	router := s.routerSnapshot()
+	if router == nil {
+		return nil, routedGenerateError{category: generateToolConfig, err: fmt.Errorf("router unavailable")}
+	}
+	requiredCaps := provider.CapGenerate | provider.CapInsert | extraCaps
+	rr := provider.RoutingRequest{
+		Model:        req.Model,
+		UseCase:      "fim",
+		RequiredCaps: requiredCaps,
+		Prompt:       req.Prompt,
+		Suffix:       req.Suffix,
+		Options: provider.ModelOptions{
+			// provider.Ptr ensures literal-zero temperatures (FIM uses 0.0
+			// for deterministic completions in import blocks) round-trip as
+			// a non-nil pointer rather than being lost as "unset" through
+			// the *float64/omitempty encoding.
+			Temperature: provider.Ptr(req.Temperature),
+			NumPredict:  req.NumPredict,
+			NumCtx:      req.NumCtx,
+			Stop:        req.Stop,
+		},
+		ExpectedOutput: provider.DefaultExpectedOutput("fim"),
+		Priority:       priority,
+		// PreferredChain intentionally left empty — see FIM pinning policy.
+	}
+	plan, err := router.Route(ctx, rr)
+	if err != nil {
+		return nil, routedGenerateError{category: generateToolRouter, err: err}
+	}
+	return plan, nil
+}
+
+// resultFromGenerateResponse maps a *provider.GenerateResponse into the
+// completion seam's GenerateResult, backfilling Model and Provider from
+// RouteOutcome when the immediate response leaves them empty (e.g. when the
+// Router answered via fallback and the provider response carried only the
+// fallback's payload without re-stamping the top-level identity). When
+// neither resp.Model nor resp.RouteOutcome carries the model identity,
+// out.Model falls back to req.Model so the FIM-pin propagates consistently
+// with resultFromAggregatedStream.
+func resultFromGenerateResponse(resp *provider.GenerateResponse, req completion.GenerateRequest) completion.GenerateResult {
+	out := completion.GenerateResult{
+		Response: resp.Response,
+		Tokens:   resp.Usage.CompletionTokens,
+		Model:    resp.Model,
+		Provider: resp.Provider,
+	}
+	if resp.RouteOutcome != nil {
+		if out.Model == "" {
+			out.Model = resp.RouteOutcome.ActualModel.Model
+		}
+		if out.Provider == "" {
+			out.Provider = resp.RouteOutcome.ActualModel.Provider
+		}
+		out.Outcome = translateRouteOutcome(resp.RouteOutcome)
+	}
+	if out.Model == "" {
+		out.Model = req.Model
+	}
+	return out
+}
+
+// resultFromAggregatedStream builds a GenerateResult after streaming
+// completion. The full Response is the concatenation of all chunk Response
+// strings; Tokens and Outcome are taken from the last chunk that surfaced
+// route metadata. When no router-side metadata is available (ExecuteGenerate
+// for a provider that doesn't populate RouteOutcome), Model falls back to the
+// request's pinned model so callers see consistent provenance.
+func resultFromAggregatedStream(full string, tokens int, outcome *provider.RouteOutcome, req completion.GenerateRequest) completion.GenerateResult {
+	out := completion.GenerateResult{
+		Response: full,
+		Tokens:   tokens,
+	}
+	if outcome != nil {
+		out.Model = outcome.ActualModel.Model
+		out.Provider = outcome.ActualModel.Provider
+		out.Outcome = translateRouteOutcome(outcome)
+	} else {
+		out.Model = req.Model
+	}
+	return out
+}
+
+// translateRouteOutcome maps provider.RouteOutcome to the consumer-owned
+// completion.RouteOutcome shape.
+//
+// RouteHint prefers the provider-authored Reason ("breaker-open on candidate
+// 1, fell through to qwen3:8b") because it is more diagnostic than a
+// synthesized model string; falls back to ActualModel.String() when Reason
+// is empty. PlannedModel is rendered via ModelKey.String() so downstream
+// telemetry can compare it to GenerateResult.Model lexically.
+//
+// Score, FallbacksUsed, and WasSticky are copied verbatim — these are the
+// load-bearing structured fields for #82 drift telemetry. Warm is not
+// included: warmth is a routing input signal, not an outcome, and querying
+// the warmth tracker at translation time produces a tautological answer
+// (the act of routing makes the model warm).
+func translateRouteOutcome(o *provider.RouteOutcome) *completion.RouteOutcome {
+	if o == nil {
+		return nil
+	}
+	hint := o.Reason
+	if hint == "" {
+		hint = o.ActualModel.String()
+	}
+	return &completion.RouteOutcome{
+		RouteHint:     hint,
+		PlannedModel:  o.PlannedModel.String(),
+		Score:         o.Score,
+		FallbacksUsed: o.FallbacksUsed,
+		WasSticky:     o.WasSticky,
+	}
+}

--- a/mcp/generate_helper_test.go
+++ b/mcp/generate_helper_test.go
@@ -1,0 +1,291 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/completion"
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// fimReqFor constructs a minimal FIM-shaped GenerateRequest for tests. It
+// carries a literal-zero Temperature on purpose — FIM completions in import
+// blocks rely on deterministic decoding, and the provider.Ptr round-trip is
+// tested at TestRoutedGenerate_RoutingRequestShape.
+func fimReqFor(model string) completion.GenerateRequest {
+	return completion.GenerateRequest{
+		Model:       model,
+		Prompt:      "func add(a, b int) int {\n\treturn ",
+		Suffix:      "\n}",
+		Temperature: 0.0,
+		NumPredict:  64,
+		NumCtx:      8192,
+		Stop:        []string{"<|endoftext|>"},
+	}
+}
+
+// newServerWithRouter builds a minimal *Server whose only wired field is the
+// router engine. routedGenerate and the fimGenerator closure consume the
+// router via routerSnapshot, so this is sufficient to exercise the FIM
+// routing semantics without standing up a full provider/registry stack.
+func newServerWithRouter(eng *recordingRouteEngine) *Server {
+	s := &Server{}
+	s.router = eng
+	return s
+}
+
+func TestRoutedGenerate_RejectsEmptyModel(t *testing.T) {
+	eng := newRecordingRouteEngine("done")
+	s := newServerWithRouter(eng)
+	req := fimReqFor("")
+	_, err := s.routedGenerate(context.Background(), req, provider.PriorityHigh, 0)
+	if err == nil {
+		t.Fatal("routedGenerate empty-model error = nil, want non-nil")
+	}
+	if got := routedGenerateCategory(err); got != generateToolConfig {
+		t.Errorf("category = %q, want %q", got, generateToolConfig)
+	}
+	if !strings.Contains(err.Error(), "FIM-family") {
+		t.Errorf("error = %q, want substring %q", err.Error(), "FIM-family")
+	}
+	if eng.called {
+		t.Error("Router.Route invoked despite empty model")
+	}
+}
+
+func TestRoutedGenerate_RouterUnavailable(t *testing.T) {
+	s := &Server{} // router nil
+	_, err := s.routedGenerate(context.Background(), fimReqFor("qwen3:8b"), provider.PriorityHigh, 0)
+	if err == nil {
+		t.Fatal("routedGenerate nil-router error = nil, want non-nil")
+	}
+	if got := routedGenerateCategory(err); got != generateToolConfig {
+		t.Errorf("category = %q, want %q", got, generateToolConfig)
+	}
+}
+
+func TestRoutedGenerate_RoutingRequestShape(t *testing.T) {
+	eng := newRecordingRouteEngine("done")
+	s := newServerWithRouter(eng)
+	req := fimReqFor("qwen3:8b")
+	plan, err := s.routedGenerate(context.Background(), req, provider.PriorityHigh, 0)
+	if err != nil {
+		t.Fatalf("routedGenerate error: %v", err)
+	}
+	if plan == nil {
+		t.Fatal("routedGenerate returned nil plan")
+	}
+	rr := eng.last
+	if rr.Model != "qwen3:8b" {
+		t.Errorf("Model = %q, want %q", rr.Model, "qwen3:8b")
+	}
+	if rr.UseCase != "fim" {
+		t.Errorf("UseCase = %q, want %q", rr.UseCase, "fim")
+	}
+	want := provider.CapGenerate | provider.CapInsert
+	if rr.RequiredCaps != want {
+		t.Errorf("RequiredCaps = %v, want %v", rr.RequiredCaps, want)
+	}
+	if rr.Suffix != req.Suffix {
+		t.Errorf("Suffix = %q, want %q", rr.Suffix, req.Suffix)
+	}
+	if rr.Prompt != req.Prompt {
+		t.Errorf("Prompt = %q, want %q", rr.Prompt, req.Prompt)
+	}
+	if rr.Priority != provider.PriorityHigh {
+		t.Errorf("Priority = %v, want %v", rr.Priority, provider.PriorityHigh)
+	}
+	if len(rr.PreferredChain) != 0 {
+		t.Errorf("PreferredChain = %v, want empty (FIM pin policy)", rr.PreferredChain)
+	}
+	if rr.ExpectedOutput != provider.DefaultExpectedOutput("fim") {
+		t.Errorf("ExpectedOutput = %d, want %d", rr.ExpectedOutput, provider.DefaultExpectedOutput("fim"))
+	}
+	if rr.Options.Temperature == nil {
+		t.Fatal("Options.Temperature is nil, want non-nil pointer (FIM uses literal-zero temperature)")
+	}
+	if got := *rr.Options.Temperature; got != req.Temperature {
+		t.Errorf("Options.Temperature = %v, want %v", got, req.Temperature)
+	}
+	if rr.Options.NumPredict != req.NumPredict {
+		t.Errorf("Options.NumPredict = %d, want %d", rr.Options.NumPredict, req.NumPredict)
+	}
+	if rr.Options.NumCtx != req.NumCtx {
+		t.Errorf("Options.NumCtx = %d, want %d", rr.Options.NumCtx, req.NumCtx)
+	}
+}
+
+func TestRoutedGenerate_StreamingAddsCapStream(t *testing.T) {
+	eng := newRecordingRouteEngine("done")
+	s := newServerWithRouter(eng)
+	_, err := s.routedGenerate(context.Background(), fimReqFor("qwen3:8b"), provider.PriorityHigh, provider.CapStream)
+	if err != nil {
+		t.Fatalf("routedGenerate error: %v", err)
+	}
+	want := provider.CapGenerate | provider.CapInsert | provider.CapStream
+	if eng.last.RequiredCaps != want {
+		t.Errorf("RequiredCaps = %v, want %v", eng.last.RequiredCaps, want)
+	}
+}
+
+func TestRoutedGenerate_PriorityForwarded(t *testing.T) {
+	for _, p := range []provider.Priority{provider.PriorityNormal, provider.PriorityHigh, provider.PriorityCritical} {
+		t.Run(p.String(), func(t *testing.T) {
+			eng := newRecordingRouteEngine("done")
+			s := newServerWithRouter(eng)
+			if _, err := s.routedGenerate(context.Background(), fimReqFor("qwen3:8b"), p, 0); err != nil {
+				t.Fatalf("routedGenerate error: %v", err)
+			}
+			if eng.last.Priority != p {
+				t.Errorf("Priority = %v, want %v", eng.last.Priority, p)
+			}
+		})
+	}
+}
+
+func TestRoutedGenerate_RouteErrorCategorised(t *testing.T) {
+	eng := newRecordingRouteEngine("done")
+	eng.routeErr = errors.New("no candidates")
+	s := newServerWithRouter(eng)
+	_, err := s.routedGenerate(context.Background(), fimReqFor("qwen3:8b"), provider.PriorityHigh, 0)
+	if err == nil {
+		t.Fatal("routedGenerate route-error = nil, want non-nil")
+	}
+	if got := routedGenerateCategory(err); got != generateToolRouter {
+		t.Errorf("category = %q, want %q", got, generateToolRouter)
+	}
+	if !errors.Is(err, eng.routeErr) {
+		t.Errorf("Unwrap chain does not preserve original route error")
+	}
+}
+
+// TestFIMGenerator_GenerateOmitsCapStream asserts the non-streaming closure
+// passes extraCaps = 0 to routedGenerate, leaving CapStream OFF in the
+// recorded RoutingRequest. Spec §6 makes CapStream streaming-only;
+// over-requesting it on Generate would make the Router over-filter.
+func TestFIMGenerator_GenerateOmitsCapStream(t *testing.T) {
+	eng := newRecordingRouteEngine("hello")
+	s := newServerWithRouter(eng)
+	gen := s.fimGenerator(provider.PriorityHigh)
+	res, err := gen.Generate(context.Background(), fimReqFor("qwen3:8b"))
+	if err != nil {
+		t.Fatalf("Generate error: %v", err)
+	}
+	if res.Response != "hello" {
+		t.Errorf("Response = %q, want %q", res.Response, "hello")
+	}
+	if eng.last.Priority != provider.PriorityHigh {
+		t.Errorf("recorded Priority = %v, want PriorityHigh", eng.last.Priority)
+	}
+	wantCaps := provider.CapGenerate | provider.CapInsert
+	if eng.last.RequiredCaps != wantCaps {
+		t.Errorf("Generate RequiredCaps = %v, want %v (must NOT include CapStream)", eng.last.RequiredCaps, wantCaps)
+	}
+	if eng.last.RequiredCaps&provider.CapStream != 0 {
+		t.Errorf("Generate RequiredCaps included CapStream; non-streaming path must pass extraCaps = 0")
+	}
+	// Outcome propagation guard for the structured #82 drift telemetry seam.
+	// recordingRouteEngine's RoutePlan returns a non-nil RouteOutcome on
+	// successful execution (provider/route_plan.go handleResult); a regression
+	// that drops translateRouteOutcome would silently leave Outcome nil here.
+	if res.Outcome == nil {
+		t.Fatal("res.Outcome is nil; mcpFIMGenerator must translate provider.RouteOutcome")
+	}
+	if want := "fake/qwen3:8b"; res.Outcome.PlannedModel != want {
+		t.Errorf("Outcome.PlannedModel = %q, want %q", res.Outcome.PlannedModel, want)
+	}
+}
+
+// TestFIMGenerator_GenerateStreamRequiresCapStream asserts the streaming
+// closure passes extraCaps = provider.CapStream to routedGenerate, and
+// that the chunk stream observed by the user callback is byte-identical
+// to the upstream provider chunk sequence with no wrapping. Together with
+// TestFIMGenerator_GenerateOmitsCapStream this proves the streaming bit
+// is set ONLY by GenerateStream and never leaks into the non-streaming
+// path.
+func TestFIMGenerator_GenerateStreamRequiresCapStream(t *testing.T) {
+	// recordingRouteEngine returns a single-chunk stream by default; the
+	// chunk parity assertion verifies the user-callback sequence is the
+	// same as the upstream provider chunk sequence with no extra wrapping.
+	eng := newRecordingRouteEngine("hello")
+	s := newServerWithRouter(eng)
+	gen := s.fimGenerator(provider.PriorityHigh)
+
+	var (
+		got       []string
+		doneSeen  bool
+		doneCount int
+	)
+	res, err := gen.GenerateStream(context.Background(), fimReqFor("qwen3:8b"), func(ch completion.GenerateChunk) error {
+		got = append(got, ch.Response)
+		if ch.Done {
+			doneSeen = true
+			doneCount++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("GenerateStream error: %v", err)
+	}
+	if want := []string{"hello"}; !equalStrings(got, want) {
+		t.Errorf("chunks = %v, want %v", got, want)
+	}
+	if res.Response != "hello" {
+		t.Errorf("aggregated Response = %q, want %q", res.Response, "hello")
+	}
+	if !doneSeen {
+		t.Error("no chunk with Done=true; Generator contract requires final chunk Done=true on success")
+	}
+	if doneCount != 1 {
+		t.Errorf("Done=true chunks = %d, want exactly 1", doneCount)
+	}
+	wantCaps := provider.CapGenerate | provider.CapInsert | provider.CapStream
+	if eng.last.RequiredCaps != wantCaps {
+		t.Errorf("GenerateStream RequiredCaps = %v, want %v", eng.last.RequiredCaps, wantCaps)
+	}
+	if eng.last.RequiredCaps&provider.CapStream == 0 {
+		t.Errorf("GenerateStream RequiredCaps missing CapStream; streaming path must pass extraCaps = provider.CapStream")
+	}
+	// Outcome propagation guard: ExecuteGenerateStream stamps RouteOutcome on
+	// the terminal Done chunk; mcpFIMGenerator captures it and translates it
+	// into completion.RouteOutcome via resultFromAggregatedStream. A regression
+	// that drops the capture would leave res.Outcome nil silently.
+	if res.Outcome == nil {
+		t.Fatal("res.Outcome is nil; streaming path must capture and translate provider.RouteOutcome from the terminal chunk")
+	}
+	if want := "fake/qwen3:8b"; res.Outcome.PlannedModel != want {
+		t.Errorf("Outcome.PlannedModel = %q, want %q", res.Outcome.PlannedModel, want)
+	}
+}
+
+func TestFIMGenerator_GenerateRejectsEmptyModelEarly(t *testing.T) {
+	eng := newRecordingRouteEngine("done")
+	s := newServerWithRouter(eng)
+	gen := s.fimGenerator(provider.PriorityHigh)
+	_, err := gen.Generate(context.Background(), fimReqFor(""))
+	if err == nil {
+		t.Fatal("Generate empty-model error = nil, want non-nil")
+	}
+	if got := routedGenerateCategory(err); got != generateToolConfig {
+		t.Errorf("category = %q, want %q", got, generateToolConfig)
+	}
+	if eng.called {
+		t.Error("Router.Route invoked despite empty model")
+	}
+}
+
+// equalStrings is redeclared locally to keep mcp tests from depending on
+// completion test fixtures (different package). Trivial slice equality.
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/mcp/generate_helper_test.go
+++ b/mcp/generate_helper_test.go
@@ -100,8 +100,12 @@ func TestRoutedGenerate_RoutingRequestShape(t *testing.T) {
 	if len(rr.PreferredChain) != 0 {
 		t.Errorf("PreferredChain = %v, want empty (FIM pin policy)", rr.PreferredChain)
 	}
-	if rr.ExpectedOutput != provider.DefaultExpectedOutput("fim") {
-		t.Errorf("ExpectedOutput = %d, want %d", rr.ExpectedOutput, provider.DefaultExpectedOutput("fim"))
+	// ExpectedOutput tracks req.NumPredict (the actual planned budget),
+	// not the generic 200-token "fim" default — Router scoring + budget
+	// gating must see the real output budget so tight-context requests
+	// don't get over-reserved or rejected.
+	if rr.ExpectedOutput != req.NumPredict {
+		t.Errorf("ExpectedOutput = %d, want %d (req.NumPredict)", rr.ExpectedOutput, req.NumPredict)
 	}
 	if rr.Options.Temperature == nil {
 		t.Fatal("Options.Temperature is nil, want non-nil pointer (FIM uses literal-zero temperature)")
@@ -115,6 +119,37 @@ func TestRoutedGenerate_RoutingRequestShape(t *testing.T) {
 	if rr.Options.NumCtx != req.NumCtx {
 		t.Errorf("Options.NumCtx = %d, want %d", rr.Options.NumCtx, req.NumCtx)
 	}
+}
+
+// TestRoutedGenerate_ExpectedOutputTracksNumPredict exercises both branches
+// of the expectedOutput selection in routedGenerate: when req.NumPredict is
+// set, it propagates verbatim; when unset (zero), the use-case default
+// (DefaultExpectedOutput("fim") = 200) is the safety fallback.
+func TestRoutedGenerate_ExpectedOutputTracksNumPredict(t *testing.T) {
+	t.Run("explicit NumPredict propagates", func(t *testing.T) {
+		eng := newRecordingRouteEngine("done")
+		s := newServerWithRouter(eng)
+		req := fimReqFor("qwen3:8b")
+		req.NumPredict = 8 // tight-context smoke-test budget
+		if _, err := s.routedGenerate(context.Background(), req, provider.PriorityHigh, 0); err != nil {
+			t.Fatalf("routedGenerate error: %v", err)
+		}
+		if eng.last.ExpectedOutput != 8 {
+			t.Errorf("ExpectedOutput = %d, want 8 (req.NumPredict)", eng.last.ExpectedOutput)
+		}
+	})
+	t.Run("zero NumPredict falls back to use-case default", func(t *testing.T) {
+		eng := newRecordingRouteEngine("done")
+		s := newServerWithRouter(eng)
+		req := fimReqFor("qwen3:8b")
+		req.NumPredict = 0
+		if _, err := s.routedGenerate(context.Background(), req, provider.PriorityHigh, 0); err != nil {
+			t.Fatalf("routedGenerate error: %v", err)
+		}
+		if want := provider.DefaultExpectedOutput("fim"); eng.last.ExpectedOutput != want {
+			t.Errorf("ExpectedOutput = %d, want %d (DefaultExpectedOutput(fim) fallback)", eng.last.ExpectedOutput, want)
+		}
+	})
 }
 
 func TestRoutedGenerate_StreamingAddsCapStream(t *testing.T) {
@@ -196,6 +231,15 @@ func TestFIMGenerator_GenerateOmitsCapStream(t *testing.T) {
 	if want := "fake/qwen3:8b"; res.Outcome.PlannedModel != want {
 		t.Errorf("Outcome.PlannedModel = %q, want %q", res.Outcome.PlannedModel, want)
 	}
+	// Drift-detector contract (per completion.RouteOutcome doc): on a
+	// successful no-fallback route, the qualified PlannedModel string
+	// must equal Provider+"/"+Model. If this fails, either the format
+	// invariants are wrong (PlannedModel unqualified, or Provider/Model
+	// qualified) or RouteOutcome translation dropped the provider
+	// component.
+	if drift := res.Outcome.PlannedModel != res.Provider+"/"+res.Model; drift {
+		t.Errorf("drift detector reported drift on a no-fallback success: PlannedModel=%q vs %q+\"/\"+%q", res.Outcome.PlannedModel, res.Provider, res.Model)
+	}
 }
 
 // TestFIMGenerator_GenerateStreamRequiresCapStream asserts the streaming
@@ -257,6 +301,14 @@ func TestFIMGenerator_GenerateStreamRequiresCapStream(t *testing.T) {
 	}
 	if want := "fake/qwen3:8b"; res.Outcome.PlannedModel != want {
 		t.Errorf("Outcome.PlannedModel = %q, want %q", res.Outcome.PlannedModel, want)
+	}
+	// Drift-detector contract on the streaming path: the qualified
+	// PlannedModel string must equal Provider+"/"+Model on a no-fallback
+	// success. Catches regressions in resultFromAggregatedStream's
+	// Provider population (the streaming sibling of the same assertion in
+	// TestFIMGenerator_GenerateOmitsCapStream).
+	if drift := res.Outcome.PlannedModel != res.Provider+"/"+res.Model; drift {
+		t.Errorf("drift detector reported drift on a no-fallback streaming success: PlannedModel=%q vs %q+\"/\"+%q", res.Outcome.PlannedModel, res.Provider, res.Model)
 	}
 }
 

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -394,7 +394,18 @@ func (s *Server) newCompletionProvider(ctx context.Context, model string) (*comp
 	if err != nil {
 		return nil, err
 	}
-	return completion.NewProvider(s.client, model, cfg)
+
+	// modelRegistry.Lookup proved this model exists for ollamaProv via
+	// /api/show. Seed the providerRegistry's routing index so Router can
+	// dispatch to it even when the bulk /api/tags-based RefreshModels at
+	// startup failed (partial Ollama outage). Idempotent; failure here is
+	// non-fatal — Router's own ProvidersForModel error will surface
+	// naturally if the seed didn't take.
+	if pReg := s.providerRegistrySnapshot(); pReg != nil {
+		_ = pReg.AddModelToIndex(model, ollamaProv.Name())
+	}
+
+	return completion.NewProviderWithGenerator(s.fimGenerator(s.fimPriority()), model, cfg)
 }
 
 // Indexer returns the current RAG indexer (nil if RAG disabled).

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -65,6 +65,9 @@ type Server struct {
 	closed          bool
 	stateVersion    uint64
 
+	fimPriorityCfg      provider.Priority
+	fimPriorityExplicit bool
+
 	mu       sync.RWMutex
 	resolved map[string]config.ResolvedModel
 
@@ -111,6 +114,22 @@ func WithTLS(cert, key string) Option {
 	return func(s *Server) {
 		s.tlsCert = cert
 		s.tlsKey = key
+	}
+}
+
+// WithFIMPriority sets the routing priority used when MCP FIM completions
+// are dispatched through provider.Router. When this option is not invoked,
+// s.fimPriority() returns provider.PriorityHigh.
+//
+// Per-consumer guidance: IDE consumers (Firn IDE) treating keystroke latency
+// as non-droppable may pass provider.PriorityCritical. Non-IDE MCP consumers
+// can leave the default, drop to provider.PriorityNormal, or set
+// provider.PriorityBackground for batch/background completion. Hard-coding
+// either default would bake one product's policy into the seam.
+func WithFIMPriority(p provider.Priority) Option {
+	return func(s *Server) {
+		s.fimPriorityCfg = p
+		s.fimPriorityExplicit = true
 	}
 }
 
@@ -398,6 +417,23 @@ func (s *Server) routerSnapshot() routeEngine {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.router
+}
+
+// fimPriority returns the configured FIM routing priority, defaulting to
+// provider.PriorityHigh when WithFIMPriority was not invoked.
+//
+// The fimPriorityExplicit boolean is required because
+// provider.PriorityBackground is the zero value of provider.Priority and is
+// itself a valid configured value; "did the caller invoke WithFIMPriority?"
+// cannot be answered by checking fimPriorityCfg == 0 alone.
+//
+// Called by newCompletionProvider when wiring completion construction
+// through s.fimGenerator.
+func (s *Server) fimPriority() provider.Priority {
+	if !s.fimPriorityExplicit {
+		return provider.PriorityHigh
+	}
+	return s.fimPriorityCfg
 }
 
 func (s *Server) providerRegistrySnapshot() *provider.Registry {

--- a/mcp/tools_completion.go
+++ b/mcp/tools_completion.go
@@ -65,7 +65,12 @@ func (s *Server) handleCompletion(ctx context.Context, req *gomcp.CallToolReques
 		Language:  args.Language,
 	})
 	if err != nil {
-		return toolError("ollama", "%v", err), nil
+		// Map through routedGenerateCategory so config/router/ollama
+		// failures surface with the right MCP tool error category instead
+		// of being flattened into "ollama". Non-routed errors (e.g. the
+		// completion provider's own nil-guard) keep the conservative
+		// "ollama" default — see routedGenerateCategory's doc.
+		return toolError(string(routedGenerateCategory(err)), "%v", err), nil
 	}
 
 	return toolResult(resp.Completion), nil

--- a/provider/registry.go
+++ b/provider/registry.go
@@ -145,6 +145,41 @@ func (r *Registry) ProvidersForModel(model string) ([]Provider, error) {
 	return result, nil
 }
 
+// AddModelToIndex registers that providerName advertises model in the routing
+// index used by ProvidersForModel. Idempotent: re-adding an existing
+// (model, providerName) pair is a no-op rather than producing duplicate
+// entries. Returns an error if either argument is empty or providerName is
+// not a registered provider.
+//
+// Intended for callers that have proof-of-existence for a single model from
+// a side channel (e.g. an /api/show response that succeeded while
+// /api/tags-based RefreshModels failed) and need to seed the routing index
+// without bulk discovery. The bulk path is RefreshModels; this is the
+// single-model fallback for partial-outage scenarios.
+func (r *Registry) AddModelToIndex(model, providerName string) error {
+	if model == "" {
+		return fmt.Errorf("provider: add model to index: model name must not be empty")
+	}
+	if providerName == "" {
+		return fmt.Errorf("provider: add model to index: provider name must not be empty")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.providers[providerName]; !exists {
+		return fmt.Errorf("provider: add model to index: provider %q not found", providerName)
+	}
+
+	for _, existing := range r.modelIndex[model] {
+		if existing == providerName {
+			return nil
+		}
+	}
+	r.modelIndex[model] = append(r.modelIndex[model], providerName)
+	return nil
+}
+
 // RefreshModels queries the named provider for its available models and updates
 // the registry's model index. This must be called after registration to populate
 // the model index for ProvidersForModel lookups.

--- a/provider/registry_test.go
+++ b/provider/registry_test.go
@@ -241,6 +241,98 @@ func TestRegistry_RefreshModels_NotFound(t *testing.T) {
 	}
 }
 
+func TestRegistry_AddModelToIndex(t *testing.T) {
+	r := NewRegistry()
+	p := &mockProvider{name: "ollama"}
+	if err := r.Register(p); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	if err := r.AddModelToIndex("qwen3:8b", "ollama"); err != nil {
+		t.Fatalf("AddModelToIndex: %v", err)
+	}
+
+	providers, err := r.ProvidersForModel("qwen3:8b")
+	if err != nil {
+		t.Fatalf("ProvidersForModel: %v", err)
+	}
+	if len(providers) != 1 || providers[0].Name() != "ollama" {
+		t.Fatalf("providers = %v, want [ollama]", providers)
+	}
+}
+
+func TestRegistry_AddModelToIndex_Idempotent(t *testing.T) {
+	r := NewRegistry()
+	p := &mockProvider{name: "ollama"}
+	_ = r.Register(p)
+
+	for i := 0; i < 3; i++ {
+		if err := r.AddModelToIndex("qwen3:8b", "ollama"); err != nil {
+			t.Fatalf("AddModelToIndex iteration %d: %v", i, err)
+		}
+	}
+
+	providers, err := r.ProvidersForModel("qwen3:8b")
+	if err != nil {
+		t.Fatalf("ProvidersForModel: %v", err)
+	}
+	if len(providers) != 1 {
+		t.Errorf("providers count = %d, want 1 (idempotency violated; duplicate entries materialised)", len(providers))
+	}
+}
+
+func TestRegistry_AddModelToIndex_UnknownProvider(t *testing.T) {
+	r := NewRegistry()
+	if err := r.AddModelToIndex("qwen3:8b", "unregistered"); err == nil {
+		t.Fatal("expected error for unregistered provider")
+	}
+	if _, err := r.ProvidersForModel("qwen3:8b"); err == nil {
+		t.Fatal("ProvidersForModel must still report no providers after rejected AddModelToIndex")
+	}
+}
+
+func TestRegistry_AddModelToIndex_EmptyArguments(t *testing.T) {
+	r := NewRegistry()
+	p := &mockProvider{name: "ollama"}
+	_ = r.Register(p)
+
+	if err := r.AddModelToIndex("", "ollama"); err == nil {
+		t.Error("empty model must be rejected")
+	}
+	if err := r.AddModelToIndex("qwen3:8b", ""); err == nil {
+		t.Error("empty provider name must be rejected")
+	}
+}
+
+func TestRegistry_AddModelToIndex_CoexistsWithRefreshModels(t *testing.T) {
+	// Seed via AddModelToIndex first, then RefreshModels: the bulk path must
+	// not duplicate or lose the explicitly-seeded entry.
+	r := NewRegistry()
+	p := &mockProvider{
+		name: "ollama",
+		models: []ModelInfo{
+			{Name: "qwen3:8b"},
+			{Name: "nomic-embed-text"},
+		},
+	}
+	_ = r.Register(p)
+
+	if err := r.AddModelToIndex("qwen3:8b", "ollama"); err != nil {
+		t.Fatalf("AddModelToIndex: %v", err)
+	}
+	if err := r.RefreshModels(context.Background(), "ollama"); err != nil {
+		t.Fatalf("RefreshModels: %v", err)
+	}
+
+	providers, err := r.ProvidersForModel("qwen3:8b")
+	if err != nil {
+		t.Fatalf("ProvidersForModel: %v", err)
+	}
+	if len(providers) != 1 {
+		t.Errorf("providers = %d, want 1 (RefreshModels must not duplicate the seeded entry)", len(providers))
+	}
+}
+
 func TestRegistry_RefreshModels_ProviderError(t *testing.T) {
 	r := NewRegistry()
 	p := &mockProvider{

--- a/provider/router_fim_capability_test.go
+++ b/provider/router_fim_capability_test.go
@@ -1,0 +1,158 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// fimCapProvider is a minimal Provider that advertises a fixed capability
+// set at the provider level. Per-profile gating in scoreCandidate filters on
+// ModelProfile.Caps, so each test seeds profiles with different cap masks
+// even though the underlying provider always reports the full superset.
+type fimCapProvider struct {
+	name   string
+	models []ModelInfo
+}
+
+func (p *fimCapProvider) Name() string { return p.name }
+func (p *fimCapProvider) Capabilities() Capability {
+	return CapGenerate | CapInsert | CapStream
+}
+func (p *fimCapProvider) Health(context.Context) error { return nil }
+func (p *fimCapProvider) Models(context.Context) ([]ModelInfo, error) {
+	return p.models, nil
+}
+func (p *fimCapProvider) Chat(context.Context, ChatRequest) (*ChatResponse, error) {
+	return nil, nil
+}
+func (p *fimCapProvider) ChatStream(context.Context, ChatRequest, func(ChatResponse) error) error {
+	return nil
+}
+func (p *fimCapProvider) Generate(_ context.Context, req GenerateRequest) (*GenerateResponse, error) {
+	return &GenerateResponse{Provider: p.name, Model: req.Model, Response: "ok", Done: true}, nil
+}
+func (p *fimCapProvider) GenerateStream(_ context.Context, req GenerateRequest, fn func(GenerateResponse) error) error {
+	return fn(GenerateResponse{Provider: p.name, Model: req.Model, Response: "ok", Done: true})
+}
+func (p *fimCapProvider) Embed(context.Context, EmbedRequest) (*EmbedResponse, error) {
+	return nil, nil
+}
+
+// routerWithFIMProfiles builds a real *Router whose ModelRegistry is seeded
+// with the given profiles and whose Registry has its model index populated
+// (via RefreshModels) so unqualified Route(req.Model = "shared-fim") calls
+// reach LookupAny → ProvidersForModel → cached Lookup. Without RefreshModels
+// the model index would be empty and the test would fail at lookup before
+// the capability gate could be exercised.
+func routerWithFIMProfiles(t *testing.T, profiles ...*ModelProfile) *Router {
+	t.Helper()
+
+	provReg := NewRegistry()
+	byProvider := map[string][]string{}
+	for _, profile := range profiles {
+		byProvider[profile.Key.Provider] = append(byProvider[profile.Key.Provider], profile.Key.Model)
+	}
+	for providerName, models := range byProvider {
+		modelInfos := make([]ModelInfo, 0, len(models))
+		for _, name := range models {
+			modelInfos = append(modelInfos, ModelInfo{Name: name})
+		}
+		prov := &fimCapProvider{name: providerName, models: modelInfos}
+		if err := provReg.Register(prov); err != nil {
+			t.Fatalf("register %s: %v", providerName, err)
+		}
+	}
+
+	mr, err := NewModelRegistry(provReg, nil)
+	if err != nil {
+		t.Fatalf("new model registry: %v", err)
+	}
+	mr.mu.Lock()
+	for _, profile := range profiles {
+		mr.profiles[profile.Key] = profile
+	}
+	mr.mu.Unlock()
+
+	for providerName := range byProvider {
+		if err := provReg.RefreshModels(context.Background(), providerName); err != nil {
+			t.Fatalf("refresh models %s: %v", providerName, err)
+		}
+	}
+
+	r := NewRouter(mr, provReg)
+	t.Cleanup(func() { _ = r.Close() })
+	return r
+}
+
+func TestRouter_FIMRequiresCapInsert(t *testing.T) {
+	model := "shared-fim"
+	r := routerWithFIMProfiles(t,
+		&ModelProfile{Key: ModelKey{Provider: "plain", Model: model}, Caps: CapGenerate, ContextWindow: 8192},
+		&ModelProfile{Key: ModelKey{Provider: "insert", Model: model}, Caps: CapGenerate | CapInsert, ContextWindow: 8192},
+	)
+	plan, err := r.Route(context.Background(), RoutingRequest{
+		Model:          model,
+		UseCase:        "fim",
+		RequiredCaps:   CapGenerate | CapInsert,
+		Prompt:         "prefix",
+		Suffix:         "suffix",
+		ExpectedOutput: DefaultExpectedOutput("fim"),
+	})
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if got := plan.Profile.Key.Provider; got != "insert" {
+		t.Fatalf("Provider = %q, want %q", got, "insert")
+	}
+}
+
+// TestRouter_FIMRejectsAllNonInsertCandidates proves the capability filter
+// is a hard gate (capabilityGate=false eliminates the candidate) rather than
+// a soft preference (low score but still selectable). With ONLY non-CapInsert
+// candidates available, a soft-preference regression would still pick the
+// best-scored candidate; the hard gate must surface ErrNoViableCandidate
+// instead. This is the negative pair to TestRouter_FIMRequiresCapInsert.
+func TestRouter_FIMRejectsAllNonInsertCandidates(t *testing.T) {
+	model := "shared-fim"
+	r := routerWithFIMProfiles(t,
+		&ModelProfile{Key: ModelKey{Provider: "plain-a", Model: model}, Caps: CapGenerate, ContextWindow: 8192},
+		&ModelProfile{Key: ModelKey{Provider: "plain-b", Model: model}, Caps: CapGenerate, ContextWindow: 8192},
+	)
+	plan, err := r.Route(context.Background(), RoutingRequest{
+		Model:          model,
+		UseCase:        "fim",
+		RequiredCaps:   CapGenerate | CapInsert,
+		Prompt:         "prefix",
+		Suffix:         "suffix",
+		ExpectedOutput: DefaultExpectedOutput("fim"),
+	})
+	if err == nil {
+		t.Fatalf("Route returned plan=%+v with nil error; want ErrNoViableCandidate", plan)
+	}
+	if !errors.Is(err, ErrNoViableCandidate) {
+		t.Errorf("Route err = %v, want errors.Is(_, ErrNoViableCandidate) — capability gate must hard-filter, not soft-prefer", err)
+	}
+}
+
+func TestRouter_FIMStreamRequiresCapStream(t *testing.T) {
+	model := "shared-fim"
+	r := routerWithFIMProfiles(t,
+		&ModelProfile{Key: ModelKey{Provider: "nostream", Model: model}, Caps: CapGenerate | CapInsert, ContextWindow: 8192},
+		&ModelProfile{Key: ModelKey{Provider: "stream", Model: model}, Caps: CapGenerate | CapInsert | CapStream, ContextWindow: 8192},
+	)
+	plan, err := r.Route(context.Background(), RoutingRequest{
+		Model:          model,
+		UseCase:        "fim",
+		RequiredCaps:   CapGenerate | CapInsert | CapStream,
+		Prompt:         "prefix",
+		Suffix:         "suffix",
+		ExpectedOutput: DefaultExpectedOutput("fim"),
+	})
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if got := plan.Profile.Key.Provider; got != "stream" {
+		t.Fatalf("Provider = %q, want %q", got, "stream")
+	}
+}

--- a/provider/router_fim_capability_test.go
+++ b/provider/router_fim_capability_test.go
@@ -8,8 +8,9 @@ import (
 
 // fimCapProvider is a minimal Provider that advertises a fixed capability
 // set at the provider level. Per-profile gating in scoreCandidate filters on
-// ModelProfile.Caps, so each test seeds profiles with different cap masks
-// even though the underlying provider always reports the full superset.
+// ModelProfile metadata, so each test seeds profiles with different cap masks
+// and templates even though the underlying provider always reports the full
+// superset.
 type fimCapProvider struct {
 	name   string
 	models []ModelInfo
@@ -132,6 +133,38 @@ func TestRouter_FIMRejectsAllNonInsertCandidates(t *testing.T) {
 	}
 	if !errors.Is(err, ErrNoViableCandidate) {
 		t.Errorf("Route err = %v, want errors.Is(_, ErrNoViableCandidate) — capability gate must hard-filter, not soft-prefer", err)
+	}
+}
+
+func TestRouter_FIMTemplateSuffixSatisfiesCapInsertGate(t *testing.T) {
+	model := "template-fim"
+	r := routerWithFIMProfiles(t,
+		&ModelProfile{
+			Key:           ModelKey{Provider: "plain", Model: model},
+			Caps:          CapGenerate,
+			Template:      "{{ .Prompt }}",
+			ContextWindow: 8192,
+		},
+		&ModelProfile{
+			Key:           ModelKey{Provider: "template", Model: model},
+			Caps:          CapGenerate,
+			Template:      "{{ .Prompt }}{{ .Suffix }}",
+			ContextWindow: 8192,
+		},
+	)
+	plan, err := r.Route(context.Background(), RoutingRequest{
+		Model:          model,
+		UseCase:        "fim",
+		RequiredCaps:   CapGenerate | CapInsert,
+		Prompt:         "prefix",
+		Suffix:         "suffix",
+		ExpectedOutput: DefaultExpectedOutput("fim"),
+	})
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if got := plan.Profile.Key.Provider; got != "template" {
+		t.Fatalf("Provider = %q, want %q (template .Suffix must satisfy CapInsert gate)", got, "template")
 	}
 }
 

--- a/provider/router_score.go
+++ b/provider/router_score.go
@@ -149,8 +149,11 @@ func scoreCandidate(
 	bd.feedbackScore = 0.5
 
 	// 4. Capability gate: if the request requires capabilities the model
-	//    doesn't have, eliminate the candidate immediately.
-	if req.RequiredCaps != 0 && !profile.Caps.Has(req.RequiredCaps) {
+	//    doesn't have, eliminate the candidate immediately. CapInsert is
+	//    satisfied by either the explicit capability bit or a live template that
+	//    proves native suffix insertion support; this keeps Router admission in
+	//    sync with ModelProfile.SupportsFIM.
+	if !profileSatisfiesRequiredCaps(profile, req.RequiredCaps) {
 		bd.capabilityGate = false
 		return bd
 	}
@@ -174,6 +177,17 @@ func scoreCandidate(
 	}
 
 	return bd
+}
+
+func profileSatisfiesRequiredCaps(profile *ModelProfile, required Capability) bool {
+	if required == 0 {
+		return true
+	}
+	caps := profile.Caps
+	if required.Has(CapInsert) && profile.SupportsFIM() {
+		caps |= CapInsert
+	}
+	return caps.Has(required)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #73. Implements [docs/superpowers/specs/2026-05-03-fim-via-router-design.md](https://github.com/kstruzzieri/go-llm/blob/feature/fim-via-router-wiring/docs/superpowers/specs/2026-05-03-fim-via-router-design.md).

## Summary

Routes MCP `complete_code` (Fill-in-the-Middle) through `provider.Router` so FIM completions get the same circuit breakers, warmth tracking, KV-cache scoring, and capability gating (`CapInsert`) as the chat / generate / embed paths shipped in #79 and #84. Compat-shim preserves all consumer signatures (Firn IDE, Flux ML, Quantum Trader).

## What changed

**Architecture** — adds a consumer-owned `completion.Generator` seam (interface + request/result/chunk types in `completion/`), with a private `generatorFromOllamaClient` adapter wrapping `*ollama.Client.Generate` / `GenerateStream` and a Router-backed `mcpFIMGenerator` closure (`mcp/server.fimGenerator`). MCP centralises FIM-shaped routing in `s.routedGenerate` returning a `*RoutePlan`; the closure branches on streaming vs non-streaming via `ExecuteGenerate` / `ExecuteGenerateStream`.

**FIM pin policy** — `routedGenerate` pins the resolved model end-to-end (no `PreferredChain`) because cross-family chain fallback can break native prompt+suffix template assembly (qwen3-coder, codellama, codestral each use distinct templates). Cross-family fallback is deferred to #85.

**Constructors** —
- `completion.NewProvider(client *ollama.Client, ...)` — legacy, unchanged signature, compat shim for existing consumers.
- `completion.NewProviderWithGenerator(generator Generator, ...)` — new additive constructor for Router-aware callers.
- `completion.CompleteStreamWithResult(...) (GenerateResult, error)` — new additive method exposing structured `RouteOutcome` for #82 drift telemetry; `CompleteStream(...) error` keeps its signature.

**Configurable priority** — `mcp.WithFIMPriority(p provider.Priority)` Option; defaults to `provider.PriorityHigh`. The `fimPriorityExplicit bool` disambiguates "unset" from "set to zero" so `PriorityBackground` (the zero value) is a valid configured choice.

**Provider observability** — `provider.Registry.AddModelToIndex` lets `newCompletionProvider` seed the routing index from a single resolved model, preserving completion resilience when bulk `RefreshModels` partially failed.

## Falsifiable acceptance (spec §8)

| # | Check | Status |
|---|---|---|
| AC1 | `go test ./...` | Green |
| AC2 | `go test -race ./completion/... ./mcp/...` | Green |
| AC3 | `go test -tags integration ./mcp/... -run TestFIMViaRouter_Smoke` | Skips with explicit reason; runs end-to-end against Ollama when `OLLAMA_FIM_INTEGRATION_MODEL` is set |
| AC4 | `go vet ./...` + `go build ./...` | Clean |
| AC5 | `NewProvider` + `NewProviderWithGenerator` both exported | `completion/inline.go:56`, `:74` |
| AC6 | `git diff develop -- completion/inline_test.go` | Empty (compat-shim contract held by assertion-by-omission) |
| AC7 | `mcp/server.go` no longer calls `completion.NewProvider(` | Only `NewProviderWithGenerator` path |
| AC8 | No `PreferredChain:` field assignment in `mcp/generate_helper.go` | Three comment-only references |

## Test plan

- [x] Unit tests: 14 new tests in `mcp/generate_helper_test.go` and `provider/router_fim_capability_test.go` covering `routedGenerate` semantics, `fimGenerator` closure, FIM-family capability gate (positive + negative), structured `RouteOutcome` propagation.
- [x] Integration tests: 8 new tests in `completion/provider_generator_test.go` covering `Provider.Complete` / `CompleteStream` / `CompleteStreamWithResult` against fake `Generator`, Outcome verbatim propagation, chunk-byte parity between streaming entry points.
- [x] End-to-end smoke: `mcp/fim_via_router_integration_test.go` (`integration` tag) drives `s.newCompletionProvider` through to `Complete` against real Ollama; asserts UseCase / Caps / Model / Priority routing trail.
- [x] Race detector clean on `completion/...` and `mcp/...`.

## Spec-deferred dependencies

- **#82 chain-fallback drift signature** — `GenerateResult.Outcome` carries structured provenance (`PlannedModel`, `Score`, `FallbacksUsed`, `WasSticky`, `RouteHint`); persistent telemetry consumption is #82's responsibility. `PlannedModel` is provider-qualified (`"provider/model"`), so the canonical drift detector is the qualified comparison `result.Outcome != nil && result.Outcome.PlannedModel != result.Provider+"/"+result.Model`.
- **#81 OpenAI-compat backend** — the seam is provider-agnostic; a future `openai-compat` Generator slots in without `completion/` surgery.

Neither is a blocker.

## Migration notes for downstream consumers

- **No constructor signature changes.** `completion.NewProvider(client *ollama.Client, ...)` keeps its exact signature; `*WithGenerator` is purely additive.
- **`CompleteStream(...) error` unchanged.** New code wanting route metadata should adopt `CompleteStreamWithResult(...) (GenerateResult, error)`.
- **Error-message wording change**: when the provider was constructed via `NewProvider(nil, ...)` (the legacy nil-client compat path), `Complete` / `CompleteStream` previously errored with `"completion: client is required"`. After this PR, both surface `"completion: generator is required"` because the underlying field has been renamed (the rename is the load-bearing refactor of #73). Consumers (Firn IDE / Flux ML / Quantum Trader) that string-match on the old substring should update to the new wording. Acceptance check #6 (`git diff develop -- completion/inline_test.go` is empty) confirms no existing test on `develop` pinned the old wording, so this is a documentation-only call-out, not a regression of pinned behavior.

## Follow-up issues filed

- #85 — `feat(completion): per-call FIM request shaping for cross-family Router fallback`
- #86 — `refactor(mcp): cache *completion.Provider by resolved model`
- Comment on #81 — `CapStrictTemplateMatch` open question task box

Generated with [Claude Code](https://claude.com/claude-code)
