### PR TITLE
fix(rag): ratify eval thresholds + review hardening (follow-up to #105)

### DIFF
--- a/cmd/rag-eval/main.go
+++ b/cmd/rag-eval/main.go
@@ -3,13 +3,15 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
-	"os"
+	"log"
 
 	"github.com/kstruzzieri/go-llm/internal/rageval"
 )
 
 func main() {
+	log.SetFlags(0)
+	log.SetPrefix("rag-eval: ")
+
 	fixturePath := flag.String("fixtures", "internal/rageval/testdata/fixtures.json", "Path to RAG evaluation fixture JSON")
 	outPath := flag.String("out", "internal/rageval/testdata/baseline.json", "Path to write baseline report JSON")
 	warmRuns := flag.Int("warm-runs", 3, "Warm retrieval runs per query")
@@ -18,19 +20,16 @@ func main() {
 
 	fixture, err := rageval.LoadFixture(*fixturePath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
+		log.Fatal(err)
 	}
 	report, err := rageval.Run(context.Background(), fixture, rageval.RunOptions{
 		WarmRuns:       *warmRuns,
 		MeasureLatency: !*noLatency,
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
+		log.Fatal(err)
 	}
 	if err := rageval.WriteReport(*outPath, report); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
+		log.Fatal(err)
 	}
 }

--- a/internal/rageval/README.md
+++ b/internal/rageval/README.md
@@ -132,3 +132,10 @@ Notable invariants:
   runs (no implicit default).
 - `TestBaselineReportShape` — committed baseline parses cleanly into
   `Report`, has the ratified threshold posture, has both modes present.
+- `TestBaselineReproducible` — re-runs `Run` and asserts all deterministic
+  summary fields match the committed `baseline.json` within 1e-9 tolerance.
+  Catches code-vs-baseline drift (someone changed a scorer without
+  regenerating) AND baseline-vs-code drift (someone edited the JSON by
+  hand). Latency fields are deliberately excluded — they vary run-to-run.
+  On a drift failure, run `go generate ./internal/rageval` if the change
+  was intentional.

--- a/internal/rageval/README.md
+++ b/internal/rageval/README.md
@@ -31,7 +31,8 @@ Regenerate the committed report with:
 ```sh
 go run ./cmd/rag-eval \
   -fixtures internal/rageval/testdata/fixtures.json \
-  -out internal/rageval/testdata/baseline.json
+  -out internal/rageval/testdata/baseline.json \
+  -no-latency
 ```
 
 Or from the package directory:
@@ -39,6 +40,10 @@ Or from the package directory:
 ```sh
 go generate ./internal/rageval
 ```
+
+The committed baseline is generated with `-no-latency` so routine regeneration
+is stable across machines. Omit `-no-latency` only for ad hoc local timing
+experiments; do not commit those volatile latency samples.
 
 The report compares:
 
@@ -93,8 +98,10 @@ uses the same 4-chars-per-token heuristic that `rag.Retriever.BuildContext`
 uses, applied to the same formatted output.
 
 Cold latency is one measurement per query. Warm latency aggregates
-`WarmRuns` repeats. Both report P50 and P95 in milliseconds. **Treat
-sub-millisecond P95 numbers on this corpus as noise**, not signal.
+`WarmRuns` repeats. Both report P50 and P95 in milliseconds when latency
+measurement is enabled. The committed baseline disables latency measurement,
+so these fields are stable zeros. **Treat sub-millisecond P95 numbers on this
+corpus as noise**, not signal.
 
 ## When to regenerate
 
@@ -106,10 +113,10 @@ Regenerate the baseline after **any** change to:
 - `rag.QueryContext` shape or temporal-scorer defaults
 - The fixtures themselves (chunks, queries, embeddings, categories)
 
-`TestBaselineReportShape` asserts the committed file is well-formed. If you
-change retriever behavior without regenerating, that test still passes but
-the committed numbers no longer reflect what the code produces. Don't skip
-the regeneration step.
+`TestBaselineReproducible` asserts the committed deterministic metrics match
+the code. `TestBaselineReportShape` asserts the committed file is well-formed,
+uses the exact ratified threshold values, and still satisfies those threshold
+floors. Don't skip the regeneration step after intentional metric changes.
 
 ## Tests
 
@@ -131,7 +138,8 @@ Notable invariants:
 - `TestRunModeHonorsZeroWarmRuns` — confirms `WarmRuns: 0` means zero warm
   runs (no implicit default).
 - `TestBaselineReportShape` — committed baseline parses cleanly into
-  `Report`, has the ratified threshold posture, has both modes present.
+  `Report`, has the exact ratified threshold values, has both modes present,
+  and satisfies the threshold floors.
 - `TestBaselineReproducible` — re-runs `Run` and asserts all deterministic
   summary fields match the committed `baseline.json` within 1e-9 tolerance.
   Catches code-vs-baseline drift (someone changed a scorer without

--- a/internal/rageval/README.md
+++ b/internal/rageval/README.md
@@ -20,7 +20,9 @@ package boundary before `#94`.
   - `code_review`
 
 The fixture uses deterministic synthetic embeddings and does not require
-Ollama or any live model.
+Ollama or any live model. `Fixture.Validate` rejects duplicate chunk IDs,
+duplicate query IDs, duplicate query text, missing/empty fields, embedding
+dimension mismatches, and queries that reference unknown chunks.
 
 ## Baseline
 
@@ -32,13 +34,101 @@ go run ./cmd/rag-eval \
   -out internal/rageval/testdata/baseline.json
 ```
 
+Or from the package directory:
+
+```sh
+go generate ./internal/rageval
+```
+
 The report compares:
 
-- `static`: `rag.Retriever.Retrieve`
-- `hybrid_search_multi`: `rag.SQLiteStore.SearchMulti`
+- `static`: `rag.Retriever.Retrieve` (dense cosine only)
+- `hybrid_search_multi`: `rag.SQLiteStore.SearchMulti` (dense + keyword +
+  structural + temporal scorers)
 
-Metrics include recall@5/10, MRR@5/10, duplicate rate, context precision
-proxy, estimated context tokens, and cold/warm latency.
+## How to read the baseline
 
-Threshold fields are intentionally `null` until Keith sets owner-approved
-values before `#95` starts.
+The report has three top-level sections.
+
+### `corpus`
+
+Static metadata about what the run measured. `vector_space_id` isolates the
+fixture from any local corpus a developer may have indexed. `notes` carries
+human-readable caveats that travel with the data — always read these.
+
+### `thresholds`
+
+**Regression floors, not aspirations.** Each non-null value is set at "best
+known minus a small buffer" so a real regression trips CI without flapping on
+natural metric noise. Posture rules:
+
+1. Floors detect drops. They do not chase improvements. Tightening after
+   sustained improvement is a `#95`-and-later activity.
+2. Where N is too small for a metric to be stable, the threshold is `null`
+   with a documented reason in `buildThresholds` (see `runner.go`).
+3. `status: "thresholds_ratified"` means an owner has approved the current
+   values. `status: "pending_owner_values_before_95"` means values are
+   placeholders.
+
+Latency thresholds are intentionally null on this baseline. The 12-chunk
+in-memory SQLite corpus with N=20 cold samples produces sub-millisecond P95
+numbers that bear no relation to production workload. Setting a number here
+would either flap on noise or be ignored when `#95` raises it against a
+realistic corpus — either way it trains the team to distrust threshold
+breaches.
+
+### `modes`
+
+Per-mode summaries (`static`, `hybrid_search_multi`) plus per-query detail.
+
+Per-query metrics are computed at K=5 and K=10. **`recall@K`'s denominator
+is `len(expected_ids)`, not K** — so a "recall@5" against a retriever that
+returned only 3 results is computed over those 3. `mrr` (reciprocal rank)
+uses 1-indexed positions and returns 0 if no expected ID appears in the
+limited result set.
+
+`context_precision_proxy` is `len(expected hits in results) / len(results)`
+— a rough proxy for "fraction of context that's relevant." `context_tokens`
+uses the same 4-chars-per-token heuristic that `rag.Retriever.BuildContext`
+uses, applied to the same formatted output.
+
+Cold latency is one measurement per query. Warm latency aggregates
+`WarmRuns` repeats. Both report P50 and P95 in milliseconds. **Treat
+sub-millisecond P95 numbers on this corpus as noise**, not signal.
+
+## When to regenerate
+
+Regenerate the baseline after **any** change to:
+
+- `rag.Retriever`, `rag.SQLiteStore.Search`, or `rag.SQLiteStore.SearchMulti`
+- Any scorer under `rag/scorer_*.go` (semantic, keyword, structural, temporal)
+- `rag.Retriever.BuildContext` formatting (affects `context_tokens` estimate)
+- `rag.QueryContext` shape or temporal-scorer defaults
+- The fixtures themselves (chunks, queries, embeddings, categories)
+
+`TestBaselineReportShape` asserts the committed file is well-formed. If you
+change retriever behavior without regenerating, that test still passes but
+the committed numbers no longer reflect what the code produces. Don't skip
+the regeneration step.
+
+## Tests
+
+```sh
+go test ./internal/rageval ./cmd/rag-eval
+```
+
+Notable invariants:
+
+- `TestFixtureValidate` — open-set category check: every query category
+  must be in the allowed set, and each allowed category must have ≥ 4
+  queries.
+- `TestFixtureValidateRejectsDuplicateQueryText` — fixture embedder relies
+  on exact-text lookup, so query-text uniqueness is a hard requirement.
+- `TestFixtureEmbedderRejectsUnknownQuery` — locks the error shape produced
+  when the fixture's exact-match contract is violated.
+- `TestRunFixtureWithoutLiveModel` — end-to-end smoke against both modes,
+  no Ollama required.
+- `TestRunModeHonorsZeroWarmRuns` — confirms `WarmRuns: 0` means zero warm
+  runs (no implicit default).
+- `TestBaselineReportShape` — committed baseline parses cleanly into
+  `Report`, has the ratified threshold posture, has both modes present.

--- a/internal/rageval/runner.go
+++ b/internal/rageval/runner.go
@@ -1,3 +1,5 @@
+//go:generate go run ../../cmd/rag-eval -fixtures testdata/fixtures.json -out testdata/baseline.json
+
 package rageval
 
 import (
@@ -10,6 +12,14 @@ import (
 
 	"github.com/kstruzzieri/go-llm/rag"
 )
+
+// contextFormatter mirrors rag.Retriever.BuildContext for token estimation.
+//
+// IMPORTANT CONTRACT: BuildContext is currently a pure formatter (no receiver
+// state). We rely on that to call it via a zero-value Retriever singleton. If
+// BuildContext ever reads receiver fields, contextTokens silently produces
+// wrong numbers. Grep for callers of BuildContext before changing it.
+var contextFormatter rag.Retriever
 
 // Run executes static and hybrid retrieval against the fixture.
 func Run(ctx context.Context, fixture *Fixture, opts RunOptions) (*Report, error) {
@@ -40,7 +50,7 @@ func Run(ctx context.Context, fixture *Fixture, opts RunOptions) (*Report, error
 	hybrid, err := runMode(ctx, "hybrid_search_multi", fixture, opts, func(ctx context.Context, q QueryFixture, k int) ([]rag.SearchResult, error) {
 		results, err := store.SearchMulti(ctx, q.Embedding, q.Query, k, rag.QueryContext{
 			CurrentFile: q.CurrentFile,
-			Timestamp:   time.Unix(1_700_000_000, 0),
+			Timestamp:   replayTimestamp,
 		})
 		if err != nil {
 			return nil, err
@@ -58,12 +68,36 @@ func Run(ctx context.Context, fixture *Fixture, opts RunOptions) (*Report, error
 	return &Report{
 		SchemaVersion: SchemaVersion,
 		Corpus:        summarizeFixture(fixture),
-		Thresholds: ThresholdSummary{
-			Owner:  "Keith",
-			Status: "pending_owner_values_before_95",
-		},
-		Modes: []ModeReport{*static, *hybrid},
+		Thresholds:    buildThresholds(),
+		Modes:         []ModeReport{*static, *hybrid},
 	}, nil
+}
+
+// buildThresholds returns the v1 regression floors ratified by the owner.
+//
+// Posture: each non-null floor is set at "best known minus a small buffer" so
+// real regressions trip CI without flapping on natural metric noise. Numbers
+// are not aspirational — they catch drops, they do not chase improvements.
+// Tightening floors after sustained improvement is a #95-and-later activity.
+//
+// Latency thresholds are intentionally null. The current baseline runs on a
+// 12-chunk in-memory SQLite corpus with N=20 cold samples per mode; P95
+// derived from that is statistically unstable and bears no relation to
+// production workload. Setting a number here would either flap on noise or
+// be ignored when #95 raises it against a realistic corpus — either way it
+// teaches the team to distrust threshold breaches. Better null than theater.
+func buildThresholds() ThresholdSummary {
+	return ThresholdSummary{
+		Owner:                             OwnerKeith,
+		Status:                            StatusThresholdsRatified,
+		MinimumStaticRecallAt5:            floatPtr(0.95), // current 0.9583; 1pp floor catches real regressions without flapping.
+		MinimumHybridRecallAt5Improvement: floatPtr(0.0),  // hybrid currently matches static; "must not regress" until corpus discriminates.
+		MaximumDuplicateRate:              floatPtr(0.05), // current 0; 5% tolerance for SearchMulti's diversification.
+		MinimumContextPrecisionProxy:      floatPtr(0.50), // current 0.51 @K=5; below 0.50 means majority of returned chunks are irrelevant.
+		MaximumAverageContextTokenGrowth:  floatPtr(0.10), // current both modes match; 10% growth flags context-bloat regression.
+		MaximumOptInHybridP95LatencyMS:    nil,            // deferred to #95: synthetic corpus latency is noise.
+		MaximumFutureDefaultP95LatencyMS:  nil,            // deferred to #95: synthetic corpus latency is noise.
+	}
 }
 
 // WriteReport writes a stable, pretty JSON report.
@@ -87,6 +121,9 @@ func runMode(ctx context.Context, mode string, fixture *Fixture, opts RunOptions
 	var warmLatencies []float64
 
 	for _, query := range fixture.Queries {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("rag eval: %s cancelled before %q: %w", mode, query.ID, err)
+		}
 		var results []rag.SearchResult
 		coldMS, err := measure(opts.MeasureLatency, func() error {
 			var retrieveErr error
@@ -100,6 +137,9 @@ func runMode(ctx context.Context, mode string, fixture *Fixture, opts RunOptions
 
 		queryWarm := make([]float64, 0, opts.WarmRuns)
 		for i := 0; i < opts.WarmRuns; i++ {
+			if err := ctx.Err(); err != nil {
+				return nil, fmt.Errorf("rag eval: %s cancelled during warm runs of %q: %w", mode, query.ID, err)
+			}
 			warmMS, err := measure(opts.MeasureLatency, func() error {
 				_, retrieveErr := retrieve(ctx, query, 10)
 				return retrieveErr
@@ -191,7 +231,9 @@ func summarizeFixture(fixture *Fixture) CorpusSummary {
 		VectorID:   vectorSpaceID,
 		Notes: []string{
 			"fixtures use deterministic synthetic embeddings; no live Ollama dependency",
-			"threshold values are owner-gated before #95",
+			"thresholds ratified for v1 regression detection; see runner.buildThresholds for posture rationale",
+			"hybrid_search_multi regresses MRR@5 vs static (~0.825 vs 1.0) on this synthetic corpus — captured for #94 scorer-weight discussion, not flagged as a blocker",
+			"latency thresholds intentionally null: N=20 cold samples on a 12-chunk in-memory SQLite corpus is statistically unstable; defer to #95 against realistic workload",
 		},
 	}
 }
@@ -228,6 +270,10 @@ func averageMetric(queries []QueryReport, k int, pick func(KMetrics) float64) fl
 	return total / float64(len(queries))
 }
 
+// computeKMetrics computes per-K metrics over the result set. If the retriever
+// returns fewer than k items, the metrics reflect the available results — i.e.
+// recall@k's denominator is len(expectedIDs), not k, so a "recall@5" against a
+// retriever that only returned 3 results is computed over those 3.
 func computeKMetrics(results []rag.SearchResult, expectedIDs []string, k int) KMetrics {
 	limited := limitResults(results, k)
 	return KMetrics{
@@ -305,9 +351,8 @@ func contextPrecision(results []rag.SearchResult, expectedIDs []string) float64 
 }
 
 func contextTokens(results []rag.SearchResult) int {
-	var retriever rag.Retriever
-	contextText := retriever.BuildContext(results, 0)
-	return (len(contextText) + 3) / 4
+	contextText := contextFormatter.BuildContext(results, 0)
+	return (len(contextText) + charsPerTokenEstimate - 1) / charsPerTokenEstimate
 }
 
 func set(ids []string) map[string]bool {
@@ -359,6 +404,15 @@ func newFixtureEmbedder(fixture *Fixture) *fixtureEmbedder {
 	return &fixtureEmbedder{byQuery: byQuery}
 }
 
+// Embed looks up a precomputed embedding by exact query-text match.
+//
+// CONTRACT: requires inputs[0] to equal a QueryFixture.Query string exactly as
+// it appears in fixtures.json. This works because rag.Retriever.Retrieve passes
+// the query through to the embedder unchanged. If Retrieve ever normalizes
+// (trim, lowercase, etc.) the query, lookup will fail with the "no fixture
+// embedding" error below — diagnose by checking what Retrieve sent vs. what the
+// fixture contains. See TestFixtureEmbedderRejectsUnknownQuery for the error
+// shape this contract produces on miss.
 func (e *fixtureEmbedder) Embed(_ context.Context, _ string, inputs []string) (rag.EmbedResult, error) {
 	if len(inputs) != 1 {
 		return rag.EmbedResult{}, fmt.Errorf("rag eval: fixture embedder expects 1 input, got %d", len(inputs))

--- a/internal/rageval/runner.go
+++ b/internal/rageval/runner.go
@@ -1,4 +1,4 @@
-//go:generate go run ../../cmd/rag-eval -fixtures testdata/fixtures.json -out testdata/baseline.json
+//go:generate go run ../../cmd/rag-eval -fixtures testdata/fixtures.json -out testdata/baseline.json -no-latency
 
 package rageval
 

--- a/internal/rageval/runner_test.go
+++ b/internal/rageval/runner_test.go
@@ -132,6 +132,8 @@ func TestRunFixtureWithoutLiveModel(t *testing.T) {
 			t.Fatalf("mode %q duplicate_rate@10 = %f, want 0 (no dedup regressions)", mode.Name, mode.Summary.DuplicateRateAt10)
 		}
 	}
+	assertRatifiedThresholdSummary(t, report.Thresholds)
+	assertReportMeetsRatifiedThresholds(t, report)
 }
 
 // TestBaselineReproducible re-runs Run against the fixture and asserts the
@@ -248,19 +250,108 @@ func TestBaselineReportShape(t *testing.T) {
 	if report.Corpus.Queries != 20 {
 		t.Fatalf("baseline queries = %d, want 20", report.Corpus.Queries)
 	}
-	if report.Thresholds.Status != StatusThresholdsRatified {
-		t.Fatalf("threshold status = %q, want %q", report.Thresholds.Status, StatusThresholdsRatified)
-	}
-	if report.Thresholds.Owner != OwnerKeith {
-		t.Fatalf("threshold owner = %q, want %q", report.Thresholds.Owner, OwnerKeith)
-	}
-	if report.Thresholds.MinimumStaticRecallAt5 == nil {
-		t.Fatal("MinimumStaticRecallAt5 must be set (non-null) per ratified posture")
-	}
-	if report.Thresholds.MaximumOptInHybridP95LatencyMS != nil {
-		t.Fatal("MaximumOptInHybridP95LatencyMS must be null until #95 sets it against a realistic corpus")
-	}
+	assertRatifiedThresholdSummary(t, report.Thresholds)
 	if len(report.Modes) != 2 {
 		t.Fatalf("baseline modes = %d, want 2", len(report.Modes))
+	}
+	assertReportMeetsRatifiedThresholds(t, &report)
+}
+
+func assertRatifiedThresholdSummary(t *testing.T, got ThresholdSummary) {
+	t.Helper()
+
+	if got.Owner != OwnerKeith {
+		t.Fatalf("threshold owner = %q, want %q", got.Owner, OwnerKeith)
+	}
+	if got.Status != StatusThresholdsRatified {
+		t.Fatalf("threshold status = %q, want %q", got.Status, StatusThresholdsRatified)
+	}
+	assertFloatPtrValue(t, "minimum_static_recall_at_5", got.MinimumStaticRecallAt5, 0.95)
+	assertFloatPtrValue(t, "minimum_hybrid_recall_at_5_improvement", got.MinimumHybridRecallAt5Improvement, 0.0)
+	assertFloatPtrValue(t, "maximum_duplicate_rate", got.MaximumDuplicateRate, 0.05)
+	assertFloatPtrValue(t, "minimum_context_precision_proxy", got.MinimumContextPrecisionProxy, 0.50)
+	assertFloatPtrValue(t, "maximum_average_context_token_growth", got.MaximumAverageContextTokenGrowth, 0.10)
+	assertNilFloatPtr(t, "maximum_opt_in_hybrid_p95_latency_ms", got.MaximumOptInHybridP95LatencyMS)
+	assertNilFloatPtr(t, "maximum_future_default_p95_latency_ms", got.MaximumFutureDefaultP95LatencyMS)
+}
+
+func assertReportMeetsRatifiedThresholds(t *testing.T, report *Report) {
+	t.Helper()
+
+	thresholds := report.Thresholds
+	assertRatifiedThresholdSummary(t, thresholds)
+
+	static := modeSummary(t, report, "static")
+	hybrid := modeSummary(t, report, "hybrid_search_multi")
+
+	if threshold := thresholds.MinimumStaticRecallAt5; threshold != nil && static.RecallAt5 < *threshold {
+		t.Fatalf("static recall_at_5 = %.4f, want >= %.4f", static.RecallAt5, *threshold)
+	}
+	if threshold := thresholds.MinimumHybridRecallAt5Improvement; threshold != nil {
+		improvement := hybrid.RecallAt5 - static.RecallAt5
+		if improvement < *threshold {
+			t.Fatalf("hybrid recall_at_5 improvement = %.4f, want >= %.4f (hybrid=%.4f static=%.4f)", improvement, *threshold, hybrid.RecallAt5, static.RecallAt5)
+		}
+	}
+	if threshold := thresholds.MaximumDuplicateRate; threshold != nil {
+		for _, mode := range report.Modes {
+			if mode.Summary.DuplicateRateAt10 > *threshold {
+				t.Fatalf("mode %q duplicate_rate_at_10 = %.4f, want <= %.4f", mode.Name, mode.Summary.DuplicateRateAt10, *threshold)
+			}
+		}
+	}
+	if threshold := thresholds.MinimumContextPrecisionProxy; threshold != nil {
+		for _, mode := range report.Modes {
+			if mode.Summary.ContextPrecisionAt5 < *threshold {
+				t.Fatalf("mode %q context_precision_at_5 = %.4f, want >= %.4f", mode.Name, mode.Summary.ContextPrecisionAt5, *threshold)
+			}
+		}
+	}
+	if threshold := thresholds.MaximumAverageContextTokenGrowth; threshold != nil {
+		assertTokenGrowthWithin(t, "average_context_tokens_at_5", hybrid.AverageContextTokensAt5, static.AverageContextTokensAt5, *threshold)
+		assertTokenGrowthWithin(t, "average_context_tokens_at_10", hybrid.AverageContextTokensAt10, static.AverageContextTokensAt10, *threshold)
+	}
+}
+
+func modeSummary(t *testing.T, report *Report, name string) ModeSummary {
+	t.Helper()
+	for _, mode := range report.Modes {
+		if mode.Name == name {
+			return mode.Summary
+		}
+	}
+	t.Fatalf("mode %q missing from report", name)
+	return ModeSummary{}
+}
+
+func assertFloatPtrValue(t *testing.T, field string, got *float64, want float64) {
+	t.Helper()
+	if got == nil {
+		t.Fatalf("%s = nil, want %.4f", field, want)
+	}
+	diff := *got - want
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > 1e-12 {
+		t.Fatalf("%s = %.12f, want %.12f", field, *got, want)
+	}
+}
+
+func assertNilFloatPtr(t *testing.T, field string, got *float64) {
+	t.Helper()
+	if got != nil {
+		t.Fatalf("%s = %.4f, want nil", field, *got)
+	}
+}
+
+func assertTokenGrowthWithin(t *testing.T, field string, got, base, maxGrowth float64) {
+	t.Helper()
+	if base <= 0 {
+		t.Fatalf("%s base = %.4f, want > 0", field, base)
+	}
+	growth := (got - base) / base
+	if growth > maxGrowth {
+		t.Fatalf("%s growth = %.4f, want <= %.4f (hybrid=%.2f static=%.2f)", field, growth, maxGrowth, got, base)
 	}
 }

--- a/internal/rageval/runner_test.go
+++ b/internal/rageval/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"sort"
 	"strings"
 	"testing"
 
@@ -19,17 +20,45 @@ func TestFixtureValidate(t *testing.T) {
 		t.Fatalf("LoadFixture: %v", err)
 	}
 	if len(fixture.Queries) != 20 {
-		t.Fatalf("queries = %d, want 20", len(fixture.Queries))
+		t.Fatalf("queries = %d, want 20 (v1 corpus contract)", len(fixture.Queries))
 	}
-	categories := map[string]int{}
+	// Categories are open-set on a per-version basis: every query must land in
+	// the allowed set, AND every allowed category must have >= 4 queries.
+	// Adding a new category requires updating allowedCategories below so the
+	// addition gets a review pass instead of silently appearing.
+	allowedCategories := map[string]int{
+		"single_hop":       0,
+		"cross_file_trace": 0,
+		"compare":          0,
+		"architecture":     0,
+		"code_review":      0,
+	}
 	for _, query := range fixture.Queries {
-		categories[query.Category]++
-	}
-	wantCategories := []string{"architecture", "code_review", "compare", "cross_file_trace", "single_hop"}
-	for _, category := range wantCategories {
-		if categories[category] != 4 {
-			t.Fatalf("category %q count = %d, want 4", category, categories[category])
+		if _, ok := allowedCategories[query.Category]; !ok {
+			t.Fatalf("query %q has category %q not in allowed set %v", query.ID, query.Category, sortedKeys(allowedCategories))
 		}
+		allowedCategories[query.Category]++
+	}
+	const minPerCategory = 4
+	for _, category := range sortedKeys(allowedCategories) {
+		if allowedCategories[category] < minPerCategory {
+			t.Fatalf("category %q has %d queries, want >= %d", category, allowedCategories[category], minPerCategory)
+		}
+	}
+}
+
+func TestFixtureEmbedderRejectsUnknownQuery(t *testing.T) {
+	fixture, err := LoadFixture(fixturePath)
+	if err != nil {
+		t.Fatalf("LoadFixture: %v", err)
+	}
+	emb := newFixtureEmbedder(fixture)
+	_, err = emb.Embed(context.Background(), "fixture-embedding", []string{"this query does not exist in the fixture"})
+	if err == nil {
+		t.Fatal("expected error for unknown query, got nil")
+	}
+	if !strings.Contains(err.Error(), "no fixture embedding") {
+		t.Fatalf("expected error to mention 'no fixture embedding', got: %v", err)
 	}
 }
 
@@ -48,6 +77,15 @@ func TestFixtureValidateRejectsDuplicateQueryText(t *testing.T) {
 	}
 }
 
+func sortedKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
 func TestRunFixtureWithoutLiveModel(t *testing.T) {
 	fixture, err := LoadFixture(fixturePath)
 	if err != nil {
@@ -63,13 +101,104 @@ func TestRunFixtureWithoutLiveModel(t *testing.T) {
 	if len(report.Modes) != 2 {
 		t.Fatalf("modes = %d, want 2", len(report.Modes))
 	}
+
+	// Per-mode minimums. Floors are below the current baseline numbers with
+	// enough slack to absorb floating-point ties (MRR) and 1-query rank flips
+	// (recall@5 on 20-query corpus = 0.05/query). Tighter floors live in
+	// the regression-detection harness (TestBaselineReproducible).
+	type modeFloor struct {
+		minRecallAt5 float64
+		minMRRAt5    float64
+	}
+	wantFloors := map[string]modeFloor{
+		"static":              {minRecallAt5: 0.95, minMRRAt5: 0.95}, // current 0.9583 / 1.0
+		"hybrid_search_multi": {minRecallAt5: 0.95, minMRRAt5: 0.80}, // current 0.9583 / 0.825 (MRR regression vs static is known; see baseline notes)
+	}
 	for _, mode := range report.Modes {
 		if len(mode.Queries) != len(fixture.Queries) {
 			t.Fatalf("mode %q queries = %d, want %d", mode.Name, len(mode.Queries), len(fixture.Queries))
 		}
-		if mode.Summary.RecallAt5 <= 0 {
-			t.Fatalf("mode %q recall@5 = %f, want > 0", mode.Name, mode.Summary.RecallAt5)
+		floor, ok := wantFloors[mode.Name]
+		if !ok {
+			t.Fatalf("mode %q has no defined floor; update wantFloors when adding modes", mode.Name)
 		}
+		if mode.Summary.RecallAt5 < floor.minRecallAt5 {
+			t.Fatalf("mode %q recall@5 = %.4f, want >= %.4f", mode.Name, mode.Summary.RecallAt5, floor.minRecallAt5)
+		}
+		if mode.Summary.MRRAt5 < floor.minMRRAt5 {
+			t.Fatalf("mode %q MRR@5 = %.4f, want >= %.4f", mode.Name, mode.Summary.MRRAt5, floor.minMRRAt5)
+		}
+		if mode.Summary.DuplicateRateAt10 != 0 {
+			t.Fatalf("mode %q duplicate_rate@10 = %f, want 0 (no dedup regressions)", mode.Name, mode.Summary.DuplicateRateAt10)
+		}
+	}
+}
+
+// TestBaselineReproducible re-runs Run against the fixture and asserts the
+// deterministic summary fields match the committed baseline.json within
+// tolerance. This catches two failure modes:
+//
+//  1. Retriever/scorer changes that shift numbers without a baseline regen.
+//  2. Manual edits to baseline.json that don't match what the code produces.
+//
+// Latency fields are deliberately not compared — they vary run-to-run. Run
+// `go generate ./internal/rageval` to regenerate after intentional changes.
+func TestBaselineReproducible(t *testing.T) {
+	fixture, err := LoadFixture(fixturePath)
+	if err != nil {
+		t.Fatalf("LoadFixture: %v", err)
+	}
+	live, err := Run(context.Background(), fixture, RunOptions{MeasureLatency: false})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	data, err := os.ReadFile(baselinePath)
+	if err != nil {
+		t.Fatalf("read baseline: %v", err)
+	}
+	var committed Report
+	if err := json.Unmarshal(data, &committed); err != nil {
+		t.Fatalf("parse baseline: %v", err)
+	}
+
+	if live.SchemaVersion != committed.SchemaVersion {
+		t.Fatalf("schema drift: live=%q committed=%q", live.SchemaVersion, committed.SchemaVersion)
+	}
+	if len(live.Modes) != len(committed.Modes) {
+		t.Fatalf("mode count: live=%d committed=%d", len(live.Modes), len(committed.Modes))
+	}
+
+	const tol = 1e-9
+	committedByName := map[string]ModeSummary{}
+	for _, m := range committed.Modes {
+		committedByName[m.Name] = m.Summary
+	}
+	for _, liveMode := range live.Modes {
+		want, ok := committedByName[liveMode.Name]
+		if !ok {
+			t.Fatalf("live mode %q absent from committed baseline; regenerate via `go generate ./internal/rageval`", liveMode.Name)
+		}
+		assertCloseFloat(t, liveMode.Name, "recall_at_5", liveMode.Summary.RecallAt5, want.RecallAt5, tol)
+		assertCloseFloat(t, liveMode.Name, "recall_at_10", liveMode.Summary.RecallAt10, want.RecallAt10, tol)
+		assertCloseFloat(t, liveMode.Name, "mrr_at_5", liveMode.Summary.MRRAt5, want.MRRAt5, tol)
+		assertCloseFloat(t, liveMode.Name, "mrr_at_10", liveMode.Summary.MRRAt10, want.MRRAt10, tol)
+		assertCloseFloat(t, liveMode.Name, "duplicate_rate_at_10", liveMode.Summary.DuplicateRateAt10, want.DuplicateRateAt10, tol)
+		assertCloseFloat(t, liveMode.Name, "context_precision_at_5", liveMode.Summary.ContextPrecisionAt5, want.ContextPrecisionAt5, tol)
+		assertCloseFloat(t, liveMode.Name, "context_precision_at_10", liveMode.Summary.ContextPrecisionAt10, want.ContextPrecisionAt10, tol)
+		assertCloseFloat(t, liveMode.Name, "average_context_tokens_at_5", liveMode.Summary.AverageContextTokensAt5, want.AverageContextTokensAt5, tol)
+		assertCloseFloat(t, liveMode.Name, "average_context_tokens_at_10", liveMode.Summary.AverageContextTokensAt10, want.AverageContextTokensAt10, tol)
+	}
+}
+
+func assertCloseFloat(t *testing.T, mode, field string, got, want, tol float64) {
+	t.Helper()
+	diff := got - want
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > tol {
+		t.Fatalf("baseline drift: mode=%q field=%q got=%g want=%g diff=%g (regenerate via `go generate ./internal/rageval` if intentional)", mode, field, got, want, diff)
 	}
 }
 
@@ -119,8 +248,17 @@ func TestBaselineReportShape(t *testing.T) {
 	if report.Corpus.Queries != 20 {
 		t.Fatalf("baseline queries = %d, want 20", report.Corpus.Queries)
 	}
-	if report.Thresholds.Status != "pending_owner_values_before_95" {
-		t.Fatalf("threshold status = %q", report.Thresholds.Status)
+	if report.Thresholds.Status != StatusThresholdsRatified {
+		t.Fatalf("threshold status = %q, want %q", report.Thresholds.Status, StatusThresholdsRatified)
+	}
+	if report.Thresholds.Owner != OwnerKeith {
+		t.Fatalf("threshold owner = %q, want %q", report.Thresholds.Owner, OwnerKeith)
+	}
+	if report.Thresholds.MinimumStaticRecallAt5 == nil {
+		t.Fatal("MinimumStaticRecallAt5 must be set (non-null) per ratified posture")
+	}
+	if report.Thresholds.MaximumOptInHybridP95LatencyMS != nil {
+		t.Fatal("MaximumOptInHybridP95LatencyMS must be null until #95 sets it against a realistic corpus")
 	}
 	if len(report.Modes) != 2 {
 		t.Fatalf("baseline modes = %d, want 2", len(report.Modes))

--- a/internal/rageval/testdata/baseline.json
+++ b/internal/rageval/testdata/baseline.json
@@ -17,19 +17,21 @@
     "vector_space_id": "fixture/rag-eval-v1",
     "notes": [
       "fixtures use deterministic synthetic embeddings; no live Ollama dependency",
-      "threshold values are owner-gated before #95"
+      "thresholds ratified for v1 regression detection; see runner.buildThresholds for posture rationale",
+      "hybrid_search_multi regresses MRR@5 vs static (~0.825 vs 1.0) on this synthetic corpus — captured for #94 scorer-weight discussion, not flagged as a blocker",
+      "latency thresholds intentionally null: N=20 cold samples on a 12-chunk in-memory SQLite corpus is statistically unstable; defer to #95 against realistic workload"
     ]
   },
   "thresholds": {
     "owner": "Keith",
-    "status": "pending_owner_values_before_95",
-    "minimum_static_recall_at_5": null,
-    "minimum_hybrid_recall_at_5_improvement": null,
-    "maximum_duplicate_rate": null,
-    "minimum_context_precision_proxy": null,
+    "status": "thresholds_ratified",
+    "minimum_static_recall_at_5": 0.95,
+    "minimum_hybrid_recall_at_5_improvement": 0,
+    "maximum_duplicate_rate": 0.05,
+    "minimum_context_precision_proxy": 0.5,
     "maximum_opt_in_hybrid_p95_latency_ms": null,
     "maximum_future_default_p95_latency_ms": null,
-    "maximum_average_context_token_growth": null
+    "maximum_average_context_token_growth": 0.1
   },
   "modes": [
     {
@@ -46,13 +48,13 @@
         "average_context_tokens_at_10": 1343.55,
         "cold_latency_ms": {
           "count": 20,
-          "p50": 0.057084,
-          "p95": 0.16294794999999992
+          "p50": 0.055104,
+          "p95": 0.10023954999999993
         },
         "warm_latency_ms": {
           "count": 60,
-          "p50": 0.058146,
-          "p95": 0.10196314999999993
+          "p50": 0.0547915,
+          "p95": 0.0840056499999999
         }
       },
       "queries": [
@@ -92,11 +94,11 @@
               "context_tokens": 1375
             }
           ],
-          "cold_latency_ms": 0.145959,
+          "cold_latency_ms": 0.09575,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.070167,
-            "p95": 0.0765039
+            "p50": 0.053209,
+            "p95": 0.0558712
           }
         },
         {
@@ -135,11 +137,11 @@
               "context_tokens": 1387
             }
           ],
-          "cold_latency_ms": 0.078042,
+          "cold_latency_ms": 0.054542,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.067583,
-            "p95": 0.0741836
+            "p50": 0.05,
+            "p95": 0.0553622
           }
         },
         {
@@ -178,11 +180,11 @@
               "context_tokens": 1372
             }
           ],
-          "cold_latency_ms": 0.075,
+          "cold_latency_ms": 0.053542,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.074792,
-            "p95": 0.0796664
+            "p50": 0.052875,
+            "p95": 0.06255
           }
         },
         {
@@ -221,11 +223,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.078208,
+          "cold_latency_ms": 0.0545,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.068917,
-            "p95": 0.0770917
+            "p50": 0.05675,
+            "p95": 0.0571622
           }
         },
         {
@@ -266,11 +268,11 @@
               "context_tokens": 1375
             }
           ],
-          "cold_latency_ms": 0.242709,
+          "cold_latency_ms": 0.060125,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.0935,
-            "p95": 0.16250030000000001
+            "p50": 0.121334,
+            "p95": 0.2538959
           }
         },
         {
@@ -313,11 +315,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.100041,
+          "cold_latency_ms": 0.185541,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.073083,
-            "p95": 0.0737211
+            "p50": 0.059666,
+            "p95": 0.0623291
           }
         },
         {
@@ -358,11 +360,11 @@
               "context_tokens": 1357
             }
           ],
-          "cold_latency_ms": 0.0785,
+          "cold_latency_ms": 0.055792,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.065625,
-            "p95": 0.0764997
+            "p50": 0.054791,
+            "p95": 0.0557666
           }
         },
         {
@@ -403,11 +405,11 @@
               "context_tokens": 1305
             }
           ],
-          "cold_latency_ms": 0.072042,
+          "cold_latency_ms": 0.055,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.097375,
-            "p95": 0.10026310000000001
+            "p50": 0.0555,
+            "p95": 0.05775
           }
         },
         {
@@ -447,11 +449,11 @@
               "context_tokens": 1387
             }
           ],
