### PR TITLE
docs(readme): add agentic RAG epic to roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ insight, _ := analyzer.AnalyzeTraining(ctx, analysis.TrainingMetrics{
 
 | Feature | Description |
 |---------|-------------|
-| Agentic RAG (epic #92) | Opt-in agentic retrieval layer on top of static RAG: query decomposition, source routing, iterative multi-hop retrieval, evidence validation, bounded self-correction. Phase 0 gates the rollout: evaluation baseline (#93) and package boundary decision (#94) before any retrieval-behavior PR. First implementation PR is the `ScoredRetriever` interface (#95). Static RAG remains the default. |
+| Agentic RAG | Opt-in agentic retrieval layer planned on top of static RAG. Static RAG remains the default. Phase 0 gates are active. |
 | In-band routing transparency | Surface `RouteOutcome` (actual model, fallbacks used, sticky decision) in MCP tool responses so callers see which model served a request rather than only the planned default. Out-of-band today via `route://*` resources. |
 | Vision support | Image inputs in chat messages |
 | ANN search | Approximate nearest neighbor search for large vector stores |

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ insight, _ := analyzer.AnalyzeTraining(ctx, analysis.TrainingMetrics{
 
 | Feature | Description |
 |---------|-------------|
+| Agentic RAG (epic #92) | Opt-in agentic retrieval layer on top of static RAG: query decomposition, source routing, iterative multi-hop retrieval, evidence validation, bounded self-correction. Phase 0 gates the rollout: evaluation baseline (#93) and package boundary decision (#94) before any retrieval-behavior PR. First implementation PR is the `ScoredRetriever` interface (#95). Static RAG remains the default. |
 | In-band routing transparency | Surface `RouteOutcome` (actual model, fallbacks used, sticky decision) in MCP tool responses so callers see which model served a request rather than only the planned default. Out-of-band today via `route://*` resources. |
 | Vision support | Image inputs in chat messages |
 | ANN search | Approximate nearest neighbor search for large vector stores |


### PR DESCRIPTION
## Summary

- Adds a short Agentic RAG entry to README's Future roadmap section
- Keeps README intentionally high-level; the detailed implementation plan stays in private planning notes
- Notes that static RAG remains the default and Phase 0 gates are active

## Context

The public tracker is #97. Phase 0 gates are #93 (evaluation baseline) and #94 (package/API boundary). The first implementation issue after those gates is #95, with MCP/query-context wiring split to #98.

This PR is a roadmap pointer only. It does not ship agentic RAG behavior.

## Test plan

- [x] `git diff` shows a single README table-row addition relative to `develop`
- [x] Markdown table still renders correctly
- [x] Reviewer eyeballs the roadmap section
