### PR TITLE
[codex] feat(rag/ast): add Go AST extractor

### DIFF
--- a/rag/ast/go_extractor.go
+++ b/rag/ast/go_extractor.go
@@ -675,12 +675,47 @@ type goValueSymbol struct {
 }
 
 type goTypeRef struct {
-	namespace string
-	name      string
+	namespace     string
+	name          string
+	keyNamespace  string
+	keyName       string
+	elemNamespace string
+	elemName      string
 }
 
 func (r goTypeRef) valid() bool {
 	return r.namespace != "" && r.name != ""
+}
+
+func (r goTypeRef) usable() bool {
+	return r.valid() || r.keyName != "" || r.elemName != ""
+}
+
+func (r goTypeRef) keyRef() goTypeRef {
+	if r.keyName == "" {
+		return goTypeRef{}
+	}
+	return goTypeRef{namespace: r.keyNamespace, name: r.keyName}
+}
+
+func (r goTypeRef) elemRef() goTypeRef {
+	if r.elemName == "" {
+		return goTypeRef{}
+	}
+	return goTypeRef{namespace: r.elemNamespace, name: r.elemName}
+}
+
+func collectionGoTypeRef(key goTypeRef, elem goTypeRef) goTypeRef {
+	ref := goTypeRef{}
+	if key.valid() {
+		ref.keyNamespace = key.namespace
+		ref.keyName = key.name
+	}
+	if elem.valid() {
+		ref.elemNamespace = elem.namespace
+		ref.elemName = elem.name
+	}
+	return ref
 }
 
 type goSymbolIndex struct {
@@ -823,7 +858,7 @@ func (s goCallScope) clone() goCallScope {
 }
 
 func (s goCallScope) declare(name string, ref goTypeRef) {
-	if name != "_" && ref.valid() {
+	if name != "_" && ref.usable() {
 		s.vars[name] = ref
 		s.local[name] = true
 	}
@@ -926,6 +961,7 @@ func (c *goCallCollector) walkStmt(stmt goast.Stmt) {
 		child := c.withScope(c.scope.clone())
 		child.walkExpr(stmt.X)
 		body := child.withScope(child.scope.clone())
+		body.bindRangeVars(stmt)
 		body.walkStmtList(stmt.Body.List)
 		child.appendFrom(body)
 		c.appendFrom(child)
@@ -1057,13 +1093,26 @@ func (c *goCallCollector) updateScopeFromAssign(stmt *goast.AssignStmt) {
 	}
 }
 
+func (c *goCallCollector) bindRangeVars(stmt *goast.RangeStmt) {
+	if stmt.Tok != token.DEFINE {
+		return
+	}
+	key, elem := goRangeTypes(c.pkg, c.file, c.scope, stmt.X)
+	if name, ok := stmt.Key.(*goast.Ident); ok {
+		c.scope.declare(name.Name, key)
+	}
+	if name, ok := stmt.Value.(*goast.Ident); ok {
+		c.scope.declare(name.Name, elem)
+	}
+}
+
 func addGoFieldList(scope goCallScope, pkg *goPackage, file *goParsedFile, fields *goast.FieldList) {
 	if fields == nil {
 		return
 	}
 	for _, field := range fields.List {
 		ref := goTypeRefFromExpr(pkg, file, field.Type)
-		if !ref.valid() {
+		if !ref.usable() {
 			continue
 		}
 		for _, name := range field.Names {
@@ -1126,22 +1175,10 @@ func goFuncReturnType(pkg *goPackage, file *goParsedFile, decl *goast.FuncDecl) 
 	if decl.Type.Results == nil {
 		return goTypeRef{}
 	}
-	total := 0
-	var result goast.Expr
 	for _, field := range decl.Type.Results.List {
-		names := len(field.Names)
-		if names == 0 {
-			names = 1
-		}
-		total += names
-		if total == 1 {
-			result = field.Type
-		}
+		return goTypeRefFromExpr(pkg, file, field.Type)
 	}
-	if total != 1 {
-		return goTypeRef{}
-	}
-	return goTypeRefFromExpr(pkg, file, result)
+	return goTypeRef{}
 }
 
 func goTypeRefFromValue(index *goSymbolIndex, pkg *goPackage, file *goParsedFile, scope goCallScope, expr goast.Expr) goTypeRef {
@@ -1186,9 +1223,28 @@ func goTypeRefFromExpr(pkg *goPackage, file *goParsedFile, expr goast.Expr) goTy
 			return goTypeRef{}
 		}
 		return goTypeRef{namespace: namespace, name: expr.Sel.Name}
+	case *goast.ArrayType:
+		return collectionGoTypeRef(goTypeRef{}, goTypeRefFromExpr(pkg, file, expr.Elt))
+	case *goast.MapType:
+		return collectionGoTypeRef(
+			goTypeRefFromExpr(pkg, file, expr.Key),
+			goTypeRefFromExpr(pkg, file, expr.Value),
+		)
+	case *goast.ChanType:
+		return collectionGoTypeRef(goTypeRef{}, goTypeRefFromExpr(pkg, file, expr.Value))
 	default:
 		return goTypeRef{}
 	}
+}
+
+func goRangeTypes(pkg *goPackage, file *goParsedFile, scope goCallScope, expr goast.Expr) (goTypeRef, goTypeRef) {
+	expr = unwrapGoInstantiation(expr)
+	if ident, ok := expr.(*goast.Ident); ok {
+		ref := scope.vars[ident.Name]
+		return ref.keyRef(), ref.elemRef()
+	}
+	ref := goTypeRefFromExpr(pkg, file, expr)
+	return ref.keyRef(), ref.elemRef()
 }
 
 func unwrapGoInstantiation(expr goast.Expr) goast.Expr {

--- a/rag/ast/go_extractor.go
+++ b/rag/ast/go_extractor.go
@@ -1139,10 +1139,16 @@ func (c *goCallCollector) recordCall(call *goast.CallExpr) {
 }
 
 func (c *goCallCollector) updateScopeFromValueSpec(spec *goast.ValueSpec) {
+	var tupleRefs []goTypeRef
+	if spec.Type == nil && len(spec.Values) == 1 {
+		tupleRefs = goTypeRefsFromValue(c.index, c.pkg, c.file, c.scope, spec.Values[0])
+	}
 	for i, name := range spec.Names {
 		ref := goTypeRef{}
 		if spec.Type != nil {
 			ref = goTypeRefFromExpr(c.pkg, c.file, spec.Type)
+		} else if i < len(tupleRefs) {
+			ref = tupleRefs[i]
 		} else if initializer := goInitializerForName(spec, i); initializer != nil {
 			ref = goTypeRefFromValue(c.index, c.pkg, c.file, c.scope, initializer)
 		}
@@ -1253,7 +1259,7 @@ func (idx *goSymbolIndex) resolveCall(pkg *goPackage, file *goParsedFile, scope 
 	base := unwrapGoInstantiation(fun)
 	switch expr := base.(type) {
 	case *goast.Ident:
-		if goBuiltinCall(expr.Name) || goPredeclaredType(expr.Name) || scope.hasTypeParam(expr.Name) || idx.hasType(goTypeRef{namespace: pkg.namespace, name: expr.Name}) {
+		if scope.hasTypeParam(expr.Name) {
 			return "", "", false
 		}
 		if calleeID := idx.function(pkg.namespace, expr.Name); calleeID != "" {
@@ -1263,6 +1269,9 @@ func (idx *goSymbolIndex) resolveCall(pkg *goPackage, file *goParsedFile, scope 
 			if calleeID := idx.function(namespace, expr.Name); calleeID != "" {
 				return calleeID, CallResolutionResolved, true
 			}
+		}
+		if goBuiltinCall(expr.Name) || goPredeclaredType(expr.Name) || idx.hasType(goTypeRef{namespace: pkg.namespace, name: expr.Name}) {
+			return "", "", false
 		}
 		return "", CallResolutionUnresolved, true
 	case *goast.SelectorExpr:

--- a/rag/ast/go_extractor.go
+++ b/rag/ast/go_extractor.go
@@ -461,7 +461,7 @@ func goFileImports(file *goast.File, packageNames map[string]string) (map[string
 		}
 		alias := packageNames[importPath]
 		if alias == "" {
-			alias = path.Base(importPath)
+			alias = goImportedPackageName(importPath)
 		}
 		if alias != "." && alias != "" {
 			imports[alias] = importPath
@@ -469,6 +469,13 @@ func goFileImports(file *goast.File, packageNames map[string]string) (map[string
 	}
 	sort.Strings(dotImports)
 	return imports, dotImports
+}
+
+func goImportedPackageName(importPath string) string {
+	if pkg, err := importer.Default().Import(importPath); err == nil && pkg.Name() != "" {
+		return pkg.Name()
+	}
+	return path.Base(importPath)
 }
 
 func goFuncNode(fset *token.FileSet, pkg *goPackage, file *goParsedFile, decl *goast.FuncDecl) SymbolNode {
@@ -757,7 +764,7 @@ func (idx *goSymbolIndex) addNode(node SymbolNode, returnType goTypeRef) {
 		}
 		idx.types[node.Namespace][node.Name] = node.ID
 	}
-	if returnType.valid() {
+	if returnType.usable() {
 		idx.returns[node.ID] = returnType
 	}
 }
@@ -1040,8 +1047,6 @@ func (c *goCallCollector) walkExpr(expr goast.Expr) {
 		switch node := node.(type) {
 		case nil:
 			return true
-		case *goast.FuncLit:
-			return false
 		case *goast.CallExpr:
 			c.recordCall(node)
 		}
@@ -1097,7 +1102,7 @@ func (c *goCallCollector) bindRangeVars(stmt *goast.RangeStmt) {
 	if stmt.Tok != token.DEFINE {
 		return
 	}
-	key, elem := goRangeTypes(c.pkg, c.file, c.scope, stmt.X)
+	key, elem := goRangeTypes(c.index, c.pkg, c.file, c.scope, stmt.X)
 	if name, ok := stmt.Key.(*goast.Ident); ok {
 		c.scope.declare(name.Name, key)
 	}
@@ -1237,13 +1242,16 @@ func goTypeRefFromExpr(pkg *goPackage, file *goParsedFile, expr goast.Expr) goTy
 	}
 }
 
-func goRangeTypes(pkg *goPackage, file *goParsedFile, scope goCallScope, expr goast.Expr) (goTypeRef, goTypeRef) {
+func goRangeTypes(index *goSymbolIndex, pkg *goPackage, file *goParsedFile, scope goCallScope, expr goast.Expr) (goTypeRef, goTypeRef) {
 	expr = unwrapGoInstantiation(expr)
 	if ident, ok := expr.(*goast.Ident); ok {
 		ref := scope.vars[ident.Name]
 		return ref.keyRef(), ref.elemRef()
 	}
-	ref := goTypeRefFromExpr(pkg, file, expr)
+	ref := goTypeRefFromValue(index, pkg, file, scope, expr)
+	if !ref.usable() {
+		ref = goTypeRefFromExpr(pkg, file, expr)
+	}
 	return ref.keyRef(), ref.elemRef()
 }
 

--- a/rag/ast/go_extractor.go
+++ b/rag/ast/go_extractor.go
@@ -1052,7 +1052,7 @@ func (idx *goSymbolIndex) resolveCall(pkg *goPackage, file *goParsedFile, scope 
 	base := unwrapGoInstantiation(fun)
 	switch expr := base.(type) {
 	case *goast.Ident:
-		if goBuiltinCall(expr.Name) || idx.hasType(goTypeRef{namespace: pkg.namespace, name: expr.Name}) {
+		if goBuiltinCall(expr.Name) || goPredeclaredType(expr.Name) || idx.hasType(goTypeRef{namespace: pkg.namespace, name: expr.Name}) {
 			return "", "", false
 		}
 		if calleeID := idx.function(pkg.namespace, expr.Name); calleeID != "" {
@@ -1205,6 +1205,18 @@ func goBuiltinCall(name string) bool {
 	case "append", "cap", "clear", "close", "complex", "copy", "delete",
 		"imag", "len", "make", "max", "min", "new", "panic", "print",
 		"println", "real", "recover":
+		return true
+	default:
+		return false
+	}
+}
+
+func goPredeclaredType(name string) bool {
+	switch name {
+	case "any", "bool", "byte", "comparable", "complex64", "complex128",
+		"error", "float32", "float64", "int", "int8", "int16", "int32",
+		"int64", "rune", "string", "uint", "uint8", "uint16", "uint32",
+		"uint64", "uintptr":
 		return true
 	default:
 		return false

--- a/rag/ast/go_extractor.go
+++ b/rag/ast/go_extractor.go
@@ -359,7 +359,7 @@ func extractGoGraph(ctx context.Context, root string, module goModule, sources [
 				case *goast.FuncDecl:
 					node := goFuncNode(fset, pkg, file, decl)
 					nodes = append(nodes, node)
-					index.addNode(node, goFuncReturnType(pkg, file, decl))
+					index.addNode(node, goFuncReturnTypes(pkg, file, decl))
 					funcs = append(funcs, goFuncSymbol{
 						pkg:  pkg,
 						file: file,
@@ -370,7 +370,7 @@ func extractGoGraph(ctx context.Context, root string, module goModule, sources [
 					genNodes, genValues := goGenDeclSymbols(fset, pkg, file, decl)
 					for _, node := range genNodes {
 						nodes = append(nodes, node)
-						index.addNode(node, goTypeRef{})
+						index.addNode(node, nil)
 					}
 					values = append(values, genValues...)
 				}
@@ -729,7 +729,7 @@ type goSymbolIndex struct {
 	functions map[string]map[string]string
 	methods   map[string]map[string]map[string]string
 	types     map[string]map[string]string
-	returns   map[string]goTypeRef
+	returns   map[string][]goTypeRef
 	imported  map[string]map[string]bool
 }
 
@@ -738,12 +738,12 @@ func newGoSymbolIndex() *goSymbolIndex {
 		functions: make(map[string]map[string]string),
 		methods:   make(map[string]map[string]map[string]string),
 		types:     make(map[string]map[string]string),
-		returns:   make(map[string]goTypeRef),
+		returns:   make(map[string][]goTypeRef),
 		imported:  make(map[string]map[string]bool),
 	}
 }
 
-func (idx *goSymbolIndex) addNode(node SymbolNode, returnType goTypeRef) {
+func (idx *goSymbolIndex) addNode(node SymbolNode, returnTypes []goTypeRef) {
 	switch node.Kind {
 	case SymbolKindFunction:
 		if idx.functions[node.Namespace] == nil {
@@ -764,8 +764,8 @@ func (idx *goSymbolIndex) addNode(node SymbolNode, returnType goTypeRef) {
 		}
 		idx.types[node.Namespace][node.Name] = node.ID
 	}
-	if returnType.usable() {
-		idx.returns[node.ID] = returnType
+	if len(returnTypes) > 0 {
+		idx.returns[node.ID] = returnTypes
 	}
 }
 
@@ -984,8 +984,9 @@ func (c *goCallCollector) walkStmt(stmt goast.Stmt) {
 		child := c.withScope(c.scope.clone())
 		child.walkStmt(stmt.Init)
 		child.walkStmt(stmt.Assign)
+		switchName := goTypeSwitchName(stmt.Assign)
 		for _, stmt := range stmt.Body.List {
-			child.walkCaseClause(stmt)
+			child.walkTypeSwitchCaseClause(stmt, switchName)
 		}
 		c.appendFrom(child)
 	case *goast.SelectStmt:
@@ -1013,6 +1014,23 @@ func (c *goCallCollector) walkCaseClause(stmt goast.Stmt) {
 	c.appendFrom(child)
 }
 
+func (c *goCallCollector) walkTypeSwitchCaseClause(stmt goast.Stmt, switchName string) {
+	clause, ok := stmt.(*goast.CaseClause)
+	if !ok {
+		c.walkStmt(stmt)
+		return
+	}
+	child := c.withScope(c.scope.clone())
+	for _, expr := range clause.List {
+		child.walkExpr(expr)
+	}
+	if switchName != "" && len(clause.List) == 1 {
+		child.scope.declare(switchName, goTypeRefFromExpr(child.pkg, child.file, clause.List[0]))
+	}
+	child.walkStmtList(clause.Body)
+	c.appendFrom(child)
+}
+
 func (c *goCallCollector) walkCommClause(stmt goast.Stmt) {
 	clause, ok := stmt.(*goast.CommClause)
 	if !ok {
@@ -1023,6 +1041,25 @@ func (c *goCallCollector) walkCommClause(stmt goast.Stmt) {
 	child.walkStmt(clause.Comm)
 	child.walkStmtList(clause.Body)
 	c.appendFrom(child)
+}
+
+func goTypeSwitchName(stmt goast.Stmt) string {
+	assign, ok := stmt.(*goast.AssignStmt)
+	if !ok || len(assign.Lhs) != 1 || len(assign.Rhs) != 1 {
+		return ""
+	}
+	if assign.Tok != token.DEFINE && assign.Tok != token.ASSIGN {
+		return ""
+	}
+	name, ok := assign.Lhs[0].(*goast.Ident)
+	if !ok || name.Name == "_" {
+		return ""
+	}
+	assertion, ok := assign.Rhs[0].(*goast.TypeAssertExpr)
+	if !ok || assertion.Type != nil {
+		return ""
+	}
+	return name.Name
 }
 
 func (c *goCallCollector) walkDecl(decl goast.Decl) {
@@ -1085,15 +1122,24 @@ func (c *goCallCollector) updateScopeFromAssign(stmt *goast.AssignStmt) {
 	if stmt.Tok != token.DEFINE {
 		return
 	}
+	var tupleRefs []goTypeRef
+	if len(stmt.Rhs) == 1 {
+		tupleRefs = goTypeRefsFromValue(c.index, c.pkg, c.file, c.scope, stmt.Rhs[0])
+	}
 	for i, lhs := range stmt.Lhs {
 		name, ok := lhs.(*goast.Ident)
-		if !ok || name.Name == "_" || i >= len(stmt.Rhs) {
+		if !ok || name.Name == "_" {
 			continue
 		}
 		if c.scope.local[name.Name] {
 			continue
 		}
-		ref := goTypeRefFromValue(c.index, c.pkg, c.file, c.scope, stmt.Rhs[i])
+		ref := goTypeRef{}
+		if i < len(tupleRefs) {
+			ref = tupleRefs[i]
+		} else if i < len(stmt.Rhs) {
+			ref = goTypeRefFromValue(c.index, c.pkg, c.file, c.scope, stmt.Rhs[i])
+		}
 		c.scope.declare(name.Name, ref)
 	}
 }
@@ -1176,34 +1222,58 @@ func (idx *goSymbolIndex) resolveCall(pkg *goPackage, file *goParsedFile, scope 
 	}
 }
 
-func goFuncReturnType(pkg *goPackage, file *goParsedFile, decl *goast.FuncDecl) goTypeRef {
+func goFuncReturnTypes(pkg *goPackage, file *goParsedFile, decl *goast.FuncDecl) []goTypeRef {
 	if decl.Type.Results == nil {
-		return goTypeRef{}
+		return nil
 	}
+	var refs []goTypeRef
 	for _, field := range decl.Type.Results.List {
-		return goTypeRefFromExpr(pkg, file, field.Type)
+		count := len(field.Names)
+		if count == 0 {
+			count = 1
+		}
+		ref := goTypeRefFromExpr(pkg, file, field.Type)
+		for i := 0; i < count; i++ {
+			refs = append(refs, ref)
+		}
 	}
-	return goTypeRef{}
+	return refs
 }
 
 func goTypeRefFromValue(index *goSymbolIndex, pkg *goPackage, file *goParsedFile, scope goCallScope, expr goast.Expr) goTypeRef {
+	refs := goTypeRefsFromValue(index, pkg, file, scope, expr)
+	if len(refs) == 0 {
+		return goTypeRef{}
+	}
+	return refs[0]
+}
+
+func goTypeRefsFromValue(index *goSymbolIndex, pkg *goPackage, file *goParsedFile, scope goCallScope, expr goast.Expr) []goTypeRef {
 	switch expr := expr.(type) {
+	case *goast.Ident:
+		if ref := scope.vars[expr.Name]; ref.usable() {
+			return []goTypeRef{ref}
+		}
 	case *goast.CompositeLit:
-		return goTypeRefFromExpr(pkg, file, expr.Type)
+		return []goTypeRef{goTypeRefFromExpr(pkg, file, expr.Type)}
 	case *goast.UnaryExpr:
 		if expr.Op == token.AND {
-			return goTypeRefFromValue(index, pkg, file, scope, expr.X)
+			return goTypeRefsFromValue(index, pkg, file, scope, expr.X)
+		}
+	case *goast.TypeAssertExpr:
+		if expr.Type != nil {
+			return []goTypeRef{goTypeRefFromExpr(pkg, file, expr.Type)}
 		}
 	case *goast.CallExpr:
 		if ref := goTypeRefFromExpr(pkg, file, unwrapGoInstantiation(expr.Fun)); index.hasType(ref) {
-			return ref
+			return []goTypeRef{ref}
 		}
 		calleeID, resolution, record := index.resolveCall(pkg, file, scope, expr.Fun)
 		if record && resolution == CallResolutionResolved {
 			return index.returns[calleeID]
 		}
 	}
-	return goTypeRef{}
+	return nil
 }
 
 func goTypeRefFromExpr(pkg *goPackage, file *goParsedFile, expr goast.Expr) goTypeRef {

--- a/rag/ast/go_extractor.go
+++ b/rag/ast/go_extractor.go
@@ -346,8 +346,9 @@ func extractGoGraph(ctx context.Context, root string, module goModule, sources [
 
 	index := newGoSymbolIndex()
 	var (
-		nodes []SymbolNode
-		funcs []goFuncSymbol
+		nodes  []SymbolNode
+		funcs  []goFuncSymbol
+		values []goValueSymbol
 	)
 	for _, pkg := range pkgs {
 		for _, file := range pkg.files {
@@ -364,16 +365,18 @@ func extractGoGraph(ctx context.Context, root string, module goModule, sources [
 						id:   node.ID,
 					})
 				case *goast.GenDecl:
-					for _, node := range goGenDeclNodes(fset, pkg, file, decl) {
+					genNodes, genValues := goGenDeclSymbols(fset, pkg, file, decl)
+					for _, node := range genNodes {
 						nodes = append(nodes, node)
 						index.addNode(node, goTypeRef{})
 					}
+					values = append(values, genValues...)
 				}
 			}
 		}
 	}
 
-	calls := extractGoCalls(fset, index, funcs)
+	calls := extractGoCalls(fset, index, funcs, values)
 	sortGoNodes(nodes)
 	sortGoCalls(calls)
 	return nodes, calls, nil
@@ -495,7 +498,7 @@ func goFuncNode(fset *token.FileSet, pkg *goPackage, file *goParsedFile, decl *g
 	}
 }
 
-func goGenDeclNodes(fset *token.FileSet, pkg *goPackage, file *goParsedFile, decl *goast.GenDecl) []SymbolNode {
+func goGenDeclSymbols(fset *token.FileSet, pkg *goPackage, file *goParsedFile, decl *goast.GenDecl) ([]SymbolNode, []goValueSymbol) {
 	switch decl.Tok {
 	case token.TYPE:
 		nodes := make([]SymbolNode, 0, len(decl.Specs))
@@ -528,9 +531,10 @@ func goGenDeclNodes(fset *token.FileSet, pkg *goPackage, file *goParsedFile, dec
 				Doc:         rawGoComment(fset, file.data, doc),
 			})
 		}
-		return nodes
+		return nodes, nil
 	case token.VAR, token.CONST:
 		var nodes []SymbolNode
+		var values []goValueSymbol
 		kind := SymbolKindVar
 		if decl.Tok == token.CONST {
 			kind = SymbolKindConst
@@ -544,7 +548,7 @@ func goGenDeclNodes(fset *token.FileSet, pkg *goPackage, file *goParsedFile, dec
 			if doc == nil {
 				doc = decl.Doc
 			}
-			for _, name := range valueSpec.Names {
+			for i, name := range valueSpec.Names {
 				id := SymbolID(SymbolKey{
 					Language:  goLanguage,
 					Kind:      kind,
@@ -563,12 +567,33 @@ func goGenDeclNodes(fset *token.FileSet, pkg *goPackage, file *goParsedFile, dec
 					Declaration: goSpecDeclaration(fset, decl.Tok, valueSpec),
 					Doc:         rawGoComment(fset, file.data, doc),
 				})
+				if initializer := goInitializerForName(valueSpec, i); initializer != nil {
+					values = append(values, goValueSymbol{
+						pkg:  pkg,
+						file: file,
+						id:   id,
+						expr: initializer,
+					})
+				}
 			}
 		}
-		return nodes
+		return nodes, values
 	default:
+		return nil, nil
+	}
+}
+
+func goInitializerForName(spec *goast.ValueSpec, nameIndex int) goast.Expr {
+	if len(spec.Values) == 0 {
 		return nil
 	}
+	if len(spec.Values) == 1 {
+		return spec.Values[0]
+	}
+	if nameIndex < len(spec.Values) {
+		return spec.Values[nameIndex]
+	}
+	return nil
 }
 
 func goTypeSymbolKind(spec *goast.TypeSpec) SymbolKind {
@@ -638,6 +663,13 @@ type goFuncSymbol struct {
 	file *goParsedFile
 	decl *goast.FuncDecl
 	id   string
+}
+
+type goValueSymbol struct {
+	pkg  *goPackage
+	file *goParsedFile
+	id   string
+	expr goast.Expr
 }
 
 type goTypeRef struct {
@@ -717,33 +749,34 @@ func (idx *goSymbolIndex) hasType(ref goTypeRef) bool {
 	return false
 }
 
-func extractGoCalls(fset *token.FileSet, index *goSymbolIndex, funcs []goFuncSymbol) []CallEdge {
+func extractGoCalls(fset *token.FileSet, index *goSymbolIndex, funcs []goFuncSymbol, values []goValueSymbol) []CallEdge {
 	var calls []CallEdge
+	for _, value := range values {
+		collector := goCallCollector{
+			fset:     fset,
+			index:    index,
+			pkg:      value.pkg,
+			file:     value.file,
+			callerID: value.id,
+			scope:    newGoCallScope(),
+		}
+		collector.walkExpr(value.expr)
+		calls = append(calls, collector.calls...)
+	}
 	for _, fn := range funcs {
 		if fn.decl.Body == nil {
 			continue
 		}
-		scope := collectGoCallScope(index, fn.pkg, fn.file, fn.decl)
-		goast.Inspect(fn.decl.Body, func(node goast.Node) bool {
-			switch node := node.(type) {
-			case *goast.FuncLit:
-				return false
-			case *goast.CallExpr:
-				calleeID, resolution, record := index.resolveCall(fn.pkg, fn.file, scope, node.Fun)
-				if !record {
-					return true
-				}
-				calls = append(calls, CallEdge{
-					CallerID:   fn.id,
-					CalleeID:   calleeID,
-					CalleeRaw:  goFormatNode(fset, node.Fun),
-					Resolution: resolution,
-					File:       fn.file.rel,
-					Line:       goLine(fset, node.Fun.Pos()),
-				})
-			}
-			return true
-		})
+		collector := goCallCollector{
+			fset:     fset,
+			index:    index,
+			pkg:      fn.pkg,
+			file:     fn.file,
+			callerID: fn.id,
+			scope:    initialGoCallScope(fn.pkg, fn.file, fn.decl),
+		}
+		collector.walkStmtList(fn.decl.Body.List)
+		calls = append(calls, collector.calls...)
 	}
 	return calls
 }
@@ -752,60 +785,250 @@ type goCallScope struct {
 	vars map[string]goTypeRef
 }
 
-func collectGoCallScope(index *goSymbolIndex, pkg *goPackage, file *goParsedFile, decl *goast.FuncDecl) goCallScope {
-	scope := goCallScope{vars: make(map[string]goTypeRef)}
+func newGoCallScope() goCallScope {
+	return goCallScope{vars: make(map[string]goTypeRef)}
+}
+
+func (s goCallScope) clone() goCallScope {
+	clone := newGoCallScope()
+	for name, ref := range s.vars {
+		clone.vars[name] = ref
+	}
+	return clone
+}
+
+func (s goCallScope) set(name string, ref goTypeRef) {
+	if name != "_" && ref.valid() {
+		s.vars[name] = ref
+	}
+}
+
+func initialGoCallScope(pkg *goPackage, file *goParsedFile, decl *goast.FuncDecl) goCallScope {
+	scope := newGoCallScope()
 	if decl.Recv != nil {
 		addGoFieldList(scope, pkg, file, decl.Recv)
 	}
 	addGoFieldList(scope, pkg, file, decl.Type.Params)
 	addGoFieldList(scope, pkg, file, decl.Type.Results)
+	return scope
+}
 
-	goast.Inspect(decl.Body, func(node goast.Node) bool {
+type goCallCollector struct {
+	fset     *token.FileSet
+	index    *goSymbolIndex
+	pkg      *goPackage
+	file     *goParsedFile
+	callerID string
+	scope    goCallScope
+	calls    []CallEdge
+}
+
+func (c *goCallCollector) withScope(scope goCallScope) goCallCollector {
+	child := *c
+	child.scope = scope
+	child.calls = nil
+	return child
+}
+
+func (c *goCallCollector) appendFrom(child goCallCollector) {
+	c.calls = append(c.calls, child.calls...)
+}
+
+func (c *goCallCollector) walkStmtList(stmts []goast.Stmt) {
+	for _, stmt := range stmts {
+		c.walkStmt(stmt)
+	}
+}
+
+func (c *goCallCollector) walkStmt(stmt goast.Stmt) {
+	switch stmt := stmt.(type) {
+	case nil:
+		return
+	case *goast.DeclStmt:
+		c.walkDecl(stmt.Decl)
+	case *goast.AssignStmt:
+		for _, expr := range stmt.Lhs {
+			c.walkExpr(expr)
+		}
+		for _, expr := range stmt.Rhs {
+			c.walkExpr(expr)
+		}
+		c.updateScopeFromAssign(stmt)
+	case *goast.ExprStmt:
+		c.walkExpr(stmt.X)
+	case *goast.ReturnStmt:
+		for _, expr := range stmt.Results {
+			c.walkExpr(expr)
+		}
+	case *goast.GoStmt:
+		c.walkExpr(stmt.Call)
+	case *goast.DeferStmt:
+		c.walkExpr(stmt.Call)
+	case *goast.SendStmt:
+		c.walkExpr(stmt.Chan)
+		c.walkExpr(stmt.Value)
+	case *goast.IncDecStmt:
+		c.walkExpr(stmt.X)
+	case *goast.BlockStmt:
+		child := c.withScope(c.scope.clone())
+		child.walkStmtList(stmt.List)
+		c.appendFrom(child)
+	case *goast.IfStmt:
+		ifScope := c.scope.clone()
+		child := c.withScope(ifScope)
+		child.walkStmt(stmt.Init)
+		child.walkExpr(stmt.Cond)
+		body := child.withScope(child.scope.clone())
+		body.walkStmtList(stmt.Body.List)
+		child.appendFrom(body)
+		if stmt.Else != nil {
+			elseBranch := child.withScope(child.scope.clone())
+			elseBranch.walkStmt(stmt.Else)
+			child.appendFrom(elseBranch)
+		}
+		c.appendFrom(child)
+	case *goast.ForStmt:
+		child := c.withScope(c.scope.clone())
+		child.walkStmt(stmt.Init)
+		child.walkExpr(stmt.Cond)
+		body := child.withScope(child.scope.clone())
+		body.walkStmtList(stmt.Body.List)
+		child.appendFrom(body)
+		child.walkStmt(stmt.Post)
+		c.appendFrom(child)
+	case *goast.RangeStmt:
+		child := c.withScope(c.scope.clone())
+		child.walkExpr(stmt.X)
+		body := child.withScope(child.scope.clone())
+		body.walkStmtList(stmt.Body.List)
+		child.appendFrom(body)
+		c.appendFrom(child)
+	case *goast.SwitchStmt:
+		child := c.withScope(c.scope.clone())
+		child.walkStmt(stmt.Init)
+		child.walkExpr(stmt.Tag)
+		for _, stmt := range stmt.Body.List {
+			child.walkCaseClause(stmt)
+		}
+		c.appendFrom(child)
+	case *goast.TypeSwitchStmt:
+		child := c.withScope(c.scope.clone())
+		child.walkStmt(stmt.Init)
+		child.walkStmt(stmt.Assign)
+		for _, stmt := range stmt.Body.List {
+			child.walkCaseClause(stmt)
+		}
+		c.appendFrom(child)
+	case *goast.SelectStmt:
+		child := c.withScope(c.scope.clone())
+		for _, stmt := range stmt.Body.List {
+			child.walkCommClause(stmt)
+		}
+		c.appendFrom(child)
+	case *goast.LabeledStmt:
+		c.walkStmt(stmt.Stmt)
+	}
+}
+
+func (c *goCallCollector) walkCaseClause(stmt goast.Stmt) {
+	clause, ok := stmt.(*goast.CaseClause)
+	if !ok {
+		c.walkStmt(stmt)
+		return
+	}
+	child := c.withScope(c.scope.clone())
+	for _, expr := range clause.List {
+		child.walkExpr(expr)
+	}
+	child.walkStmtList(clause.Body)
+	c.appendFrom(child)
+}
+
+func (c *goCallCollector) walkCommClause(stmt goast.Stmt) {
+	clause, ok := stmt.(*goast.CommClause)
+	if !ok {
+		c.walkStmt(stmt)
+		return
+	}
+	child := c.withScope(c.scope.clone())
+	child.walkStmt(clause.Comm)
+	child.walkStmtList(clause.Body)
+	c.appendFrom(child)
+}
+
+func (c *goCallCollector) walkDecl(decl goast.Decl) {
+	gen, ok := decl.(*goast.GenDecl)
+	if !ok {
+		return
+	}
+	for _, spec := range gen.Specs {
+		valueSpec, ok := spec.(*goast.ValueSpec)
+		if !ok {
+			continue
+		}
+		for _, expr := range valueSpec.Values {
+			c.walkExpr(expr)
+		}
+		c.updateScopeFromValueSpec(valueSpec)
+	}
+}
+
+func (c *goCallCollector) walkExpr(expr goast.Expr) {
+	goast.Inspect(expr, func(node goast.Node) bool {
 		switch node := node.(type) {
+		case nil:
+			return true
 		case *goast.FuncLit:
 			return false
-		case *goast.DeclStmt:
-			gen, ok := node.Decl.(*goast.GenDecl)
-			if !ok || gen.Tok != token.VAR {
-				return true
-			}
-			for _, spec := range gen.Specs {
-				valueSpec, ok := spec.(*goast.ValueSpec)
-				if !ok {
-					continue
-				}
-				for i, name := range valueSpec.Names {
-					if name.Name == "_" {
-						continue
-					}
-					ref := goTypeRef{}
-					if valueSpec.Type != nil {
-						ref = goTypeRefFromExpr(pkg, file, valueSpec.Type)
-					} else if i < len(valueSpec.Values) {
-						ref = goTypeRefFromValue(index, pkg, file, scope, valueSpec.Values[i])
-					}
-					if ref.valid() {
-						scope.vars[name.Name] = ref
-					}
-				}
-			}
-		case *goast.AssignStmt:
-			if node.Tok != token.DEFINE && node.Tok != token.ASSIGN {
-				return true
-			}
-			for i, lhs := range node.Lhs {
-				name, ok := lhs.(*goast.Ident)
-				if !ok || name.Name == "_" || i >= len(node.Rhs) {
-					continue
-				}
-				if ref := goTypeRefFromValue(index, pkg, file, scope, node.Rhs[i]); ref.valid() {
-					scope.vars[name.Name] = ref
-				}
-			}
+		case *goast.CallExpr:
+			c.recordCall(node)
 		}
 		return true
 	})
-	return scope
+}
+
+func (c *goCallCollector) recordCall(call *goast.CallExpr) {
+	calleeID, resolution, record := c.index.resolveCall(c.pkg, c.file, c.scope, call.Fun)
+	if !record {
+		return
+	}
+	c.calls = append(c.calls, CallEdge{
+		CallerID:   c.callerID,
+		CalleeID:   calleeID,
+		CalleeRaw:  goFormatNode(c.fset, call.Fun),
+		Resolution: resolution,
+		File:       c.file.rel,
+		Line:       goLine(c.fset, call.Fun.Pos()),
+	})
+}
+
+func (c *goCallCollector) updateScopeFromValueSpec(spec *goast.ValueSpec) {
+	for i, name := range spec.Names {
+		ref := goTypeRef{}
+		if spec.Type != nil {
+			ref = goTypeRefFromExpr(c.pkg, c.file, spec.Type)
+		} else if initializer := goInitializerForName(spec, i); initializer != nil {
+			ref = goTypeRefFromValue(c.index, c.pkg, c.file, c.scope, initializer)
+		}
+		c.scope.set(name.Name, ref)
+	}
+}
+
+func (c *goCallCollector) updateScopeFromAssign(stmt *goast.AssignStmt) {
+	if stmt.Tok != token.DEFINE {
+		return
+	}
+	for i, lhs := range stmt.Lhs {
+		name, ok := lhs.(*goast.Ident)
+		if !ok || name.Name == "_" || i >= len(stmt.Rhs) {
+			continue
+		}
+		if _, exists := c.scope.vars[name.Name]; exists {
+			continue
+		}
+		ref := goTypeRefFromValue(c.index, c.pkg, c.file, c.scope, stmt.Rhs[i])
+		c.scope.set(name.Name, ref)
+	}
 }
 
 func addGoFieldList(scope goCallScope, pkg *goPackage, file *goParsedFile, fields *goast.FieldList) {

--- a/rag/ast/go_extractor.go
+++ b/rag/ast/go_extractor.go
@@ -9,8 +9,10 @@ import (
 	"fmt"
 	goast "go/ast"
 	"go/format"
+	"go/importer"
 	"go/parser"
 	"go/token"
+	"go/types"
 	"io/fs"
 	"os"
 	"path"
@@ -686,6 +688,7 @@ type goSymbolIndex struct {
 	methods   map[string]map[string]map[string]string
 	types     map[string]map[string]string
 	returns   map[string]goTypeRef
+	imported  map[string]map[string]bool
 }
 
 func newGoSymbolIndex() *goSymbolIndex {
@@ -694,6 +697,7 @@ func newGoSymbolIndex() *goSymbolIndex {
 		methods:   make(map[string]map[string]map[string]string),
 		types:     make(map[string]map[string]string),
 		returns:   make(map[string]goTypeRef),
+		imported:  make(map[string]map[string]bool),
 	}
 }
 
@@ -749,6 +753,23 @@ func (idx *goSymbolIndex) hasType(ref goTypeRef) bool {
 	return false
 }
 
+func (idx *goSymbolIndex) importedType(importPath string, name string) bool {
+	byName, ok := idx.imported[importPath]
+	if !ok {
+		byName = make(map[string]bool)
+		pkg, err := importer.Default().Import(importPath)
+		if err == nil {
+			for _, exported := range pkg.Scope().Names() {
+				if _, ok := pkg.Scope().Lookup(exported).(*types.TypeName); ok {
+					byName[exported] = true
+				}
+			}
+		}
+		idx.imported[importPath] = byName
+	}
+	return byName[name]
+}
+
 func extractGoCalls(fset *token.FileSet, index *goSymbolIndex, funcs []goFuncSymbol, values []goValueSymbol) []CallEdge {
 	var calls []CallEdge
 	for _, value := range values {
@@ -782,11 +803,15 @@ func extractGoCalls(fset *token.FileSet, index *goSymbolIndex, funcs []goFuncSym
 }
 
 type goCallScope struct {
-	vars map[string]goTypeRef
+	vars  map[string]goTypeRef
+	local map[string]bool
 }
 
 func newGoCallScope() goCallScope {
-	return goCallScope{vars: make(map[string]goTypeRef)}
+	return goCallScope{
+		vars:  make(map[string]goTypeRef),
+		local: make(map[string]bool),
+	}
 }
 
 func (s goCallScope) clone() goCallScope {
@@ -797,9 +822,10 @@ func (s goCallScope) clone() goCallScope {
 	return clone
 }
 
-func (s goCallScope) set(name string, ref goTypeRef) {
+func (s goCallScope) declare(name string, ref goTypeRef) {
 	if name != "_" && ref.valid() {
 		s.vars[name] = ref
+		s.local[name] = true
 	}
 }
 
@@ -1010,7 +1036,7 @@ func (c *goCallCollector) updateScopeFromValueSpec(spec *goast.ValueSpec) {
 		} else if initializer := goInitializerForName(spec, i); initializer != nil {
 			ref = goTypeRefFromValue(c.index, c.pkg, c.file, c.scope, initializer)
 		}
-		c.scope.set(name.Name, ref)
+		c.scope.declare(name.Name, ref)
 	}
 }
 
@@ -1023,11 +1049,11 @@ func (c *goCallCollector) updateScopeFromAssign(stmt *goast.AssignStmt) {
 		if !ok || name.Name == "_" || i >= len(stmt.Rhs) {
 			continue
 		}
-		if _, exists := c.scope.vars[name.Name]; exists {
+		if c.scope.local[name.Name] {
 			continue
 		}
 		ref := goTypeRefFromValue(c.index, c.pkg, c.file, c.scope, stmt.Rhs[i])
-		c.scope.set(name.Name, ref)
+		c.scope.declare(name.Name, ref)
 	}
 }
 
@@ -1041,9 +1067,7 @@ func addGoFieldList(scope goCallScope, pkg *goPackage, file *goParsedFile, field
 			continue
 		}
 		for _, name := range field.Names {
-			if name.Name != "_" {
-				scope.vars[name.Name] = ref
-			}
+			scope.declare(name.Name, ref)
 		}
 	}
 }
@@ -1074,6 +1098,9 @@ func (idx *goSymbolIndex) resolveCall(pkg *goPackage, file *goParsedFile, scope 
 			}
 			if namespace, ok := file.imports[ident.Name]; ok {
 				if idx.hasType(goTypeRef{namespace: namespace, name: expr.Sel.Name}) {
+					return "", "", false
+				}
+				if idx.importedType(namespace, expr.Sel.Name) {
 					return "", "", false
 				}
 				if calleeID := idx.function(namespace, expr.Sel.Name); calleeID != "" {

--- a/rag/ast/go_extractor.go
+++ b/rag/ast/go_extractor.go
@@ -845,14 +845,16 @@ func extractGoCalls(fset *token.FileSet, index *goSymbolIndex, funcs []goFuncSym
 }
 
 type goCallScope struct {
-	vars  map[string]goTypeRef
-	local map[string]bool
+	vars       map[string]goTypeRef
+	typeParams map[string]bool
+	local      map[string]bool
 }
 
 func newGoCallScope() goCallScope {
 	return goCallScope{
-		vars:  make(map[string]goTypeRef),
-		local: make(map[string]bool),
+		vars:       make(map[string]goTypeRef),
+		typeParams: make(map[string]bool),
+		local:      make(map[string]bool),
 	}
 }
 
@@ -860,6 +862,9 @@ func (s goCallScope) clone() goCallScope {
 	clone := newGoCallScope()
 	for name, ref := range s.vars {
 		clone.vars[name] = ref
+	}
+	for name := range s.typeParams {
+		clone.typeParams[name] = true
 	}
 	return clone
 }
@@ -871,8 +876,19 @@ func (s goCallScope) declare(name string, ref goTypeRef) {
 	}
 }
 
+func (s goCallScope) declareTypeParam(name string) {
+	if name != "" && name != "_" {
+		s.typeParams[name] = true
+	}
+}
+
+func (s goCallScope) hasTypeParam(name string) bool {
+	return s.typeParams[name]
+}
+
 func initialGoCallScope(pkg *goPackage, file *goParsedFile, decl *goast.FuncDecl) goCallScope {
 	scope := newGoCallScope()
+	addGoFuncTypeParams(scope, decl)
 	if decl.Recv != nil {
 		addGoFieldList(scope, pkg, file, decl.Recv)
 	}
@@ -1084,11 +1100,27 @@ func (c *goCallCollector) walkExpr(expr goast.Expr) {
 		switch node := node.(type) {
 		case nil:
 			return true
+		case *goast.FuncLit:
+			c.walkFuncLit(node)
+			return false
 		case *goast.CallExpr:
 			c.recordCall(node)
 		}
 		return true
 	})
+}
+
+func (c *goCallCollector) walkFuncLit(lit *goast.FuncLit) {
+	if lit == nil || lit.Body == nil {
+		return
+	}
+	child := c.withScope(c.scope.clone())
+	if lit.Type != nil {
+		addGoFieldList(child.scope, c.pkg, c.file, lit.Type.Params)
+		addGoFieldList(child.scope, c.pkg, c.file, lit.Type.Results)
+	}
+	child.walkStmtList(lit.Body.List)
+	c.appendFrom(child)
 }
 
 func (c *goCallCollector) recordCall(call *goast.CallExpr) {
@@ -1172,11 +1204,56 @@ func addGoFieldList(scope goCallScope, pkg *goPackage, file *goParsedFile, field
 	}
 }
 
+func addGoFuncTypeParams(scope goCallScope, decl *goast.FuncDecl) {
+	if decl == nil || decl.Type == nil {
+		return
+	}
+	addGoTypeParamFieldList(scope, decl.Type.TypeParams)
+	if decl.Recv == nil {
+		return
+	}
+	for _, field := range decl.Recv.List {
+		addGoReceiverTypeParams(scope, field.Type)
+	}
+}
+
+func addGoTypeParamFieldList(scope goCallScope, fields *goast.FieldList) {
+	if fields == nil {
+		return
+	}
+	for _, field := range fields.List {
+		for _, name := range field.Names {
+			scope.declareTypeParam(name.Name)
+		}
+	}
+}
+
+func addGoReceiverTypeParams(scope goCallScope, expr goast.Expr) {
+	switch expr := expr.(type) {
+	case *goast.IndexExpr:
+		addGoReceiverTypeParam(scope, expr.Index)
+	case *goast.IndexListExpr:
+		for _, index := range expr.Indices {
+			addGoReceiverTypeParam(scope, index)
+		}
+	case *goast.ParenExpr:
+		addGoReceiverTypeParams(scope, expr.X)
+	case *goast.StarExpr:
+		addGoReceiverTypeParams(scope, expr.X)
+	}
+}
+
+func addGoReceiverTypeParam(scope goCallScope, expr goast.Expr) {
+	if ident, ok := expr.(*goast.Ident); ok {
+		scope.declareTypeParam(ident.Name)
+	}
+}
+
 func (idx *goSymbolIndex) resolveCall(pkg *goPackage, file *goParsedFile, scope goCallScope, fun goast.Expr) (string, CallResolution, bool) {
 	base := unwrapGoInstantiation(fun)
 	switch expr := base.(type) {
 	case *goast.Ident:
-		if goBuiltinCall(expr.Name) || goPredeclaredType(expr.Name) || idx.hasType(goTypeRef{namespace: pkg.namespace, name: expr.Name}) {
+		if goBuiltinCall(expr.Name) || goPredeclaredType(expr.Name) || scope.hasTypeParam(expr.Name) || idx.hasType(goTypeRef{namespace: pkg.namespace, name: expr.Name}) {
 			return "", "", false
 		}
 		if calleeID := idx.function(pkg.namespace, expr.Name); calleeID != "" {

--- a/rag/ast/go_extractor.go
+++ b/rag/ast/go_extractor.go
@@ -1,0 +1,1031 @@
+package ast
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	goast "go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	goLanguage                 = "go"
+	goExtractorSignaturePrefix = "go-ast-extractor"
+	goExtractorVersion         = "go-ast-v1"
+)
+
+// GoExtractor walks Go source trees with the standard library go/ast parser.
+// The zero value is ready for use and safe for concurrent calls.
+type GoExtractor struct{}
+
+// Languages implements [Extractor].
+func (GoExtractor) Languages() []string { return []string{goLanguage} }
+
+// Extract implements [Extractor].
+func (GoExtractor) Extract(ctx context.Context, scope string, root string, vectorSpaceID string) (SymbolGraph, error) {
+	canonicalRoot := canonicalGraphPath(root)
+	sources, sourceDigest, err := collectGoSources(ctx, root)
+	if err != nil {
+		return SymbolGraph{}, err
+	}
+	module := goModule{}
+	if len(sources) > 0 {
+		module, err = findGoModule(root)
+		if err != nil {
+			return SymbolGraph{}, err
+		}
+	}
+
+	signature := encodeGoExtractionSignature(goExtractionSignature{
+		Version:       goExtractorVersion,
+		Scope:         scope,
+		VectorSpaceID: vectorSpaceID,
+		Root:          canonicalRoot,
+		SourceDigest:  sourceDigest,
+		ModuleRoot:    module.signatureRoot(),
+		ModulePath:    module.path,
+		ModuleDigest:  module.digest,
+	})
+	graph := SymbolGraph{
+		Scope:               scope,
+		VectorSpaceID:       vectorSpaceID,
+		ExtractionSignature: signature,
+		Root:                canonicalRoot,
+	}
+	if len(sources) == 0 {
+		return graph, nil
+	}
+
+	nodes, calls, err := extractGoGraph(ctx, root, module, sources)
+	if err != nil {
+		return SymbolGraph{}, err
+	}
+	graph.Nodes = nodes
+	graph.Calls = calls
+	return graph, nil
+}
+
+// Stale implements [Extractor].
+func (GoExtractor) Stale(ctx context.Context, scope string, root string, prevSignature string) (bool, error) {
+	if prevSignature == "" {
+		return true, nil
+	}
+	prev, ok := decodeGoExtractionSignature(prevSignature)
+	if !ok {
+		return true, nil
+	}
+	canonicalRoot := canonicalGraphPath(root)
+	if prev.Version != goExtractorVersion || prev.Scope != scope || prev.Root != canonicalRoot {
+		return true, nil
+	}
+
+	sources, sourceDigest, err := collectGoSources(ctx, root)
+	if err != nil {
+		return false, err
+	}
+	module := goModule{}
+	if len(sources) > 0 {
+		module, err = findGoModule(root)
+		if err != nil {
+			return false, err
+		}
+	}
+	return prev.SourceDigest != sourceDigest ||
+		prev.ModuleRoot != module.signatureRoot() ||
+		prev.ModulePath != module.path ||
+		prev.ModuleDigest != module.digest, nil
+}
+
+type goExtractionSignature struct {
+	Version       string `json:"version"`
+	Scope         string `json:"scope"`
+	VectorSpaceID string `json:"vector_space_id"`
+	Root          string `json:"root"`
+	SourceDigest  string `json:"source_digest"`
+	ModuleRoot    string `json:"module_root,omitempty"`
+	ModulePath    string `json:"module_path,omitempty"`
+	ModuleDigest  string `json:"module_digest,omitempty"`
+}
+
+func encodeGoExtractionSignature(sig goExtractionSignature) string {
+	raw, err := json.Marshal(sig)
+	if err != nil {
+		return goExtractorSignaturePrefix + ":"
+	}
+	return goExtractorSignaturePrefix + ":" + base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func decodeGoExtractionSignature(raw string) (goExtractionSignature, bool) {
+	encoded, ok := strings.CutPrefix(raw, goExtractorSignaturePrefix+":")
+	if !ok || encoded == "" {
+		return goExtractionSignature{}, false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return goExtractionSignature{}, false
+	}
+	var sig goExtractionSignature
+	if err := json.Unmarshal(payload, &sig); err != nil {
+		return goExtractionSignature{}, false
+	}
+	return sig, true
+}
+
+type goSourceFile struct {
+	path    string
+	absPath string
+	rel     string
+	data    []byte
+}
+
+func collectGoSources(ctx context.Context, root string) ([]goSourceFile, string, error) {
+	nativeRoot := filepath.Clean(root)
+	var sources []goSourceFile
+	err := filepath.WalkDir(nativeRoot, func(filePath string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if filePath != nativeRoot && skipGoSourceDir(entry.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 || strings.ToLower(filepath.Ext(filePath)) != ".go" {
+			return nil
+		}
+
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(nativeRoot, filePath)
+		if err != nil {
+			return err
+		}
+		absPath, err := filepath.Abs(filePath)
+		if err != nil {
+			return err
+		}
+		sources = append(sources, goSourceFile{
+			path:    filePath,
+			absPath: filepath.Clean(absPath),
+			rel:     canonicalRelPath(rel),
+			data:    data,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, "", fmt.Errorf("rag/ast: walk Go sources in %q: %w", root, err)
+	}
+
+	sort.Slice(sources, func(i, j int) bool {
+		return sources[i].rel < sources[j].rel
+	})
+	h := sha256.New()
+	for _, source := range sources {
+		_, _ = h.Write([]byte(source.rel))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write(source.data)
+		_, _ = h.Write([]byte{0})
+	}
+	return sources, fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+func skipGoSourceDir(name string) bool {
+	switch name {
+	case ".git", "vendor", "node_modules", "dist", "__pycache__":
+		return true
+	default:
+		return false
+	}
+}
+
+func canonicalGraphPath(filePath string) string {
+	return filepath.ToSlash(filepath.Clean(filePath))
+}
+
+func canonicalRelPath(filePath string) string {
+	rel := filepath.ToSlash(filepath.Clean(filePath))
+	return strings.TrimPrefix(rel, "./")
+}
+
+type goModule struct {
+	found  bool
+	root   string
+	path   string
+	digest string
+}
+
+func (m goModule) signatureRoot() string {
+	if !m.found {
+		return ""
+	}
+	return filepath.ToSlash(filepath.Clean(m.root))
+}
+
+func findGoModule(root string) (goModule, error) {
+	absRoot, err := filepath.Abs(filepath.Clean(root))
+	if err != nil {
+		return goModule{}, fmt.Errorf("rag/ast: resolve root %q: %w", root, err)
+	}
+	for dir := absRoot; ; dir = filepath.Dir(dir) {
+		modPath := filepath.Join(dir, "go.mod")
+		data, err := os.ReadFile(modPath)
+		if err == nil {
+			modulePath := parseGoModulePath(data)
+			if modulePath == "" {
+				return goModule{}, fmt.Errorf("rag/ast: parse module path in %q", modPath)
+			}
+			sum := sha256.Sum256(data)
+			return goModule{found: true, root: dir, path: modulePath, digest: fmt.Sprintf("%x", sum[:])}, nil
+		}
+		if !os.IsNotExist(err) {
+			return goModule{}, fmt.Errorf("rag/ast: read %q: %w", modPath, err)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return goModule{}, nil
+		}
+	}
+}
+
+func parseGoModulePath(data []byte) string {
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "//") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[0] != "module" {
+			continue
+		}
+		modulePath := fields[1]
+		if unquoted, err := strconv.Unquote(modulePath); err == nil {
+			return unquoted
+		}
+		return modulePath
+	}
+	return ""
+}
+
+type goPackage struct {
+	name      string
+	namespace string
+	dir       string
+	files     []*goParsedFile
+}
+
+type goParsedFile struct {
+	path       string
+	rel        string
+	data       []byte
+	file       *goast.File
+	imports    map[string]string
+	dotImports []string
+}
+
+func extractGoGraph(ctx context.Context, root string, module goModule, sources []goSourceFile) ([]SymbolNode, []CallEdge, error) {
+	fset := token.NewFileSet()
+	packages := make(map[string]*goPackage)
+	for _, source := range sources {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
+		parsed, err := parser.ParseFile(fset, source.path, source.data, parser.ParseComments|parser.AllErrors)
+		if err != nil {
+			return nil, nil, fmt.Errorf("rag/ast: parse Go file %q: %w", source.rel, err)
+		}
+		dir := filepath.Dir(source.absPath)
+		key := dir + "\x00" + parsed.Name.Name
+		pkg := packages[key]
+		if pkg == nil {
+			pkg = &goPackage{
+				name:      parsed.Name.Name,
+				namespace: goNamespaceForPackage(root, dir, parsed.Name.Name, module),
+				dir:       dir,
+			}
+			packages[key] = pkg
+		}
+		pkg.files = append(pkg.files, &goParsedFile{
+			path: source.path,
+			rel:  source.rel,
+			data: source.data,
+			file: parsed,
+		})
+	}
+
+	pkgs := sortedGoPackages(packages)
+	packageNames := make(map[string]string, len(pkgs))
+	for _, pkg := range pkgs {
+		packageNames[pkg.namespace] = pkg.name
+	}
+	for _, pkg := range pkgs {
+		sort.Slice(pkg.files, func(i, j int) bool {
+			return pkg.files[i].rel < pkg.files[j].rel
+		})
+		for _, file := range pkg.files {
+			file.imports, file.dotImports = goFileImports(file.file, packageNames)
+		}
+	}
+
+	index := newGoSymbolIndex()
+	var (
+		nodes []SymbolNode
+		funcs []goFuncSymbol
+	)
+	for _, pkg := range pkgs {
+		for _, file := range pkg.files {
+			for _, decl := range file.file.Decls {
+				switch decl := decl.(type) {
+				case *goast.FuncDecl:
+					node := goFuncNode(fset, pkg, file, decl)
+					nodes = append(nodes, node)
+					index.addNode(node, goFuncReturnType(pkg, file, decl))
+					funcs = append(funcs, goFuncSymbol{
+						pkg:  pkg,
+						file: file,
+						decl: decl,
+						id:   node.ID,
+					})
+				case *goast.GenDecl:
+					for _, node := range goGenDeclNodes(fset, pkg, file, decl) {
+						nodes = append(nodes, node)
+						index.addNode(node, goTypeRef{})
+					}
+				}
+			}
+		}
+	}
+
+	calls := extractGoCalls(fset, index, funcs)
+	sortGoNodes(nodes)
+	sortGoCalls(calls)
+	return nodes, calls, nil
+}
+
+func sortedGoPackages(packages map[string]*goPackage) []*goPackage {
+	out := make([]*goPackage, 0, len(packages))
+	for _, pkg := range packages {
+		out = append(out, pkg)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].namespace != out[j].namespace {
+			return out[i].namespace < out[j].namespace
+		}
+		if out[i].name != out[j].name {
+			return out[i].name < out[j].name
+		}
+		return out[i].dir < out[j].dir
+	})
+	return out
+}
+
+func goNamespaceForPackage(root string, dir string, packageName string, module goModule) string {
+	base := ""
+	absDir, err := filepath.Abs(dir)
+	if err == nil && module.found {
+		if rel, err := filepath.Rel(module.root, absDir); err == nil && relWithinRoot(rel) {
+			rel = canonicalRelPath(rel)
+			if rel == "." {
+				base = module.path
+			} else {
+				base = path.Join(module.path, rel)
+			}
+		}
+	}
+	if base == "" {
+		absRoot, rootErr := filepath.Abs(filepath.Clean(root))
+		if err == nil && rootErr == nil {
+			if rel, relErr := filepath.Rel(absRoot, absDir); relErr == nil && relWithinRoot(rel) {
+				rel = canonicalRelPath(rel)
+				if rel == "." {
+					base = packageName
+				} else {
+					base = rel
+				}
+			}
+		}
+	}
+	if base == "" {
+		base = packageName
+	}
+	if strings.HasSuffix(packageName, "_test") && base != packageName {
+		return base + "_test"
+	}
+	return base
+}
+
+func relWithinRoot(rel string) bool {
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func goFileImports(file *goast.File, packageNames map[string]string) (map[string]string, []string) {
+	imports := make(map[string]string)
+	var dotImports []string
+	for _, spec := range file.Imports {
+		importPath, err := strconv.Unquote(spec.Path.Value)
+		if err != nil || importPath == "" {
+			continue
+		}
+		if spec.Name != nil {
+			switch spec.Name.Name {
+			case "_":
+				continue
+			case ".":
+				dotImports = append(dotImports, importPath)
+			default:
+				imports[spec.Name.Name] = importPath
+			}
+			continue
+		}
+		alias := packageNames[importPath]
+		if alias == "" {
+			alias = path.Base(importPath)
+		}
+		if alias != "." && alias != "" {
+			imports[alias] = importPath
+		}
+	}
+	sort.Strings(dotImports)
+	return imports, dotImports
+}
+
+func goFuncNode(fset *token.FileSet, pkg *goPackage, file *goParsedFile, decl *goast.FuncDecl) SymbolNode {
+	kind := SymbolKindFunction
+	receiver := ""
+	if decl.Recv != nil && len(decl.Recv.List) > 0 {
+		kind = SymbolKindMethod
+		receiver = goReceiverName(decl.Recv.List[0].Type)
+	}
+	id := SymbolID(SymbolKey{
+		Language:  goLanguage,
+		Kind:      kind,
+		Namespace: pkg.namespace,
+		Receiver:  receiver,
+		Name:      decl.Name.Name,
+	})
+	return SymbolNode{
+		ID:          id,
+		Language:    goLanguage,
+		Kind:        kind,
+		Namespace:   pkg.namespace,
+		Name:        decl.Name.Name,
+		Receiver:    receiver,
+		File:        file.rel,
+		StartLine:   goLine(fset, decl.Pos()),
+		EndLine:     goLine(fset, decl.End()),
+		Declaration: goFuncDeclaration(fset, decl),
+		Doc:         rawGoComment(fset, file.data, decl.Doc),
+	}
+}
+
+func goGenDeclNodes(fset *token.FileSet, pkg *goPackage, file *goParsedFile, decl *goast.GenDecl) []SymbolNode {
+	switch decl.Tok {
+	case token.TYPE:
+		nodes := make([]SymbolNode, 0, len(decl.Specs))
+		for _, spec := range decl.Specs {
+			typeSpec, ok := spec.(*goast.TypeSpec)
+			if !ok {
+				continue
+			}
+			kind := goTypeSymbolKind(typeSpec)
+			id := SymbolID(SymbolKey{
+				Language:  goLanguage,
+				Kind:      kind,
+				Namespace: pkg.namespace,
+				Name:      typeSpec.Name.Name,
+			})
+			doc := typeSpec.Doc
+			if doc == nil {
+				doc = decl.Doc
+			}
+			nodes = append(nodes, SymbolNode{
+				ID:          id,
+				Language:    goLanguage,
+				Kind:        kind,
+				Namespace:   pkg.namespace,
+				Name:        typeSpec.Name.Name,
+				File:        file.rel,
+				StartLine:   goLine(fset, typeSpec.Pos()),
+				EndLine:     goLine(fset, typeSpec.End()),
+				Declaration: goSpecDeclaration(fset, token.TYPE, typeSpec),
+				Doc:         rawGoComment(fset, file.data, doc),
+			})
+		}
+		return nodes
+	case token.VAR, token.CONST:
+		var nodes []SymbolNode
+		kind := SymbolKindVar
+		if decl.Tok == token.CONST {
+			kind = SymbolKindConst
+		}
+		for _, spec := range decl.Specs {
+			valueSpec, ok := spec.(*goast.ValueSpec)
+			if !ok {
+				continue
+			}
+			doc := valueSpec.Doc
+			if doc == nil {
+				doc = decl.Doc
+			}
+			for _, name := range valueSpec.Names {
+				id := SymbolID(SymbolKey{
+					Language:  goLanguage,
+					Kind:      kind,
+					Namespace: pkg.namespace,
+					Name:      name.Name,
+				})
+				nodes = append(nodes, SymbolNode{
+					ID:          id,
+					Language:    goLanguage,
+					Kind:        kind,
+					Namespace:   pkg.namespace,
+					Name:        name.Name,
+					File:        file.rel,
+					StartLine:   goLine(fset, valueSpec.Pos()),
+					EndLine:     goLine(fset, valueSpec.End()),
+					Declaration: goSpecDeclaration(fset, decl.Tok, valueSpec),
+					Doc:         rawGoComment(fset, file.data, doc),
+				})
+			}
+		}
+		return nodes
+	default:
+		return nil
+	}
+}
+
+func goTypeSymbolKind(spec *goast.TypeSpec) SymbolKind {
+	switch spec.Type.(type) {
+	case *goast.StructType:
+		return SymbolKindStruct
+	case *goast.InterfaceType:
+		return SymbolKindInterface
+	default:
+		return SymbolKindType
+	}
+}
+
+func goFuncDeclaration(fset *token.FileSet, decl *goast.FuncDecl) string {
+	clone := *decl
+	clone.Doc = nil
+	clone.Body = nil
+	return goFormatNode(fset, &clone)
+}
+
+func goSpecDeclaration(fset *token.FileSet, tok token.Token, spec goast.Spec) string {
+	switch spec := spec.(type) {
+	case *goast.TypeSpec:
+		clone := *spec
+		clone.Doc = nil
+		clone.Comment = nil
+		return goFormatNode(fset, &goast.GenDecl{Tok: tok, Specs: []goast.Spec{&clone}})
+	case *goast.ValueSpec:
+		clone := *spec
+		clone.Doc = nil
+		clone.Comment = nil
+		return goFormatNode(fset, &goast.GenDecl{Tok: tok, Specs: []goast.Spec{&clone}})
+	default:
+		return ""
+	}
+}
+
+func rawGoComment(fset *token.FileSet, source []byte, group *goast.CommentGroup) string {
+	if group == nil {
+		return ""
+	}
+	start := fset.PositionFor(group.Pos(), false).Offset
+	end := fset.PositionFor(group.End(), false).Offset
+	if start >= 0 && end >= start && end <= len(source) {
+		return string(source[start:end])
+	}
+	return strings.TrimRight(group.Text(), "\n")
+}
+
+func goLine(fset *token.FileSet, pos token.Pos) int {
+	if !pos.IsValid() {
+		return 0
+	}
+	return fset.PositionFor(pos, false).Line
+}
+
+func goFormatNode(fset *token.FileSet, node any) string {
+	var buf bytes.Buffer
+	if err := format.Node(&buf, fset, node); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(buf.String())
+}
+
+type goFuncSymbol struct {
+	pkg  *goPackage
+	file *goParsedFile
+	decl *goast.FuncDecl
+	id   string
+}
+
+type goTypeRef struct {
+	namespace string
+	name      string
+}
+
+func (r goTypeRef) valid() bool {
+	return r.namespace != "" && r.name != ""
+}
+
+type goSymbolIndex struct {
+	functions map[string]map[string]string
+	methods   map[string]map[string]map[string]string
+	types     map[string]map[string]string
+	returns   map[string]goTypeRef
+}
+
+func newGoSymbolIndex() *goSymbolIndex {
+	return &goSymbolIndex{
+		functions: make(map[string]map[string]string),
+		methods:   make(map[string]map[string]map[string]string),
+		types:     make(map[string]map[string]string),
+		returns:   make(map[string]goTypeRef),
+	}
+}
+
+func (idx *goSymbolIndex) addNode(node SymbolNode, returnType goTypeRef) {
+	switch node.Kind {
+	case SymbolKindFunction:
+		if idx.functions[node.Namespace] == nil {
+			idx.functions[node.Namespace] = make(map[string]string)
+		}
+		idx.functions[node.Namespace][node.Name] = node.ID
+	case SymbolKindMethod:
+		if idx.methods[node.Namespace] == nil {
+			idx.methods[node.Namespace] = make(map[string]map[string]string)
+		}
+		if idx.methods[node.Namespace][node.Receiver] == nil {
+			idx.methods[node.Namespace][node.Receiver] = make(map[string]string)
+		}
+		idx.methods[node.Namespace][node.Receiver][node.Name] = node.ID
+	case SymbolKindStruct, SymbolKindInterface, SymbolKindType:
+		if idx.types[node.Namespace] == nil {
+			idx.types[node.Namespace] = make(map[string]string)
+		}
+		idx.types[node.Namespace][node.Name] = node.ID
+	}
+	if returnType.valid() {
+		idx.returns[node.ID] = returnType
+	}
+}
+
+func (idx *goSymbolIndex) function(namespace string, name string) string {
+	if byName := idx.functions[namespace]; byName != nil {
+		return byName[name]
+	}
+	return ""
+}
+
+func (idx *goSymbolIndex) method(namespace string, receiver string, name string) string {
+	if byReceiver := idx.methods[namespace]; byReceiver != nil {
+		if byName := byReceiver[receiver]; byName != nil {
+			return byName[name]
+		}
+	}
+	return ""
+}
+
+func (idx *goSymbolIndex) hasType(ref goTypeRef) bool {
+	if !ref.valid() {
+		return false
+	}
+	if byName := idx.types[ref.namespace]; byName != nil {
+		return byName[ref.name] != ""
+	}
+	return false
+}
+
+func extractGoCalls(fset *token.FileSet, index *goSymbolIndex, funcs []goFuncSymbol) []CallEdge {
+	var calls []CallEdge
+	for _, fn := range funcs {
+		if fn.decl.Body == nil {
+			continue
+		}
+		scope := collectGoCallScope(index, fn.pkg, fn.file, fn.decl)
+		goast.Inspect(fn.decl.Body, func(node goast.Node) bool {
+			switch node := node.(type) {
+			case *goast.FuncLit:
+				return false
+			case *goast.CallExpr:
+				calleeID, resolution, record := index.resolveCall(fn.pkg, fn.file, scope, node.Fun)
+				if !record {
+					return true
+				}
+				calls = append(calls, CallEdge{
+					CallerID:   fn.id,
+					CalleeID:   calleeID,
+					CalleeRaw:  goFormatNode(fset, node.Fun),
+					Resolution: resolution,
+					File:       fn.file.rel,
+					Line:       goLine(fset, node.Fun.Pos()),
+				})
+			}
+			return true
+		})
+	}
+	return calls
+}
+
+type goCallScope struct {
+	vars map[string]goTypeRef
+}
+
+func collectGoCallScope(index *goSymbolIndex, pkg *goPackage, file *goParsedFile, decl *goast.FuncDecl) goCallScope {
+	scope := goCallScope{vars: make(map[string]goTypeRef)}
+	if decl.Recv != nil {
+		addGoFieldList(scope, pkg, file, decl.Recv)
+	}
+	addGoFieldList(scope, pkg, file, decl.Type.Params)
+	addGoFieldList(scope, pkg, file, decl.Type.Results)
+
+	goast.Inspect(decl.Body, func(node goast.Node) bool {
+		switch node := node.(type) {
+		case *goast.FuncLit:
+			return false
+		case *goast.DeclStmt:
+			gen, ok := node.Decl.(*goast.GenDecl)
+			if !ok || gen.Tok != token.VAR {
+				return true
+			}
+			for _, spec := range gen.Specs {
+				valueSpec, ok := spec.(*goast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for i, name := range valueSpec.Names {
+					if name.Name == "_" {
+						continue
+					}
+					ref := goTypeRef{}
+					if valueSpec.Type != nil {
+						ref = goTypeRefFromExpr(pkg, file, valueSpec.Type)
+					} else if i < len(valueSpec.Values) {
+						ref = goTypeRefFromValue(index, pkg, file, scope, valueSpec.Values[i])
+					}
+					if ref.valid() {
+						scope.vars[name.Name] = ref
+					}
+				}
+			}
+		case *goast.AssignStmt:
+			if node.Tok != token.DEFINE && node.Tok != token.ASSIGN {
+				return true
+			}
+			for i, lhs := range node.Lhs {
+				name, ok := lhs.(*goast.Ident)
+				if !ok || name.Name == "_" || i >= len(node.Rhs) {
+					continue
+				}
+				if ref := goTypeRefFromValue(index, pkg, file, scope, node.Rhs[i]); ref.valid() {
+					scope.vars[name.Name] = ref
+				}
+			}
+		}
+		return true
+	})
+	return scope
+}
+
+func addGoFieldList(scope goCallScope, pkg *goPackage, file *goParsedFile, fields *goast.FieldList) {
+	if fields == nil {
+		return
+	}
+	for _, field := range fields.List {
+		ref := goTypeRefFromExpr(pkg, file, field.Type)
+		if !ref.valid() {
+			continue
+		}
+		for _, name := range field.Names {
+			if name.Name != "_" {
+				scope.vars[name.Name] = ref
+			}
+		}
+	}
+}
+
+func (idx *goSymbolIndex) resolveCall(pkg *goPackage, file *goParsedFile, scope goCallScope, fun goast.Expr) (string, CallResolution, bool) {
+	base := unwrapGoInstantiation(fun)
+	switch expr := base.(type) {
+	case *goast.Ident:
+		if goBuiltinCall(expr.Name) || idx.hasType(goTypeRef{namespace: pkg.namespace, name: expr.Name}) {
+			return "", "", false
+		}
+		if calleeID := idx.function(pkg.namespace, expr.Name); calleeID != "" {
+			return calleeID, CallResolutionResolved, true
+		}
+		for _, namespace := range file.dotImports {
+			if calleeID := idx.function(namespace, expr.Name); calleeID != "" {
+				return calleeID, CallResolutionResolved, true
+			}
+		}
+		return "", CallResolutionUnresolved, true
+	case *goast.SelectorExpr:
+		if ident, ok := expr.X.(*goast.Ident); ok {
+			if ref, ok := scope.vars[ident.Name]; ok && ref.valid() {
+				if calleeID := idx.method(ref.namespace, ref.name, expr.Sel.Name); calleeID != "" {
+					return calleeID, CallResolutionResolved, true
+				}
+				return "", CallResolutionUnresolved, true
+			}
+			if namespace, ok := file.imports[ident.Name]; ok {
+				if idx.hasType(goTypeRef{namespace: namespace, name: expr.Sel.Name}) {
+					return "", "", false
+				}
+				if calleeID := idx.function(namespace, expr.Sel.Name); calleeID != "" {
+					return calleeID, CallResolutionResolved, true
+				}
+				return "", CallResolutionUnresolved, true
+			}
+		}
+		if ref := goTypeRefFromValue(idx, pkg, file, scope, expr.X); ref.valid() {
+			if calleeID := idx.method(ref.namespace, ref.name, expr.Sel.Name); calleeID != "" {
+				return calleeID, CallResolutionResolved, true
+			}
+		}
+		return "", CallResolutionUnresolved, true
+	case *goast.FuncLit:
+		return "", "", false
+	default:
+		return "", CallResolutionNotAttempted, true
+	}
+}
+
+func goFuncReturnType(pkg *goPackage, file *goParsedFile, decl *goast.FuncDecl) goTypeRef {
+	if decl.Type.Results == nil {
+		return goTypeRef{}
+	}
+	total := 0
+	var result goast.Expr
+	for _, field := range decl.Type.Results.List {
+		names := len(field.Names)
+		if names == 0 {
+			names = 1
+		}
+		total += names
+		if total == 1 {
+			result = field.Type
+		}
+	}
+	if total != 1 {
+		return goTypeRef{}
+	}
+	return goTypeRefFromExpr(pkg, file, result)
+}
+
+func goTypeRefFromValue(index *goSymbolIndex, pkg *goPackage, file *goParsedFile, scope goCallScope, expr goast.Expr) goTypeRef {
+	switch expr := expr.(type) {
+	case *goast.CompositeLit:
+		return goTypeRefFromExpr(pkg, file, expr.Type)
+	case *goast.UnaryExpr:
+		if expr.Op == token.AND {
+			return goTypeRefFromValue(index, pkg, file, scope, expr.X)
+		}
+	case *goast.CallExpr:
+		if ref := goTypeRefFromExpr(pkg, file, unwrapGoInstantiation(expr.Fun)); index.hasType(ref) {
+			return ref
+		}
+		calleeID, resolution, record := index.resolveCall(pkg, file, scope, expr.Fun)
+		if record && resolution == CallResolutionResolved {
+			return index.returns[calleeID]
+		}
+	}
+	return goTypeRef{}
+}
+
+func goTypeRefFromExpr(pkg *goPackage, file *goParsedFile, expr goast.Expr) goTypeRef {
+	expr = unwrapGoInstantiation(expr)
+	switch expr := expr.(type) {
+	case *goast.Ident:
+		if expr.Name == "" {
+			return goTypeRef{}
+		}
+		return goTypeRef{namespace: pkg.namespace, name: expr.Name}
+	case *goast.StarExpr:
+		return goTypeRefFromExpr(pkg, file, expr.X)
+	case *goast.ParenExpr:
+		return goTypeRefFromExpr(pkg, file, expr.X)
+	case *goast.SelectorExpr:
+		ident, ok := expr.X.(*goast.Ident)
+		if !ok {
+			return goTypeRef{}
+		}
+		namespace := file.imports[ident.Name]
+		if namespace == "" {
+			return goTypeRef{}
+		}
+		return goTypeRef{namespace: namespace, name: expr.Sel.Name}
+	default:
+		return goTypeRef{}
+	}
+}
+
+func unwrapGoInstantiation(expr goast.Expr) goast.Expr {
+	switch expr := expr.(type) {
+	case *goast.IndexExpr:
+		return unwrapGoInstantiation(expr.X)
+	case *goast.IndexListExpr:
+		return unwrapGoInstantiation(expr.X)
+	case *goast.ParenExpr:
+		return unwrapGoInstantiation(expr.X)
+	default:
+		return expr
+	}
+}
+
+func goReceiverName(expr goast.Expr) string {
+	ref := goReceiverBase(expr)
+	if ref == "" {
+		return goFormatNode(token.NewFileSet(), expr)
+	}
+	return ref
+}
+
+func goReceiverBase(expr goast.Expr) string {
+	switch expr := unwrapGoInstantiation(expr).(type) {
+	case *goast.Ident:
+		return expr.Name
+	case *goast.StarExpr:
+		return goReceiverBase(expr.X)
+	case *goast.ParenExpr:
+		return goReceiverBase(expr.X)
+	case *goast.SelectorExpr:
+		return expr.Sel.Name
+	default:
+		return ""
+	}
+}
+
+func goBuiltinCall(name string) bool {
+	switch name {
+	case "append", "cap", "clear", "close", "complex", "copy", "delete",
+		"imag", "len", "make", "max", "min", "new", "panic", "print",
+		"println", "real", "recover":
+		return true
+	default:
+		return false
+	}
+}
+
+func sortGoNodes(nodes []SymbolNode) {
+	sort.Slice(nodes, func(i, j int) bool {
+		if nodes[i].File != nodes[j].File {
+			return nodes[i].File < nodes[j].File
+		}
+		if nodes[i].StartLine != nodes[j].StartLine {
+			return nodes[i].StartLine < nodes[j].StartLine
+		}
+		if nodes[i].EndLine != nodes[j].EndLine {
+			return nodes[i].EndLine < nodes[j].EndLine
+		}
+		if nodes[i].Kind != nodes[j].Kind {
+			return nodes[i].Kind < nodes[j].Kind
+		}
+		if nodes[i].Receiver != nodes[j].Receiver {
+			return nodes[i].Receiver < nodes[j].Receiver
+		}
+		if nodes[i].Name != nodes[j].Name {
+			return nodes[i].Name < nodes[j].Name
+		}
+		return nodes[i].ID < nodes[j].ID
+	})
+}
+
+func sortGoCalls(calls []CallEdge) {
+	sort.Slice(calls, func(i, j int) bool {
+		if calls[i].File != calls[j].File {
+			return calls[i].File < calls[j].File
+		}
+		if calls[i].Line != calls[j].Line {
+			return calls[i].Line < calls[j].Line
+		}
+		if calls[i].CallerID != calls[j].CallerID {
+			return calls[i].CallerID < calls[j].CallerID
+		}
+		if calls[i].CalleeRaw != calls[j].CalleeRaw {
+			return calls[i].CalleeRaw < calls[j].CalleeRaw
+		}
+		return calls[i].CalleeID < calls[j].CalleeID
+	})
+}

--- a/rag/ast/go_extractor_test.go
+++ b/rag/ast/go_extractor_test.go
@@ -1,0 +1,329 @@
+package ast
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var _ Extractor = GoExtractor{}
+
+func TestGoExtractorEmptyTreeAndStale(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	extractor := GoExtractor{}
+
+	if got := extractor.Languages(); len(got) != 1 || got[0] != "go" {
+		t.Fatalf("Languages() = %v, want [go]", got)
+	}
+	graph, err := extractor.Extract(ctx, "scope-1", root, "vsid-1")
+	if err != nil {
+		t.Fatalf("Extract empty tree: %v", err)
+	}
+	if graph.Scope != "scope-1" || graph.VectorSpaceID != "vsid-1" {
+		t.Fatalf("graph scope/vsid = %q/%q, want scope-1/vsid-1", graph.Scope, graph.VectorSpaceID)
+	}
+	if graph.Root != filepath.ToSlash(filepath.Clean(root)) {
+		t.Fatalf("graph root = %q, want canonical temp root", graph.Root)
+	}
+	if graph.ExtractionSignature == "" {
+		t.Fatal("empty tree signature is empty")
+	}
+	if len(graph.Nodes) != 0 || len(graph.Calls) != 0 {
+		t.Fatalf("empty tree graph produced nodes=%d calls=%d", len(graph.Nodes), len(graph.Calls))
+	}
+
+	stale, err := extractor.Stale(ctx, "scope-1", root, graph.ExtractionSignature)
+	if err != nil {
+		t.Fatalf("Stale: %v", err)
+	}
+	if stale {
+		t.Fatal("Stale returned true for unchanged empty tree")
+	}
+	stale, err = extractor.Stale(ctx, "other-scope", root, graph.ExtractionSignature)
+	if err != nil {
+		t.Fatalf("Stale with other scope: %v", err)
+	}
+	if !stale {
+		t.Fatal("Stale returned false for mismatched scope")
+	}
+	stale, err = extractor.Stale(ctx, "scope-1", root, "not-a-go-signature")
+	if err != nil {
+		t.Fatalf("Stale with bad signature: %v", err)
+	}
+	if !stale {
+		t.Fatal("Stale returned false for malformed signature")
+	}
+}
+
+func TestGoExtractorExtractsSymbolsAndCalls(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	writeTestFile(t, root, "go.mod", "module example.com/demo\n\ngo 1.25\n")
+	writeTestFile(t, root, "internal/util/util.go", `package util
+
+type Client struct{}
+
+func Helper() {}
+
+func (c Client) Do() {}
+`)
+	writeTestFile(t, root, "app/service.go", `package app
+
+import (
+	"fmt"
+
+	"example.com/demo/internal/util"
+)
+
+const Answer = 42
+
+var Default = Service{}
+
+// Service handles work.
+type Service struct{}
+
+type Runner interface {
+	Run()
+}
+
+type Alias string
+
+func NewService() *Service {
+	return &Service{}
+}
+
+func Local() {}
+
+func Top() {
+	Local()
+	s := Service{}
+	s.Handle()
+	util.Helper()
+	client := util.Client{}
+	client.Do()
+	made := NewService()
+	made.Handle()
+	fmt.Println(Answer)
+	_ = len([]int{1})
+}
+
+func (s *Service) Handle() {
+	Local()
+	util.Helper()
+}
+`)
+
+	graph, err := GoExtractor{}.Extract(ctx, "scope-1", root, "vsid-1")
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if graph.Scope != "scope-1" || graph.VectorSpaceID != "vsid-1" || graph.ExtractionSignature == "" {
+		t.Fatalf("graph metadata not stamped correctly: %+v", graph)
+	}
+
+	appNS := "example.com/demo/app"
+	utilNS := "example.com/demo/internal/util"
+	wantNodes := []SymbolNode{
+		{Kind: SymbolKindConst, Namespace: appNS, Name: "Answer", File: "app/service.go"},
+		{Kind: SymbolKindVar, Namespace: appNS, Name: "Default", File: "app/service.go"},
+		{Kind: SymbolKindStruct, Namespace: appNS, Name: "Service", File: "app/service.go"},
+		{Kind: SymbolKindInterface, Namespace: appNS, Name: "Runner", File: "app/service.go"},
+		{Kind: SymbolKindType, Namespace: appNS, Name: "Alias", File: "app/service.go"},
+		{Kind: SymbolKindFunction, Namespace: appNS, Name: "NewService", File: "app/service.go"},
+		{Kind: SymbolKindFunction, Namespace: appNS, Name: "Local", File: "app/service.go"},
+		{Kind: SymbolKindFunction, Namespace: appNS, Name: "Top", File: "app/service.go"},
+		{Kind: SymbolKindMethod, Namespace: appNS, Receiver: "Service", Name: "Handle", File: "app/service.go"},
+		{Kind: SymbolKindStruct, Namespace: utilNS, Name: "Client", File: "internal/util/util.go"},
+		{Kind: SymbolKindFunction, Namespace: utilNS, Name: "Helper", File: "internal/util/util.go"},
+		{Kind: SymbolKindMethod, Namespace: utilNS, Receiver: "Client", Name: "Do", File: "internal/util/util.go"},
+	}
+	if len(graph.Nodes) != len(wantNodes) {
+		t.Fatalf("node count = %d, want %d: %+v", len(graph.Nodes), len(wantNodes), graph.Nodes)
+	}
+
+	nodes := make(map[string]SymbolNode, len(graph.Nodes))
+	for _, node := range graph.Nodes {
+		if node.Language != "go" {
+			t.Fatalf("node %s language = %q, want go", node.Name, node.Language)
+		}
+		if node.StartLine < 1 || node.EndLine < node.StartLine {
+			t.Fatalf("node %s has invalid line range [%d,%d]", node.Name, node.StartLine, node.EndLine)
+		}
+		nodes[node.ID] = node
+	}
+	for _, want := range wantNodes {
+		id := SymbolID(SymbolKey{
+			Language:  "go",
+			Kind:      want.Kind,
+			Namespace: want.Namespace,
+			Receiver:  want.Receiver,
+			Name:      want.Name,
+		})
+		got, ok := nodes[id]
+		if !ok {
+			t.Fatalf("missing node %s/%s/%s", want.Namespace, want.Receiver, want.Name)
+		}
+		if got.File != want.File {
+			t.Fatalf("node %s file = %q, want %q", want.Name, got.File, want.File)
+		}
+		if got.Declaration == "" {
+			t.Fatalf("node %s declaration is empty", want.Name)
+		}
+	}
+
+	service := nodes[SymbolID(SymbolKey{Language: "go", Kind: SymbolKindStruct, Namespace: appNS, Name: "Service"})]
+	if service.Doc != "// Service handles work." {
+		t.Fatalf("Service doc = %q, want raw comment", service.Doc)
+	}
+	handle := nodes[SymbolID(SymbolKey{Language: "go", Kind: SymbolKindMethod, Namespace: appNS, Receiver: "Service", Name: "Handle"})]
+	if !strings.HasPrefix(handle.Declaration, "func (s *Service) Handle()") {
+		t.Fatalf("Handle declaration = %q", handle.Declaration)
+	}
+
+	topID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: appNS, Name: "Top"})
+	handleID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindMethod, Namespace: appNS, Receiver: "Service", Name: "Handle"})
+	localID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: appNS, Name: "Local"})
+	helperID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: utilNS, Name: "Helper"})
+	utilDoID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindMethod, Namespace: utilNS, Receiver: "Client", Name: "Do"})
+	newServiceID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: appNS, Name: "NewService"})
+
+	wantCalls := []CallEdge{
+		{CallerID: topID, CalleeRaw: "Local", Resolution: CallResolutionResolved, CalleeID: localID},
+		{CallerID: topID, CalleeRaw: "s.Handle", Resolution: CallResolutionResolved, CalleeID: handleID},
+		{CallerID: topID, CalleeRaw: "util.Helper", Resolution: CallResolutionResolved, CalleeID: helperID},
+		{CallerID: topID, CalleeRaw: "client.Do", Resolution: CallResolutionResolved, CalleeID: utilDoID},
+		{CallerID: topID, CalleeRaw: "NewService", Resolution: CallResolutionResolved, CalleeID: newServiceID},
+		{CallerID: topID, CalleeRaw: "made.Handle", Resolution: CallResolutionResolved, CalleeID: handleID},
+		{CallerID: topID, CalleeRaw: "fmt.Println", Resolution: CallResolutionUnresolved},
+		{CallerID: handleID, CalleeRaw: "Local", Resolution: CallResolutionResolved, CalleeID: localID},
+		{CallerID: handleID, CalleeRaw: "util.Helper", Resolution: CallResolutionResolved, CalleeID: helperID},
+	}
+	if len(graph.Calls) != len(wantCalls) {
+		t.Fatalf("call count = %d, want %d: %+v", len(graph.Calls), len(wantCalls), graph.Calls)
+	}
+	for _, edge := range graph.Calls {
+		if err := edge.Validate(); err != nil {
+			t.Fatalf("invalid edge %+v: %v", edge, err)
+		}
+		if edge.File != "app/service.go" {
+			t.Fatalf("edge file = %q, want app/service.go", edge.File)
+		}
+	}
+	for _, want := range wantCalls {
+		got, ok := findCall(graph.Calls, want.CallerID, want.CalleeRaw)
+		if !ok {
+			t.Fatalf("missing call caller=%q raw=%q", want.CallerID, want.CalleeRaw)
+		}
+		if got.Resolution != want.Resolution || got.CalleeID != want.CalleeID {
+			t.Fatalf("call %q resolution/id = %q/%q, want %q/%q",
+				want.CalleeRaw, got.Resolution, got.CalleeID, want.Resolution, want.CalleeID)
+		}
+	}
+}
+
+func TestGoExtractorStaleTracksSourceAndVectorSpace(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	goModPath := writeTestFile(t, root, "go.mod", "module example.com/stale\n\ngo 1.25\n")
+	sourcePath := writeTestFile(t, root, "pkg/pkg.go", "package pkg\n\nfunc A() {}\n")
+
+	extractor := GoExtractor{}
+	graph, err := extractor.Extract(ctx, "scope-1", root, "vsid-1")
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	stale, err := extractor.Stale(ctx, "scope-1", root, graph.ExtractionSignature)
+	if err != nil {
+		t.Fatalf("Stale unchanged: %v", err)
+	}
+	if stale {
+		t.Fatal("Stale returned true before source changed")
+	}
+
+	nextGraph, err := extractor.Extract(ctx, "scope-1", root, "vsid-2")
+	if err != nil {
+		t.Fatalf("Extract with new vsid: %v", err)
+	}
+	if nextGraph.ExtractionSignature == graph.ExtractionSignature {
+		t.Fatal("signature did not change when vectorSpaceID changed")
+	}
+
+	if err := os.WriteFile(goModPath, []byte("module example.com/stale2\n\ngo 1.25\n"), 0o644); err != nil {
+		t.Fatalf("modify go.mod: %v", err)
+	}
+	stale, err = extractor.Stale(ctx, "scope-1", root, graph.ExtractionSignature)
+	if err != nil {
+		t.Fatalf("Stale after module change: %v", err)
+	}
+	if !stale {
+		t.Fatal("Stale returned false after module path changed")
+	}
+	if err := os.WriteFile(goModPath, []byte("module example.com/stale\n\ngo 1.25\n"), 0o644); err != nil {
+		t.Fatalf("restore go.mod: %v", err)
+	}
+
+	if err := os.WriteFile(sourcePath, []byte("package pkg\n\nfunc A() {}\nfunc B() {}\n"), 0o644); err != nil {
+		t.Fatalf("modify source: %v", err)
+	}
+	stale, err = extractor.Stale(ctx, "scope-1", root, graph.ExtractionSignature)
+	if err != nil {
+		t.Fatalf("Stale after source change: %v", err)
+	}
+	if !stale {
+		t.Fatal("Stale returned false after source changed")
+	}
+}
+
+func TestGoExtractorReturnsParseErrors(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "broken.go", "package broken\n\nfunc Broken( {\n")
+
+	_, err := GoExtractor{}.Extract(context.Background(), "scope-1", root, "vsid-1")
+	if err == nil {
+		t.Fatal("Extract returned nil error for invalid Go source")
+	}
+	if !strings.Contains(err.Error(), "parse Go file") {
+		t.Fatalf("parse error = %v, want parse Go file context", err)
+	}
+}
+
+func writeTestFile(t *testing.T, root string, rel string, content string) string {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create dir for %s: %v", rel, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+	return path
+}
+
+func findCall(calls []CallEdge, callerID string, raw string) (CallEdge, bool) {
+	for _, call := range calls {
+		if call.CallerID == callerID && call.CalleeRaw == raw {
+			return call, true
+		}
+	}
+	return CallEdge{}, false
+}
+
+func TestGoExtractorStaleMissingRootReturnsError(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "missing")
+	signature := encodeGoExtractionSignature(goExtractionSignature{
+		Version: goExtractorVersion,
+		Scope:   "scope-1",
+		Root:    filepath.ToSlash(filepath.Clean(root)),
+	})
+	_, err := GoExtractor{}.Stale(context.Background(), "scope-1", root, signature)
+	if err == nil {
+		t.Fatal("Stale returned nil error for missing root")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Stale missing root error = %v, want os.ErrNotExist", err)
+	}
+}

--- a/rag/ast/go_extractor_test.go
+++ b/rag/ast/go_extractor_test.go
@@ -302,6 +302,56 @@ func Use(w Worker) {
 	}
 }
 
+func TestGoExtractorInfersRangeVarsAndFirstReturnType(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	writeTestFile(t, root, "go.mod", "module example.com/range\n\ngo 1.25\n")
+	writeTestFile(t, root, "range.go", `package rangevars
+
+type Client struct{}
+
+func (Client) Do() {}
+
+func NewClient() (Client, error) {
+	return Client{}, nil
+}
+
+func Use(clients []Client) {
+	for _, c := range clients {
+		c.Do()
+	}
+	made, err := NewClient()
+	_ = err
+	made.Do()
+}
+`)
+
+	graph, err := GoExtractor{}.Extract(ctx, "scope-1", root, "vsid-1")
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	ns := "example.com/range"
+	useID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: ns, Name: "Use"})
+	doID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindMethod, Namespace: ns, Receiver: "Client", Name: "Do"})
+	newClientID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: ns, Name: "NewClient"})
+
+	wantCalls := []CallEdge{
+		{CallerID: useID, CalleeRaw: "c.Do", Resolution: CallResolutionResolved, CalleeID: doID},
+		{CallerID: useID, CalleeRaw: "NewClient", Resolution: CallResolutionResolved, CalleeID: newClientID},
+		{CallerID: useID, CalleeRaw: "made.Do", Resolution: CallResolutionResolved, CalleeID: doID},
+	}
+	for _, want := range wantCalls {
+		got, ok := findCall(graph.Calls, want.CallerID, want.CalleeRaw)
+		if !ok {
+			t.Fatalf("missing call caller=%q raw=%q; calls=%+v", want.CallerID, want.CalleeRaw, graph.Calls)
+		}
+		if got.Resolution != want.Resolution || got.CalleeID != want.CalleeID {
+			t.Fatalf("call %q resolution/id = %q/%q, want %q/%q",
+				want.CalleeRaw, got.Resolution, got.CalleeID, want.Resolution, want.CalleeID)
+		}
+	}
+}
+
 func TestGoExtractorStaleTracksSourceAndVectorSpace(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()

--- a/rag/ast/go_extractor_test.go
+++ b/rag/ast/go_extractor_test.go
@@ -108,6 +108,8 @@ func Top() {
 	made := NewService()
 	made.Handle()
 	fmt.Println(Answer)
+	_ = int(Answer)
+	_ = string([]byte{'x'})
 	_ = len([]int{1})
 }
 

--- a/rag/ast/go_extractor_test.go
+++ b/rag/ast/go_extractor_test.go
@@ -316,8 +316,15 @@ func NewClient() (Client, error) {
 	return Client{}, nil
 }
 
+func NewClients() []Client {
+	return nil
+}
+
 func Use(clients []Client) {
 	for _, c := range clients {
+		c.Do()
+	}
+	for _, c := range NewClients() {
 		c.Do()
 	}
 	made, err := NewClient()
@@ -334,9 +341,10 @@ func Use(clients []Client) {
 	useID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: ns, Name: "Use"})
 	doID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindMethod, Namespace: ns, Receiver: "Client", Name: "Do"})
 	newClientID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: ns, Name: "NewClient"})
+	newClientsID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: ns, Name: "NewClients"})
 
 	wantCalls := []CallEdge{
-		{CallerID: useID, CalleeRaw: "c.Do", Resolution: CallResolutionResolved, CalleeID: doID},
+		{CallerID: useID, CalleeRaw: "NewClients", Resolution: CallResolutionResolved, CalleeID: newClientsID},
 		{CallerID: useID, CalleeRaw: "NewClient", Resolution: CallResolutionResolved, CalleeID: newClientID},
 		{CallerID: useID, CalleeRaw: "made.Do", Resolution: CallResolutionResolved, CalleeID: doID},
 	}
@@ -349,6 +357,64 @@ func Use(clients []Client) {
 			t.Fatalf("call %q resolution/id = %q/%q, want %q/%q",
 				want.CalleeRaw, got.Resolution, got.CalleeID, want.Resolution, want.CalleeID)
 		}
+	}
+	var rangeCalls int
+	for _, call := range graph.Calls {
+		if call.CallerID == useID && call.CalleeRaw == "c.Do" {
+			if call.Resolution != CallResolutionResolved || call.CalleeID != doID {
+				t.Fatalf("c.Do call = %+v, want resolved Client.Do", call)
+			}
+			rangeCalls++
+		}
+	}
+	if rangeCalls != 2 {
+		t.Fatalf("resolved c.Do range calls = %d, want 2; calls=%+v", rangeCalls, graph.Calls)
+	}
+}
+
+func TestGoExtractorTraversesFunctionLiterals(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	writeTestFile(t, root, "go.mod", "module example.com/closures\n\ngo 1.25\n")
+	writeTestFile(t, root, "closures.go", `package closures
+
+func Local() {}
+
+func Use() {
+	go func() {
+		Local()
+	}()
+	defer func() {
+		Local()
+	}()
+}
+`)
+
+	graph, err := GoExtractor{}.Extract(ctx, "scope-1", root, "vsid-1")
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	ns := "example.com/closures"
+	useID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: ns, Name: "Use"})
+	localID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: ns, Name: "Local"})
+
+	var localCalls int
+	for _, call := range graph.Calls {
+		if call.CallerID == useID && call.CalleeRaw == "Local" {
+			if call.Resolution != CallResolutionResolved || call.CalleeID != localID {
+				t.Fatalf("Local call = %+v, want resolved Local", call)
+			}
+			localCalls++
+		}
+	}
+	if localCalls != 2 {
+		t.Fatalf("Local calls from closures = %d, want 2; calls=%+v", localCalls, graph.Calls)
+	}
+}
+
+func TestGoImportedPackageNameUsesPackageClause(t *testing.T) {
+	if got := goImportedPackageName("math/rand/v2"); got != "rand" {
+		t.Fatalf("goImportedPackageName(math/rand/v2) = %q, want rand", got)
 	}
 }
 

--- a/rag/ast/go_extractor_test.go
+++ b/rag/ast/go_extractor_test.go
@@ -450,6 +450,8 @@ func Use(v any) {
 	b.Do()
 	c := v.(Client)
 	c.Do()
+	var _, declared = Pair()
+	declared.Do()
 	_, paired := Pair()
 	paired.Do()
 	switch narrowed := v.(type) {
@@ -472,6 +474,7 @@ func Use(v any) {
 		{CallerID: useID, CalleeRaw: "b.Do", Resolution: CallResolutionResolved, CalleeID: doID},
 		{CallerID: useID, CalleeRaw: "c.Do", Resolution: CallResolutionResolved, CalleeID: doID},
 		{CallerID: useID, CalleeRaw: "Pair", Resolution: CallResolutionResolved, CalleeID: pairID},
+		{CallerID: useID, CalleeRaw: "declared.Do", Resolution: CallResolutionResolved, CalleeID: doID},
 		{CallerID: useID, CalleeRaw: "paired.Do", Resolution: CallResolutionResolved, CalleeID: doID},
 		{CallerID: useID, CalleeRaw: "narrowed.Do", Resolution: CallResolutionResolved, CalleeID: doID},
 	}
@@ -484,6 +487,51 @@ func Use(v any) {
 			t.Fatalf("call %q resolution/id = %q/%q, want %q/%q",
 				want.CalleeRaw, got.Resolution, got.CalleeID, want.Resolution, want.CalleeID)
 		}
+	}
+}
+
+func TestGoExtractorResolvesShadowedPredeclaredFunctions(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	writeTestFile(t, root, "go.mod", "module example.com/predeclared\n\ngo 1.25\n")
+	writeTestFile(t, root, "predeclared.go", `package predeclared
+
+func len() {}
+
+func string() {}
+
+func Use() {
+	len()
+	string()
+	cap([]int{})
+}
+`)
+
+	graph, err := GoExtractor{}.Extract(ctx, "scope-1", root, "vsid-1")
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	ns := "example.com/predeclared"
+	useID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: ns, Name: "Use"})
+	lenID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: ns, Name: "len"})
+	stringID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: ns, Name: "string"})
+
+	wantCalls := []CallEdge{
+		{CallerID: useID, CalleeRaw: "len", Resolution: CallResolutionResolved, CalleeID: lenID},
+		{CallerID: useID, CalleeRaw: "string", Resolution: CallResolutionResolved, CalleeID: stringID},
+	}
+	for _, want := range wantCalls {
+		got, ok := findCall(graph.Calls, want.CallerID, want.CalleeRaw)
+		if !ok {
+			t.Fatalf("missing call caller=%q raw=%q; calls=%+v", want.CallerID, want.CalleeRaw, graph.Calls)
+		}
+		if got.Resolution != want.Resolution || got.CalleeID != want.CalleeID {
+			t.Fatalf("call %q resolution/id = %q/%q, want %q/%q",
+				want.CalleeRaw, got.Resolution, got.CalleeID, want.Resolution, want.CalleeID)
+		}
+	}
+	if _, ok := findCall(graph.Calls, useID, "cap"); ok {
+		t.Fatalf("builtin cap recorded as call; calls=%+v", graph.Calls)
 	}
 }
 

--- a/rag/ast/go_extractor_test.go
+++ b/rag/ast/go_extractor_test.go
@@ -75,6 +75,7 @@ func (c Client) Do() {}
 
 import (
 	"fmt"
+	"time"
 
 	"example.com/demo/internal/util"
 )
@@ -110,6 +111,7 @@ func Top() {
 	fmt.Println(Answer)
 	_ = int(Answer)
 	_ = string([]byte{'x'})
+	_ = time.Duration(Answer)
 	_ = len([]int{1})
 }
 
@@ -249,6 +251,10 @@ func Use(w Worker) {
 	w.Work()
 	fresh := Impl{}
 	fresh.Work()
+	if true {
+		w := Impl{}
+		w.Work()
+	}
 }
 `)
 
@@ -260,6 +266,7 @@ func Use(w Worker) {
 	useID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: ns, Name: "Use"})
 	workID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindMethod, Namespace: ns, Receiver: "Impl", Name: "Work"})
 
+	var resolvedShadowCalls int
 	var unresolvedWorkerCalls int
 	for _, call := range graph.Calls {
 		if call.CallerID != useID {
@@ -267,10 +274,20 @@ func Use(w Worker) {
 		}
 		switch call.CalleeRaw {
 		case "w.Work":
-			if call.Resolution != CallResolutionUnresolved || call.CalleeID != "" {
-				t.Fatalf("w.Work call = %+v, want unresolved with no callee ID", call)
+			switch call.Resolution {
+			case CallResolutionUnresolved:
+				if call.CalleeID != "" {
+					t.Fatalf("unresolved w.Work call carried callee ID: %+v", call)
+				}
+				unresolvedWorkerCalls++
+			case CallResolutionResolved:
+				if call.CalleeID != workID {
+					t.Fatalf("resolved w.Work call = %+v, want Impl.Work", call)
+				}
+				resolvedShadowCalls++
+			default:
+				t.Fatalf("w.Work call = %+v, want resolved or unresolved", call)
 			}
-			unresolvedWorkerCalls++
 		case "fresh.Work":
 			if call.Resolution != CallResolutionResolved || call.CalleeID != workID {
 				t.Fatalf("fresh.Work call = %+v, want resolved Impl.Work", call)
@@ -279,6 +296,9 @@ func Use(w Worker) {
 	}
 	if unresolvedWorkerCalls != 2 {
 		t.Fatalf("unresolved w.Work calls = %d, want 2; calls=%+v", unresolvedWorkerCalls, graph.Calls)
+	}
+	if resolvedShadowCalls != 1 {
+		t.Fatalf("resolved shadowed w.Work calls = %d, want 1; calls=%+v", resolvedShadowCalls, graph.Calls)
 	}
 }
 

--- a/rag/ast/go_extractor_test.go
+++ b/rag/ast/go_extractor_test.go
@@ -378,15 +378,22 @@ func TestGoExtractorTraversesFunctionLiterals(t *testing.T) {
 	writeTestFile(t, root, "go.mod", "module example.com/closures\n\ngo 1.25\n")
 	writeTestFile(t, root, "closures.go", `package closures
 
+type Client struct{}
+
+func (Client) Do() {}
+
 func Local() {}
 
 func Use() {
 	go func() {
 		Local()
+		c := Client{}
+		c.Do()
 	}()
-	defer func() {
+	defer func(c Client) {
 		Local()
-	}()
+		c.Do()
+	}(Client{})
 }
 `)
 
@@ -397,8 +404,10 @@ func Use() {
 	ns := "example.com/closures"
 	useID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: ns, Name: "Use"})
 	localID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: ns, Name: "Local"})
+	doID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindMethod, Namespace: ns, Receiver: "Client", Name: "Do"})
 
 	var localCalls int
+	var doCalls int
 	for _, call := range graph.Calls {
 		if call.CallerID == useID && call.CalleeRaw == "Local" {
 			if call.Resolution != CallResolutionResolved || call.CalleeID != localID {
@@ -406,9 +415,18 @@ func Use() {
 			}
 			localCalls++
 		}
+		if call.CallerID == useID && call.CalleeRaw == "c.Do" {
+			if call.Resolution != CallResolutionResolved || call.CalleeID != doID {
+				t.Fatalf("c.Do call = %+v, want resolved Client.Do", call)
+			}
+			doCalls++
+		}
 	}
 	if localCalls != 2 {
 		t.Fatalf("Local calls from closures = %d, want 2; calls=%+v", localCalls, graph.Calls)
+	}
+	if doCalls != 2 {
+		t.Fatalf("resolved c.Do calls from closures = %d, want 2; calls=%+v", doCalls, graph.Calls)
 	}
 }
 
@@ -465,6 +483,49 @@ func Use(v any) {
 		if got.Resolution != want.Resolution || got.CalleeID != want.CalleeID {
 			t.Fatalf("call %q resolution/id = %q/%q, want %q/%q",
 				want.CalleeRaw, got.Resolution, got.CalleeID, want.Resolution, want.CalleeID)
+		}
+	}
+}
+
+func TestGoExtractorSkipsTypeParameterConversions(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	writeTestFile(t, root, "go.mod", "module example.com/generic\n\ngo 1.25\n")
+	writeTestFile(t, root, "generic.go", `package generic
+
+type Box[T any] struct{}
+
+func Real() {}
+
+func Convert[T ~int](x int) T {
+	Real()
+	return T(x)
+}
+
+func (b Box[T]) Use(x int) T {
+	return T(x)
+}
+`)
+
+	graph, err := GoExtractor{}.Extract(ctx, "scope-1", root, "vsid-1")
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	ns := "example.com/generic"
+	convertID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: ns, Name: "Convert"})
+	useID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindMethod, Namespace: ns, Receiver: "Box", Name: "Use"})
+	realID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: ns, Name: "Real"})
+
+	got, ok := findCall(graph.Calls, convertID, "Real")
+	if !ok {
+		t.Fatalf("missing Real call; calls=%+v", graph.Calls)
+	}
+	if got.Resolution != CallResolutionResolved || got.CalleeID != realID {
+		t.Fatalf("Real call = %+v, want resolved Real", got)
+	}
+	for _, call := range graph.Calls {
+		if (call.CallerID == convertID || call.CallerID == useID) && call.CalleeRaw == "T" {
+			t.Fatalf("type parameter conversion recorded as call: %+v; calls=%+v", call, graph.Calls)
 		}
 	}
 }

--- a/rag/ast/go_extractor_test.go
+++ b/rag/ast/go_extractor_test.go
@@ -81,7 +81,7 @@ import (
 
 const Answer = 42
 
-var Default = Service{}
+var Default = NewService()
 
 // Service handles work.
 type Service struct{}
@@ -185,6 +185,7 @@ func (s *Service) Handle() {
 	}
 
 	topID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: appNS, Name: "Top"})
+	defaultID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindVar, Namespace: appNS, Name: "Default"})
 	handleID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindMethod, Namespace: appNS, Receiver: "Service", Name: "Handle"})
 	localID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: appNS, Name: "Local"})
 	helperID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: utilNS, Name: "Helper"})
@@ -192,6 +193,7 @@ func (s *Service) Handle() {
 	newServiceID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: appNS, Name: "NewService"})
 
 	wantCalls := []CallEdge{
+		{CallerID: defaultID, CalleeRaw: "NewService", Resolution: CallResolutionResolved, CalleeID: newServiceID},
 		{CallerID: topID, CalleeRaw: "Local", Resolution: CallResolutionResolved, CalleeID: localID},
 		{CallerID: topID, CalleeRaw: "s.Handle", Resolution: CallResolutionResolved, CalleeID: handleID},
 		{CallerID: topID, CalleeRaw: "util.Helper", Resolution: CallResolutionResolved, CalleeID: helperID},
@@ -222,6 +224,59 @@ func (s *Service) Handle() {
 			t.Fatalf("call %q resolution/id = %q/%q, want %q/%q",
 				want.CalleeRaw, got.Resolution, got.CalleeID, want.Resolution, want.CalleeID)
 		}
+	}
+}
+
+func TestGoExtractorUsesStatementOrderedScope(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	writeTestFile(t, root, "go.mod", "module example.com/order\n\ngo 1.25\n")
+	writeTestFile(t, root, "order.go", `package order
+
+type Worker interface {
+	Work()
+}
+
+type Impl struct{}
+
+func (Impl) Work() {}
+
+func Use(w Worker) {
+	w.Work()
+	w = Impl{}
+	w.Work()
+	fresh := Impl{}
+	fresh.Work()
+}
+`)
+
+	graph, err := GoExtractor{}.Extract(ctx, "scope-1", root, "vsid-1")
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	ns := "example.com/order"
+	useID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: ns, Name: "Use"})
+	workID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindMethod, Namespace: ns, Receiver: "Impl", Name: "Work"})
+
+	var unresolvedWorkerCalls int
+	for _, call := range graph.Calls {
+		if call.CallerID != useID {
+			continue
+		}
+		switch call.CalleeRaw {
+		case "w.Work":
+			if call.Resolution != CallResolutionUnresolved || call.CalleeID != "" {
+				t.Fatalf("w.Work call = %+v, want unresolved with no callee ID", call)
+			}
+			unresolvedWorkerCalls++
+		case "fresh.Work":
+			if call.Resolution != CallResolutionResolved || call.CalleeID != workID {
+				t.Fatalf("fresh.Work call = %+v, want resolved Impl.Work", call)
+			}
+		}
+	}
+	if unresolvedWorkerCalls != 2 {
+		t.Fatalf("unresolved w.Work calls = %d, want 2; calls=%+v", unresolvedWorkerCalls, graph.Calls)
 	}
 }
 

--- a/rag/ast/go_extractor_test.go
+++ b/rag/ast/go_extractor_test.go
@@ -412,6 +412,63 @@ func Use() {
 	}
 }
 
+func TestGoExtractorInfersCopiesAssertionsTuplesAndTypeSwitches(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	writeTestFile(t, root, "go.mod", "module example.com/flow\n\ngo 1.25\n")
+	writeTestFile(t, root, "flow.go", `package flow
+
+type Client struct{}
+
+func (Client) Do() {}
+
+func Pair() (error, Client) {
+	return nil, Client{}
+}
+
+func Use(v any) {
+	a := Client{}
+	b := a
+	b.Do()
+	c := v.(Client)
+	c.Do()
+	_, paired := Pair()
+	paired.Do()
+	switch narrowed := v.(type) {
+	case Client:
+		narrowed.Do()
+	}
+}
+`)
+
+	graph, err := GoExtractor{}.Extract(ctx, "scope-1", root, "vsid-1")
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	ns := "example.com/flow"
+	useID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: ns, Name: "Use"})
+	doID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindMethod, Namespace: ns, Receiver: "Client", Name: "Do"})
+	pairID := SymbolID(SymbolKey{Language: "go", Kind: SymbolKindFunction, Namespace: ns, Name: "Pair"})
+
+	wantCalls := []CallEdge{
+		{CallerID: useID, CalleeRaw: "b.Do", Resolution: CallResolutionResolved, CalleeID: doID},
+		{CallerID: useID, CalleeRaw: "c.Do", Resolution: CallResolutionResolved, CalleeID: doID},
+		{CallerID: useID, CalleeRaw: "Pair", Resolution: CallResolutionResolved, CalleeID: pairID},
+		{CallerID: useID, CalleeRaw: "paired.Do", Resolution: CallResolutionResolved, CalleeID: doID},
+		{CallerID: useID, CalleeRaw: "narrowed.Do", Resolution: CallResolutionResolved, CalleeID: doID},
+	}
+	for _, want := range wantCalls {
+		got, ok := findCall(graph.Calls, want.CallerID, want.CalleeRaw)
+		if !ok {
+			t.Fatalf("missing call caller=%q raw=%q; calls=%+v", want.CallerID, want.CalleeRaw, graph.Calls)
+		}
+		if got.Resolution != want.Resolution || got.CalleeID != want.CalleeID {
+			t.Fatalf("call %q resolution/id = %q/%q, want %q/%q",
+				want.CalleeRaw, got.Resolution, got.CalleeID, want.Resolution, want.CalleeID)
+		}
+	}
+}
+
 func TestGoImportedPackageNameUsesPackageClause(t *testing.T) {
 	if got := goImportedPackageName("math/rand/v2"); got != "rand" {
 		t.Fatalf("goImportedPackageName(math/rand/v2) = %q, want rand", got)


### PR DESCRIPTION
## Summary

Implements issue #108 step 2: a real Go AST extractor for `rag/ast` using the scoped symbol graph contracts merged in #109.

This PR adds `GoExtractor`, which walks Go source trees and emits a typed `SymbolGraph` with:

- package/module-scoped symbol nodes for functions, methods, structs, interfaces, type aliases, vars, and consts
- call edges for function bodies and top-level var/const initializers
- best-effort call resolution for same-package functions, imported package functions, simple receiver method calls, and return-value-derived receivers
- explicit unresolved edges for calls the extractor attempts but cannot resolve
- source/module extraction signatures for `Extractor.Stale`

No consumers are wired in this PR; existing runtime behavior remains unchanged.

## Review Fixes

The follow-up commit addresses the review findings from the local formal/adversarial/defensive pass:

- top-level binding initializers now emit call edges
- function call extraction now walks statements in order instead of inferring variable types from a whole-body scan

## Validation

- `go test ./rag/ast`
- `go test -race ./rag/ast`
- `go test ./...`
- `go vet ./...`
- `gofmt -l rag/ast`
- pre-push hook: lint, race tests, compile smoke

Refs #108.
