### PR TITLE
feat(rag): persistent drift signature foundation (#82 Phase 1)

### DIFF
--- a/rag/errors.go
+++ b/rag/errors.go
@@ -1,0 +1,26 @@
+// Package rag — sentinel errors.
+//
+// These two sentinels are kept distinct because the recovery action diverges:
+//
+//   - ErrVectorSpaceMismatch: query-side fix — the corpus is consistent but
+//     the embedder produced an embedding in a different vector space.
+//     Reconfigure the embedder (or its model) to match the corpus.
+//
+//   - ErrCorpusMixedVectorSpaces: corpus-side fix — chunks from multiple
+//     incompatible vector spaces coexist (or legacy unknown-vsid rows
+//     coexist with known ones). The only safe recovery is a full re-index.
+package rag
+
+import "errors"
+
+var (
+	// ErrVectorSpaceMismatch indicates the query embedding's vector-space
+	// identifier does not match the (single) vector space found in the
+	// corpus, or the query embedder did not produce a VectorSpaceID at all.
+	ErrVectorSpaceMismatch = errors.New("rag: vector-space mismatch")
+
+	// ErrCorpusMixedVectorSpaces indicates the corpus contains chunks from
+	// more than one vector space, or a partially-migrated corpus where
+	// known-vsid rows coexist with legacy unknown-vsid rows.
+	ErrCorpusMixedVectorSpaces = errors.New("rag: corpus contains mixed vector spaces")
+)

--- a/rag/indexer.go
+++ b/rag/indexer.go
@@ -37,6 +37,21 @@ type atomicSourceReplacerWithHash interface {
 	ReplaceSourceWithHash(ctx context.Context, source string, chunks []Chunk, embeddings [][]float64, sourceHash string) error
 }
 
+// atomicSourceReplacerWithVectorSpaceID extends atomicSourceReplacerWithHash
+// with vector-space identifier persistence. Stores that implement the
+// capability support drift detection at retrieval time; stores that only
+// implement atomicSourceReplacerWithHash silently drop the vsid.
+type atomicSourceReplacerWithVectorSpaceID interface {
+	ReplaceSourceWithHashAndVectorSpaceID(
+		ctx context.Context,
+		source string,
+		chunks []Chunk,
+		embeddings [][]float64,
+		sourceHash string,
+		vectorSpaceID string,
+	) error
+}
+
 // IndexerOption configures an Indexer.
 type IndexerOption func(*Indexer)
 

--- a/rag/migration.go
+++ b/rag/migration.go
@@ -37,6 +37,11 @@ var migrations = []migration{
 		description: "add source_content_hash for incremental indexing",
 		fn:          migrateV4,
 	},
+	{
+		version:     5,
+		description: "add vector_space_id column with non-empty partial index",
+		fn:          migrateV5,
+	},
 }
 
 // migrateV1 creates the baseline chunks table and indexes.
@@ -133,6 +138,25 @@ func migrateV4(tx *sql.Tx) error {
 	_, err := tx.Exec(`ALTER TABLE chunks ADD COLUMN source_content_hash TEXT NOT NULL DEFAULT ''`)
 	if err != nil {
 		return fmt.Errorf("rag: migrate v4: %w", err)
+	}
+	return nil
+}
+
+// migrateV5 adds the vector_space_id column and a partial index over
+// non-empty values. Legacy rows keep the empty default; the partial-index
+// predicate keeps them out of the index, so probe queries that filter on
+// vector_space_id <> '' stay cheap regardless of corpus size.
+func migrateV5(tx *sql.Tx) error {
+	stmts := []string{
+		`ALTER TABLE chunks ADD COLUMN vector_space_id TEXT NOT NULL DEFAULT ''`,
+		`CREATE INDEX IF NOT EXISTS idx_chunks_vector_space_id_nonempty
+			ON chunks(vector_space_id)
+			WHERE vector_space_id <> ''`,
+	}
+	for _, stmt := range stmts {
+		if _, err := tx.Exec(stmt); err != nil {
+			return fmt.Errorf("rag: migrate v5: %w", err)
+		}
 	}
 	return nil
 }

