### PR TITLE
docs: refresh CLAUDE.md and README.md to reflect Router/MCP wiring and compat package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,16 +12,21 @@
 go-llm/
 ├── ollama/          # Ollama REST API client (chat, generate, embeddings, models)
 ├── config/          # Model configuration loader (models.json, resolve, fallback)
-├── provider/        # Intelligent model routing (Router, circuit breakers, warmth, scoring)
+├── provider/        # Use-case-aware Router (chat/fim/embedding/reasoning/analysis/code-review/agent profiles), circuit breakers, warmth, sticky routing, scoring, fallback chains
 ├── rag/             # RAG: chunking, SQLite vector store, indexing, retrieval
 ├── completion/      # IDE inline completion (Fill-in-the-Middle)
 ├── analysis/        # Domain-specific analysis helpers (code review, ML metrics, trading)
-├── mcp/             # MCP server: tools, prompts, resources over stdio/HTTP/2
+├── mcp/             # MCP server: tools, prompts, resources over stdio/HTTP/2 — wired through provider.Router
 ├── conversation/    # Persistent conversation storage with SQLite
 ├── feedback/        # Implicit user behavioral signal collection
 ├── fingerprint/     # Model profiling (latency benchmarks, capability detection)
 ├── prefetch/        # Predictive cache-warming engine for RAG retrieval
-├── cmd/go-llm-mcp/  # Standalone MCP server binary
+├── compat/          # OpenAI-compatible endpoint shim (chat, completions, model aliases, concurrency limiter)
+├── cmd/
+│   ├── go-llm-mcp/  # Standalone MCP server binary (stdio + HTTP/2)
+│   ├── fim-smoke/   # FIM smoke-test harness
+│   └── llm-bench/   # Model latency benchmark
+├── docs/            # Reference documentation (BYO models, design notes)
 └── testdata/        # Test fixtures
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,12 +24,15 @@ Designed for embedding into Go applications that need LLM capabilities: chat, to
 | `rag/parquet/` | Parquet dataset exporter for ML pipeline interop — exports vector store contents with quality metrics and configurable precision. |
 | `completion/` | IDE inline completion via Fill-in-the-Middle (FIM) with context window management. Sync and streaming APIs. |
 | `analysis/` | Domain-specific analysis helpers — code review (with optional RAG context), ML training metrics, and trading strategy analysis. |
-| `mcp/` | MCP server exposing go-llm as tools, prompts, and resources over stdio and HTTP/2 transports. |
+| `mcp/` | MCP server exposing go-llm as tools, prompts, and resources over stdio and HTTP/2 transports. Tool calls flow through `provider.Router`. |
 | `conversation/` | Persistent conversation storage with SQLite. |
 | `feedback/` | Implicit user behavioral signal collection for retrieval quality improvement. |
 | `fingerprint/` | Model profiling — latency benchmarks and capability detection. |
 | `prefetch/` | Predictive cache-warming engine for RAG retrieval. |
+| `compat/` | OpenAI-compatible endpoint shim — chat, completions, model aliases, and a concurrency limiter for clients that speak OpenAI's API but want to target local Ollama models. |
 | `cmd/go-llm-mcp/` | Standalone MCP server binary with stdio and HTTP/2 support. |
+| `cmd/fim-smoke/` | Smoke-test harness for Fill-in-the-Middle completion against a running Ollama. |
+| `cmd/llm-bench/` | Latency benchmark for the configured model lineup. |
 
 ## Requirements
 
@@ -292,7 +295,7 @@ Claude Desktop configuration (`claude_desktop_config.json`):
 }
 ```
 
-The server exposes 19 tools (chat, generate, code completion, embeddings, RAG, model management, analysis), 4 prompt templates, and 5 resources. Chat, generate, completion, embedding, and analysis tools accept an optional `model` parameter; when omitted, the configured default for that use-case is used.
+The server exposes 19 tools (chat, generate, code completion, embeddings, RAG, model management, analysis), 4 prompt templates, and 5 resources. Chat, generate, completion, embedding, and analysis tools accept an optional `model` parameter; when omitted, the request is routed by `provider.Router` using a use-case-appropriate weight profile (chat / fim / embedding / reasoning / analysis / code-review / agent), with circuit-breaker-aware fallback. Routing state for diagnostics is exposed via the `route://breakers`, `route://warmth`, and `route://sticky` resources. (The actual model that served a given call is computed internally as `RouteOutcome.ActualModel` but is not currently included in tool responses; see Roadmap.)
 
 ## Parquet Export
 
