### PR TITLE
feat(provider, config): provider-instance naming + config capability overlay (PR1 of #81)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -83,6 +83,14 @@ var validModelTypes = map[string]bool{
 	"embedding": true,
 }
 
+// validAPIFormats enumerates the allowed values for ProviderConfig.APIFormat.
+// Empty is also allowed and is materialized to "ollama" by applyDefaults so
+// existing configs that predate the field continue to load unchanged.
+var validAPIFormats = map[string]bool{
+	"ollama":        true,
+	"openai-compat": true,
+}
+
 // typeCompatible reports whether a model of fromType can fall back to a model of toType.
 // Embedding models can only fall back to other embedding models.
 // Dense and MoE models are interchangeable as fallbacks.
@@ -240,12 +248,16 @@ func MustLoad(path string) *Config {
 
 // applyDefaults materializes implicit provider assignments and timeout defaults.
 func (cfg *Config) applyDefaults() {
-	// Default timeout to 5m for any provider that has a zero timeout.
+	// Default timeout to 5m for any provider that has a zero timeout; default
+	// empty APIFormat to "ollama" so configs predating the field keep working.
 	for key, p := range cfg.Providers {
 		if p.Timeout.Duration == 0 {
 			p.Timeout.Duration = 5 * time.Minute
-			cfg.Providers[key] = p
 		}
+		if p.APIFormat == "" {
+			p.APIFormat = "ollama"
+		}
+		cfg.Providers[key] = p
 	}
 
 	// Materialize implicit provider: models without an explicit provider get "ollama".
@@ -281,6 +293,12 @@ func (cfg *Config) validate() error {
 		}
 		if u.Scheme == "" || u.Host == "" {
 			return fmt.Errorf("config: provider %q: base_url must include scheme and host", key)
+		}
+		// Empty api_format defaults to "ollama" via applyDefaults; only
+		// reject explicit unknown values so a typo like "ollma" surfaces
+		// at load time instead of silently degrading.
+		if p.APIFormat != "" && !validAPIFormats[p.APIFormat] {
+			return fmt.Errorf("config: provider %q: invalid api_format %q", key, p.APIFormat)
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -54,6 +54,13 @@ type ProviderConfig struct {
 }
 
 // ModelConfig describes a model's identity, capabilities, and fallback chain.
+//
+// Capabilities is an optional explicit override of the type-derived default
+// capability set. When non-empty it REPLACES the derived set (not merges)
+// so users can carve down capabilities for backends that don't expose every
+// endpoint — e.g. ["chat", "stream"] for an OpenAI-compat server lacking
+// /v1/completions. When empty, capabilities derive from Type per
+// ResolvedCapabilities. See validCapabilityNames for the accepted vocabulary.
 type ModelConfig struct {
 	Name          string   `json:"name"`
 	Provider      string   `json:"provider,omitempty"`
@@ -62,6 +69,7 @@ type ModelConfig struct {
 	Parameters    string   `json:"parameters,omitempty"`
 	ContextWindow int      `json:"context_window,omitempty"`
 	Dimensions    int      `json:"dimensions,omitempty"`
+	Capabilities  []string `json:"capabilities,omitempty"`
 	Fallbacks     []string `json:"fallbacks,omitempty"`
 }
 
@@ -89,6 +97,64 @@ var validModelTypes = map[string]bool{
 var validAPIFormats = map[string]bool{
 	"ollama":        true,
 	"openai-compat": true,
+}
+
+// validCapabilityNames is the schema vocabulary for ModelConfig.Capabilities.
+// Canonical single-bit names match provider.Capability.String() output; the
+// catalog aliases are also accepted so users can mirror values they see in
+// catalog.json or /api/show capability arrays. The provider package owns
+// the bitmask conversion (see provider.ParseCapsStrict).
+var validCapabilityNames = map[string]bool{
+	// Canonical single-bit names.
+	"chat":      true,
+	"generate":  true,
+	"stream":    true,
+	"embed":     true,
+	"tool_call": true,
+	"thinking":  true,
+	"insert":    true,
+	// Catalog aliases retained for compatibility.
+	"completion": true,
+	"tools":      true,
+	"embedding":  true,
+}
+
+// embeddingOnlyCapabilities are the capability tokens permitted on a model
+// with Type=="embedding". Hybrid models that need additional capabilities
+// must be configured as "dense" or "moe" with explicit capabilities; see
+// the ModelConfig doc.
+var embeddingOnlyCapabilities = map[string]bool{
+	"embed":     true,
+	"embedding": true,
+}
+
+// derivedCapabilitiesByType is the default capability vocabulary applied
+// when ModelConfig.Capabilities is empty. Insert, tool_call, and thinking
+// are never derived — they require explicit declaration or later runtime
+// proof from the provider.
+var derivedCapabilitiesByType = map[string][]string{
+	"dense":     {"chat", "generate", "stream"},
+	"moe":       {"chat", "generate", "stream"},
+	"embedding": {"embed"},
+}
+
+// ResolvedCapabilities returns the effective capability tokens for this
+// model. Explicit Capabilities entries REPLACE the type-derived default set
+// (not merge); an empty list yields the derive-from-type defaults. The
+// returned slice is a fresh copy callers may freely mutate.
+func (m ModelConfig) ResolvedCapabilities() []string {
+	if len(m.Capabilities) > 0 {
+		out := make([]string, len(m.Capabilities))
+		copy(out, m.Capabilities)
+		return out
+	}
+	derived := derivedCapabilitiesByType[m.Type]
+	if len(derived) == 0 {
+		return nil
+	}
+	out := make([]string, len(derived))
+	copy(out, derived)
+	return out
 }
 
 // typeCompatible reports whether a model of fromType can fall back to a model of toType.
@@ -318,6 +384,21 @@ func (cfg *Config) validate() error {
 		}
 		if !validModelTypes[m.Type] {
 			return fmt.Errorf("config: model %q: invalid type %q", role, m.Type)
+		}
+
+		// Validate explicit capabilities (only when provided; empty defers to
+		// type-driven derivation). Strict-reject unknowns so typos surface at
+		// load time, then enforce the embedding-type-must-only-embed invariant
+		// per the design contract.
+		if len(m.Capabilities) > 0 {
+			for _, cap := range m.Capabilities {
+				if !validCapabilityNames[cap] {
+					return fmt.Errorf("config: model %q: unknown capability %q", role, cap)
+				}
+				if m.Type == "embedding" && !embeddingOnlyCapabilities[cap] {
+					return fmt.Errorf("config: model %q: type %q must declare only embedding capabilities, got %q", role, m.Type, cap)
+				}
+			}
 		}
 
 		// Check provider exists. Use local variable to resolve implicit default.

--- a/config/config.go
+++ b/config/config.go
@@ -417,16 +417,18 @@ func (cfg *Config) validate() error {
 			}
 		}
 
-		// Check provider exists. Use local variable to resolve implicit default.
-		provider := m.Provider
-		if provider == "" {
-			provider = "ollama"
+		// Check provider exists. Use a local name distinct from the imported
+		// "provider" package — shadowing would silently break any future
+		// edit that needs to call provider.X inside this loop body.
+		providerKey := m.Provider
+		if providerKey == "" {
+			providerKey = "ollama"
 		}
-		if _, ok := cfg.Providers[provider]; !ok {
+		if _, ok := cfg.Providers[providerKey]; !ok {
 			if m.Provider == "" {
 				return fmt.Errorf("config: model %q: implicit provider \"ollama\" not found", role)
 			}
-			return fmt.Errorf("config: model %q: provider %q not found", role, provider)
+			return fmt.Errorf("config: model %q: provider %q not found", role, providerKey)
 		}
 
 		// Validate fallbacks.

--- a/config/config.go
+++ b/config/config.go
@@ -167,7 +167,14 @@ func typeCompatible(fromType, toType string) bool {
 	return true
 }
 
-// Provider returns a pointer to the ProviderConfig for the given key, or nil if not found.
+// Provider returns a pointer to the ProviderConfig for the given key, or
+// nil if not found.
+//
+// The returned pointer addresses a COPY of the map value (Go does not allow
+// taking the address of a map entry). Treat the result as read-only — any
+// mutation through this pointer affects only the local copy, never the
+// underlying Config. Callers that need a live, mutable handle should
+// modify c.Providers[key] directly.
 func (c *Config) Provider(key string) *ProviderConfig {
 	p, ok := c.Providers[key]
 	if !ok {
@@ -221,6 +228,10 @@ func (c *Config) MustModelFor(useCase string) string {
 // Provider means the caller constructed Config programmatically and
 // skipped applyDefaults, in which case lying about the owner would
 // misdirect downstream callers.
+//
+// As with Provider(), the returned pointer addresses a COPY of the map
+// value and must be treated as read-only — mutations do not propagate to
+// the underlying Config.
 func (c *Config) ProviderFor(role string) *ProviderConfig {
 	m, ok := c.Models[role]
 	if !ok {

--- a/config/config.go
+++ b/config/config.go
@@ -210,19 +210,26 @@ func (c *Config) MustModelFor(useCase string) string {
 }
 
 // ProviderFor returns the provider config for a given role's model.
-// It looks up the role in Models to find the Provider field (defaulted to "ollama"),
-// then returns the corresponding ProviderConfig. Returns nil if the role or its
-// provider is not found.
+// It looks up the role in Models to find the Provider field, then returns
+// the corresponding ProviderConfig. Returns nil if the role does not exist,
+// the model has no Provider set (programmatic Config that bypassed
+// applyDefaults), or the named provider is not present in cfg.Providers.
+//
+// This mirrors resolveRole's contract — empty Provider is not silently
+// defaulted to "ollama". Load+applyDefaults guarantees a non-empty Provider
+// for every model loaded from models.json; reaching this method with empty
+// Provider means the caller constructed Config programmatically and
+// skipped applyDefaults, in which case lying about the owner would
+// misdirect downstream callers.
 func (c *Config) ProviderFor(role string) *ProviderConfig {
 	m, ok := c.Models[role]
 	if !ok {
 		return nil
 	}
-	provider := m.Provider
-	if provider == "" {
-		provider = "ollama"
+	if m.Provider == "" {
+		return nil
 	}
-	return c.Provider(provider)
+	return c.Provider(m.Provider)
 }
 
 // Default discovers and loads the configuration file from standard locations.

--- a/config/config.go
+++ b/config/config.go
@@ -431,12 +431,12 @@ func (cfg *Config) validate() error {
 		// Check provider exists. Use a local name distinct from the imported
 		// "provider" package — shadowing would silently break any future
 		// edit that needs to call provider.X inside this loop body.
-		providerKey := m.Provider
+		providerKey, implicit := m.Provider, false
 		if providerKey == "" {
-			providerKey = "ollama"
+			providerKey, implicit = "ollama", true
 		}
 		if _, ok := cfg.Providers[providerKey]; !ok {
-			if m.Provider == "" {
+			if implicit {
 				return fmt.Errorf("config: model %q: implicit provider \"ollama\" not found", role)
 			}
 			return fmt.Errorf("config: model %q: provider %q not found", role, providerKey)

--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,10 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
+
+	"github.com/kstruzzieri/go-llm/provider"
 )
 
 // Duration wraps time.Duration with JSON marshal/unmarshal support.
@@ -99,33 +102,26 @@ var validAPIFormats = map[string]bool{
 	"openai-compat": true,
 }
 
-// validCapabilityNames is the schema vocabulary for ModelConfig.Capabilities.
-// Canonical single-bit names match provider.Capability.String() output; the
-// catalog aliases are also accepted so users can mirror values they see in
-// catalog.json or /api/show capability arrays. The provider package owns
-// the bitmask conversion (see provider.ParseCapsStrict).
-var validCapabilityNames = map[string]bool{
-	// Canonical single-bit names.
-	"chat":      true,
-	"generate":  true,
-	"stream":    true,
-	"embed":     true,
-	"tool_call": true,
-	"thinking":  true,
-	"insert":    true,
-	// Catalog aliases retained for compatibility.
-	"completion": true,
-	"tools":      true,
-	"embedding":  true,
-}
+// validCapabilityNames is the schema vocabulary for ModelConfig.Capabilities,
+// derived from provider.CanonicalCapabilityNames so the two never drift.
+// User config accepts ONLY canonical single-bit names; catalog aliases like
+// "completion" or "tools" that expand multiple bits are intentionally
+// forbidden here so the "explicit Capabilities REPLACE derived" contract
+// holds without surprise expansion at the override merge.
+var validCapabilityNames = func() map[string]bool {
+	m := make(map[string]bool, len(provider.CanonicalCapabilityNames))
+	for _, name := range provider.CanonicalCapabilityNames {
+		m[name] = true
+	}
+	return m
+}()
 
 // embeddingOnlyCapabilities are the capability tokens permitted on a model
 // with Type=="embedding". Hybrid models that need additional capabilities
 // must be configured as "dense" or "moe" with explicit capabilities; see
 // the ModelConfig doc.
 var embeddingOnlyCapabilities = map[string]bool{
-	"embed":     true,
-	"embedding": true,
+	"embed": true,
 }
 
 // derivedCapabilitiesByType is the default capability vocabulary applied
@@ -388,16 +384,29 @@ func (cfg *Config) validate() error {
 
 		// Validate explicit capabilities (only when provided; empty defers to
 		// type-driven derivation). Strict-reject unknowns so typos surface at
-		// load time, then enforce the embedding-type-must-only-embed invariant
-		// per the design contract.
+		// load time, and reject multi-bit aliases like "completion" so the
+		// "explicit Capabilities REPLACE derived" contract holds without
+		// surprise expansion at the override merge. Then enforce the
+		// embedding-type-must-only-embed invariant per the design contract.
+		// Tokens are lowercased to match provider.ParseCapsStrict's behavior;
+		// JSON case ("Chat" vs "chat") must not cause silent disagreement.
 		if len(m.Capabilities) > 0 {
 			for _, cap := range m.Capabilities {
-				if !validCapabilityNames[cap] {
-					return fmt.Errorf("config: model %q: unknown capability %q", role, cap)
+				lower := strings.ToLower(cap)
+				if !validCapabilityNames[lower] {
+					return fmt.Errorf("config: model %q: unknown or non-canonical capability %q (canonical names: %v)", role, cap, provider.CanonicalCapabilityNames)
 				}
-				if m.Type == "embedding" && !embeddingOnlyCapabilities[cap] {
+				if m.Type == "embedding" && !embeddingOnlyCapabilities[lower] {
 					return fmt.Errorf("config: model %q: type %q must declare only embedding capabilities, got %q", role, m.Type, cap)
 				}
+			}
+			// Final round-trip check: provider must accept the same tokens.
+			// This catches drift if CanonicalCapabilityNames and the parser
+			// ever diverge — a class of bug the consume-shared-list pattern
+			// is designed to make impossible, but worth asserting in case
+			// someone bypasses the list.
+			if _, err := provider.ParseCapsStrict(m.Capabilities); err != nil {
+				return fmt.Errorf("config: model %q: %w", role, err)
 			}
 		}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -328,6 +328,37 @@ func TestLoad_CapabilityValidation(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+
+	// User config rejects multi-bit aliases: the REPLACES contract on
+	// override would otherwise leak expanded bits the user excluded.
+	// Catalog/runtime metadata sources may still use them; user config
+	// must declare canonical single-bit names only.
+	t.Run("multi-bit aliases rejected in user config", func(t *testing.T) {
+		for _, alias := range []string{"completion", "tools", "embedding"} {
+			bad := writeTempJSON(t, `{
+				"providers": {"ollama": {"base_url": "http://localhost:11434"}},
+				"models": {"m": {"name": "x", "type": "dense", "capabilities": ["`+alias+`"]}},
+				"defaults": {}
+			}`)
+			_, err := Load(bad)
+			if err == nil {
+				t.Errorf("expected error for alias %q in user config, got nil", alias)
+			}
+		}
+	})
+
+	// JSON-source casing must not produce silent disagreement between
+	// config validation and provider parsing. Both lowercase before lookup.
+	t.Run("mixed-case capability tokens accepted", func(t *testing.T) {
+		good := writeTempJSON(t, `{
+			"providers": {"ollama": {"base_url": "http://localhost:11434"}},
+			"models": {"m": {"name": "x", "type": "dense", "capabilities": ["Chat", "STREAM"]}},
+			"defaults": {}
+		}`)
+		if _, err := Load(good); err != nil {
+			t.Fatalf("unexpected error for mixed-case tokens: %v", err)
+		}
+	})
 }
 
 func TestLoad_APIFormatValidation(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -721,16 +721,23 @@ func TestProviderFor(t *testing.T) {
 	}
 
 	// Programmatic Config with explicit Provider works as expected.
+	// APIFormat must flow through unchanged so downstream callers that
+	// branch on it (e.g. provider construction picking ollama vs
+	// openai-compat) see the same value the config declared.
 	explicit := &Config{
 		Providers: map[string]ProviderConfig{
-			"my-instance": {BaseURL: "http://manual:11434"},
+			"my-instance": {BaseURL: "http://manual:11434", APIFormat: "openai-compat"},
 		},
 		Models: map[string]ModelConfig{
 			"test": {Name: "m", Type: "dense", Provider: "my-instance"},
 		},
 	}
-	if ep := explicit.ProviderFor("test"); ep == nil || ep.BaseURL != "http://manual:11434" {
+	ep := explicit.ProviderFor("test")
+	if ep == nil || ep.BaseURL != "http://manual:11434" {
 		t.Errorf("ProviderFor with explicit Provider should return the named instance, got %+v", ep)
+	}
+	if ep != nil && ep.APIFormat != "openai-compat" {
+		t.Errorf("ProviderFor APIFormat = %q, want %q (must flow through resolved ProviderConfig)", ep.APIFormat, "openai-compat")
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -237,6 +237,79 @@ func TestLoad_APIFormatDefaulting(t *testing.T) {
 	}
 }
 
+// TestLoad_ProductionModelsJSON_NoBehaviorChange pins the claim from the
+// PR description: existing single-Ollama deployments see no behavior change
+// from the new Capabilities field. The repo's actual models.json has no
+// capabilities populated on any model; every ResolvedCapabilities() result
+// must match the derive-from-type defaults so routing decisions made on
+// top of those caps remain identical to develop's behavior.
+func TestLoad_ProductionModelsJSON_NoBehaviorChange(t *testing.T) {
+	cfg, err := Load("../models.json")
+	if err != nil {
+		t.Fatalf("repo models.json fails to load after PR1 changes: %v", err)
+	}
+
+	for role, m := range cfg.Models {
+		t.Run(role, func(t *testing.T) {
+			if len(m.Capabilities) != 0 {
+				t.Skipf("model %q now has explicit capabilities; remove this skip when production config opts in", role)
+			}
+			got := m.ResolvedCapabilities()
+			var want []string
+			switch m.Type {
+			case "dense", "moe":
+				want = []string{"chat", "generate", "stream"}
+			case "embedding":
+				want = []string{"embed"}
+			default:
+				t.Fatalf("model %q has unexpected type %q", role, m.Type)
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("ResolvedCapabilities = %v, want %v (production model %q derive-from-type)", got, want, role)
+			}
+		})
+	}
+}
+
+// TestLoad_CapabilitiesExample exercises the testdata/capabilities.json
+// fixture so the documented usage stays valid and a regression in the
+// schema vocabulary cannot quietly desync from the example.
+func TestLoad_CapabilitiesExample(t *testing.T) {
+	cfg, err := Load("testdata/capabilities.json")
+	if err != nil {
+		t.Fatalf("capabilities.json fixture fails to load: %v", err)
+	}
+
+	carved := cfg.Models["carved-down"]
+	if got := carved.ResolvedCapabilities(); !reflect.DeepEqual(got, []string{"chat", "stream"}) {
+		t.Errorf("carved-down capabilities = %v, want [chat stream] (explicit replaces derived)", got)
+	}
+
+	withTools := cfg.Models["with-tools"]
+	if got := withTools.ResolvedCapabilities(); !reflect.DeepEqual(got, []string{"chat", "generate", "stream", "tool_call"}) {
+		t.Errorf("with-tools capabilities = %v, want [chat generate stream tool_call]", got)
+	}
+
+	general := cfg.Models["general"]
+	if got := general.ResolvedCapabilities(); !reflect.DeepEqual(got, []string{"chat", "generate", "stream"}) {
+		t.Errorf("general (derive-from-type) = %v, want [chat generate stream]", got)
+	}
+
+	emb := cfg.Models["embedding"]
+	if got := emb.ResolvedCapabilities(); !reflect.DeepEqual(got, []string{"embed"}) {
+		t.Errorf("embedding (derive-from-type) = %v, want [embed]", got)
+	}
+
+	// The remote-llamacpp provider should carry api_format through Load.
+	remote := cfg.Provider("remote-llamacpp")
+	if remote == nil {
+		t.Fatal("remote-llamacpp provider missing")
+	}
+	if remote.APIFormat != "openai-compat" {
+		t.Errorf("remote-llamacpp api_format = %q, want openai-compat", remote.APIFormat)
+	}
+}
+
 func TestModelConfig_ResolvedCapabilities(t *testing.T) {
 	tests := []struct {
 		name string

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -174,6 +174,62 @@ func TestLoad_TimeoutDefaulting(t *testing.T) {
 	}
 }
 
+func TestLoad_APIFormatDefaulting(t *testing.T) {
+	// Empty api_format must materialize to "ollama" via applyDefaults so
+	// configs that predate the field keep working.
+	noFormat := writeTempJSON(t, `{
+		"providers": {"ollama": {"base_url": "http://localhost:11434"}},
+		"models": {"m": {"name": "x", "type": "dense"}},
+		"defaults": {}
+	}`)
+	cfg, err := Load(noFormat)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	p := cfg.Provider("ollama")
+	if p == nil {
+		t.Fatal("expected provider 'ollama' to exist")
+	}
+	if p.APIFormat != "ollama" {
+		t.Errorf("default api_format: got %q, want %q", p.APIFormat, "ollama")
+	}
+
+	// Explicit known values pass through unchanged.
+	explicit := writeTempJSON(t, `{
+		"providers": {"local": {"base_url": "http://localhost:8080", "api_format": "openai-compat"}},
+		"models": {"m": {"name": "x", "type": "dense", "provider": "local"}},
+		"defaults": {}
+	}`)
+	cfg2, err := Load(explicit)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	p2 := cfg2.Provider("local")
+	if p2 == nil {
+		t.Fatal("expected provider 'local' to exist")
+	}
+	if p2.APIFormat != "openai-compat" {
+		t.Errorf("explicit api_format: got %q, want %q", p2.APIFormat, "openai-compat")
+	}
+}
+
+func TestLoad_APIFormatValidation(t *testing.T) {
+	// Unknown explicit api_format must be rejected at load time so typos
+	// surface immediately instead of silently defaulting.
+	bad := writeTempJSON(t, `{
+		"providers": {"ollama": {"base_url": "http://localhost:11434", "api_format": "ollma"}},
+		"models": {"m": {"name": "x", "type": "dense"}},
+		"defaults": {}
+	}`)
+	_, err := Load(bad)
+	if err == nil {
+		t.Fatal("expected error for unknown api_format, got nil")
+	}
+	if !strings.Contains(err.Error(), "api_format") || !strings.Contains(err.Error(), "ollma") {
+		t.Errorf("error should mention api_format and the bad value, got: %v", err)
+	}
+}
+
 func TestLoad_MoEFallbackCompatibility(t *testing.T) {
 	cfg, err := Load("testdata/valid.json")
 	if err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -212,6 +212,29 @@ func TestLoad_APIFormatDefaulting(t *testing.T) {
 	if p2.APIFormat != "openai-compat" {
 		t.Errorf("explicit api_format: got %q, want %q", p2.APIFormat, "openai-compat")
 	}
+
+	// Explicit api_format on a provider with non-zero timeout must survive
+	// applyDefaults — guards against the regression where the write-back
+	// only fired inside the timeout-default branch.
+	explicitBoth := writeTempJSON(t, `{
+		"providers": {"local": {"base_url": "http://localhost:8080", "api_format": "openai-compat", "timeout": "10s"}},
+		"models": {"m": {"name": "x", "type": "dense", "provider": "local"}},
+		"defaults": {}
+	}`)
+	cfg3, err := Load(explicitBoth)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	p3 := cfg3.Provider("local")
+	if p3 == nil {
+		t.Fatal("expected provider 'local' to exist")
+	}
+	if p3.APIFormat != "openai-compat" {
+		t.Errorf("api_format with explicit timeout: got %q, want %q (applyDefaults regression)", p3.APIFormat, "openai-compat")
+	}
+	if p3.Timeout.Duration != 10*time.Second {
+		t.Errorf("explicit timeout: got %v, want 10s", p3.Timeout.Duration)
+	}
 }
 
 func TestModelConfig_ResolvedCapabilities(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -704,8 +704,10 @@ func TestProviderFor(t *testing.T) {
 		t.Error("expected ProviderFor(\"nonexistent\") to be nil")
 	}
 
-	// ProviderFor defaults to "ollama" for programmatically constructed configs
-	// where the Provider field was never materialized by Load.
+	// Programmatic Config with empty Provider returns nil rather than
+	// silently defaulting to "ollama" — mirrors the resolveRole contract.
+	// applyDefaults (run by Load) materializes the default; callers that
+	// bypass Load must set Provider explicitly.
 	manualCfg := &Config{
 		Providers: map[string]ProviderConfig{
 			"ollama": {BaseURL: "http://manual:11434"},
@@ -714,12 +716,21 @@ func TestProviderFor(t *testing.T) {
 			"test": {Name: "m", Type: "dense"}, // no Provider set
 		},
 	}
-	mp := manualCfg.ProviderFor("test")
-	if mp == nil {
-		t.Fatal("expected ProviderFor to default to ollama for empty Provider field")
+	if mp := manualCfg.ProviderFor("test"); mp != nil {
+		t.Errorf("ProviderFor with empty Provider must return nil, got %+v", mp)
 	}
-	if mp.BaseURL != "http://manual:11434" {
-		t.Errorf("BaseURL = %q, want %q", mp.BaseURL, "http://manual:11434")
+
+	// Programmatic Config with explicit Provider works as expected.
+	explicit := &Config{
+		Providers: map[string]ProviderConfig{
+			"my-instance": {BaseURL: "http://manual:11434"},
+		},
+		Models: map[string]ModelConfig{
+			"test": {Name: "m", Type: "dense", Provider: "my-instance"},
+		},
+	}
+	if ep := explicit.ProviderFor("test"); ep == nil || ep.BaseURL != "http://manual:11434" {
+		t.Errorf("ProviderFor with explicit Provider should return the named instance, got %+v", ep)
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -211,6 +212,122 @@ func TestLoad_APIFormatDefaulting(t *testing.T) {
 	if p2.APIFormat != "openai-compat" {
 		t.Errorf("explicit api_format: got %q, want %q", p2.APIFormat, "openai-compat")
 	}
+}
+
+func TestModelConfig_ResolvedCapabilities(t *testing.T) {
+	tests := []struct {
+		name string
+		m    ModelConfig
+		want []string
+	}{
+		{
+			name: "dense default",
+			m:    ModelConfig{Type: "dense"},
+			want: []string{"chat", "generate", "stream"},
+		},
+		{
+			name: "moe default",
+			m:    ModelConfig{Type: "moe"},
+			want: []string{"chat", "generate", "stream"},
+		},
+		{
+			name: "embedding default",
+			m:    ModelConfig{Type: "embedding"},
+			want: []string{"embed"},
+		},
+		{
+			name: "explicit replaces derived (carve-down for missing /v1/completions)",
+			m:    ModelConfig{Type: "dense", Capabilities: []string{"chat", "stream"}},
+			want: []string{"chat", "stream"},
+		},
+		{
+			name: "explicit replaces derived (no merge with chat/generate/stream)",
+			m:    ModelConfig{Type: "dense", Capabilities: []string{"chat"}},
+			want: []string{"chat"},
+		},
+		{
+			name: "explicit on embedding",
+			m:    ModelConfig{Type: "embedding", Capabilities: []string{"embed"}},
+			want: []string{"embed"},
+		},
+		{
+			name: "unknown type yields nil",
+			m:    ModelConfig{Type: "bogus"},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.m.ResolvedCapabilities()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	t.Run("returned slice is independent copy", func(t *testing.T) {
+		m := ModelConfig{Type: "dense"}
+		first := m.ResolvedCapabilities()
+		first[0] = "mutated"
+		second := m.ResolvedCapabilities()
+		if second[0] == "mutated" {
+			t.Error("ResolvedCapabilities returned aliased slice; mutation leaked across calls")
+		}
+	})
+}
+
+func TestLoad_CapabilityValidation(t *testing.T) {
+	t.Run("unknown capability rejected", func(t *testing.T) {
+		bad := writeTempJSON(t, `{
+			"providers": {"ollama": {"base_url": "http://localhost:11434"}},
+			"models": {"m": {"name": "x", "type": "dense", "capabilities": ["chat", "nonexistent"]}},
+			"defaults": {}
+		}`)
+		_, err := Load(bad)
+		if err == nil {
+			t.Fatal("expected error for unknown capability, got nil")
+		}
+		if !strings.Contains(err.Error(), "nonexistent") {
+			t.Errorf("error should mention bad capability, got: %v", err)
+		}
+	})
+
+	t.Run("embedding type with non-embedding capability rejected", func(t *testing.T) {
+		bad := writeTempJSON(t, `{
+			"providers": {"ollama": {"base_url": "http://localhost:11434"}},
+			"models": {"m": {"name": "x", "type": "embedding", "capabilities": ["chat"]}},
+			"defaults": {}
+		}`)
+		_, err := Load(bad)
+		if err == nil {
+			t.Fatal("expected error for embedding type with chat capability, got nil")
+		}
+		if !strings.Contains(err.Error(), "embedding") || !strings.Contains(err.Error(), "chat") {
+			t.Errorf("error should mention type and bad capability, got: %v", err)
+		}
+	})
+
+	t.Run("embedding type with explicit embed capability accepted", func(t *testing.T) {
+		good := writeTempJSON(t, `{
+			"providers": {"ollama": {"base_url": "http://localhost:11434"}},
+			"models": {"m": {"name": "x", "type": "embedding", "capabilities": ["embed"]}},
+			"defaults": {}
+		}`)
+		if _, err := Load(good); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("dense type with carved-down capabilities accepted", func(t *testing.T) {
+		good := writeTempJSON(t, `{
+			"providers": {"ollama": {"base_url": "http://localhost:11434"}},
+			"models": {"m": {"name": "x", "type": "dense", "capabilities": ["chat", "stream"]}},
+			"defaults": {}
+		}`)
+		if _, err := Load(good); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func TestLoad_APIFormatValidation(t *testing.T) {

--- a/config/resolve.go
+++ b/config/resolve.go
@@ -107,12 +107,12 @@ func (c *Config) resolveRole(role string, available map[string]bool, onStack map
 
 	// Load+applyDefaults guarantees a non-empty Provider for every model.
 	// Reaching this with an empty Provider means the caller constructed
-	// Config programmatically and skipped applyDefaults — silently
-	// inserting "ollama" here would lie to downstream consumers about
-	// which provider instance owns the model. Surface it as a real
-	// configuration error instead.
+	// Config programmatically and skipped Load — silently inserting
+	// "ollama" here would lie to downstream consumers about which provider
+	// instance owns the model. Surface it as a real configuration error
+	// pointing the caller at the exported APIs they should use instead.
 	if m.Provider == "" {
-		return ResolvedModel{}, fmt.Errorf("config: role %q has empty provider; programmatic Configs must call applyDefaults or set Provider explicitly", role)
+		return ResolvedModel{}, fmt.Errorf("config: role %q has empty provider; use config.Load to materialize defaults or set ModelConfig.Provider explicitly", role)
 	}
 
 	// Try primary model.

--- a/config/resolve.go
+++ b/config/resolve.go
@@ -105,18 +105,19 @@ func (c *Config) resolveRole(role string, available map[string]bool, onStack map
 		return ResolvedModel{}, fmt.Errorf("config: unknown role %q", role)
 	}
 
-	// applyDefaults guarantees a non-empty Provider, but resolveRole can be
-	// reached on a Config that was constructed programmatically without going
-	// through Load — fall back to "ollama" for that path so downstream callers
-	// always see a populated Provider.
-	provider := m.Provider
-	if provider == "" {
-		provider = "ollama"
+	// Load+applyDefaults guarantees a non-empty Provider for every model.
+	// Reaching this with an empty Provider means the caller constructed
+	// Config programmatically and skipped applyDefaults — silently
+	// inserting "ollama" here would lie to downstream consumers about
+	// which provider instance owns the model. Surface it as a real
+	// configuration error instead.
+	if m.Provider == "" {
+		return ResolvedModel{}, fmt.Errorf("config: role %q has empty provider; programmatic Configs must call applyDefaults or set Provider explicitly", role)
 	}
 
 	// Try primary model.
 	if available[m.Name] {
-		return ResolvedModel{Name: m.Name, Role: role, Provider: provider, IsFallback: false}, nil
+		return ResolvedModel{Name: m.Name, Role: role, Provider: m.Provider, IsFallback: false}, nil
 	}
 
 	// Walk fallback chain: try each fallback role (and transitively its own fallbacks).

--- a/config/resolve.go
+++ b/config/resolve.go
@@ -13,9 +13,15 @@ type ModelChecker interface {
 }
 
 // ResolvedModel is the result of resolving a role to an available model.
+// Provider tracks the provider instance that owns the actually-resolved model,
+// including the fallback case — if role "coding" on provider "local-a" falls
+// back to role "fast" on provider "local-b", Provider is "local-b". The
+// originally-requested provider/role belongs in chain metadata or route
+// outcome planning, not here.
 type ResolvedModel struct {
 	Name       string // the model name that was selected
 	Role       string // the role of the resolved model (may differ from requested role if fallback)
+	Provider   string // the provider instance owning the resolved model
 	IsFallback bool   // true if the primary model wasn't available
 }
 
@@ -99,9 +105,18 @@ func (c *Config) resolveRole(role string, available map[string]bool, onStack map
 		return ResolvedModel{}, fmt.Errorf("config: unknown role %q", role)
 	}
 
+	// applyDefaults guarantees a non-empty Provider, but resolveRole can be
+	// reached on a Config that was constructed programmatically without going
+	// through Load — fall back to "ollama" for that path so downstream callers
+	// always see a populated Provider.
+	provider := m.Provider
+	if provider == "" {
+		provider = "ollama"
+	}
+
 	// Try primary model.
 	if available[m.Name] {
-		return ResolvedModel{Name: m.Name, Role: role, IsFallback: false}, nil
+		return ResolvedModel{Name: m.Name, Role: role, Provider: provider, IsFallback: false}, nil
 	}
 
 	// Walk fallback chain: try each fallback role (and transitively its own fallbacks).

--- a/config/resolve_test.go
+++ b/config/resolve_test.go
@@ -70,6 +70,32 @@ func TestResolve_FallbackUsed(t *testing.T) {
 	}
 }
 
+// TestResolve_EmptyProviderErrors verifies the resolver surfaces an empty
+// Provider as a real config error rather than silently inserting "ollama".
+// Empty Provider is only reachable on Configs constructed programmatically
+// without going through Load+applyDefaults; lying about the owner would
+// route downstream calls to a provider the caller never declared.
+func TestResolve_EmptyProviderErrors(t *testing.T) {
+	cfg := &Config{
+		Providers: map[string]ProviderConfig{
+			"ollama": {BaseURL: "http://localhost:11434"},
+		},
+		Models: map[string]ModelConfig{
+			"chat-role": {Name: "some-model", Type: "dense"}, // Provider intentionally empty
+		},
+		Defaults: map[string]string{"chat": "chat-role"},
+	}
+	checker := &mockChecker{models: []string{"some-model"}}
+
+	_, err := cfg.Resolve(context.Background(), checker, "chat")
+	if err == nil {
+		t.Fatal("expected error for empty Provider, got nil")
+	}
+	if !strings.Contains(err.Error(), "empty provider") {
+		t.Errorf("error should mention empty provider, got: %v", err)
+	}
+}
+
 // TestResolve_FallbackCrossProvider verifies the resolved Provider tracks
 // the fallback's owner, not the originally-requested one. Per design:
 // requested role "coding"/provider "local-a" falling back to role "fast"/
@@ -249,10 +275,10 @@ func TestResolveAll_NoneAvailable(t *testing.T) {
 func TestResolve_DiamondFallbackGraph(t *testing.T) {
 	cfg := &Config{
 		Models: map[string]ModelConfig{
-			"a": {Name: "model-a", Fallbacks: []string{"b", "c"}},
-			"b": {Name: "model-b", Fallbacks: []string{"d"}},
-			"c": {Name: "model-c", Fallbacks: []string{"d"}},
-			"d": {Name: "model-d"},
+			"a": {Name: "model-a", Provider: "ollama", Fallbacks: []string{"b", "c"}},
+			"b": {Name: "model-b", Provider: "ollama", Fallbacks: []string{"d"}},
+			"c": {Name: "model-c", Provider: "ollama", Fallbacks: []string{"d"}},
+			"d": {Name: "model-d", Provider: "ollama"},
 		},
 		Defaults: map[string]string{
 			"test": "a",
@@ -279,8 +305,8 @@ func TestResolve_DiamondFallbackGraph(t *testing.T) {
 func TestResolve_CircularFallbackTerminates(t *testing.T) {
 	cfg := &Config{
 		Models: map[string]ModelConfig{
-			"a": {Name: "model-a", Fallbacks: []string{"b"}},
-			"b": {Name: "model-b", Fallbacks: []string{"a"}}, // cycle: a → b → a
+			"a": {Name: "model-a", Provider: "ollama", Fallbacks: []string{"b"}},
+			"b": {Name: "model-b", Provider: "ollama", Fallbacks: []string{"a"}}, // cycle: a → b → a
 		},
 		Defaults: map[string]string{
 			"test": "a",

--- a/config/resolve_test.go
+++ b/config/resolve_test.go
@@ -39,6 +39,9 @@ func TestResolve_PrimaryAvailable(t *testing.T) {
 	if got.Role != "general" {
 		t.Errorf("Role = %q, want %q", got.Role, "general")
 	}
+	if got.Provider != "ollama" {
+		t.Errorf("Provider = %q, want %q", got.Provider, "ollama")
+	}
 	if got.IsFallback {
 		t.Error("IsFallback = true, want false")
 	}
@@ -58,6 +61,50 @@ func TestResolve_FallbackUsed(t *testing.T) {
 	}
 	if got.Role != "lightweight" {
 		t.Errorf("Role = %q, want %q", got.Role, "lightweight")
+	}
+	if got.Provider != "ollama" {
+		t.Errorf("Provider = %q, want %q", got.Provider, "ollama")
+	}
+	if !got.IsFallback {
+		t.Error("IsFallback = false, want true")
+	}
+}
+
+// TestResolve_FallbackCrossProvider verifies the resolved Provider tracks
+// the fallback's owner, not the originally-requested one. Per design:
+// requested role "coding"/provider "local-a" falling back to role "fast"/
+// provider "local-b" must yield Provider="local-b".
+func TestResolve_FallbackCrossProvider(t *testing.T) {
+	crossProvider := writeTempJSON(t, `{
+		"providers": {
+			"local-a": {"base_url": "http://localhost:11434"},
+			"local-b": {"base_url": "http://localhost:8080", "api_format": "openai-compat"}
+		},
+		"models": {
+			"primary":  {"name": "model-a", "provider": "local-a", "type": "dense", "fallbacks": ["backup"]},
+			"backup":   {"name": "model-b", "provider": "local-b", "type": "dense"}
+		},
+		"defaults": {"chat": "primary"}
+	}`)
+	cfg, err := Load(crossProvider)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	// Only the backup model is available, forcing fallback.
+	checker := &mockChecker{models: []string{"model-b"}}
+
+	got, err := cfg.Resolve(context.Background(), checker, "chat")
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+	if got.Name != "model-b" {
+		t.Errorf("Name = %q, want %q", got.Name, "model-b")
+	}
+	if got.Role != "backup" {
+		t.Errorf("Role = %q, want %q", got.Role, "backup")
+	}
+	if got.Provider != "local-b" {
+		t.Errorf("Provider = %q, want %q (must track resolved owner, not requested)", got.Provider, "local-b")
 	}
 	if !got.IsFallback {
 		t.Error("IsFallback = false, want true")

--- a/config/testdata/capabilities.json
+++ b/config/testdata/capabilities.json
@@ -8,7 +8,7 @@
       "base_url": "http://localhost:8080",
       "timeout": "30s",
       "api_format": "openai-compat",
-      "api_key": "$LLAMACPP_API_KEY"
+      "api_key": "REPLACE_ME"
     }
   },
   "models": {

--- a/config/testdata/capabilities.json
+++ b/config/testdata/capabilities.json
@@ -1,0 +1,46 @@
+{
+  "providers": {
+    "ollama": {
+      "base_url": "http://localhost:11434",
+      "timeout": "5m"
+    },
+    "remote-llamacpp": {
+      "base_url": "http://localhost:8080",
+      "timeout": "30s",
+      "api_format": "openai-compat",
+      "api_key": "$LLAMACPP_API_KEY"
+    }
+  },
+  "models": {
+    "general": {
+      "name": "gemma4:31b",
+      "provider": "ollama",
+      "type": "dense",
+      "context_window": 256000
+    },
+    "carved-down": {
+      "name": "qwen2.5-coder-14b",
+      "provider": "remote-llamacpp",
+      "description": "Example: this llama.cpp build exposes chat + stream but not /v1/completions; carve down explicitly.",
+      "type": "dense",
+      "capabilities": ["chat", "stream"]
+    },
+    "with-tools": {
+      "name": "qwen3.5:27b",
+      "provider": "ollama",
+      "description": "Example: declare tool_call explicitly (never derived from type).",
+      "type": "dense",
+      "capabilities": ["chat", "generate", "stream", "tool_call"]
+    },
+    "embedding": {
+      "name": "qwen3-embedding:8b",
+      "provider": "ollama",
+      "type": "embedding",
+      "dimensions": 4096
+    }
+  },
+  "defaults": {
+    "chat": "general",
+    "embedding": "embedding"
+  }
+}

--- a/provider/catalog.go
+++ b/provider/catalog.go
@@ -292,6 +292,23 @@ func parseCaps(caps []string) Capability {
 	return c
 }
 
+// aliasSuggestions maps known catalog/runtime aliases that ParseCapsStrict
+// rejects to a "did you mean" replacement in canonical user-config form.
+// Used to make the rejection error actionable when the user typed a
+// recognizable shorthand (the most common mistake) rather than dumping
+// the full canonical vocabulary and leaving them to guess.
+//
+// Tokens not in this map fall back to the canonical-names list in the
+// error message. "insert" is NOT here because it is itself canonical —
+// catalog parseCaps expands it to generate+stream+insert, but strict
+// parsing accepts it as the single CapInsert bit, which is the right
+// answer for user config.
+var aliasSuggestions = map[string]string{
+	"tools":      `"tool_call"`,
+	"embedding":  `"embed"`,
+	"completion": `"chat", "generate", and/or "stream" (was a multi-bit alias; pick the bits you actually want)`,
+}
+
 // ParseCapsStrict converts a slice of canonical-only capability tokens to
 // a bitmask. Each token must be a name from CanonicalCapabilityNames; any
 // non-canonical token is rejected — including aliases that would expand
@@ -301,11 +318,18 @@ func parseCaps(caps []string) Capability {
 // canonical spelling is "tool_call"). Intended for validating
 // user-authored capability lists in models.json where any non-canonical
 // token would risk silent bit-set divergence from what the user wrote.
+//
+// Rejection errors include a "did you mean" hint when the rejected token
+// is a known alias (e.g. "tools" -> suggest "tool_call"); otherwise they
+// fall back to listing the canonical vocabulary.
 func ParseCapsStrict(caps []string) (Capability, error) {
 	var c Capability
 	for _, s := range caps {
 		bit, ok := canonicalCapability(s)
 		if !ok {
+			if hint, known := aliasSuggestions[strings.ToLower(s)]; known {
+				return 0, fmt.Errorf("provider: unknown or non-canonical capability %q (did you mean %s?)", s, hint)
+			}
 			return 0, fmt.Errorf("provider: unknown or non-canonical capability %q (canonical names: %v)", s, CanonicalCapabilityNames)
 		}
 		c |= bit

--- a/provider/catalog.go
+++ b/provider/catalog.go
@@ -184,28 +184,78 @@ func parseTier(s string) Tier {
 	}
 }
 
-// parseCaps converts a string slice of capability names from catalog JSON
-// to a Capability bitmask. The catalog uses higher-level labels:
-//   - "completion" implies CapChat | CapGenerate | CapStream
-//   - "insert" implies CapGenerate | CapStream | CapInsert
-//   - "tools" implies CapToolCall
-//   - "embedding" implies CapEmbed
-//   - "thinking" implies CapThinking
+// capabilityFor maps a single capability token to its bitmask contribution.
+// It accepts both the canonical lowercase names matching Capability.String()
+// output ("chat", "generate", "stream", "embed", "tool_call", "thinking",
+// "insert") and the higher-level catalog aliases used by catalog.json:
+//
+//	"completion" -> CapChat | CapGenerate | CapStream
+//	"insert"     -> CapGenerate | CapStream | CapInsert
+//	"tools"      -> CapToolCall
+//	"embedding"  -> CapEmbed
+//	"thinking"   -> CapThinking
+//
+// Tokens are lowercased before matching. The boolean return reports whether
+// the token was recognized; callers decide whether unknowns are an error
+// (user config) or a silent skip (upstream metadata sources).
+func capabilityFor(token string) (Capability, bool) {
+	switch strings.ToLower(token) {
+	// Canonical single-bit names.
+	case "chat":
+		return CapChat, true
+	case "generate":
+		return CapGenerate, true
+	case "stream":
+		return CapStream, true
+	case "embed":
+		return CapEmbed, true
+	case "tool_call":
+		return CapToolCall, true
+	case "thinking":
+		return CapThinking, true
+	case "insert":
+		// "insert" intentionally implies generate+stream+insert because
+		// FIM consumers expect the full path; standalone CapInsert without
+		// generate/stream is not a useful state in this codebase.
+		return CapGenerate | CapStream | CapInsert, true
+	// Catalog aliases retained for compatibility with catalog.json and
+	// upstream caps strings emitted by fingerprint / Ollama /api/show.
+	case "completion":
+		return CapChat | CapGenerate | CapStream, true
+	case "tools":
+		return CapToolCall, true
+	case "embedding":
+		return CapEmbed, true
+	}
+	return 0, false
+}
+
+// parseCaps converts a string slice of capability names to a bitmask,
+// silently skipping unknown tokens. Suitable for upstream metadata sources
+// (catalog.json, fingerprint cache, provider /api/show) where graceful
+// degradation across schema versions is the right behavior. User config
+// should use ParseCapsStrict instead so typos surface at load time.
 func parseCaps(caps []string) Capability {
 	var c Capability
 	for _, s := range caps {
-		switch strings.ToLower(s) {
-		case "completion":
-			c |= CapChat | CapGenerate | CapStream
-		case "insert":
-			c |= CapGenerate | CapStream | CapInsert
-		case "tools":
-			c |= CapToolCall
-		case "embedding":
-			c |= CapEmbed
-		case "thinking":
-			c |= CapThinking
+		if bit, ok := capabilityFor(s); ok {
+			c |= bit
 		}
 	}
 	return c
+}
+
+// ParseCapsStrict is the strict variant of parseCaps: it returns an error on
+// the first unknown token. Intended for validating user-authored capability
+// lists in models.json where a silent skip would hide configuration mistakes.
+func ParseCapsStrict(caps []string) (Capability, error) {
+	var c Capability
+	for _, s := range caps {
+		bit, ok := capabilityFor(s)
+		if !ok {
+			return 0, fmt.Errorf("provider: unknown capability %q", s)
+		}
+		c |= bit
+	}
+	return c, nil
 }

--- a/provider/catalog.go
+++ b/provider/catalog.go
@@ -184,23 +184,35 @@ func parseTier(s string) Tier {
 	}
 }
 
-// capabilityFor maps a single capability token to its bitmask contribution.
-// It accepts both the canonical lowercase names matching Capability.String()
-// output ("chat", "generate", "stream", "embed", "tool_call", "thinking",
-// "insert") and the higher-level catalog aliases used by catalog.json:
+// CanonicalCapabilityNames is the user-facing capability vocabulary: each
+// token maps to exactly one Capability bit. Aliases like "completion" that
+// expand to multiple bits are NOT in this set — they remain valid only in
+// catalog.json and upstream metadata sources (handled by parseCaps).
 //
-//	"completion" -> CapChat | CapGenerate | CapStream
-//	"insert"     -> CapGenerate | CapStream | CapInsert
-//	"tools"      -> CapToolCall
-//	"embedding"  -> CapEmbed
-//	"thinking"   -> CapThinking
+// Exported so config validation in adjacent packages can use this list as
+// the single source of truth for "valid user-config capability tokens"
+// rather than maintaining a parallel set that could drift.
+var CanonicalCapabilityNames = []string{
+	"chat",
+	"generate",
+	"stream",
+	"embed",
+	"tool_call",
+	"thinking",
+	"insert",
+}
+
+// canonicalCapability maps a single canonical token to its single-bit
+// contribution. Used by ParseCapsStrict for user-config validation where
+// each token must mean exactly one bit and aliases are forbidden so the
+// "explicit Capabilities REPLACE derived" contract holds without surprise
+// expansion.
 //
-// Tokens are lowercased before matching. The boolean return reports whether
-// the token was recognized; callers decide whether unknowns are an error
-// (user config) or a silent skip (upstream metadata sources).
-func capabilityFor(token string) (Capability, bool) {
+// Catalog aliases that expand multiple bits (e.g. "insert" -> generate+
+// stream+insert) are handled by aliasedCapability, used only by parseCaps
+// for catalog.json and runtime /api/show output.
+func canonicalCapability(token string) (Capability, bool) {
 	switch strings.ToLower(token) {
-	// Canonical single-bit names.
 	case "chat":
 		return CapChat, true
 	case "generate":
@@ -214,12 +226,43 @@ func capabilityFor(token string) (Capability, bool) {
 	case "thinking":
 		return CapThinking, true
 	case "insert":
-		// "insert" intentionally implies generate+stream+insert because
-		// FIM consumers expect the full path; standalone CapInsert without
-		// generate/stream is not a useful state in this codebase.
+		return CapInsert, true
+	}
+	return 0, false
+}
+
+// aliasedCapability maps catalog/runtime tokens (including aliases that
+// expand multiple bits) to their bitmask contribution. NOT used for
+// user-config — see canonicalCapability and ParseCapsStrict for that path.
+//
+//	"completion" -> CapChat | CapGenerate | CapStream
+//	"insert"     -> CapGenerate | CapStream | CapInsert (full FIM path)
+//	"tools"      -> CapToolCall
+//	"embedding"  -> CapEmbed
+//	"thinking"   -> CapThinking
+//
+// All canonical names are also accepted so catalog.json may use either
+// shorthand or canonical form interchangeably.
+func aliasedCapability(token string) (Capability, bool) {
+	switch strings.ToLower(token) {
+	// Canonical single-bit names (also valid in catalog/runtime input).
+	case "chat":
+		return CapChat, true
+	case "generate":
+		return CapGenerate, true
+	case "stream":
+		return CapStream, true
+	case "embed":
+		return CapEmbed, true
+	case "tool_call":
+		return CapToolCall, true
+	case "thinking":
+		return CapThinking, true
+	// Catalog aliases — multi-bit expansion is intentional here because
+	// these are author-controlled shorthand strings in catalog.json,
+	// fingerprint records, and Ollama /api/show capability arrays.
+	case "insert":
 		return CapGenerate | CapStream | CapInsert, true
-	// Catalog aliases retained for compatibility with catalog.json and
-	// upstream caps strings emitted by fingerprint / Ollama /api/show.
 	case "completion":
 		return CapChat | CapGenerate | CapStream, true
 	case "tools":
@@ -233,27 +276,33 @@ func capabilityFor(token string) (Capability, bool) {
 // parseCaps converts a string slice of capability names to a bitmask,
 // silently skipping unknown tokens. Suitable for upstream metadata sources
 // (catalog.json, fingerprint cache, provider /api/show) where graceful
-// degradation across schema versions is the right behavior. User config
-// should use ParseCapsStrict instead so typos surface at load time.
+// degradation across schema versions is the right behavior. Catalog
+// aliases that expand multiple bits are honored here.
+//
+// User config MUST use ParseCapsStrict instead: aliases are forbidden in
+// user-facing config so the "explicit Capabilities REPLACE derived"
+// contract holds without surprise expansion.
 func parseCaps(caps []string) Capability {
 	var c Capability
 	for _, s := range caps {
-		if bit, ok := capabilityFor(s); ok {
+		if bit, ok := aliasedCapability(s); ok {
 			c |= bit
 		}
 	}
 	return c
 }
 
-// ParseCapsStrict is the strict variant of parseCaps: it returns an error on
-// the first unknown token. Intended for validating user-authored capability
-// lists in models.json where a silent skip would hide configuration mistakes.
+// ParseCapsStrict converts a slice of canonical-only capability tokens to
+// a bitmask. Each token must map to exactly one Capability bit; unknown
+// tokens AND multi-bit aliases (e.g. "completion", "tools") are rejected.
+// Intended for validating user-authored capability lists in models.json
+// where alias expansion would silently re-add bits the user excluded.
 func ParseCapsStrict(caps []string) (Capability, error) {
 	var c Capability
 	for _, s := range caps {
-		bit, ok := capabilityFor(s)
+		bit, ok := canonicalCapability(s)
 		if !ok {
-			return 0, fmt.Errorf("provider: unknown capability %q", s)
+			return 0, fmt.Errorf("provider: unknown or non-canonical capability %q (canonical names: %v)", s, CanonicalCapabilityNames)
 		}
 		c |= bit
 	}

--- a/provider/catalog.go
+++ b/provider/catalog.go
@@ -293,10 +293,14 @@ func parseCaps(caps []string) Capability {
 }
 
 // ParseCapsStrict converts a slice of canonical-only capability tokens to
-// a bitmask. Each token must map to exactly one Capability bit; unknown
-// tokens AND multi-bit aliases (e.g. "completion", "tools") are rejected.
-// Intended for validating user-authored capability lists in models.json
-// where alias expansion would silently re-add bits the user excluded.
+// a bitmask. Each token must be a name from CanonicalCapabilityNames; any
+// non-canonical token is rejected — including aliases that would expand
+// to multiple bits ("completion" -> chat+generate+stream, the catalog
+// shorthand "insert" -> generate+stream+insert) AND single-bit aliases
+// that merely shadow a canonical name ("tools" is rejected because the
+// canonical spelling is "tool_call"). Intended for validating
+// user-authored capability lists in models.json where any non-canonical
+// token would risk silent bit-set divergence from what the user wrote.
 func ParseCapsStrict(caps []string) (Capability, error) {
 	var c Capability
 	for _, s := range caps {

--- a/provider/catalog_test.go
+++ b/provider/catalog_test.go
@@ -600,14 +600,37 @@ func TestParseCaps(t *testing.T) {
 }
 
 func TestParseCapsStrict(t *testing.T) {
-	t.Run("known tokens succeed", func(t *testing.T) {
-		got, err := ParseCapsStrict([]string{"chat", "stream", "embed"})
+	t.Run("canonical tokens succeed (each maps to single bit)", func(t *testing.T) {
+		got, err := ParseCapsStrict([]string{"chat", "stream", "embed", "insert"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		want := CapChat | CapStream | CapEmbed
+		want := CapChat | CapStream | CapEmbed | CapInsert
 		if got != want {
 			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+	t.Run("insert is single-bit only (no generate+stream expansion)", func(t *testing.T) {
+		// Critical: aliasedCapability expands "insert" to generate+stream+insert,
+		// but ParseCapsStrict must NOT — otherwise user config ["chat","insert"]
+		// silently adds generate+stream, violating the REPLACES contract.
+		got, err := ParseCapsStrict([]string{"insert"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != CapInsert {
+			t.Errorf("got %v, want %v (insert must NOT expand under strict parser)", got, CapInsert)
+		}
+	})
+	t.Run("multi-bit aliases rejected", func(t *testing.T) {
+		// "completion", "tools", "embedding" are catalog shorthand that
+		// expand multiple bits. They MUST NOT be accepted by the user-config
+		// path — otherwise the REPLACES contract leaks expanded bits.
+		for _, alias := range []string{"completion", "tools", "embedding"} {
+			_, err := ParseCapsStrict([]string{alias})
+			if err == nil {
+				t.Errorf("expected error for alias %q, got nil", alias)
+			}
 		}
 	})
 	t.Run("unknown token rejected", func(t *testing.T) {
@@ -628,4 +651,33 @@ func TestParseCapsStrict(t *testing.T) {
 			t.Errorf("got %v, want 0", got)
 		}
 	})
+	t.Run("case-insensitive (mixed case accepted)", func(t *testing.T) {
+		got, err := ParseCapsStrict([]string{"Chat", "STREAM"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := CapChat | CapStream
+		if got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+}
+
+func TestCanonicalCapabilityNames_Stable(t *testing.T) {
+	// Guard against accidental drift: the public list is consumed by adjacent
+	// packages as the single source of truth for user-config vocabulary. If
+	// names are added/removed, downstream config validation must update too.
+	want := map[string]bool{
+		"chat": true, "generate": true, "stream": true, "embed": true,
+		"tool_call": true, "thinking": true, "insert": true,
+	}
+	if len(CanonicalCapabilityNames) != len(want) {
+		t.Fatalf("CanonicalCapabilityNames length = %d, want %d (%v vs %v)",
+			len(CanonicalCapabilityNames), len(want), CanonicalCapabilityNames, want)
+	}
+	for _, name := range CanonicalCapabilityNames {
+		if !want[name] {
+			t.Errorf("unexpected canonical name %q", name)
+		}
+	}
 }

--- a/provider/catalog_test.go
+++ b/provider/catalog_test.go
@@ -633,6 +633,43 @@ func TestParseCapsStrict(t *testing.T) {
 			}
 		}
 	})
+	t.Run("known alias rejection includes did-you-mean hint", func(t *testing.T) {
+		// Known alias -> canonical mappings make the rejection actionable.
+		// Without the hint the user only sees the full vocabulary dump and
+		// has to guess which canonical token they meant.
+		cases := map[string]string{
+			"tools":      "tool_call",
+			"Tools":      "tool_call", // case-insensitive lookup
+			"embedding":  "embed",
+			"completion": "chat",
+		}
+		for alias, wantSubstr := range cases {
+			_, err := ParseCapsStrict([]string{alias})
+			if err == nil {
+				t.Fatalf("expected error for alias %q, got nil", alias)
+			}
+			if !strings.Contains(err.Error(), "did you mean") {
+				t.Errorf("error for %q should include 'did you mean' hint, got: %v", alias, err)
+			}
+			if !strings.Contains(err.Error(), wantSubstr) {
+				t.Errorf("error for %q should suggest %q, got: %v", alias, wantSubstr, err)
+			}
+		}
+	})
+	t.Run("unknown (non-alias) rejection falls back to canonical-names list", func(t *testing.T) {
+		// Tokens not in aliasSuggestions should still get the vocabulary
+		// dump so the user has something to work with.
+		_, err := ParseCapsStrict([]string{"totallyfake"})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "canonical names:") {
+			t.Errorf("unknown token error should list canonical names, got: %v", err)
+		}
+		if strings.Contains(err.Error(), "did you mean") {
+			t.Errorf("unknown (non-alias) token error should NOT include did-you-mean, got: %v", err)
+		}
+	})
 	t.Run("unknown token rejected", func(t *testing.T) {
 		_, err := ParseCapsStrict([]string{"chat", "nonexistent"})
 		if err == nil {

--- a/provider/catalog_test.go
+++ b/provider/catalog_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -557,6 +558,36 @@ func TestParseCaps(t *testing.T) {
 			input: []string{"completion", "nonexistent"},
 			want:  CapChat | CapGenerate | CapStream,
 		},
+		{
+			name:  "canonical chat token",
+			input: []string{"chat"},
+			want:  CapChat,
+		},
+		{
+			name:  "canonical generate token",
+			input: []string{"generate"},
+			want:  CapGenerate,
+		},
+		{
+			name:  "canonical stream token",
+			input: []string{"stream"},
+			want:  CapStream,
+		},
+		{
+			name:  "canonical embed token",
+			input: []string{"embed"},
+			want:  CapEmbed,
+		},
+		{
+			name:  "canonical tool_call token",
+			input: []string{"tool_call"},
+			want:  CapToolCall,
+		},
+		{
+			name:  "mixed canonical and aliases",
+			input: []string{"chat", "stream", "tools"},
+			want:  CapChat | CapStream | CapToolCall,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -566,4 +597,35 @@ func TestParseCaps(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseCapsStrict(t *testing.T) {
+	t.Run("known tokens succeed", func(t *testing.T) {
+		got, err := ParseCapsStrict([]string{"chat", "stream", "embed"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := CapChat | CapStream | CapEmbed
+		if got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+	t.Run("unknown token rejected", func(t *testing.T) {
+		_, err := ParseCapsStrict([]string{"chat", "nonexistent"})
+		if err == nil {
+			t.Fatal("expected error for unknown token, got nil")
+		}
+		if !strings.Contains(err.Error(), "nonexistent") {
+			t.Errorf("error should mention the bad token, got: %v", err)
+		}
+	})
+	t.Run("empty input is no error", func(t *testing.T) {
+		got, err := ParseCapsStrict(nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 0 {
+			t.Errorf("got %v, want 0", got)
+		}
+	})
 }

--- a/provider/model_registry.go
+++ b/provider/model_registry.go
@@ -46,28 +46,29 @@ type ModelRegistry struct {
 
 // CapabilityOverride returns the user-declared canonical capability tokens
 // for a model key, or nil when no override is configured for the key. When
-// non-nil, the returned slice REPLACES the merge-derived Caps on the
-// resulting ModelProfile so users can carve down capabilities below what
-// the static catalog or runtime probe claims — e.g. removing "generate"
-// for an OpenAI-compatible server that lacks /v1/completions.
+// non-nil and well-formed, the returned slice REPLACES the merge-derived
+// Caps on the resulting ModelProfile so users can carve down capabilities
+// below what the static catalog or runtime probe claims — e.g. removing
+// "generate" for an OpenAI-compatible server that lacks /v1/completions.
 //
 // Tokens MUST be canonical single-bit names (see CanonicalCapabilityNames /
-// ParseCapsStrict). Multi-bit aliases like "completion" or "insert" expand
-// silently under the lenient parseCaps used here, which would defeat the
-// REPLACES contract; validators (e.g. config.validate) must reject aliases
-// before they reach this seam.
+// ParseCapsStrict). Non-canonical tokens — unknowns AND catalog aliases
+// that would expand to multiple bits like "completion" or the catalog
+// shorthand "insert" → generate+stream+insert — are REJECTED at the apply
+// site, not silently expanded. On rejection the merge-derived caps are
+// preserved unchanged so a misconfigured override cannot cripple a model
+// for every router gate downstream.
 //
 // Replacement is wholesale and applies AFTER every other merge layer,
 // including the runtime-template-driven CapInsert toggle in merge(). An
-// override that omits "insert" silently drops CapInsert even if the
-// model's template indicates FIM support — this is by design (the user's
-// declaration wins) but is a sharp interaction worth knowing.
+// override that omits "insert" drops runtime-detected CapInsert by design
+// (the user's declaration wins); this is a sharp interaction worth knowing.
 //
-// Returning a nil slice means "no override applied for this key" — the
-// merge-derived caps are used unchanged. Returning a non-nil but empty
-// or all-unknown slice would yield zero capabilities, which is treated
-// as an anomaly and ignored by merge(); see the override application
-// site for details.
+// Return semantics:
+//   - nil slice: no override applied for this key; merge-derived caps used
+//   - empty []string: ignored (no zero-out)
+//   - any non-canonical token: ignored (no silent expansion)
+//   - parses to zero caps: ignored (same crippling hazard)
 type CapabilityOverride func(key ModelKey) []string
 
 // SetCapabilityOverride installs (or clears) the capability override hook.
@@ -466,24 +467,29 @@ func (r *ModelRegistry) merge(
 	// e.g. ["chat", "stream"] genuinely removes CapGenerate even if the
 	// static catalog or runtime template detection claims it.
 	//
-	// Two corner cases are deliberately ignored rather than applied:
+	// Three corner cases are deliberately ignored rather than applied:
 	//   1. Non-nil but empty slice — would silently zero out the profile.
 	//      Treated as anomaly; keep merged caps and skip the replace.
-	//   2. Non-empty slice that parses to zero (all unknown tokens) — same
-	//      hazard. Validators upstream MUST reject unknowns; reaching this
-	//      branch with zero parsed caps means a programmatic caller
-	//      bypassed validation. Refuse the replacement rather than
-	//      cripple the profile.
+	//   2. Non-canonical tokens (catalog aliases like "completion" or
+	//      "insert"-as-FIM-shorthand) — these would silently expand to
+	//      multiple bits and defeat the REPLACES contract. ParseCapsStrict
+	//      rejects them; on error we keep merged caps and skip the replace.
+	//   3. Non-empty slice that parses to zero (theoretically reachable
+	//      only via a programmatic bypass) — same crippling hazard as
+	//      case 1. Refuse the replacement rather than zero the profile.
 	//
-	// Lenient parseCaps matches the other merge sources; config validation
-	// already rejected unknown tokens and multi-bit aliases for any
-	// override sourced from models.json.
+	// ParseCapsStrict (canonical-only) is used here so the parser at the
+	// apply site matches the parser at the validation site (config.validate
+	// also routes through ParseCapsStrict). Using lenient parseCaps would
+	// re-introduce alias expansion for tokens like "insert" (single bit
+	// under strict, three bits under lenient), reopening the contract gap
+	// that motivated the canonical-only split in the first place.
 	r.mu.RLock()
 	override := r.capOverride
 	r.mu.RUnlock()
 	if override != nil {
 		if cfgCaps := override(key); len(cfgCaps) > 0 {
-			if parsed := parseCaps(cfgCaps); parsed != 0 {
+			if parsed, err := ParseCapsStrict(cfgCaps); err == nil && parsed != 0 {
 				profile.Caps = parsed
 			}
 		}

--- a/provider/model_registry.go
+++ b/provider/model_registry.go
@@ -56,12 +56,24 @@ type ModelRegistry struct {
 type CapabilityOverride func(key ModelKey) []string
 
 // SetCapabilityOverride installs (or clears) the capability override hook.
-// Pass nil to disable overrides. Safe for concurrent use; the new function
-// takes effect on subsequent Refresh or Lookup calls that miss the cache.
+// Pass nil to disable overrides. Safe for concurrent use.
+//
+// Installing or clearing an override invalidates the entire profile cache
+// so the new policy applies to every subsequent Lookup, not just to
+// previously-uncached keys. This matches the "Rebuild downstream objects
+// when cache refreshes" principle that keeps the wiring sequence
+// (build registry -> RefreshModels -> install override) correct regardless
+// of which step warmed which entries.
 func (r *ModelRegistry) SetCapabilityOverride(fn CapabilityOverride) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.capOverride = fn
+	// Cached profiles were merged under the previous override (possibly
+	// nil); flush them so the next Lookup re-runs merge with the new
+	// override in effect. Skipping this flush is the bug class where a
+	// warm cache silently shadows config changes — see feedback memory
+	// on rebuilding downstream state when a cache source changes.
+	clear(r.profiles)
 }
 
 // directModelInfoProvider is an optional provider capability that returns

--- a/provider/model_registry.go
+++ b/provider/model_registry.go
@@ -46,13 +46,28 @@ type ModelRegistry struct {
 
 // CapabilityOverride returns the user-declared canonical capability tokens
 // for a model key, or nil when no override is configured for the key. When
-// non-nil, the returned slice REPLACES the merge-derived Caps on the resulting
-// ModelProfile so users can carve down capabilities below what the static
-// catalog or runtime probe claims — e.g. removing "generate" for an
-// OpenAI-compatible server that lacks /v1/completions.
+// non-nil, the returned slice REPLACES the merge-derived Caps on the
+// resulting ModelProfile so users can carve down capabilities below what
+// the static catalog or runtime probe claims — e.g. removing "generate"
+// for an OpenAI-compatible server that lacks /v1/completions.
 //
-// Returning a non-nil empty slice yields a profile with zero capabilities;
-// callers that want "no override applied" must return nil.
+// Tokens MUST be canonical single-bit names (see CanonicalCapabilityNames /
+// ParseCapsStrict). Multi-bit aliases like "completion" or "insert" expand
+// silently under the lenient parseCaps used here, which would defeat the
+// REPLACES contract; validators (e.g. config.validate) must reject aliases
+// before they reach this seam.
+//
+// Replacement is wholesale and applies AFTER every other merge layer,
+// including the runtime-template-driven CapInsert toggle in merge(). An
+// override that omits "insert" silently drops CapInsert even if the
+// model's template indicates FIM support — this is by design (the user's
+// declaration wins) but is a sharp interaction worth knowing.
+//
+// Returning a nil slice means "no override applied for this key" — the
+// merge-derived caps are used unchanged. Returning a non-nil but empty
+// or all-unknown slice would yield zero capabilities, which is treated
+// as an anomaly and ignored by merge(); see the override application
+// site for details.
 type CapabilityOverride func(key ModelKey) []string
 
 // SetCapabilityOverride installs (or clears) the capability override hook.
@@ -445,17 +460,32 @@ func (r *ModelRegistry) merge(
 		profile.Family = parsed.NormalizedFamily()
 	}
 
-	// Config capability override (final precedence). A non-nil result REPLACES
-	// the merged Caps wholesale — this is the escape hatch the design contract
-	// guarantees, e.g. ["chat", "stream"] genuinely removes CapGenerate even
-	// if the static catalog claims it. Lenient parseCaps matches the other
-	// merge sources; config validation already rejected unknown tokens.
+	// Config capability override (final precedence). A non-nil, non-empty
+	// result that parses to a non-zero bitmask REPLACES the merged Caps
+	// wholesale — this is the escape hatch the design contract guarantees,
+	// e.g. ["chat", "stream"] genuinely removes CapGenerate even if the
+	// static catalog or runtime template detection claims it.
+	//
+	// Two corner cases are deliberately ignored rather than applied:
+	//   1. Non-nil but empty slice — would silently zero out the profile.
+	//      Treated as anomaly; keep merged caps and skip the replace.
+	//   2. Non-empty slice that parses to zero (all unknown tokens) — same
+	//      hazard. Validators upstream MUST reject unknowns; reaching this
+	//      branch with zero parsed caps means a programmatic caller
+	//      bypassed validation. Refuse the replacement rather than
+	//      cripple the profile.
+	//
+	// Lenient parseCaps matches the other merge sources; config validation
+	// already rejected unknown tokens and multi-bit aliases for any
+	// override sourced from models.json.
 	r.mu.RLock()
 	override := r.capOverride
 	r.mu.RUnlock()
 	if override != nil {
-		if cfgCaps := override(key); cfgCaps != nil {
-			profile.Caps = parseCaps(cfgCaps)
+		if cfgCaps := override(key); len(cfgCaps) > 0 {
+			if parsed := parseCaps(cfgCaps); parsed != 0 {
+				profile.Caps = parsed
+			}
 		}
 	}
 

--- a/provider/model_registry.go
+++ b/provider/model_registry.go
@@ -43,6 +43,7 @@ type ModelRegistry struct {
 	providers       ProviderResolver
 	capOverride     CapabilityOverride
 	overrideVersion uint64
+	rejectionHook   OverrideRejectionHook
 }
 
 // CapabilityOverride returns the user-declared canonical capability tokens
@@ -58,7 +59,10 @@ type ModelRegistry struct {
 // shorthand "insert" → generate+stream+insert — are REJECTED at the apply
 // site, not silently expanded. On rejection the merge-derived caps are
 // preserved unchanged so a misconfigured override cannot cripple a model
-// for every router gate downstream.
+// for every router gate downstream. Install an OverrideRejectionHook via
+// SetOverrideRejectionHook to surface rejections; otherwise the drop is
+// silent by design (preserves backward compatibility for callers that
+// only set the override).
 //
 // Replacement is wholesale and applies AFTER every other merge layer,
 // including the runtime-template-driven CapInsert toggle in merge(). An
@@ -71,6 +75,36 @@ type ModelRegistry struct {
 //   - any non-canonical token: ignored (no silent expansion)
 //   - parses to zero caps: ignored (same crippling hazard)
 type CapabilityOverride func(key ModelKey) []string
+
+// OverrideRejectionHook is called when a capability override returned a
+// non-empty token slice that failed strict canonical-only parsing — i.e.
+// the override was applied at the registry but had to be DROPPED because
+// the tokens were unknown or were multi-bit aliases that would silently
+// expand and violate the REPLACES contract.
+//
+// The merged profile preserves its pre-override caps in this case (fail
+// safe), so the hook is the only signal the misconfiguration ever happened.
+// Without it the override is silently swallowed and the operator sees
+// router decisions that don't match the config they wrote.
+//
+// Typical implementations log the rejection or emit a metric. Hooks MUST
+// be cheap and non-blocking — they run inside merge() on every cache miss
+// for the affected key until a Refresh clears the cached pre-override
+// profile, so a slow hook would amplify into a hot-path stall.
+type OverrideRejectionHook func(key ModelKey, tokens []string, err error)
+
+// SetOverrideRejectionHook installs (or clears) the rejection-callback
+// hook. Pass nil to disable. Safe for concurrent use.
+//
+// Unlike SetCapabilityOverride this does NOT invalidate the cache: the
+// hook only fires when an override is rejected at merge time, and changing
+// observability shouldn't churn the cache. Callers that need rejections
+// surfaced for already-merged profiles must call Refresh themselves.
+func (r *ModelRegistry) SetOverrideRejectionHook(fn OverrideRejectionHook) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.rejectionHook = fn
+}
 
 // SetCapabilityOverride installs (or clears) the capability override hook.
 // Pass nil to disable overrides. Safe for concurrent use.
@@ -280,15 +314,17 @@ func (r *ModelRegistry) FIMConfigFor(ctx context.Context, key ModelKey) (*FIMCon
 //  2. Fingerprint: capability probing data, benchmarked resource observations
 //  3. Runtime: context_window, parameter_size, quant_level, digest (freshest)
 func (r *ModelRegistry) buildProfile(ctx context.Context, key ModelKey) (*ModelProfile, error) {
-	// Snapshot (override, version) FIRST so the policy a single buildProfile
-	// applies is fixed at start, and the cache write at the end can detect
-	// any concurrent SetCapabilityOverride. Reading later (after slow IO
-	// like queryRuntime) would shrink the visible TOCTOU window but also
-	// leave the same race against the cache write itself; reading first
-	// keeps the contract simple: one buildProfile -> one policy version.
+	// Snapshot (override, version, rejectionHook) FIRST so the policy a
+	// single buildProfile applies is fixed at start, and the cache write
+	// at the end can detect any concurrent SetCapabilityOverride. Reading
+	// later (after slow IO like queryRuntime) would shrink the visible
+	// TOCTOU window but also leave the same race against the cache write
+	// itself; reading first keeps the contract simple: one buildProfile ->
+	// one policy version.
 	r.mu.RLock()
 	override := r.capOverride
 	overrideVer := r.overrideVersion
+	rejectionHook := r.rejectionHook
 	r.mu.RUnlock()
 
 	// Layer 1: Runtime query.
@@ -321,8 +357,9 @@ func (r *ModelRegistry) buildProfile(ctx context.Context, key ModelKey) (*ModelP
 		// Ignore errors -- fingerprint is optional enrichment.
 	}
 
-	// Merge layers using the override snapshot taken at function entry.
-	profile := r.merge(key, runtimeInfo, staticProfile, fpProfile, parsed, override)
+	// Merge layers using the (override, rejectionHook) snapshot taken at
+	// function entry.
+	profile := r.merge(key, runtimeInfo, staticProfile, fpProfile, parsed, override, rejectionHook)
 
 	// Cache the result iff the override snapshot is still current.
 	r.mu.Lock()
@@ -379,6 +416,7 @@ func (r *ModelRegistry) merge(
 	fp *fingerprint.Profile,
 	parsed ParsedModel,
 	override CapabilityOverride,
+	rejectionHook OverrideRejectionHook,
 ) *ModelProfile {
 	profile := &ModelProfile{
 		Key:       key,
@@ -517,8 +555,19 @@ func (r *ModelRegistry) merge(
 	// to close.
 	if override != nil {
 		if cfgCaps := override(key); len(cfgCaps) > 0 {
-			if parsed, err := ParseCapsStrict(cfgCaps); err == nil && parsed != 0 {
-				profile.Caps = parsed
+			parsedCaps, err := ParseCapsStrict(cfgCaps)
+			switch {
+			case err != nil:
+				// Non-canonical tokens (e.g. catalog aliases that would
+				// expand to multiple bits) — fire the rejection hook so
+				// the operator can see the misconfiguration. Without this
+				// signal the drop is silent and the only symptom is router
+				// decisions that don't match the config.
+				if rejectionHook != nil {
+					rejectionHook(key, cfgCaps, err)
+				}
+			case parsedCaps != 0:
+				profile.Caps = parsedCaps
 			}
 		}
 	}

--- a/provider/model_registry.go
+++ b/provider/model_registry.go
@@ -36,11 +36,32 @@ type ProviderResolver interface {
 // implementation returns the cached profile on cache hit without digest
 // revalidation; callers that need freshness guarantees must use Refresh.
 type ModelRegistry struct {
-	mu        sync.RWMutex
-	profiles  map[ModelKey]*ModelProfile
-	catalog   *staticCatalog
-	fpStore   fingerprint.Store
-	providers ProviderResolver
+	mu          sync.RWMutex
+	profiles    map[ModelKey]*ModelProfile
+	catalog     *staticCatalog
+	fpStore     fingerprint.Store
+	providers   ProviderResolver
+	capOverride CapabilityOverride
+}
+
+// CapabilityOverride returns the user-declared canonical capability tokens
+// for a model key, or nil when no override is configured for the key. When
+// non-nil, the returned slice REPLACES the merge-derived Caps on the resulting
+// ModelProfile so users can carve down capabilities below what the static
+// catalog or runtime probe claims — e.g. removing "generate" for an
+// OpenAI-compatible server that lacks /v1/completions.
+//
+// Returning a non-nil empty slice yields a profile with zero capabilities;
+// callers that want "no override applied" must return nil.
+type CapabilityOverride func(key ModelKey) []string
+
+// SetCapabilityOverride installs (or clears) the capability override hook.
+// Pass nil to disable overrides. Safe for concurrent use; the new function
+// takes effect on subsequent Refresh or Lookup calls that miss the cache.
+func (r *ModelRegistry) SetCapabilityOverride(fn CapabilityOverride) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.capOverride = fn
 }
 
 // directModelInfoProvider is an optional provider capability that returns
@@ -410,6 +431,20 @@ func (r *ModelRegistry) merge(
 	// Set family from parsed name if still empty.
 	if profile.Family == "" {
 		profile.Family = parsed.NormalizedFamily()
+	}
+
+	// Config capability override (final precedence). A non-nil result REPLACES
+	// the merged Caps wholesale — this is the escape hatch the design contract
+	// guarantees, e.g. ["chat", "stream"] genuinely removes CapGenerate even
+	// if the static catalog claims it. Lenient parseCaps matches the other
+	// merge sources; config validation already rejected unknown tokens.
+	r.mu.RLock()
+	override := r.capOverride
+	r.mu.RUnlock()
+	if override != nil {
+		if cfgCaps := override(key); cfgCaps != nil {
+			profile.Caps = parseCaps(cfgCaps)
+		}
 	}
 
 	return profile

--- a/provider/model_registry.go
+++ b/provider/model_registry.go
@@ -36,12 +36,13 @@ type ProviderResolver interface {
 // implementation returns the cached profile on cache hit without digest
 // revalidation; callers that need freshness guarantees must use Refresh.
 type ModelRegistry struct {
-	mu          sync.RWMutex
-	profiles    map[ModelKey]*ModelProfile
-	catalog     *staticCatalog
-	fpStore     fingerprint.Store
-	providers   ProviderResolver
-	capOverride CapabilityOverride
+	mu              sync.RWMutex
+	profiles        map[ModelKey]*ModelProfile
+	catalog         *staticCatalog
+	fpStore         fingerprint.Store
+	providers       ProviderResolver
+	capOverride     CapabilityOverride
+	overrideVersion uint64
 }
 
 // CapabilityOverride returns the user-declared canonical capability tokens
@@ -80,10 +81,20 @@ type CapabilityOverride func(key ModelKey) []string
 // when cache refreshes" principle that keeps the wiring sequence
 // (build registry -> RefreshModels -> install override) correct regardless
 // of which step warmed which entries.
+//
+// Concurrency model: cache invalidation alone is not enough. An in-flight
+// buildProfile that read the OLD override before this call could otherwise
+// finish, write the stale-policy profile to the freshly-cleared map, and
+// shadow this swap until the next Refresh. To prevent that TOCTOU window
+// the override version is bumped here; buildProfile snapshots the version
+// alongside the override and only writes its result to the cache if the
+// version is still current at write time. Stale results are returned to
+// the caller (correct for that caller's snapshot) but never cached.
 func (r *ModelRegistry) SetCapabilityOverride(fn CapabilityOverride) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.capOverride = fn
+	r.overrideVersion++
 	// Cached profiles were merged under the previous override (possibly
 	// nil); flush them so the next Lookup re-runs merge with the new
 	// override in effect. Skipping this flush is the bug class where a
@@ -269,6 +280,17 @@ func (r *ModelRegistry) FIMConfigFor(ctx context.Context, key ModelKey) (*FIMCon
 //  2. Fingerprint: capability probing data, benchmarked resource observations
 //  3. Runtime: context_window, parameter_size, quant_level, digest (freshest)
 func (r *ModelRegistry) buildProfile(ctx context.Context, key ModelKey) (*ModelProfile, error) {
+	// Snapshot (override, version) FIRST so the policy a single buildProfile
+	// applies is fixed at start, and the cache write at the end can detect
+	// any concurrent SetCapabilityOverride. Reading later (after slow IO
+	// like queryRuntime) would shrink the visible TOCTOU window but also
+	// leave the same race against the cache write itself; reading first
+	// keeps the contract simple: one buildProfile -> one policy version.
+	r.mu.RLock()
+	override := r.capOverride
+	overrideVer := r.overrideVersion
+	r.mu.RUnlock()
+
 	// Layer 1: Runtime query.
 	runtimeInfo, err := r.queryRuntime(ctx, key)
 	if err != nil {
@@ -299,12 +321,14 @@ func (r *ModelRegistry) buildProfile(ctx context.Context, key ModelKey) (*ModelP
 		// Ignore errors -- fingerprint is optional enrichment.
 	}
 
-	// Merge layers.
-	profile := r.merge(key, runtimeInfo, staticProfile, fpProfile, parsed)
+	// Merge layers using the override snapshot taken at function entry.
+	profile := r.merge(key, runtimeInfo, staticProfile, fpProfile, parsed, override)
 
-	// Cache the result.
+	// Cache the result iff the override snapshot is still current.
 	r.mu.Lock()
-	r.profiles[key] = profile
+	if r.overrideVersion == overrideVer {
+		r.profiles[key] = profile
+	}
 	r.mu.Unlock()
 
 	return profile, nil
@@ -354,6 +378,7 @@ func (r *ModelRegistry) merge(
 	static *ModelProfile,
 	fp *fingerprint.Profile,
 	parsed ParsedModel,
+	override CapabilityOverride,
 ) *ModelProfile {
 	profile := &ModelProfile{
 		Key:       key,
@@ -484,9 +509,12 @@ func (r *ModelRegistry) merge(
 	// re-introduce alias expansion for tokens like "insert" (single bit
 	// under strict, three bits under lenient), reopening the contract gap
 	// that motivated the canonical-only split in the first place.
-	r.mu.RLock()
-	override := r.capOverride
-	r.mu.RUnlock()
+	//
+	// The override is passed in by buildProfile (not read here from r)
+	// so the merge applies the SAME override the caller version-checks
+	// at cache-write time. Reading r.capOverride here would reintroduce
+	// the TOCTOU window SetCapabilityOverride's version counter exists
+	// to close.
 	if override != nil {
 		if cfgCaps := override(key); len(cfgCaps) > 0 {
 			if parsed, err := ParseCapsStrict(cfgCaps); err == nil && parsed != 0 {

--- a/provider/model_registry_test.go
+++ b/provider/model_registry_test.go
@@ -1270,3 +1270,102 @@ func TestSortProfiles(t *testing.T) {
 		}
 	}
 }
+
+// TestModelRegistry_CapabilityOverride_Replaces verifies that a configured
+// CapabilityOverride wholesale replaces the merge-derived Caps. This is the
+// design contract that lets users carve down capabilities for backends
+// missing endpoints (e.g. ["chat", "stream"] removes generate even when
+// the runtime probe claimed it).
+func TestModelRegistry_CapabilityOverride_Replaces(t *testing.T) {
+	ctx := context.Background()
+
+	// Runtime claims completion (chat|generate|stream) + tools.
+	prov := &mrMockProvider{
+		name: "ollama",
+		caps: CapChat | CapGenerate | CapStream | CapToolCall,
+		models: []ModelInfo{
+			{
+				Name:         "qwen3:8b",
+				Family:       "qwen3",
+				Capabilities: []string{"completion", "tools"},
+			},
+		},
+	}
+	reg := &mrMockProviderRegistry{providers: map[string]Provider{"ollama": prov}}
+	mr, err := NewModelRegistry(reg, newMrMockFingerprintStore())
+	if err != nil {
+		t.Fatalf("NewModelRegistry: %v", err)
+	}
+
+	// User carves down to chat+stream only — generate must be removed.
+	mr.SetCapabilityOverride(func(key ModelKey) []string {
+		if key.Model == "qwen3:8b" {
+			return []string{"chat", "stream"}
+		}
+		return nil
+	})
+
+	key := ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+	profile, err := mr.Lookup(ctx, key)
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+
+	want := CapChat | CapStream
+	if profile.Caps != want {
+		t.Errorf("Caps = %v, want %v (override should wholesale replace, not merge)", profile.Caps, want)
+	}
+	if profile.Caps.Has(CapGenerate) {
+		t.Error("CapGenerate present after override that excluded it; replace semantics violated")
+	}
+	if profile.Caps.Has(CapToolCall) {
+		t.Error("CapToolCall present after override that excluded it; replace semantics violated")
+	}
+}
+
+// TestModelRegistry_CapabilityOverride_NilSkipped verifies that the override
+// hook can return nil for a key to defer to merge-derived caps. Necessary so
+// users can declare capabilities for some models and let others auto-derive.
+// Compares against a baseline registry with no override to avoid hardcoding
+// the static catalog's contribution for the test model.
+func TestModelRegistry_CapabilityOverride_NilSkipped(t *testing.T) {
+	ctx := context.Background()
+
+	newProv := func() *mrMockProvider {
+		return &mrMockProvider{
+			name: "ollama",
+			caps: CapChat | CapGenerate | CapStream,
+			models: []ModelInfo{
+				{Name: "qwen3:8b", Family: "qwen3", Capabilities: []string{"completion"}},
+			},
+		}
+	}
+
+	baselineReg := &mrMockProviderRegistry{providers: map[string]Provider{"ollama": newProv()}}
+	baseline, err := NewModelRegistry(baselineReg, newMrMockFingerprintStore())
+	if err != nil {
+		t.Fatalf("baseline NewModelRegistry: %v", err)
+	}
+	baselineProfile, err := baseline.Lookup(ctx, ModelKey{Provider: "ollama", Model: "qwen3:8b"})
+	if err != nil {
+		t.Fatalf("baseline Lookup: %v", err)
+	}
+
+	overrideReg := &mrMockProviderRegistry{providers: map[string]Provider{"ollama": newProv()}}
+	withOverride, err := NewModelRegistry(overrideReg, newMrMockFingerprintStore())
+	if err != nil {
+		t.Fatalf("override NewModelRegistry: %v", err)
+	}
+	withOverride.SetCapabilityOverride(func(_ ModelKey) []string {
+		return nil // defer to merge for all keys
+	})
+
+	overrideProfile, err := withOverride.Lookup(ctx, ModelKey{Provider: "ollama", Model: "qwen3:8b"})
+	if err != nil {
+		t.Fatalf("override Lookup: %v", err)
+	}
+
+	if overrideProfile.Caps != baselineProfile.Caps {
+		t.Errorf("Caps with nil-returning override = %v, want %v (must match baseline)", overrideProfile.Caps, baselineProfile.Caps)
+	}
+}

--- a/provider/model_registry_test.go
+++ b/provider/model_registry_test.go
@@ -1418,6 +1418,111 @@ func TestModelRegistry_CapabilityOverride_NonCanonicalTokensRejected(t *testing.
 	}
 }
 
+// TestModelRegistry_OverrideRejectionHook_FiresOnNonCanonicalToken verifies
+// that rejections at the override apply site are observable via the
+// installed hook — the fail-safe (keep merged caps) is preserved, AND the
+// operator gets a signal so the misconfiguration doesn't go silent.
+// Without the hook the only symptom is router decisions that don't match
+// the config the operator wrote, which is exactly the silent-failure
+// class we are surfacing here.
+func TestModelRegistry_OverrideRejectionHook_FiresOnNonCanonicalToken(t *testing.T) {
+	ctx := context.Background()
+
+	prov := &mrMockProvider{
+		name: "ollama",
+		caps: CapChat | CapGenerate | CapStream,
+		models: []ModelInfo{
+			{Name: "qwen3:8b", Family: "qwen3", Capabilities: []string{"completion"}},
+		},
+	}
+	reg := &mrMockProviderRegistry{providers: map[string]Provider{"ollama": prov}}
+	mr, err := NewModelRegistry(reg, newMrMockFingerprintStore())
+	if err != nil {
+		t.Fatalf("NewModelRegistry: %v", err)
+	}
+
+	type rejection struct {
+		key    ModelKey
+		tokens []string
+		err    error
+	}
+	var (
+		mu          sync.Mutex
+		rejections  []rejection
+	)
+	mr.SetOverrideRejectionHook(func(k ModelKey, tokens []string, err error) {
+		mu.Lock()
+		defer mu.Unlock()
+		rejections = append(rejections, rejection{k, tokens, err})
+	})
+	mr.SetCapabilityOverride(func(_ ModelKey) []string {
+		return []string{"completion"} // multi-bit alias → rejected
+	})
+
+	key := ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+	profile, err := mr.Lookup(ctx, key)
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+
+	// Fail-safe still holds: merged caps preserved.
+	if !profile.Caps.Has(CapChat) {
+		t.Errorf("merged caps lost after rejection; expected fail-safe to keep them, got %v", profile.Caps)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(rejections) != 1 {
+		t.Fatalf("rejection hook fired %d times, want 1", len(rejections))
+	}
+	r := rejections[0]
+	if r.key != key {
+		t.Errorf("rejection key = %v, want %v", r.key, key)
+	}
+	if len(r.tokens) != 1 || r.tokens[0] != "completion" {
+		t.Errorf("rejection tokens = %v, want [completion]", r.tokens)
+	}
+	if r.err == nil {
+		t.Error("rejection err = nil, want non-nil ParseCapsStrict error")
+	}
+}
+
+// TestModelRegistry_OverrideRejectionHook_NotCalledOnAcceptedOverride
+// guards against false-positive observability: when the override parses
+// cleanly the hook MUST NOT fire, otherwise operators see noise on every
+// healthy config and learn to ignore the signal.
+func TestModelRegistry_OverrideRejectionHook_NotCalledOnAcceptedOverride(t *testing.T) {
+	ctx := context.Background()
+
+	prov := &mrMockProvider{
+		name: "ollama",
+		caps: CapChat | CapGenerate | CapStream,
+		models: []ModelInfo{
+			{Name: "qwen3:8b", Family: "qwen3", Capabilities: []string{"completion"}},
+		},
+	}
+	reg := &mrMockProviderRegistry{providers: map[string]Provider{"ollama": prov}}
+	mr, err := NewModelRegistry(reg, newMrMockFingerprintStore())
+	if err != nil {
+		t.Fatalf("NewModelRegistry: %v", err)
+	}
+
+	var fired int
+	mr.SetOverrideRejectionHook(func(_ ModelKey, _ []string, _ error) {
+		fired++
+	})
+	mr.SetCapabilityOverride(func(_ ModelKey) []string {
+		return []string{"chat", "stream"} // canonical: accepted
+	})
+
+	if _, err := mr.Lookup(ctx, ModelKey{Provider: "ollama", Model: "qwen3:8b"}); err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if fired != 0 {
+		t.Errorf("rejection hook fired %d times on accepted override, want 0", fired)
+	}
+}
+
 // TestModelRegistry_CapabilityOverride_ZeroCapsGuard verifies the merge
 // refuses to wholesale-replace with zero caps when the override returns
 // a non-nil but effectively empty result. This protects against

--- a/provider/model_registry_test.go
+++ b/provider/model_registry_test.go
@@ -1409,8 +1409,20 @@ func TestModelRegistry_CapabilityOverride_NonCanonicalTokensRejected(t *testing.
 			if err != nil {
 				t.Fatalf("Lookup: %v", err)
 			}
-			// Override was rejected → merged caps preserved → CapChat present
-			// from the runtime "completion" capability.
+			// CapChat is the probe because:
+			//   - It is present in the merged caps from the runtime
+			//     "completion" alias (aliasedCapability expands
+			//     "completion" -> CapChat|CapGenerate|CapStream).
+			//   - Under a buggy silent expansion via parseCaps, "tools"
+			//     and "embedding" would REPLACE Caps with bitmasks that
+			//     EXCLUDE CapChat (CapToolCall and CapEmbed respectively),
+			//     so CapChat-absent is the distinguishing canary that the
+			//     override was wrongly applied.
+			//   - The "completion" sub-case is weaker: silent expansion
+			//     would yield CapChat|CapGenerate|CapStream which still
+			//     includes CapChat, so the probe doesn't distinguish for
+			//     that single token. The other two sub-cases share the
+			//     same rejection code path and carry the proof.
 			if !profile.Caps.Has(CapChat) {
 				t.Errorf("merged caps lost after override [%q] was rejected; expected fail-safe to keep them, got %v", alias, profile.Caps)
 			}

--- a/provider/model_registry_test.go
+++ b/provider/model_registry_test.go
@@ -1323,6 +1323,108 @@ func TestModelRegistry_CapabilityOverride_Replaces(t *testing.T) {
 	}
 }
 
+// TestModelRegistry_CapabilityOverride_ZeroCapsGuard verifies the merge
+// refuses to wholesale-replace with zero caps when the override returns
+// a non-nil but effectively empty result. This protects against
+// programmatic callers that bypass config validation and would otherwise
+// produce profiles unusable by every router gate.
+func TestModelRegistry_CapabilityOverride_ZeroCapsGuard(t *testing.T) {
+	ctx := context.Background()
+
+	prov := &mrMockProvider{
+		name: "ollama",
+		caps: CapChat | CapGenerate | CapStream,
+		models: []ModelInfo{
+			{Name: "qwen3:8b", Family: "qwen3", Capabilities: []string{"completion"}},
+		},
+	}
+	reg := &mrMockProviderRegistry{providers: map[string]Provider{"ollama": prov}}
+
+	tests := []struct {
+		name     string
+		override func(ModelKey) []string
+	}{
+		{
+			name:     "non-nil empty slice keeps merged caps",
+			override: func(_ ModelKey) []string { return []string{} },
+		},
+		{
+			name:     "all-unknown tokens (parse to zero) keeps merged caps",
+			override: func(_ ModelKey) []string { return []string{"nonexistent", "alsobad"} },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mr, err := NewModelRegistry(reg, newMrMockFingerprintStore())
+			if err != nil {
+				t.Fatalf("NewModelRegistry: %v", err)
+			}
+			mr.SetCapabilityOverride(tt.override)
+
+			profile, err := mr.Lookup(ctx, ModelKey{Provider: "ollama", Model: "qwen3:8b"})
+			if err != nil {
+				t.Fatalf("Lookup: %v", err)
+			}
+			if profile.Caps == 0 {
+				t.Errorf("Caps = 0 after %s; merge must refuse zero-cap replacement to avoid crippling the profile", tt.name)
+			}
+			if !profile.Caps.Has(CapChat) {
+				t.Errorf("Caps missing CapChat after %s = %v", tt.name, profile.Caps)
+			}
+		})
+	}
+}
+
+// TestModelRegistry_CapabilityOverride_WipesRuntimeCapInsert documents
+// that an override which omits "insert" wipes runtime-template-detected
+// CapInsert. This is by design (user declaration wins) but the
+// interaction is sharp enough to be worth pinning down with a test.
+func TestModelRegistry_CapabilityOverride_WipesRuntimeCapInsert(t *testing.T) {
+	ctx := context.Background()
+
+	// A template that uses .Suffix triggers CapInsert in merge().
+	prov := &mrMockProvider{
+		name: "ollama",
+		caps: CapChat | CapGenerate | CapStream | CapInsert,
+		models: []ModelInfo{
+			{
+				Name:         "fim-model",
+				Family:       "qwen3-coder",
+				Template:     "{{ .Prompt }}{{ .Suffix }}",
+				Capabilities: []string{"completion", "insert"},
+			},
+		},
+	}
+	reg := &mrMockProviderRegistry{providers: map[string]Provider{"ollama": prov}}
+	mr, err := NewModelRegistry(reg, newMrMockFingerprintStore())
+	if err != nil {
+		t.Fatalf("NewModelRegistry: %v", err)
+	}
+
+	// Without override, runtime template detection adds CapInsert.
+	baseline, err := mr.Lookup(ctx, ModelKey{Provider: "ollama", Model: "fim-model"})
+	if err != nil {
+		t.Fatalf("baseline Lookup: %v", err)
+	}
+	if !baseline.Caps.Has(CapInsert) {
+		t.Fatal("precondition: expected runtime template to add CapInsert")
+	}
+
+	// Override carves down to chat+stream — explicit declaration wins,
+	// including dropping runtime-detected CapInsert.
+	mr.SetCapabilityOverride(func(_ ModelKey) []string {
+		return []string{"chat", "stream"}
+	})
+	overridden, err := mr.Lookup(ctx, ModelKey{Provider: "ollama", Model: "fim-model"})
+	if err != nil {
+		t.Fatalf("overridden Lookup: %v", err)
+	}
+	if overridden.Caps.Has(CapInsert) {
+		t.Errorf("Caps unexpectedly retained CapInsert after override = %v; user declaration must win over runtime detection", overridden.Caps)
+	}
+}
+
 // TestModelRegistry_CapabilityOverride_FlushesCacheOnInstall verifies that
 // SetCapabilityOverride invalidates already-cached profiles so a consumer
 // that installs the override AFTER warming the cache (the natural wiring

--- a/provider/model_registry_test.go
+++ b/provider/model_registry_test.go
@@ -1585,6 +1585,109 @@ func TestModelRegistry_CapabilityOverride_FlushesCacheOnInstall(t *testing.T) {
 	}
 }
 
+// gateMockProvider wraps mrMockProvider with a synchronization channel that
+// blocks Models() until released. Used to deterministically interleave
+// buildProfile with a concurrent SetCapabilityOverride for the TOCTOU test.
+type gateMockProvider struct {
+	*mrMockProvider
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (g *gateMockProvider) Models(ctx context.Context) ([]ModelInfo, error) {
+	select {
+	case g.entered <- struct{}{}:
+	default:
+	}
+	select {
+	case <-g.release:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return g.mrMockProvider.Models(ctx)
+}
+
+// TestModelRegistry_CapabilityOverride_TOCTOUDoesNotCacheStaleProfile verifies
+// the version-counter guard: an in-flight buildProfile that snapshotted the
+// OLD override must NOT write its result to the cache after SetCapabilityOverride
+// has raced ahead and bumped the version. Without the guard, the stale-policy
+// profile would land in the freshly-cleared map and shadow the swap until
+// the next Refresh — a silent staleness bug the cache-flush alone cannot fix.
+func TestModelRegistry_CapabilityOverride_TOCTOUDoesNotCacheStaleProfile(t *testing.T) {
+	ctx := context.Background()
+
+	base := &mrMockProvider{
+		name: "ollama",
+		caps: CapChat | CapGenerate | CapStream,
+		models: []ModelInfo{
+			{Name: "qwen3:8b", Family: "qwen3", Capabilities: []string{"completion"}},
+		},
+	}
+	gated := &gateMockProvider{
+		mrMockProvider: base,
+		entered:        make(chan struct{}, 1),
+		release:        make(chan struct{}),
+	}
+	reg := &mrMockProviderRegistry{providers: map[string]Provider{"ollama": gated}}
+	mr, err := NewModelRegistry(reg, newMrMockFingerprintStore())
+	if err != nil {
+		t.Fatalf("NewModelRegistry: %v", err)
+	}
+	key := ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+
+	// Install initial override BEFORE the racing Lookup, so the in-flight
+	// buildProfile snapshots a non-nil override that will go stale.
+	oldOverride := func(_ ModelKey) []string { return []string{"chat", "generate"} }
+	mr.SetCapabilityOverride(oldOverride)
+
+	// Goroutine A: Lookup blocks inside Models() until release fires.
+	type result struct {
+		profile *ModelProfile
+		err     error
+	}
+	done := make(chan result, 1)
+	go func() {
+		p, err := mr.Lookup(ctx, key)
+		done <- result{p, err}
+	}()
+
+	// Wait for the racing Lookup to enter Models() — it has now snapshotted
+	// the old override + old version.
+	<-gated.entered
+
+	// Goroutine B: install a different override mid-flight. This bumps the
+	// version counter and clears the (currently empty) cache.
+	newOverride := func(_ ModelKey) []string { return []string{"chat", "stream"} }
+	mr.SetCapabilityOverride(newOverride)
+
+	// Release the gated Models() call so buildProfile completes and reaches
+	// the version-check at cache write time.
+	close(gated.release)
+	res := <-done
+	if res.err != nil {
+		t.Fatalf("Lookup: %v", res.err)
+	}
+
+	// The racing Lookup correctly reflects the override IT observed
+	// (CapChat|CapGenerate) — returning the stale snapshot to that caller
+	// is the right answer.
+	wantStale := CapChat | CapGenerate
+	if res.profile.Caps != wantStale {
+		t.Errorf("racing Lookup result = %v, want %v (old override snapshot must apply to its own return value)", res.profile.Caps, wantStale)
+	}
+
+	// Critical: the stale-policy profile MUST NOT have been cached.
+	// A subsequent Lookup must re-run merge under the NEW override.
+	next, err := mr.Lookup(ctx, key)
+	if err != nil {
+		t.Fatalf("post-swap Lookup: %v", err)
+	}
+	wantFresh := CapChat | CapStream
+	if next.Caps != wantFresh {
+		t.Errorf("post-swap Lookup Caps = %v, want %v — stale profile shadowed the override swap (TOCTOU regression)", next.Caps, wantFresh)
+	}
+}
+
 // TestModelRegistry_CapabilityOverride_ConcurrentSwap exercises hot-swapping
 // the override concurrently with Lookup calls. Designed to run under `go test
 // -race` to surface unprotected access to capOverride or profiles.

--- a/provider/model_registry_test.go
+++ b/provider/model_registry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -1488,6 +1489,61 @@ func TestModelRegistry_CapabilityOverride_FlushesCacheOnInstall(t *testing.T) {
 	if !reverted.Caps.Has(CapGenerate) {
 		t.Errorf("Caps after clearing override missing CapGenerate; clearing must also flush cache, got %v", reverted.Caps)
 	}
+}
+
+// TestModelRegistry_CapabilityOverride_ConcurrentSwap exercises hot-swapping
+// the override concurrently with Lookup calls. Designed to run under `go test
+// -race` to surface unprotected access to capOverride or profiles.
+func TestModelRegistry_CapabilityOverride_ConcurrentSwap(t *testing.T) {
+	ctx := context.Background()
+
+	prov := &mrMockProvider{
+		name: "ollama",
+		caps: CapChat | CapGenerate | CapStream,
+		models: []ModelInfo{
+			{Name: "qwen3:8b", Family: "qwen3", Capabilities: []string{"completion"}},
+		},
+	}
+	reg := &mrMockProviderRegistry{providers: map[string]Provider{"ollama": prov}}
+	mr, err := NewModelRegistry(reg, newMrMockFingerprintStore())
+	if err != nil {
+		t.Fatalf("NewModelRegistry: %v", err)
+	}
+	key := ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+
+	const writers = 4
+	const readers = 8
+	const iters = 50
+
+	overrides := []CapabilityOverride{
+		nil,
+		func(_ ModelKey) []string { return []string{"chat", "stream"} },
+		func(_ ModelKey) []string { return []string{"chat"} },
+		func(_ ModelKey) []string { return nil },
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(writers + readers)
+	for w := 0; w < writers; w++ {
+		go func(seed int) {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				mr.SetCapabilityOverride(overrides[(i+seed)%len(overrides)])
+			}
+		}(w)
+	}
+	for r := 0; r < readers; r++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				if _, err := mr.Lookup(ctx, key); err != nil {
+					t.Errorf("Lookup: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 // TestModelRegistry_CapabilityOverride_NilSkipped verifies that the override

--- a/provider/model_registry_test.go
+++ b/provider/model_registry_test.go
@@ -1324,6 +1324,100 @@ func TestModelRegistry_CapabilityOverride_Replaces(t *testing.T) {
 	}
 }
 
+// TestModelRegistry_CapabilityOverride_InsertIsSingleBit pins the most
+// important user-facing contract: ["chat", "insert"] means "exactly chat
+// and insert" — NOT chat+generate+stream+insert via alias expansion.
+//
+// Regression test for the half-fix discovered in the second review cycle:
+// ParseCapsStrict at the validation site enforces single-bit "insert", but
+// the override apply site previously called the lenient parseCaps, which
+// re-expanded "insert" to three bits — silently re-adding the very caps
+// the REPLACES contract was supposed to remove.
+func TestModelRegistry_CapabilityOverride_InsertIsSingleBit(t *testing.T) {
+	ctx := context.Background()
+
+	// Runtime template signals FIM, so all the bits an alias-expansion
+	// would re-add are claimed by lower merge layers; if anything leaks
+	// through into the override result, the test catches it.
+	prov := &mrMockProvider{
+		name: "ollama",
+		caps: CapChat | CapGenerate | CapStream | CapInsert,
+		models: []ModelInfo{
+			{
+				Name:         "fim-model",
+				Family:       "qwen3-coder",
+				Template:     "{{ .Prompt }}{{ .Suffix }}",
+				Capabilities: []string{"completion", "insert"},
+			},
+		},
+	}
+	reg := &mrMockProviderRegistry{providers: map[string]Provider{"ollama": prov}}
+	mr, err := NewModelRegistry(reg, newMrMockFingerprintStore())
+	if err != nil {
+		t.Fatalf("NewModelRegistry: %v", err)
+	}
+
+	mr.SetCapabilityOverride(func(_ ModelKey) []string {
+		return []string{"chat", "insert"}
+	})
+
+	profile, err := mr.Lookup(ctx, ModelKey{Provider: "ollama", Model: "fim-model"})
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+
+	want := CapChat | CapInsert
+	if profile.Caps != want {
+		t.Errorf("Caps = %v, want %v (override [\"chat\", \"insert\"] must NOT alias-expand insert to generate+stream+insert)", profile.Caps, want)
+	}
+	if profile.Caps.Has(CapGenerate) {
+		t.Error("CapGenerate present after override [\"chat\", \"insert\"]; alias expansion at apply site is the bug this test exists to prevent")
+	}
+	if profile.Caps.Has(CapStream) {
+		t.Error("CapStream present after override [\"chat\", \"insert\"]; alias expansion at apply site is the bug this test exists to prevent")
+	}
+}
+
+// TestModelRegistry_CapabilityOverride_NonCanonicalTokensRejected verifies
+// that a programmatic caller passing catalog aliases (rather than canonical
+// single-bit names) sees the override IGNORED rather than silently expanded.
+// Config validation rejects aliases upstream; reaching the apply site with
+// an alias means the validation was bypassed, in which case we must
+// fail safe (keep merged caps) instead of leaking expansion bits.
+func TestModelRegistry_CapabilityOverride_NonCanonicalTokensRejected(t *testing.T) {
+	ctx := context.Background()
+
+	prov := &mrMockProvider{
+		name: "ollama",
+		caps: CapChat | CapGenerate | CapStream,
+		models: []ModelInfo{
+			{Name: "qwen3:8b", Family: "qwen3", Capabilities: []string{"completion"}},
+		},
+	}
+	reg := &mrMockProviderRegistry{providers: map[string]Provider{"ollama": prov}}
+
+	for _, alias := range []string{"completion", "tools", "embedding"} {
+		t.Run(alias, func(t *testing.T) {
+			mr, err := NewModelRegistry(reg, newMrMockFingerprintStore())
+			if err != nil {
+				t.Fatalf("NewModelRegistry: %v", err)
+			}
+			mr.SetCapabilityOverride(func(_ ModelKey) []string {
+				return []string{alias}
+			})
+			profile, err := mr.Lookup(ctx, ModelKey{Provider: "ollama", Model: "qwen3:8b"})
+			if err != nil {
+				t.Fatalf("Lookup: %v", err)
+			}
+			// Override was rejected → merged caps preserved → CapChat present
+			// from the runtime "completion" capability.
+			if !profile.Caps.Has(CapChat) {
+				t.Errorf("merged caps lost after override [%q] was rejected; expected fail-safe to keep them, got %v", alias, profile.Caps)
+			}
+		})
+	}
+}
+
 // TestModelRegistry_CapabilityOverride_ZeroCapsGuard verifies the merge
 // refuses to wholesale-replace with zero caps when the override returns
 // a non-nil but effectively empty result. This protects against

--- a/provider/model_registry_test.go
+++ b/provider/model_registry_test.go
@@ -1323,6 +1323,71 @@ func TestModelRegistry_CapabilityOverride_Replaces(t *testing.T) {
 	}
 }
 
+// TestModelRegistry_CapabilityOverride_FlushesCacheOnInstall verifies that
+// SetCapabilityOverride invalidates already-cached profiles so a consumer
+// that installs the override AFTER warming the cache (the natural wiring
+// sequence: build registry -> RefreshModels -> install override) still
+// sees the new policy on the very next Lookup. Without the flush, cached
+// profiles would silently shadow the override.
+func TestModelRegistry_CapabilityOverride_FlushesCacheOnInstall(t *testing.T) {
+	ctx := context.Background()
+
+	prov := &mrMockProvider{
+		name: "ollama",
+		caps: CapChat | CapGenerate | CapStream | CapToolCall,
+		models: []ModelInfo{
+			{Name: "qwen3:8b", Family: "qwen3", Capabilities: []string{"completion", "tools"}},
+		},
+	}
+	reg := &mrMockProviderRegistry{providers: map[string]Provider{"ollama": prov}}
+	mr, err := NewModelRegistry(reg, newMrMockFingerprintStore())
+	if err != nil {
+		t.Fatalf("NewModelRegistry: %v", err)
+	}
+
+	key := ModelKey{Provider: "ollama", Model: "qwen3:8b"}
+
+	// Warm the cache without an override installed — simulates the natural
+	// startup sequence where Refresh populates the cache before config-driven
+	// overrides are wired.
+	warmed, err := mr.Lookup(ctx, key)
+	if err != nil {
+		t.Fatalf("warm Lookup: %v", err)
+	}
+	if !warmed.Caps.Has(CapGenerate) {
+		t.Fatal("preconditions: expected CapGenerate before override")
+	}
+
+	// Now install the override — must invalidate the cached profile so the
+	// next Lookup re-merges with the override applied.
+	mr.SetCapabilityOverride(func(k ModelKey) []string {
+		if k.Model == "qwen3:8b" {
+			return []string{"chat", "stream"}
+		}
+		return nil
+	})
+
+	postOverride, err := mr.Lookup(ctx, key)
+	if err != nil {
+		t.Fatalf("post-override Lookup: %v", err)
+	}
+	want := CapChat | CapStream
+	if postOverride.Caps != want {
+		t.Errorf("Caps = %v, want %v (override installed AFTER warm cache must take effect on next Lookup)", postOverride.Caps, want)
+	}
+
+	// Clearing the override must also flush so the cached overridden profile
+	// is not silently served after revert.
+	mr.SetCapabilityOverride(nil)
+	reverted, err := mr.Lookup(ctx, key)
+	if err != nil {
+		t.Fatalf("post-clear Lookup: %v", err)
+	}
+	if !reverted.Caps.Has(CapGenerate) {
+		t.Errorf("Caps after clearing override missing CapGenerate; clearing must also flush cache, got %v", reverted.Caps)
+	}
+}
+
 // TestModelRegistry_CapabilityOverride_NilSkipped verifies that the override
 // hook can return nil for a key to defer to merge-derived caps. Necessary so
 // users can declare capabilities for some models and let others auto-derive.

--- a/provider/ollama.go
+++ b/provider/ollama.go
@@ -43,6 +43,19 @@ func WithThinkBudget(budget *ThinkBudget) OllamaOption {
 	}
 }
 
+// WithProviderName overrides the registry identity returned by Name() and
+// stamped on every response's Provider field. The default name is "ollama";
+// supply a config-key instance name (e.g. "shared-ollama-vm") when registering
+// multiple instances of the same backend kind. Empty values are ignored so the
+// default remains in force.
+func WithProviderName(name string) OllamaOption {
+	return func(p *OllamaProvider) {
+		if name != "" {
+			p.name = name
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // OllamaProvider
 // ---------------------------------------------------------------------------
@@ -52,6 +65,7 @@ func WithThinkBudget(budget *ThinkBudget) OllamaOption {
 // and non-streaming) and graceful cancellation with partial results on all
 // streaming methods.
 type OllamaProvider struct {
+	name        string
 	client      *ollama.Client
 	thinkMode   ThinkMode
 	thinkTags   ThinkTags
@@ -60,10 +74,12 @@ type OllamaProvider struct {
 }
 
 // NewOllamaProvider creates a Provider backed by the given ollama.Client.
-// Options configure think-tag parsing behavior. By default, ThinkAuto mode
-// with standard <think></think> tags is used.
+// Options configure think-tag parsing and the registry identity. By default,
+// ThinkAuto mode with standard <think></think> tags is used and Name() returns
+// "ollama"; use WithProviderName to register additional instances.
 func NewOllamaProvider(client *ollama.Client, opts ...OllamaOption) *OllamaProvider {
 	p := &OllamaProvider{
+		name:      "ollama",
 		client:    client,
 		thinkMode: ThinkAuto,
 		thinkTags: DefaultThinkTags(),
@@ -89,9 +105,12 @@ func (p *OllamaProvider) shouldExtractThinking(opts ModelOptions) bool {
 	}
 }
 
-// Name returns the canonical provider identifier "ollama".
+// Name returns the registry identity for this provider instance. Defaults to
+// "ollama" unless WithProviderName overrode it; the value is also stamped on
+// every response's Provider field so RouteOutcome attribution stays accurate
+// when multiple instances of the same backend kind coexist.
 func (p *OllamaProvider) Name() string {
-	return "ollama"
+	return p.name
 }
 
 // Capabilities returns the bitmask of features the Ollama backend supports.
@@ -180,7 +199,7 @@ func (p *OllamaProvider) Chat(ctx context.Context, req ChatRequest) (*ChatRespon
 
 	return &ChatResponse{
 		Model:     oResp.Model,
-		Provider:  "ollama",
+		Provider:  p.name,
 		Content:   content,
 		Thinking:  thinking,
 		ToolCalls: toProviderToolCalls(oResp.Message.ToolCalls),
@@ -232,7 +251,7 @@ func (p *OllamaProvider) ChatStream(ctx context.Context, req ChatRequest, fn fun
 		OnThinking: func(s string) error {
 			resp := ChatResponse{
 				Model:    lastModel,
-				Provider: "ollama",
+				Provider: p.name,
 				Thinking: s,
 			}
 			if err := fn(resp); err != nil {
@@ -244,7 +263,7 @@ func (p *OllamaProvider) ChatStream(ctx context.Context, req ChatRequest, fn fun
 		OnContent: func(s string) error {
 			resp := ChatResponse{
 				Model:    lastModel,
-				Provider: "ollama",
+				Provider: p.name,
 				Content:  s,
 			}
 			if err := fn(resp); err != nil {
@@ -294,7 +313,7 @@ func (p *OllamaProvider) ChatStream(ctx context.Context, req ChatRequest, fn fun
 
 			doneResp := ChatResponse{
 				Model:     oResp.Model,
-				Provider:  "ollama",
+				Provider:  p.name,
 				ToolCalls: lastToolCalls,
 				Done:      true,
 				Usage:     lastUsage,
@@ -307,7 +326,7 @@ func (p *OllamaProvider) ChatStream(ctx context.Context, req ChatRequest, fn fun
 		if len(oResp.Message.ToolCalls) > 0 {
 			tcResp := ChatResponse{
 				Model:     oResp.Model,
-				Provider:  "ollama",
+				Provider:  p.name,
 				ToolCalls: toProviderToolCalls(oResp.Message.ToolCalls),
 			}
 			return fn(tcResp)
@@ -329,7 +348,7 @@ func (p *OllamaProvider) ChatStream(ctx context.Context, req ChatRequest, fn fun
 
 		partial := ChatResponse{
 			Model:     model,
-			Provider:  "ollama",
+			Provider:  p.name,
 			ToolCalls: lastToolCalls,
 			Done:      true,
 			Partial:   true,
@@ -367,7 +386,7 @@ func (p *OllamaProvider) Generate(ctx context.Context, req GenerateRequest) (*Ge
 
 	return &GenerateResponse{
 		Model:    oResp.Model,
-		Provider: "ollama",
+		Provider: p.name,
 		Response: oResp.Response,
 		Done:     true,
 		Usage: Usage{
@@ -420,7 +439,7 @@ func (p *OllamaProvider) GenerateStream(ctx context.Context, req GenerateRequest
 
 		resp := GenerateResponse{
 			Model:    oResp.Model,
-			Provider: "ollama",
+			Provider: p.name,
 			Response: oResp.Response,
 			Done:     oResp.Done,
 			Usage:    lastUsage,
@@ -442,7 +461,7 @@ func (p *OllamaProvider) GenerateStream(ctx context.Context, req GenerateRequest
 		}
 		partial := GenerateResponse{
 			Model:    model,
-			Provider: "ollama",
+			Provider: p.name,
 			Done:     true,
 			Partial:  true,
 			Usage:    lastUsage,
@@ -495,7 +514,7 @@ func (p *OllamaProvider) Embed(ctx context.Context, req EmbedRequest) (*EmbedRes
 		}
 		return &EmbedResponse{
 			Model:      req.Model,
-			Provider:   "ollama",
+			Provider:   p.name,
 			Embeddings: embeddings,
 			Usage: Usage{
 				PromptTokens: len(req.Input),

--- a/provider/ollama.go
+++ b/provider/ollama.go
@@ -45,14 +45,21 @@ func WithThinkBudget(budget *ThinkBudget) OllamaOption {
 
 // WithProviderName overrides the registry identity returned by Name() and
 // stamped on every response's Provider field. The default name is "ollama";
-// supply a config-key instance name (e.g. "shared-ollama-vm") when registering
-// multiple instances of the same backend kind. Empty values are ignored so the
-// default remains in force.
+// supply a config-key instance name (e.g. "shared-ollama-vm") when
+// registering multiple instances of the same backend kind.
+//
+// Panics if name is empty: an empty registry identity is a configuration
+// bug that would otherwise produce a provider whose Registry.Register
+// fails later with a less-actionable error. Fail fast at construction
+// instead of silently keeping the default — caller has obviously passed
+// a misconfigured value rather than meaning "use default" (in which case
+// they would simply omit the option).
 func WithProviderName(name string) OllamaOption {
+	if name == "" {
+		panic("provider: WithProviderName called with empty name; omit the option to use the default \"ollama\"")
+	}
 	return func(p *OllamaProvider) {
-		if name != "" {
-			p.name = name
-		}
+		p.name = name
 	}
 }
 

--- a/provider/ollama_test.go
+++ b/provider/ollama_test.go
@@ -118,6 +118,110 @@ func TestOllamaProvider_ResponseProviderField(t *testing.T) {
 	}
 }
 
+// TestOllamaProvider_ResponseProviderField_AllPaths covers the response.Provider
+// stamping on the paths the basic ResponseProviderField test misses: Generate
+// (non-streaming), GenerateStream, and ChatStream. All four call sites in
+// ChatStream are exercised by streaming a content chunk followed by a done.
+func TestOllamaProvider_ResponseProviderField_AllPaths(t *testing.T) {
+	const instance = "my-renamed-instance"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/generate":
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			// Single non-streaming response if Stream is false; ndjson stream otherwise.
+			// The ollama client distinguishes via the request payload; emit a
+			// streaming sequence either way and let the parser dispatch.
+			enc := json.NewEncoder(w)
+			_ = enc.Encode(map[string]any{"model": "qwen3:8b", "response": "hel", "done": false})
+			_ = enc.Encode(map[string]any{"model": "qwen3:8b", "response": "lo", "done": true, "eval_count": 2})
+		case "/api/chat":
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			enc := json.NewEncoder(w)
+			_ = enc.Encode(map[string]any{
+				"model":   "qwen3:8b",
+				"message": map[string]string{"role": "assistant", "content": "hello"},
+				"done":    false,
+			})
+			_ = enc.Encode(map[string]any{
+				"model":   "qwen3:8b",
+				"message": map[string]string{"role": "assistant", "content": ""},
+				"done":    true,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	p := NewOllamaProvider(c, WithProviderName(instance))
+
+	// Generate (non-streaming)
+	t.Run("Generate", func(t *testing.T) {
+		resp, err := p.Generate(context.Background(), GenerateRequest{
+			Model:  "qwen3:8b",
+			Prompt: "say hi",
+		})
+		if err != nil {
+			t.Fatalf("Generate: %v", err)
+		}
+		if resp.Provider != instance {
+			t.Errorf("Provider = %q, want %q", resp.Provider, instance)
+		}
+	})
+
+	// GenerateStream
+	t.Run("GenerateStream", func(t *testing.T) {
+		var providers []string
+		err := p.GenerateStream(context.Background(), GenerateRequest{
+			Model:  "qwen3:8b",
+			Prompt: "say hi",
+			Stream: true,
+		}, func(resp GenerateResponse) error {
+			providers = append(providers, resp.Provider)
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("GenerateStream: %v", err)
+		}
+		if len(providers) == 0 {
+			t.Fatal("no chunks received")
+		}
+		for i, got := range providers {
+			if got != instance {
+				t.Errorf("chunk %d Provider = %q, want %q", i, got, instance)
+			}
+		}
+	})
+
+	// ChatStream emits multiple response shapes (thinking, content, done,
+	// tool calls, partial-on-cancel). Provider must be the configured name
+	// for every one of them.
+	t.Run("ChatStream", func(t *testing.T) {
+		var providers []string
+		err := p.ChatStream(context.Background(), ChatRequest{
+			Model:    "qwen3:8b",
+			Messages: []ChatMessage{{Role: "user", Content: "hi"}},
+			Stream:   true,
+		}, func(resp ChatResponse) error {
+			providers = append(providers, resp.Provider)
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("ChatStream: %v", err)
+		}
+		if len(providers) == 0 {
+			t.Fatal("no chunks received")
+		}
+		for i, got := range providers {
+			if got != instance {
+				t.Errorf("chunk %d Provider = %q, want %q", i, got, instance)
+			}
+		}
+	})
+}
+
 func TestOllamaProvider_Capabilities(t *testing.T) {
 	c := ollama.NewClient()
 	p := NewOllamaProvider(c)

--- a/provider/ollama_test.go
+++ b/provider/ollama_test.go
@@ -27,6 +27,79 @@ func TestOllamaProvider_Name(t *testing.T) {
 	}
 }
 
+func TestOllamaProvider_WithProviderName(t *testing.T) {
+	tests := []struct {
+		name     string
+		override string
+		want     string
+	}{
+		{"override applied", "shared-ollama-vm", "shared-ollama-vm"},
+		{"empty override ignored", "", "ollama"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := ollama.NewClient()
+			p := NewOllamaProvider(c, WithProviderName(tt.override))
+			if got := p.Name(); got != tt.want {
+				t.Errorf("Name() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestOllamaProvider_ResponseProviderField verifies the configured instance
+// name is stamped on every response variant, not just Name(). This matters
+// because RouteOutcome attribution and downstream RAG vsid synthesis read
+// the response's Provider field, not a separate registry lookup.
+func TestOllamaProvider_ResponseProviderField(t *testing.T) {
+	const instance = "my-llama-instance"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/chat":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"model":   "qwen3:8b",
+				"message": map[string]string{"role": "assistant", "content": "hi"},
+				"done":    true,
+			})
+		case "/api/embed":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"embeddings": [][]float64{{0.1, 0.2}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	p := NewOllamaProvider(c, WithProviderName(instance))
+
+	chatResp, err := p.Chat(context.Background(), ChatRequest{
+		Model:    "qwen3:8b",
+		Messages: []ChatMessage{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if chatResp.Provider != instance {
+		t.Errorf("Chat response Provider = %q, want %q", chatResp.Provider, instance)
+	}
+
+	embResp, err := p.Embed(context.Background(), EmbedRequest{
+		Model: "qwen3-embedding:8b",
+		Input: []string{"text"},
+	})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if embResp.Provider != instance {
+		t.Errorf("Embed response Provider = %q, want %q", embResp.Provider, instance)
+	}
+}
+
 func TestOllamaProvider_Capabilities(t *testing.T) {
 	c := ollama.NewClient()
 	p := NewOllamaProvider(c)

--- a/provider/ollama_test.go
+++ b/provider/ollama_test.go
@@ -28,23 +28,41 @@ func TestOllamaProvider_Name(t *testing.T) {
 }
 
 func TestOllamaProvider_WithProviderName(t *testing.T) {
-	tests := []struct {
-		name     string
-		override string
-		want     string
-	}{
-		{"override applied", "shared-ollama-vm", "shared-ollama-vm"},
-		{"empty override ignored", "", "ollama"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := ollama.NewClient()
-			p := NewOllamaProvider(c, WithProviderName(tt.override))
-			if got := p.Name(); got != tt.want {
-				t.Errorf("Name() = %q, want %q", got, tt.want)
+	t.Run("override applied", func(t *testing.T) {
+		c := ollama.NewClient()
+		p := NewOllamaProvider(c, WithProviderName("shared-ollama-vm"))
+		if got := p.Name(); got != "shared-ollama-vm" {
+			t.Errorf("Name() = %q, want %q", got, "shared-ollama-vm")
+		}
+	})
+
+	t.Run("default preserved when option omitted", func(t *testing.T) {
+		c := ollama.NewClient()
+		p := NewOllamaProvider(c)
+		if got := p.Name(); got != "ollama" {
+			t.Errorf("Name() = %q, want %q", got, "ollama")
+		}
+	})
+
+	// Fail-fast on empty: silent ignore would let a misconfigured factory
+	// produce a provider whose Registry.Register later fails with a less
+	// actionable error.
+	t.Run("empty name panics", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatal("expected panic on empty name, got nil")
 			}
-		})
-	}
+			msg, ok := r.(string)
+			if !ok {
+				t.Fatalf("expected string panic value, got %T: %v", r, r)
+			}
+			if !strings.Contains(msg, "WithProviderName") || !strings.Contains(msg, "empty") {
+				t.Errorf("panic message should explain the misuse, got: %q", msg)
+			}
+		}()
+		_ = WithProviderName("")
+	})
 }
 
 // TestOllamaProvider_ResponseProviderField verifies the configured instance


### PR DESCRIPTION
## Summary

Foundation for adding non-Ollama backends (refs #81). No new providers in this PR; lays the schema and routing groundwork the openai-compat provider (PR2) and the resolver rewire (PR3) build on. No behavior change for existing single-Ollama deployments.

## What's in

- **Provider instance name vs API format**: `WithProviderName` option on `OllamaProvider` makes `Name()` configurable; the configured value is stamped on every response's `Provider` field. Default stays `"ollama"`.
- **ProviderConfig.APIFormat validation**: empty defaults to `"ollama"` via `applyDefaults`; unknown explicit values (e.g. typo `"ollma"`) fail load.
- **ResolvedModel.Provider**: tracks the actually-resolved provider including fallback paths (e.g. role on provider A falling back to a model on provider B yields `Provider="B"`).
- **ModelConfig.Capabilities** with derive-from-type:
  - `dense`/`moe` → `["chat", "generate", "stream"]`
  - `embedding` → `["embed"]`
  - Explicit capabilities REPLACE the derived set (not merge).
  - `insert`, `tool_call`, `thinking` never derived — explicit-only.
  - Type `"embedding"` may only declare embedding capabilities (strict).
- **parseCaps vocabulary expanded** to accept canonical names (`chat`, `generate`, `stream`, `embed`, `tool_call`, `thinking`, `insert`) alongside existing aliases. New `ParseCapsStrict` errors on unknown tokens for user-config validation.
- **ModelRegistry.CapabilityOverride** hook: consumer-installed function lets resolved `ModelConfig.Capabilities` wholesale-replace merged Caps, e.g. removing `generate` for an OpenAI-compat server lacking `/v1/completions`.

## What's not in this PR

- No new provider package — that's PR2 (`provider/openaicompat/`).
- MCP server doesn't install the capability override yet — that's PR4 (wiring).
- `refreshResolved` still resolves against `s.client` only — that's PR3.
- Two upstream sites still hardcode `Provider: "ollama"` (`analysis/types.go:51`, `rag/embedder.go:73`) — harmless today since defaults still match; cleaned up in PR3/PR4.

## Test plan

- [x] `go test ./... -count=1 -race` — all packages green
- [x] Tests added for: WithProviderName default + override, response Provider field per-instance, APIFormat default + reject typo, ResolvedModel.Provider across fallback, derive-from-type for all type values, explicit replaces derived (carve-down), embedding strict-rejection, canonical and alias capability tokens, ParseCapsStrict unknown-rejection, ModelRegistry override replaces vs nil-defers
- [x] `go vet ./...` clean
- [x] No breaking changes to existing constructors

Generated with [Claude Code](https://claude.com/claude-code)