### PR TITLE
chore: ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 docs/plans/
 docs/superpowers/
 docs/llm/traces/
+.DS_Store


### PR DESCRIPTION
## Summary

Adds `.DS_Store` to `.gitignore` so macOS Finder metadata stops surfacing in `git status` across the `cmd/` tree during the #82 multi-PR rollout. Single bare-name pattern matches at any depth.

## Test plan

- [x] `git check-ignore .DS_Store cmd/.DS_Store cmd/llm-bench/.DS_Store cmd/llm-bench/testdata/.DS_Store` prints all four paths
- [x] `git status --short` shows clean working tree after deleting the local untracked `.DS_Store` files