### PR TITLE
test(rag): harden retriever vector-space enforcement

### DIFF
--- a/rag/retriever.go
+++ b/rag/retriever.go
@@ -37,8 +37,10 @@ type RetrieverOption func(*Retriever)
 
 // WithRetrieverModel sets the embedding model for query embedding (default:
 // "nomic-embed-text"). The retriever model must match the model used when
-// the corpus was indexed; mismatches surface as SQLiteStore.Search dimension
-// errors at query time rather than silent zero-score results.
+// the corpus was indexed. Stores that expose vector-space provenance reject
+// mismatches before search. Legacy/non-prober stores only retain Search's
+// dimension guard, so same-dimension vector-space drift remains undetectable
+// there until the store opts into vector-space probing.
 func WithRetrieverModel(model string) RetrieverOption {
 	return func(r *Retriever) {
 		r.model = model
@@ -102,7 +104,7 @@ func (r *Retriever) Retrieve(ctx context.Context, query string, k int) ([]Search
 
 	results, err := r.store.Search(ctx, embedding, k)
 	if err != nil {
-		return nil, fmt.Errorf("%w: search: %w", ErrStoreOperation, err)
+		return nil, fmt.Errorf("rag: search: %w: %w", ErrStoreOperation, err)
 	}
 
 	return results, nil
@@ -125,7 +127,7 @@ func validateQueryVectorSpace(queryVectorSpaceID string, probe vectorSpaceProbe)
 		return fmt.Errorf("%w: corpus has multiple known vector spaces %v", ErrCorpusMixedVectorSpaces, probe.KnownIDs)
 	}
 	if len(probe.KnownIDs) == 1 && probe.HasUnknown {
-		return fmt.Errorf("%w: corpus has known vector space %q plus legacy unknown rows", ErrCorpusMixedVectorSpaces, probe.KnownIDs[0])
+		return fmt.Errorf("%w: corpus has known vector space %q plus chunks with unknown legacy vector space", ErrCorpusMixedVectorSpaces, probe.KnownIDs[0])
 	}
 	if len(probe.KnownIDs) == 0 {
 		// Empty and fully-legacy corpora cannot be validated by vsid. Preserve

--- a/rag/retriever_embedder_test.go
+++ b/rag/retriever_embedder_test.go
@@ -81,7 +81,73 @@ func TestNewRetrieverWithEmbedder_AppliesRetrieverModel(t *testing.T) {
 	}
 }
 
-func TestRetriever_VectorSpaceMismatchFailsClosed(t *testing.T) {
+func TestRetrieve_VSIDMismatch_errsClosed(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	chunks := []Chunk{{ID: "c1", Content: "stored", Source: "s.go", StartLine: 1, EndLine: 1, Metadata: map[string]string{}}}
+	if err := store.ReplaceSourceWithHashAndVectorSpaceID(ctx, "s.go", chunks, [][]float64{{1, 0}}, "hash", "ollama/nomic-embed-text"); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+	spyStore := &countingSQLiteRetrieverStore{SQLiteStore: store}
+
+	emb := &recordingEmbedder{result: EmbedResult{
+		Embeddings:    [][]float64{{1, 0}},
+		Provider:      "ollama",
+		Model:         "qwen3-embedding:8b",
+		VectorSpaceID: "ollama/qwen3-embedding:8b",
+	}}
+	r, err := NewRetrieverWithEmbedder(emb, spyStore)
+	if err != nil {
+		t.Fatalf("NewRetrieverWithEmbedder: %v", err)
+	}
+
+	_, err = r.Retrieve(ctx, "question", 1)
+	if !errors.Is(err, ErrVectorSpaceMismatch) {
+		t.Fatalf("Retrieve error = %v, want ErrVectorSpaceMismatch", err)
+	}
+	for _, want := range []string{"ollama/nomic-embed-text", "ollama/qwen3-embedding:8b"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Retrieve error = %q, want it to contain %q", err.Error(), want)
+		}
+	}
+	if spyStore.searchCalls != 0 {
+		t.Fatalf("Search calls = %d, want 0 on vector-space mismatch", spyStore.searchCalls)
+	}
+}
+
+func TestRetrieve_VSIDMatch_proceeds(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	chunks := []Chunk{{ID: "c1", Content: "stored", Source: "s.go", StartLine: 1, EndLine: 1, Metadata: map[string]string{}}}
+	if err := store.ReplaceSourceWithHashAndVectorSpaceID(ctx, "s.go", chunks, [][]float64{{1, 0}}, "hash", "X"); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+	spyStore := &countingSQLiteRetrieverStore{SQLiteStore: store}
+
+	emb := &recordingEmbedder{result: EmbedResult{
+		Embeddings:    [][]float64{{1, 0}},
+		VectorSpaceID: "X",
+	}}
+	r, err := NewRetrieverWithEmbedder(emb, spyStore)
+	if err != nil {
+		t.Fatalf("NewRetrieverWithEmbedder: %v", err)
+	}
+
+	results, err := r.Retrieve(ctx, "question", 1)
+	if err != nil {
+		t.Fatalf("Retrieve error: %v", err)
+	}
+	if spyStore.searchCalls != 1 {
+		t.Fatalf("Search calls = %d, want 1", spyStore.searchCalls)
+	}
+	if len(results) != 1 || results[0].Chunk.ID != "c1" {
+		t.Fatalf("results = %+v, want c1", results)
+	}
+}
+
+func TestRetrieve_emptyQueryVSID_errs(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
 
@@ -89,75 +155,246 @@ func TestRetriever_VectorSpaceMismatchFailsClosed(t *testing.T) {
 	if err := store.ReplaceSourceWithHashAndVectorSpaceID(ctx, "s.go", chunks, [][]float64{{1, 0}}, "hash", "ollama/indexed"); err != nil {
 		t.Fatalf("seed store: %v", err)
 	}
+	spyStore := &countingSQLiteRetrieverStore{SQLiteStore: store}
+
+	emb := &recordingEmbedder{result: EmbedResult{Embeddings: [][]float64{{1, 0}}}}
+	r, err := NewRetrieverWithEmbedder(emb, spyStore)
+	if err != nil {
+		t.Fatalf("NewRetrieverWithEmbedder: %v", err)
+	}
+
+	_, err = r.Retrieve(ctx, "question", 1)
+	if !errors.Is(err, ErrVectorSpaceMismatch) {
+		t.Fatalf("Retrieve error = %v, want ErrVectorSpaceMismatch", err)
+	}
+	if !strings.Contains(err.Error(), "no VectorSpaceID") {
+		t.Errorf("Retrieve error = %q, want it to mention missing VectorSpaceID", err.Error())
+	}
+	if spyStore.searchCalls != 0 {
+		t.Fatalf("Search calls = %d, want 0 on missing query vector-space id", spyStore.searchCalls)
+	}
+}
+
+func TestRetrieve_mixedCorpus_errs(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	insertVSIDRow(t, store, "a", "Z")
+	insertVSIDRow(t, store, "b", "A")
+	spyStore := &countingSQLiteRetrieverStore{SQLiteStore: store}
 
 	emb := &recordingEmbedder{result: EmbedResult{
-		Embeddings:    [][]float64{{1, 0}},
-		Provider:      "ollama",
-		Model:         "query",
-		VectorSpaceID: "ollama/query",
+		Embeddings:    [][]float64{{1}},
+		VectorSpaceID: "A",
+	}}
+	r, err := NewRetrieverWithEmbedder(emb, spyStore)
+	if err != nil {
+		t.Fatalf("NewRetrieverWithEmbedder: %v", err)
+	}
+
+	_, err = r.Retrieve(ctx, "question", 1)
+	if !errors.Is(err, ErrCorpusMixedVectorSpaces) {
+		t.Fatalf("Retrieve error = %v, want ErrCorpusMixedVectorSpaces", err)
+	}
+	for _, want := range []string{"A", "Z"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Retrieve error = %q, want it to contain %q", err.Error(), want)
+		}
+	}
+	if spyStore.searchCalls != 0 {
+		t.Fatalf("Search calls = %d, want 0 on mixed corpus", spyStore.searchCalls)
+	}
+}
+
+func TestRetrieve_partialMigration_errs(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	for i := 0; i < 10; i++ {
+		insertVSIDRow(t, store, "known-"+string(rune('a'+i)), "X")
+		insertVSIDRow(t, store, "legacy-"+string(rune('a'+i)), "")
+	}
+	spyStore := &countingSQLiteRetrieverStore{SQLiteStore: store}
+
+	emb := &recordingEmbedder{result: EmbedResult{
+		Embeddings:    [][]float64{{1}},
+		VectorSpaceID: "X",
+	}}
+	r, err := NewRetrieverWithEmbedder(emb, spyStore)
+	if err != nil {
+		t.Fatalf("NewRetrieverWithEmbedder: %v", err)
+	}
+
+	_, err = r.Retrieve(ctx, "question", 1)
+	if !errors.Is(err, ErrCorpusMixedVectorSpaces) {
+		t.Fatalf("Retrieve error = %v, want ErrCorpusMixedVectorSpaces", err)
+	}
+	for _, want := range []string{"X", "unknown legacy vector space"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Retrieve error = %q, want it to contain %q", err.Error(), want)
+		}
+	}
+	if spyStore.searchCalls != 0 {
+		t.Fatalf("Search calls = %d, want 0 on partial migration", spyStore.searchCalls)
+	}
+}
+
+func TestRetrieve_fullyLegacy_proceeds(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	insertVSIDRow(t, store, "a", "")
+	insertVSIDRow(t, store, "b", "")
+	spyStore := &countingSQLiteRetrieverStore{SQLiteStore: store}
+
+	emb := &recordingEmbedder{result: EmbedResult{
+		Embeddings:    [][]float64{{1}},
+		VectorSpaceID: "new-space",
+	}}
+	r, err := NewRetrieverWithEmbedder(emb, spyStore)
+	if err != nil {
+		t.Fatalf("NewRetrieverWithEmbedder: %v", err)
+	}
+
+	results, err := r.Retrieve(ctx, "question", 5)
+	if err != nil {
+		t.Fatalf("Retrieve error: %v", err)
+	}
+	if spyStore.searchCalls != 1 {
+		t.Fatalf("Search calls = %d, want 1", spyStore.searchCalls)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
+	}
+}
+
+func TestRetrieve_emptyCorpus_proceeds(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	spyStore := &countingSQLiteRetrieverStore{SQLiteStore: store}
+
+	emb := &recordingEmbedder{result: EmbedResult{
+		Embeddings:    [][]float64{{1}},
+		VectorSpaceID: "new-space",
+	}}
+	r, err := NewRetrieverWithEmbedder(emb, spyStore)
+	if err != nil {
+		t.Fatalf("NewRetrieverWithEmbedder: %v", err)
+	}
+
+	results, err := r.Retrieve(ctx, "question", 5)
+	if err != nil {
+		t.Fatalf("Retrieve error: %v", err)
+	}
+	if spyStore.searchCalls != 1 {
+		t.Fatalf("Search calls = %d, want 1", spyStore.searchCalls)
+	}
+	if len(results) != 0 {
+		t.Fatalf("results = %d, want 0", len(results))
+	}
+}
+
+func TestRetrieve_searchWrapperPreserved(t *testing.T) {
+	errBoom := errors.New("boom")
+	store := &retrieverProbingStore{
+		retrieverPlainStore: retrieverPlainStore{searchErr: errBoom},
+		probe:               vectorSpaceProbe{KnownIDs: []string{"X"}},
+	}
+	emb := &recordingEmbedder{result: EmbedResult{
+		Embeddings:    [][]float64{{1}},
+		VectorSpaceID: "X",
 	}}
 	r, err := NewRetrieverWithEmbedder(emb, store)
 	if err != nil {
 		t.Fatalf("NewRetrieverWithEmbedder: %v", err)
 	}
 
-	_, err = r.Retrieve(ctx, "question", 1)
-	if !errors.Is(err, ErrVectorSpaceMismatch) {
-		t.Fatalf("Retrieve error = %v, want ErrVectorSpaceMismatch", err)
+	_, err = r.Retrieve(context.Background(), "question", 1)
+	if err == nil {
+		t.Fatal("Retrieve error = nil, want search error")
+	}
+	if !strings.HasPrefix(err.Error(), "rag: search:") {
+		t.Fatalf("Retrieve error = %q, want prefix %q", err.Error(), "rag: search:")
+	}
+	if !errors.Is(err, errBoom) {
+		t.Fatalf("Retrieve error = %v, want it to wrap errBoom", err)
+	}
+	if !errors.Is(err, ErrStoreOperation) {
+		t.Fatalf("Retrieve error = %v, want it to wrap ErrStoreOperation", err)
 	}
 }
 
-func TestRetriever_MissingQueryVectorSpaceFailsClosed(t *testing.T) {
-	store := newTestStore(t)
-	ctx := context.Background()
-
-	chunks := []Chunk{{ID: "c1", Content: "stored", Source: "s.go", StartLine: 1, EndLine: 1, Metadata: map[string]string{}}}
-	if err := store.ReplaceSourceWithHashAndVectorSpaceID(ctx, "s.go", chunks, [][]float64{{1, 0}}, "hash", "ollama/indexed"); err != nil {
-		t.Fatalf("seed store: %v", err)
+func TestRetrieve_storeWithoutProber_skipsCheck(t *testing.T) {
+	store := &retrieverPlainStore{
+		searchResults: []SearchResult{{Chunk: Chunk{ID: "c1"}, Score: 1}},
 	}
-
-	emb := &recordingEmbedder{result: EmbedResult{Embeddings: [][]float64{{1, 0}}}}
+	emb := &recordingEmbedder{result: EmbedResult{
+		Embeddings:    [][]float64{{1}},
+		VectorSpaceID: "query-space",
+	}}
 	r, err := NewRetrieverWithEmbedder(emb, store)
 	if err != nil {
 		t.Fatalf("NewRetrieverWithEmbedder: %v", err)
 	}
 
-	_, err = r.Retrieve(ctx, "question", 1)
-	if !errors.Is(err, ErrVectorSpaceMismatch) {
-		t.Fatalf("Retrieve error = %v, want ErrVectorSpaceMismatch", err)
+	results, err := r.Retrieve(context.Background(), "question", 1)
+	if err != nil {
+		t.Fatalf("Retrieve error: %v", err)
+	}
+	if store.searchCalls != 1 {
+		t.Fatalf("Search calls = %d, want 1", store.searchCalls)
+	}
+	if len(results) != 1 || results[0].Chunk.ID != "c1" {
+		t.Fatalf("results = %+v, want c1", results)
 	}
 }
 
-func TestRetriever_MixedCorpusVectorSpacesFailClosed(t *testing.T) {
-	for _, tt := range []struct {
-		name string
-		ids  []string
-	}{
-		{name: "two known", ids: []string{"A", "B"}},
-		{name: "known plus legacy", ids: []string{"A", ""}},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			store := newTestStore(t)
-			ctx := context.Background()
-			for i, id := range tt.ids {
-				insertVSIDRow(t, store, string(rune('a'+i)), id)
-			}
+type countingSQLiteRetrieverStore struct {
+	*SQLiteStore
+	searchCalls int
+}
 
-			emb := &recordingEmbedder{result: EmbedResult{
-				Embeddings:    [][]float64{{1}},
-				Provider:      "fake",
-				Model:         "A",
-				VectorSpaceID: "A",
-			}}
-			r, err := NewRetrieverWithEmbedder(emb, store)
-			if err != nil {
-				t.Fatalf("NewRetrieverWithEmbedder: %v", err)
-			}
+func (s *countingSQLiteRetrieverStore) Search(ctx context.Context, queryEmbedding []float64, k int) ([]SearchResult, error) {
+	s.searchCalls++
+	return s.SQLiteStore.Search(ctx, queryEmbedding, k)
+}
 
-			_, err = r.Retrieve(ctx, "question", 1)
-			if !errors.Is(err, ErrCorpusMixedVectorSpaces) {
-				t.Fatalf("Retrieve error = %v, want ErrCorpusMixedVectorSpaces", err)
-			}
-		})
+type retrieverPlainStore struct {
+	searchResults []SearchResult
+	searchErr     error
+	searchCalls   int
+}
+
+func (s *retrieverPlainStore) Store(context.Context, []Chunk, [][]float64) error {
+	return nil
+}
+
+func (s *retrieverPlainStore) Search(context.Context, []float64, int) ([]SearchResult, error) {
+	s.searchCalls++
+	if s.searchErr != nil {
+		return nil, s.searchErr
 	}
+	return s.searchResults, nil
+}
+
+func (s *retrieverPlainStore) DeleteBySource(context.Context, string) error {
+	return nil
+}
+
+func (s *retrieverPlainStore) Stats(context.Context) (StoreStats, error) {
+	return StoreStats{}, nil
+}
+
+func (s *retrieverPlainStore) Close() error {
+	return nil
+}
+
+type retrieverProbingStore struct {
+	retrieverPlainStore
+	probe    vectorSpaceProbe
+	probeErr error
+}
+
+func (s *retrieverProbingStore) ProbeVectorSpaces(context.Context) (vectorSpaceProbe, error) {
+	if s.probeErr != nil {
+		return vectorSpaceProbe{}, s.probeErr
+	}
+	return s.probe, nil
 }


### PR DESCRIPTION
## Summary

- Tighten retriever error text around vector-space mismatch and partial legacy corpora.
- Preserve the existing `rag: search:` store-error prefix while still wrapping `ErrStoreOperation`.
- Expand #82 Phase 4 retrieval tests for VSID mismatch, matching VSID, missing query VSID, mixed corpus, partial migration, fully legacy corpus, empty corpus, search error wrapping, and stores without vector-space probes.

## Why

This handles the remaining retriever read-path enforcement slice for #82 after PRs #90, #99, and #101 landed the schema/probe, write path, and source-signature repair phases.

Refs #82.

## Validation

- `go test ./rag/...`
- `go test ./...`
- pre-push hook: lint, race tests, compile smoke

## Notes

Opened as draft for review because these were pre-existing local dirty files that were not attached to an open PR.