### PR TITLE
feat(rag): add agentic RAG evaluation baseline harness

### DIFF
--- a/cmd/rag-eval/main.go
+++ b/cmd/rag-eval/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/kstruzzieri/go-llm/internal/rageval"
+)
+
+func main() {
+	fixturePath := flag.String("fixtures", "internal/rageval/testdata/fixtures.json", "Path to RAG evaluation fixture JSON")
+	outPath := flag.String("out", "internal/rageval/testdata/baseline.json", "Path to write baseline report JSON")
+	warmRuns := flag.Int("warm-runs", 3, "Warm retrieval runs per query")
+	noLatency := flag.Bool("no-latency", false, "Disable wall-clock latency measurement")
+	flag.Parse()
+
+	fixture, err := rageval.LoadFixture(*fixturePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	report, err := rageval.Run(context.Background(), fixture, rageval.RunOptions{
+		WarmRuns:       *warmRuns,
+		MeasureLatency: !*noLatency,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	if err := rageval.WriteReport(*outPath, report); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}

--- a/internal/rageval/README.md
+++ b/internal/rageval/README.md
@@ -1,0 +1,44 @@
+# RAG Evaluation Baseline
+
+This internal package supports issue `#93`: agentic RAG Phase 0 evaluation
+fixtures and baseline metrics.
+
+It is intentionally under `internal/` so the harness does not decide the public
+package boundary before `#94`.
+
+## Fixtures
+
+`testdata/fixtures.json` contains:
+
+- 12 synthetic code chunks
+- 20 golden queries
+- 5 required categories with 4 queries each:
+  - `single_hop`
+  - `cross_file_trace`
+  - `compare`
+  - `architecture`
+  - `code_review`
+
+The fixture uses deterministic synthetic embeddings and does not require
+Ollama or any live model.
+
+## Baseline
+
+Regenerate the committed report with:
+
+```sh
+go run ./cmd/rag-eval \
+  -fixtures internal/rageval/testdata/fixtures.json \
+  -out internal/rageval/testdata/baseline.json
+```
+
+The report compares:
+
+- `static`: `rag.Retriever.Retrieve`
+- `hybrid_search_multi`: `rag.SQLiteStore.SearchMulti`
+
+Metrics include recall@5/10, MRR@5/10, duplicate rate, context precision
+proxy, estimated context tokens, and cold/warm latency.
+
+Threshold fields are intentionally `null` until Keith sets owner-approved
+values before `#95` starts.

--- a/internal/rageval/fixture.go
+++ b/internal/rageval/fixture.go
@@ -59,6 +59,7 @@ func (f *Fixture) Validate() error {
 	}
 
 	queries := make(map[string]struct{}, len(f.Queries))
+	queryTexts := make(map[string]string, len(f.Queries))
 	for i, query := range f.Queries {
 		if query.ID == "" {
 			return fmt.Errorf("rag eval: query %d missing id", i)
@@ -72,6 +73,9 @@ func (f *Fixture) Validate() error {
 		if query.Query == "" {
 			return fmt.Errorf("rag eval: query %q missing query text", query.ID)
 		}
+		if previousID, exists := queryTexts[query.Query]; exists {
+			return fmt.Errorf("rag eval: duplicate query text %q used by queries %q and %q", query.Query, previousID, query.ID)
+		}
 		if len(query.Embedding) != dim {
 			return fmt.Errorf("rag eval: query %q embedding dim=%d, want %d", query.ID, len(query.Embedding), dim)
 		}
@@ -84,6 +88,7 @@ func (f *Fixture) Validate() error {
 			}
 		}
 		queries[query.ID] = struct{}{}
+		queryTexts[query.Query] = query.ID
 	}
 	return nil
 }

--- a/internal/rageval/fixture.go
+++ b/internal/rageval/fixture.go
@@ -1,0 +1,89 @@
+package rageval
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// LoadFixture reads a golden RAG evaluation fixture from disk.
+func LoadFixture(path string) (*Fixture, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("rag eval: read fixture: %w", err)
+	}
+	var fixture Fixture
+	if err := json.Unmarshal(data, &fixture); err != nil {
+		return nil, fmt.Errorf("rag eval: parse fixture: %w", err)
+	}
+	if err := fixture.Validate(); err != nil {
+		return nil, err
+	}
+	return &fixture, nil
+}
+
+// Validate checks the fixture's internal references.
+func (f *Fixture) Validate() error {
+	if f == nil {
+		return fmt.Errorf("rag eval: fixture is nil")
+	}
+	if len(f.Corpus) == 0 {
+		return fmt.Errorf("rag eval: fixture corpus is empty")
+	}
+	if len(f.Queries) == 0 {
+		return fmt.Errorf("rag eval: fixture queries are empty")
+	}
+
+	chunks := make(map[string]FixtureChunk, len(f.Corpus))
+	var dim int
+	for i, chunk := range f.Corpus {
+		if chunk.ID == "" {
+			return fmt.Errorf("rag eval: corpus chunk %d missing id", i)
+		}
+		if _, exists := chunks[chunk.ID]; exists {
+			return fmt.Errorf("rag eval: duplicate chunk id %q", chunk.ID)
+		}
+		if chunk.Source == "" {
+			return fmt.Errorf("rag eval: chunk %q missing source", chunk.ID)
+		}
+		if len(chunk.Embedding) == 0 {
+			return fmt.Errorf("rag eval: chunk %q missing embedding", chunk.ID)
+		}
+		if dim == 0 {
+			dim = len(chunk.Embedding)
+		}
+		if len(chunk.Embedding) != dim {
+			return fmt.Errorf("rag eval: chunk %q embedding dim=%d, want %d", chunk.ID, len(chunk.Embedding), dim)
+		}
+		chunks[chunk.ID] = chunk
+	}
+
+	queries := make(map[string]struct{}, len(f.Queries))
+	for i, query := range f.Queries {
+		if query.ID == "" {
+			return fmt.Errorf("rag eval: query %d missing id", i)
+		}
+		if _, exists := queries[query.ID]; exists {
+			return fmt.Errorf("rag eval: duplicate query id %q", query.ID)
+		}
+		if query.Category == "" {
+			return fmt.Errorf("rag eval: query %q missing category", query.ID)
+		}
+		if query.Query == "" {
+			return fmt.Errorf("rag eval: query %q missing query text", query.ID)
+		}
+		if len(query.Embedding) != dim {
+			return fmt.Errorf("rag eval: query %q embedding dim=%d, want %d", query.ID, len(query.Embedding), dim)
+		}
+		if len(query.ExpectedIDs) == 0 {
+			return fmt.Errorf("rag eval: query %q missing expected ids", query.ID)
+		}
+		for _, id := range query.ExpectedIDs {
+			if _, ok := chunks[id]; !ok {
+				return fmt.Errorf("rag eval: query %q references unknown chunk %q", query.ID, id)
+			}
+		}
+		queries[query.ID] = struct{}{}
+	}
+	return nil
+}

--- a/internal/rageval/runner.go
+++ b/internal/rageval/runner.go
@@ -1,0 +1,376 @@
+package rageval
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/rag"
+)
+
+// Run executes static and hybrid retrieval against the fixture.
+func Run(ctx context.Context, fixture *Fixture, opts RunOptions) (*Report, error) {
+	opts = defaultRunOptions(opts)
+	if err := fixture.Validate(); err != nil {
+		return nil, err
+	}
+
+	store, err := buildStore(ctx, fixture)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = store.Close() }()
+
+	embedder := newFixtureEmbedder(fixture)
+	retriever, err := rag.NewRetrieverWithEmbedder(embedder, store, rag.WithRetrieverModel("fixture-embedding"))
+	if err != nil {
+		return nil, fmt.Errorf("rag eval: create retriever: %w", err)
+	}
+
+	static, err := runMode(ctx, "static", fixture, opts, func(ctx context.Context, q QueryFixture, k int) ([]rag.SearchResult, error) {
+		return retriever.Retrieve(ctx, q.Query, k)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	hybrid, err := runMode(ctx, "hybrid_search_multi", fixture, opts, func(ctx context.Context, q QueryFixture, k int) ([]rag.SearchResult, error) {
+		results, err := store.SearchMulti(ctx, q.Embedding, q.Query, k, rag.QueryContext{
+			CurrentFile: q.CurrentFile,
+			Timestamp:   time.Unix(1_700_000_000, 0),
+		})
+		if err != nil {
+			return nil, err
+		}
+		searchResults := make([]rag.SearchResult, len(results))
+		for i, result := range results {
+			searchResults[i] = result.SearchResult
+		}
+		return searchResults, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &Report{
+		SchemaVersion: SchemaVersion,
+		Corpus:        summarizeFixture(fixture),
+		Thresholds: ThresholdSummary{
+			Owner:  "Keith",
+			Status: "pending_owner_values_before_95",
+		},
+		Modes: []ModeReport{*static, *hybrid},
+	}, nil
+}
+
+// WriteReport writes a stable, pretty JSON report.
+func WriteReport(path string, report *Report) error {
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("rag eval: marshal report: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("rag eval: write report: %w", err)
+	}
+	return nil
+}
+
+type retrieveFunc func(context.Context, QueryFixture, int) ([]rag.SearchResult, error)
+
+func runMode(ctx context.Context, mode string, fixture *Fixture, opts RunOptions, retrieve retrieveFunc) (*ModeReport, error) {
+	queryReports := make([]QueryReport, 0, len(fixture.Queries))
+	var coldLatencies []float64
+	var warmLatencies []float64
+
+	for _, query := range fixture.Queries {
+		var results []rag.SearchResult
+		coldMS, err := measure(opts.MeasureLatency, func() error {
+			var retrieveErr error
+			results, retrieveErr = retrieve(ctx, query, 10)
+			return retrieveErr
+		})
+		if err != nil {
+			return nil, fmt.Errorf("rag eval: %s retrieve %q: %w", mode, query.ID, err)
+		}
+		coldLatencies = append(coldLatencies, coldMS)
+
+		queryWarm := make([]float64, 0, opts.WarmRuns)
+		for i := 0; i < opts.WarmRuns; i++ {
+			warmMS, err := measure(opts.MeasureLatency, func() error {
+				_, retrieveErr := retrieve(ctx, query, 10)
+				return retrieveErr
+			})
+			if err != nil {
+				return nil, fmt.Errorf("rag eval: %s warm retrieve %q: %w", mode, query.ID, err)
+			}
+			queryWarm = append(queryWarm, warmMS)
+			warmLatencies = append(warmLatencies, warmMS)
+		}
+
+		queryReports = append(queryReports, QueryReport{
+			ID:            query.ID,
+			Category:      query.Category,
+			ExpectedIDs:   append([]string(nil), query.ExpectedIDs...),
+			ResultIDs:     resultIDs(results),
+			Metrics:       []KMetrics{computeKMetrics(results, query.ExpectedIDs, 5), computeKMetrics(results, query.ExpectedIDs, 10)},
+			ColdLatencyMS: coldMS,
+			WarmLatencyMS: summarizeLatencies(queryWarm),
+		})
+	}
+
+	return &ModeReport{
+		Name:    mode,
+		Summary: summarizeMode(queryReports, coldLatencies, warmLatencies),
+		Queries: queryReports,
+	}, nil
+}
+
+func measure(enabled bool, fn func() error) (float64, error) {
+	if !enabled {
+		return 0, fn()
+	}
+	start := time.Now()
+	err := fn()
+	return elapsedMS(time.Since(start)), err
+}
+
+func buildStore(ctx context.Context, fixture *Fixture) (*rag.SQLiteStore, error) {
+	store, err := rag.NewSQLiteStore(":memory:")
+	if err != nil {
+		return nil, fmt.Errorf("rag eval: create sqlite store: %w", err)
+	}
+	grouped := make(map[string][]int)
+	for i, chunk := range fixture.Corpus {
+		grouped[chunk.Source] = append(grouped[chunk.Source], i)
+	}
+	sources := make([]string, 0, len(grouped))
+	for source := range grouped {
+		sources = append(sources, source)
+	}
+	sort.Strings(sources)
+	for _, source := range sources {
+		indexes := grouped[source]
+		chunks := make([]rag.Chunk, 0, len(indexes))
+		embeddings := make([][]float64, 0, len(indexes))
+		for _, idx := range indexes {
+			fixtureChunk := fixture.Corpus[idx]
+			chunks = append(chunks, rag.Chunk{
+				ID:        fixtureChunk.ID,
+				Source:    fixtureChunk.Source,
+				StartLine: fixtureChunk.StartLine,
+				EndLine:   fixtureChunk.EndLine,
+				Language:  fixtureChunk.Language,
+				StableKey: fixtureChunk.StableKey,
+				Content:   fixtureChunk.Content,
+				Metadata:  fixtureChunk.Metadata,
+			})
+			embeddings = append(embeddings, append([]float64(nil), fixtureChunk.Embedding...))
+		}
+		if err := store.ReplaceSourceWithHashAndVectorSpaceID(ctx, source, chunks, embeddings, "fixture:"+source, vectorSpaceID); err != nil {
+			_ = store.Close()
+			return nil, fmt.Errorf("rag eval: seed source %q: %w", source, err)
+		}
+	}
+	return store, nil
+}
+
+func summarizeFixture(fixture *Fixture) CorpusSummary {
+	categories := make(map[string]int)
+	for _, query := range fixture.Queries {
+		categories[query.Category]++
+	}
+	return CorpusSummary{
+		Chunks:     len(fixture.Corpus),
+		Queries:    len(fixture.Queries),
+		Categories: categories,
+		TopK:       []int{5, 10},
+		VectorID:   vectorSpaceID,
+		Notes: []string{
+			"fixtures use deterministic synthetic embeddings; no live Ollama dependency",
+			"threshold values are owner-gated before #95",
+		},
+	}
+}
+
+func summarizeMode(queries []QueryReport, cold, warm []float64) ModeSummary {
+	return ModeSummary{
+		RecallAt5:                averageMetric(queries, 5, func(m KMetrics) float64 { return m.Recall }),
+		RecallAt10:               averageMetric(queries, 10, func(m KMetrics) float64 { return m.Recall }),
+		MRRAt5:                   averageMetric(queries, 5, func(m KMetrics) float64 { return m.MRR }),
+		MRRAt10:                  averageMetric(queries, 10, func(m KMetrics) float64 { return m.MRR }),
+		DuplicateRateAt10:        averageMetric(queries, 10, func(m KMetrics) float64 { return m.DuplicateRate }),
+		ContextPrecisionAt5:      averageMetric(queries, 5, func(m KMetrics) float64 { return m.ContextPrecisionProxy }),
+		ContextPrecisionAt10:     averageMetric(queries, 10, func(m KMetrics) float64 { return m.ContextPrecisionProxy }),
+		AverageContextTokensAt5:  averageMetric(queries, 5, func(m KMetrics) float64 { return float64(m.ContextTokens) }),
+		AverageContextTokensAt10: averageMetric(queries, 10, func(m KMetrics) float64 { return float64(m.ContextTokens) }),
+		ColdLatencyMS:            summarizeLatencies(cold),
+		WarmLatencyMS:            summarizeLatencies(warm),
+	}
+}
+
+func averageMetric(queries []QueryReport, k int, pick func(KMetrics) float64) float64 {
+	if len(queries) == 0 {
+		return 0
+	}
+	var total float64
+	for _, query := range queries {
+		for _, metric := range query.Metrics {
+			if metric.K == k {
+				total += pick(metric)
+				break
+			}
+		}
+	}
+	return total / float64(len(queries))
+}
+
+func computeKMetrics(results []rag.SearchResult, expectedIDs []string, k int) KMetrics {
+	limited := limitResults(results, k)
+	return KMetrics{
+		K:                     k,
+		Recall:                recall(limited, expectedIDs),
+		MRR:                   reciprocalRank(limited, expectedIDs),
+		DuplicateRate:         duplicateRate(limited),
+		ContextPrecisionProxy: contextPrecision(limited, expectedIDs),
+		ContextTokens:         contextTokens(limited),
+	}
+}
+
+func limitResults(results []rag.SearchResult, k int) []rag.SearchResult {
+	if k <= 0 || len(results) <= k {
+		return results
+	}
+	return results[:k]
+}
+
+func resultIDs(results []rag.SearchResult) []string {
+	ids := make([]string, len(results))
+	for i, result := range results {
+		ids[i] = result.Chunk.ID
+	}
+	return ids
+}
+
+func recall(results []rag.SearchResult, expectedIDs []string) float64 {
+	if len(expectedIDs) == 0 {
+		return 0
+	}
+	expected := set(expectedIDs)
+	hits := 0
+	for _, result := range results {
+		if expected[result.Chunk.ID] {
+			hits++
+		}
+	}
+	return float64(hits) / float64(len(expected))
+}
+
+func reciprocalRank(results []rag.SearchResult, expectedIDs []string) float64 {
+	expected := set(expectedIDs)
+	for i, result := range results {
+		if expected[result.Chunk.ID] {
+			return 1 / float64(i+1)
+		}
+	}
+	return 0
+}
+
+func duplicateRate(results []rag.SearchResult) float64 {
+	if len(results) == 0 {
+		return 0
+	}
+	seen := make(map[string]struct{}, len(results))
+	for _, result := range results {
+		seen[result.Chunk.ID] = struct{}{}
+	}
+	return float64(len(results)-len(seen)) / float64(len(results))
+}
+
+func contextPrecision(results []rag.SearchResult, expectedIDs []string) float64 {
+	if len(results) == 0 {
+		return 0
+	}
+	expected := set(expectedIDs)
+	hits := 0
+	for _, result := range results {
+		if expected[result.Chunk.ID] {
+			hits++
+		}
+	}
+	return float64(hits) / float64(len(results))
+}
+
+func contextTokens(results []rag.SearchResult) int {
+	var retriever rag.Retriever
+	contextText := retriever.BuildContext(results, 0)
+	return (len(contextText) + 3) / 4
+}
+
+func set(ids []string) map[string]bool {
+	out := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		out[id] = true
+	}
+	return out
+}
+
+func summarizeLatencies(values []float64) LatencySummary {
+	if len(values) == 0 {
+		return LatencySummary{}
+	}
+	cp := append([]float64(nil), values...)
+	sort.Float64s(cp)
+	return LatencySummary{
+		Count: len(cp),
+		P50:   percentile(cp, 0.50),
+		P95:   percentile(cp, 0.95),
+	}
+}
+
+func percentile(sorted []float64, p float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	if len(sorted) == 1 {
+		return sorted[0]
+	}
+	pos := p * float64(len(sorted)-1)
+	idx := int(pos)
+	if idx >= len(sorted)-1 {
+		return sorted[len(sorted)-1]
+	}
+	frac := pos - float64(idx)
+	return sorted[idx] + (sorted[idx+1]-sorted[idx])*frac
+}
+
+type fixtureEmbedder struct {
+	byQuery map[string][]float64
+}
+
+func newFixtureEmbedder(fixture *Fixture) *fixtureEmbedder {
+	byQuery := make(map[string][]float64, len(fixture.Queries))
+	for _, query := range fixture.Queries {
+		byQuery[query.Query] = append([]float64(nil), query.Embedding...)
+	}
+	return &fixtureEmbedder{byQuery: byQuery}
+}
+
+func (e *fixtureEmbedder) Embed(_ context.Context, _ string, inputs []string) (rag.EmbedResult, error) {
+	if len(inputs) != 1 {
+		return rag.EmbedResult{}, fmt.Errorf("rag eval: fixture embedder expects 1 input, got %d", len(inputs))
+	}
+	embedding, ok := e.byQuery[inputs[0]]
+	if !ok {
+		return rag.EmbedResult{}, fmt.Errorf("rag eval: no fixture embedding for query %q", inputs[0])
+	}
+	return rag.EmbedResult{
+		Embeddings:    [][]float64{append([]float64(nil), embedding...)},
+		Provider:      "fixture",
+		Model:         "rag-eval-v1",
+		VectorSpaceID: vectorSpaceID,
+	}, nil
+}

--- a/internal/rageval/runner_test.go
+++ b/internal/rageval/runner_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
+
+	"github.com/kstruzzieri/go-llm/rag"
 )
 
 const fixturePath = "testdata/fixtures.json"
@@ -30,6 +33,21 @@ func TestFixtureValidate(t *testing.T) {
 	}
 }
 
+func TestFixtureValidateRejectsDuplicateQueryText(t *testing.T) {
+	fixture, err := LoadFixture(fixturePath)
+	if err != nil {
+		t.Fatalf("LoadFixture: %v", err)
+	}
+	fixture.Queries[1].Query = fixture.Queries[0].Query
+	err = fixture.Validate()
+	if err == nil {
+		t.Fatal("expected error for duplicate query text, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate query text") {
+		t.Fatalf("expected error to mention duplicate query text, got: %v", err)
+	}
+}
+
 func TestRunFixtureWithoutLiveModel(t *testing.T) {
 	fixture, err := LoadFixture(fixturePath)
 	if err != nil {
@@ -51,6 +69,37 @@ func TestRunFixtureWithoutLiveModel(t *testing.T) {
 		}
 		if mode.Summary.RecallAt5 <= 0 {
 			t.Fatalf("mode %q recall@5 = %f, want > 0", mode.Name, mode.Summary.RecallAt5)
+		}
+	}
+}
+
+func TestRunModeHonorsZeroWarmRuns(t *testing.T) {
+	fixture, err := LoadFixture(fixturePath)
+	if err != nil {
+		t.Fatalf("LoadFixture: %v", err)
+	}
+
+	calls := 0
+	report, err := runMode(context.Background(), "test", fixture, RunOptions{WarmRuns: 0, MeasureLatency: false}, func(_ context.Context, query QueryFixture, _ int) ([]rag.SearchResult, error) {
+		calls++
+		return []rag.SearchResult{
+			{
+				Chunk: rag.Chunk{
+					ID:      query.ExpectedIDs[0],
+					Content: "fixture result",
+				},
+			},
+		}, nil
+	})
+	if err != nil {
+		t.Fatalf("runMode: %v", err)
+	}
+	if calls != len(fixture.Queries) {
+		t.Fatalf("retrieve calls = %d, want %d cold calls only", calls, len(fixture.Queries))
+	}
+	for _, query := range report.Queries {
+		if query.WarmLatencyMS.Count != 0 {
+			t.Fatalf("query %q warm latency count = %d, want 0", query.ID, query.WarmLatencyMS.Count)
 		}
 	}
 }

--- a/internal/rageval/runner_test.go
+++ b/internal/rageval/runner_test.go
@@ -1,0 +1,79 @@
+package rageval
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+const fixturePath = "testdata/fixtures.json"
+const baselinePath = "testdata/baseline.json"
+
+func TestFixtureValidate(t *testing.T) {
+	fixture, err := LoadFixture(fixturePath)
+	if err != nil {
+		t.Fatalf("LoadFixture: %v", err)
+	}
+	if len(fixture.Queries) != 20 {
+		t.Fatalf("queries = %d, want 20", len(fixture.Queries))
+	}
+	categories := map[string]int{}
+	for _, query := range fixture.Queries {
+		categories[query.Category]++
+	}
+	wantCategories := []string{"architecture", "code_review", "compare", "cross_file_trace", "single_hop"}
+	for _, category := range wantCategories {
+		if categories[category] != 4 {
+			t.Fatalf("category %q count = %d, want 4", category, categories[category])
+		}
+	}
+}
+
+func TestRunFixtureWithoutLiveModel(t *testing.T) {
+	fixture, err := LoadFixture(fixturePath)
+	if err != nil {
+		t.Fatalf("LoadFixture: %v", err)
+	}
+	report, err := Run(context.Background(), fixture, RunOptions{MeasureLatency: false})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if report.SchemaVersion != SchemaVersion {
+		t.Fatalf("SchemaVersion = %q, want %q", report.SchemaVersion, SchemaVersion)
+	}
+	if len(report.Modes) != 2 {
+		t.Fatalf("modes = %d, want 2", len(report.Modes))
+	}
+	for _, mode := range report.Modes {
+		if len(mode.Queries) != len(fixture.Queries) {
+			t.Fatalf("mode %q queries = %d, want %d", mode.Name, len(mode.Queries), len(fixture.Queries))
+		}
+		if mode.Summary.RecallAt5 <= 0 {
+			t.Fatalf("mode %q recall@5 = %f, want > 0", mode.Name, mode.Summary.RecallAt5)
+		}
+	}
+}
+
+func TestBaselineReportShape(t *testing.T) {
+	data, err := os.ReadFile(baselinePath)
+	if err != nil {
+		t.Fatalf("read baseline: %v", err)
+	}
+	var report Report
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("parse baseline: %v", err)
+	}
+	if report.SchemaVersion != SchemaVersion {
+		t.Fatalf("SchemaVersion = %q, want %q", report.SchemaVersion, SchemaVersion)
+	}
+	if report.Corpus.Queries != 20 {
+		t.Fatalf("baseline queries = %d, want 20", report.Corpus.Queries)
+	}
+	if report.Thresholds.Status != "pending_owner_values_before_95" {
+		t.Fatalf("threshold status = %q", report.Thresholds.Status)
+	}
+	if len(report.Modes) != 2 {
+		t.Fatalf("baseline modes = %d, want 2", len(report.Modes))
+	}
+}

--- a/internal/rageval/testdata/baseline.json
+++ b/internal/rageval/testdata/baseline.json
@@ -1,0 +1,1876 @@
+{
+  "schema_version": "rag-eval-baseline/v1",
+  "corpus": {
+    "chunks": 12,
+    "queries": 20,
+    "categories": {
+      "architecture": 4,
+      "code_review": 4,
+      "compare": 4,
+      "cross_file_trace": 4,
+      "single_hop": 4
+    },
+    "top_k": [
+      5,
+      10
+    ],
+    "vector_space_id": "fixture/rag-eval-v1",
+    "notes": [
+      "fixtures use deterministic synthetic embeddings; no live Ollama dependency",
+      "threshold values are owner-gated before #95"
+    ]
+  },
+  "thresholds": {
+    "owner": "Keith",
+    "status": "pending_owner_values_before_95",
+    "minimum_static_recall_at_5": null,
+    "minimum_hybrid_recall_at_5_improvement": null,
+    "maximum_duplicate_rate": null,
+    "minimum_context_precision_proxy": null,
+    "maximum_opt_in_hybrid_p95_latency_ms": null,
+    "maximum_future_default_p95_latency_ms": null,
+    "maximum_average_context_token_growth": null
+  },
+  "modes": [
+    {
+      "name": "static",
+      "summary": {
+        "recall_at_5": 0.9583333333333334,
+        "recall_at_10": 1,
+        "mrr_at_5": 1,
+        "mrr_at_10": 1,
+        "duplicate_rate_at_10": 0,
+        "context_precision_at_5": 0.51,
+        "context_precision_at_10": 0.27,
+        "average_context_tokens_at_5": 666.85,
+        "average_context_tokens_at_10": 1343.55,
+        "cold_latency_ms": {
+          "count": 20,
+          "p50": 0.057084,
+          "p95": 0.16294794999999992
+        },
+        "warm_latency_ms": {
+          "count": 60,
+          "p50": 0.058146,
+          "p95": 0.10196314999999993
+        }
+      },
+      "queries": [
+        {
+          "id": "single_login_handler",
+          "category": "single_hop",
+          "expected_ids": [
+            "auth_handler_login"
+          ],
+          "result_ids": [
+            "auth_handler_login",
+            "middleware_require_auth",
+            "auth_service_login",
+            "users_repository_find",
+            "api_router_new",
+            "errors_app_error",
+            "config_loader_load",
+            "orders_service_place",
+            "orders_repository_save",
+            "inventory_service_reserve"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.2,
+              "context_tokens": 697
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.1,
+              "context_tokens": 1375
+            }
+          ],
+          "cold_latency_ms": 0.145959,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.070167,
+            "p95": 0.0765039
+          }
+        },
+        {
+          "id": "single_find_by_email",
+          "category": "single_hop",
+          "expected_ids": [
+            "users_repository_find"
+          ],
+          "result_ids": [
+            "users_repository_find",
+            "auth_service_login",
+            "auth_handler_login",
+            "orders_repository_save",
+            "middleware_require_auth",
+            "orders_service_place",
+            "api_router_new",
+            "inventory_service_reserve",
+            "errors_app_error",
+            "payments_client_charge"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.2,
+              "context_tokens": 678
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.1,
+              "context_tokens": 1387
+            }
+          ],
+          "cold_latency_ms": 0.078042,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.067583,
+            "p95": 0.0741836
+          }
+        },
+        {
+          "id": "single_require_auth",
+          "category": "single_hop",
+          "expected_ids": [
+            "middleware_require_auth"
+          ],
+          "result_ids": [
+            "middleware_require_auth",
+            "auth_handler_login",
+            "auth_service_login",
+            "api_router_new",
+            "users_repository_find",
+            "errors_app_error",
+            "config_loader_load",
+            "shipping_service_create",
+            "orders_service_place",
+            "inventory_service_reserve"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.2,
+              "context_tokens": 697
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.1,
+              "context_tokens": 1372
+            }
+          ],
+          "cold_latency_ms": 0.075,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.074792,
+            "p95": 0.0796664
+          }
+        },
+        {
+          "id": "single_payment_charge",
+          "category": "single_hop",
+          "expected_ids": [
+            "payments_client_charge"
+          ],
+          "result_ids": [
+            "payments_client_charge",
+            "shipping_service_create",
+            "config_loader_load",
+            "orders_service_place",
+            "inventory_service_reserve",
+            "errors_app_error",
+            "orders_repository_save",
+            "api_router_new",
+            "auth_service_login",
+            "users_repository_find"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.2,
+              "context_tokens": 667
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.1,
+              "context_tokens": 1303
+            }
+          ],
+          "cold_latency_ms": 0.078208,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.068917,
+            "p95": 0.0770917
+          }
+        },
+        {
+          "id": "trace_login_flow",
+          "category": "cross_file_trace",
+          "expected_ids": [
+            "auth_handler_login",
+            "auth_service_login",
+            "users_repository_find"
+          ],
+          "result_ids": [
+            "auth_service_login",
+            "auth_handler_login",
+            "users_repository_find",
+            "middleware_require_auth",
+            "api_router_new",
+            "errors_app_error",
+            "orders_repository_save",
+            "orders_service_place",
+            "inventory_service_reserve",
+            "config_loader_load"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.6,
+              "context_tokens": 697
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.3,
+              "context_tokens": 1375
+            }
+          ],
+          "cold_latency_ms": 0.242709,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.0935,
+            "p95": 0.16250030000000001
+          }
+        },
+        {
+          "id": "trace_order_checkout_flow",
+          "category": "cross_file_trace",
+          "expected_ids": [
+            "orders_service_place",
+            "inventory_service_reserve",
+            "payments_client_charge",
+            "orders_repository_save",
+            "shipping_service_create"
+          ],
+          "result_ids": [
+            "orders_service_place",
+            "shipping_service_create",
+            "inventory_service_reserve",
+            "payments_client_charge",
+            "orders_repository_save",
+            "config_loader_load",
+            "errors_app_error",
+            "api_router_new",
+            "users_repository_find",
+            "auth_service_login"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 1,
+              "context_tokens": 646
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.5,
+              "context_tokens": 1303
+            }
+          ],
+          "cold_latency_ms": 0.100041,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.073083,
+            "p95": 0.0737211
+          }
+        },
+        {
+          "id": "trace_protected_route",
+          "category": "cross_file_trace",
+          "expected_ids": [
+            "api_router_new",
+            "middleware_require_auth",
+            "orders_service_place"
+          ],
+          "result_ids": [
+            "api_router_new",
+            "middleware_require_auth",
+            "auth_handler_login",
+            "shipping_service_create",
+            "auth_service_login",
+            "orders_service_place",
+            "inventory_service_reserve",
+            "users_repository_find",
+            "config_loader_load",
+            "payments_client_charge"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 0.6666666666666666,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.4,
+              "context_tokens": 672
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.3,
+              "context_tokens": 1357
+            }
+          ],
+          "cold_latency_ms": 0.0785,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.065625,
+            "p95": 0.0764997
+          }
+        },
+        {
+          "id": "trace_config_to_runtime",
+          "category": "cross_file_trace",
+          "expected_ids": [
+            "config_loader_load",
+            "api_router_new",
+            "payments_client_charge"
+          ],
+          "result_ids": [
+            "config_loader_load",
+            "payments_client_charge",
+            "shipping_service_create",
+            "api_router_new",
+            "errors_app_error",
+            "orders_service_place",
+            "inventory_service_reserve",
+            "middleware_require_auth",
+            "orders_repository_save",
+            "auth_handler_login"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.6,
+              "context_tokens": 595
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.3,
+              "context_tokens": 1305
+            }
+          ],
+          "cold_latency_ms": 0.072042,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.097375,
+            "p95": 0.10026310000000001
+          }
+        },
+        {
+          "id": "compare_auth_service_repository",
+          "category": "compare",
+          "expected_ids": [
+            "auth_service_login",
+            "users_repository_find"
+          ],
+          "result_ids": [
+            "users_repository_find",
+            "auth_service_login",
+            "auth_handler_login",
+            "middleware_require_auth",
+            "orders_repository_save",
+            "api_router_new",
+            "errors_app_error",
+            "orders_service_place",
+            "inventory_service_reserve",
+            "payments_client_charge"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.4,
+              "context_tokens": 678
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.2,
+              "context_tokens": 1387
+            }
+          ],
+          "cold_latency_ms": 0.056709,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.053375,
+            "p95": 0.053712499999999996
+          }
+        },
+        {
+          "id": "compare_payment_inventory",
+          "category": "compare",
+          "expected_ids": [
+            "payments_client_charge",
+            "inventory_service_reserve"
+          ],
+          "result_ids": [
+            "payments_client_charge",
+            "shipping_service_create",
+            "inventory_service_reserve",
+            "orders_service_place",
+            "orders_repository_save",
+            "config_loader_load",
+            "errors_app_error",
+            "api_router_new",
+            "users_repository_find",
+            "auth_service_login"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.4,
+              "context_tokens": 646
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.2,
+              "context_tokens": 1303
+            }
+          ],
+          "cold_latency_ms": 0.05225,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.050792,
+            "p95": 0.051467
+          }
+        },
+        {
+          "id": "compare_handler_middleware",
+          "category": "compare",
+          "expected_ids": [
+            "auth_handler_login",
+            "middleware_require_auth"
+          ],
+          "result_ids": [
+            "middleware_require_auth",
+            "auth_handler_login",
+            "auth_service_login",
+            "users_repository_find",
+            "api_router_new",
+            "errors_app_error",
+            "config_loader_load",
+            "shipping_service_create",
+            "orders_service_place",
+            "inventory_service_reserve"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.4,
+              "context_tokens": 697
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.2,
+              "context_tokens": 1372
+            }
+          ],
+          "cold_latency_ms": 0.054833,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.051208,
+            "p95": 0.055033
+          }
+        },
+        {
+          "id": "compare_order_service_repository",
+          "category": "compare",
+          "expected_ids": [
+            "orders_service_place",
+            "orders_repository_save"
+          ],
+          "result_ids": [
+            "orders_repository_save",
+            "orders_service_place",
+            "inventory_service_reserve",
+            "shipping_service_create",
+            "payments_client_charge",
+            "users_repository_find",
+            "errors_app_error",
+            "api_router_new",
+            "auth_service_login",
+            "config_loader_load"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.4,
+              "context_tokens": 646
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.2,
+              "context_tokens": 1303
+            }
+          ],
+          "cold_latency_ms": 0.052709,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.05125,
+            "p95": 0.0516622
+          }
+        },
+        {
+          "id": "architecture_routes",
+          "category": "architecture",
+          "expected_ids": [
+            "api_router_new",
+            "auth_handler_login",
+            "middleware_require_auth",
+            "orders_service_place"
+          ],
+          "result_ids": [
+            "api_router_new",
+            "middleware_require_auth",
+            "auth_handler_login",
+            "shipping_service_create",
+            "auth_service_login",
+            "orders_service_place",
+            "inventory_service_reserve",
+            "config_loader_load",
+            "users_repository_find",
+            "payments_client_charge"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 0.75,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.6,
+              "context_tokens": 672
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.4,
+              "context_tokens": 1357
+            }
+          ],
+          "cold_latency_ms": 0.05275,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.062083,
+            "p95": 0.0626086
+          }
+        },
+        {
+          "id": "architecture_order_coordination",
+          "category": "architecture",
+          "expected_ids": [
+            "orders_service_place",
+            "inventory_service_reserve",
+            "payments_client_charge",
+            "orders_repository_save",
+            "shipping_service_create"
+          ],
+          "result_ids": [
+            "orders_service_place",
+            "shipping_service_create",
+            "inventory_service_reserve",
+            "payments_client_charge",
+            "orders_repository_save",
+            "config_loader_load",
+            "api_router_new",
+            "errors_app_error",
+            "users_repository_find",
+            "auth_service_login"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 1,
+              "context_tokens": 646
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.5,
+              "context_tokens": 1303
+            }
+          ],
+          "cold_latency_ms": 0.050375,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.050833,
+            "p95": 0.0521461
+          }
+        },
+        {
+          "id": "architecture_auth_sessions",
+          "category": "architecture",
+          "expected_ids": [
+            "auth_service_login",
+            "middleware_require_auth",
+            "auth_handler_login"
+          ],
+          "result_ids": [
+            "auth_handler_login",
+            "middleware_require_auth",
+            "auth_service_login",
+            "users_repository_find",
+            "api_router_new",
+            "errors_app_error",
+            "config_loader_load",
+            "orders_service_place",
+            "shipping_service_create",
+            "orders_repository_save"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.6,
+              "context_tokens": 697
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.3,
+              "context_tokens": 1339
+            }
+          ],
+          "cold_latency_ms": 0.0555,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.055417,
+            "p95": 0.0561667
+          }
+        },
+        {
+          "id": "architecture_error_model",
+          "category": "architecture",
+          "expected_ids": [
+            "errors_app_error",
+            "auth_handler_login",
+            "inventory_service_reserve",
+            "config_loader_load"
+          ],
+          "result_ids": [
+            "errors_app_error",
+            "payments_client_charge",
+            "inventory_service_reserve",
+            "config_loader_load",
+            "orders_service_place",
+            "shipping_service_create",
+            "auth_service_login",
+            "middleware_require_auth",
+            "auth_handler_login",
+            "api_router_new"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 0.75,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.6,
+              "context_tokens": 718
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.4,
+              "context_tokens": 1383
+            }
+          ],
+          "cold_latency_ms": 0.053166,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.128167,
+            "p95": 0.33764109999999997
+          }
+        },
+        {
+          "id": "review_validate_password",
+          "category": "code_review",
+          "expected_ids": [
+            "auth_service_login",
+            "auth_handler_login",
+            "errors_app_error"
+          ],
+          "result_ids": [
+            "auth_service_login",
+            "auth_handler_login",
+            "middleware_require_auth",
+            "users_repository_find",
+            "errors_app_error",
+            "api_router_new",
+            "inventory_service_reserve",
+            "orders_service_place",
+            "config_loader_load",
+            "payments_client_charge"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.6,
+              "context_tokens": 726
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.3,
+              "context_tokens": 1408
+            }
+          ],
+          "cold_latency_ms": 0.15875,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.057667,
+            "p95": 0.058529199999999997
+          }
+        },
+        {
+          "id": "review_place_order",
+          "category": "code_review",
+          "expected_ids": [
+            "orders_service_place",
+            "inventory_service_reserve",
+            "payments_client_charge",
+            "orders_repository_save",
+            "shipping_service_create"
+          ],
+          "result_ids": [
+            "inventory_service_reserve",
+            "orders_service_place",
+            "payments_client_charge",
+            "shipping_service_create",
+            "orders_repository_save",
+            "errors_app_error",
+            "config_loader_load",
+            "api_router_new",
+            "users_repository_find",
+            "auth_service_login"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 1,
+              "context_tokens": 646
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.5,
+              "context_tokens": 1303
+            }
+          ],
+          "cold_latency_ms": 0.057459,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.05575,
+            "p95": 0.056875
+          }
+        },
+        {
+          "id": "review_load_config",
+          "category": "code_review",
+          "expected_ids": [
+            "config_loader_load",
+            "errors_app_error"
+          ],
+          "result_ids": [
+            "config_loader_load",
+            "payments_client_charge",
+            "errors_app_error",
+            "shipping_service_create",
+            "inventory_service_reserve",
+            "orders_service_place",
+            "api_router_new",
+            "middleware_require_auth",
+            "auth_service_login",
+            "orders_repository_save"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.4,
+              "context_tokens": 608
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.2,
+              "context_tokens": 1333
+            }
+          ],
+          "cold_latency_ms": 0.05375,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.053084,
+            "p95": 0.0568334
+          }
+        },
+        {
+          "id": "review_payment_charge",
+          "category": "code_review",
+          "expected_ids": [
+            "payments_client_charge",
+            "errors_app_error"
+          ],
+          "result_ids": [
+            "payments_client_charge",
+            "shipping_service_create",
+            "config_loader_load",
+            "errors_app_error",
+            "inventory_service_reserve",
+            "orders_service_place",
+            "orders_repository_save",
+            "api_router_new",
+            "auth_service_login",
+            "users_repository_find"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.4,
+              "context_tokens": 608
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.2,
+              "context_tokens": 1303
+            }
+          ],
+          "cold_latency_ms": 0.052875,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.052333,
+            "p95": 0.05799579999999999
+          }
+        }
+      ]
+    },
+    {
+      "name": "hybrid_search_multi",
+      "summary": {
+        "recall_at_5": 0.9583333333333334,
+        "recall_at_10": 1,
+        "mrr_at_5": 0.825,
+        "mrr_at_10": 0.825,
+        "duplicate_rate_at_10": 0,
+        "context_precision_at_5": 0.51,
+        "context_precision_at_10": 0.27,
+        "average_context_tokens_at_5": 665.25,
+        "average_context_tokens_at_10": 1343.55,
+        "cold_latency_ms": {
+          "count": 20,
+          "p50": 0.19425,
+          "p95": 0.35700384999999984
+        },
+        "warm_latency_ms": {
+          "count": 60,
+          "p50": 0.190979,
+          "p95": 0.3451475999999997
+        }
+      },
+      "queries": [
+        {
+          "id": "single_login_handler",
+          "category": "single_hop",
+          "expected_ids": [
+            "auth_handler_login"
+          ],
+          "result_ids": [
+            "api_router_new",
+            "auth_handler_login",
+            "middleware_require_auth",
+            "auth_service_login",
+            "users_repository_find",
+            "errors_app_error",
+            "config_loader_load",
+            "orders_service_place",
+            "orders_repository_save",
+            "inventory_service_reserve"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 0.5,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.2,
+              "context_tokens": 697
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 0.5,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.1,
+              "context_tokens": 1375
+            }
+          ],
+          "cold_latency_ms": 0.18725,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.101916,
+            "p95": 0.10446659999999999
+          }
+        },
+        {
+          "id": "single_find_by_email",
+          "category": "single_hop",
+          "expected_ids": [
+            "users_repository_find"
+          ],
+          "result_ids": [
+            "auth_service_login",
+            "auth_handler_login",
+            "users_repository_find",
+            "orders_repository_save",
+            "middleware_require_auth",
+            "orders_service_place",
+            "api_router_new",
+            "inventory_service_reserve",
+            "errors_app_error",
+            "payments_client_charge"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 0.3333333333333333,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.2,
+              "context_tokens": 678
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 0.3333333333333333,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.1,
+              "context_tokens": 1387
+            }
+          ],
+          "cold_latency_ms": 0.108417,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.098041,
+            "p95": 0.1001047
+          }
+        },
+        {
+          "id": "single_require_auth",
+          "category": "single_hop",
+          "expected_ids": [
+            "middleware_require_auth"
+          ],
+          "result_ids": [
+            "api_router_new",
+            "middleware_require_auth",
+            "auth_handler_login",
+            "auth_service_login",
+            "users_repository_find",
+            "errors_app_error",
+            "config_loader_load",
+            "shipping_service_create",
+            "orders_service_place",
+            "inventory_service_reserve"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 0.5,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.2,
+              "context_tokens": 697
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 0.5,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.1,
+              "context_tokens": 1372
+            }
+          ],
+          "cold_latency_ms": 0.100458,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.098084,
+            "p95": 0.0991703
+          }
+        },
+        {
+          "id": "single_payment_charge",
+          "category": "single_hop",
+          "expected_ids": [
+            "payments_client_charge"
+          ],
+          "result_ids": [
+            "orders_service_place",
+            "orders_repository_save",
+            "payments_client_charge",
+            "shipping_service_create",
+            "config_loader_load",
+            "inventory_service_reserve",
+            "errors_app_error",
+            "api_router_new",
+            "auth_service_login",
+            "users_repository_find"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 0.3333333333333333,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.2,
+              "context_tokens": 635
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 0.3333333333333333,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.1,
+              "context_tokens": 1303
+            }
+          ],
+          "cold_latency_ms": 0.113,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.11,
+            "p95": 0.1122122
+          }
+        },
+        {
+          "id": "trace_login_flow",
+          "category": "cross_file_trace",
+          "expected_ids": [
+            "auth_handler_login",
+            "auth_service_login",
+            "users_repository_find"
+          ],
+          "result_ids": [
+            "auth_handler_login",
+            "auth_service_login",
+            "users_repository_find",
+            "middleware_require_auth",
+            "api_router_new",
+            "errors_app_error",
+            "orders_repository_save",
+            "orders_service_place",
+            "inventory_service_reserve",
+            "config_loader_load"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.6,
+              "context_tokens": 697
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.3,
+              "context_tokens": 1375
+            }
+          ],
+          "cold_latency_ms": 0.347208,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.339833,
+            "p95": 0.5169826999999999
+          }
+        },
+        {
+          "id": "trace_order_checkout_flow",
+          "category": "cross_file_trace",
+          "expected_ids": [
+            "orders_service_place",
+            "inventory_service_reserve",
+            "payments_client_charge",
+            "orders_repository_save",
+            "shipping_service_create"
+          ],
+          "result_ids": [
+            "orders_service_place",
+            "orders_repository_save",
+            "shipping_service_create",
+            "inventory_service_reserve",
+            "payments_client_charge",
+            "config_loader_load",
+            "errors_app_error",
+            "api_router_new",
+            "users_repository_find",
+            "auth_service_login"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 1,
+              "context_tokens": 646
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.5,
+              "context_tokens": 1303
+            }
+          ],
+          "cold_latency_ms": 0.261041,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.25275,
+            "p95": 0.2813997
+          }
+        },
+        {
+          "id": "trace_protected_route",
+          "category": "cross_file_trace",
+          "expected_ids": [
+            "api_router_new",
+            "middleware_require_auth",
+            "orders_service_place"
+          ],
+          "result_ids": [
+            "api_router_new",
+            "middleware_require_auth",
+            "auth_handler_login",
+            "shipping_service_create",
+            "auth_service_login",
+            "orders_service_place",
+            "inventory_service_reserve",
+            "users_repository_find",
+            "config_loader_load",
+            "payments_client_charge"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 0.6666666666666666,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.4,
+              "context_tokens": 672
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.3,
+              "context_tokens": 1357
+            }
+          ],
+          "cold_latency_ms": 0.202625,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.185458,
+            "p95": 0.1866577
+          }
+        },
+        {
+          "id": "trace_config_to_runtime",
+          "category": "cross_file_trace",
+          "expected_ids": [
+            "config_loader_load",
+            "api_router_new",
+            "payments_client_charge"
+          ],
+          "result_ids": [
+            "config_loader_load",
+            "payments_client_charge",
+            "shipping_service_create",
+            "api_router_new",
+            "errors_app_error",
+            "orders_service_place",
+            "inventory_service_reserve",
+            "middleware_require_auth",
+            "orders_repository_save",
+            "auth_handler_login"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.6,
+              "context_tokens": 595
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.3,
+              "context_tokens": 1305
+            }
+          ],
+          "cold_latency_ms": 0.19475,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.190166,
+            "p95": 0.19162939999999998
+          }
+        },
+        {
+          "id": "compare_auth_service_repository",
+          "category": "compare",
+          "expected_ids": [
+            "auth_service_login",
+            "users_repository_find"
+          ],
+          "result_ids": [
+            "auth_service_login",
+            "auth_handler_login",
+            "users_repository_find",
+            "middleware_require_auth",
+            "orders_repository_save",
+            "api_router_new",
+            "errors_app_error",
+            "orders_service_place",
+            "inventory_service_reserve",
+            "payments_client_charge"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.4,
+              "context_tokens": 678
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.2,
+              "context_tokens": 1387
+            }
+          ],
+          "cold_latency_ms": 0.15275,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.157833,
+            "p95": 0.16522019999999998
+          }
+        },
+        {
+          "id": "compare_payment_inventory",
+          "category": "compare",
+          "expected_ids": [
+            "payments_client_charge",
+            "inventory_service_reserve"
+          ],
+          "result_ids": [
+            "orders_service_place",
+            "orders_repository_save",
+            "payments_client_charge",
+            "shipping_service_create",
+            "inventory_service_reserve",
+            "config_loader_load",
+            "errors_app_error",
+            "api_router_new",
+            "users_repository_find",
+            "auth_service_login"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 0.3333333333333333,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.4,
+              "context_tokens": 646
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 0.3333333333333333,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.2,
+              "context_tokens": 1303
+            }
+          ],
+          "cold_latency_ms": 0.134458,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.124125,
+            "p95": 0.12735059999999998
+          }
+        },
+        {
+          "id": "compare_handler_middleware",
+          "category": "compare",
+          "expected_ids": [
+            "auth_handler_login",
+            "middleware_require_auth"
+          ],
+          "result_ids": [
+            "api_router_new",
+            "middleware_require_auth",
+            "auth_handler_login",
+            "auth_service_login",
+            "users_repository_find",
+            "errors_app_error",
+            "config_loader_load",
+            "shipping_service_create",
+            "orders_service_place",
+            "inventory_service_reserve"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 0.5,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.4,
+              "context_tokens": 697
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 0.5,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.2,
+              "context_tokens": 1372
+            }
+          ],
+          "cold_latency_ms": 0.12425,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.131458,
+            "p95": 0.1334452
+          }
+        },
+        {
+          "id": "compare_order_service_repository",
+          "category": "compare",
+          "expected_ids": [
+            "orders_service_place",
+            "orders_repository_save"
+          ],
+          "result_ids": [
+            "orders_service_place",
+            "orders_repository_save",
+            "inventory_service_reserve",
+            "shipping_service_create",
+            "payments_client_charge",
+            "users_repository_find",
+            "errors_app_error",
+            "api_router_new",
+            "auth_service_login",
+            "config_loader_load"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.4,
+              "context_tokens": 646
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.2,
+              "context_tokens": 1303
+            }
+          ],
+          "cold_latency_ms": 0.160542,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.312792,
+            "p95": 0.4582536
+          }
+        },
+        {
+          "id": "architecture_routes",
+          "category": "architecture",
+          "expected_ids": [
+            "api_router_new",
+            "auth_handler_login",
+            "middleware_require_auth",
+            "orders_service_place"
+          ],
+          "result_ids": [
+            "api_router_new",
+            "middleware_require_auth",
+            "auth_handler_login",
+            "shipping_service_create",
+            "auth_service_login",
+            "orders_service_place",
+            "inventory_service_reserve",
+            "config_loader_load",
+            "users_repository_find",
+            "payments_client_charge"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 0.75,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.6,
+              "context_tokens": 672
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.4,
+              "context_tokens": 1357
+            }
+          ],
+          "cold_latency_ms": 0.29025,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.255375,
+            "p95": 0.2593872
+          }
+        },
+        {
+          "id": "architecture_order_coordination",
+          "category": "architecture",
+          "expected_ids": [
+            "orders_service_place",
+            "inventory_service_reserve",
+            "payments_client_charge",
+            "orders_repository_save",
+            "shipping_service_create"
+          ],
+          "result_ids": [
+            "orders_service_place",
+            "orders_repository_save",
+            "shipping_service_create",
+            "inventory_service_reserve",
+            "payments_client_charge",
+            "config_loader_load",
+            "api_router_new",
+            "errors_app_error",
+            "users_repository_find",
+            "auth_service_login"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 1,
+              "context_tokens": 646
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.5,
+              "context_tokens": 1303
+            }
+          ],
+          "cold_latency_ms": 0.218541,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.200709,
+            "p95": 0.2062584
+          }
+        },
+        {
+          "id": "architecture_auth_sessions",
+          "category": "architecture",
+          "expected_ids": [
+            "auth_service_login",
+            "middleware_require_auth",
+            "auth_handler_login"
+          ],
+          "result_ids": [
+            "middleware_require_auth",
+            "auth_handler_login",
+            "auth_service_login",
+            "users_repository_find",
+            "api_router_new",
+            "errors_app_error",
+            "config_loader_load",
+            "orders_service_place",
+            "shipping_service_create",
+            "orders_repository_save"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.6,
+              "context_tokens": 697
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.3,
+              "context_tokens": 1339
+            }
+          ],
+          "cold_latency_ms": 0.1755,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.175667,
+            "p95": 0.1800545
+          }
+        },
+        {
+          "id": "architecture_error_model",
+          "category": "architecture",
+          "expected_ids": [
+            "errors_app_error",
+            "auth_handler_login",
+            "inventory_service_reserve",
+            "config_loader_load"
+          ],
+          "result_ids": [
+            "errors_app_error",
+            "payments_client_charge",
+            "inventory_service_reserve",
+            "config_loader_load",
+            "orders_service_place",
+            "shipping_service_create",
+            "auth_service_login",
+            "middleware_require_auth",
+            "auth_handler_login",
+            "api_router_new"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 0.75,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.6,
+              "context_tokens": 718
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.4,
+              "context_tokens": 1383
+            }
+          ],
+          "cold_latency_ms": 0.19375,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.21575,
+            "p95": 0.2552744
+          }
+        },
+        {
+          "id": "review_validate_password",
+          "category": "code_review",
+          "expected_ids": [
+            "auth_service_login",
+            "auth_handler_login",
+            "errors_app_error"
+          ],
+          "result_ids": [
+            "auth_service_login",
+            "auth_handler_login",
+            "middleware_require_auth",
+            "users_repository_find",
+            "errors_app_error",
+            "api_router_new",
+            "inventory_service_reserve",
+            "orders_service_place",
+            "config_loader_load",
+            "payments_client_charge"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.6,
+              "context_tokens": 726
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.3,
+              "context_tokens": 1408
+            }
+          ],
+          "cold_latency_ms": 0.233375,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.2325,
+            "p95": 0.2341119
+          }
+        },
+        {
+          "id": "review_place_order",
+          "category": "code_review",
+          "expected_ids": [
+            "orders_service_place",
+            "inventory_service_reserve",
+            "payments_client_charge",
+            "orders_repository_save",
+            "shipping_service_create"
+          ],
+          "result_ids": [
+            "orders_service_place",
+            "orders_repository_save",
+            "inventory_service_reserve",
+            "payments_client_charge",
+            "shipping_service_create",
+            "errors_app_error",
+            "config_loader_load",
+            "api_router_new",
+            "users_repository_find",
+            "auth_service_login"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 1,
+              "context_tokens": 646
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.5,
+              "context_tokens": 1303
+            }
+          ],
+          "cold_latency_ms": 0.279542,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.265084,
+            "p95": 0.2776462
+          }
+        },
+        {
+          "id": "review_load_config",
+          "category": "code_review",
+          "expected_ids": [
+            "config_loader_load",
+            "errors_app_error"
+          ],
+          "result_ids": [
+            "config_loader_load",
+            "payments_client_charge",
+            "errors_app_error",
+            "shipping_service_create",
+            "inventory_service_reserve",
+            "orders_service_place",
+            "api_router_new",
+            "middleware_require_auth",
+            "auth_service_login",
+            "orders_repository_save"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.4,
+              "context_tokens": 608
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.2,
+              "context_tokens": 1333
+            }
+          ],
+          "cold_latency_ms": 0.3095,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.229208,
+            "p95": 0.27882049999999997
+          }
+        },
+        {
+          "id": "review_payment_charge",
+          "category": "code_review",
+          "expected_ids": [
+            "payments_client_charge",
+            "errors_app_error"
+          ],
+          "result_ids": [
+            "payments_client_charge",
+            "shipping_service_create",
+            "config_loader_load",
+            "errors_app_error",
+            "inventory_service_reserve",
+            "orders_service_place",
+            "orders_repository_save",
+            "api_router_new",
+            "auth_service_login",
+            "users_repository_find"
+          ],
+          "metrics": [
+            {
+              "k": 5,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.4,
+              "context_tokens": 608
+            },
+            {
+              "k": 10,
+              "recall": 1,
+              "mrr": 1,
+              "duplicate_rate": 0,
+              "context_precision_proxy": 0.2,
+              "context_tokens": 1303
+            }
+          ],
+          "cold_latency_ms": 0.543125,
+          "warm_latency_ms": {
+            "count": 3,
+            "p50": 0.298417,
+            "p95": 0.43135419999999997
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/internal/rageval/testdata/fixtures.json
+++ b/internal/rageval/testdata/fixtures.json
@@ -1,0 +1,322 @@
+{
+  "corpus": [
+    {
+      "id": "auth_handler_login",
+      "source": "synthetic/auth/handler.go",
+      "start_line": 10,
+      "end_line": 44,
+      "language": "go",
+      "stable_key": "synthetic/auth/handler.go::LoginHandler#0",
+      "content": "func LoginHandler(service *AuthService) http.HandlerFunc {\n    return func(w http.ResponseWriter, r *http.Request) {\n        var req LoginRequest\n        if err := decodeJSON(r.Body, &req); err != nil {\n            writeError(w, NewBadRequest(\"invalid login body\"))\n            return\n        }\n        session, err := service.Login(r.Context(), req.Email, req.Password)\n        if err != nil {\n            writeError(w, err)\n            return\n        }\n        writeJSON(w, http.StatusOK, session)\n    }\n}",
+      "metadata": {
+        "symbol": "LoginHandler"
+      },
+      "embedding": [0.96, 0.02, 0.18, 0.0, 0.12, 0.18]
+    },
+    {
+      "id": "auth_service_login",
+      "source": "synthetic/auth/service.go",
+      "start_line": 18,
+      "end_line": 78,
+      "language": "go",
+      "stable_key": "synthetic/auth/service.go::AuthService.Login#0",
+      "content": "type AuthService struct {\n    users    *UserRepository\n    sessions *SessionSigner\n}\n\nfunc (s *AuthService) Login(ctx context.Context, email, password string) (*Session, error) {\n    user, err := s.users.FindByEmail(ctx, email)\n    if err != nil {\n        return nil, NewUnauthorized(\"invalid credentials\")\n    }\n    if !ValidatePassword(password, user.PasswordHash) {\n        return nil, NewUnauthorized(\"invalid credentials\")\n    }\n    return s.sessions.IssueSession(user.ID)\n}\n\nfunc ValidatePassword(password, storedHash string) bool {\n    return subtle.ConstantTimeCompare(hash(password), []byte(storedHash)) == 1\n}",
+      "metadata": {
+        "symbol": "AuthService.Login"
+      },
+      "embedding": [0.9, 0.06, 0.05, 0.0, 0.26, 0.32]
+    },
+    {
+      "id": "users_repository_find",
+      "source": "synthetic/users/repository.go",
+      "start_line": 7,
+      "end_line": 40,
+      "language": "go",
+      "stable_key": "synthetic/users/repository.go::UserRepository.FindByEmail#0",
+      "content": "type UserRepository struct {\n    db *sql.DB\n}\n\nfunc (r *UserRepository) FindByEmail(ctx context.Context, email string) (*User, error) {\n    row := r.db.QueryRowContext(ctx, `SELECT id, email, password_hash FROM users WHERE email = ?`, email)\n    var user User\n    if err := row.Scan(&user.ID, &user.Email, &user.PasswordHash); err != nil {\n        return nil, err\n    }\n    return &user, nil\n}",
+      "metadata": {
+        "symbol": "UserRepository.FindByEmail"
+      },
+      "embedding": [0.72, 0.05, 0.0, 0.05, 0.08, 0.8]
+    },
+    {
+      "id": "middleware_require_auth",
+      "source": "synthetic/middleware/auth.go",
+      "start_line": 12,
+      "end_line": 54,
+      "language": "go",
+      "stable_key": "synthetic/middleware/auth.go::RequireAuth#0",
+      "content": "func RequireAuth(verifier *SessionVerifier, next http.Handler) http.Handler {\n    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {\n        token := bearerToken(r.Header.Get(\"Authorization\"))\n        claims, err := verifier.Verify(token)\n        if err != nil {\n            writeError(w, NewUnauthorized(\"missing or invalid session\"))\n            return\n        }\n        ctx := context.WithValue(r.Context(), userIDKey{}, claims.UserID)\n        next.ServeHTTP(w, r.WithContext(ctx))\n    })\n}",
+      "metadata": {
+        "symbol": "RequireAuth"
+      },
+      "embedding": [0.82, 0.0, 0.38, 0.0, 0.15, 0.05]
+    },
+    {
+      "id": "api_router_new",
+      "source": "synthetic/api/router.go",
+      "start_line": 9,
+      "end_line": 50,
+      "language": "go",
+      "stable_key": "synthetic/api/router.go::NewRouter#0",
+      "content": "func NewRouter(auth *AuthService, orders *OrderService, verifier *SessionVerifier) http.Handler {\n    mux := http.NewServeMux()\n    mux.Handle(\"POST /login\", LoginHandler(auth))\n    mux.Handle(\"POST /orders\", RequireAuth(verifier, OrderHandler(orders)))\n    mux.Handle(\"GET /orders/{id}\", RequireAuth(verifier, OrderStatusHandler(orders)))\n    return requestLogger(recoverPanics(mux))\n}",
+      "metadata": {
+        "symbol": "NewRouter"
+      },
+      "embedding": [0.42, 0.32, 0.92, 0.08, 0.05, 0.06]
+    },
+    {
+      "id": "orders_service_place",
+      "source": "synthetic/orders/service.go",
+      "start_line": 20,
+      "end_line": 92,
+      "language": "go",
+      "stable_key": "synthetic/orders/service.go::OrderService.PlaceOrder#0",
+      "content": "type OrderService struct {\n    inventory *InventoryService\n    payments  *PaymentClient\n    shipping  *ShippingService\n    orders    *OrderRepository\n}\n\nfunc (s *OrderService) PlaceOrder(ctx context.Context, req OrderRequest) (*Order, error) {\n    reservation, err := s.inventory.Reserve(ctx, req.Items)\n    if err != nil {\n        return nil, err\n    }\n    charge, err := s.payments.Charge(ctx, req.PaymentToken, reservation.Total)\n    if err != nil {\n        s.inventory.Release(ctx, reservation.ID)\n        return nil, err\n    }\n    order := NewOrder(req.CustomerID, reservation, charge)\n    if err := s.orders.Save(ctx, order); err != nil {\n        return nil, err\n    }\n    return order, s.shipping.CreateShipment(ctx, order)\n}",
+      "metadata": {
+        "symbol": "OrderService.PlaceOrder"
+      },
+      "embedding": [0.04, 0.98, 0.08, 0.2, 0.34, 0.35]
+    },
+    {
+      "id": "orders_repository_save",
+      "source": "synthetic/orders/repository.go",
+      "start_line": 8,
+      "end_line": 46,
+      "language": "go",
+      "stable_key": "synthetic/orders/repository.go::OrderRepository.Save#0",
+      "content": "type OrderRepository struct {\n    db *sql.DB\n}\n\nfunc (r *OrderRepository) Save(ctx context.Context, order *Order) error {\n    _, err := r.db.ExecContext(ctx, `INSERT INTO orders (id, customer_id, total, status) VALUES (?, ?, ?, ?)`, order.ID, order.CustomerID, order.Total, order.Status)\n    return err\n}",
+      "metadata": {
+        "symbol": "OrderRepository.Save"
+      },
+      "embedding": [0.02, 0.76, 0.0, 0.12, 0.05, 0.83]
+    },
+    {
+      "id": "inventory_service_reserve",
+      "source": "synthetic/inventory/service.go",
+      "start_line": 14,
+      "end_line": 60,
+      "language": "go",
+      "stable_key": "synthetic/inventory/service.go::InventoryService.Reserve#0",
+      "content": "func (s *InventoryService) Reserve(ctx context.Context, items []LineItem) (*Reservation, error) {\n    for _, item := range items {\n        if item.Quantity <= 0 {\n            return nil, NewBadRequest(\"quantity must be positive\")\n        }\n        if !s.stock.HasAvailable(ctx, item.SKU, item.Quantity) {\n            return nil, NewConflict(\"insufficient inventory\")\n        }\n    }\n    return s.stock.CreateReservation(ctx, items)\n}",
+      "metadata": {
+        "symbol": "InventoryService.Reserve"
+      },
+      "embedding": [0.0, 0.82, 0.08, 0.14, 0.42, 0.24]
+    },
+    {
+      "id": "payments_client_charge",
+      "source": "synthetic/payments/client.go",
+      "start_line": 10,
+      "end_line": 70,
+      "language": "go",
+      "stable_key": "synthetic/payments/client.go::PaymentClient.Charge#0",
+      "content": "type PaymentClient struct {\n    endpoint string\n    http     *http.Client\n}\n\nfunc (c *PaymentClient) Charge(ctx context.Context, token string, amount Money) (*Charge, error) {\n    if token == \"\" {\n        return nil, NewBadRequest(\"payment token is required\")\n    }\n    req := newChargeRequest(token, amount)\n    resp, err := c.http.Do(req.WithContext(ctx))\n    if err != nil {\n        return nil, err\n    }\n    return decodeCharge(resp)\n}",
+      "metadata": {
+        "symbol": "PaymentClient.Charge"
+      },
+      "embedding": [0.0, 0.72, 0.02, 0.72, 0.38, 0.12]
+    },
+    {
+      "id": "shipping_service_create",
+      "source": "synthetic/shipping/service.go",
+      "start_line": 11,
+      "end_line": 48,
+      "language": "go",
+      "stable_key": "synthetic/shipping/service.go::ShippingService.CreateShipment#0",
+      "content": "func (s *ShippingService) CreateShipment(ctx context.Context, order *Order) error {\n    label, err := s.carrier.BuyLabel(ctx, order.ShippingAddress, order.Items)\n    if err != nil {\n        return err\n    }\n    order.Status = StatusReadyToShip\n    order.ShipmentID = label.ID\n    return nil\n}",
+      "metadata": {
+        "symbol": "ShippingService.CreateShipment"
+      },
+      "embedding": [0.0, 0.66, 0.24, 0.42, 0.18, 0.08]
+    },
+    {
+      "id": "config_loader_load",
+      "source": "synthetic/config/config.go",
+      "start_line": 5,
+      "end_line": 56,
+      "language": "go",
+      "stable_key": "synthetic/config/config.go::LoadConfig#0",
+      "content": "func LoadConfig(path string) (*Config, error) {\n    data, err := os.ReadFile(path)\n    if err != nil {\n        return nil, err\n    }\n    var cfg Config\n    if err := json.Unmarshal(data, &cfg); err != nil {\n        return nil, err\n    }\n    if cfg.DatabaseURL == \"\" || cfg.PaymentEndpoint == \"\" {\n        return nil, NewBadRequest(\"missing required configuration\")\n    }\n    return &cfg, nil\n}",
+      "metadata": {
+        "symbol": "LoadConfig"
+      },
+      "embedding": [0.05, 0.08, 0.32, 0.92, 0.32, 0.05]
+    },
+    {
+      "id": "errors_app_error",
+      "source": "synthetic/errors/errors.go",
+      "start_line": 3,
+      "end_line": 52,
+      "language": "go",
+      "stable_key": "synthetic/errors/errors.go::AppError#0",
+      "content": "type AppError struct {\n    Code    string\n    Message string\n    Status  int\n}\n\nfunc NewBadRequest(message string) *AppError {\n    return &AppError{Code: \"bad_request\", Message: message, Status: http.StatusBadRequest}\n}\n\nfunc NewUnauthorized(message string) *AppError {\n    return &AppError{Code: \"unauthorized\", Message: message, Status: http.StatusUnauthorized}\n}\n\nfunc NewConflict(message string) *AppError {\n    return &AppError{Code: \"conflict\", Message: message, Status: http.StatusConflict}\n}",
+      "metadata": {
+        "symbol": "AppError"
+      },
+      "embedding": [0.2, 0.18, 0.06, 0.24, 0.96, 0.05]
+    }
+  ],
+  "queries": [
+    {
+      "id": "single_login_handler",
+      "category": "single_hop",
+      "query": "Where is LoginHandler defined?",
+      "expected_ids": ["auth_handler_login"],
+      "current_file": "synthetic/api/router.go",
+      "embedding": [1.0, 0.0, 0.16, 0.0, 0.08, 0.12]
+    },
+    {
+      "id": "single_find_by_email",
+      "category": "single_hop",
+      "query": "Where is FindByEmail implemented?",
+      "expected_ids": ["users_repository_find"],
+      "current_file": "synthetic/auth/service.go",
+      "embedding": [0.7, 0.04, 0.0, 0.02, 0.04, 0.92]
+    },
+    {
+      "id": "single_require_auth",
+      "category": "single_hop",
+      "query": "Where is RequireAuth defined?",
+      "expected_ids": ["middleware_require_auth"],
+      "current_file": "synthetic/api/router.go",
+      "embedding": [0.86, 0.0, 0.44, 0.0, 0.1, 0.02]
+    },
+    {
+      "id": "single_payment_charge",
+      "category": "single_hop",
+      "query": "Where is PaymentClient.Charge implemented?",
+      "expected_ids": ["payments_client_charge"],
+      "current_file": "synthetic/orders/service.go",
+      "embedding": [0.0, 0.7, 0.02, 0.82, 0.34, 0.08]
+    },
+    {
+      "id": "trace_login_flow",
+      "category": "cross_file_trace",
+      "query": "How does a login request flow from HTTP handler to service to user lookup?",
+      "expected_ids": ["auth_handler_login", "auth_service_login", "users_repository_find"],
+      "current_file": "synthetic/auth/handler.go",
+      "embedding": [0.94, 0.04, 0.1, 0.02, 0.16, 0.42]
+    },
+    {
+      "id": "trace_order_checkout_flow",
+      "category": "cross_file_trace",
+      "query": "How does PlaceOrder coordinate inventory reservation, payment charge, order save, and shipment creation?",
+      "expected_ids": ["orders_service_place", "inventory_service_reserve", "payments_client_charge", "orders_repository_save", "shipping_service_create"],
+      "current_file": "synthetic/orders/service.go",
+      "embedding": [0.0, 0.96, 0.14, 0.48, 0.25, 0.36]
+    },
+    {
+      "id": "trace_protected_route",
+      "category": "cross_file_trace",
+      "query": "How does a protected order route attach session claims before calling the handler?",
+      "expected_ids": ["api_router_new", "middleware_require_auth", "orders_service_place"],
+      "current_file": "synthetic/api/router.go",
+      "embedding": [0.58, 0.46, 0.86, 0.04, 0.08, 0.04]
+    },
+    {
+      "id": "trace_config_to_runtime",
+      "category": "cross_file_trace",
+      "query": "How is configuration loaded before wiring runtime dependencies such as payment endpoints and routes?",
+      "expected_ids": ["config_loader_load", "api_router_new", "payments_client_charge"],
+      "current_file": "synthetic/config/config.go",
+      "embedding": [0.1, 0.22, 0.46, 0.94, 0.2, 0.04]
+    },
+    {
+      "id": "compare_auth_service_repository",
+      "category": "compare",
+      "query": "What is the difference between AuthService.Login and UserRepository.FindByEmail?",
+      "expected_ids": ["auth_service_login", "users_repository_find"],
+      "current_file": "synthetic/auth/service.go",
+      "embedding": [0.86, 0.05, 0.02, 0.03, 0.14, 0.62]
+    },
+    {
+      "id": "compare_payment_inventory",
+      "category": "compare",
+      "query": "Compare PaymentClient.Charge and InventoryService.Reserve responsibilities.",
+      "expected_ids": ["payments_client_charge", "inventory_service_reserve"],
+      "current_file": "synthetic/orders/service.go",
+      "embedding": [0.0, 0.8, 0.06, 0.58, 0.44, 0.18]
+    },
+    {
+      "id": "compare_handler_middleware",
+      "category": "compare",
+      "query": "How does LoginHandler differ from RequireAuth middleware?",
+      "expected_ids": ["auth_handler_login", "middleware_require_auth"],
+      "current_file": "synthetic/api/router.go",
+      "embedding": [0.94, 0.0, 0.36, 0.0, 0.12, 0.08]
+    },
+    {
+      "id": "compare_order_service_repository",
+      "category": "compare",
+      "query": "What is the difference between OrderService.PlaceOrder and OrderRepository.Save?",
+      "expected_ids": ["orders_service_place", "orders_repository_save"],
+      "current_file": "synthetic/orders/service.go",
+      "embedding": [0.0, 0.94, 0.04, 0.16, 0.18, 0.72]
+    },
+    {
+      "id": "architecture_routes",
+      "category": "architecture",
+      "query": "How does the routing layer map HTTP paths to auth and order handlers?",
+      "expected_ids": ["api_router_new", "auth_handler_login", "middleware_require_auth", "orders_service_place"],
+      "current_file": "synthetic/api/router.go",
+      "embedding": [0.52, 0.36, 0.98, 0.06, 0.05, 0.06]
+    },
+    {
+      "id": "architecture_order_coordination",
+      "category": "architecture",
+      "query": "How is order placement architected across inventory, payments, persistence, and shipping?",
+      "expected_ids": ["orders_service_place", "inventory_service_reserve", "payments_client_charge", "orders_repository_save", "shipping_service_create"],
+      "current_file": "synthetic/orders/service.go",
+      "embedding": [0.0, 0.98, 0.18, 0.46, 0.22, 0.42]
+    },
+    {
+      "id": "architecture_auth_sessions",
+      "category": "architecture",
+      "query": "How are authentication sessions issued and later verified?",
+      "expected_ids": ["auth_service_login", "middleware_require_auth", "auth_handler_login"],
+      "current_file": "synthetic/middleware/auth.go",
+      "embedding": [0.94, 0.02, 0.32, 0.0, 0.16, 0.16]
+    },
+    {
+      "id": "architecture_error_model",
+      "category": "architecture",
+      "query": "How does the application model bad request, unauthorized, and conflict errors?",
+      "expected_ids": ["errors_app_error", "auth_handler_login", "inventory_service_reserve", "config_loader_load"],
+      "current_file": "synthetic/errors/errors.go",
+      "embedding": [0.28, 0.24, 0.08, 0.28, 0.98, 0.04]
+    },
+    {
+      "id": "review_validate_password",
+      "category": "code_review",
+      "query": "What edge cases should be reviewed in ValidatePassword and login credential handling?",
+      "expected_ids": ["auth_service_login", "auth_handler_login", "errors_app_error"],
+      "current_file": "synthetic/auth/service.go",
+      "embedding": [0.88, 0.02, 0.04, 0.02, 0.52, 0.2]
+    },
+    {
+      "id": "review_place_order",
+      "category": "code_review",
+      "query": "What edge cases should be reviewed in PlaceOrder around payment failure, inventory release, persistence, and shipment?",
+      "expected_ids": ["orders_service_place", "inventory_service_reserve", "payments_client_charge", "orders_repository_save", "shipping_service_create"],
+      "current_file": "synthetic/orders/service.go",
+      "embedding": [0.0, 0.94, 0.08, 0.36, 0.62, 0.36]
+    },
+    {
+      "id": "review_load_config",
+      "category": "code_review",
+      "query": "What edge cases should be reviewed in LoadConfig for missing files, JSON parse errors, and required fields?",
+      "expected_ids": ["config_loader_load", "errors_app_error"],
+      "current_file": "synthetic/config/config.go",
+      "embedding": [0.08, 0.1, 0.24, 0.96, 0.62, 0.04]
+    },
+    {
+      "id": "review_payment_charge",
+      "category": "code_review",
+      "query": "What edge cases should be reviewed in PaymentClient.Charge around empty tokens, HTTP failures, and response decoding?",
+      "expected_ids": ["payments_client_charge", "errors_app_error"],
+      "current_file": "synthetic/payments/client.go",
+      "embedding": [0.0, 0.62, 0.02, 0.84, 0.72, 0.06]
+    }
+  ]
+}

--- a/internal/rageval/types.go
+++ b/internal/rageval/types.go
@@ -1,0 +1,131 @@
+package rageval
+
+import "time"
+
+const (
+	SchemaVersion = "rag-eval-baseline/v1"
+	vectorSpaceID = "fixture/rag-eval-v1"
+)
+
+// Fixture is the committed golden retrieval corpus and query set.
+type Fixture struct {
+	Corpus  []FixtureChunk `json:"corpus"`
+	Queries []QueryFixture `json:"queries"`
+}
+
+// FixtureChunk is one indexed chunk in the synthetic evaluation corpus.
+type FixtureChunk struct {
+	ID        string            `json:"id"`
+	Source    string            `json:"source"`
+	StartLine int               `json:"start_line"`
+	EndLine   int               `json:"end_line"`
+	Language  string            `json:"language"`
+	StableKey string            `json:"stable_key"`
+	Content   string            `json:"content"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+	Embedding []float64         `json:"embedding"`
+}
+
+// QueryFixture is one golden retrieval question.
+type QueryFixture struct {
+	ID          string    `json:"id"`
+	Category    string    `json:"category"`
+	Query       string    `json:"query"`
+	ExpectedIDs []string  `json:"expected_ids"`
+	CurrentFile string    `json:"current_file,omitempty"`
+	Embedding   []float64 `json:"embedding"`
+}
+
+// RunOptions controls baseline generation.
+type RunOptions struct {
+	WarmRuns       int
+	MeasureLatency bool
+}
+
+// Report is the stable JSON output committed as the baseline artifact.
+type Report struct {
+	SchemaVersion string           `json:"schema_version"`
+	Corpus        CorpusSummary    `json:"corpus"`
+	Thresholds    ThresholdSummary `json:"thresholds"`
+	Modes         []ModeReport     `json:"modes"`
+}
+
+type CorpusSummary struct {
+	Chunks     int            `json:"chunks"`
+	Queries    int            `json:"queries"`
+	Categories map[string]int `json:"categories"`
+	TopK       []int          `json:"top_k"`
+	VectorID   string         `json:"vector_space_id"`
+	Notes      []string       `json:"notes"`
+}
+
+type ThresholdSummary struct {
+	Owner                             string   `json:"owner"`
+	Status                            string   `json:"status"`
+	MinimumStaticRecallAt5            *float64 `json:"minimum_static_recall_at_5"`
+	MinimumHybridRecallAt5Improvement *float64 `json:"minimum_hybrid_recall_at_5_improvement"`
+	MaximumDuplicateRate              *float64 `json:"maximum_duplicate_rate"`
+	MinimumContextPrecisionProxy      *float64 `json:"minimum_context_precision_proxy"`
+	MaximumOptInHybridP95LatencyMS    *float64 `json:"maximum_opt_in_hybrid_p95_latency_ms"`
+	MaximumFutureDefaultP95LatencyMS  *float64 `json:"maximum_future_default_p95_latency_ms"`
+	MaximumAverageContextTokenGrowth  *float64 `json:"maximum_average_context_token_growth"`
+}
+
+type ModeReport struct {
+	Name    string        `json:"name"`
+	Summary ModeSummary   `json:"summary"`
+	Queries []QueryReport `json:"queries"`
+}
+
+type ModeSummary struct {
+	RecallAt5                float64        `json:"recall_at_5"`
+	RecallAt10               float64        `json:"recall_at_10"`
+	MRRAt5                   float64        `json:"mrr_at_5"`
+	MRRAt10                  float64        `json:"mrr_at_10"`
+	DuplicateRateAt10        float64        `json:"duplicate_rate_at_10"`
+	ContextPrecisionAt5      float64        `json:"context_precision_at_5"`
+	ContextPrecisionAt10     float64        `json:"context_precision_at_10"`
+	AverageContextTokensAt5  float64        `json:"average_context_tokens_at_5"`
+	AverageContextTokensAt10 float64        `json:"average_context_tokens_at_10"`
+	ColdLatencyMS            LatencySummary `json:"cold_latency_ms"`
+	WarmLatencyMS            LatencySummary `json:"warm_latency_ms"`
+}
+
+type QueryReport struct {
+	ID            string         `json:"id"`
+	Category      string         `json:"category"`
+	ExpectedIDs   []string       `json:"expected_ids"`
+	ResultIDs     []string       `json:"result_ids"`
+	Metrics       []KMetrics     `json:"metrics"`
+	ColdLatencyMS float64        `json:"cold_latency_ms"`
+	WarmLatencyMS LatencySummary `json:"warm_latency_ms"`
+}
+
+type KMetrics struct {
+	K                     int     `json:"k"`
+	Recall                float64 `json:"recall"`
+	MRR                   float64 `json:"mrr"`
+	DuplicateRate         float64 `json:"duplicate_rate"`
+	ContextPrecisionProxy float64 `json:"context_precision_proxy"`
+	ContextTokens         int     `json:"context_tokens"`
+}
+
+type LatencySummary struct {
+	Count int     `json:"count"`
+	P50   float64 `json:"p50"`
+	P95   float64 `json:"p95"`
+}
+
+func defaultRunOptions(opts RunOptions) RunOptions {
+	if opts.WarmRuns < 0 {
+		opts.WarmRuns = 0
+	}
+	if opts.WarmRuns == 0 {
+		opts.WarmRuns = 3
+	}
+	return opts
+}
+
+func elapsedMS(d time.Duration) float64 {
+	return float64(d.Nanoseconds()) / float64(time.Millisecond)
+}

--- a/internal/rageval/types.go
+++ b/internal/rageval/types.go
@@ -120,9 +120,6 @@ func defaultRunOptions(opts RunOptions) RunOptions {
 	if opts.WarmRuns < 0 {
 		opts.WarmRuns = 0
 	}
-	if opts.WarmRuns == 0 {
-		opts.WarmRuns = 3
-	}
 	return opts
 }
 


### PR DESCRIPTION
## Summary

- Add an internal `rageval` fixture runner for #93 without exporting new public RAG APIs before #94.
- Add a synthetic golden corpus with 12 chunks and 20 queries across the required five categories.
- Add `cmd/rag-eval` to regenerate the baseline report comparing static `Retriever.Retrieve` with hybrid `SearchMulti`.
- Commit the initial baseline report with recall, MRR, duplicate rate, context precision proxy, estimated context tokens, and cold/warm latency.
- **Owner-ratified v1 regression thresholds** (commit e8eaf90) with documented posture in `runner.buildThresholds`.
- **Review-pass hardening** addressing all H/M/L findings from a comprehensive `/code-review` cycle.

## Current baseline

- static recall@5: 0.9583
- static recall@10: 1.0
- hybrid recall@5: 0.9583
- hybrid recall@10: 1.0

## Ratified thresholds (v1 posture)

Floors detect regressions; they do not chase improvements. See `runner.buildThresholds` for full rationale.

| Field | Value | Rationale |
|---|---|---|
| `minimum_static_recall_at_5` | 0.95 | current 0.9583; 1pp floor catches real regressions without flapping |
| `minimum_hybrid_recall_at_5_improvement` | 0.0 | hybrid currently matches static; "must not regress" until corpus discriminates |
| `maximum_duplicate_rate` | 0.05 | current 0; 5% tolerance for SearchMulti's diversification |
| `minimum_context_precision_proxy` | 0.50 | current 0.51 @K=5; below 0.50 means majority of returned chunks are irrelevant |
| `maximum_average_context_token_growth` | 0.10 | current both modes match; 10% growth flags context-bloat regression |
| `maximum_opt_in_hybrid_p95_latency_ms` | **null** | N=20 samples on 12-chunk in-memory SQLite is statistically unstable; defer to #95 |
| `maximum_future_default_p95_latency_ms` | **null** | same — synthetic-corpus latency is not load-bearing |

## Known finding for #94

**Hybrid `search_multi` regresses MRR@5 from 1.0 → ~0.825 vs static** on this synthetic corpus. Captured in `baseline.json` notes for #94 scorer-weight discussion, not flagged as a blocker for this PR.

## Validation

- `go test ./internal/rageval ./cmd/rag-eval`
- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/rageval ./cmd/rag-eval`
- pre-push hook: lint, race tests, compile smoke

Refs #93.