-          "cold_latency_ms": 0.056709,
+          "cold_latency_ms": 0.055208,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.053375,
-            "p95": 0.053712499999999996
+            "p50": 0.0515,
+            "p95": 0.0555131
           }
         },
         {
@@ -491,11 +493,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.05225,
+          "cold_latency_ms": 0.052417,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.050792,
-            "p95": 0.051467
+            "p50": 0.051083,
+            "p95": 0.0527336
           }
         },
         {
@@ -535,11 +537,11 @@
               "context_tokens": 1372
             }
           ],
-          "cold_latency_ms": 0.054833,
+          "cold_latency_ms": 0.050583,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.051208,
-            "p95": 0.055033
+            "p50": 0.050375,
+            "p95": 0.053975
           }
         },
         {
@@ -579,11 +581,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.052709,
+          "cold_latency_ms": 0.05475,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.05125,
-            "p95": 0.0516622
+            "p50": 0.051,
+            "p95": 0.0522753
           }
         },
         {
@@ -625,11 +627,11 @@
               "context_tokens": 1357
             }
           ],
-          "cold_latency_ms": 0.05275,
+          "cold_latency_ms": 0.050375,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.062083,
-            "p95": 0.0626086
+            "p50": 0.051084,
+            "p95": 0.0520956
           }
         },
         {
@@ -672,11 +674,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.050375,
+          "cold_latency_ms": 0.051167,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.050833,
-            "p95": 0.0521461
+            "p50": 0.050458,
+            "p95": 0.051133
           }
         },
         {
@@ -717,11 +719,11 @@
               "context_tokens": 1339
             }
           ],
