### PR TITLE
ci: make local full suite the default

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 set -eu
 
-docker compose -f docker-compose.ci.yml run --rm ci ./scripts/ci-local --mode pre-push
+docker compose -f docker-compose.ci.yml run --rm ci ./scripts/ci-local --mode full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,7 @@
 name: CI
 
 on:
-  pull_request:
-    branches: [develop, main]
-  push:
-    branches: [develop, main]
+  workflow_dispatch:
 
 # Cancel stale PR runs on new pushes; let push builds on develop/main complete
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  pull_request:
+    branches: [develop, main]
   workflow_dispatch:
 
 # Cancel stale PR runs on new pushes; let push builds on develop/main complete

--- a/.github/workflows/darwin-smoke.yml
+++ b/.github/workflows/darwin-smoke.yml
@@ -1,10 +1,6 @@
 name: macOS Compile Smoke
 
 on:
-  pull_request:
-    branches: [develop, main]
-  push:
-    branches: [develop, main]
   workflow_dispatch:
 
 # Cancel stale PR runs on new pushes; let push builds on develop/main complete

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ go test ./...
 go test ./... -v
 ```
 
-For the pre-push and full local CI suites, see [`docs/local-ci.md`](docs/local-ci.md). The Docker-backed pre-push hook runs lint plus race tests before pushes.
+For the pre-push and full local CI suites, see [`docs/local-ci.md`](docs/local-ci.md). The Docker-backed pre-push hook runs the full local suite before pushes; GitHub Actions are manual fallback checks.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -376,7 +376,21 @@ go test ./...
 go test ./... -v
 ```
 
-For the pre-push and full local CI suites, see [`docs/local-ci.md`](docs/local-ci.md). The Docker-backed pre-push hook runs the full local suite before pushes; GitHub Actions are manual fallback checks.
+### Local CI
+
+Enable the Docker-backed pre-push hook once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Run the same full suite manually:
+
+```bash
+docker compose -f docker-compose.ci.yml run --rm ci ./scripts/ci-local --mode full
+```
+
+`full` includes `golangci-lint run`, `go test -race ./...`, and `go test -run '^$' ./...`. The pre-push hook runs that full suite automatically before pushes; GitHub Actions are manual fallback checks. See [`docs/local-ci.md`](docs/local-ci.md) for the full local CI workflow.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ Run the same full suite manually:
 docker compose -f docker-compose.ci.yml run --rm ci ./scripts/ci-local --mode full
 ```
 
-`full` includes `golangci-lint run`, `go test -race ./...`, and `go test -run '^$' ./...`. The pre-push hook runs that full suite automatically before pushes; GitHub Actions are manual fallback checks. See [`docs/local-ci.md`](docs/local-ci.md) for the full local CI workflow.
+`full` includes `golangci-lint run`, `go test -race ./...`, and `go test -run '^$' ./...`. The pre-push hook runs that full suite automatically before pushes. GitHub still runs the required `Lint & Test` workflow on PRs to satisfy branch protection; push-triggered Actions and macOS smoke remain disabled unless manually dispatched. See [`docs/local-ci.md`](docs/local-ci.md) for the full local CI workflow.
 
 ## License
 

--- a/docs/local-ci.md
+++ b/docs/local-ci.md
@@ -29,7 +29,7 @@ The Docker runner builds from `Dockerfile.ci`, mounts the repository at `/worksp
 1. Make code changes normally.
 2. Run `scripts/ci-local --mode pre-push` for a faster host-side check while iterating, or use the Docker command above when you want the pinned CI toolchain.
 3. Push the branch. The `.githooks/pre-push` hook automatically runs the Docker-backed `full` suite and blocks the push on failure.
-4. GitHub Actions are manual-only; use the Actions tab workflow dispatch button only when you intentionally want a remote confirmation run.
+4. GitHub runs the required `Lint & Test` workflow on PRs to satisfy branch protection. Push-triggered Actions and macOS smoke are disabled unless manually dispatched.
 
 ## Command Contract
 
@@ -80,7 +80,9 @@ That means pushes fail locally if lint, race tests, or compile-smoke checks fail
 
 ## GitHub Actions
 
-The GitHub Actions workflows are kept as manual fallback checks through `workflow_dispatch`, but they do not run automatically on `push` or `pull_request`. Local Docker CI is the blocking path for normal development.
+The `CI` workflow still runs on `pull_request` so the protected `develop` branch receives the required `Lint & Test` status. It does not run on ordinary pushes.
+
+The macOS compile-smoke workflow is kept as a manual fallback check through `workflow_dispatch`. Local Docker CI is the blocking path before pushes during normal development.
 
 ## Notes
 

--- a/docs/local-ci.md
+++ b/docs/local-ci.md
@@ -1,6 +1,6 @@
 # Local CI
 
-This repository uses a Docker-backed local CI runner so lint and race tests run before pushes without relying on GitHub Actions minutes.
+This repository uses a Docker-backed local CI runner so lint, race tests, and compile-smoke checks run before pushes without relying on GitHub Actions minutes.
 
 ## Quickstart
 
