### PR TITLE
feat(rag/ast): structural symbol graph skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
 .claude
 docs/plans/
+docs/spikes/
 docs/superpowers/
 docs/llm/traces/
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ go-llm/
 ├── config/          # Model configuration loader (models.json, resolve, fallback)
 ├── provider/        # Use-case-aware Router (chat/fim/embedding/reasoning/analysis/code-review/agent profiles), circuit breakers, warmth, sticky routing, scoring, fallback chains
 ├── rag/             # RAG: chunking, SQLite vector store, indexing, retrieval
-├── rag/ast/         # Structural symbol graph: Extractor + SymbolStore interfaces (skeleton)
+├── rag/ast/         # Scoped structural symbol graph: Extractor + SymbolStore interfaces (skeleton)
 ├── completion/      # IDE inline completion (Fill-in-the-Middle)
 ├── analysis/        # Domain-specific analysis helpers (code review, ML metrics, trading)
 ├── mcp/             # MCP server: tools, prompts, resources over stdio/HTTP/2 — wired through provider.Router

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ go-llm/
 ├── config/          # Model configuration loader (models.json, resolve, fallback)
 ├── provider/        # Use-case-aware Router (chat/fim/embedding/reasoning/analysis/code-review/agent profiles), circuit breakers, warmth, sticky routing, scoring, fallback chains
 ├── rag/             # RAG: chunking, SQLite vector store, indexing, retrieval
+├── rag/ast/         # Structural symbol graph: Extractor + SymbolStore interfaces (skeleton)
 ├── completion/      # IDE inline completion (Fill-in-the-Middle)
 ├── analysis/        # Domain-specific analysis helpers (code review, ML metrics, trading)
 ├── mcp/             # MCP server: tools, prompts, resources over stdio/HTTP/2 — wired through provider.Router

--- a/rag/ast/errors.go
+++ b/rag/ast/errors.go
@@ -19,4 +19,12 @@ var (
 	// because the symbol graph may drift independently of the chunk store
 	// during partial migrations.
 	ErrVectorSpaceMismatch = errors.New("rag/ast: vector-space mismatch")
+
+	// ErrInvalidGraph indicates a graph or edge violates the SymbolStore
+	// persistence contract.
+	ErrInvalidGraph = errors.New("rag/ast: invalid graph")
+
+	// ErrInvalidArgument indicates a caller supplied an invalid read argument
+	// such as a negative limit.
+	ErrInvalidArgument = errors.New("rag/ast: invalid argument")
 )

--- a/rag/ast/errors.go
+++ b/rag/ast/errors.go
@@ -1,0 +1,22 @@
+package ast
+
+import "errors"
+
+// Sentinel errors. Distinct from rag's own sentinels because the recovery
+// action diverges: rag/ vsid mismatches mean "re-embed"; rag/ast vsid
+// mismatches mean "re-extract the AST graph". Both can happen independently
+// when callers mix-and-match stores.
+//
+// Error strings are namespaced "rag/ast: ..." to match the full import path
+// and disambiguate from go/ast in log aggregators.
+var (
+	// ErrSymbolNotFound indicates GetSymbol or SymbolEnclosing could not
+	// resolve the requested symbol or location to a node in the store.
+	ErrSymbolNotFound = errors.New("rag/ast: symbol not found")
+
+	// ErrVectorSpaceMismatch indicates a read attempted to use a vsid not
+	// present in the store. Distinct from rag.ErrVectorSpaceMismatch
+	// because the symbol graph may drift independently of the chunk store
+	// during partial migrations.
+	ErrVectorSpaceMismatch = errors.New("rag/ast: vector-space mismatch")
+)