-          "cold_latency_ms": 0.0555,
+          "cold_latency_ms": 0.050708,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.055417,
-            "p95": 0.0561667
+            "p50": 0.0575,
+            "p95": 0.0593369
           }
         },
         {
@@ -763,11 +765,11 @@
               "context_tokens": 1383
             }
           ],
-          "cold_latency_ms": 0.053166,
+          "cold_latency_ms": 0.082875,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.128167,
-            "p95": 0.33764109999999997
+            "p50": 0.082041,
+            "p95": 0.16300409999999999
           }
         },
         {
@@ -808,11 +810,11 @@
               "context_tokens": 1408
             }
           ],
-          "cold_latency_ms": 0.15875,
+          "cold_latency_ms": 0.0575,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.057667,
-            "p95": 0.058529199999999997
+            "p50": 0.054792,
+            "p95": 0.0603045
           }
         },
         {
@@ -855,11 +857,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.057459,
+          "cold_latency_ms": 0.055792,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.05575,
-            "p95": 0.056875
+            "p50": 0.058083,
+            "p95": 0.058533
           }
         },
         {
@@ -899,11 +901,11 @@
               "context_tokens": 1333
             }
           ],
-          "cold_latency_ms": 0.05375,
+          "cold_latency_ms": 0.057833,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.053084,
-            "p95": 0.0568334
+            "p50": 0.056416,
+            "p95": 0.0565663
           }
         },
         {
@@ -943,11 +945,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.052875,
+          "cold_latency_ms": 0.05625,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.052333,
-            "p95": 0.05799579999999999
+            "p50": 0.0575,
+            "p95": 0.058512499999999995
           }
         }
       ]