@@ -330,11 +333,25 @@ insight, _ := analyzer.AnalyzeTraining(ctx, analysis.TrainingMetrics{
 
 ## Roadmap
 
+### Recently shipped
+
 | Feature | Description |
 |---------|-------------|
-| Router-MCP integration | Wire provider.Router into MCP server for intelligent model selection with circuit breakers and fallback chains |
-| FIM intelligence | Adaptive token budgets and multi-family stop tokens for completion |
-| OpenAI-compatible endpoint | `compat/` package exposing an OpenAI-compatible API over local Ollama models |
+| Provider Router → MCP | `mcp/` chat/generate/embed/completion tools and analysis handlers route through `provider.Router` with use-case-aware weight profiles, circuit breakers, warmth scoring, and sticky preference. Routing state surfaced via `route://breakers`, `route://warmth`, `route://sticky` resources. |
+| FIM via Router | Completion routing with FIM-family pinning, template prompt support, and empty-suffix semantics — `provider.Router` chooses the actual completion model under the hood. |
+
+### In progress
+
+| Feature | Description |
+|---------|-------------|
+| OpenAI-compatible endpoint | `compat/` package exposes local Ollama models via an OpenAI-compatible chat/completions API for clients that speak OpenAI's API but want a local backend. Concurrency limiter and model-alias resolution are in place; further hardening ongoing. |
+| Persistent drift signature | Per-chunk vector-space identity in the RAG SQLite store so cross-run drift across embedding-model boundaries is detected at query time. Closes the chain-fallback channel that the in-memory drift guard left open. |
+
+### Future
+
+| Feature | Description |
+|---------|-------------|
+| In-band routing transparency | Surface `RouteOutcome` (actual model, fallbacks used, sticky decision) in MCP tool responses so callers see which model served a request rather than only the planned default. Out-of-band today via `route://*` resources. |
 | Vision support | Image inputs in chat messages |
 | ANN search | Approximate nearest neighbor search for large vector stores |
 

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ Claude Desktop configuration (`claude_desktop_config.json`):
 }
 ```
 
-The server exposes 19 tools (chat, generate, code completion, embeddings, RAG, model management, analysis), 4 prompt templates, and 5 resources. Chat, generate, completion, embedding, and analysis tools accept an optional `model` parameter; when omitted, the request is routed by `provider.Router` using a use-case-appropriate weight profile (chat / fim / embedding / reasoning / analysis / code-review / agent), with circuit-breaker-aware fallback. Routing state for diagnostics is exposed via the `route://breakers`, `route://warmth`, and `route://sticky` resources. (The actual model that served a given call is computed internally as `RouteOutcome.ActualModel` but is not currently included in tool responses; see Roadmap.)
+The server exposes 19 tools (chat, generate, code completion, embeddings, RAG, model management, analysis), 4 prompt templates, 7 concrete resources, and 1 resource template. Chat, generate, completion, embedding, and analysis tools accept an optional `model` parameter; when omitted, the request is routed by `provider.Router` using a use-case-appropriate weight profile (chat / fim / embedding / reasoning / analysis / code-review / agent), with circuit-breaker-aware fallback. Routing state for diagnostics is exposed via the `route://breakers`, `route://warmth`, and `route://sticky` resources. (The actual model that served a given call is computed internally as `RouteOutcome.ActualModel` but is not currently included in tool responses; see Roadmap.)
 
 ## Parquet Export
 


### PR DESCRIPTION
## Summary

Architecture and roadmap drifted relative to recently-shipped work. This PR updates `CLAUDE.md` and `README.md` for honest, current state, without overclaiming routing transparency we don't yet expose.

## What changed

**`CLAUDE.md`**
- Architecture tree adds `compat/` (OpenAI-compatible endpoint shim) and `docs/`.
- `cmd/` expanded to list `go-llm-mcp/`, `fim-smoke/`, `llm-bench/`.
- `provider/` description tightened to call out use-case-aware Router with circuit breakers, warmth, sticky routing, scoring, and fallback chains.
- `mcp/` description notes that tool calls flow through `provider.Router`.

**`README.md`**
- Packages table adds `compat/`, `cmd/fim-smoke/`, `cmd/llm-bench/`.
- MCP Server section: model selection now described as Router-driven with use-case weight profiles (chat / fim / embedding / reasoning / analysis / code-review / agent) and circuit-breaker-aware fallback. Routing state surfaced via `route://breakers`, `route://warmth`, `route://sticky` resources. Honest acknowledgement that `RouteOutcome.ActualModel` is not yet returned in tool responses (linked to a Future roadmap entry; follow-up issue #89).
- Roadmap restructured into **Recently shipped** / **In progress** / **Future**:
  - Recently shipped: Provider Router → MCP, FIM via Router (#87).
  - In progress: OpenAI-compatible endpoint (`compat/`), persistent drift signature (#82).
  - Future: in-band routing transparency (#89), vision support, ANN search.

## Why now

OpenCode + go-llm-mcp wire-up testing surfaced the gap between docs and reality (e.g., README claimed Router-MCP integration as roadmap when it's been wired through chat/generate/embed/completion + analysis handlers).

## Non-goals

No code or behavior changes. Quick Start examples were not modernized to use router-aware constructors (`NewIndexerWithEmbedder`, `NewRetrieverWithEmbedder`); existing examples still compile and work via the additive-constructor pattern.

## Test plan

- [x] `grep`-verified package list against actual repo (`compat/`, three `cmd/` subdirs, `docs/` all present).
- [x] `grep`-verified "19 tools" claim still accurate (chat=1, generate=1, completion=1, embed=2, models=3, rag=5, analysis=6).
- [x] No code touched, so existing CI signal is sufficient.

Generated with [Claude Code](https://claude.com/claude-code)