@@ -13,13 +13,13 @@ git config core.hooksPath .githooks
 Run the same suite the hook runs:
 
 ```bash
-docker compose -f docker-compose.ci.yml run --rm ci ./scripts/ci-local --mode pre-push
+docker compose -f docker-compose.ci.yml run --rm ci ./scripts/ci-local --mode full
 ```
 
-Run the full local suite before opening or updating a PR:
+Run the faster pre-push subset manually when you do not need the compile-smoke pass:
 
 ```bash
-docker compose -f docker-compose.ci.yml run --rm ci ./scripts/ci-local --mode full
+docker compose -f docker-compose.ci.yml run --rm ci ./scripts/ci-local --mode pre-push
 ```
 
 The Docker runner builds from `Dockerfile.ci`, mounts the repository at `/workspace`, and keeps named cache volumes for Go modules, Go build output, and golangci-lint data.
@@ -27,31 +27,31 @@ The Docker runner builds from `Dockerfile.ci`, mounts the repository at `/worksp
 ## Typical Workflow
 
 1. Make code changes normally.
-2. Run `scripts/ci-local --mode pre-push` for a host-side check, or use the Docker command above when you want the pinned CI toolchain.
-3. Push the branch. The `.githooks/pre-push` hook automatically runs the Docker-backed `pre-push` suite and blocks the push on failure.
-4. Run `scripts/ci-local --mode full` or its Docker equivalent before PR handoff when broad compile behavior may have changed.
+2. Run `scripts/ci-local --mode pre-push` for a faster host-side check while iterating, or use the Docker command above when you want the pinned CI toolchain.
+3. Push the branch. The `.githooks/pre-push` hook automatically runs the Docker-backed `full` suite and blocks the push on failure.
+4. GitHub Actions are manual-only; use the Actions tab workflow dispatch button only when you intentionally want a remote confirmation run.
 
 ## Command Contract
 
-Run the pre-push suite directly on the host:
+Run the faster pre-push subset directly on the host:
 
 ```bash
 scripts/ci-local --mode pre-push
 ```
 
-Run the full suite directly on the host:
+Run the full suite directly on the host. This includes all `pre-push` checks plus compile smoke:
 
 ```bash
 scripts/ci-local --mode full
 ```
 
-Run the pre-push suite inside Docker:
+Run the faster pre-push subset inside Docker:
 
 ```bash
 docker compose -f docker-compose.ci.yml run --rm ci ./scripts/ci-local --mode pre-push
 ```
 
-Run the full suite inside Docker:
+Run the full suite inside Docker. This is what the pre-push hook runs automatically:
 
 ```bash
 docker compose -f docker-compose.ci.yml run --rm ci ./scripts/ci-local --mode full
@@ -70,13 +70,17 @@ docker compose -f docker-compose.ci.yml run --rm ci ./scripts/ci-local --mode fu
 
 ## Git Hook
 
-The pre-push hook lives at `.githooks/pre-push` and runs:
+The pre-push hook lives at `.githooks/pre-push` and runs the full Docker-backed suite:
 
 ```bash
-docker compose -f docker-compose.ci.yml run --rm ci ./scripts/ci-local --mode pre-push
+docker compose -f docker-compose.ci.yml run --rm ci ./scripts/ci-local --mode full
 ```
 
-That means pushes fail fast if lint or race tests fail locally.
+That means pushes fail locally if lint, race tests, or compile-smoke checks fail.
+
+## GitHub Actions
+
+The GitHub Actions workflows are kept as manual fallback checks through `workflow_dispatch`, but they do not run automatically on `push` or `pull_request`. Local Docker CI is the blocking path for normal development.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- run the Docker-backed full local CI suite from the pre-push hook
- keep the required `Lint & Test` GitHub check running on PRs so branch protection remains satisfied
- disable push-triggered Actions and keep macOS smoke manual-only
- update local CI docs and README to clarify pre-push vs full behavior

## Full local CI setup
Enable the hook once per clone:

```bash
git config core.hooksPath .githooks
```

Run the same full suite manually:

```bash
docker compose -f docker-compose.ci.yml run --rm ci ./scripts/ci-local --mode full
```

The `full` suite includes `golangci-lint run`, `go test -race ./...`, and `go test -run '^$' ./...`. After the hook is enabled, pushes run that suite automatically before Git sends the branch.

## GitHub Actions behavior
- `CI / Lint & Test` still runs on `pull_request` because `develop` branch protection requires that status.
- Ordinary `push` events no longer run GitHub Actions.
- macOS compile smoke remains available through manual `workflow_dispatch`.

## Validation
- docker compose -f docker-compose.ci.yml run --rm ci ./scripts/ci-local --mode full
- push hook ran the full suite successfully before publishing the branch
- push hook ran the full suite successfully again before pushing README setup docs
- push hook ran the full suite successfully after restoring the required PR `Lint & Test` trigger