@@ -966,13 +968,13 @@
         "average_context_tokens_at_10": 1343.55,
         "cold_latency_ms": {
           "count": 20,
-          "p50": 0.19425,
-          "p95": 0.35700384999999984
+          "p50": 0.17602099999999998,
+          "p95": 0.24353334999999998
         },
         "warm_latency_ms": {
           "count": 60,
-          "p50": 0.190979,
-          "p95": 0.3451475999999997
+          "p50": 0.169167,
+          "p95": 0.2870062499999999
         }
       },
       "queries": [
@@ -1012,11 +1014,11 @@
               "context_tokens": 1375
             }
           ],
-          "cold_latency_ms": 0.18725,
+          "cold_latency_ms": 0.175792,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.101916,
-            "p95": 0.10446659999999999
+            "p50": 0.104708,
+            "p95": 0.1091333
           }
         },
         {
@@ -1055,11 +1057,11 @@
               "context_tokens": 1387
             }
           ],
-          "cold_latency_ms": 0.108417,
+          "cold_latency_ms": 0.102291,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.098041,
-            "p95": 0.1001047
+            "p50": 0.105125,
+            "p95": 0.1053122
           }
         },
         {
@@ -1098,11 +1100,11 @@
               "context_tokens": 1372
             }
           ],
-          "cold_latency_ms": 0.100458,
+          "cold_latency_ms": 0.102625,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.098084,
-            "p95": 0.0991703
+            "p50": 0.097083,
+            "p95": 0.1015083
           }
         },
         {
@@ -1141,11 +1143,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.113,
+          "cold_latency_ms": 0.111417,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.11,
-            "p95": 0.1122122
+            "p50": 0.109958,
+            "p95": 0.1101839
           }
         },
         {
@@ -1186,11 +1188,11 @@
               "context_tokens": 1375
             }
           ],
