### PR TITLE
[codex] #82 Phase 3 persistent drift signature

### DIFF
--- a/rag/incremental.go
+++ b/rag/incremental.go
@@ -41,7 +41,7 @@ type chunkerSignatureProvider interface {
 
 // sourceSignatureVersion identifies the persisted source signature format.
 // Bump this when the index inputs change in a way that requires full re-embed.
-const sourceSignatureVersion = 1
+const sourceSignatureVersion = 2
 
 // sourceSignature captures the inputs that determine whether persisted
 // embeddings can be safely reused for a source file.

--- a/rag/incremental_test.go
+++ b/rag/incremental_test.go
@@ -194,6 +194,29 @@ func TestMockSourceHashChecker(t *testing.T) {
 	}
 }
 
+func TestSourceSignatureV1V2Incompatible(t *testing.T) {
+	if sourceSignatureVersion != 2 {
+		t.Fatalf("sourceSignatureVersion = %d, want 2", sourceSignatureVersion)
+	}
+
+	v2 := sourceSignature{
+		Version:          sourceSignatureVersion,
+		ContentHash:      contentHash("package main"),
+		EmbeddingModel:   "qwen3-embedding:8b",
+		Chunker:          "test-chunker",
+		StableKeyVersion: stableKeyVersion,
+	}
+	v1 := v2
+	v1.Version = 1
+
+	if v1.compatibleWith(v2) {
+		t.Fatal("v1 source signature should be incompatible with v2")
+	}
+	if v1.String() == v2.String() {
+		t.Fatal("v1 and v2 source signatures should serialize differently")
+	}
+}
+
 func TestChunkerSignatureIncludesConfig(t *testing.T) {
 	swA, err := NewSlidingWindowChunker(64, 8)
 	if err != nil {

--- a/rag/indexer_incremental_test.go
+++ b/rag/indexer_incremental_test.go
@@ -925,6 +925,153 @@ func TestIndexFileIncremental_EmptyStoredHashForcesFullReembed(t *testing.T) {
 	}
 }
 
+func TestIndexerV2ForcesReembedOnV1SourceSignature(t *testing.T) {
+	store, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("NewSQLiteStore() error: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const wantVSID = "fake/m"
+	var embedInputs [][]string
+	emb := EmbedderFunc(func(_ context.Context, _ string, inputs []string) (EmbedResult, error) {
+		embedInputs = append(embedInputs, append([]string(nil), inputs...))
+		embeddings := make([][]float64, len(inputs))
+		for i := range inputs {
+			embeddings[i] = []float64{float64(i + 1), 0}
+		}
+		return EmbedResult{
+			Embeddings:    embeddings,
+			Provider:      "fake",
+			Model:         "m",
+			VectorSpaceID: wantVSID,
+		}, nil
+	})
+
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "f.go")
+	if err := os.WriteFile(path, []byte("same content"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	idx, err := NewIndexerWithEmbedder(emb, store, WithEmbeddingModel("m"), WithWorkspaceRoot(tmpDir))
+	if err != nil {
+		t.Fatalf("NewIndexerWithEmbedder() error: %v", err)
+	}
+	idx.chunker = incrementalVSIDFixtureChunker("func A() { return 1 }", "func A() { return 42 }")
+
+	oldChunks, err := idx.chunker.Chunk(path, "same content")
+	if err != nil {
+		t.Fatalf("chunk seed: %v", err)
+	}
+	populateFixtureStableKeys(t, oldChunks, tmpDir)
+
+	legacySig := idx.currentSourceSignature("same content")
+	legacySig.Version = 1
+	if err := store.ReplaceSourceWithHashAndVectorSpaceID(
+		context.Background(),
+		path,
+		oldChunks,
+		[][]float64{{1, 0}, {0, 1}},
+		legacySig.String(),
+		wantVSID,
+	); err != nil {
+		t.Fatalf("seed v1 rows: %v", err)
+	}
+
+	embedInputs = nil
+	if err := idx.IndexFileIncremental(context.Background(), path); err != nil {
+		t.Fatalf("IndexFileIncremental() error: %v", err)
+	}
+
+	if len(embedInputs) != 1 || len(embedInputs[0]) != len(oldChunks) {
+		t.Fatalf("embed calls = %#v, want one full re-embed of %d chunks", embedInputs, len(oldChunks))
+	}
+
+	hashAfter, err := store.GetSourceHash(context.Background(), path)
+	if err != nil {
+		t.Fatalf("GetSourceHash() error: %v", err)
+	}
+	afterSig, ok := parseSourceSignature(hashAfter)
+	if !ok {
+		t.Fatalf("parse source signature after reindex failed for %q", hashAfter)
+	}
+	if afterSig.Version != sourceSignatureVersion {
+		t.Fatalf("source signature version after reindex = %d, want %d", afterSig.Version, sourceSignatureVersion)
+	}
+	if hashAfter == legacySig.String() {
+		t.Fatal("source hash still has v1 signature after forced re-embed")
+	}
+}
+
+func TestIndexerV2RepairsV1LegacyUnknownVSID(t *testing.T) {
+	store, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		t.Fatalf("NewSQLiteStore() error: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const wantVSID = "fake/m"
+	var embedInputs [][]string
+	emb := EmbedderFunc(func(_ context.Context, _ string, inputs []string) (EmbedResult, error) {
+		embedInputs = append(embedInputs, append([]string(nil), inputs...))
+		embeddings := make([][]float64, len(inputs))
+		for i := range inputs {
+			embeddings[i] = []float64{float64(i + 1), 0}
+		}
+		return EmbedResult{
+			Embeddings:    embeddings,
+			Provider:      "fake",
+			Model:         "m",
+			VectorSpaceID: wantVSID,
+		}, nil
+	})
+
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "f.go")
+	if err := os.WriteFile(path, []byte("same content"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	idx, err := NewIndexerWithEmbedder(emb, store, WithEmbeddingModel("m"), WithWorkspaceRoot(tmpDir))
+	if err != nil {
+		t.Fatalf("NewIndexerWithEmbedder() error: %v", err)
+	}
+	idx.chunker = incrementalVSIDFixtureChunker("func A() { return 1 }", "func A() { return 42 }")
+
+	oldChunks, err := idx.chunker.Chunk(path, "same content")
+	if err != nil {
+		t.Fatalf("chunk seed: %v", err)
+	}
+	populateFixtureStableKeys(t, oldChunks, tmpDir)
+
+	legacySig := idx.currentSourceSignature("same content")
+	legacySig.Version = 1
+	if err := store.ReplaceSourceWithHash(context.Background(), path, oldChunks, [][]float64{{1, 0}, {0, 1}}, legacySig.String()); err != nil {
+		t.Fatalf("seed v1 legacy rows: %v", err)
+	}
+
+	embedInputs = nil
+	if err := idx.IndexFileIncremental(context.Background(), path); err != nil {
+		t.Fatalf("IndexFileIncremental() error: %v", err)
+	}
+
+	if len(embedInputs) != 1 || len(embedInputs[0]) != len(oldChunks) {
+		t.Fatalf("embed calls = %#v, want one full re-embed of %d chunks", embedInputs, len(oldChunks))
+	}
+
+	var count int
+	var minVSID, maxVSID string
+	if err := store.db.QueryRowContext(context.Background(),
+		`SELECT COUNT(*), MIN(vector_space_id), MAX(vector_space_id) FROM chunks WHERE source = ?`, path).
+		Scan(&count, &minVSID, &maxVSID); err != nil {
+		t.Fatalf("query vector_space_id summary: %v", err)
+	}
+	if count != len(oldChunks) || minVSID != wantVSID || maxVSID != wantVSID {
+		t.Fatalf("vector_space_id summary = count %d min %q max %q, want %d/%q/%q", count, minVSID, maxVSID, len(oldChunks), wantVSID, wantVSID)
+	}
+}
+
 func TestIndexFileIncremental_HashInvalidatedByChunkerConfig(t *testing.T) {
 	var embedCount atomic.Int32
 	srv := newBatchCountingEmbedServer(4, &embedCount)


### PR DESCRIPTION
## Summary

- Bump RAG source signatures from v1 to v2 so legacy indexed rows no longer hit the unchanged-content fast path.
- Add regression coverage proving v1 signatures force a full re-embed and are rewritten as v2.
- Add coverage for v1 legacy rows with empty `vector_space_id`, verifying the repair path rewrites them with the resolved VSID.

## Why

Phase 3 prepares the store for retrieval-time vector-space enforcement in Phase 4. The one-time v2 signature invalidation ensures cached embeddings from older rows are not reused without provenance.

## Impact

Existing corpora with v1 source signatures will perform a one-time full re-embed on the next incremental index. Retrieval behavior is unchanged in this PR.

## Validation

- `go test ./rag/...`
- `go test ./...`
- `go vet ./...`
- pre-push hook: lint + race tests