### PR TITLE
[codex] Add Docker-backed local CI

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -eu
+
+docker compose -f docker-compose.ci.yml run --rm ci ./scripts/ci-local --mode pre-push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,16 +32,3 @@ jobs:
 
       - name: Test
         run: go test -race ./...
-
-  darwin-smoke:
-    name: macOS Compile Smoke
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Compile smoke
-        run: go test -run '^$' ./...

--- a/.github/workflows/darwin-smoke.yml
+++ b/.github/workflows/darwin-smoke.yml
@@ -1,7 +1,16 @@
 name: macOS Compile Smoke
 
 on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop, main]
   workflow_dispatch:
+
+# Cancel stale PR runs on new pushes; let push builds on develop/main complete
+concurrency:
+  group: darwin-smoke-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/darwin-smoke.yml
+++ b/.github/workflows/darwin-smoke.yml
@@ -1,0 +1,21 @@
+name: macOS Compile Smoke
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  darwin-smoke:
+    name: macOS Compile Smoke
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Compile smoke
+        run: go test -run '^$' ./...

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1.7
+
+FROM golang:1.25-alpine
+
+ARG GOLANGCI_LINT_VERSION=v2.11.4
+
+ENV CGO_ENABLED=1 \
+    GOCACHE=/root/.cache/go-build \
+    GOLANGCI_LINT_CACHE=/root/.cache/golangci-lint
+
+WORKDIR /workspace
+
+RUN apk add --no-cache \
+      bash \
+      build-base \
+      ca-certificates \
+      git
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
+
+CMD ["./scripts/ci-local", "--mode", "pre-push"]

--- a/README.md
+++ b/README.md
@@ -376,6 +376,8 @@ go test ./...
 go test ./... -v
 ```
 
+For the pre-push and full local CI suites, see [`docs/local-ci.md`](docs/local-ci.md). The Docker-backed pre-push hook runs lint plus race tests before pushes.
+
 ## License
 
 MIT

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,17 @@
+services:
+  ci:
+    build:
+      context: .
+      dockerfile: Dockerfile.ci
+    working_dir: /workspace
+    command: ["./scripts/ci-local", "--mode", "pre-push"]
+    volumes:
+      - .:/workspace
+      - go-build-cache:/root/.cache/go-build
+      - go-mod-cache:/go/pkg/mod
+      - golangci-lint-cache:/root/.cache/golangci-lint
+
+volumes:
+  go-build-cache:
+  go-mod-cache:
+  golangci-lint-cache:

--- a/docs/local-ci.md
+++ b/docs/local-ci.md
@@ -1,0 +1,83 @@
+# Local CI
+
+This repository uses a Docker-backed local CI runner so lint and race tests run before pushes without relying on GitHub Actions minutes.
+
+## Quickstart
+
+Enable the pre-push hook once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Run the same suite the hook runs:
+
+```bash
+docker compose -f docker-compose.ci.yml run --rm ci ./scripts/ci-local --mode pre-push
+```
+
+Run the full local suite before opening or updating a PR:
+
+```bash
+docker compose -f docker-compose.ci.yml run --rm ci ./scripts/ci-local --mode full
+```
+
+The Docker runner builds from `Dockerfile.ci`, mounts the repository at `/workspace`, and keeps named cache volumes for Go modules, Go build output, and golangci-lint data.
+
+## Typical Workflow
+
+1. Make code changes normally.
+2. Run `scripts/ci-local --mode pre-push` for a host-side check, or use the Docker command above when you want the pinned CI toolchain.
+3. Push the branch. The `.githooks/pre-push` hook automatically runs the Docker-backed `pre-push` suite and blocks the push on failure.
+4. Run `scripts/ci-local --mode full` or its Docker equivalent before PR handoff when broad compile behavior may have changed.
+
+## Command Contract
+
+Run the pre-push suite directly on the host:
+
+```bash
+scripts/ci-local --mode pre-push
+```
+
+Run the full suite directly on the host:
+
+```bash
+scripts/ci-local --mode full
+```
+
+Run the pre-push suite inside Docker:
+
+```bash
+docker compose -f docker-compose.ci.yml run --rm ci ./scripts/ci-local --mode pre-push
+```
+
+Run the full suite inside Docker:
+
+```bash
+docker compose -f docker-compose.ci.yml run --rm ci ./scripts/ci-local --mode full
+```
+
+## Check Sets
+
+`pre-push` runs:
+
+- `golangci-lint run`
+- `go test -race ./...`
+
+`full` runs the pre-push suite plus:
+
+- `go test -run '^$' ./...`
+
+## Git Hook
+
+The pre-push hook lives at `.githooks/pre-push` and runs:
+
+```bash
+docker compose -f docker-compose.ci.yml run --rm ci ./scripts/ci-local --mode pre-push
+```
+
+That means pushes fail fast if lint or race tests fail locally.
+
+## Notes
+
+The CI image is based on `golang:1.25-alpine` to match `go.mod`. It installs `build-base` and sets `CGO_ENABLED=1` because Go's race detector requires cgo support even though the module itself avoids cgo-only dependencies.

--- a/scripts/ci-local
+++ b/scripts/ci-local
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="pre-push"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/ci-local [--mode pre-push|full]
+
+Modes:
+  pre-push  Run fast deterministic checks intended for every push.
+  full      Run pre-push checks plus slower compile smoke checks.
+USAGE
+}
+
+section() {
+  printf '\n==> %s\n' "$1"
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'missing required command: %s\n' "$1" >&2
+    exit 127
+  fi
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --mode)
+      if [ "$#" -lt 2 ]; then
+        printf '--mode requires a value\n' >&2
+        usage >&2
+        exit 2
+      fi
+      mode="$2"
+      shift 2
+      ;;
+    --mode=*)
+      mode="${1#*=}"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$mode" in
+  pre-push|full)
+    ;;
+  *)
+    printf 'unknown mode: %s\n' "$mode" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+require_cmd golangci-lint
+require_cmd go
+
+section "lint"
+golangci-lint run
+
+section "race tests"
+go test -race ./...
+
+if [ "$mode" = "full" ]; then
+  section "compile smoke"
+  go test -run '^$' ./...
+fi


### PR DESCRIPTION
## Summary

Adds a repo-local local CI contract for go-llm:

- `scripts/ci-local --mode pre-push` runs `golangci-lint run` and `go test -race ./...`.
- `scripts/ci-local --mode full` also runs `go test -run '^$' ./...`.
- `Dockerfile.ci` and `docker-compose.ci.yml` provide a pinned Docker-backed runner with Go/golangci-lint caches.
- `.githooks/pre-push` runs the Docker-backed pre-push suite before pushes.
- `docs/local-ci.md` documents quickstart, command contract, check sets, and the expected workflow.

## GitHub Actions Cost Control

Keeps the Linux lint/race workflow on PRs and protected branch pushes, but moves the macOS compile smoke check out of the default CI workflow into a manual `workflow_dispatch` workflow.

## Validation

- `scripts/ci-local --mode full`
- `docker compose -f docker-compose.ci.yml run --rm ci ./scripts/ci-local --mode full`
- `docker compose -f docker-compose.ci.yml run --rm ci ./scripts/ci-local --mode pre-push`
- Push pre-push hook ran successfully during `git push -u origin codex/go-llm-local-ci`