-          "cold_latency_ms": 0.347208,
+          "cold_latency_ms": 0.216042,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.339833,
-            "p95": 0.5169826999999999
+            "p50": 0.320375,
+            "p95": 0.414425
           }
         },
         {
@@ -1233,11 +1235,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.261041,
+          "cold_latency_ms": 0.217,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.25275,
-            "p95": 0.2813997
+            "p50": 0.201833,
+            "p95": 0.2027708
           }
         },
         {
@@ -1278,11 +1280,11 @@
               "context_tokens": 1357
             }
           ],
-          "cold_latency_ms": 0.202625,
+          "cold_latency_ms": 0.20025,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.185458,
-            "p95": 0.1866577
+            "p50": 0.18875,
+            "p95": 0.19411219999999998
           }
         },
         {
@@ -1323,11 +1325,11 @@
               "context_tokens": 1305
             }
           ],
-          "cold_latency_ms": 0.19475,
+          "cold_latency_ms": 0.20275,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.190166,
-            "p95": 0.19162939999999998
+            "p50": 0.207625,
+            "p95": 0.2129872
           }
         },
         {
@@ -1367,11 +1369,11 @@
               "context_tokens": 1387
             }
           ],
-          "cold_latency_ms": 0.15275,
+          "cold_latency_ms": 0.162375,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.157833,
-            "p95": 0.16522019999999998
+            "p50": 0.181833,
+            "p95": 0.2657958
           }
         },
         {
@@ -1411,11 +1413,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.134458,
+          "cold_latency_ms": 0.13925,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.124125,
-            "p95": 0.12735059999999998
+            "p50": 0.132459,
+            "p95": 0.13335809999999998
           }
         },
         {
@@ -1455,11 +1457,11 @@
               "context_tokens": 1372
             }
           ],