--- a/rag/migration_test.go
+++ b/rag/migration_test.go
@@ -3,6 +3,7 @@ package rag
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,14 +13,14 @@ import (
 func TestMigrationFreshDB(t *testing.T) {
 	store := newTestStore(t)
 
-	// Verify rag_schema_version exists with version 4.
+	// Verify rag_schema_version exists with the latest applied version.
 	var maxVersion int
 	err := store.db.QueryRow(`SELECT MAX(version) FROM rag_schema_version`).Scan(&maxVersion)
 	if err != nil {
 		t.Fatalf("query rag_schema_version: %v", err)
 	}
-	if maxVersion != 4 {
-		t.Errorf("max schema version = %d, want 4", maxVersion)
+	if maxVersion != 5 {
+		t.Errorf("max schema version = %d, want 5", maxVersion)
 	}
 
 	// Verify chunks_fts virtual table exists.
@@ -102,14 +103,14 @@ func TestMigrationExistingDB(t *testing.T) {
 		t.Fatalf("runMigrations() error: %v", err)
 	}
 
-	// Verify version upgraded to 4.
+	// Verify version upgraded to the latest applied version.
 	var maxVersion int
 	err = db.QueryRow(`SELECT MAX(version) FROM rag_schema_version`).Scan(&maxVersion)
 	if err != nil {
 		t.Fatalf("query schema version: %v", err)
 	}
-	if maxVersion != 4 {
-		t.Errorf("max schema version = %d, want 4", maxVersion)
+	if maxVersion != 5 {
+		t.Errorf("max schema version = %d, want 5", maxVersion)
 	}
 
 	// Verify indexed_at was backfilled (should be non-zero).
@@ -393,13 +394,13 @@ func TestMigrationIdempotency(t *testing.T) {
 		t.Fatalf("second runMigrations() error: %v", err)
 	}
 
-	// Verify version is still 4 (not duplicated).
+	// Verify version count is unchanged after re-run (no duplicates).
 	var count int
 	if err := db.QueryRow(`SELECT COUNT(*) FROM rag_schema_version`).Scan(&count); err != nil {
 		t.Fatalf("count versions: %v", err)
 	}
-	if count != 4 {
-		t.Errorf("expected 4 version records (v1, v2, v3, v4), got %d", count)
+	if count != 5 {
+		t.Errorf("expected 5 version records (v1..v5), got %d", count)
 	}
 }
 
@@ -476,14 +477,14 @@ func TestFTS5UpsertConsistency(t *testing.T) {
 func TestMigrationV4SourceContentHash(t *testing.T) {
 	store := newTestStore(t)
 
-	// Verify max schema version is 4.
+	// Verify max schema version is the latest applied version.
 	var maxVersion int
 	err := store.db.QueryRow(`SELECT MAX(version) FROM rag_schema_version`).Scan(&maxVersion)
 	if err != nil {
 		t.Fatalf("query rag_schema_version: %v", err)
 	}
-	if maxVersion != 4 {
-		t.Errorf("max schema version = %d, want 4", maxVersion)
+	if maxVersion != 5 {
+		t.Errorf("max schema version = %d, want 5", maxVersion)
 	}
 
 	// Verify source_content_hash column exists by inserting and querying it.
@@ -578,14 +579,14 @@ func TestMigrationV4ExistingDB(t *testing.T) {
 		t.Fatalf("runMigrations() error: %v", err)
 	}
 
-	// Verify version upgraded to 4.
+	// Verify version upgraded to the latest applied version.
 	var maxVersion int
 	err = db.QueryRow(`SELECT MAX(version) FROM rag_schema_version`).Scan(&maxVersion)
 	if err != nil {
 		t.Fatalf("query schema version: %v", err)
 	}
-	if maxVersion != 4 {
-		t.Errorf("max schema version = %d, want 4", maxVersion)
+	if maxVersion != 5 {
+		t.Errorf("max schema version = %d, want 5", maxVersion)
 	}
 
 	// Verify existing row has empty default hash.
@@ -656,13 +657,13 @@ func TestMigrationHalfAppliedV2(t *testing.T) {
 		t.Fatalf("runMigrations() on half-applied v2: %v", err)
 	}
 
-	// Verify version recorded as 4 (v2 detected, then v3+v4 applied).
+	// Verify version recorded at latest (v2 detected, then v3+v4+v5 applied).
 	var maxVersion int
 	if err := db.QueryRow(`SELECT MAX(version) FROM rag_schema_version`).Scan(&maxVersion); err != nil {
 		t.Fatalf("query version: %v", err)
 	}
-	if maxVersion != 4 {
-		t.Errorf("max version = %d, want 4", maxVersion)
+	if maxVersion != 5 {
+		t.Errorf("max version = %d, want 5", maxVersion)
 	}
 }
 
@@ -728,12 +729,310 @@ func TestMigrationHalfAppliedV2WithV1Recorded(t *testing.T) {
 		t.Fatalf("runMigrations() on v2 schema with v1 recorded: %v", err)
 	}
 
-	// Verify version is now 4 (v2 detected, then v3+v4 applied).
+	// Verify version is now at latest (v2 detected, then v3+v4+v5 applied).
 	var maxVersion int
 	if err := db.QueryRow(`SELECT MAX(version) FROM rag_schema_version`).Scan(&maxVersion); err != nil {
 		t.Fatalf("query version: %v", err)
 	}
-	if maxVersion != 4 {
-		t.Errorf("max version = %d, want 4", maxVersion)
+	if maxVersion != 5 {
+		t.Errorf("max version = %d, want 5", maxVersion)
+	}
+}
+
+// v4Schema is the chunks-table shape after migrations 1-4. Used by the v5
+// migration tests to set up a pre-v5 fixture.
+const v4Schema = `
+CREATE TABLE chunks (
+	id TEXT PRIMARY KEY,
+	content TEXT NOT NULL,
+	source TEXT NOT NULL,
+	start_line INTEGER NOT NULL,
+	end_line INTEGER NOT NULL,
+	language TEXT NOT NULL DEFAULT '',
+	metadata TEXT NOT NULL DEFAULT '{}',
+	embedding TEXT NOT NULL,
+	indexed_at INTEGER NOT NULL DEFAULT 0,
+	stable_key TEXT NOT NULL DEFAULT '',
+	source_content_hash TEXT NOT NULL DEFAULT ''
+);
+CREATE INDEX idx_chunks_source_line ON chunks(source, start_line);
+CREATE INDEX idx_chunks_lang_source_line ON chunks(language, source, start_line);
+CREATE INDEX idx_chunks_stable_key ON chunks(stable_key);
+CREATE VIRTUAL TABLE chunks_fts USING fts5(
+	content, source,
+	content=chunks, content_rowid=rowid
+);
+CREATE TRIGGER chunks_ai AFTER INSERT ON chunks BEGIN
+	INSERT INTO chunks_fts(rowid, content, source)
+	VALUES (new.rowid, new.content, new.source);
+END;
+CREATE TRIGGER chunks_ad AFTER DELETE ON chunks BEGIN
+	INSERT INTO chunks_fts(chunks_fts, rowid, content, source)
+	VALUES ('delete', old.rowid, old.content, old.source);
+END;
+CREATE TRIGGER chunks_au AFTER UPDATE ON chunks BEGIN
+	INSERT INTO chunks_fts(chunks_fts, rowid, content, source)
+	VALUES ('delete', old.rowid, old.content, old.source);
+	INSERT INTO chunks_fts(rowid, content, source)
+	VALUES (new.rowid, new.content, new.source);
+END;
+CREATE TABLE rag_schema_version (
+	version     INTEGER PRIMARY KEY,
+	description TEXT NOT NULL,
+	applied_at  INTEGER NOT NULL
+);
+INSERT INTO rag_schema_version (version, description, applied_at) VALUES (1, 'baseline schema', 1000);
+INSERT INTO rag_schema_version (version, description, applied_at) VALUES (2, 'add indexed_at, FTS5 index, and sync triggers', 1000);
+INSERT INTO rag_schema_version (version, description, applied_at) VALUES (3, 'add stable_key column for chunk identity', 1000);
+INSERT INTO rag_schema_version (version, description, applied_at) VALUES (4, 'add source_content_hash for incremental indexing', 1000);
+`
+
+// openV4DB returns an in-memory SQLite handle pre-loaded with the v4 schema
+// fixture. Single MaxOpenConns keeps schema state on one connection.
+func openV4DB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(v4Schema); err != nil {
+		t.Fatalf("create v4 schema: %v", err)
+	}
+	return db
+}
+
+func TestMigration_v4_to_v5_addsColumn(t *testing.T) {
+	db := openV4DB(t)
+
+	// Pre-existing v4 row, written without knowledge of vector_space_id.
+	if _, err := db.Exec(
+		`INSERT INTO chunks (id, content, source, start_line, end_line, language, metadata, embedding, indexed_at, stable_key, source_content_hash)
+		 VALUES ('legacy-1', 'hello', 'main.go', 1, 5, 'go', '{}', '[0.1]', 12345, 'sk1', 'h1')`,
+	); err != nil {
+		t.Fatalf("seed v4 row: %v", err)
+	}
+
+	if err := runMigrations(db); err != nil {
+		t.Fatalf("runMigrations() error: %v", err)
+	}
+
+	var maxVersion int
+	if err := db.QueryRow(`SELECT MAX(version) FROM rag_schema_version`).Scan(&maxVersion); err != nil {
+		t.Fatalf("query version: %v", err)
+	}
+	if maxVersion != 5 {
+		t.Errorf("max schema version = %d, want 5", maxVersion)
+	}
+
+	rows, err := db.Query(`PRAGMA table_info(chunks)`)
+	if err != nil {
+		t.Fatalf("pragma table_info: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var (
+		found   bool
+		colType string
+		notNull int
+		dfltVal sql.NullString
+	)
+	for rows.Next() {
+		var (
+			cid   int
+			name  string
+			ctype string
+			nn    int
+			dflt  sql.NullString
+			pk    int
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &nn, &dflt, &pk); err != nil {
+			t.Fatalf("scan pragma row: %v", err)
+		}
+		if name == "vector_space_id" {
+			found = true
+			colType = ctype
+			notNull = nn
+			dfltVal = dflt
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("pragma rows.Err: %v", err)
+	}
+	if !found {
+		t.Fatal("vector_space_id column missing after v5 migration")
+	}
+	if colType != "TEXT" {
+		t.Errorf("vector_space_id type = %q, want TEXT", colType)
+	}
+	if notNull != 1 {
+		t.Errorf("vector_space_id NOT NULL = %d, want 1", notNull)
+	}
+	// SQLite stores the default literal verbatim, including quotes.
+	if !dfltVal.Valid || dfltVal.String != "''" {
+		t.Errorf("vector_space_id default = %v, want ''", dfltVal)
+	}
+
+	var vsid string
+	if err := db.QueryRow(
+		`SELECT vector_space_id FROM chunks WHERE id = 'legacy-1'`,
+	).Scan(&vsid); err != nil {
+		t.Fatalf("scan vector_space_id: %v", err)
+	}
+	if vsid != "" {
+		t.Errorf("legacy row vector_space_id = %q, want \"\"", vsid)
+	}
+}
+
+func TestMigration_v4_to_v5_partialIndex(t *testing.T) {
+	db := openV4DB(t)
+	if err := runMigrations(db); err != nil {
+		t.Fatalf("runMigrations() error: %v", err)
+	}
+
+	rowsToInsert := []struct {
+		id, vsid string
+	}{
+		{"a", ""},
+		{"b", "ollama/qwen3-embedding:8b"},
+		{"c", "ollama/nomic-embed-text"},
+		{"d", ""},
+	}
+	for _, r := range rowsToInsert {
+		if _, err := db.Exec(
+			`INSERT INTO chunks (id, content, source, start_line, end_line, language, metadata, embedding, indexed_at, stable_key, source_content_hash, vector_space_id)
+			 VALUES (?, 'x', 's.go', 1, 1, 'go', '{}', '[0.1]', 1, '', '', ?)`,
+			r.id, r.vsid,
+		); err != nil {
+			t.Fatalf("insert %s: %v", r.id, err)
+		}
+	}
+
+	planRows, err := db.Query(`EXPLAIN QUERY PLAN
+		SELECT vector_space_id FROM chunks
+		 WHERE vector_space_id <> ''
+		 ORDER BY vector_space_id ASC
+		 LIMIT 1`)
+	if err != nil {
+		t.Fatalf("explain query plan: %v", err)
+	}
+	defer func() { _ = planRows.Close() }()
+
+	var planText string
+	for planRows.Next() {
+		var (
+			id     int
+			parent int
+			notUsd int
+			detail string
+		)
+		if err := planRows.Scan(&id, &parent, &notUsd, &detail); err != nil {
+			t.Fatalf("scan plan: %v", err)
+		}
+		planText += detail + "\n"
+	}
+	if err := planRows.Err(); err != nil {
+		t.Fatalf("plan rows.Err: %v", err)
+	}
+	if !strings.Contains(planText, "idx_chunks_vector_space_id_nonempty") {
+		t.Errorf("query plan does not reference idx_chunks_vector_space_id_nonempty:\n%s", planText)
+	}
+
+	var nonEmptyCount int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM chunks WHERE vector_space_id <> ''`,
+	).Scan(&nonEmptyCount); err != nil {
+		t.Fatalf("count non-empty: %v", err)
+	}
+	if nonEmptyCount != 2 {
+		t.Errorf("non-empty count = %d, want 2", nonEmptyCount)
+	}
+}
+
+// TestMigration_v5_partialIndex_descBookend pairs with TestMigration_v4_to_v5_partialIndex
+// to verify both ASC and DESC bookend probes serve from the partial index.
+// ProbeVectorSpaces relies on this for its lex-min/lex-max single-index-entry
+// reads; without coverage of the DESC plan, a planner regression could
+// silently turn the max-bookend into a full index scan.
+func TestMigration_v5_partialIndex_descBookend(t *testing.T) {
+	db := openV4DB(t)
+	if err := runMigrations(db); err != nil {
+		t.Fatalf("runMigrations() error: %v", err)
+	}
+
+	// Insert in non-alphabetical order so DESC plan is meaningful.
+	for _, r := range []struct{ id, vsid string }{
+		{"a", "B"},
+		{"b", "A"},
+	} {
+		if _, err := db.Exec(
+			`INSERT INTO chunks (id, content, source, start_line, end_line, language, metadata, embedding, indexed_at, stable_key, source_content_hash, vector_space_id)
+			 VALUES (?, 'x', 's.go', 1, 1, 'go', '{}', '[0.1]', 1, '', '', ?)`,
+			r.id, r.vsid,
+		); err != nil {
+			t.Fatalf("insert %s: %v", r.id, err)
+		}
+	}
+
+	planRows, err := db.Query(`EXPLAIN QUERY PLAN
+		SELECT vector_space_id FROM chunks
+		 WHERE vector_space_id <> ''
+		 ORDER BY vector_space_id DESC
+		 LIMIT 1`)
+	if err != nil {
+		t.Fatalf("explain query plan: %v", err)
+	}
+	defer func() { _ = planRows.Close() }()
+
+	var planText string
+	for planRows.Next() {
+		var (
+			id     int
+			parent int
+			notUsd int
+			detail string
+		)
+		if err := planRows.Scan(&id, &parent, &notUsd, &detail); err != nil {
+			t.Fatalf("scan plan: %v", err)
+		}
+		planText += detail + "\n"
+	}
+	if err := planRows.Err(); err != nil {
+		t.Fatalf("plan rows.Err: %v", err)
+	}
+	if !strings.Contains(planText, "idx_chunks_vector_space_id_nonempty") {
+		t.Errorf("DESC bookend plan does not reference idx_chunks_vector_space_id_nonempty:\n%s", planText)
+	}
+}
+
+func TestMigration_v5_open_idempotent(t *testing.T) {
+	db := openV4DB(t)
+
+	if err := runMigrations(db); err != nil {
+		t.Fatalf("first runMigrations() error: %v", err)
+	}
+	var firstVersion int
+	if err := db.QueryRow(`SELECT MAX(version) FROM rag_schema_version`).Scan(&firstVersion); err != nil {
+		t.Fatalf("query first version: %v", err)
+	}
+	if firstVersion != 5 {
+		t.Fatalf("first run max version = %d, want 5", firstVersion)
+	}
+
+	var firstRowCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM rag_schema_version`).Scan(&firstRowCount); err != nil {
+		t.Fatalf("count version rows: %v", err)
+	}
+
+	if err := runMigrations(db); err != nil {
+		t.Fatalf("second runMigrations() error: %v", err)
+	}
+	var secondRowCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM rag_schema_version`).Scan(&secondRowCount); err != nil {
+		t.Fatalf("count version rows after re-run: %v", err)
+	}
+	if secondRowCount != firstRowCount {
+		t.Errorf("schema_version rows after re-open = %d, want %d (no duplicate inserts)", secondRowCount, firstRowCount)
 	}
 }

--- a/rag/retriever.go
+++ b/rag/retriever.go
@@ -15,6 +15,23 @@ type Retriever struct {
 	store    VectorStore
 }
 
+// vectorSpaceProbe summarizes the vector-space-id distribution across a
+// corpus. KnownIDs is a deduped sample (capped at 2) of distinct non-empty
+// vsids; HasUnknown reports whether any chunks still carry the empty-string
+// legacy vsid. The two fields are orthogonal — both can be true for a
+// partially migrated corpus.
+type vectorSpaceProbe struct {
+	KnownIDs   []string
+	HasUnknown bool
+}
+
+// vectorSpaceProber is the optional capability a VectorStore can implement
+// to expose its vsid distribution. Stores that don't implement it skip the
+// drift check.
+type vectorSpaceProber interface {
+	ProbeVectorSpaces(ctx context.Context) (vectorSpaceProbe, error)
+}
+
 // RetrieverOption configures a Retriever.
 type RetrieverOption func(*Retriever)
 

--- a/rag/sqlite_store.go
+++ b/rag/sqlite_store.go
@@ -64,6 +64,64 @@ func (s *SQLiteStore) DB() *sql.DB {
 	return s.db
 }
 
+// ProbeVectorSpaces summarizes the vector_space_id distribution across the
+// chunks table. It returns the lex min and max non-empty vsid (deduped to
+// at most two entries) plus a flag indicating any legacy empty-vsid rows.
+//
+// The bookend (ASC LIMIT 1 / DESC LIMIT 1) form is preferred over
+// DISTINCT...LIMIT 2 because the partial index idx_chunks_vector_space_id_nonempty
+// is ordered by vsid, so each bookend serves from a single index entry. A
+// DISTINCT scan would generally walk the index to prove no second distinct
+// value exists. Returned IDs are also deterministic across SQLite versions,
+// which matters for tests that assert returned IDs.
+func (s *SQLiteStore) ProbeVectorSpaces(ctx context.Context) (vectorSpaceProbe, error) {
+	var minID string
+	err := s.db.QueryRowContext(ctx, `
+		SELECT vector_space_id
+		  FROM chunks
+		 WHERE vector_space_id <> ''
+		 ORDER BY vector_space_id ASC
+		 LIMIT 1`).Scan(&minID)
+	if err != nil && err != sql.ErrNoRows {
+		return vectorSpaceProbe{}, fmt.Errorf("rag: probe min vector space: %w", err)
+	}
+	hasKnown := err != sql.ErrNoRows
+
+	var maxID string
+	if hasKnown {
+		if err := s.db.QueryRowContext(ctx, `
+			SELECT vector_space_id
+			  FROM chunks
+			 WHERE vector_space_id <> ''
+			 ORDER BY vector_space_id DESC
+			 LIMIT 1`).Scan(&maxID); err != nil {
+			return vectorSpaceProbe{}, fmt.Errorf("rag: probe max vector space: %w", err)
+		}
+	}
+
+	// EXISTS short-circuits on first match. Worst case is a fully-migrated
+	// corpus (no empties) which scans the table; SQLite's sequential scan
+	// is acceptable, and the alternative — an index over the empty
+	// predicate — would defeat the partial-index design.
+	var hasUnknown bool
+	if err := s.db.QueryRowContext(ctx, `
+		SELECT EXISTS(SELECT 1 FROM chunks WHERE vector_space_id = '')
+		`).Scan(&hasUnknown); err != nil {
+		return vectorSpaceProbe{}, fmt.Errorf("rag: probe unknown vector spaces: %w", err)
+	}
+
+	probe := vectorSpaceProbe{HasUnknown: hasUnknown}
+	if hasKnown {
+		if minID == maxID {
+			probe.KnownIDs = []string{minID}
+		} else {
+			// Min/max bookends are sufficient evidence of ≥2 distinct values.
+			probe.KnownIDs = []string{minID, maxID}
+		}
+	}
+	return probe, nil
+}
+
 func validateStoreInputs(chunks []Chunk, embeddings [][]float64) error {
 	if len(chunks) != len(embeddings) {
 		return fmt.Errorf("rag: store: chunks/embeddings length mismatch (%d vs %d)", len(chunks), len(embeddings))

--- a/rag/sqlite_store_test.go
+++ b/rag/sqlite_store_test.go
@@ -3,6 +3,7 @@ package rag
 import (
 	"context"
 	"math"
+	"reflect"
 	"testing"
 )
 
@@ -862,5 +863,145 @@ func TestDifferentSourcesDifferentHashes(t *testing.T) {
 	}
 	if gotHashB != hashB {
 		t.Errorf("beta hash = %q, want %q", gotHashB, hashB)
+	}
+}
+
+// insertVSIDRow writes a chunk row with the given vector_space_id directly,
+// bypassing the public Store API which does not yet accept vsid.
+func insertVSIDRow(t *testing.T, store *SQLiteStore, id, vsid string) {
+	t.Helper()
+	if _, err := store.db.Exec(
+		`INSERT INTO chunks (id, content, source, start_line, end_line, language, metadata, embedding, indexed_at, stable_key, source_content_hash, vector_space_id)
+		 VALUES (?, 'x', 's.go', 1, 1, 'go', '{}', '[0.1]', 1, '', '', ?)`,
+		id, vsid,
+	); err != nil {
+		t.Fatalf("insert vsid row %q/%q: %v", id, vsid, err)
+	}
+}
+
+func TestProbeVectorSpaces_empty(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	probe, err := store.ProbeVectorSpaces(ctx)
+	if err != nil {
+		t.Fatalf("ProbeVectorSpaces: %v", err)
+	}
+	want := vectorSpaceProbe{KnownIDs: nil, HasUnknown: false}
+	if !reflect.DeepEqual(probe, want) {
+		t.Errorf("probe = %+v, want %+v", probe, want)
+	}
+}
+
+func TestProbeVectorSpaces_singleKnown(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	for _, id := range []string{"a", "b", "c"} {
+		insertVSIDRow(t, store, id, "X")
+	}
+
+	probe, err := store.ProbeVectorSpaces(ctx)
+	if err != nil {
+		t.Fatalf("ProbeVectorSpaces: %v", err)
+	}
+	want := vectorSpaceProbe{KnownIDs: []string{"X"}, HasUnknown: false}
+	if !reflect.DeepEqual(probe, want) {
+		t.Errorf("probe = %+v, want %+v", probe, want)
+	}
+}
+
+func TestProbeVectorSpaces_singleKnown_plusUnknown(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	insertVSIDRow(t, store, "a", "X")
+	insertVSIDRow(t, store, "b", "X")
+	insertVSIDRow(t, store, "c", "")
+	insertVSIDRow(t, store, "d", "")
+
+	probe, err := store.ProbeVectorSpaces(ctx)
+	if err != nil {
+		t.Fatalf("ProbeVectorSpaces: %v", err)
+	}
+	want := vectorSpaceProbe{KnownIDs: []string{"X"}, HasUnknown: true}
+	if !reflect.DeepEqual(probe, want) {
+		t.Errorf("probe = %+v, want %+v", probe, want)
+	}
+}
+
+func TestProbeVectorSpaces_twoKnown(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Insert in non-alphabetical order to verify bookend probe sorts.
+	insertVSIDRow(t, store, "a", "Y")
+	insertVSIDRow(t, store, "b", "A")
+
+	probe, err := store.ProbeVectorSpaces(ctx)
+	if err != nil {
+		t.Fatalf("ProbeVectorSpaces: %v", err)
+	}
+	want := vectorSpaceProbe{KnownIDs: []string{"A", "Y"}, HasUnknown: false}
+	if !reflect.DeepEqual(probe, want) {
+		t.Errorf("probe = %+v, want %+v", probe, want)
+	}
+}
+
+func TestProbeVectorSpaces_twoKnown_plusUnknown(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	insertVSIDRow(t, store, "a", "Y")
+	insertVSIDRow(t, store, "b", "A")
+	insertVSIDRow(t, store, "c", "")
+
+	probe, err := store.ProbeVectorSpaces(ctx)
+	if err != nil {
+		t.Fatalf("ProbeVectorSpaces: %v", err)
+	}
+	want := vectorSpaceProbe{KnownIDs: []string{"A", "Y"}, HasUnknown: true}
+	if !reflect.DeepEqual(probe, want) {
+		t.Errorf("probe = %+v, want %+v", probe, want)
+	}
+}
+
+func TestProbeVectorSpaces_fullyLegacy(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	for _, id := range []string{"a", "b", "c"} {
+		insertVSIDRow(t, store, id, "")
+	}
+
+	probe, err := store.ProbeVectorSpaces(ctx)
+	if err != nil {
+		t.Fatalf("ProbeVectorSpaces: %v", err)
+	}
+	want := vectorSpaceProbe{KnownIDs: nil, HasUnknown: true}
+	if !reflect.DeepEqual(probe, want) {
+		t.Errorf("probe = %+v, want %+v", probe, want)
+	}
+}
+
+// TestProbeVectorSpaces_threeKnown_returnsBookends documents that the bookend
+// strategy returns only the lex min/max even if a middle vsid exists. This
+// is intentional — Retriever's decision matrix only cares whether ≥2 distinct
+// values exist; deeper enumeration would not change the outcome.
+func TestProbeVectorSpaces_threeKnown_returnsBookends(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	insertVSIDRow(t, store, "a", "A")
+	insertVSIDRow(t, store, "b", "M")
+	insertVSIDRow(t, store, "c", "Z")
+
+	probe, err := store.ProbeVectorSpaces(ctx)
+	if err != nil {
+		t.Fatalf("ProbeVectorSpaces: %v", err)
+	}
+	want := vectorSpaceProbe{KnownIDs: []string{"A", "Z"}, HasUnknown: false}
+	if !reflect.DeepEqual(probe, want) {
+		t.Errorf("probe = %+v, want %+v", probe, want)
 	}
 }


### PR DESCRIPTION
## Summary

Phase 1 of the persistent drift signature work for #82. Lays the SQLite schema, sentinel errors, and capability-tier interfaces that Phases 2-4 will wire into the indexer write path, the incremental-signature bump, and the retriever read path respectively.

**No behavior change in this PR.** Retriever and Indexer continue to take existing paths; the new seams are present but not yet invoked.

## What's in scope

- `rag/migration.go` — v5 migration: `vector_space_id TEXT NOT NULL DEFAULT ''` + partial index `idx_chunks_vector_space_id_nonempty` on non-empty values
- `rag/errors.go` (new) — `ErrVectorSpaceMismatch` and `ErrCorpusMixedVectorSpaces` sentinels with diverging-recovery rationale
- `rag/sqlite_store.go` — `ProbeVectorSpaces` impl using bookend ASC/DESC `LIMIT 1` queries (single index entries via the partial index) plus `EXISTS` for legacy empty-vsid presence
- `rag/indexer.go` — `atomicSourceReplacerWithVectorSpaceID` interface declaration (consumer wired in Phase 2)
- `rag/retriever.go` — `vectorSpaceProbe` struct + `vectorSpaceProber` interface declarations (consumer wired in Phase 4)

## Tests added (11 new)

| Test | Verifies |
|------|----------|
| `TestMigration_v4_to_v5_addsColumn` | Column shape (`TEXT NOT NULL DEFAULT ''`); legacy rows backfill to `''` |
| `TestMigration_v4_to_v5_partialIndex` | ASC bookend `EXPLAIN QUERY PLAN` references partial index |
| `TestMigration_v5_partialIndex_descBookend` | DESC bookend plan also references partial index |
| `TestMigration_v5_open_idempotent` | Re-opening DB does not duplicate version rows |
| `TestProbeVectorSpaces_empty` | Empty corpus returns `{nil, false}` |
| `TestProbeVectorSpaces_singleKnown` | Uniform corpus returns `{[X], false}` |
| `TestProbeVectorSpaces_singleKnown_plusUnknown` | Mixed known/legacy returns `{[X], true}` |
| `TestProbeVectorSpaces_twoKnown` | Bookend order independent of insert order |
| `TestProbeVectorSpaces_twoKnown_plusUnknown` | Returns `{[A, Y], true}` |
| `TestProbeVectorSpaces_fullyLegacy` | Only empties returns `{nil, true}` |
| `TestProbeVectorSpaces_threeKnown_returnsBookends` | Bookend strategy: middle id not enumerated |

Existing migration tests (`TestMigrationFreshDB`, `TestMigrationIdempotency`, `TestMigrationV4*`, `TestMigrationHalfApplied*`) bumped from `want 4` to `want 5` to track the new latest version.

## Verification gate

```bash
go vet ./...               # clean
go test ./rag/...          # green
go test -race ./rag/...    # green
go test ./...              # green; no consumer-package regressions (mcp, completion, provider, ...)
```

Spec §10.1 observable also checked: ASC/DESC bookend `EXPLAIN QUERY PLAN` references `idx_chunks_vector_space_id_nonempty`.

## Phase 4 design notes (surfaced from review, not blocking Phase 1)

- **Probe is non-transactional** by design (matches spec §4.6). Three sequential `QueryRowContext` calls — concurrent writers between min and max queries can yield a phantom `sql.ErrNoRows` from the max query, which the code wraps as a hard error. Phase 4's consumer will need a policy: retry, fail-open, or surface to the user.
- **`EXISTS empty` query is a sequential scan.** The partial index on `WHERE vector_space_id <> ''` does not help the empty-equality predicate. On a fully-migrated corpus, the EXISTS query scans the chunks table. Phase 4 should consider whether per-call cost on the `Retriever.Retrieve` hot path is acceptable for multi-GB stores (Firn IDE), or whether we want a 'fully migrated' cache.

## Migration safety

- Forward-only: no down migration. v4 code reading a v5 schema is fine — `runMigrations` skips already-applied versions and the new column is `NOT NULL DEFAULT ''`, so v4 INSERTs that don't enumerate it succeed.
- `ALTER TABLE ADD COLUMN` with constant `DEFAULT` is O(1) on modern SQLite (3.35+); modernc.org/sqlite ships 3.45+. Multi-GB stores migrate near-instantly.

## Test plan

- [x] CI green
- [x] Reviewer confirms no public-API surface added (capability interfaces are package-internal)
- [x] Reviewer confirms migration is forward-compatible (v4 code against v5 schema works)

Refs #82