--- a/rag/ast/errors_test.go
+++ b/rag/ast/errors_test.go
@@ -14,6 +14,8 @@ func TestSentinelsWrapTransparently(t *testing.T) {
 	cases := []error{
 		ErrSymbolNotFound,
 		ErrVectorSpaceMismatch,
+		ErrInvalidGraph,
+		ErrInvalidArgument,
 	}
 	for _, sentinel := range cases {
 		t.Run(sentinel.Error(), func(t *testing.T) {
@@ -33,7 +35,7 @@ func TestSentinelsWrapTransparently(t *testing.T) {
 func TestSentinelNamespace(t *testing.T) {
 	// All sentinel messages must start with "rag/ast: " so log aggregators
 	// can disambiguate from go/ast and the rag package's own sentinels.
-	for _, err := range []error{ErrSymbolNotFound, ErrVectorSpaceMismatch} {
+	for _, err := range []error{ErrSymbolNotFound, ErrVectorSpaceMismatch, ErrInvalidGraph, ErrInvalidArgument} {
 		if !strings.HasPrefix(err.Error(), "rag/ast: ") {
 			t.Errorf("sentinel %q lacks 'rag/ast: ' namespace prefix", err.Error())
 		}

--- a/rag/ast/errors_test.go
+++ b/rag/ast/errors_test.go
@@ -1,0 +1,41 @@
+package ast
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestSentinelsWrapTransparently(t *testing.T) {
+	// Verify that a caller wrapping a sentinel with fmt.Errorf("...: %w", ...)
+	// can still be matched via errors.Is — this is the contract every
+	// downstream consumer (rag.Indexer, MCP tools) will rely on.
+	cases := []error{
+		ErrSymbolNotFound,
+		ErrVectorSpaceMismatch,
+	}
+	for _, sentinel := range cases {
+		t.Run(sentinel.Error(), func(t *testing.T) {
+			wrapped := fmt.Errorf("rag/ast: load symbol %q: %w", "pkg#Symbol", sentinel)
+			if !errors.Is(wrapped, sentinel) {
+				t.Errorf("errors.Is(wrapped, %v) = false; wrapping broke sentinel identity", sentinel)
+			}
+			// Double-wrapping (common in layered code) must also work.
+			doubled := fmt.Errorf("store.get: %w", wrapped)
+			if !errors.Is(doubled, sentinel) {
+				t.Errorf("errors.Is(double-wrapped, %v) = false", sentinel)
+			}
+		})
+	}
+}
+
+func TestSentinelNamespace(t *testing.T) {
+	// All sentinel messages must start with "rag/ast: " so log aggregators
+	// can disambiguate from go/ast and the rag package's own sentinels.
+	for _, err := range []error{ErrSymbolNotFound, ErrVectorSpaceMismatch} {
+		if !strings.HasPrefix(err.Error(), "rag/ast: ") {
+			t.Errorf("sentinel %q lacks 'rag/ast: ' namespace prefix", err.Error())
+		}
+	}
+}

--- a/rag/ast/extractor.go
+++ b/rag/ast/extractor.go
@@ -1,0 +1,41 @@
+package ast
+
+import "context"
+
+// Extractor walks a source tree and produces a [SymbolGraph]. The interface
+// is language-agnostic so a single [SymbolStore] consumer can be wired to
+// language-specific extractors (Go via go/ast, tree-sitter for others)
+// without leaking parser types across the seam.
+//
+// Implementations MUST be safe for concurrent use; a caller indexing many
+// roots in parallel will invoke Extract from multiple goroutines.
+type Extractor interface {
+	// Languages returns the set of language identifiers this extractor can
+	// produce graphs for, using rag.Chunk.Language tokens ("go", "python",
+	// "typescript", ...). The returned slice MUST be safe for the caller
+	// to read concurrently with future Extract calls.
+	Languages() []string
+
+	// Extract walks root and produces a graph stamped with vectorSpaceID.
+	// An empty graph with nil error is the correct response for a tree
+	// containing no sources in any of this extractor's languages — that
+	// case is success, not failure. Errors are reserved for IO / parse
+	// failures the caller cannot recover from.
+	//
+	// The returned [SymbolGraph.Root] MUST equal root after the same
+	// canonicalization Extract applies to node files (filepath.Clean +
+	// forward slashes), so paths join cleanly.
+	Extract(ctx context.Context, root string, vectorSpaceID string) (SymbolGraph, error)
+
+	// Stale reports whether a graph previously extracted from root and
+	// stamped with prevSignature can still be reused, or whether the
+	// caller must re-extract. The signature is an opaque token defined
+	// by the extractor itself — it MAY encode the vector-space identity,
+	// source-file fingerprints, the extractor's own version, the toolchain
+	// version, or any combination. Callers treat it as a string and pass
+	// it back unchanged.
+	//
+	// Returning (true, nil) forces re-extraction. Returning (false, nil)
+	// authorizes reuse of the previously persisted graph.
+	Stale(ctx context.Context, root string, prevSignature string) (bool, error)
+}

--- a/rag/ast/extractor.go
+++ b/rag/ast/extractor.go
@@ -16,7 +16,9 @@ type Extractor interface {
 	// to read concurrently with future Extract calls.
 	Languages() []string
 
-	// Extract walks root and produces a graph stamped with vectorSpaceID.
+	// Extract walks root and produces a graph stamped with scope and
+	// vectorSpaceID. Scope is the caller-defined corpus/root/index namespace
+	// used by SymbolStore to isolate graphs that share the same vector space.
 	// An empty graph with nil error is the correct response for a tree
 	// containing no sources in any of this extractor's languages — that
 	// case is success, not failure. Errors are reserved for IO / parse
@@ -25,11 +27,13 @@ type Extractor interface {
 	// The returned [SymbolGraph.Root] MUST equal root after the same
 	// canonicalization Extract applies to node files (filepath.Clean +
 	// forward slashes), so paths join cleanly.
-	Extract(ctx context.Context, root string, vectorSpaceID string) (SymbolGraph, error)
+	// The returned [SymbolGraph.ExtractionSignature] is the opaque token
+	// callers persist and later pass to Stale.
+	Extract(ctx context.Context, scope string, root string, vectorSpaceID string) (SymbolGraph, error)
 
 	// Stale reports whether a graph previously extracted from root and
-	// stamped with prevSignature can still be reused, or whether the
-	// caller must re-extract. The signature is an opaque token defined
+	// scope, then stamped with prevSignature, can still be reused, or whether
+	// the caller must re-extract. The signature is an opaque token defined
 	// by the extractor itself — it MAY encode the vector-space identity,
 	// source-file fingerprints, the extractor's own version, the toolchain
 	// version, or any combination. Callers treat it as a string and pass
@@ -37,5 +41,5 @@ type Extractor interface {
 	//
 	// Returning (true, nil) forces re-extraction. Returning (false, nil)
 	// authorizes reuse of the previously persisted graph.
-	Stale(ctx context.Context, root string, prevSignature string) (bool, error)
+	Stale(ctx context.Context, scope string, root string, prevSignature string) (bool, error)
 }

--- a/rag/ast/noop.go
+++ b/rag/ast/noop.go
@@ -1,60 +1,86 @@
 package ast
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+)
 
 // NoOpExtractor satisfies [Extractor] without doing any work. It is the
 // safe choice for callers that have not yet wired a real extractor:
-// Languages reports no supported languages, Extract returns an empty
-// graph stamped with the requested vsid, and Stale always reports true
-// (so any previously-cached state is invalidated rather than served).
+// Languages reports no supported languages, Extract returns an empty graph
+// stamped with the requested scope/vsid, and Stale always reports true (so any
+// previously-cached state is invalidated rather than served).
 type NoOpExtractor struct{}
 
 // Languages implements [Extractor]. Returns nil — claiming no languages
 // lets callers short-circuit on the Languages check before invoking Extract.
 func (NoOpExtractor) Languages() []string { return nil }
 
-// Extract implements [Extractor]. Always succeeds with an empty graph
-// stamped with the requested vsid and root.
-func (NoOpExtractor) Extract(_ context.Context, root string, vectorSpaceID string) (SymbolGraph, error) {
-	return SymbolGraph{VectorSpaceID: vectorSpaceID, Root: root}, nil
+// Extract implements [Extractor]. Always succeeds with an empty graph stamped
+// with the requested scope, vsid, and canonicalized root.
+func (NoOpExtractor) Extract(_ context.Context, scope string, root string, vectorSpaceID string) (SymbolGraph, error) {
+	return SymbolGraph{
+		Scope:         scope,
+		VectorSpaceID: vectorSpaceID,
+		Root:          filepath.ToSlash(filepath.Clean(root)),
+	}, nil
 }
 
 // Stale implements [Extractor]. Always returns true so a caller relying on
 // a no-op extractor never accidentally serves a stale persisted graph; this
 // is fail-closed by design and matches the safety stance the package's
 // drift-signature scope inherits from the chunk store.
-func (NoOpExtractor) Stale(_ context.Context, _ string, _ string) (bool, error) {
+func (NoOpExtractor) Stale(_ context.Context, _ string, _ string, _ string) (bool, error) {
 	return true, nil
 }
 
 // NoOpStore satisfies [SymbolStore] without persisting anything. Writes
-// succeed silently; reads return [ErrSymbolNotFound] (singular) or empty
-// slices (plural). Useful as the default when AST persistence has not
-// been wired in by the consumer.
+// succeed silently; reads return [ErrSymbolNotFound] (singular) or an empty
+// [CallSet] (plural). Useful as the default when AST persistence has not been
+// wired in by the consumer.
 type NoOpStore struct{}
 
 // UpsertGraph implements [SymbolStore].
-func (NoOpStore) UpsertGraph(_ context.Context, _ SymbolGraph) error { return nil }
+func (NoOpStore) UpsertGraph(_ context.Context, graph SymbolGraph) error {
+	for i, edge := range graph.Calls {
+		if err := edge.Validate(); err != nil {
+			return fmt.Errorf("call edge %d: %w", i, err)
+		}
+	}
+	return nil
+}
 
-// DeleteByVectorSpace implements [SymbolStore].
-func (NoOpStore) DeleteByVectorSpace(_ context.Context, _ string) error { return nil }
+// DeleteGraph implements [SymbolStore].
+func (NoOpStore) DeleteGraph(_ context.Context, _ string, _ string) error { return nil }
+
+// ExtractionSignature implements [SymbolStore].
+func (NoOpStore) ExtractionSignature(_ context.Context, _ string, _ string) (string, error) {
+	return "", ErrSymbolNotFound
+}
 
 // GetSymbol implements [SymbolStore].
-func (NoOpStore) GetSymbol(_ context.Context, _ string, _ string) (SymbolNode, error) {
+func (NoOpStore) GetSymbol(_ context.Context, _ string, _ string, _ string) (SymbolNode, error) {
 	return SymbolNode{}, ErrSymbolNotFound
 }
 
 // SymbolEnclosing implements [SymbolStore].
-func (NoOpStore) SymbolEnclosing(_ context.Context, _ string, _ string, _ int) (SymbolNode, error) {
+func (NoOpStore) SymbolEnclosing(_ context.Context, _ string, _ string, _ string, _ int) (SymbolNode, error) {
 	return SymbolNode{}, ErrSymbolNotFound
 }
 
 // Callers implements [SymbolStore].
-func (NoOpStore) Callers(_ context.Context, _ string, _ string, _ int) ([]CallSite, error) {
-	return nil, nil
+func (NoOpStore) Callers(_ context.Context, _ string, _ string, _ string, limit int) (CallSet, error) {
+	if limit < 0 {
+		return CallSet{}, fmt.Errorf("%w: negative callers limit %d", ErrInvalidArgument, limit)
+	}
+	return CallSet{}, nil
 }
 
 // Callees implements [SymbolStore].
-func (NoOpStore) Callees(_ context.Context, _ string, _ string, _ int) ([]CallSite, error) {
-	return nil, nil
+func (NoOpStore) Callees(_ context.Context, _ string, _ string, _ string, limit int) (CallSet, error) {
+	if limit < 0 {
+		return CallSet{}, fmt.Errorf("%w: negative callees limit %d", ErrInvalidArgument, limit)
+	}
+	return CallSet{}, nil
 }

--- a/rag/ast/noop.go
+++ b/rag/ast/noop.go
@@ -1,0 +1,60 @@
+package ast
+
+import "context"
+
+// NoOpExtractor satisfies [Extractor] without doing any work. It is the
+// safe choice for callers that have not yet wired a real extractor:
+// Languages reports no supported languages, Extract returns an empty
+// graph stamped with the requested vsid, and Stale always reports true
+// (so any previously-cached state is invalidated rather than served).
+type NoOpExtractor struct{}
+
+// Languages implements [Extractor]. Returns nil — claiming no languages
+// lets callers short-circuit on the Languages check before invoking Extract.
+func (NoOpExtractor) Languages() []string { return nil }
+
+// Extract implements [Extractor]. Always succeeds with an empty graph
+// stamped with the requested vsid and root.
+func (NoOpExtractor) Extract(_ context.Context, root string, vectorSpaceID string) (SymbolGraph, error) {
+	return SymbolGraph{VectorSpaceID: vectorSpaceID, Root: root}, nil
+}
+
+// Stale implements [Extractor]. Always returns true so a caller relying on
+// a no-op extractor never accidentally serves a stale persisted graph; this
+// is fail-closed by design and matches the safety stance the package's
+// drift-signature scope inherits from the chunk store.
+func (NoOpExtractor) Stale(_ context.Context, _ string, _ string) (bool, error) {
+	return true, nil
+}
+
+// NoOpStore satisfies [SymbolStore] without persisting anything. Writes
+// succeed silently; reads return [ErrSymbolNotFound] (singular) or empty
+// slices (plural). Useful as the default when AST persistence has not
+// been wired in by the consumer.
+type NoOpStore struct{}
+
+// UpsertGraph implements [SymbolStore].
+func (NoOpStore) UpsertGraph(_ context.Context, _ SymbolGraph) error { return nil }
+
+// DeleteByVectorSpace implements [SymbolStore].
+func (NoOpStore) DeleteByVectorSpace(_ context.Context, _ string) error { return nil }
+
+// GetSymbol implements [SymbolStore].
+func (NoOpStore) GetSymbol(_ context.Context, _ string, _ string) (SymbolNode, error) {
+	return SymbolNode{}, ErrSymbolNotFound
+}
+
+// SymbolEnclosing implements [SymbolStore].
+func (NoOpStore) SymbolEnclosing(_ context.Context, _ string, _ string, _ int) (SymbolNode, error) {
+	return SymbolNode{}, ErrSymbolNotFound
+}
+
+// Callers implements [SymbolStore].
+func (NoOpStore) Callers(_ context.Context, _ string, _ string, _ int) ([]CallSite, error) {
+	return nil, nil
+}
+
+// Callees implements [SymbolStore].
+func (NoOpStore) Callees(_ context.Context, _ string, _ string, _ int) ([]CallSite, error) {
+	return nil, nil
+}

--- a/rag/ast/noop_test.go
+++ b/rag/ast/noop_test.go
@@ -21,20 +21,26 @@ func TestNoOpExtractor(t *testing.T) {
 	if got := e.Languages(); got != nil {
 		t.Errorf("NoOpExtractor.Languages = %v, want nil", got)
 	}
-	g, err := e.Extract(ctx, "/tmp/example", "vsid-1")
+	g, err := e.Extract(ctx, "scope-1", "/tmp/example/../example", "vsid-1")
 	if err != nil {
 		t.Fatalf("NoOpExtractor.Extract: %v", err)
+	}
+	if g.Scope != "scope-1" {
+		t.Errorf("NoOpExtractor.Extract did not stamp scope: got %q", g.Scope)
 	}
 	if g.VectorSpaceID != "vsid-1" {
 		t.Errorf("NoOpExtractor.Extract did not stamp vsid: got %q", g.VectorSpaceID)
 	}
 	if g.Root != "/tmp/example" {
-		t.Errorf("NoOpExtractor.Extract did not stamp root: got %q", g.Root)
+		t.Errorf("NoOpExtractor.Extract did not canonicalize root: got %q", g.Root)
+	}
+	if g.ExtractionSignature != "" {
+		t.Errorf("NoOpExtractor.Extract signature = %q, want empty", g.ExtractionSignature)
 	}
 	if len(g.Nodes)+len(g.Calls) != 0 {
 		t.Errorf("NoOpExtractor.Extract produced non-empty graph: %+v", g)
 	}
-	stale, err := e.Stale(ctx, "/tmp/example", "any-signature")
+	stale, err := e.Stale(ctx, "scope-1", "/tmp/example", "any-signature")
 	if err != nil {
 		t.Fatalf("NoOpExtractor.Stale: %v", err)
 	}
@@ -46,44 +52,71 @@ func TestNoOpExtractor(t *testing.T) {
 func TestNoOpStoreWrites(t *testing.T) {
 	var s NoOpStore
 	ctx := context.Background()
-	if err := s.UpsertGraph(ctx, SymbolGraph{VectorSpaceID: "vsid-1"}); err != nil {
+	if err := s.UpsertGraph(ctx, SymbolGraph{Scope: "scope-1", VectorSpaceID: "vsid-1"}); err != nil {
 		t.Errorf("UpsertGraph: %v", err)
 	}
-	if err := s.DeleteByVectorSpace(ctx, "vsid-1"); err != nil {
-		t.Errorf("DeleteByVectorSpace: %v", err)
+	if err := s.DeleteGraph(ctx, "scope-1", "vsid-1"); err != nil {
+		t.Errorf("DeleteGraph: %v", err)
+	}
+}
+
+func TestNoOpStoreRejectsInvalidCallEdge(t *testing.T) {
+	var s NoOpStore
+	err := s.UpsertGraph(context.Background(), SymbolGraph{
+		Scope:         "scope-1",
+		VectorSpaceID: "vsid-1",
+		Calls: []CallEdge{
+			{CallerID: "caller", Resolution: CallResolutionResolved, Line: 1},
+		},
+	})
+	if !errors.Is(err, ErrInvalidGraph) {
+		t.Fatalf("UpsertGraph error = %v, want ErrInvalidGraph", err)
 	}
 }
 
 func TestNoOpStoreReadsAreNotFound(t *testing.T) {
 	var s NoOpStore
 	ctx := context.Background()
-	if _, err := s.GetSymbol(ctx, "vsid-1", "pkg#Symbol"); !errors.Is(err, ErrSymbolNotFound) {
+	if _, err := s.ExtractionSignature(ctx, "scope-1", "vsid-1"); !errors.Is(err, ErrSymbolNotFound) {
+		t.Errorf("ExtractionSignature error: got %v, want %v", err, ErrSymbolNotFound)
+	}
+	if _, err := s.GetSymbol(ctx, "scope-1", "vsid-1", "symbol"); !errors.Is(err, ErrSymbolNotFound) {
 		t.Errorf("GetSymbol error: got %v, want %v", err, ErrSymbolNotFound)
 	}
-	if _, err := s.SymbolEnclosing(ctx, "vsid-1", "x.go", 10); !errors.Is(err, ErrSymbolNotFound) {
+	if _, err := s.SymbolEnclosing(ctx, "scope-1", "vsid-1", "x.go", 10); !errors.Is(err, ErrSymbolNotFound) {
 		t.Errorf("SymbolEnclosing error: got %v, want %v", err, ErrSymbolNotFound)
 	}
-	callers, err := s.Callers(ctx, "vsid-1", "pkg#Symbol", 0)
-	if err != nil || callers != nil {
-		t.Errorf("Callers: got (%v, %v), want (nil, nil)", callers, err)
+	callers, err := s.Callers(ctx, "scope-1", "vsid-1", "symbol", 0)
+	if err != nil || len(callers.Sites) != 0 || callers.Truncated {
+		t.Errorf("Callers: got (%+v, %v), want empty non-truncated result", callers, err)
 	}
-	callees, err := s.Callees(ctx, "vsid-1", "pkg#Symbol", 0)
-	if err != nil || callees != nil {
-		t.Errorf("Callees: got (%v, %v), want (nil, nil)", callees, err)
+	callees, err := s.Callees(ctx, "scope-1", "vsid-1", "symbol", 0)
+	if err != nil || len(callees.Sites) != 0 || callees.Truncated {
+		t.Errorf("Callees: got (%+v, %v), want empty non-truncated result", callees, err)
 	}
 }
 
-// TestNoOpStoreCallersLimit exercises the limit parameter contract — the
-// no-op store has no entries so any limit returns nil, but verifying the
-// signature here ensures the parameter is plumbed.
-func TestNoOpStoreCallersLimit(t *testing.T) {
+// TestNoOpStoreCallLimits exercises the limit parameter contract. The no-op
+// store has no entries, so non-negative limits return an empty result; negative
+// limits are rejected like real stores should reject them.
+func TestNoOpStoreCallLimits(t *testing.T) {
 	var s NoOpStore
 	ctx := context.Background()
-	for _, lim := range []int{0, 1, 100, -1} {
-		callers, err := s.Callers(ctx, "vsid-1", "pkg#Symbol", lim)
-		if err != nil || callers != nil {
-			t.Errorf("limit=%d: got (%v, %v), want (nil, nil)", lim, callers, err)
+	for _, lim := range []int{0, 1, 100} {
+		callers, err := s.Callers(ctx, "scope-1", "vsid-1", "symbol", lim)
+		if err != nil || len(callers.Sites) != 0 || callers.Truncated {
+			t.Errorf("callers limit=%d: got (%+v, %v), want empty non-truncated result", lim, callers, err)
 		}
+		callees, err := s.Callees(ctx, "scope-1", "vsid-1", "symbol", lim)
+		if err != nil || len(callees.Sites) != 0 || callees.Truncated {
+			t.Errorf("callees limit=%d: got (%+v, %v), want empty non-truncated result", lim, callees, err)
+		}
+	}
+	if _, err := s.Callers(ctx, "scope-1", "vsid-1", "symbol", -1); !errors.Is(err, ErrInvalidArgument) {
+		t.Errorf("negative Callers limit error = %v, want ErrInvalidArgument", err)
+	}
+	if _, err := s.Callees(ctx, "scope-1", "vsid-1", "symbol", -1); !errors.Is(err, ErrInvalidArgument) {
+		t.Errorf("negative Callees limit error = %v, want ErrInvalidArgument", err)
 	}
 }
 
@@ -102,16 +135,16 @@ func TestNoOpsConcurrent(t *testing.T) {
 	for i := 0; i < workers; i++ {
 		go func() {
 			defer wg.Done()
-			if _, err := extractor.Extract(ctx, "/tmp", "vsid-1"); err != nil {
+			if _, err := extractor.Extract(ctx, "scope-1", "/tmp", "vsid-1"); err != nil {
 				t.Errorf("Extract: %v", err)
 			}
-			if _, err := extractor.Stale(ctx, "/tmp", "sig"); err != nil {
+			if _, err := extractor.Stale(ctx, "scope-1", "/tmp", "sig"); err != nil {
 				t.Errorf("Stale: %v", err)
 			}
-			if err := store.UpsertGraph(ctx, SymbolGraph{VectorSpaceID: "vsid-1"}); err != nil {
+			if err := store.UpsertGraph(ctx, SymbolGraph{Scope: "scope-1", VectorSpaceID: "vsid-1"}); err != nil {
 				t.Errorf("UpsertGraph: %v", err)
 			}
-			if _, err := store.GetSymbol(ctx, "vsid-1", "x"); !errors.Is(err, ErrSymbolNotFound) {
+			if _, err := store.GetSymbol(ctx, "scope-1", "vsid-1", "x"); !errors.Is(err, ErrSymbolNotFound) {
 				t.Errorf("GetSymbol: %v", err)
 			}
 		}()

--- a/rag/ast/noop_test.go
+++ b/rag/ast/noop_test.go
@@ -1,0 +1,120 @@
+package ast
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+// Compile-time interface conformance checks — drift in the Extractor or
+// SymbolStore signatures will fail the build here before any test runs.
+var (
+	_ SymbolStore = NoOpStore{}
+	_ Extractor   = NoOpExtractor{}
+)
+
+func TestNoOpExtractor(t *testing.T) {
+	var e NoOpExtractor
+	ctx := context.Background()
+
+	if got := e.Languages(); got != nil {
+		t.Errorf("NoOpExtractor.Languages = %v, want nil", got)
+	}
+	g, err := e.Extract(ctx, "/tmp/example", "vsid-1")
+	if err != nil {
+		t.Fatalf("NoOpExtractor.Extract: %v", err)
+	}
+	if g.VectorSpaceID != "vsid-1" {
+		t.Errorf("NoOpExtractor.Extract did not stamp vsid: got %q", g.VectorSpaceID)
+	}
+	if g.Root != "/tmp/example" {
+		t.Errorf("NoOpExtractor.Extract did not stamp root: got %q", g.Root)
+	}
+	if len(g.Nodes)+len(g.Calls) != 0 {
+		t.Errorf("NoOpExtractor.Extract produced non-empty graph: %+v", g)
+	}
+	stale, err := e.Stale(ctx, "/tmp/example", "any-signature")
+	if err != nil {
+		t.Fatalf("NoOpExtractor.Stale: %v", err)
+	}
+	if !stale {
+		t.Errorf("NoOpExtractor.Stale = false, want true (fail-closed default)")
+	}
+}
+
+func TestNoOpStoreWrites(t *testing.T) {
+	var s NoOpStore
+	ctx := context.Background()
+	if err := s.UpsertGraph(ctx, SymbolGraph{VectorSpaceID: "vsid-1"}); err != nil {
+		t.Errorf("UpsertGraph: %v", err)
+	}
+	if err := s.DeleteByVectorSpace(ctx, "vsid-1"); err != nil {
+		t.Errorf("DeleteByVectorSpace: %v", err)
+	}
+}
+
+func TestNoOpStoreReadsAreNotFound(t *testing.T) {
+	var s NoOpStore
+	ctx := context.Background()
+	if _, err := s.GetSymbol(ctx, "vsid-1", "pkg#Symbol"); !errors.Is(err, ErrSymbolNotFound) {
+		t.Errorf("GetSymbol error: got %v, want %v", err, ErrSymbolNotFound)
+	}
+	if _, err := s.SymbolEnclosing(ctx, "vsid-1", "x.go", 10); !errors.Is(err, ErrSymbolNotFound) {
+		t.Errorf("SymbolEnclosing error: got %v, want %v", err, ErrSymbolNotFound)
+	}
+	callers, err := s.Callers(ctx, "vsid-1", "pkg#Symbol", 0)
+	if err != nil || callers != nil {
+		t.Errorf("Callers: got (%v, %v), want (nil, nil)", callers, err)
+	}
+	callees, err := s.Callees(ctx, "vsid-1", "pkg#Symbol", 0)
+	if err != nil || callees != nil {
+		t.Errorf("Callees: got (%v, %v), want (nil, nil)", callees, err)
+	}
+}
+
+// TestNoOpStoreCallersLimit exercises the limit parameter contract — the
+// no-op store has no entries so any limit returns nil, but verifying the
+// signature here ensures the parameter is plumbed.
+func TestNoOpStoreCallersLimit(t *testing.T) {
+	var s NoOpStore
+	ctx := context.Background()
+	for _, lim := range []int{0, 1, 100, -1} {
+		callers, err := s.Callers(ctx, "vsid-1", "pkg#Symbol", lim)
+		if err != nil || callers != nil {
+			t.Errorf("limit=%d: got (%v, %v), want (nil, nil)", lim, callers, err)
+		}
+	}
+}
+
+// TestNoOpsConcurrent verifies the "safe for concurrent use" claim on the
+// no-op implementations. Empty structs are trivially safe; this test
+// documents the contract and lets the race detector confirm.
+func TestNoOpsConcurrent(t *testing.T) {
+	var (
+		extractor NoOpExtractor
+		store     NoOpStore
+		ctx       = context.Background()
+		wg        sync.WaitGroup
+	)
+	const workers = 32
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			if _, err := extractor.Extract(ctx, "/tmp", "vsid-1"); err != nil {
+				t.Errorf("Extract: %v", err)
+			}
+			if _, err := extractor.Stale(ctx, "/tmp", "sig"); err != nil {
+				t.Errorf("Stale: %v", err)
+			}
+			if err := store.UpsertGraph(ctx, SymbolGraph{VectorSpaceID: "vsid-1"}); err != nil {
+				t.Errorf("UpsertGraph: %v", err)
+			}
+			if _, err := store.GetSymbol(ctx, "vsid-1", "x"); !errors.Is(err, ErrSymbolNotFound) {
+				t.Errorf("GetSymbol: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/rag/ast/store.go
+++ b/rag/ast/store.go
@@ -13,46 +13,59 @@ type CallSite struct {
 	Edge   CallEdge
 }
 
+// CallSet is a bounded callers/callees result. Truncated reports whether more
+// matching edges existed than the store returned.
+type CallSet struct {
+	Sites     []CallSite
+	Truncated bool
+}
+
 // SymbolStore persists and serves symbol graphs. A single implementation
 // handles both halves; the interface is intentionally NOT split into
 // reader/writer because no real consumer has yet justified the split.
 //
-// Every write carries a VectorSpaceID via the [SymbolGraph]; every read
-// filters by one explicitly. A vector-space change atomically invalidates
-// the graph alongside the parallel chunk store.
+// Every write carries Scope and VectorSpaceID via the [SymbolGraph]; every
+// read filters by both explicitly. Scope isolates corpora/roots that share an
+// embedder; vector-space changes invalidate the graph alongside the parallel
+// chunk store within that scope.
 type SymbolStore interface {
 	// UpsertGraph atomically replaces every row previously written under
-	// graph.VectorSpaceID with the contents of graph. Implementations MUST
-	// be transactional — a partially-written graph would leave the read
-	// path returning nodes with edges pointing at missing endpoints.
+	// (graph.Scope, graph.VectorSpaceID) with the contents of graph, including
+	// graph.ExtractionSignature. Implementations MUST be transactional and MUST
+	// reject invalid call edges with an error wrapping [ErrInvalidGraph].
 	UpsertGraph(ctx context.Context, graph SymbolGraph) error
 
-	// DeleteByVectorSpace removes every row stamped with vectorSpaceID.
-	// Used for "drop without replacement" workflows (vsid retirement,
-	// migration cleanup) — NOT as a precursor to UpsertGraph, which
-	// already replaces atomically.
-	DeleteByVectorSpace(ctx context.Context, vectorSpaceID string) error
+	// DeleteGraph removes every row stamped with (scope, vectorSpaceID). Used
+	// for "drop without replacement" workflows (vsid retirement, migration
+	// cleanup) — NOT as a precursor to UpsertGraph, which already replaces
+	// atomically.
+	DeleteGraph(ctx context.Context, scope string, vectorSpaceID string) error
 
-	// GetSymbol resolves a SymbolID to its node within vectorSpaceID.
+	// ExtractionSignature returns the opaque signature persisted with the
+	// current graph for (scope, vectorSpaceID). Callers pass this value back to
+	// Extractor.Stale. Returns [ErrSymbolNotFound] when no graph is recorded.
+	ExtractionSignature(ctx context.Context, scope string, vectorSpaceID string) (string, error)
+
+	// GetSymbol resolves a SymbolID to its node within (scope, vectorSpaceID).
 	// Returns [ErrSymbolNotFound] when the ID is not present in the
-	// store for that vsid.
-	GetSymbol(ctx context.Context, vectorSpaceID string, symbolID string) (SymbolNode, error)
+	// store for that scope/vsid.
+	GetSymbol(ctx context.Context, scope string, vectorSpaceID string, symbolID string) (SymbolNode, error)
 
 	// SymbolEnclosing returns the node whose [StartLine, EndLine] range
 	// contains line, within file (canonicalized the same way the indexer
 	// canonicalizes SymbolNode.File). Returns [ErrSymbolNotFound] when
 	// no enclosing symbol is recorded.
-	SymbolEnclosing(ctx context.Context, vectorSpaceID string, file string, line int) (SymbolNode, error)
+	SymbolEnclosing(ctx context.Context, scope string, vectorSpaceID string, file string, line int) (SymbolNode, error)
 
 	// Callers returns up to limit symbols that call symbolID, with the
-	// edge that connects each one to symbolID. A limit of 0 means
-	// unlimited. Implementations SHOULD enforce a default cap when the
-	// caller passes 0 on a known-hot symbol; the interface does not
-	// require any particular ordering.
-	Callers(ctx context.Context, vectorSpaceID string, symbolID string, limit int) ([]CallSite, error)
+	// edge that connects each one to symbolID. A limit of 0 lets the store use
+	// its defensive default cap. Negative limits are invalid and MUST return
+	// an error. CallSet.Truncated reports whether more matches existed than
+	// were returned.
+	Callers(ctx context.Context, scope string, vectorSpaceID string, symbolID string, limit int) (CallSet, error)
 
 	// Callees returns up to limit symbols called by symbolID, with the
 	// edge that connects symbolID to each one. Same limit semantics as
 	// Callers.
-	Callees(ctx context.Context, vectorSpaceID string, symbolID string, limit int) ([]CallSite, error)
+	Callees(ctx context.Context, scope string, vectorSpaceID string, symbolID string, limit int) (CallSet, error)
 }

--- a/rag/ast/store.go
+++ b/rag/ast/store.go
@@ -1,0 +1,58 @@
+package ast
+
+import "context"
+
+// CallSite pairs a related symbol with the edge that connects it to the
+// symbol the caller asked about. Returned by [SymbolStore.Callers] and
+// [SymbolStore.Callees] so call-site File/Line are not lost in the lookup.
+//
+// For Callers(target): Symbol is the caller, Edge.CalleeID == target.
+// For Callees(target): Symbol is the callee, Edge.CallerID == target.
+type CallSite struct {
+	Symbol SymbolNode
+	Edge   CallEdge
+}
+
+// SymbolStore persists and serves symbol graphs. A single implementation
+// handles both halves; the interface is intentionally NOT split into
+// reader/writer because no real consumer has yet justified the split.
+//
+// Every write carries a VectorSpaceID via the [SymbolGraph]; every read
+// filters by one explicitly. A vector-space change atomically invalidates
+// the graph alongside the parallel chunk store.
+type SymbolStore interface {
+	// UpsertGraph atomically replaces every row previously written under
+	// graph.VectorSpaceID with the contents of graph. Implementations MUST
+	// be transactional — a partially-written graph would leave the read
+	// path returning nodes with edges pointing at missing endpoints.
+	UpsertGraph(ctx context.Context, graph SymbolGraph) error
+
+	// DeleteByVectorSpace removes every row stamped with vectorSpaceID.
+	// Used for "drop without replacement" workflows (vsid retirement,
+	// migration cleanup) — NOT as a precursor to UpsertGraph, which
+	// already replaces atomically.
+	DeleteByVectorSpace(ctx context.Context, vectorSpaceID string) error
+
+	// GetSymbol resolves a SymbolID to its node within vectorSpaceID.
+	// Returns [ErrSymbolNotFound] when the ID is not present in the
+	// store for that vsid.
+	GetSymbol(ctx context.Context, vectorSpaceID string, symbolID string) (SymbolNode, error)
+
+	// SymbolEnclosing returns the node whose [StartLine, EndLine] range
+	// contains line, within file (canonicalized the same way the indexer
+	// canonicalizes SymbolNode.File). Returns [ErrSymbolNotFound] when
+	// no enclosing symbol is recorded.
+	SymbolEnclosing(ctx context.Context, vectorSpaceID string, file string, line int) (SymbolNode, error)
+
+	// Callers returns up to limit symbols that call symbolID, with the
+	// edge that connects each one to symbolID. A limit of 0 means
+	// unlimited. Implementations SHOULD enforce a default cap when the
+	// caller passes 0 on a known-hot symbol; the interface does not
+	// require any particular ordering.
+	Callers(ctx context.Context, vectorSpaceID string, symbolID string, limit int) ([]CallSite, error)
+
+	// Callees returns up to limit symbols called by symbolID, with the
+	// edge that connects symbolID to each one. Same limit semantics as
+	// Callers.
+	Callees(ctx context.Context, vectorSpaceID string, symbolID string, limit int) ([]CallSite, error)
+}

--- a/rag/ast/types.go
+++ b/rag/ast/types.go
@@ -1,0 +1,130 @@
+// Package ast models a structural symbol graph that lives alongside the
+// rag chunk store. Where rag's chunks carry only text + position, an [Extractor]
+// produces a [SymbolGraph] of named program entities (functions, methods,
+// types, top-level bindings) with edges (call relationships) between them.
+// Together a chunk store and a symbol graph give the retriever both lexical
+// recall and structural reach.
+//
+// # Drift signature
+//
+// Every [SymbolGraph] is stamped with a VectorSpaceID — an opaque string
+// identifying the vector space the parallel chunk store was written for.
+// When the chunk store re-embeds under a new vector space, the symbol graph
+// must be re-extracted and re-stamped: nodes and edges from the old vsid
+// become unreachable in one atomic step. This invariant exists at the graph
+// level only; individual nodes do not carry their own vsid.
+//
+// # Storage shape
+//
+// [SymbolGraph] is a write-only transport structure: an extractor produces
+// one, a [SymbolStore] consumes one. Consumers MUST NOT traverse the graph
+// by linear scan of its slices — the store builds the indexes needed for
+// O(1) lookup and exposes them via its read methods. The graph itself is
+// permitted to be unindexed and unsorted.
+//
+// # Trust boundary
+//
+// [SymbolNode.Signature] and [SymbolNode.Doc] carry raw source content from
+// arbitrary files an extractor was pointed at. Extractors MUST NOT
+// pre-sanitize them — the data is structural truth. Any consumer that
+// surfaces these fields to an LLM (MCP tool outputs, chat prompts) owns
+// the sanitization required to mitigate prompt injection from hostile
+// source comments. This package guarantees fidelity, not safety.
+package ast
+
+// SymbolKind is the structural category of a [SymbolNode]. Typed string
+// (not iota) so the value survives JSON round-trips without a custom
+// marshaler.
+type SymbolKind string
+
+const (
+	SymbolKindUnknown   SymbolKind = "unknown"
+	SymbolKindFunction  SymbolKind = "function"
+	SymbolKindMethod    SymbolKind = "method"
+	SymbolKindStruct    SymbolKind = "struct"
+	SymbolKindInterface SymbolKind = "interface"
+	SymbolKindVar       SymbolKind = "var"
+	SymbolKindConst     SymbolKind = "const"
+	SymbolKindType      SymbolKind = "type"
+)
+
+// SymbolNode is a single resolved program entity. ID is the stable identity
+// used as the endpoint of every edge in the graph; see [SymbolID]. The
+// node does NOT carry its VectorSpaceID — the enclosing [SymbolGraph] owns
+// that for the whole batch.
+//
+// Signature and Doc contain raw, unsanitized source content; see the
+// package-level "Trust boundary" note.
+type SymbolNode struct {
+	ID        string
+	Kind      SymbolKind
+	Name      string // bare identifier (e.g. "ValidateToken")
+	Receiver  string // method receiver type, empty for non-methods
+	PkgPath   string // canonical Go module path (per go.mod major-version rules)
+	File      string // canonicalized per [SymbolGraph.Root]
+	StartLine int    // 1-indexed
+	EndLine   int    // 1-indexed, inclusive
+	Signature string // formatted func signature or type definition (raw)
+	Doc       string // associated godoc comment if any (raw)
+}
+
+// CallEdge represents a call relationship between two symbols. Three states
+// are representable via (CalleeID, Resolved):
+//
+//	Resolved=true,  CalleeID!="" — extractor identified the target SymbolID
+//	Resolved=false, CalleeID==""  — extractor attempted resolution and failed
+//	Resolved=false, CalleeID==""  — extractor did not attempt (heuristic mode)
+//
+// (The latter two states are presently indistinguishable; M2's go/types
+// integration will introduce a third boolean if the distinction becomes
+// load-bearing.)
+type CallEdge struct {
+	CallerID  string
+	CalleeID  string // resolved SymbolID; empty when Resolved=false
+	CalleeRaw string // unresolved identifier as it appeared in source
+	Resolved  bool   // true iff the extractor produced a valid CalleeID
+	File      string // canonicalized per [SymbolGraph.Root]
+	Line      int    // 1-indexed
+}
+
+// SymbolGraph is the result of a single extraction pass — a transport
+// structure between an [Extractor] and a [SymbolStore]. Callers consume
+// graphs by handing them to a store, not by traversal.
+//
+// Root anchors all File fields in Nodes and Calls. Paths inside the graph
+// are filepath.Clean'd with forward slashes, relative to Root.
+type SymbolGraph struct {
+	VectorSpaceID string // drift signature stamped on every persisted row
+	Root          string // anchor for SymbolNode.File and CallEdge.File
+	Nodes         []SymbolNode
+	Calls         []CallEdge
+}
+
+// symbolIDSep separates the three components of a SymbolID. '#' is
+// forbidden in Go module paths (per golang.org/ref/mod) and in Go
+// identifiers (per the language spec). Using the same separator at both
+// boundaries makes the encoding a bijection for every input that does
+// not itself contain '#'.
+const symbolIDSep = "#"
+
+// SymbolID derives the stable identity used as the endpoint of every edge.
+// The encoding is always three components joined by '#':
+//
+//	free function: "<pkgPath>##<name>"   (empty receiver slot)
+//	method:        "<pkgPath>#<receiver>#<name>"
+//
+// Because '#' cannot appear in a well-formed Go module path or Go
+// identifier, the encoding is a bijection: distinct inputs produce
+// distinct outputs, and the parts can be recovered with strings.Split.
+//
+// Inputs are NOT validated. Callers that pass strings containing '#'
+// get malformed IDs back; the function does not panic.
+//
+// TODO(keith): revisit in the milestone that introduces a real Go
+// extractor — generics (type parameters), pointer vs. value receivers,
+// anonymous functions, and methods promoted via embedding all need
+// explicit policies. The current form is the minimum needed to make
+// non-pathological symbols round-trip through tests.
+func SymbolID(pkgPath, receiver, name string) string {
+	return pkgPath + symbolIDSep + receiver + symbolIDSep + name
+}

--- a/rag/ast/types.go
+++ b/rag/ast/types.go
@@ -1,18 +1,22 @@
-// Package ast models a structural symbol graph that lives alongside the
-// rag chunk store. Where rag's chunks carry only text + position, an [Extractor]
+// Package ast models a structural symbol graph that lives alongside the rag
+// chunk store. Where rag's chunks carry only text + position, an [Extractor]
 // produces a [SymbolGraph] of named program entities (functions, methods,
 // types, top-level bindings) with edges (call relationships) between them.
 // Together a chunk store and a symbol graph give the retriever both lexical
 // recall and structural reach.
 //
-// # Drift signature
+// # Scope and drift signature
 //
-// Every [SymbolGraph] is stamped with a VectorSpaceID — an opaque string
-// identifying the vector space the parallel chunk store was written for.
+// Every [SymbolGraph] is stamped with both Scope and VectorSpaceID. Scope is
+// the caller-defined corpus/root/index namespace; VectorSpaceID is the opaque
+// embedding-space identity used by the parallel chunk store. Stores key graph
+// rows by (scope, vectorSpaceID), never by vectorSpaceID alone, so two corpora
+// indexed with the same embedder cannot delete or read each other's graph.
+//
 // When the chunk store re-embeds under a new vector space, the symbol graph
-// must be re-extracted and re-stamped: nodes and edges from the old vsid
-// become unreachable in one atomic step. This invariant exists at the graph
-// level only; individual nodes do not carry their own vsid.
+// must be re-extracted and re-stamped. Nodes and edges from the old vsid become
+// unreachable within the same scope in one atomic step. This invariant exists
+// at the graph level only; individual nodes do not carry their own scope/vsid.
 //
 // # Storage shape
 //
@@ -24,13 +28,19 @@
 //
 // # Trust boundary
 //
-// [SymbolNode.Signature] and [SymbolNode.Doc] carry raw source content from
+// [SymbolNode.Declaration] and [SymbolNode.Doc] carry raw source content from
 // arbitrary files an extractor was pointed at. Extractors MUST NOT
 // pre-sanitize them — the data is structural truth. Any consumer that
 // surfaces these fields to an LLM (MCP tool outputs, chat prompts) owns
 // the sanitization required to mitigate prompt injection from hostile
 // source comments. This package guarantees fidelity, not safety.
 package ast
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+)
 
 // SymbolKind is the structural category of a [SymbolNode]. Typed string
 // (not iota) so the value survives JSON round-trips without a custom
@@ -48,43 +58,89 @@ const (
 	SymbolKindType      SymbolKind = "type"
 )
 
-// SymbolNode is a single resolved program entity. ID is the stable identity
-// used as the endpoint of every edge in the graph; see [SymbolID]. The
-// node does NOT carry its VectorSpaceID — the enclosing [SymbolGraph] owns
-// that for the whole batch.
-//
-// Signature and Doc contain raw, unsanitized source content; see the
-// package-level "Trust boundary" note.
-type SymbolNode struct {
-	ID        string
-	Kind      SymbolKind
-	Name      string // bare identifier (e.g. "ValidateToken")
-	Receiver  string // method receiver type, empty for non-methods
-	PkgPath   string // canonical Go module path (per go.mod major-version rules)
-	File      string // canonicalized per [SymbolGraph.Root]
-	StartLine int    // 1-indexed
-	EndLine   int    // 1-indexed, inclusive
-	Signature string // formatted func signature or type definition (raw)
-	Doc       string // associated godoc comment if any (raw)
+// CallResolution records how much work an extractor did to identify a call's
+// target. The zero value is invalid; use one of the constants below.
+type CallResolution string
+
+const (
+	CallResolutionResolved     CallResolution = "resolved"
+	CallResolutionUnresolved   CallResolution = "unresolved"
+	CallResolutionNotAttempted CallResolution = "not_attempted"
+)
+
+// SymbolKey is the language-neutral identity material encoded by [SymbolID].
+// Namespace is the language's package/module/scope path. Disambiguator is an
+// optional, language-specific stable suffix for overloads, local functions,
+// anonymous functions, or any construct that cannot be uniquely named by the
+// other fields alone. Go extractors normally leave Disambiguator empty.
+type SymbolKey struct {
+	Language      string
+	Kind          SymbolKind
+	Namespace     string
+	Receiver      string
+	Name          string
+	Disambiguator string
 }
 
-// CallEdge represents a call relationship between two symbols. Three states
-// are representable via (CalleeID, Resolved):
+// SymbolNode is a single resolved program entity. ID is the stable identity
+// used as the endpoint of every edge in the graph; see [SymbolID]. The
+// node does NOT carry its Scope or VectorSpaceID — the enclosing [SymbolGraph]
+// owns those for the whole batch.
 //
-//	Resolved=true,  CalleeID!="" — extractor identified the target SymbolID
-//	Resolved=false, CalleeID==""  — extractor attempted resolution and failed
-//	Resolved=false, CalleeID==""  — extractor did not attempt (heuristic mode)
+// Declaration and Doc contain raw, unsanitized source content; see the
+// package-level "Trust boundary" note.
+type SymbolNode struct {
+	ID            string
+	Language      string     // rag.Chunk.Language token (e.g. "go", "python")
+	Kind          SymbolKind // structural category
+	Namespace     string     // package/module/scope path in the source language
+	Name          string     // bare identifier (e.g. "ValidateToken")
+	Receiver      string     // method receiver/class/type, empty for non-methods
+	Disambiguator string     // optional stable suffix for overloads/local symbols
+	File          string     // canonicalized per [SymbolGraph.Root]
+	StartLine     int        // 1-indexed
+	EndLine       int        // 1-indexed, inclusive
+	Declaration   string     // formatted declaration/signature/type definition (raw)
+	Doc           string     // associated source doc/comment if any (raw)
+}
+
+// CallEdge represents a call relationship between two symbols. Resolution
+// makes the extraction state explicit:
 //
-// (The latter two states are presently indistinguishable; M2's go/types
-// integration will introduce a third boolean if the distinction becomes
-// load-bearing.)
+//	CallResolutionResolved     — extractor identified CalleeID
+//	CallResolutionUnresolved   — extractor attempted resolution and failed
+//	CallResolutionNotAttempted — extractor recorded a heuristic/raw call only
 type CallEdge struct {
-	CallerID  string
-	CalleeID  string // resolved SymbolID; empty when Resolved=false
-	CalleeRaw string // unresolved identifier as it appeared in source
-	Resolved  bool   // true iff the extractor produced a valid CalleeID
-	File      string // canonicalized per [SymbolGraph.Root]
-	Line      int    // 1-indexed
+	CallerID   string
+	CalleeID   string         // resolved SymbolID; required only when resolved
+	CalleeRaw  string         // identifier/expression as it appeared in source
+	Resolution CallResolution // explicit resolution state
+	File       string         // canonicalized per [SymbolGraph.Root]
+	Line       int            // 1-indexed
+}
+
+// Validate checks the defensive invariants a store must enforce before
+// persisting an edge.
+func (e CallEdge) Validate() error {
+	if e.CallerID == "" {
+		return fmt.Errorf("%w: call edge missing caller id", ErrInvalidGraph)
+	}
+	if e.Line < 1 {
+		return fmt.Errorf("%w: call edge line must be >= 1", ErrInvalidGraph)
+	}
+	switch e.Resolution {
+	case CallResolutionResolved:
+		if e.CalleeID == "" {
+			return fmt.Errorf("%w: resolved call edge missing callee id", ErrInvalidGraph)
+		}
+	case CallResolutionUnresolved, CallResolutionNotAttempted:
+		if e.CalleeID != "" {
+			return fmt.Errorf("%w: unresolved call edge must not carry callee id", ErrInvalidGraph)
+		}
+	default:
+		return fmt.Errorf("%w: unknown call resolution %q", ErrInvalidGraph, e.Resolution)
+	}
+	return nil
 }
 
 // SymbolGraph is the result of a single extraction pass — a transport
@@ -94,37 +150,63 @@ type CallEdge struct {
 // Root anchors all File fields in Nodes and Calls. Paths inside the graph
 // are filepath.Clean'd with forward slashes, relative to Root.
 type SymbolGraph struct {
-	VectorSpaceID string // drift signature stamped on every persisted row
-	Root          string // anchor for SymbolNode.File and CallEdge.File
-	Nodes         []SymbolNode
-	Calls         []CallEdge
+	Scope               string // caller-defined corpus/root/index namespace
+	VectorSpaceID       string // embedding-space identity stamped on persisted rows
+	ExtractionSignature string // opaque token persisted for Extractor.Stale
+	Root                string // anchor for SymbolNode.File and CallEdge.File
+	Nodes               []SymbolNode
+	Calls               []CallEdge
 }
 
-// symbolIDSep separates the three components of a SymbolID. '#' is
-// forbidden in Go module paths (per golang.org/ref/mod) and in Go
-// identifiers (per the language spec). Using the same separator at both
-// boundaries makes the encoding a bijection for every input that does
-// not itself contain '#'.
+// symbolIDSep separates base64url-encoded SymbolID components. '#' is not in
+// the raw URL-safe base64 alphabet, so arbitrary component text remains a
+// bijection without relying on any one language's identifier grammar.
 const symbolIDSep = "#"
 
+const symbolIDPrefix = "symbol-v1"
+
 // SymbolID derives the stable identity used as the endpoint of every edge.
-// The encoding is always three components joined by '#':
-//
-//	free function: "<pkgPath>##<name>"   (empty receiver slot)
-//	method:        "<pkgPath>#<receiver>#<name>"
-//
-// Because '#' cannot appear in a well-formed Go module path or Go
-// identifier, the encoding is a bijection: distinct inputs produce
-// distinct outputs, and the parts can be recovered with strings.Split.
-//
-// Inputs are NOT validated. Callers that pass strings containing '#'
-// get malformed IDs back; the function does not panic.
-//
-// TODO(keith): revisit in the milestone that introduces a real Go
-// extractor — generics (type parameters), pointer vs. value receivers,
-// anonymous functions, and methods promoted via embedding all need
-// explicit policies. The current form is the minimum needed to make
-// non-pathological symbols round-trip through tests.
-func SymbolID(pkgPath, receiver, name string) string {
-	return pkgPath + symbolIDSep + receiver + symbolIDSep + name
+// It is language-neutral: each key component is base64url encoded before
+// joining, so names containing punctuation, separators, or non-Go syntax do
+// not collide. Extractors are responsible for filling Disambiguator whenever
+// their language can have multiple distinct symbols with the same language,
+// kind, namespace, receiver, and name.
+func SymbolID(key SymbolKey) string {
+	parts := []string{
+		symbolIDPrefix,
+		encodeSymbolIDPart(key.Language),
+		encodeSymbolIDPart(string(key.Kind)),
+		encodeSymbolIDPart(key.Namespace),
+		encodeSymbolIDPart(key.Receiver),
+		encodeSymbolIDPart(key.Name),
+		encodeSymbolIDPart(key.Disambiguator),
+	}
+	return strings.Join(parts, symbolIDSep)
+}
+
+func encodeSymbolIDPart(part string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(part))
+}
+
+func decodeSymbolID(id string) (SymbolKey, bool) {
+	parts := strings.Split(id, symbolIDSep)
+	if len(parts) != 7 || parts[0] != symbolIDPrefix {
+		return SymbolKey{}, false
+	}
+	decoded := make([]string, 0, 6)
+	for _, part := range parts[1:] {
+		raw, err := base64.RawURLEncoding.DecodeString(part)
+		if err != nil {
+			return SymbolKey{}, false
+		}
+		decoded = append(decoded, string(raw))
+	}
+	return SymbolKey{
+		Language:      decoded[0],
+		Kind:          SymbolKind(decoded[1]),
+		Namespace:     decoded[2],
+		Receiver:      decoded[3],
+		Name:          decoded[4],
+		Disambiguator: decoded[5],
+	}, true
 }

--- a/rag/ast/types_test.go
+++ b/rag/ast/types_test.go
@@ -1,126 +1,149 @@
 package ast
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
 
 func TestSymbolID(t *testing.T) {
 	tests := []struct {
-		name     string
-		pkgPath  string
-		receiver string
-		symbol   string
-		want     string
+		name string
+		key  SymbolKey
 	}{
 		{
-			name:    "free function",
-			pkgPath: "github.com/kstruzzieri/go-llm/rag",
-			symbol:  "NewIndexer",
-			want:    "github.com/kstruzzieri/go-llm/rag##NewIndexer",
+			name: "go free function",
+			key: SymbolKey{
+				Language:  "go",
+				Kind:      SymbolKindFunction,
+				Namespace: "github.com/kstruzzieri/go-llm/rag",
+				Name:      "NewIndexer",
+			},
 		},
 		{
-			name:     "method",
-			pkgPath:  "github.com/kstruzzieri/go-llm/rag",
-			receiver: "Indexer",
-			symbol:   "IndexFile",
-			want:     "github.com/kstruzzieri/go-llm/rag#Indexer#IndexFile",
+			name: "go method",
+			key: SymbolKey{
+				Language:  "go",
+				Kind:      SymbolKindMethod,
+				Namespace: "github.com/kstruzzieri/go-llm/rag",
+				Receiver:  "Indexer",
+				Name:      "IndexFile",
+			},
 		},
 		{
-			name:    "main package free function",
-			pkgPath: "main",
-			symbol:  "main",
-			want:    "main##main",
+			name: "overloaded method",
+			key: SymbolKey{
+				Language:      "java",
+				Kind:          SymbolKindMethod,
+				Namespace:     "com.example.Service",
+				Receiver:      "Service",
+				Name:          "Handle",
+				Disambiguator: "(Request)Response",
+			},
 		},
 		{
-			// Pathological input from the criticize-review collision
-			// argument: pkgPath has a dot, receiver and name look like
-			// a method on a dotted-receiver type. The '#' boundaries
-			// keep this distinct from any free-function form with the
-			// same characters.
-			name:     "dotted pkgPath method",
-			pkgPath:  "github.com/foo.bar/baz",
-			receiver: "Type",
-			symbol:   "Method",
-			want:     "github.com/foo.bar/baz#Type#Method",
-		},
-		{
-			name:   "empty pkgPath",
-			symbol: "Foo",
-			want:   "##Foo",
-		},
-		{
-			name:    "empty name",
-			pkgPath: "pkg",
-			want:    "pkg##",
+			name: "punctuation from non-go syntax",
+			key: SymbolKey{
+				Language:      "typescript",
+				Kind:          SymbolKindFunction,
+				Namespace:     "src/routes/admin#users.ts",
+				Name:          "GET /admin/:id",
+				Disambiguator: "export const GET = async (...)",
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := SymbolID(tt.pkgPath, tt.receiver, tt.symbol)
-			if got != tt.want {
-				t.Errorf("SymbolID(%q, %q, %q) = %q, want %q", tt.pkgPath, tt.receiver, tt.symbol, got, tt.want)
+			id := SymbolID(tt.key)
+			got, ok := decodeSymbolID(id)
+			if !ok {
+				t.Fatalf("decodeSymbolID(%q) failed", id)
+			}
+			if got != tt.key {
+				t.Errorf("SymbolID round-trip = %+v, want %+v", got, tt.key)
 			}
 		})
 	}
 }
 
-// TestSymbolIDNoCollisionAcrossDottedPkgPaths pins the collision-resistance
-// property that motivated the '#' separator choice. Includes the exact
-// cases the criticize-review identified as collision risks under the old
-// dot-separator encoding.
-func TestSymbolIDNoCollisionAcrossDottedPkgPaths(t *testing.T) {
-	cases := [][3]string{
-		{"foo.bar", "", "baz"},
-		{"foo", "bar", "baz"},
-		{"foo", "", "bar.baz"},
-		{"foo.bar.baz", "", "x"},
-		{"foo.bar", "baz", "qux"},
-		{"foo", "bar.baz", "qux"}, // even pathological dots-in-receiver are safe
+func TestSymbolIDWireFormat(t *testing.T) {
+	key := SymbolKey{
+		Language:  "go",
+		Kind:      SymbolKindFunction,
+		Namespace: "pkg",
+		Name:      "Foo",
 	}
-	seen := make(map[string][3]string, len(cases))
-	for _, c := range cases {
-		id := SymbolID(c[0], c[1], c[2])
-		if prev, ok := seen[id]; ok {
-			t.Errorf("SymbolID collision: %v and %v both produced %q", prev, c, id)
-		}
-		seen[id] = c
+	const want = "symbol-v1#Z28#ZnVuY3Rpb24#cGtn##Rm9v#"
+	if got := SymbolID(key); got != want {
+		t.Errorf("SymbolID wire format = %q, want %q", got, want)
 	}
 }
 
-// FuzzSymbolID asserts the bijection property: for any (pkg, recv, name)
-// where no component contains '#', the resulting ID splits back into the
-// original three components on '#'.
+func TestSymbolIDNoCollisionAcrossAmbiguousInputs(t *testing.T) {
+	cases := []SymbolKey{
+		{Language: "go", Kind: SymbolKindFunction, Namespace: "foo#bar", Name: "baz"},
+		{Language: "go", Kind: SymbolKindFunction, Namespace: "foo", Receiver: "bar", Name: "baz"},
+		{Language: "go", Kind: SymbolKindMethod, Namespace: "foo", Receiver: "bar", Name: "baz"},
+		{Language: "java", Kind: SymbolKindMethod, Namespace: "foo", Receiver: "bar", Name: "baz"},
+		{Language: "java", Kind: SymbolKindMethod, Namespace: "foo", Receiver: "bar", Name: "baz", Disambiguator: "(int)"},
+		{Language: "java", Kind: SymbolKindMethod, Namespace: "foo", Receiver: "bar", Name: "baz", Disambiguator: "(string)"},
+	}
+	seen := make(map[string]SymbolKey, len(cases))
+	for _, key := range cases {
+		id := SymbolID(key)
+		if prev, ok := seen[id]; ok {
+			t.Errorf("SymbolID collision: %+v and %+v both produced %q", prev, key, id)
+		}
+		seen[id] = key
+	}
+}
+
+// FuzzSymbolID asserts the bijection property for arbitrary component text,
+// including characters that would be separators in simpler encodings.
 func FuzzSymbolID(f *testing.F) {
-	f.Add("pkg", "", "Name")
-	f.Add("github.com/x/y", "Recv", "Method")
-	f.Add("pkg.with.dots", "", "Name")
-	f.Add("", "", "")
-	f.Add("foo.bar", "Type", "Method")
-	f.Fuzz(func(t *testing.T, pkg, recv, name string) {
-		// Contract: components MUST NOT contain '#' (the separator).
-		// '#' is illegal in Go module paths and Go identifiers, so
-		// well-formed extractor output always satisfies this.
-		if strings.ContainsRune(pkg, '#') ||
-			strings.ContainsRune(recv, '#') ||
-			strings.ContainsRune(name, '#') {
-			t.Skip()
+	f.Add("go", "function", "pkg", "", "Name", "")
+	f.Add("go", "method", "github.com/x/y", "Recv", "Method", "")
+	f.Add("typescript", "function", "src/a#b.ts", "", "GET /:id", "export const GET")
+	f.Add("", "", "", "", "", "")
+	f.Fuzz(func(t *testing.T, lang, kind, namespace, recv, name, disambiguator string) {
+		key := SymbolKey{
+			Language:      lang,
+			Kind:          SymbolKind(kind),
+			Namespace:     namespace,
+			Receiver:      recv,
+			Name:          name,
+			Disambiguator: disambiguator,
 		}
-		id := SymbolID(pkg, recv, name)
+		id := SymbolID(key)
 		parts := strings.Split(id, "#")
-		if len(parts) != 3 {
-			t.Errorf("SymbolID(%q, %q, %q) = %q split to %d parts, want 3", pkg, recv, name, id, len(parts))
-			return
+		if len(parts) != 7 {
+			t.Fatalf("SymbolID(%+v) = %q split to %d parts, want 7", key, id, len(parts))
 		}
-		if parts[0] != pkg || parts[1] != recv || parts[2] != name {
-			t.Errorf("SymbolID(%q, %q, %q) = %q failed round-trip: parts=%v", pkg, recv, name, id, parts)
+		for _, part := range parts[1:] {
+			if strings.Contains(part, "#") {
+				t.Fatalf("encoded SymbolID part %q contains separator", part)
+			}
+		}
+		got, ok := decodeSymbolID(id)
+		if !ok {
+			t.Fatalf("decodeSymbolID(%q) failed", id)
+		}
+		if got != key {
+			t.Errorf("SymbolID(%+v) = %q failed round-trip: %+v", key, id, got)
 		}
 	})
 }
 
 func BenchmarkSymbolID(b *testing.B) {
+	key := SymbolKey{
+		Language:  "go",
+		Kind:      SymbolKindMethod,
+		Namespace: "github.com/kstruzzieri/go-llm/rag",
+		Receiver:  "Indexer",
+		Name:      "IndexFile",
+	}
 	for i := 0; i < b.N; i++ {
-		_ = SymbolID("github.com/kstruzzieri/go-llm/rag", "Indexer", "IndexFile")
+		_ = SymbolID(key)
 	}
 }
 
@@ -132,6 +155,9 @@ func TestSymbolNodeZeroValue(t *testing.T) {
 	if n.Kind == SymbolKindUnknown {
 		t.Errorf("zero SymbolNode.Kind should NOT equal SymbolKindUnknown (%q); unknown is an explicit value, not the default", SymbolKindUnknown)
 	}
+	if n.Declaration != "" {
+		t.Errorf("zero SymbolNode.Declaration = %q, want empty", n.Declaration)
+	}
 }
 
 func TestSymbolGraphZeroValue(t *testing.T) {
@@ -139,8 +165,9 @@ func TestSymbolGraphZeroValue(t *testing.T) {
 	if len(g.Nodes) != 0 || len(g.Calls) != 0 {
 		t.Errorf("zero SymbolGraph should have empty slices, got nodes=%d calls=%d", len(g.Nodes), len(g.Calls))
 	}
-	if g.VectorSpaceID != "" || g.Root != "" {
-		t.Errorf("zero SymbolGraph should have empty vsid+root, got vsid=%q root=%q", g.VectorSpaceID, g.Root)
+	if g.Scope != "" || g.VectorSpaceID != "" || g.ExtractionSignature != "" || g.Root != "" {
+		t.Errorf("zero SymbolGraph should have empty scope+vsid+signature+root, got scope=%q vsid=%q signature=%q root=%q",
+			g.Scope, g.VectorSpaceID, g.ExtractionSignature, g.Root)
 	}
 }
 
@@ -162,5 +189,77 @@ func TestSymbolKindConstants(t *testing.T) {
 		if got := string(k); got != want {
 			t.Errorf("SymbolKind wire format drift: got %q, want %q", got, want)
 		}
+	}
+}
+
+func TestCallResolutionConstants(t *testing.T) {
+	wireFormat := map[CallResolution]string{
+		CallResolutionResolved:     "resolved",
+		CallResolutionUnresolved:   "unresolved",
+		CallResolutionNotAttempted: "not_attempted",
+	}
+	for k, want := range wireFormat {
+		if got := string(k); got != want {
+			t.Errorf("CallResolution wire format drift: got %q, want %q", got, want)
+		}
+	}
+}
+
+func TestCallEdgeValidate(t *testing.T) {
+	validResolved := CallEdge{
+		CallerID:   "caller",
+		CalleeID:   "callee",
+		CalleeRaw:  "Do",
+		Resolution: CallResolutionResolved,
+		File:       "x.go",
+		Line:       10,
+	}
+	if err := validResolved.Validate(); err != nil {
+		t.Fatalf("valid resolved edge failed validation: %v", err)
+	}
+
+	validUnresolved := CallEdge{
+		CallerID:   "caller",
+		CalleeRaw:  "unknown.Do",
+		Resolution: CallResolutionUnresolved,
+		File:       "x.go",
+		Line:       11,
+	}
+	if err := validUnresolved.Validate(); err != nil {
+		t.Fatalf("valid unresolved edge failed validation: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		edge CallEdge
+	}{
+		{
+			name: "missing caller",
+			edge: CallEdge{CalleeID: "callee", Resolution: CallResolutionResolved, Line: 1},
+		},
+		{
+			name: "invalid line",
+			edge: CallEdge{CallerID: "caller", CalleeID: "callee", Resolution: CallResolutionResolved},
+		},
+		{
+			name: "resolved without callee id",
+			edge: CallEdge{CallerID: "caller", Resolution: CallResolutionResolved, Line: 1},
+		},
+		{
+			name: "unresolved with callee id",
+			edge: CallEdge{CallerID: "caller", CalleeID: "callee", Resolution: CallResolutionUnresolved, Line: 1},
+		},
+		{
+			name: "unknown resolution",
+			edge: CallEdge{CallerID: "caller", Resolution: CallResolution("maybe"), Line: 1},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.edge.Validate()
+			if !errors.Is(err, ErrInvalidGraph) {
+				t.Fatalf("Validate error = %v, want ErrInvalidGraph", err)
+			}
+		})
 	}
 }

--- a/rag/ast/types_test.go
+++ b/rag/ast/types_test.go
@@ -1,0 +1,166 @@
+package ast
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSymbolID(t *testing.T) {
+	tests := []struct {
+		name     string
+		pkgPath  string
+		receiver string
+		symbol   string
+		want     string
+	}{
+		{
+			name:    "free function",
+			pkgPath: "github.com/kstruzzieri/go-llm/rag",
+			symbol:  "NewIndexer",
+			want:    "github.com/kstruzzieri/go-llm/rag##NewIndexer",
+		},
+		{
+			name:     "method",
+			pkgPath:  "github.com/kstruzzieri/go-llm/rag",
+			receiver: "Indexer",
+			symbol:   "IndexFile",
+			want:     "github.com/kstruzzieri/go-llm/rag#Indexer#IndexFile",
+		},
+		{
+			name:    "main package free function",
+			pkgPath: "main",
+			symbol:  "main",
+			want:    "main##main",
+		},
+		{
+			// Pathological input from the criticize-review collision
+			// argument: pkgPath has a dot, receiver and name look like
+			// a method on a dotted-receiver type. The '#' boundaries
+			// keep this distinct from any free-function form with the
+			// same characters.
+			name:     "dotted pkgPath method",
+			pkgPath:  "github.com/foo.bar/baz",
+			receiver: "Type",
+			symbol:   "Method",
+			want:     "github.com/foo.bar/baz#Type#Method",
+		},
+		{
+			name:   "empty pkgPath",
+			symbol: "Foo",
+			want:   "##Foo",
+		},
+		{
+			name:    "empty name",
+			pkgPath: "pkg",
+			want:    "pkg##",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SymbolID(tt.pkgPath, tt.receiver, tt.symbol)
+			if got != tt.want {
+				t.Errorf("SymbolID(%q, %q, %q) = %q, want %q", tt.pkgPath, tt.receiver, tt.symbol, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSymbolIDNoCollisionAcrossDottedPkgPaths pins the collision-resistance
+// property that motivated the '#' separator choice. Includes the exact
+// cases the criticize-review identified as collision risks under the old
+// dot-separator encoding.
+func TestSymbolIDNoCollisionAcrossDottedPkgPaths(t *testing.T) {
+	cases := [][3]string{
+		{"foo.bar", "", "baz"},
+		{"foo", "bar", "baz"},
+		{"foo", "", "bar.baz"},
+		{"foo.bar.baz", "", "x"},
+		{"foo.bar", "baz", "qux"},
+		{"foo", "bar.baz", "qux"}, // even pathological dots-in-receiver are safe
+	}
+	seen := make(map[string][3]string, len(cases))
+	for _, c := range cases {
+		id := SymbolID(c[0], c[1], c[2])
+		if prev, ok := seen[id]; ok {
+			t.Errorf("SymbolID collision: %v and %v both produced %q", prev, c, id)
+		}
+		seen[id] = c
+	}
+}
+
+// FuzzSymbolID asserts the bijection property: for any (pkg, recv, name)
+// where no component contains '#', the resulting ID splits back into the
+// original three components on '#'.
+func FuzzSymbolID(f *testing.F) {
+	f.Add("pkg", "", "Name")
+	f.Add("github.com/x/y", "Recv", "Method")
+	f.Add("pkg.with.dots", "", "Name")
+	f.Add("", "", "")
+	f.Add("foo.bar", "Type", "Method")
+	f.Fuzz(func(t *testing.T, pkg, recv, name string) {
+		// Contract: components MUST NOT contain '#' (the separator).
+		// '#' is illegal in Go module paths and Go identifiers, so
+		// well-formed extractor output always satisfies this.
+		if strings.ContainsRune(pkg, '#') ||
+			strings.ContainsRune(recv, '#') ||
+			strings.ContainsRune(name, '#') {
+			t.Skip()
+		}
+		id := SymbolID(pkg, recv, name)
+		parts := strings.Split(id, "#")
+		if len(parts) != 3 {
+			t.Errorf("SymbolID(%q, %q, %q) = %q split to %d parts, want 3", pkg, recv, name, id, len(parts))
+			return
+		}
+		if parts[0] != pkg || parts[1] != recv || parts[2] != name {
+			t.Errorf("SymbolID(%q, %q, %q) = %q failed round-trip: parts=%v", pkg, recv, name, id, parts)
+		}
+	})
+}
+
+func BenchmarkSymbolID(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = SymbolID("github.com/kstruzzieri/go-llm/rag", "Indexer", "IndexFile")
+	}
+}
+
+func TestSymbolNodeZeroValue(t *testing.T) {
+	var n SymbolNode
+	if n.Kind != "" {
+		t.Errorf("zero SymbolNode.Kind = %q, want \"\" (Kind is left unset on zero value)", n.Kind)
+	}
+	if n.Kind == SymbolKindUnknown {
+		t.Errorf("zero SymbolNode.Kind should NOT equal SymbolKindUnknown (%q); unknown is an explicit value, not the default", SymbolKindUnknown)
+	}
+}
+
+func TestSymbolGraphZeroValue(t *testing.T) {
+	var g SymbolGraph
+	if len(g.Nodes) != 0 || len(g.Calls) != 0 {
+		t.Errorf("zero SymbolGraph should have empty slices, got nodes=%d calls=%d", len(g.Nodes), len(g.Calls))
+	}
+	if g.VectorSpaceID != "" || g.Root != "" {
+		t.Errorf("zero SymbolGraph should have empty vsid+root, got vsid=%q root=%q", g.VectorSpaceID, g.Root)
+	}
+}
+
+func TestSymbolKindConstants(t *testing.T) {
+	// Pin the wire encoding for every defined kind. If any of these
+	// strings changes, serialized graphs from older indexes will fail
+	// to round-trip — make the change loud.
+	wireFormat := map[SymbolKind]string{
+		SymbolKindUnknown:   "unknown",
+		SymbolKindFunction:  "function",
+		SymbolKindMethod:    "method",
+		SymbolKindStruct:    "struct",
+		SymbolKindInterface: "interface",
+		SymbolKindVar:       "var",
+		SymbolKindConst:     "const",
+		SymbolKindType:      "type",
+	}
+	for k, want := range wireFormat {
+		if got := string(k); got != want {
+			t.Errorf("SymbolKind wire format drift: got %q, want %q", got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Introduces `rag/ast/` — a new package providing language-agnostic interfaces for a structural symbol graph that can live alongside the rag chunk store. **Foundation only**: no consumer is wired, no existing behavior changes.

Refs #108.

## What's in the package

| File | Purpose |
|---|---|
| `types.go` | `SymbolKind`, `SymbolNode`, `CallEdge`, `SymbolGraph`, `SymbolID()` |
| `extractor.go` | `Extractor` interface (`Languages`, `Extract`, `Stale`) |
| `store.go` | `SymbolStore` interface + `CallSite` (preserves call-site file/line) |
| `noop.go` | `NoOpExtractor`, `NoOpStore` — fail-closed defaults |
| `errors.go` | Sentinels (`ErrSymbolNotFound`, `ErrVectorSpaceMismatch`) namespaced `rag/ast:` |
| `*_test.go` | Table-driven contract tests, fuzz, benchmark, error-wrapping, concurrent-use |

## Key design choices

- **`SymbolID` encoding**: `<pkgPath>#<receiver>#<name>`. `#` is forbidden in Go module paths and Go identifiers, so the encoding is a bijection on well-formed input. Verified via fuzz test (3.1M executions, 0 collisions).
- **Drift signature**: `SymbolGraph` owns one `VectorSpaceID`; nodes inherit it. `Stale` takes an opaque `prevSignature` so the extractor can encode any staleness inputs (vsid, source mtimes, extractor version, toolchain version) without API change.
- **Trust boundary**: `SymbolNode.Signature` and `.Doc` carry raw source. Sanitization for prompt-injection mitigation is the responsibility of any MCP/LLM exposure layer, not this package.
- **Surface budget**: 9 public items (5 types, 2 interfaces, 2 sentinels, 2 no-ops). Speculative API (`ImplementsEdge`, `TestEdge`, `ExtractorFunc`, reader/writer split, `ErrUnsupportedLanguage`) deferred to the milestones that produce or need them.

Also adds `docs/spikes/` to `.gitignore` (matches existing `docs/plans/` and `docs/superpowers/` patterns) and lists the new package in CLAUDE.md.

## Test plan

- [x] `go test ./...` — all 18 packages green
- [x] `go vet ./...` — clean
- [x] `go test -race ./rag/ast/...` — clean
- [x] `gofmt -l rag/ast/` — empty
- [x] `go test -fuzz=FuzzSymbolID -fuzztime=3s ./rag/ast/...` — 3,130,867 executions, 0 collisions
- [x] `/code-review` cycles run until clean
- [x] `/criticize-review` — 29 findings fixed, including a real collision found in the first encoding attempt

Generated with [Claude Code](https://claude.com/claude-code)