-          "cold_latency_ms": 0.12425,
+          "cold_latency_ms": 0.128792,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.131458,
-            "p95": 0.1334452
+            "p50": 0.126417,
+            "p95": 0.1267923
           }
         },
         {
@@ -1499,11 +1501,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.160542,
+          "cold_latency_ms": 0.171375,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.312792,
-            "p95": 0.4582536
+            "p50": 0.168667,
+            "p95": 0.16956700000000002
           }
         },
         {
@@ -1545,11 +1547,11 @@
               "context_tokens": 1357
             }
           ],
-          "cold_latency_ms": 0.29025,
+          "cold_latency_ms": 0.214041,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.255375,
-            "p95": 0.2593872
+            "p50": 0.28525,
+            "p95": 0.3766378
           }
         },
         {
@@ -1592,11 +1594,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.218541,
+          "cold_latency_ms": 0.17625,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.200709,
-            "p95": 0.2062584
+            "p50": 0.165,
+            "p95": 0.1678503
           }
         },
         {
@@ -1637,11 +1639,11 @@
               "context_tokens": 1339
             }
           ],
-          "cold_latency_ms": 0.1755,
+          "cold_latency_ms": 0.140875,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.175667,
-            "p95": 0.1800545
+            "p50": 0.134125,
+            "p95": 0.1341628
           }
         },
         {
@@ -1683,11 +1685,11 @@
               "context_tokens": 1383
             }
           ],
-          "cold_latency_ms": 0.19375,
+          "cold_latency_ms": 0.163042,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.21575,
-            "p95": 0.2552744
+            "p50": 0.16,
+            "p95": 0.1616119
           }
         },
         {
@@ -1728,11 +1730,11 @@
               "context_tokens": 1408
             }
           ],
-          "cold_latency_ms": 0.233375,
+          "cold_latency_ms": 0.185458,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.2325,
-            "p95": 0.2341119
+            "p50": 0.177459,
+            "p95": 0.1800078
           }
         },
         {
@@ -1775,11 +1777,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.279542,
+          "cold_latency_ms": 0.222584,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.265084,
-            "p95": 0.2776462
+            "p50": 0.2205,
+            "p95": 0.2230875
           }
         },
         {
@@ -1819,11 +1821,11 @@
               "context_tokens": 1333
             }
           ],
-          "cold_latency_ms": 0.3095,
+          "cold_latency_ms": 0.2435,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.229208,
-            "p95": 0.27882049999999997
+            "p50": 0.242417,
+            "p95": 0.2431289
           }
         },
         {
@@ -1863,11 +1865,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.543125,
+          "cold_latency_ms": 0.244167,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.298417,
-            "p95": 0.43135419999999997
+            "p50": 0.224666,
+            "p95": 0.24079129999999999
           }
         }
       ]

--- a/internal/rageval/testdata/baseline.json
+++ b/internal/rageval/testdata/baseline.json
@@ -48,13 +48,13 @@
         "average_context_tokens_at_10": 1343.55,
         "cold_latency_ms": {
           "count": 20,
-          "p50": 0.055104,
-          "p95": 0.10023954999999993
+          "p50": 0,
+          "p95": 0
         },
         "warm_latency_ms": {
           "count": 60,
-          "p50": 0.0547915,
-          "p95": 0.0840056499999999
+          "p50": 0,
+          "p95": 0
         }
       },
       "queries": [
@@ -94,11 +94,11 @@
               "context_tokens": 1375
             }
           ],
-          "cold_latency_ms": 0.09575,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.053209,
-            "p95": 0.0558712
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -137,11 +137,11 @@
               "context_tokens": 1387
             }
           ],
-          "cold_latency_ms": 0.054542,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.05,
-            "p95": 0.0553622
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -180,11 +180,11 @@
               "context_tokens": 1372
             }
           ],
-          "cold_latency_ms": 0.053542,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.052875,
-            "p95": 0.06255
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -223,11 +223,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.0545,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.05675,
-            "p95": 0.0571622
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -268,11 +268,11 @@
               "context_tokens": 1375
             }
           ],
-          "cold_latency_ms": 0.060125,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.121334,
-            "p95": 0.2538959
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -315,11 +315,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.185541,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.059666,
-            "p95": 0.0623291
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -360,11 +360,11 @@
               "context_tokens": 1357
             }
           ],
-          "cold_latency_ms": 0.055792,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.054791,
-            "p95": 0.0557666
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -405,11 +405,11 @@
               "context_tokens": 1305
             }
           ],
-          "cold_latency_ms": 0.055,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.0555,
-            "p95": 0.05775
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -449,11 +449,11 @@
               "context_tokens": 1387
             }
           ],
-          "cold_latency_ms": 0.055208,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.0515,
-            "p95": 0.0555131
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -493,11 +493,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.052417,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.051083,
-            "p95": 0.0527336
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -537,11 +537,11 @@
               "context_tokens": 1372
             }
           ],
-          "cold_latency_ms": 0.050583,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.050375,
-            "p95": 0.053975
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -581,11 +581,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.05475,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.051,
-            "p95": 0.0522753
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -627,11 +627,11 @@
               "context_tokens": 1357
             }
           ],
-          "cold_latency_ms": 0.050375,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.051084,
-            "p95": 0.0520956
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -674,11 +674,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.051167,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.050458,
-            "p95": 0.051133
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -719,11 +719,11 @@
               "context_tokens": 1339
             }
           ],
-          "cold_latency_ms": 0.050708,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.0575,
-            "p95": 0.0593369
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -765,11 +765,11 @@
               "context_tokens": 1383
             }
           ],
-          "cold_latency_ms": 0.082875,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.082041,
-            "p95": 0.16300409999999999
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -810,11 +810,11 @@
               "context_tokens": 1408
             }
           ],
-          "cold_latency_ms": 0.0575,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.054792,
-            "p95": 0.0603045
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -857,11 +857,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.055792,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.058083,
-            "p95": 0.058533
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -901,11 +901,11 @@
               "context_tokens": 1333
             }
           ],
-          "cold_latency_ms": 0.057833,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.056416,
-            "p95": 0.0565663
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -945,11 +945,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.05625,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.0575,
-            "p95": 0.058512499999999995
+            "p50": 0,
+            "p95": 0
           }
         }
       ]
@@ -968,13 +968,13 @@
         "average_context_tokens_at_10": 1343.55,
         "cold_latency_ms": {
           "count": 20,
-          "p50": 0.17602099999999998,
-          "p95": 0.24353334999999998
+          "p50": 0,
+          "p95": 0
         },
         "warm_latency_ms": {
           "count": 60,
-          "p50": 0.169167,
-          "p95": 0.2870062499999999
+          "p50": 0,
+          "p95": 0
         }
       },
       "queries": [
@@ -1014,11 +1014,11 @@
               "context_tokens": 1375
             }
           ],
-          "cold_latency_ms": 0.175792,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.104708,
-            "p95": 0.1091333
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -1057,11 +1057,11 @@
               "context_tokens": 1387
             }
           ],
-          "cold_latency_ms": 0.102291,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.105125,
-            "p95": 0.1053122
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -1100,11 +1100,11 @@
               "context_tokens": 1372
             }
           ],
-          "cold_latency_ms": 0.102625,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.097083,
-            "p95": 0.1015083
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -1143,11 +1143,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.111417,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.109958,
-            "p95": 0.1101839
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -1188,11 +1188,11 @@
               "context_tokens": 1375
             }
           ],
-          "cold_latency_ms": 0.216042,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.320375,
-            "p95": 0.414425
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -1235,11 +1235,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.217,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.201833,
-            "p95": 0.2027708
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -1280,11 +1280,11 @@
               "context_tokens": 1357
             }
           ],
-          "cold_latency_ms": 0.20025,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.18875,
-            "p95": 0.19411219999999998
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -1325,11 +1325,11 @@
               "context_tokens": 1305
             }
           ],
-          "cold_latency_ms": 0.20275,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.207625,
-            "p95": 0.2129872
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -1369,11 +1369,11 @@
               "context_tokens": 1387
             }
           ],
-          "cold_latency_ms": 0.162375,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.181833,
-            "p95": 0.2657958
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -1413,11 +1413,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.13925,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.132459,
-            "p95": 0.13335809999999998
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -1457,11 +1457,11 @@
               "context_tokens": 1372
             }
           ],
-          "cold_latency_ms": 0.128792,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.126417,
-            "p95": 0.1267923
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -1501,11 +1501,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.171375,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.168667,
-            "p95": 0.16956700000000002
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -1547,11 +1547,11 @@
               "context_tokens": 1357
             }
           ],
-          "cold_latency_ms": 0.214041,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.28525,
-            "p95": 0.3766378
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -1594,11 +1594,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.17625,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.165,
-            "p95": 0.1678503
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -1639,11 +1639,11 @@
               "context_tokens": 1339
             }
           ],
-          "cold_latency_ms": 0.140875,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.134125,
-            "p95": 0.1341628
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -1685,11 +1685,11 @@
               "context_tokens": 1383
             }
           ],
-          "cold_latency_ms": 0.163042,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.16,
-            "p95": 0.1616119
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -1730,11 +1730,11 @@
               "context_tokens": 1408
             }
           ],
-          "cold_latency_ms": 0.185458,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.177459,
-            "p95": 0.1800078
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -1777,11 +1777,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.222584,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.2205,
-            "p95": 0.2230875
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -1821,11 +1821,11 @@
               "context_tokens": 1333
             }
           ],
-          "cold_latency_ms": 0.2435,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.242417,
-            "p95": 0.2431289
+            "p50": 0,
+            "p95": 0
           }
         },
         {
@@ -1865,11 +1865,11 @@
               "context_tokens": 1303
             }
           ],
-          "cold_latency_ms": 0.244167,
+          "cold_latency_ms": 0,
           "warm_latency_ms": {
             "count": 3,
-            "p50": 0.224666,
-            "p95": 0.24079129999999999
+            "p50": 0,
+            "p95": 0
           }
         }
       ]

--- a/internal/rageval/types.go
+++ b/internal/rageval/types.go
@@ -3,9 +3,41 @@ package rageval
 import "time"
 
 const (
+	// SchemaVersion identifies the JSON shape of Report. Bump on incompatible
+	// changes so future readers can detect drift between code and committed
+	// baseline.json. v1 → v2 migration is unspecified until #95 ratifies the
+	// agentic RAG public package surface.
 	SchemaVersion = "rag-eval-baseline/v1"
+
+	// vectorSpaceID isolates the eval fixture from any real corpus a developer
+	// may have indexed locally.
 	vectorSpaceID = "fixture/rag-eval-v1"
+
+	// OwnerKeith identifies the human accountable for threshold values.
+	OwnerKeith = "Keith"
+
+	// StatusPendingOwnerBefore95 marks reports generated before owner ratification.
+	StatusPendingOwnerBefore95 = "pending_owner_values_before_95"
+
+	// StatusThresholdsRatified marks reports whose non-null thresholds are
+	// owner-approved regression floors (not aspirational targets).
+	StatusThresholdsRatified = "thresholds_ratified"
+
+	// charsPerTokenEstimate is the heuristic rag.Retriever.BuildContext uses
+	// to convert a maxTokens budget to a character budget. Mirror it here so
+	// contextTokens() produces a comparable estimate.
+	charsPerTokenEstimate = 4
 )
+
+// replayTimestamp freezes QueryContext.Timestamp passed into hybrid retrieval
+// so the temporal scorer produces deterministic output across runs. The chosen
+// value (2023-11-14 22:13:20 UTC) is arbitrary but must never change — updating
+// it would invalidate every committed baseline's hybrid numbers.
+var replayTimestamp = time.Unix(1_700_000_000, 0)
+
+// floatPtr returns a pointer to v. Used to populate nullable ThresholdSummary
+// fields without per-call temporary variables.
+func floatPtr(v float64) *float64 { return &v }
 
 // Fixture is the committed golden retrieval corpus and query set.
 type Fixture struct {


### PR DESCRIPTION
## Why this is a follow-up

PR #105 was merged before its `/code-review` cycle landed. This PR carries the review hardening that should have been part of #105:

- Owner-ratified v1 regression thresholds (5 non-null, 2 deliberately null)
- HIGH/MEDIUM/LOW review findings from the `/code-review` cycle
- Strengthened test assertions and a baseline-reproducibility test
- README rewritten with an interpretation guide

No new public API surface; all changes are inside `internal/rageval` plus `cmd/rag-eval`.

## Ratified thresholds (v1 posture)

Floors detect regressions; they do not chase improvements. See `runner.buildThresholds` for full rationale.

| Field | Value | Rationale |
|---|---|---|
| `minimum_static_recall_at_5` | 0.95 | current 0.9583; 1pp floor catches real regressions without flapping |
| `minimum_hybrid_recall_at_5_improvement` | 0.0 | hybrid currently matches static; "must not regress" until corpus discriminates |
| `maximum_duplicate_rate` | 0.05 | current 0; 5% tolerance for SearchMulti diversification |
| `minimum_context_precision_proxy` | 0.50 | current 0.51 @K=5; below 0.50 means majority of context is irrelevant |
| `maximum_average_context_token_growth` | 0.10 | current both modes match; 10% growth flags context-bloat regression |
| `maximum_opt_in_hybrid_p95_latency_ms` | **null** | N=20 cold samples on 12-chunk in-memory SQLite is statistically unstable; defer to #95 against realistic workload |
| `maximum_future_default_p95_latency_ms` | **null** | same — synthetic-corpus latency is not load-bearing |

## Review findings addressed

**HIGH:**
- `contextFormatter` package-level singleton with documented purity contract on `rag.Retriever.BuildContext` (was zero-value `Retriever` literal with implicit contract assumption).
- `TestBaselineReproducible` re-runs `Run` and asserts deterministic summary fields match committed `baseline.json` within `1e-9` tolerance — catches code-vs-baseline and baseline-vs-code drift.
- `TestRunFixtureWithoutLiveModel` now asserts per-mode minimums (static recall@5 ≥ 0.95 / MRR@5 ≥ 0.95; hybrid recall@5 ≥ 0.95 / MRR@5 ≥ 0.80) instead of a `> 0` sanity floor.
- `fixtureEmbedder.Embed` exact-match contract documented; `TestFixtureEmbedderRejectsUnknownQuery` locks the failure shape.
- Baseline notes flag hybrid MRR@5 regression (~0.825 vs 1.0 static) for #94 scorer-weight discussion.

**MEDIUM:**
- `runMode` honors `ctx.Done()` between queries and warm runs.
- `replayTimestamp` extracted from a magic `time.Unix(1_700_000_000, 0)` literal.
- `TestFixtureValidate` uses open-set category assertion (new categories surface for review rather than silently appearing).
- `OwnerKeith` / `StatusPendingOwnerBefore95` / `StatusThresholdsRatified` typed constants.
- `computeKMetrics` documents partial-result semantics for recall@K.

**LOW:**
- `cmd/rag-eval` uses `log.Fatal` with structured prefix.
- `//go:generate` directive for `go generate` workflow.
- `SchemaVersion` documents v1 → vN migration intent.

## Known finding for #94

Hybrid `SearchMulti` regresses MRR@5 from 1.0 (static) → ~0.825 on this synthetic corpus. Captured in `baseline.json` notes and the test floor (≥ 0.80) catches deeper regressions. Surfacing as scorer-weight discussion input for #94.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/rageval ./cmd/rag-eval`
- pre-push hook: lint, race tests, compile smoke

## Recovery context

The fix work originated on `codex/93-agentic-rag-eval-baseline` after #105 merged. Cherry-picked here onto a fresh branch off latest `develop` for a clean follow-up review.

Refs #93. Follows #105.