### PR TITLE
feat(provider/openaicompat): OpenAI-compatible local-server provider backend (PR2 of #81)

### DIFF
--- a/provider/openaicompat/client.go
+++ b/provider/openaicompat/client.go
@@ -1,0 +1,189 @@
+package openaicompat
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Client is a thin HTTP wrapper for OpenAI-compatible endpoints. It handles
+// Bearer auth, JSON encoding, error-envelope unwrapping, and produces SSE
+// readers for streaming responses. It does NOT itself know about chat /
+// completion / embedding shapes — those live with the Provider impl that
+// composes this client.
+//
+// Client is safe for concurrent use; the underlying http.Client and
+// configuration are read-only after construction.
+type Client struct {
+	baseURL string
+	apiKey  string
+	hc      *http.Client
+}
+
+// ClientOption configures a Client.
+type ClientOption func(*Client)
+
+// WithHTTPClient overrides the default http.Client (default: a 5-minute-timeout
+// client). Pass a pre-configured client to share connection pools, attach
+// middleware, or tighten the timeout for low-latency local servers.
+func WithHTTPClient(hc *http.Client) ClientOption {
+	return func(c *Client) {
+		if hc != nil {
+			c.hc = hc
+		}
+	}
+}
+
+// WithAPIKey sets the Bearer token sent in the Authorization header. Empty
+// disables the header entirely — appropriate for local servers that don't
+// enforce auth (vanilla llama.cpp --api, default LM Studio).
+func WithAPIKey(key string) ClientOption {
+	return func(c *Client) {
+		c.apiKey = key
+	}
+}
+
+// NewClient builds a Client targeting baseURL. The URL should be the server
+// root WITHOUT the /v1 suffix; per-endpoint paths are appended internally
+// so callers don't have to remember which endpoints live under /v1. Any
+// trailing slash on baseURL is stripped.
+//
+// The default http.Client uses a 5-minute timeout, matching the
+// config.ProviderConfig default. Override via WithHTTPClient for shorter
+// (low-latency local) or longer (large-batch embedding) requests.
+func NewClient(baseURL string, opts ...ClientOption) *Client {
+	c := &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		hc:      &http.Client{Timeout: 5 * time.Minute},
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// postJSON sends a JSON request and decodes a JSON response. Non-2xx
+// responses are unwrapped into an OpenAI-shape error so callers see the
+// server's own error message rather than just an HTTP status code.
+//
+// The path argument is the endpoint (e.g. "/v1/chat/completions"); it is
+// appended to baseURL verbatim.
+func (c *Client) postJSON(ctx context.Context, path string, body any, out any) error {
+	resp, err := c.post(ctx, path, body, "application/json")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if err := decodeJSONOrError(resp, out); err != nil {
+		return err
+	}
+	return nil
+}
+
+// postSSE sends a JSON request and returns an *sseReader for the streaming
+// response body. The caller MUST Close the reader; failing to do so leaks
+// the connection. Non-2xx responses are converted to errors before any
+// reader is returned, so callers can rely on a returned reader being live.
+func (c *Client) postSSE(ctx context.Context, path string, body any) (*sseReader, error) {
+	resp, err := c.post(ctx, path, body, "application/json")
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode/100 != 2 {
+		err := readErrorEnvelope(resp)
+		_ = resp.Body.Close()
+		return nil, err
+	}
+	return newSSEReader(resp.Body), nil
+}
+
+// getJSON sends a GET request and decodes a JSON response. Used for
+// /v1/models discovery and health probing.
+func (c *Client) getJSON(ctx context.Context, path string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return fmt.Errorf("openaicompat: build %s: %w", path, err)
+	}
+	c.setHeaders(req, "")
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("openaicompat: %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+	return decodeJSONOrError(resp, out)
+}
+
+// post is the shared transport for postJSON / postSSE. It marshals body
+// to JSON, sets headers including auth, and returns the raw response for
+// the caller to consume.
+func (c *Client) post(ctx context.Context, path string, body any, contentType string) (*http.Response, error) {
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("openaicompat: marshal %s body: %w", path, err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(buf))
+	if err != nil {
+		return nil, fmt.Errorf("openaicompat: build %s: %w", path, err)
+	}
+	c.setHeaders(req, contentType)
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("openaicompat: %s: %w", path, err)
+	}
+	return resp, nil
+}
+
+// setHeaders applies Authorization (when APIKey is set), Accept, and
+// optional Content-Type to req.
+func (c *Client) setHeaders(req *http.Request, contentType string) {
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+}
+
+// decodeJSONOrError reads resp.Body. On 2xx, it JSON-decodes into out. On
+// non-2xx, it parses an OpenAI error envelope and returns it as an error.
+func decodeJSONOrError(resp *http.Response, out any) error {
+	if resp.StatusCode/100 != 2 {
+		return readErrorEnvelope(resp)
+	}
+	if out == nil {
+		// Drain the body so the connection can be reused.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("openaicompat: decode response: %w", err)
+	}
+	return nil
+}
+
+// readErrorEnvelope reads resp.Body looking for an OpenAI-shape error.
+// Falls back to a plain "<status>: <body>" when the body is not a valid
+// error envelope, so HTML error pages and bare strings still produce a
+// usable error message rather than swallowing the failure.
+func readErrorEnvelope(resp *http.Response) error {
+	const limit = 64 * 1024
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, limit))
+	body = bytes.TrimSpace(body)
+
+	var env errorEnvelope
+	if json.Unmarshal(body, &env) == nil && env.Error.Message != "" {
+		return fmt.Errorf("openaicompat: %s: %s", resp.Status, env.Error.Message)
+	}
+	if len(body) > 0 {
+		return fmt.Errorf("openaicompat: %s: %s", resp.Status, string(body))
+	}
+	return fmt.Errorf("openaicompat: %s", resp.Status)
+}

--- a/provider/openaicompat/client.go
+++ b/provider/openaicompat/client.go
@@ -78,7 +78,7 @@ func (c *Client) postJSON(ctx context.Context, path string, body any, out any) e
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if err := decodeJSONOrError(resp, out); err != nil {
 		return err
@@ -116,7 +116,7 @@ func (c *Client) getJSON(ctx context.Context, path string, out any) error {
 	if err != nil {
 		return fmt.Errorf("openaicompat: %s: %w", path, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	return decodeJSONOrError(resp, out)
 }
 

--- a/provider/openaicompat/doc.go
+++ b/provider/openaicompat/doc.go
@@ -1,0 +1,29 @@
+// Package openaicompat implements provider.Provider against OpenAI-compatible
+// local model servers (LM Studio, llama.cpp --api, vLLM, text-generation-inference,
+// and similar). It speaks the OpenAI REST/SSE wire format:
+//
+//	POST /v1/chat/completions   chat (sync + streaming)
+//	POST /v1/completions        raw generation + FIM via "suffix"
+//	POST /v1/embeddings         vector embeddings
+//	GET  /v1/models             model discovery
+//
+// The package is the inbound client-side complement to the repo's outbound
+// compat/ package (which exposes go-llm AS an OpenAI server). The two have
+// no shared types by design: compat/ depends on provider/, so importing it
+// from a provider sub-package would invert the layering. Wire shapes are
+// re-declared here with only the fields this client actually consumes.
+//
+// Wiring: config.ProviderConfig.APIFormat == "openai-compat" selects this
+// backend. Pass a per-instance name via WithProviderName when more than one
+// OpenAI-compat server is registered (e.g. "lmstudio-laptop" alongside
+// "vllm-workstation"), matching the OllamaProvider naming convention.
+//
+// Capability semantics: OpenAI-compat servers vary widely in what they
+// actually implement. The constructor advertises a permissive default
+// (CapChat|CapGenerate|CapStream|CapEmbed|CapToolCall); users should carve
+// down per model via config.ModelConfig.Capabilities for backends missing
+// a specific endpoint (e.g. removing "generate" for a server without
+// /v1/completions). Native FIM detection (CapInsert) is intentionally NOT
+// in the default set because OpenAI-compat servers don't expose template
+// metadata equivalent to Ollama's /api/show — opt in explicitly when known.
+package openaicompat

--- a/provider/openaicompat/doc.go
+++ b/provider/openaicompat/doc.go
@@ -27,4 +27,12 @@
 // /v1/completions). Native FIM detection (CapInsert) is intentionally NOT
 // in the default set because OpenAI-compat servers don't expose template
 // metadata equivalent to Ollama's /api/show — opt in explicitly when known.
+//
+// Streaming tool-call semantics: OpenAI streams tool-call arguments as
+// JSON fragments that are only meaningful once concatenated. ChatStream
+// accumulates fragments silently across deltas and surfaces the assembled
+// ToolCalls slice ONLY on the final Done chunk (or on the synthetic
+// Done+Partial chunk if the context is cancelled mid-stream). Consumers
+// building incremental tool-call UI should treat the Done chunk as the
+// single authoritative source for tool-call payloads.
 package openaicompat

--- a/provider/openaicompat/doc.go
+++ b/provider/openaicompat/doc.go
@@ -13,10 +13,11 @@
 // from a provider sub-package would invert the layering. Wire shapes are
 // re-declared here with only the fields this client actually consumes.
 //
-// Wiring: config.ProviderConfig.APIFormat == "openai-compat" selects this
-// backend. Pass a per-instance name via WithProviderName when more than one
-// OpenAI-compat server is registered (e.g. "lmstudio-laptop" alongside
-// "vllm-workstation"), matching the OllamaProvider naming convention.
+// Intended wiring: callers that construct providers from config.ProviderConfig
+// should map APIFormat == "openai-compat" to this backend. Pass a per-instance
+// name via WithProviderName when more than one OpenAI-compat server is
+// registered (e.g. "lmstudio-laptop" alongside "vllm-workstation"), matching
+// the OllamaProvider naming convention.
 //
 // Capability semantics: OpenAI-compat servers vary widely in what they
 // actually implement. The constructor advertises a permissive default

--- a/provider/openaicompat/openaicompat.go
+++ b/provider/openaicompat/openaicompat.go
@@ -2,12 +2,14 @@
 package openaicompat
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/kstruzzieri/go-llm/provider"
 	"golang.org/x/sync/singleflight"
@@ -239,7 +241,9 @@ func (p *Provider) ChatStream(ctx context.Context, req provider.ChatRequest, fn 
 		lastUsage      provider.Usage
 		chunksReceived int
 		callbackErr    error
+		streamErr      error
 		finished       bool
+		toolCalls      streamToolCallAccumulator
 	)
 
 	parser := provider.NewThinkParser(provider.ThinkParserConfig{
@@ -268,6 +272,9 @@ func (p *Provider) ChatStream(ctx context.Context, req provider.ChatRequest, fn 
 	for {
 		payload, readErr := reader.Next()
 		if readErr != nil {
+			if !errors.Is(readErr, errStreamDone) {
+				streamErr = readErr
+			}
 			break
 		}
 
@@ -294,15 +301,7 @@ func (p *Provider) ChatStream(ctx context.Context, req provider.ChatRequest, fn 
 		choice := chunk.Choices[0]
 
 		if len(choice.Delta.ToolCalls) > 0 {
-			lastToolCalls = toProviderToolCalls(choice.Delta.ToolCalls)
-			if err := fn(provider.ChatResponse{
-				Model:     lastModel,
-				Provider:  p.name,
-				ToolCalls: lastToolCalls,
-			}); err != nil {
-				callbackErr = err
-				break
-			}
+			lastToolCalls = toolCalls.Add(choice.Delta.ToolCalls)
 		}
 		if choice.Delta.Content != "" {
 			if err := parser.Process(choice.Delta.Content); err != nil {
@@ -348,6 +347,9 @@ func (p *Provider) ChatStream(ctx context.Context, req provider.ChatRequest, fn 
 			Usage:     lastUsage,
 		})
 		return fmt.Errorf("provider: openaicompat: chat stream: %w", ctx.Err())
+	}
+	if streamErr != nil {
+		return fmt.Errorf("provider: openaicompat: chat stream: %w", streamErr)
 	}
 
 	return nil
@@ -421,12 +423,16 @@ func (p *Provider) GenerateStream(ctx context.Context, req provider.GenerateRequ
 		lastUsage      provider.Usage
 		chunksReceived int
 		callbackErr    error
+		streamErr      error
 		finished       bool
 	)
 
 	for {
 		payload, readErr := reader.Next()
 		if readErr != nil {
+			if !errors.Is(readErr, errStreamDone) {
+				streamErr = readErr
+			}
 			break
 		}
 
@@ -485,6 +491,9 @@ func (p *Provider) GenerateStream(ctx context.Context, req provider.GenerateRequ
 			Usage:    lastUsage,
 		})
 		return fmt.Errorf("provider: openaicompat: generate stream: %w", ctx.Err())
+	}
+	if streamErr != nil {
+		return fmt.Errorf("provider: openaicompat: generate stream: %w", streamErr)
 	}
 
 	return nil
@@ -564,12 +573,17 @@ func (p *Provider) Embed(ctx context.Context, req provider.EmbedRequest) (*provi
 	}
 }
 
-// embedKey builds a singleflight dedup key from model + sha256 of joined
-// inputs. Identical to the OllamaProvider helper; duplicated here so the
-// sub-package has no upward dependency on unexported symbols in provider/.
+// embedKey builds a singleflight dedup key from model + length-prefixed inputs.
+// Length prefixes keep distinct inputs with embedded NUL bytes from colliding.
 func embedKey(model string, inputs []string) string {
-	h := sha256.Sum256([]byte(strings.Join(inputs, "\x00")))
-	return model + ":" + hex.EncodeToString(h[:])
+	h := sha256.New()
+	var lenBuf [8]byte
+	for _, input := range inputs {
+		binary.BigEndian.PutUint64(lenBuf[:], uint64(len(input)))
+		_, _ = h.Write(lenBuf[:])
+		_, _ = h.Write([]byte(input))
+	}
+	return model + ":" + hex.EncodeToString(h.Sum(nil))
 }
 
 // ---------------------------------------------------------------------------
@@ -692,7 +706,7 @@ func toWireToolCalls(calls []provider.ToolCall) []chatToolCall {
 			Type: c.Type,
 			Function: chatToolCallFunction{
 				Name:      c.Function.Name,
-				Arguments: c.Function.Arguments,
+				Arguments: encodeToolCallArguments(c.Function.Arguments),
 			},
 		}
 	}
@@ -706,16 +720,174 @@ func toProviderToolCalls(calls []chatToolCall) []provider.ToolCall {
 	}
 	out := make([]provider.ToolCall, len(calls))
 	for i, c := range calls {
+		index := i
+		if c.Index != nil {
+			index = *c.Index
+		}
 		out[i] = provider.ToolCall{
 			ID:   c.ID,
-			Type: c.Type,
+			Type: firstNonEmpty(c.Type, "function"),
 			Function: provider.ToolCallFunction{
+				Index:     index,
 				Name:      c.Function.Name,
-				Arguments: c.Function.Arguments,
+				Arguments: normalizeToolCallArguments(c.Function.Arguments),
 			},
 		}
 	}
 	return out
+}
+
+type streamToolCallAccumulator struct {
+	order        []int
+	calls        map[int]*streamToolCall
+	lastIndex    int
+	hasLastIndex bool
+}
+
+type streamToolCall struct {
+	id        string
+	callType  string
+	name      string
+	arguments string
+}
+
+// Add merges OpenAI streaming tool-call deltas, whose arguments commonly arrive
+// as fragments keyed by tool_calls[].index.
+//
+// Index resolution precedence per delta:
+//  1. delta.Index when set — the canonical OpenAI signal.
+//  2. The most-recently-used index (lastIndex) when at least one tool call
+//     has already been observed — covers servers that send Index on the
+//     opening delta and omit it on subsequent argument-only fragments
+//     (the common single-tool case).
+//  3. Loop position — bootstrap fallback for the very first delta when no
+//     index has been seen yet.
+//
+// The lastIndex fallback is wrong in the pathological multi-tool case where
+// a server sends Index on the opening deltas but then emits arg-only deltas
+// with neither Index nor a way to disambiguate which call they extend.
+// OpenAI's reference servers do not produce that shape; the consequence of
+// the heuristic in that case is "arguments attach to the most recently
+// active call" — degraded but not silently corrupted across the wrong slot.
+func (a *streamToolCallAccumulator) Add(deltas []chatToolCall) []provider.ToolCall {
+	if a.calls == nil {
+		a.calls = make(map[int]*streamToolCall, len(deltas))
+	}
+	for position, delta := range deltas {
+		index := a.resolveIndex(delta, position)
+		call := a.calls[index]
+		if call == nil {
+			call = &streamToolCall{}
+			a.calls[index] = call
+			a.order = append(a.order, index)
+		}
+		if delta.ID != "" {
+			call.id = delta.ID
+		}
+		if delta.Type != "" {
+			call.callType = delta.Type
+		}
+		if delta.Function.Name != "" {
+			call.name = delta.Function.Name
+		}
+		call.arguments += decodeToolCallArgumentFragment(delta.Function.Arguments)
+		a.lastIndex = index
+		a.hasLastIndex = true
+	}
+	return a.Snapshot()
+}
+
+// resolveIndex implements the index-precedence rules documented on Add.
+func (a *streamToolCallAccumulator) resolveIndex(delta chatToolCall, position int) int {
+	if delta.Index != nil {
+		return *delta.Index
+	}
+	if a.hasLastIndex {
+		return a.lastIndex
+	}
+	return position
+}
+
+func (a *streamToolCallAccumulator) Snapshot() []provider.ToolCall {
+	if len(a.order) == 0 {
+		return nil
+	}
+	out := make([]provider.ToolCall, 0, len(a.order))
+	for _, index := range a.order {
+		call := a.calls[index]
+		out = append(out, provider.ToolCall{
+			ID:   call.id,
+			Type: firstNonEmpty(call.callType, "function"),
+			Function: provider.ToolCallFunction{
+				Index:     index,
+				Name:      call.name,
+				Arguments: normalizeToolCallArguments(json.RawMessage(call.arguments)),
+			},
+		})
+	}
+	return out
+}
+
+func decodeToolCallArgumentFragment(raw json.RawMessage) string {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(trimmed, &s); err == nil {
+		return s
+	}
+	return string(trimmed)
+}
+
+func normalizeToolCallArguments(raw json.RawMessage) json.RawMessage {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(trimmed, &s); err == nil {
+		if s == "" {
+			return nil
+		}
+		if json.Valid([]byte(s)) {
+			return json.RawMessage(append([]byte(nil), s...))
+		}
+		return mustJSONRawString(s)
+	}
+	if json.Valid(trimmed) {
+		return json.RawMessage(append([]byte(nil), trimmed...))
+	}
+	return mustJSONRawString(string(trimmed))
+}
+
+func encodeToolCallArguments(raw json.RawMessage) json.RawMessage {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(trimmed, &s); err == nil {
+		return json.RawMessage(append([]byte(nil), trimmed...))
+	}
+	return mustJSONRawString(string(trimmed))
+}
+
+func mustJSONRawString(s string) json.RawMessage {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return nil
+	}
+	return json.RawMessage(b)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // Compile-time assertion that *Provider satisfies provider.Provider.

--- a/provider/openaicompat/openaicompat.go
+++ b/provider/openaicompat/openaicompat.go
@@ -750,7 +750,21 @@ type streamToolCall struct {
 	callType  string
 	name      string
 	arguments string
+	argMode   fragmentMode
 }
+
+// fragmentMode locks the argument-fragment encoding for a single tool call
+// after the first non-empty fragment arrives. Once locked, subsequent
+// fragments are decoded with the same mode so a server that switches
+// between JSON-string envelopes and raw partial JSON mid-stream cannot
+// produce an unparseable concatenation.
+type fragmentMode uint8
+
+const (
+	fragModeUnknown fragmentMode = iota
+	fragModeEncoded              // fragment was a JSON-encoded string envelope
+	fragModeRaw                  // fragment was raw partial JSON
+)
 
 // Add merges OpenAI streaming tool-call deltas, whose arguments commonly arrive
 // as fragments keyed by tool_calls[].index.
@@ -791,7 +805,11 @@ func (a *streamToolCallAccumulator) Add(deltas []chatToolCall) []provider.ToolCa
 		if delta.Function.Name != "" {
 			call.name = delta.Function.Name
 		}
-		call.arguments += decodeToolCallArgumentFragment(delta.Function.Arguments)
+		fragment, mode := decodeToolCallArgumentFragment(delta.Function.Arguments, call.argMode)
+		if call.argMode == fragModeUnknown {
+			call.argMode = mode
+		}
+		call.arguments += fragment
 		a.lastIndex = index
 		a.hasLastIndex = true
 	}
@@ -829,16 +847,41 @@ func (a *streamToolCallAccumulator) Snapshot() []provider.ToolCall {
 	return out
 }
 
-func decodeToolCallArgumentFragment(raw json.RawMessage) string {
+// decodeToolCallArgumentFragment extracts the argument-string payload from a
+// single streaming-delta fragment. OpenAI's streaming spec is loose: some
+// servers send each fragment as a JSON-encoded string ("{\"q\""), others
+// send raw partial JSON ({"q") that is only valid once concatenated.
+//
+// The locked argument forces consistent decoding once a call has seen its
+// first non-empty fragment: a server cannot switch from encoded to raw or
+// vice versa mid-stream without producing an unparseable concatenation.
+// Returns the decoded fragment text plus the mode used (which the caller
+// stores on the per-call accumulator state to lock subsequent fragments).
+//
+// fragModeUnknown locked input lets the function probe the first fragment;
+// the locked return is then enforced on subsequent fragments by the caller.
+func decodeToolCallArgumentFragment(raw json.RawMessage, locked fragmentMode) (string, fragmentMode) {
 	trimmed := bytes.TrimSpace(raw)
 	if len(trimmed) == 0 || string(trimmed) == "null" {
-		return ""
+		return "", locked
 	}
+	switch locked {
+	case fragModeEncoded:
+		var s string
+		if err := json.Unmarshal(trimmed, &s); err == nil {
+			return s, fragModeEncoded
+		}
+		// Server violated its own mode — best-effort fall through as raw.
+		return string(trimmed), fragModeEncoded
+	case fragModeRaw:
+		return string(trimmed), fragModeRaw
+	}
+	// fragModeUnknown — probe the first fragment to lock the mode.
 	var s string
 	if err := json.Unmarshal(trimmed, &s); err == nil {
-		return s
+		return s, fragModeEncoded
 	}
-	return string(trimmed)
+	return string(trimmed), fragModeRaw
 }
 
 // normalizeToolCallArguments unwraps OpenAI's JSON-string envelope around

--- a/provider/openaicompat/openaicompat.go
+++ b/provider/openaicompat/openaicompat.go
@@ -217,13 +217,19 @@ func (p *Provider) Chat(ctx context.Context, req provider.ChatRequest) (*provide
 
 // ChatStream sends a streaming /v1/chat/completions request and invokes fn
 // for each chunk. Content is processed through a per-request ThinkParser to
-// separate reasoning from content in real time. Tool-call deltas are
-// emitted as standalone chunks alongside content/thinking.
+// separate reasoning from content in real time.
+//
+// Tool-call emission policy: OpenAI streams tool-call arguments as
+// fragments that are only meaningful once concatenated, so this provider
+// accumulates them silently across deltas and surfaces the assembled
+// ToolCalls slice only on the final Done chunk. Consumers building
+// incremental tool-call UI should treat the Done chunk as the single
+// authoritative source for tool-call payloads on a given stream.
 //
 // Cancellation policy mirrors OllamaProvider: if the context is cancelled
 // after at least one chunk has been received, the parser is flushed and a
-// final synthetic Done+Partial chunk is emitted before the context error
-// is returned.
+// final synthetic Done+Partial chunk is emitted (carrying whatever tool
+// calls had been accumulated so far) before the context error is returned.
 func (p *Provider) ChatStream(ctx context.Context, req provider.ChatRequest, fn func(provider.ChatResponse) error) error {
 	if fn == nil {
 		return fmt.Errorf("provider: openaicompat: chat stream: callback function is required")
@@ -574,8 +580,15 @@ func (p *Provider) Embed(ctx context.Context, req provider.EmbedRequest) (*provi
 	}
 }
 
-// embedKey builds a singleflight dedup key from model + length-prefixed inputs.
-// Length prefixes keep distinct inputs with embedded NUL bytes from colliding.
+// embedKey builds a singleflight dedup key from model + length-prefixed
+// inputs. Length prefixes keep distinct inputs with embedded NUL bytes
+// from colliding.
+//
+// The "model:hexhash" layout is collision-free because hex.EncodeToString
+// produces only [0-9a-f] — a model name containing a literal ':' cannot
+// be confused with the separator+hash boundary. If this is ever changed
+// to a non-hex encoding (e.g. base64 with ':' in its alphabet) the
+// separator must be re-chosen.
 func embedKey(model string, inputs []string) string {
 	h := sha256.New()
 	var lenBuf [8]byte
@@ -696,6 +709,16 @@ func toWireTools(tools []provider.Tool) []chatTool {
 }
 
 // toWireToolCalls converts provider tool calls to the OpenAI wire shape.
+//
+// Note: provider.ToolCallFunction.Index is intentionally NOT copied to
+// chatToolCall.Index here. OpenAI's spec treats `index` as a response-only
+// field used to correlate streaming deltas; sending it on an outbound
+// request can be rejected by strict server-side schema validators
+// (notably some self-hosted vLLM and llama.cpp setups). The asymmetry is
+// intentional and parallels what an OpenAI-spec-conformant client must do —
+// it is NOT a missing-feature gap relative to OllamaProvider, which
+// preserves Function.Index outbound because Ollama's wire shape accepts
+// it.
 func toWireToolCalls(calls []provider.ToolCall) []chatToolCall {
 	if len(calls) == 0 {
 		return nil
@@ -937,6 +960,19 @@ func isJSONObjectOrArray(s string) bool {
 	return false
 }
 
+// encodeToolCallArguments produces the canonical OpenAI outbound shape for
+// tool-call arguments: a JSON-encoded string of the inner payload. It
+// accepts EITHER raw JSON (e.g. `{"q":"go"}` from upstream provider-side
+// callers) OR an already-encoded JSON string (when round-tripping
+// previously-received arguments back to the server) and emits the
+// already-encoded form in both cases.
+//
+// Empty input AND the literal "null" both collapse to nil — the outbound
+// wire then omits the arguments field entirely (json.RawMessage(nil) +
+// omitempty). OpenAI does not distinguish "arguments: null" from
+// arguments-omitted at the schema level today, so a caller passing the
+// "null" literal to mean "no arguments" gets the same outbound shape as
+// passing a nil RawMessage.
 func encodeToolCallArguments(raw json.RawMessage) json.RawMessage {
 	trimmed := bytes.TrimSpace(raw)
 	if len(trimmed) == 0 || string(trimmed) == "null" {
@@ -944,11 +980,19 @@ func encodeToolCallArguments(raw json.RawMessage) json.RawMessage {
 	}
 	var s string
 	if err := json.Unmarshal(trimmed, &s); err == nil {
+		// Already JSON-string-encoded — pass through verbatim.
 		return json.RawMessage(append([]byte(nil), trimmed...))
 	}
+	// Raw JSON — wrap as the OpenAI canonical string envelope.
 	return mustJSONRawString(string(trimmed))
 }
 
+// mustJSONRawString JSON-encodes s as a string literal and returns it as
+// a json.RawMessage. json.Marshal of a string is documented as infallible
+// for valid UTF-8; the nil return on error is reachable only for invalid
+// UTF-8 in tool-call arguments, which is already broken at the upstream
+// model and would surface as missing arguments on the outbound wire — the
+// least-bad failure mode.
 func mustJSONRawString(s string) json.RawMessage {
 	b, err := json.Marshal(s)
 	if err != nil {
@@ -957,6 +1001,11 @@ func mustJSONRawString(s string) json.RawMessage {
 	return json.RawMessage(b)
 }
 
+// firstNonEmpty returns the first non-empty string in values, or "" when
+// all values are empty. Used to default tool-call Type to "function" when
+// neither the response nor a delta carries the field — OpenAI's spec
+// only defines "function" today, but storing whatever the server emits
+// keeps the door open to future tool types without round-trip loss.
 func firstNonEmpty(values ...string) string {
 	for _, v := range values {
 		if v != "" {

--- a/provider/openaicompat/openaicompat.go
+++ b/provider/openaicompat/openaicompat.go
@@ -231,7 +231,7 @@ func (p *Provider) ChatStream(ctx context.Context, req provider.ChatRequest, fn 
 	if err != nil {
 		return fmt.Errorf("provider: openaicompat: chat stream: %w", err)
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 
 	var (
 		lastModel      string
@@ -414,7 +414,7 @@ func (p *Provider) GenerateStream(ctx context.Context, req provider.GenerateRequ
 	if err != nil {
 		return fmt.Errorf("provider: openaicompat: generate stream: %w", err)
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 
 	var (
 		lastModel      string

--- a/provider/openaicompat/openaicompat.go
+++ b/provider/openaicompat/openaicompat.go
@@ -339,24 +339,29 @@ func (p *Provider) ChatStream(ctx context.Context, req provider.ChatRequest, fn 
 		return callbackErr
 	}
 
-	if ctx.Err() != nil && chunksReceived > 0 && !finished {
-		_ = parser.Flush()
-		model := lastModel
-		if model == "" {
-			model = req.Model
+	if ctx.Err() != nil {
+		if chunksReceived > 0 && !finished {
+			_ = parser.Flush()
+			model := lastModel
+			if model == "" {
+				model = req.Model
+			}
+			_ = fn(provider.ChatResponse{
+				Model:     model,
+				Provider:  p.name,
+				ToolCalls: lastToolCalls,
+				Done:      true,
+				Partial:   true,
+				Usage:     lastUsage,
+			})
 		}
-		_ = fn(provider.ChatResponse{
-			Model:     model,
-			Provider:  p.name,
-			ToolCalls: lastToolCalls,
-			Done:      true,
-			Partial:   true,
-			Usage:     lastUsage,
-		})
 		return fmt.Errorf("provider: openaicompat: chat stream: %w", ctx.Err())
 	}
 	if streamErr != nil {
 		return fmt.Errorf("provider: openaicompat: chat stream: %w", streamErr)
+	}
+	if !finished {
+		return fmt.Errorf("provider: openaicompat: chat stream: ended before final chunk")
 	}
 
 	return nil
@@ -485,22 +490,27 @@ func (p *Provider) GenerateStream(ctx context.Context, req provider.GenerateRequ
 		return callbackErr
 	}
 
-	if ctx.Err() != nil && chunksReceived > 0 && !finished {
-		model := lastModel
-		if model == "" {
-			model = req.Model
+	if ctx.Err() != nil {
+		if chunksReceived > 0 && !finished {
+			model := lastModel
+			if model == "" {
+				model = req.Model
+			}
+			_ = fn(provider.GenerateResponse{
+				Model:    model,
+				Provider: p.name,
+				Done:     true,
+				Partial:  true,
+				Usage:    lastUsage,
+			})
 		}
-		_ = fn(provider.GenerateResponse{
-			Model:    model,
-			Provider: p.name,
-			Done:     true,
-			Partial:  true,
-			Usage:    lastUsage,
-		})
 		return fmt.Errorf("provider: openaicompat: generate stream: %w", ctx.Err())
 	}
 	if streamErr != nil {
 		return fmt.Errorf("provider: openaicompat: generate stream: %w", streamErr)
+	}
+	if !finished {
+		return fmt.Errorf("provider: openaicompat: generate stream: ended before final chunk")
 	}
 
 	return nil

--- a/provider/openaicompat/openaicompat.go
+++ b/provider/openaicompat/openaicompat.go
@@ -1,0 +1,722 @@
+// Package openaicompat — Provider impl. See doc.go for the package overview.
+package openaicompat
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/kstruzzieri/go-llm/provider"
+	"golang.org/x/sync/singleflight"
+)
+
+const defaultProviderName = "openai-compat"
+
+// ---------------------------------------------------------------------------
+// Provider construction + options
+// ---------------------------------------------------------------------------
+
+// Option configures a Provider.
+type Option func(*Provider)
+
+// WithProviderName overrides the registry identity returned by Name() and
+// stamped on every response's Provider field. Default is "openai-compat";
+// supply a config-key instance name (e.g. "vllm-workstation") when
+// registering multiple OpenAI-compat instances. Mirrors the OllamaProvider
+// option of the same name; behavior is parallel.
+//
+// Panics on empty input — an empty registry identity is a configuration
+// bug that would otherwise produce a Provider whose Registry.Register
+// fails later with a less-actionable error. Fail fast at construction
+// instead of silently keeping the default.
+func WithProviderName(name string) Option {
+	if name == "" {
+		panic("openaicompat: WithProviderName called with empty name; omit the option to use the default \"openai-compat\"")
+	}
+	return func(p *Provider) {
+		p.name = name
+	}
+}
+
+// WithThinkMode sets the ThinkMode used when constructing per-request
+// ThinkParsers. Defaults to ThinkAuto (extract whenever tags appear).
+func WithThinkMode(mode provider.ThinkMode) Option {
+	return func(p *Provider) {
+		p.thinkMode = mode
+	}
+}
+
+// WithThinkTags overrides the default <think></think> delimiters.
+func WithThinkTags(tags provider.ThinkTags) Option {
+	return func(p *Provider) {
+		p.thinkTags = tags
+	}
+}
+
+// WithThinkBudget sets a budget constraint for thinking extraction.
+func WithThinkBudget(budget *provider.ThinkBudget) Option {
+	return func(p *Provider) {
+		p.thinkBudget = budget
+	}
+}
+
+// WithCapabilities overrides the default capability bitmask returned by
+// Capabilities(). Use when the target server is known to lack a specific
+// endpoint (e.g. a llama.cpp build without /v1/embeddings). Note: this
+// affects the Provider-level Capabilities() report only; per-model
+// carve-down should still be done via config.ModelConfig.Capabilities.
+func WithCapabilities(caps provider.Capability) Option {
+	return func(p *Provider) {
+		p.caps = caps
+	}
+}
+
+// Provider implements provider.Provider against an OpenAI-compatible server.
+// It composes a Client for HTTP/SSE transport and shares the same
+// ThinkParser / singleflight patterns as OllamaProvider so behavior is
+// consistent across backend kinds.
+type Provider struct {
+	name        string
+	client      *Client
+	caps        provider.Capability
+	thinkMode   provider.ThinkMode
+	thinkTags   provider.ThinkTags
+	thinkBudget *provider.ThinkBudget
+	embedGroup  singleflight.Group
+}
+
+// NewProvider creates a Provider backed by the given Client. Options
+// configure registry identity, thinking, and capability advertisement.
+//
+// Default capabilities are CapChat | CapGenerate | CapStream | CapEmbed |
+// CapToolCall. CapInsert is intentionally NOT advertised by default because
+// OpenAI-compat servers vary on FIM support and the spec offers no probe
+// equivalent to Ollama's template inspection; opt in via WithCapabilities
+// when the target server is known to support it.
+func NewProvider(client *Client, opts ...Option) *Provider {
+	p := &Provider{
+		name:      defaultProviderName,
+		client:    client,
+		caps:      provider.CapChat | provider.CapGenerate | provider.CapStream | provider.CapEmbed | provider.CapToolCall,
+		thinkMode: provider.ThinkAuto,
+		thinkTags: provider.DefaultThinkTags(),
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// ---------------------------------------------------------------------------
+// Identity / Capability / Health
+// ---------------------------------------------------------------------------
+
+// Name returns the registry identity for this Provider instance. Defaults
+// to "openai-compat" unless WithProviderName overrode it; the value is
+// also stamped on every response's Provider field.
+func (p *Provider) Name() string {
+	return p.name
+}
+
+// Capabilities returns the bitmask of features this Provider advertises.
+// See NewProvider for the default set and the rationale for omitting
+// CapInsert by default.
+func (p *Provider) Capabilities() provider.Capability {
+	return p.caps
+}
+
+// Health probes the server with a /v1/models request. A 2xx response is
+// the same liveness signal Ollama's IsAvailable uses for /api/tags —
+// minimal, no special endpoint required, and works against every
+// OpenAI-compat implementation since /v1/models is the spec's only
+// mandatory GET.
+func (p *Provider) Health(ctx context.Context) error {
+	var resp modelsResponse
+	if err := p.client.getJSON(ctx, "/v1/models", &resp); err != nil {
+		return fmt.Errorf("provider: openaicompat: health: %w", err)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Models discovery
+// ---------------------------------------------------------------------------
+
+// Models returns the list of models advertised by /v1/models. OpenAI-compat
+// servers expose only the ID reliably; Family, ParameterSize, QuantLevel,
+// Template, Capabilities, ContextWindow, and Digest are NOT part of the
+// /v1/models spec and will be empty/zero. Consumers needing those fields
+// should populate them via models.json (catalog merge happens upstream in
+// ModelRegistry).
+func (p *Provider) Models(ctx context.Context) ([]provider.ModelInfo, error) {
+	var resp modelsResponse
+	if err := p.client.getJSON(ctx, "/v1/models", &resp); err != nil {
+		return nil, fmt.Errorf("provider: openaicompat: list models: %w", err)
+	}
+	out := make([]provider.ModelInfo, len(resp.Data))
+	for i, m := range resp.Data {
+		out[i] = provider.ModelInfo{Name: m.ID}
+	}
+	return out, nil
+}
+
+// ---------------------------------------------------------------------------
+// Chat (non-streaming)
+// ---------------------------------------------------------------------------
+
+// Chat sends a non-streaming /v1/chat/completions request. Content is
+// processed through ExtractThinking to separate inline reasoning from
+// the final answer, matching the OllamaProvider contract.
+func (p *Provider) Chat(ctx context.Context, req provider.ChatRequest) (*provider.ChatResponse, error) {
+	body := toChatRequest(req, false)
+	var resp chatResponse
+	if err := p.client.postJSON(ctx, "/v1/chat/completions", body, &resp); err != nil {
+		return nil, fmt.Errorf("provider: openaicompat: chat: %w", err)
+	}
+
+	if len(resp.Choices) == 0 {
+		return nil, fmt.Errorf("provider: openaicompat: chat: response had no choices")
+	}
+	msg := resp.Choices[0].Message
+
+	content := msg.Content
+	thinking := ""
+	if p.shouldExtractThinking(req.Options) {
+		content, thinking = provider.ExtractThinking(msg.Content, p.thinkTags)
+	}
+
+	model := resp.Model
+	if model == "" {
+		model = req.Model
+	}
+
+	return &provider.ChatResponse{
+		Model:     model,
+		Provider:  p.name,
+		Content:   content,
+		Thinking:  thinking,
+		ToolCalls: toProviderToolCalls(msg.ToolCalls),
+		Done:      true,
+		Usage: provider.Usage{
+			PromptTokens:     resp.Usage.PromptTokens,
+			CompletionTokens: resp.Usage.CompletionTokens,
+			TotalTokens:      resp.Usage.TotalTokens,
+		},
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// ChatStream (streaming with think-tag extraction)
+// ---------------------------------------------------------------------------
+
+// ChatStream sends a streaming /v1/chat/completions request and invokes fn
+// for each chunk. Content is processed through a per-request ThinkParser to
+// separate reasoning from content in real time. Tool-call deltas are
+// emitted as standalone chunks alongside content/thinking.
+//
+// Cancellation policy mirrors OllamaProvider: if the context is cancelled
+// after at least one chunk has been received, the parser is flushed and a
+// final synthetic Done+Partial chunk is emitted before the context error
+// is returned.
+func (p *Provider) ChatStream(ctx context.Context, req provider.ChatRequest, fn func(provider.ChatResponse) error) error {
+	if fn == nil {
+		return fmt.Errorf("provider: openaicompat: chat stream: callback function is required")
+	}
+
+	body := toChatRequest(req, true)
+	reader, err := p.client.postSSE(ctx, "/v1/chat/completions", body)
+	if err != nil {
+		return fmt.Errorf("provider: openaicompat: chat stream: %w", err)
+	}
+	defer reader.Close()
+
+	var (
+		lastModel      string
+		lastToolCalls  []provider.ToolCall
+		lastUsage      provider.Usage
+		chunksReceived int
+		callbackErr    error
+		finished       bool
+	)
+
+	parser := provider.NewThinkParser(provider.ThinkParserConfig{
+		Mode: p.thinkMode,
+		Tags: p.thinkTags,
+		OnThinking: func(s string) error {
+			err := fn(provider.ChatResponse{Model: lastModel, Provider: p.name, Thinking: s})
+			if err != nil {
+				callbackErr = err
+			}
+			return err
+		},
+		OnContent: func(s string) error {
+			err := fn(provider.ChatResponse{Model: lastModel, Provider: p.name, Content: s})
+			if err != nil {
+				callbackErr = err
+			}
+			return err
+		},
+		Budget: p.thinkBudget,
+	})
+	if p.thinkMode == provider.ThinkToggle {
+		parser.SetActive(thinkToggleActive(req.Options))
+	}
+
+	for {
+		payload, readErr := reader.Next()
+		if readErr != nil {
+			break
+		}
+
+		var chunk chatChunk
+		if err := json.Unmarshal(payload, &chunk); err != nil {
+			// Skip malformed chunks rather than aborting the stream — servers
+			// occasionally inject keepalive comments or oddly-shaped frames.
+			continue
+		}
+		chunksReceived++
+		if chunk.Model != "" {
+			lastModel = chunk.Model
+		}
+		if chunk.Usage != nil {
+			lastUsage = provider.Usage{
+				PromptTokens:     chunk.Usage.PromptTokens,
+				CompletionTokens: chunk.Usage.CompletionTokens,
+				TotalTokens:      chunk.Usage.TotalTokens,
+			}
+		}
+		if len(chunk.Choices) == 0 {
+			continue
+		}
+		choice := chunk.Choices[0]
+
+		if len(choice.Delta.ToolCalls) > 0 {
+			lastToolCalls = toProviderToolCalls(choice.Delta.ToolCalls)
+			if err := fn(provider.ChatResponse{
+				Model:     lastModel,
+				Provider:  p.name,
+				ToolCalls: lastToolCalls,
+			}); err != nil {
+				callbackErr = err
+				break
+			}
+		}
+		if choice.Delta.Content != "" {
+			if err := parser.Process(choice.Delta.Content); err != nil {
+				callbackErr = err
+				break
+			}
+		}
+		if choice.FinishReason != nil {
+			finished = true
+			if err := parser.Flush(); err != nil {
+				callbackErr = err
+				break
+			}
+			if err := fn(provider.ChatResponse{
+				Model:     lastModel,
+				Provider:  p.name,
+				ToolCalls: lastToolCalls,
+				Done:      true,
+				Usage:     lastUsage,
+			}); err != nil {
+				callbackErr = err
+			}
+			break
+		}
+	}
+
+	if callbackErr != nil {
+		return callbackErr
+	}
+
+	if ctx.Err() != nil && chunksReceived > 0 && !finished {
+		_ = parser.Flush()
+		model := lastModel
+		if model == "" {
+			model = req.Model
+		}
+		_ = fn(provider.ChatResponse{
+			Model:     model,
+			Provider:  p.name,
+			ToolCalls: lastToolCalls,
+			Done:      true,
+			Partial:   true,
+			Usage:     lastUsage,
+		})
+		return fmt.Errorf("provider: openaicompat: chat stream: %w", ctx.Err())
+	}
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Generate (non-streaming, /v1/completions, FIM via suffix)
+// ---------------------------------------------------------------------------
+
+// Generate sends a non-streaming /v1/completions request. When req.Suffix
+// is set, the underlying server is expected to run native FIM (vLLM and
+// llama.cpp --api both support this); when empty, behaves as plain
+// left-to-right generation.
+//
+// System prompts are NOT supported by /v1/completions in OpenAI's spec; if
+// req.System is set, it is prepended to req.Prompt with a newline boundary
+// so callers can keep using the provider-agnostic ChatRequest shape without
+// losing the directive. This is best-effort and may not match every
+// server's instruction-tuning expectations.
+func (p *Provider) Generate(ctx context.Context, req provider.GenerateRequest) (*provider.GenerateResponse, error) {
+	body := toCompletionRequest(req, false)
+	var resp completionResponse
+	if err := p.client.postJSON(ctx, "/v1/completions", body, &resp); err != nil {
+		return nil, fmt.Errorf("provider: openaicompat: generate: %w", err)
+	}
+
+	if len(resp.Choices) == 0 {
+		return nil, fmt.Errorf("provider: openaicompat: generate: response had no choices")
+	}
+	text := resp.Choices[0].Text
+
+	model := resp.Model
+	if model == "" {
+		model = req.Model
+	}
+
+	return &provider.GenerateResponse{
+		Model:    model,
+		Provider: p.name,
+		Response: text,
+		Done:     true,
+		Usage: provider.Usage{
+			PromptTokens:     resp.Usage.PromptTokens,
+			CompletionTokens: resp.Usage.CompletionTokens,
+			TotalTokens:      resp.Usage.TotalTokens,
+		},
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// GenerateStream (streaming /v1/completions)
+// ---------------------------------------------------------------------------
+
+// GenerateStream sends a streaming /v1/completions request. Each chunk's
+// delta text is forwarded to fn. Cancellation policy matches ChatStream:
+// emit a final Done+Partial chunk if cancelled mid-stream.
+func (p *Provider) GenerateStream(ctx context.Context, req provider.GenerateRequest, fn func(provider.GenerateResponse) error) error {
+	if fn == nil {
+		return fmt.Errorf("provider: openaicompat: generate stream: callback function is required")
+	}
+
+	body := toCompletionRequest(req, true)
+	reader, err := p.client.postSSE(ctx, "/v1/completions", body)
+	if err != nil {
+		return fmt.Errorf("provider: openaicompat: generate stream: %w", err)
+	}
+	defer reader.Close()
+
+	var (
+		lastModel      string
+		lastUsage      provider.Usage
+		chunksReceived int
+		callbackErr    error
+		finished       bool
+	)
+
+	for {
+		payload, readErr := reader.Next()
+		if readErr != nil {
+			break
+		}
+
+		var chunk completionChunk
+		if err := json.Unmarshal(payload, &chunk); err != nil {
+			continue
+		}
+		chunksReceived++
+		if chunk.Model != "" {
+			lastModel = chunk.Model
+		}
+		if chunk.Usage != nil {
+			lastUsage = provider.Usage{
+				PromptTokens:     chunk.Usage.PromptTokens,
+				CompletionTokens: chunk.Usage.CompletionTokens,
+				TotalTokens:      chunk.Usage.TotalTokens,
+			}
+		}
+		if len(chunk.Choices) == 0 {
+			continue
+		}
+		choice := chunk.Choices[0]
+		isFinal := choice.FinishReason != nil
+
+		resp := provider.GenerateResponse{
+			Model:    lastModel,
+			Provider: p.name,
+			Response: choice.Text,
+			Done:     isFinal,
+			Usage:    lastUsage,
+		}
+		if err := fn(resp); err != nil {
+			callbackErr = err
+			break
+		}
+		if isFinal {
+			finished = true
+			break
+		}
+	}
+
+	if callbackErr != nil {
+		return callbackErr
+	}
+
+	if ctx.Err() != nil && chunksReceived > 0 && !finished {
+		model := lastModel
+		if model == "" {
+			model = req.Model
+		}
+		_ = fn(provider.GenerateResponse{
+			Model:    model,
+			Provider: p.name,
+			Done:     true,
+			Partial:  true,
+			Usage:    lastUsage,
+		})
+		return fmt.Errorf("provider: openaicompat: generate stream: %w", ctx.Err())
+	}
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Embed (with singleflight deduplication)
+// ---------------------------------------------------------------------------
+
+// Embed generates vector embeddings via /v1/embeddings. Concurrent identical
+// requests (same model + inputs) are deduplicated via singleflight to avoid
+// redundant compute during batch RAG indexing, matching OllamaProvider's
+// behavior.
+//
+// Returns are reordered by index defensively — OpenAI's spec says the data
+// array order is unspecified, only that each entry's Index field maps back
+// to the request Input position. Most servers preserve order in practice,
+// but the reorder makes the contract explicit.
+func (p *Provider) Embed(ctx context.Context, req provider.EmbedRequest) (*provider.EmbedResponse, error) {
+	if req.Model == "" {
+		return nil, fmt.Errorf("provider: openaicompat: embed: model name is required")
+	}
+	if len(req.Input) == 0 {
+		return nil, fmt.Errorf("provider: openaicompat: embed: at least one input text is required")
+	}
+
+	key := embedKey(req.Model, req.Input)
+	sharedCtx := context.WithoutCancel(ctx)
+	ch := p.embedGroup.DoChan(key, func() (any, error) {
+		body := embedRequest{Model: req.Model, Input: req.Input}
+		var resp embedResponse
+		if err := p.client.postJSON(sharedCtx, "/v1/embeddings", body, &resp); err != nil {
+			return nil, fmt.Errorf("provider: openaicompat: embed: %w", err)
+		}
+		if len(resp.Data) != len(req.Input) {
+			return nil, fmt.Errorf("provider: openaicompat: embed: server returned %d embeddings for %d inputs", len(resp.Data), len(req.Input))
+		}
+		ordered := make([][]float64, len(req.Input))
+		for _, doc := range resp.Data {
+			if doc.Index < 0 || doc.Index >= len(ordered) {
+				return nil, fmt.Errorf("provider: openaicompat: embed: server returned out-of-range index %d", doc.Index)
+			}
+			ordered[doc.Index] = doc.Embedding
+		}
+		for i, emb := range ordered {
+			if emb == nil {
+				return nil, fmt.Errorf("provider: openaicompat: embed: server skipped index %d", i)
+			}
+		}
+		return &provider.EmbedResponse{
+			Model:      req.Model,
+			Provider:   p.name,
+			Embeddings: ordered,
+			Usage: provider.Usage{
+				PromptTokens: resp.Usage.PromptTokens,
+				TotalTokens:  resp.Usage.TotalTokens,
+			},
+		}, nil
+	})
+
+	select {
+	case res := <-ch:
+		if res.Err != nil {
+			return nil, res.Err
+		}
+		// Defensive copy: singleflight shares the result pointer.
+		shared := res.Val.(*provider.EmbedResponse)
+		copied := *shared
+		copied.Embeddings = make([][]float64, len(shared.Embeddings))
+		for i, emb := range shared.Embeddings {
+			copied.Embeddings[i] = make([]float64, len(emb))
+			copy(copied.Embeddings[i], emb)
+		}
+		return &copied, nil
+	case <-ctx.Done():
+		return nil, fmt.Errorf("provider: openaicompat: embed: %w", ctx.Err())
+	}
+}
+
+// embedKey builds a singleflight dedup key from model + sha256 of joined
+// inputs. Identical to the OllamaProvider helper; duplicated here so the
+// sub-package has no upward dependency on unexported symbols in provider/.
+func embedKey(model string, inputs []string) string {
+	h := sha256.Sum256([]byte(strings.Join(inputs, "\x00")))
+	return model + ":" + hex.EncodeToString(h[:])
+}
+
+// ---------------------------------------------------------------------------
+// Thinking helpers
+// ---------------------------------------------------------------------------
+
+// shouldExtractThinking mirrors OllamaProvider's per-request decision.
+func (p *Provider) shouldExtractThinking(opts provider.ModelOptions) bool {
+	switch p.thinkMode {
+	case provider.ThinkNone:
+		return false
+	case provider.ThinkToggle:
+		return thinkToggleActive(opts)
+	default:
+		return true
+	}
+}
+
+// thinkToggleActive reports whether ThinkToggle mode is active for opts.
+func thinkToggleActive(opts provider.ModelOptions) bool {
+	return opts.Think != nil && *opts.Think
+}
+
+// ---------------------------------------------------------------------------
+// Provider -> OpenAI request conversion
+// ---------------------------------------------------------------------------
+
+// toChatRequest converts a provider ChatRequest to the OpenAI wire shape.
+// stream is passed explicitly because the request body's Stream field is
+// the source of truth for the HTTP path (postJSON vs postSSE).
+func toChatRequest(req provider.ChatRequest, stream bool) chatRequest {
+	msgs := make([]chatMessage, len(req.Messages))
+	for i, m := range req.Messages {
+		msgs[i] = chatMessage{
+			Role:       m.Role,
+			Content:    m.Content,
+			Name:       m.ToolName,
+			ToolCallID: m.ToolCallID,
+			ToolCalls:  toWireToolCalls(m.ToolCalls),
+		}
+	}
+	r := chatRequest{
+		Model:    req.Model,
+		Messages: msgs,
+		Stream:   stream,
+		Tools:    toWireTools(req.Tools),
+	}
+	applyOptionsChat(&r, req.Options)
+	return r
+}
+
+// toCompletionRequest converts a provider GenerateRequest to the OpenAI
+// /v1/completions wire shape. System is prepended to Prompt when set
+// because /v1/completions has no system field.
+func toCompletionRequest(req provider.GenerateRequest, stream bool) completionRequest {
+	prompt := req.Prompt
+	if req.System != "" {
+		prompt = req.System + "\n" + prompt
+	}
+	r := completionRequest{
+		Model:  req.Model,
+		Prompt: prompt,
+		Suffix: req.Suffix,
+		Stream: stream,
+	}
+	applyOptionsCompletion(&r, req.Options)
+	return r
+}
+
+// applyOptionsChat copies relevant ModelOptions onto a chatRequest. Pointer
+// fields preserve "unset vs zero" semantics — OpenAI treats temperature=0
+// differently from "not specified".
+func applyOptionsChat(r *chatRequest, opts provider.ModelOptions) {
+	r.Temperature = opts.Temperature
+	r.TopP = opts.TopP
+	r.MaxTokens = opts.NumPredict
+	if len(opts.Stop) > 0 {
+		r.Stop = opts.Stop
+	}
+}
+
+// applyOptionsCompletion copies relevant ModelOptions onto a completionRequest.
+func applyOptionsCompletion(r *completionRequest, opts provider.ModelOptions) {
+	r.Temperature = opts.Temperature
+	r.TopP = opts.TopP
+	r.MaxTokens = opts.NumPredict
+	if len(opts.Stop) > 0 {
+		r.Stop = opts.Stop
+	}
+}
+
+// toWireTools converts provider tools to the OpenAI wire shape.
+func toWireTools(tools []provider.Tool) []chatTool {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]chatTool, len(tools))
+	for i, t := range tools {
+		out[i] = chatTool{
+			Type: t.Type,
+			Function: chatFunction{
+				Name:        t.Function.Name,
+				Description: t.Function.Description,
+				Parameters:  t.Function.Parameters,
+			},
+		}
+	}
+	return out
+}
+
+// toWireToolCalls converts provider tool calls to the OpenAI wire shape.
+func toWireToolCalls(calls []provider.ToolCall) []chatToolCall {
+	if len(calls) == 0 {
+		return nil
+	}
+	out := make([]chatToolCall, len(calls))
+	for i, c := range calls {
+		out[i] = chatToolCall{
+			ID:   c.ID,
+			Type: c.Type,
+			Function: chatToolCallFunction{
+				Name:      c.Function.Name,
+				Arguments: c.Function.Arguments,
+			},
+		}
+	}
+	return out
+}
+
+// toProviderToolCalls converts OpenAI wire tool calls to provider shape.
+func toProviderToolCalls(calls []chatToolCall) []provider.ToolCall {
+	if len(calls) == 0 {
+		return nil
+	}
+	out := make([]provider.ToolCall, len(calls))
+	for i, c := range calls {
+		out[i] = provider.ToolCall{
+			ID:   c.ID,
+			Type: c.Type,
+			Function: provider.ToolCallFunction{
+				Name:      c.Function.Name,
+				Arguments: c.Function.Arguments,
+			},
+		}
+	}
+	return out
+}
+
+// Compile-time assertion that *Provider satisfies provider.Provider.
+var _ provider.Provider = (*Provider)(nil)

--- a/provider/openaicompat/openaicompat.go
+++ b/provider/openaicompat/openaicompat.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/kstruzzieri/go-llm/provider"
 	"golang.org/x/sync/singleflight"
@@ -840,6 +841,19 @@ func decodeToolCallArgumentFragment(raw json.RawMessage) string {
 	return string(trimmed)
 }
 
+// normalizeToolCallArguments unwraps OpenAI's JSON-string envelope around
+// tool-call arguments and returns the inner JSON value, OR re-encodes a
+// raw payload as the canonical string envelope when the input is already
+// loose JSON. Empty / "null" inputs collapse to nil so downstream consumers
+// see "no arguments" uniformly.
+//
+// Scalar JSON literals inside the string envelope (e.g. "42", "true",
+// "null") are preserved as JSON-encoded strings rather than unwrapped to
+// bare scalars — the inner string was the original argument value, and
+// type-narrowing to a JSON number/bool would silently change the data
+// shape the tool implementation receives. Object and array literals ARE
+// unwrapped because that is the canonical tool-call shape providers
+// actually consume.
 func normalizeToolCallArguments(raw json.RawMessage) json.RawMessage {
 	trimmed := bytes.TrimSpace(raw)
 	if len(trimmed) == 0 || string(trimmed) == "null" {
@@ -850,7 +864,10 @@ func normalizeToolCallArguments(raw json.RawMessage) json.RawMessage {
 		if s == "" {
 			return nil
 		}
-		if json.Valid([]byte(s)) {
+		// Only unwrap when the inner value is a JSON object or array — the
+		// canonical tool-call shape. Bare scalars (numbers, bools, "null")
+		// stay wrapped to preserve the originally-emitted type.
+		if isJSONObjectOrArray(s) {
 			return json.RawMessage(append([]byte(nil), s...))
 		}
 		return mustJSONRawString(s)
@@ -859,6 +876,22 @@ func normalizeToolCallArguments(raw json.RawMessage) json.RawMessage {
 		return json.RawMessage(append([]byte(nil), trimmed...))
 	}
 	return mustJSONRawString(string(trimmed))
+}
+
+// isJSONObjectOrArray reports whether s begins with '{' or '[' after trim
+// AND is well-formed JSON. Used by normalizeToolCallArguments to decide
+// when an inner JSON-string-encoded value is safe to unwrap (object/array)
+// vs must be preserved as a JSON-encoded string (scalar literals).
+func isJSONObjectOrArray(s string) bool {
+	trimmed := strings.TrimLeft(s, " \t\r\n")
+	if trimmed == "" {
+		return false
+	}
+	switch trimmed[0] {
+	case '{', '[':
+		return json.Valid([]byte(s))
+	}
+	return false
 }
 
 func encodeToolCallArguments(raw json.RawMessage) json.RawMessage {

--- a/provider/openaicompat/openaicompat_test.go
+++ b/provider/openaicompat/openaicompat_test.go
@@ -1010,6 +1010,41 @@ func TestProvider_ChatStream_SSEReadError_ReturnsError(t *testing.T) {
 	}
 }
 
+func TestProvider_ChatStream_DoneWithoutFinishReason_ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		f := w.(http.Flusher)
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", marshalJSON(t, chatChunk{
+			Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{Content: "partial"}}},
+		}))
+		_, _ = fmt.Fprintf(w, "data: [DONE]\n\n")
+		f.Flush()
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL), WithThinkMode(provider.ThinkNone))
+	var sawContent, sawDone bool
+	err := p.ChatStream(context.Background(), provider.ChatRequest{Model: "m"}, func(r provider.ChatResponse) error {
+		if r.Content == "partial" {
+			sawContent = true
+		}
+		if r.Done {
+			sawDone = true
+		}
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "ended before final chunk") {
+		t.Fatalf("expected incomplete stream error, got %v", err)
+	}
+	if !sawContent {
+		t.Fatal("expected content chunk before incomplete stream error")
+	}
+	if sawDone {
+		t.Fatal("must not synthesize a successful Done chunk for [DONE] without finish_reason")
+	}
+}
+
 // TestProvider_ChatStream_EOFMidFrame_PropagatesError covers the
 // connection-reset / abrupt-close failure mode: a server begins writing
 // an SSE frame, flushes a partial "data: " prefix without the closing
@@ -1177,6 +1212,41 @@ func TestProvider_GenerateStream_SSEReadError_ReturnsError(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "sse read") {
 		t.Fatalf("expected propagated SSE read error, got %v", err)
+	}
+}
+
+func TestProvider_GenerateStream_DoneWithoutFinishReason_ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		f := w.(http.Flusher)
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", marshalJSON(t, completionChunk{
+			Model: "m", Choices: []completionChunkChoice{{Text: "partial"}},
+		}))
+		_, _ = fmt.Fprintf(w, "data: [DONE]\n\n")
+		f.Flush()
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL))
+	var sawText, sawDone bool
+	err := p.GenerateStream(context.Background(), provider.GenerateRequest{Model: "m", Prompt: "x"}, func(r provider.GenerateResponse) error {
+		if r.Response == "partial" {
+			sawText = true
+		}
+		if r.Done {
+			sawDone = true
+		}
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "ended before final chunk") {
+		t.Fatalf("expected incomplete stream error, got %v", err)
+	}
+	if !sawText {
+		t.Fatal("expected text chunk before incomplete stream error")
+	}
+	if sawDone {
+		t.Fatal("must not synthesize a successful Done chunk for [DONE] without finish_reason")
 	}
 }
 

--- a/provider/openaicompat/openaicompat_test.go
+++ b/provider/openaicompat/openaicompat_test.go
@@ -787,7 +787,7 @@ func TestProvider_Embed_Singleflight_Dedups(t *testing.T) {
 func TestSSEReader_ParsesDataLines(t *testing.T) {
 	body := io.NopCloser(strings.NewReader("data: {\"a\":1}\n\ndata: {\"b\":2}\n\ndata: [DONE]\n\n"))
 	r := newSSEReader(body)
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 
 	p1, err := r.Next()
 	if err != nil {
@@ -808,7 +808,7 @@ func TestSSEReader_ParsesDataLines(t *testing.T) {
 func TestSSEReader_SkipsCommentsAndNonDataLines(t *testing.T) {
 	body := io.NopCloser(strings.NewReader(": keepalive\nevent: ping\nid: 1\ndata: {\"x\":1}\n\ndata: [DONE]\n\n"))
 	r := newSSEReader(body)
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 
 	p, err := r.Next()
 	if err != nil {
@@ -824,7 +824,7 @@ func TestSSEReader_EOFWithoutDone_IsStreamDone(t *testing.T) {
 	// must treat that as normal termination rather than an error.
 	body := io.NopCloser(strings.NewReader("data: {\"x\":1}\n\n"))
 	r := newSSEReader(body)
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 
 	if _, err := r.Next(); err != nil {
 		t.Fatalf("first Next: %v", err)

--- a/provider/openaicompat/openaicompat_test.go
+++ b/provider/openaicompat/openaicompat_test.go
@@ -630,6 +630,60 @@ func TestProvider_ChatStream_FragmentedToolCall_AssembledOnDone(t *testing.T) {
 	}
 }
 
+// TestProvider_ChatStream_FragmentedToolCall_LockedEncodingMode verifies
+// that argument-fragment decoding stays in the mode locked by the FIRST
+// non-empty fragment. A server that sent the first fragment as a
+// JSON-string envelope cannot mid-stream switch to raw partial JSON —
+// the accumulator would otherwise produce an unparseable concatenation.
+// Test: server emits encoded first fragment, then a raw-looking second
+// fragment; the accumulator unwraps both consistently and assembles
+// valid final JSON.
+func TestProvider_ChatStream_FragmentedToolCall_LockedEncodingMode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeSSE(t, w, []chatChunk{
+			{Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{
+				ToolCalls: []chatToolCall{{
+					Index: intPtr(0), ID: "call_1", Type: "function",
+					Function: chatToolCallFunction{Name: "search"},
+				}},
+			}}}},
+			// First non-empty fragment is JSON-string-encoded — locks mode.
+			{Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{
+				ToolCalls: []chatToolCall{{Index: intPtr(0),
+					Function: chatToolCallFunction{Arguments: rawJSONString(t, `{"q":`)}}},
+			}}}},
+			// Second fragment is also JSON-string-encoded (the locked mode);
+			// decoding under the locked mode yields the inner string.
+			{Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{
+				ToolCalls: []chatToolCall{{Index: intPtr(0),
+					Function: chatToolCallFunction{Arguments: rawJSONString(t, `"go"}`)}}},
+			}}}},
+			{Model: "m", Choices: []chatChunkChoice{{
+				Delta: chatMessage{}, FinishReason: stringPtr("tool_calls"),
+			}}},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL))
+	var final provider.ChatResponse
+	err := p.ChatStream(context.Background(), provider.ChatRequest{Model: "m"}, func(r provider.ChatResponse) error {
+		if r.Done {
+			final = r
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ChatStream: %v", err)
+	}
+	if len(final.ToolCalls) != 1 {
+		t.Fatalf("ToolCalls len = %d, want 1", len(final.ToolCalls))
+	}
+	if got := string(final.ToolCalls[0].Function.Arguments); got != `{"q":"go"}` {
+		t.Errorf("locked-mode assembled arguments = %s, want %s", got, `{"q":"go"}`)
+	}
+}
+
 // TestProvider_ChatStream_FragmentedToolCall_NilIndexUsesLastKnown verifies
 // that arg-only deltas with no Index field (a real shape vLLM emits after
 // the opening tool delta) attach to the most-recently-active call rather

--- a/provider/openaicompat/openaicompat_test.go
+++ b/provider/openaicompat/openaicompat_test.go
@@ -414,6 +414,45 @@ func TestProvider_Chat_RequestBody_ToolCallArgumentsEncodedAsString(t *testing.T
 	}
 }
 
+// TestNormalizeToolCallArguments_PreservesScalarLiterals locks the rule
+// that scalar JSON literals wrapped in OpenAI's JSON-string envelope are
+// preserved as strings rather than narrowed to bare scalars. Tool
+// implementations declare argument shapes via JSON Schema — a string-typed
+// parameter accidentally arriving as a JSON number would break runtime
+// type checks downstream.
+func TestNormalizeToolCallArguments_PreservesScalarLiterals(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// Object / array unwrap to canonical tool-call shape.
+		{"json object string -> raw object", `"{\"q\":\"go\"}"`, `{"q":"go"}`},
+		{"json array string -> raw array", `"[1,2,3]"`, `[1,2,3]`},
+		// Scalar literals stay wrapped — the inner value WAS a string and
+		// downstream consumers must keep it that way.
+		{"numeric literal stays wrapped", `"42"`, `"42"`},
+		{"bool literal stays wrapped", `"true"`, `"true"`},
+		{"null literal stays wrapped", `"null"`, `"null"`},
+		{"non-json string stays wrapped", `"hello"`, `"hello"`},
+		// Empty / nil / null collapse.
+		{"empty input -> nil", ``, ``},
+		{"null literal -> nil", `null`, ``},
+		{"empty string envelope -> nil", `""`, ``},
+		// Raw inputs (no envelope) pass through.
+		{"raw object passes through", `{"q":"go"}`, `{"q":"go"}`},
+		{"raw array passes through", `[1,2]`, `[1,2]`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeToolCallArguments(json.RawMessage(tt.in))
+			if string(got) != tt.want {
+				t.Errorf("normalize(%q) = %q, want %q", tt.in, string(got), tt.want)
+			}
+		})
+	}
+}
+
 func TestProvider_Chat_ToolCallArgumentsStringDecoded(t *testing.T) {
 	srv := newMockServer(t, mockServerOpts{
 		chatResponse: chatResponse{

--- a/provider/openaicompat/openaicompat_test.go
+++ b/provider/openaicompat/openaicompat_test.go
@@ -372,6 +372,81 @@ func TestProvider_Chat_RequestBodyShape(t *testing.T) {
 	}
 }
 
+func TestProvider_Chat_RequestBody_ToolCallArgumentsEncodedAsString(t *testing.T) {
+	var captured chatRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(chatResponse{
+			Choices: []chatChoice{{Message: chatMessage{Content: "ok"}}},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL))
+	_, err := p.Chat(context.Background(), provider.ChatRequest{
+		Model: "m",
+		Messages: []provider.ChatMessage{{
+			Role: "assistant",
+			ToolCalls: []provider.ToolCall{{
+				ID:   "call_1",
+				Type: "function",
+				Function: provider.ToolCallFunction{
+					Name:      "search",
+					Arguments: json.RawMessage(`{"q":"go"}`),
+				},
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if len(captured.Messages) != 1 || len(captured.Messages[0].ToolCalls) != 1 {
+		t.Fatalf("captured tool calls = %+v", captured.Messages)
+	}
+	var args string
+	if err := json.Unmarshal(captured.Messages[0].ToolCalls[0].Function.Arguments, &args); err != nil {
+		t.Fatalf("arguments should be an OpenAI-style JSON string, got %s: %v", captured.Messages[0].ToolCalls[0].Function.Arguments, err)
+	}
+	if args != `{"q":"go"}` {
+		t.Errorf("arguments string = %q, want raw object JSON", args)
+	}
+}
+
+func TestProvider_Chat_ToolCallArgumentsStringDecoded(t *testing.T) {
+	srv := newMockServer(t, mockServerOpts{
+		chatResponse: chatResponse{
+			Choices: []chatChoice{{Message: chatMessage{
+				ToolCalls: []chatToolCall{{
+					ID:   "call_1",
+					Type: "function",
+					Function: chatToolCallFunction{
+						Name:      "search",
+						Arguments: rawJSONString(t, `{"q":"go"}`),
+					},
+				}},
+			}}},
+		},
+	})
+	defer srv.close()
+
+	p := NewProvider(NewClient(srv.url))
+	resp, err := p.Chat(context.Background(), provider.ChatRequest{Model: "m"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if len(resp.ToolCalls) != 1 {
+		t.Fatalf("ToolCalls len = %d, want 1", len(resp.ToolCalls))
+	}
+	if got := string(resp.ToolCalls[0].Function.Arguments); got != `{"q":"go"}` {
+		t.Errorf("Arguments = %s, want decoded JSON object", got)
+	}
+	if resp.ToolCalls[0].Function.Index != 0 {
+		t.Errorf("Index = %d, want 0", resp.ToolCalls[0].Function.Index)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // ChatStream
 // ---------------------------------------------------------------------------
@@ -451,6 +526,221 @@ func TestProvider_ChatStream_ToolCallDelta_Emitted(t *testing.T) {
 	}
 	if !sawToolCall {
 		t.Error("tool-call delta was not surfaced as a standalone chunk")
+	}
+}
+
+func TestProvider_ChatStream_FragmentedToolCall_AssembledOnDone(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeSSE(t, w, []chatChunk{
+			{Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{
+				ToolCalls: []chatToolCall{{
+					Index: intPtr(0),
+					ID:    "call_1",
+					Type:  "function",
+					Function: chatToolCallFunction{
+						Name: "search",
+					},
+				}},
+			}}}},
+			{Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{
+				ToolCalls: []chatToolCall{{
+					Index: intPtr(0),
+					Function: chatToolCallFunction{
+						Arguments: rawJSONString(t, `{"q"`),
+					},
+				}},
+			}}}},
+			{Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{
+				ToolCalls: []chatToolCall{{
+					Index: intPtr(0),
+					Function: chatToolCallFunction{
+						Arguments: rawJSONString(t, `:"go"}`),
+					},
+				}},
+			}}}},
+			{Model: "m", Choices: []chatChunkChoice{{
+				Delta: chatMessage{}, FinishReason: stringPtr("tool_calls"),
+			}}},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL))
+	var final provider.ChatResponse
+	err := p.ChatStream(context.Background(), provider.ChatRequest{Model: "m"}, func(r provider.ChatResponse) error {
+		if r.Done {
+			final = r
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ChatStream: %v", err)
+	}
+	if !final.Done {
+		t.Fatal("missing final Done chunk")
+	}
+	if len(final.ToolCalls) != 1 {
+		t.Fatalf("final ToolCalls len = %d, want 1: %+v", len(final.ToolCalls), final.ToolCalls)
+	}
+	call := final.ToolCalls[0]
+	if call.ID != "call_1" || call.Function.Name != "search" || call.Function.Index != 0 {
+		t.Errorf("assembled call metadata = %+v", call)
+	}
+	if got := string(call.Function.Arguments); got != `{"q":"go"}` {
+		t.Errorf("assembled arguments = %s, want decoded JSON object", got)
+	}
+}
+
+// TestProvider_ChatStream_FragmentedToolCall_NilIndexUsesLastKnown verifies
+// that arg-only deltas with no Index field (a real shape vLLM emits after
+// the opening tool delta) attach to the most-recently-active call rather
+// than the per-chunk loop position. Without the lastIndex fallback the
+// fragments would silently land on slot 0 even after the active call moved
+// to slot 1.
+func TestProvider_ChatStream_FragmentedToolCall_NilIndexUsesLastKnown(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeSSE(t, w, []chatChunk{
+			// Opening delta names the call at index 0.
+			{Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{
+				ToolCalls: []chatToolCall{{
+					Index: intPtr(0), ID: "call_1", Type: "function",
+					Function: chatToolCallFunction{Name: "search"},
+				}},
+			}}}},
+			// Subsequent arg-only deltas omit Index — must still attach to call_1.
+			{Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{
+				ToolCalls: []chatToolCall{{
+					Function: chatToolCallFunction{Arguments: rawJSONString(t, `{"q"`)},
+				}},
+			}}}},
+			{Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{
+				ToolCalls: []chatToolCall{{
+					Function: chatToolCallFunction{Arguments: rawJSONString(t, `:"go"}`)},
+				}},
+			}}}},
+			{Model: "m", Choices: []chatChunkChoice{{
+				Delta: chatMessage{}, FinishReason: stringPtr("tool_calls"),
+			}}},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL))
+	var final provider.ChatResponse
+	err := p.ChatStream(context.Background(), provider.ChatRequest{Model: "m"}, func(r provider.ChatResponse) error {
+		if r.Done {
+			final = r
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ChatStream: %v", err)
+	}
+	if len(final.ToolCalls) != 1 {
+		t.Fatalf("ToolCalls len = %d, want 1 (nil-Index fragments must attach to last-known call, not spawn new slots): %+v", len(final.ToolCalls), final.ToolCalls)
+	}
+	if got := string(final.ToolCalls[0].Function.Arguments); got != `{"q":"go"}` {
+		t.Errorf("assembled arguments = %s, want fragments concatenated under last-known index", got)
+	}
+}
+
+// TestProvider_ChatStream_MultiToolFragmented_AssembledIndependently
+// covers two concurrent tool_calls with interleaved arg fragments. The
+// accumulator must keep slot 0 and slot 1 fragments separate even when
+// they arrive in mixed order.
+func TestProvider_ChatStream_MultiToolFragmented_AssembledIndependently(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeSSE(t, w, []chatChunk{
+			// Both tools opened in the same delta.
+			{Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{
+				ToolCalls: []chatToolCall{
+					{Index: intPtr(0), ID: "call_a", Type: "function", Function: chatToolCallFunction{Name: "search"}},
+					{Index: intPtr(1), ID: "call_b", Type: "function", Function: chatToolCallFunction{Name: "fetch"}},
+				},
+			}}}},
+			// Interleaved arg fragments.
+			{Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{
+				ToolCalls: []chatToolCall{{Index: intPtr(1), Function: chatToolCallFunction{Arguments: rawJSONString(t, `{"url":"`)}}},
+			}}}},
+			{Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{
+				ToolCalls: []chatToolCall{{Index: intPtr(0), Function: chatToolCallFunction{Arguments: rawJSONString(t, `{"q":"go"}`)}}},
+			}}}},
+			{Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{
+				ToolCalls: []chatToolCall{{Index: intPtr(1), Function: chatToolCallFunction{Arguments: rawJSONString(t, `x.com"}`)}}},
+			}}}},
+			{Model: "m", Choices: []chatChunkChoice{{
+				Delta: chatMessage{}, FinishReason: stringPtr("tool_calls"),
+			}}},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL))
+	var final provider.ChatResponse
+	err := p.ChatStream(context.Background(), provider.ChatRequest{Model: "m"}, func(r provider.ChatResponse) error {
+		if r.Done {
+			final = r
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ChatStream: %v", err)
+	}
+	if len(final.ToolCalls) != 2 {
+		t.Fatalf("ToolCalls len = %d, want 2: %+v", len(final.ToolCalls), final.ToolCalls)
+	}
+	// Snapshot order follows first-appearance, so call_a (index 0) comes first.
+	if final.ToolCalls[0].ID != "call_a" || final.ToolCalls[1].ID != "call_b" {
+		t.Errorf("ToolCalls order = %q,%q; want call_a,call_b (first-appearance ordering)",
+			final.ToolCalls[0].ID, final.ToolCalls[1].ID)
+	}
+	if got := string(final.ToolCalls[0].Function.Arguments); got != `{"q":"go"}` {
+		t.Errorf("call_a arguments = %s, want isolated to slot 0", got)
+	}
+	if got := string(final.ToolCalls[1].Function.Arguments); got != `{"url":"x.com"}` {
+		t.Errorf("call_b arguments = %s, want fragments correctly concatenated under slot 1", got)
+	}
+}
+
+// TestProvider_ChatStream_FragmentedToolCall_OrderByFirstAppearance
+// confirms snapshot order tracks first-appearance even when indexes arrive
+// out of natural order (e.g. index 1 before index 0). This is the contract
+// downstream consumers depend on for stable iteration.
+func TestProvider_ChatStream_FragmentedToolCall_OrderByFirstAppearance(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeSSE(t, w, []chatChunk{
+			{Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{
+				ToolCalls: []chatToolCall{{Index: intPtr(1), ID: "second-but-first-seen", Type: "function",
+					Function: chatToolCallFunction{Name: "b", Arguments: rawJSONString(t, `{}`)}}},
+			}}}},
+			{Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{
+				ToolCalls: []chatToolCall{{Index: intPtr(0), ID: "first-but-second-seen", Type: "function",
+					Function: chatToolCallFunction{Name: "a", Arguments: rawJSONString(t, `{}`)}}},
+			}}}},
+			{Model: "m", Choices: []chatChunkChoice{{
+				Delta: chatMessage{}, FinishReason: stringPtr("tool_calls"),
+			}}},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL))
+	var final provider.ChatResponse
+	err := p.ChatStream(context.Background(), provider.ChatRequest{Model: "m"}, func(r provider.ChatResponse) error {
+		if r.Done {
+			final = r
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ChatStream: %v", err)
+	}
+	if len(final.ToolCalls) != 2 {
+		t.Fatalf("ToolCalls len = %d, want 2", len(final.ToolCalls))
+	}
+	if final.ToolCalls[0].ID != "second-but-first-seen" {
+		t.Errorf("first ToolCall.ID = %q, want %q (snapshot order should track first-appearance, not numeric index)",
+			final.ToolCalls[0].ID, "second-but-first-seen")
 	}
 }
 
@@ -548,6 +838,24 @@ func TestProvider_ChatStream_MalformedChunk_Skipped(t *testing.T) {
 	}
 	if saw != "good" {
 		t.Errorf("Content = %q, want %q (malformed chunk should be skipped, good one preserved)", saw, "good")
+	}
+}
+
+func TestProvider_ChatStream_SSEReadError_ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", strings.Repeat("x", 1024*1024+1))
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL))
+	err := p.ChatStream(context.Background(), provider.ChatRequest{Model: "m"}, func(provider.ChatResponse) error {
+		t.Fatal("callback should not be invoked for an unreadable SSE frame")
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "sse read") {
+		t.Fatalf("expected propagated SSE read error, got %v", err)
 	}
 }
 
@@ -651,6 +959,24 @@ func TestProvider_GenerateStream_DeliversChunks(t *testing.T) {
 	}
 	if !lastDone {
 		t.Error("last chunk should be Done")
+	}
+}
+
+func TestProvider_GenerateStream_SSEReadError_ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", strings.Repeat("x", 1024*1024+1))
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL))
+	err := p.GenerateStream(context.Background(), provider.GenerateRequest{Model: "m", Prompt: "x"}, func(provider.GenerateResponse) error {
+		t.Fatal("callback should not be invoked for an unreadable SSE frame")
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "sse read") {
+		t.Fatalf("expected propagated SSE read error, got %v", err)
 	}
 }
 
@@ -780,6 +1106,64 @@ func TestProvider_Embed_Singleflight_Dedups(t *testing.T) {
 	}
 }
 
+func TestProvider_Embed_SingleflightKey_NULInputsDoNotCollide(t *testing.T) {
+	var calls int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&calls, 1)
+		var req embedRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		time.Sleep(40 * time.Millisecond)
+		data := make([]embeddingDoc, len(req.Input))
+		for i := range req.Input {
+			data[i] = embeddingDoc{Index: i, Embedding: []float64{float64(len(req.Input)), float64(i)}}
+		}
+		_ = json.NewEncoder(w).Encode(embedResponse{Data: data})
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL))
+	reqs := []provider.EmbedRequest{
+		{Model: "m", Input: []string{"a\x00b"}},
+		{Model: "m", Input: []string{"a", "b"}},
+	}
+	type embedResult struct {
+		count int
+		err   error
+	}
+	results := make([]embedResult, len(reqs))
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(len(reqs))
+	for i := range reqs {
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			resp, err := p.Embed(context.Background(), reqs[i])
+			results[i].err = err
+			if resp != nil {
+				results[i].count = len(resp.Embeddings)
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, res := range results {
+		if res.err != nil {
+			t.Fatalf("Embed[%d]: %v", i, res.err)
+		}
+		if res.count != len(reqs[i].Input) {
+			t.Fatalf("Embed[%d] returned %d embeddings for %d inputs", i, res.count, len(reqs[i].Input))
+		}
+	}
+	if got := atomic.LoadInt64(&calls); got != 2 {
+		t.Fatalf("upstream calls = %d, want 2 distinct calls for NUL-containing inputs", got)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // SSE reader unit tests
 // ---------------------------------------------------------------------------
@@ -901,3 +1285,14 @@ func marshalJSON(t *testing.T, v any) string {
 }
 
 func stringPtr(s string) *string { return &s }
+
+func intPtr(i int) *int { return &i }
+
+func rawJSONString(t *testing.T, s string) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal string: %v", err)
+	}
+	return json.RawMessage(b)
+}

--- a/provider/openaicompat/openaicompat_test.go
+++ b/provider/openaicompat/openaicompat_test.go
@@ -536,7 +536,13 @@ func TestProvider_ChatStream_DeliversChunksThenDone(t *testing.T) {
 	}
 }
 
-func TestProvider_ChatStream_ToolCallDelta_Emitted(t *testing.T) {
+// TestProvider_ChatStream_SingleToolCall_AssembledOnDone verifies the
+// simplest tool-call streaming shape: one delta carrying a complete call,
+// followed by a finish delta. The call must appear on the Done chunk
+// (not on the opening delta — the accumulator deliberately suppresses
+// per-delta tool-call emission so consumers see one authoritative
+// payload, matching OpenAI streaming semantics).
+func TestProvider_ChatStream_SingleToolCall_AssembledOnDone(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		writeSSE(t, w, []chatChunk{
 			{Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{
@@ -553,18 +559,27 @@ func TestProvider_ChatStream_ToolCallDelta_Emitted(t *testing.T) {
 	defer srv.Close()
 
 	p := NewProvider(NewClient(srv.URL))
-	var sawToolCall bool
+	var (
+		preDoneSeenCall bool
+		doneCall        provider.ToolCall
+	)
 	err := p.ChatStream(context.Background(), provider.ChatRequest{Model: "m"}, func(r provider.ChatResponse) error {
-		if len(r.ToolCalls) > 0 && r.ToolCalls[0].Function.Name == "search" {
-			sawToolCall = true
+		if r.Done && len(r.ToolCalls) > 0 {
+			doneCall = r.ToolCalls[0]
+		}
+		if !r.Done && len(r.ToolCalls) > 0 {
+			preDoneSeenCall = true
 		}
 		return nil
 	})
 	if err != nil {
 		t.Fatalf("ChatStream: %v", err)
 	}
-	if !sawToolCall {
-		t.Error("tool-call delta was not surfaced as a standalone chunk")
+	if preDoneSeenCall {
+		t.Error("tool calls were emitted before Done; the contract is assemble-on-Done so consumers see one authoritative payload")
+	}
+	if doneCall.Function.Name != "search" {
+		t.Errorf("Done chunk missing assembled tool call, got %+v", doneCall)
 	}
 }
 

--- a/provider/openaicompat/openaicompat_test.go
+++ b/provider/openaicompat/openaicompat_test.go
@@ -1,0 +1,903 @@
+package openaicompat
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// ---------------------------------------------------------------------------
+// Construction, Name, Capabilities, options
+// ---------------------------------------------------------------------------
+
+func TestProvider_Name_Default(t *testing.T) {
+	p := NewProvider(NewClient("http://localhost:8080"))
+	if got := p.Name(); got != "openai-compat" {
+		t.Errorf("Name() = %q, want %q", got, "openai-compat")
+	}
+}
+
+func TestProvider_WithProviderName(t *testing.T) {
+	t.Run("override applied", func(t *testing.T) {
+		p := NewProvider(NewClient("http://x"), WithProviderName("vllm-workstation"))
+		if got := p.Name(); got != "vllm-workstation" {
+			t.Errorf("Name() = %q, want %q", got, "vllm-workstation")
+		}
+	})
+	t.Run("empty name panics", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatal("expected panic on empty name, got nil")
+			}
+			msg, ok := r.(string)
+			if !ok {
+				t.Fatalf("expected string panic value, got %T", r)
+			}
+			if !strings.Contains(msg, "WithProviderName") || !strings.Contains(msg, "empty") {
+				t.Errorf("panic message should explain misuse, got: %q", msg)
+			}
+		}()
+		_ = WithProviderName("")
+	})
+}
+
+func TestProvider_Capabilities_DefaultExcludesInsert(t *testing.T) {
+	// CapInsert is intentionally NOT advertised by default because
+	// OpenAI-compat servers don't expose a probe equivalent to Ollama's
+	// template inspection. Users must opt in via WithCapabilities when
+	// the target server is known to support native FIM.
+	p := NewProvider(NewClient("http://x"))
+	caps := p.Capabilities()
+	for _, want := range []provider.Capability{
+		provider.CapChat, provider.CapGenerate, provider.CapStream,
+		provider.CapEmbed, provider.CapToolCall,
+	} {
+		if !caps.Has(want) {
+			t.Errorf("default Capabilities missing %v, got %v", want, caps)
+		}
+	}
+	if caps.Has(provider.CapInsert) {
+		t.Errorf("default Capabilities should NOT include CapInsert, got %v", caps)
+	}
+}
+
+func TestProvider_WithCapabilities_Override(t *testing.T) {
+	p := NewProvider(NewClient("http://x"), WithCapabilities(provider.CapChat|provider.CapInsert))
+	if !p.Capabilities().Has(provider.CapInsert) {
+		t.Error("WithCapabilities did not propagate CapInsert")
+	}
+	if p.Capabilities().Has(provider.CapEmbed) {
+		t.Error("WithCapabilities should replace, not merge — default CapEmbed leaked")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Client: baseURL hygiene + auth header + error envelope
+// ---------------------------------------------------------------------------
+
+func TestClient_BaseURL_TrimsTrailingSlash(t *testing.T) {
+	srv := newMockServer(t, mockServerOpts{})
+	defer srv.close()
+
+	// With trailing slash on baseURL the request URL must NOT be
+	// "//v1/models" (double slash); strip-once at construction time.
+	c := NewClient(srv.url + "/")
+	p := NewProvider(c)
+	if err := p.Health(context.Background()); err != nil {
+		t.Fatalf("Health failed with trailing-slash baseURL: %v", err)
+	}
+	if got, want := srv.lastPath.Load().(string), "/v1/models"; got != want {
+		t.Errorf("request path = %q, want %q", got, want)
+	}
+}
+
+func TestClient_BearerAuth_HeaderSet(t *testing.T) {
+	const token = "sk-test-token"
+	srv := newMockServer(t, mockServerOpts{})
+	defer srv.close()
+
+	c := NewClient(srv.url, WithAPIKey(token))
+	p := NewProvider(c)
+	if err := p.Health(context.Background()); err != nil {
+		t.Fatalf("Health: %v", err)
+	}
+	if got := srv.lastAuth.Load().(string); got != "Bearer "+token {
+		t.Errorf("Authorization header = %q, want %q", got, "Bearer "+token)
+	}
+}
+
+func TestClient_BearerAuth_OmittedWhenEmpty(t *testing.T) {
+	// Local servers without auth (vanilla llama.cpp --api) shouldn't see
+	// a Bearer header at all; sending one could trip overly-strict
+	// reverse proxies.
+	srv := newMockServer(t, mockServerOpts{})
+	defer srv.close()
+
+	c := NewClient(srv.url) // no APIKey
+	p := NewProvider(c)
+	if err := p.Health(context.Background()); err != nil {
+		t.Fatalf("Health: %v", err)
+	}
+	if got := srv.lastAuth.Load().(string); got != "" {
+		t.Errorf("Authorization header should be absent, got %q", got)
+	}
+}
+
+func TestClient_ErrorEnvelope_Unwrapped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(errorEnvelope{
+			Error: errorPayload{Message: "model not found", Type: "invalid_request_error"},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	p := NewProvider(c)
+	_, err := p.Chat(context.Background(), provider.ChatRequest{Model: "missing"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "model not found") {
+		t.Errorf("error should surface the OpenAI message, got: %v", err)
+	}
+}
+
+func TestClient_NonJSONError_FallsBackToBody(t *testing.T) {
+	// HTML error pages (proxy / load balancer) must still produce a
+	// useful error message rather than swallowing the failure.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("<html>502 Bad Gateway</html>"))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	p := NewProvider(c)
+	_, err := p.Chat(context.Background(), provider.ChatRequest{Model: "x"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "502") {
+		t.Errorf("error should mention status, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Health + Models
+// ---------------------------------------------------------------------------
+
+func TestProvider_Health_Success(t *testing.T) {
+	srv := newMockServer(t, mockServerOpts{})
+	defer srv.close()
+
+	p := NewProvider(NewClient(srv.url))
+	if err := p.Health(context.Background()); err != nil {
+		t.Errorf("Health: %v", err)
+	}
+}
+
+func TestProvider_Models_ListsServerIDs(t *testing.T) {
+	srv := newMockServer(t, mockServerOpts{
+		models: []modelEntry{
+			{ID: "qwen3:8b"},
+			{ID: "gpt-oss-7b"},
+		},
+	})
+	defer srv.close()
+
+	p := NewProvider(NewClient(srv.url))
+	models, err := p.Models(context.Background())
+	if err != nil {
+		t.Fatalf("Models: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("got %d models, want 2", len(models))
+	}
+	if models[0].Name != "qwen3:8b" || models[1].Name != "gpt-oss-7b" {
+		t.Errorf("Models = %+v, want IDs qwen3:8b, gpt-oss-7b", models)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Chat (non-streaming)
+// ---------------------------------------------------------------------------
+
+func TestProvider_Chat_Success(t *testing.T) {
+	srv := newMockServer(t, mockServerOpts{
+		chatResponse: chatResponse{
+			ID:    "chatcmpl-1",
+			Model: "qwen3:8b",
+			Choices: []chatChoice{{
+				Index: 0,
+				Message: chatMessage{
+					Role:    "assistant",
+					Content: "hello world",
+				},
+				FinishReason: "stop",
+			}},
+			Usage: usage{PromptTokens: 4, CompletionTokens: 2, TotalTokens: 6},
+		},
+	})
+	defer srv.close()
+
+	p := NewProvider(NewClient(srv.url), WithProviderName("vllm-test"))
+	resp, err := p.Chat(context.Background(), provider.ChatRequest{
+		Model:    "qwen3:8b",
+		Messages: []provider.ChatMessage{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Content != "hello world" {
+		t.Errorf("Content = %q, want %q", resp.Content, "hello world")
+	}
+	if resp.Provider != "vllm-test" {
+		t.Errorf("Provider = %q, want %q (instance name must be stamped on response)", resp.Provider, "vllm-test")
+	}
+	if resp.Model != "qwen3:8b" {
+		t.Errorf("Model = %q, want qwen3:8b", resp.Model)
+	}
+	if resp.Usage.TotalTokens != 6 {
+		t.Errorf("Usage.TotalTokens = %d, want 6", resp.Usage.TotalTokens)
+	}
+	if !resp.Done {
+		t.Error("Done should be true on non-streaming response")
+	}
+}
+
+func TestProvider_Chat_ExtractsInlineThinking(t *testing.T) {
+	srv := newMockServer(t, mockServerOpts{
+		chatResponse: chatResponse{
+			Model: "deepseek-r1",
+			Choices: []chatChoice{{
+				Message: chatMessage{Role: "assistant", Content: "<think>let me think</think>final answer"},
+			}},
+		},
+	})
+	defer srv.close()
+
+	p := NewProvider(NewClient(srv.url))
+	resp, err := p.Chat(context.Background(), provider.ChatRequest{Model: "deepseek-r1"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Content != "final answer" {
+		t.Errorf("Content = %q, want %q (think tags must be stripped)", resp.Content, "final answer")
+	}
+	if !strings.Contains(resp.Thinking, "let me think") {
+		t.Errorf("Thinking = %q, want it to contain extracted reasoning", resp.Thinking)
+	}
+}
+
+func TestProvider_Chat_ThinkNone_KeepsTagsInline(t *testing.T) {
+	// When thinking is disabled at construction, raw content (including
+	// tags) must pass through unchanged — the caller has opted out of
+	// the parse pass and expects byte-for-byte fidelity.
+	srv := newMockServer(t, mockServerOpts{
+		chatResponse: chatResponse{
+			Choices: []chatChoice{{Message: chatMessage{Content: "<think>x</think>y"}}},
+		},
+	})
+	defer srv.close()
+
+	p := NewProvider(NewClient(srv.url), WithThinkMode(provider.ThinkNone))
+	resp, err := p.Chat(context.Background(), provider.ChatRequest{Model: "m"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Content != "<think>x</think>y" {
+		t.Errorf("Content = %q, want raw bytes preserved with ThinkNone", resp.Content)
+	}
+	if resp.Thinking != "" {
+		t.Errorf("Thinking = %q, want empty with ThinkNone", resp.Thinking)
+	}
+}
+
+func TestProvider_Chat_NoChoices_ReturnsError(t *testing.T) {
+	srv := newMockServer(t, mockServerOpts{
+		chatResponse: chatResponse{ID: "empty", Choices: nil},
+	})
+	defer srv.close()
+
+	p := NewProvider(NewClient(srv.url))
+	_, err := p.Chat(context.Background(), provider.ChatRequest{Model: "m"})
+	if err == nil || !strings.Contains(err.Error(), "no choices") {
+		t.Errorf("expected 'no choices' error, got: %v", err)
+	}
+}
+
+func TestProvider_Chat_RequestBodyShape(t *testing.T) {
+	// Confirm tool definitions, ModelOptions, and messages are translated
+	// to the OpenAI wire shape — this is the contract that lets stock
+	// OpenAI SDKs respond.
+	var captured chatRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(chatResponse{
+			Choices: []chatChoice{{Message: chatMessage{Content: "ok"}}},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL))
+	_, err := p.Chat(context.Background(), provider.ChatRequest{
+		Model:    "m",
+		Messages: []provider.ChatMessage{{Role: "user", Content: "hi"}},
+		Options: provider.ModelOptions{
+			Temperature: provider.Ptr(0.7),
+			NumPredict:  100,
+			Stop:        []string{"\n\n"},
+		},
+		Tools: []provider.Tool{{
+			Type: "function",
+			Function: provider.ToolFunction{
+				Name: "search", Description: "search the web",
+				Parameters: json.RawMessage(`{"type":"object"}`),
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if captured.Model != "m" || len(captured.Messages) != 1 {
+		t.Errorf("model/messages not propagated: %+v", captured)
+	}
+	if captured.Temperature == nil || *captured.Temperature != 0.7 {
+		t.Errorf("Temperature not propagated: %+v", captured.Temperature)
+	}
+	if captured.MaxTokens != 100 {
+		t.Errorf("MaxTokens = %d, want 100 (NumPredict -> max_tokens)", captured.MaxTokens)
+	}
+	if len(captured.Stop) != 1 || captured.Stop[0] != "\n\n" {
+		t.Errorf("Stop = %v, want [\\n\\n]", captured.Stop)
+	}
+	if len(captured.Tools) != 1 || captured.Tools[0].Function.Name != "search" {
+		t.Errorf("Tools not propagated: %+v", captured.Tools)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ChatStream
+// ---------------------------------------------------------------------------
+
+func TestProvider_ChatStream_DeliversChunksThenDone(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeSSE(t, w, []chatChunk{
+			{Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{Content: "hello"}}}},
+			{Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{Content: " world"}}}},
+			{Model: "m", Choices: []chatChunkChoice{{
+				Delta: chatMessage{}, FinishReason: stringPtr("stop"),
+			}}, Usage: &usage{PromptTokens: 1, CompletionTokens: 2, TotalTokens: 3}},
+		})
+	}))
+	defer srv.Close()
+
+	// ThinkNone disables the think-parser's lookahead buffering so each
+	// content delta surfaces as a discrete chunk — the chunk-cadence
+	// contract is what this test asserts. The think-extraction path has
+	// its own coverage in TestProvider_Chat_ExtractsInlineThinking.
+	p := NewProvider(NewClient(srv.URL),
+		WithProviderName("inst-1"),
+		WithThinkMode(provider.ThinkNone),
+	)
+	var got []provider.ChatResponse
+	err := p.ChatStream(context.Background(), provider.ChatRequest{Model: "m"}, func(r provider.ChatResponse) error {
+		got = append(got, r)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ChatStream: %v", err)
+	}
+	// 2 content chunks (one per delta) + 1 done.
+	if len(got) < 3 {
+		t.Fatalf("got %d chunks, want >= 3: %+v", len(got), got)
+	}
+	last := got[len(got)-1]
+	if !last.Done {
+		t.Errorf("last chunk should be Done, got %+v", last)
+	}
+	if last.Usage.TotalTokens != 3 {
+		t.Errorf("last.Usage = %+v, want TotalTokens=3", last.Usage)
+	}
+	for _, chunk := range got {
+		if chunk.Provider != "inst-1" {
+			t.Errorf("chunk.Provider = %q, want inst-1 (instance name stamp must hold across stream)", chunk.Provider)
+		}
+	}
+}
+
+func TestProvider_ChatStream_ToolCallDelta_Emitted(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeSSE(t, w, []chatChunk{
+			{Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{
+				ToolCalls: []chatToolCall{{
+					ID: "call_1", Type: "function",
+					Function: chatToolCallFunction{Name: "search", Arguments: json.RawMessage(`{"q":"go"}`)},
+				}},
+			}}}},
+			{Model: "m", Choices: []chatChunkChoice{{
+				Delta: chatMessage{}, FinishReason: stringPtr("tool_calls"),
+			}}},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL))
+	var sawToolCall bool
+	err := p.ChatStream(context.Background(), provider.ChatRequest{Model: "m"}, func(r provider.ChatResponse) error {
+		if len(r.ToolCalls) > 0 && r.ToolCalls[0].Function.Name == "search" {
+			sawToolCall = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ChatStream: %v", err)
+	}
+	if !sawToolCall {
+		t.Error("tool-call delta was not surfaced as a standalone chunk")
+	}
+}
+
+func TestProvider_ChatStream_CancelMidStream_EmitsPartial(t *testing.T) {
+	// Server sends one chunk, then blocks. We cancel from INSIDE the
+	// callback (right after observing chunk 1), eliminating the race
+	// between "did the client see chunk 1?" and "did cancel fire?".
+	// Without ThinkNone the partial-content delta would sit in the
+	// parser's lookahead buffer and never reach fn — so the callback
+	// would never fire and the cancel signal would never trigger.
+	hold := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Errorf("response writer does not flush")
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", marshalJSON(t, chatChunk{
+			Model:   "m",
+			Choices: []chatChunkChoice{{Delta: chatMessage{Content: "partial-content"}}},
+		}))
+		flusher.Flush()
+		select {
+		case <-hold:
+		case <-r.Context().Done():
+		}
+	}))
+	defer srv.Close()
+	defer close(hold)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p := NewProvider(NewClient(srv.URL), WithThinkMode(provider.ThinkNone))
+	var (
+		mu        sync.Mutex
+		responses []provider.ChatResponse
+	)
+	err := p.ChatStream(ctx, provider.ChatRequest{Model: "m"}, func(r provider.ChatResponse) error {
+		mu.Lock()
+		responses = append(responses, r)
+		// Cancel after observing the first content chunk. The subsequent
+		// reader.Next() will fail with the ctx error, triggering the
+		// partial-emission code path.
+		if r.Content == "partial-content" {
+			cancel()
+		}
+		mu.Unlock()
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "context") {
+		t.Errorf("expected ctx error, got %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(responses) < 2 {
+		t.Fatalf("expected >= 2 chunks (content + synthetic Done+Partial), got %d: %+v", len(responses), responses)
+	}
+	last := responses[len(responses)-1]
+	if !last.Done || !last.Partial {
+		t.Errorf("last chunk should be Done+Partial after mid-stream cancel, got %+v", last)
+	}
+}
+
+func TestProvider_ChatStream_MalformedChunk_Skipped(t *testing.T) {
+	// Proxies and middleboxes sometimes inject keepalive frames or
+	// oddly-shaped JSON; the stream should tolerate them rather than abort.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		f := w.(http.Flusher)
+		_, _ = fmt.Fprintf(w, ": keepalive comment\n\n")
+		_, _ = fmt.Fprintf(w, "data: {not json}\n\n")
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", marshalJSON(t, chatChunk{
+			Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{Content: "good"}}},
+		}))
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", marshalJSON(t, chatChunk{
+			Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{}, FinishReason: stringPtr("stop")}},
+		}))
+		_, _ = fmt.Fprintf(w, "data: [DONE]\n\n")
+		f.Flush()
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL))
+	var saw string
+	err := p.ChatStream(context.Background(), provider.ChatRequest{Model: "m"}, func(r provider.ChatResponse) error {
+		saw += r.Content
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ChatStream: %v", err)
+	}
+	if saw != "good" {
+		t.Errorf("Content = %q, want %q (malformed chunk should be skipped, good one preserved)", saw, "good")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Generate (non-streaming /v1/completions) + FIM via suffix
+// ---------------------------------------------------------------------------
+
+func TestProvider_Generate_FIM_SuffixPropagated(t *testing.T) {
+	var captured completionRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/completions" {
+			t.Errorf("expected /v1/completions, got %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(completionResponse{
+			Model: "m", Choices: []completionChoice{{Text: "middle"}},
+			Usage: usage{TotalTokens: 1},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL))
+	resp, err := p.Generate(context.Background(), provider.GenerateRequest{
+		Model:  "m",
+		Prompt: "before",
+		Suffix: "after",
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if captured.Suffix != "after" {
+		t.Errorf("Suffix not propagated: %q", captured.Suffix)
+	}
+	if captured.Prompt != "before" {
+		t.Errorf("Prompt = %q, want %q", captured.Prompt, "before")
+	}
+	if resp.Response != "middle" {
+		t.Errorf("Response = %q, want middle", resp.Response)
+	}
+}
+
+func TestProvider_Generate_System_PrependedToPrompt(t *testing.T) {
+	// /v1/completions has no system field. Provider prepends System to
+	// Prompt with a newline boundary so the directive isn't silently lost.
+	var captured completionRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&captured)
+		_ = json.NewEncoder(w).Encode(completionResponse{
+			Choices: []completionChoice{{Text: "ok"}},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL))
+	_, err := p.Generate(context.Background(), provider.GenerateRequest{
+		Model: "m", System: "You are concise.", Prompt: "explain bayes",
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if !strings.HasPrefix(captured.Prompt, "You are concise.\n") {
+		t.Errorf("System should be prepended to Prompt, got: %q", captured.Prompt)
+	}
+}
+
+func TestProvider_GenerateStream_DeliversChunks(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		f := w.(http.Flusher)
+		for _, txt := range []string{"a", "b", "c"} {
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", marshalJSON(t, completionChunk{
+				Model: "m", Choices: []completionChunkChoice{{Text: txt}},
+			}))
+			f.Flush()
+		}
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", marshalJSON(t, completionChunk{
+			Model: "m", Choices: []completionChunkChoice{{Text: "", FinishReason: stringPtr("stop")}},
+		}))
+		_, _ = fmt.Fprintf(w, "data: [DONE]\n\n")
+		f.Flush()
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL))
+	var combined string
+	var lastDone bool
+	err := p.GenerateStream(context.Background(), provider.GenerateRequest{Model: "m", Prompt: "x"},
+		func(r provider.GenerateResponse) error {
+			combined += r.Response
+			lastDone = r.Done
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("GenerateStream: %v", err)
+	}
+	if combined != "abc" {
+		t.Errorf("combined = %q, want abc", combined)
+	}
+	if !lastDone {
+		t.Error("last chunk should be Done")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Embed (singleflight dedup + index-based reorder + error paths)
+// ---------------------------------------------------------------------------
+
+func TestProvider_Embed_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(embedResponse{
+			Model: "embed-m",
+			Data: []embeddingDoc{
+				{Index: 0, Embedding: []float64{0.1, 0.2}},
+				{Index: 1, Embedding: []float64{0.3, 0.4}},
+			},
+			Usage: usage{PromptTokens: 4},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL))
+	resp, err := p.Embed(context.Background(), provider.EmbedRequest{
+		Model: "embed-m", Input: []string{"a", "b"},
+	})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(resp.Embeddings) != 2 || resp.Embeddings[0][0] != 0.1 {
+		t.Errorf("Embeddings = %+v", resp.Embeddings)
+	}
+}
+
+func TestProvider_Embed_ReordersByIndex(t *testing.T) {
+	// Spec says data array order is unspecified; provider must reorder
+	// using Index so callers can rely on positional alignment with Input.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(embedResponse{
+			Data: []embeddingDoc{
+				{Index: 1, Embedding: []float64{2}},
+				{Index: 0, Embedding: []float64{1}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL))
+	resp, err := p.Embed(context.Background(), provider.EmbedRequest{Model: "m", Input: []string{"a", "b"}})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if resp.Embeddings[0][0] != 1 || resp.Embeddings[1][0] != 2 {
+		t.Errorf("not reordered by index: %+v", resp.Embeddings)
+	}
+}
+
+func TestProvider_Embed_MismatchedCount_Errors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(embedResponse{
+			Data: []embeddingDoc{{Index: 0, Embedding: []float64{1}}},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL))
+	_, err := p.Embed(context.Background(), provider.EmbedRequest{Model: "m", Input: []string{"a", "b"}})
+	if err == nil || !strings.Contains(err.Error(), "1 embeddings for 2 inputs") {
+		t.Errorf("expected count-mismatch error, got: %v", err)
+	}
+}
+
+func TestProvider_Embed_OutOfRangeIndex_Errors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(embedResponse{
+			Data: []embeddingDoc{
+				{Index: 0, Embedding: []float64{1}},
+				{Index: 5, Embedding: []float64{2}}, // out of range
+			},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL))
+	_, err := p.Embed(context.Background(), provider.EmbedRequest{Model: "m", Input: []string{"a", "b"}})
+	if err == nil || !strings.Contains(err.Error(), "out-of-range index") {
+		t.Errorf("expected out-of-range error, got: %v", err)
+	}
+}
+
+func TestProvider_Embed_EmptyInput_Errors(t *testing.T) {
+	p := NewProvider(NewClient("http://x"))
+	_, err := p.Embed(context.Background(), provider.EmbedRequest{Model: "m"})
+	if err == nil || !strings.Contains(err.Error(), "at least one input") {
+		t.Errorf("expected empty-input error, got: %v", err)
+	}
+}
+
+func TestProvider_Embed_Singleflight_Dedups(t *testing.T) {
+	// Concurrent identical embed requests must collapse to ONE upstream
+	// call — this is the optimization that makes batch RAG indexing
+	// affordable.
+	var calls int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt64(&calls, 1)
+		time.Sleep(20 * time.Millisecond) // hold so the second caller piggybacks
+		_ = json.NewEncoder(w).Encode(embedResponse{
+			Data: []embeddingDoc{{Index: 0, Embedding: []float64{42}}},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL))
+	req := provider.EmbedRequest{Model: "m", Input: []string{"same-text"}}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			defer wg.Done()
+			if _, err := p.Embed(context.Background(), req); err != nil {
+				t.Errorf("Embed: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	if got := atomic.LoadInt64(&calls); got != 1 {
+		t.Errorf("upstream calls = %d, want 1 (singleflight should have deduped)", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SSE reader unit tests
+// ---------------------------------------------------------------------------
+
+func TestSSEReader_ParsesDataLines(t *testing.T) {
+	body := io.NopCloser(strings.NewReader("data: {\"a\":1}\n\ndata: {\"b\":2}\n\ndata: [DONE]\n\n"))
+	r := newSSEReader(body)
+	defer r.Close()
+
+	p1, err := r.Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if string(p1) != `{"a":1}` {
+		t.Errorf("first payload = %q, want %q", p1, `{"a":1}`)
+	}
+	p2, err := r.Next()
+	if err != nil || string(p2) != `{"b":2}` {
+		t.Errorf("second payload = %q err=%v", p2, err)
+	}
+	if _, err := r.Next(); err != errStreamDone {
+		t.Errorf("[DONE] should produce errStreamDone, got %v", err)
+	}
+}
+
+func TestSSEReader_SkipsCommentsAndNonDataLines(t *testing.T) {
+	body := io.NopCloser(strings.NewReader(": keepalive\nevent: ping\nid: 1\ndata: {\"x\":1}\n\ndata: [DONE]\n\n"))
+	r := newSSEReader(body)
+	defer r.Close()
+
+	p, err := r.Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if string(p) != `{"x":1}` {
+		t.Errorf("payload = %q, want %q", p, `{"x":1}`)
+	}
+}
+
+func TestSSEReader_EOFWithoutDone_IsStreamDone(t *testing.T) {
+	// Some servers close the stream without emitting [DONE]; the reader
+	// must treat that as normal termination rather than an error.
+	body := io.NopCloser(strings.NewReader("data: {\"x\":1}\n\n"))
+	r := newSSEReader(body)
+	defer r.Close()
+
+	if _, err := r.Next(); err != nil {
+		t.Fatalf("first Next: %v", err)
+	}
+	if _, err := r.Next(); err != errStreamDone {
+		t.Errorf("EOF should produce errStreamDone, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Mock-server helper
+// ---------------------------------------------------------------------------
+
+type mockServerOpts struct {
+	models       []modelEntry
+	chatResponse chatResponse
+}
+
+type mockServer struct {
+	url      string
+	srv      *httptest.Server
+	lastPath atomic.Value // string
+	lastAuth atomic.Value // string
+}
+
+func (m *mockServer) close() { m.srv.Close() }
+
+func newMockServer(t *testing.T, opts mockServerOpts) *mockServer {
+	t.Helper()
+	m := &mockServer{}
+	m.lastPath.Store("")
+	m.lastAuth.Store("")
+
+	m.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.lastPath.Store(r.URL.Path)
+		m.lastAuth.Store(r.Header.Get("Authorization"))
+		switch {
+		case r.URL.Path == "/v1/models" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(modelsResponse{Data: opts.models})
+		case r.URL.Path == "/v1/chat/completions" && r.Method == http.MethodPost:
+			_ = json.NewEncoder(w).Encode(opts.chatResponse)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	m.url = m.srv.URL
+	return m
+}
+
+// writeSSE writes a slice of chunks as SSE events terminated by [DONE].
+func writeSSE(t *testing.T, w http.ResponseWriter, chunks []chatChunk) {
+	t.Helper()
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		t.Fatalf("response writer doesn't flush")
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(http.StatusOK)
+	for _, c := range chunks {
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", marshalJSON(t, c))
+		flusher.Flush()
+	}
+	_, _ = fmt.Fprintf(w, "data: [DONE]\n\n")
+	flusher.Flush()
+}
+
+func marshalJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+func stringPtr(s string) *string { return &s }

--- a/provider/openaicompat/openaicompat_test.go
+++ b/provider/openaicompat/openaicompat_test.go
@@ -372,6 +372,49 @@ func TestProvider_Chat_RequestBodyShape(t *testing.T) {
 	}
 }
 
+// TestProvider_Chat_RequestBody_OmitsToolCallIndex verifies that the
+// outbound wire does NOT carry an `index` field on tool_calls entries.
+// OpenAI treats index as response-only — strict server-side schema
+// validators (some vLLM and llama.cpp builds) reject requests that
+// include it. The omission is enforced by toWireToolCalls deliberately
+// not copying Function.Index and by chatToolCall.Index using
+// `*int` + omitempty. A regression that starts sending `"index":0` on
+// every request would break those servers silently; this test pins
+// the contract.
+func TestProvider_Chat_RequestBody_OmitsToolCallIndex(t *testing.T) {
+	var rawBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawBody, _ = io.ReadAll(r.Body)
+		_ = json.NewEncoder(w).Encode(chatResponse{
+			Choices: []chatChoice{{Message: chatMessage{Content: "ok"}}},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL))
+	_, err := p.Chat(context.Background(), provider.ChatRequest{
+		Model: "m",
+		Messages: []provider.ChatMessage{{
+			Role: "assistant",
+			ToolCalls: []provider.ToolCall{{
+				ID:   "call_1",
+				Type: "function",
+				Function: provider.ToolCallFunction{
+					Index:     3, // non-zero on purpose — caller might have it set
+					Name:      "search",
+					Arguments: json.RawMessage(`{"q":"go"}`),
+				},
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if strings.Contains(string(rawBody), `"index"`) {
+		t.Errorf("outbound body must not include tool_call index field, body was: %s", string(rawBody))
+	}
+}
+
 func TestProvider_Chat_RequestBody_ToolCallArgumentsEncodedAsString(t *testing.T) {
 	var captured chatRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -964,6 +1007,55 @@ func TestProvider_ChatStream_SSEReadError_ReturnsError(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "sse read") {
 		t.Fatalf("expected propagated SSE read error, got %v", err)
+	}
+}
+
+// TestProvider_ChatStream_EOFMidFrame_PropagatesError covers the
+// connection-reset / abrupt-close failure mode: a server begins writing
+// an SSE frame, flushes a partial "data: " prefix without the closing
+// blank line, then closes the connection. The reader must surface this
+// as a stream error rather than silently terminating via errStreamDone,
+// otherwise consumers would see "success with no Done chunk" and not
+// know to retry. Distinct from cancel-mid-stream (which has its own
+// chunksReceived > 0 + partial-emission path) because here NO complete
+// chunk was ever delivered.
+func TestProvider_ChatStream_EOFMidFrame_PropagatesError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("response writer does not flush")
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		// Partial frame: prefix only, no closing blank line, then close.
+		_, _ = fmt.Fprint(w, "data: {\"id\":\"chunk-")
+		flusher.Flush()
+		// Hijack to slam the connection shut so the client sees an
+		// unterminated frame, not a clean [DONE]. httptest's default
+		// behavior on handler return is to close cleanly which surfaces
+		// as scanner.Err == nil. Hijacking guarantees an abrupt close.
+		if hj, hjOK := w.(http.Hijacker); hjOK {
+			conn, _, _ := hj.Hijack()
+			if conn != nil {
+				_ = conn.Close()
+			}
+		}
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL))
+	err := p.ChatStream(context.Background(), provider.ChatRequest{Model: "m"}, func(provider.ChatResponse) error {
+		t.Fatal("callback must not fire — no complete chunk was delivered")
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected error from mid-frame EOF, got nil")
+	}
+	// Either bufio detects the truncation (sse read err) or the http
+	// client surfaces the connection close — both are valid surfacing
+	// paths; the contract is "do not silently succeed".
+	if !strings.Contains(err.Error(), "chat stream") {
+		t.Errorf("error should be wrapped with chat-stream context, got: %v", err)
 	}
 }
 

--- a/provider/openaicompat/sse.go
+++ b/provider/openaicompat/sse.go
@@ -1,0 +1,85 @@
+package openaicompat
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// sseReader iterates one OpenAI-shape SSE event at a time. The wire format is
+// "data: <json>\n\n" frames terminated by the literal "data: [DONE]\n\n"
+// sentinel. Comments (": keepalive") and non-data fields (event:, id:, retry:)
+// are tolerated and skipped so we don't choke on proxy keepalives.
+//
+// The reader is single-use: callers MUST Close the underlying body. Errors
+// other than io.EOF are returned from Next(); io.EOF and the [DONE] sentinel
+// both produce errStreamDone, which callers should treat as normal termination.
+type sseReader struct {
+	body    io.ReadCloser
+	scanner *bufio.Scanner
+}
+
+// errStreamDone is returned by sseReader.Next when the stream ends, either
+// via OpenAI's [DONE] sentinel or via io.EOF on the underlying connection.
+// Both are NORMAL termination signals — callers should not surface this
+// as an error to upstream code. Sentinel value (not a wrapped error) so
+// errors.Is checks are cheap.
+var errStreamDone = errors.New("openaicompat: sse stream done")
+
+// newSSEReader wraps body in an sseReader. The scanner uses a generous
+// buffer (1 MiB) because individual chat-completion chunks can include
+// long tool-call argument payloads; the default 64 KiB would error on
+// those.
+func newSSEReader(body io.ReadCloser) *sseReader {
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	return &sseReader{
+		body:    body,
+		scanner: scanner,
+	}
+}
+
+// Next returns the next data: payload as raw JSON bytes. It returns
+// errStreamDone when the [DONE] sentinel is reached or the underlying
+// connection EOFs. Other read errors are wrapped and returned verbatim.
+//
+// Per the SSE spec, an event is terminated by a blank line — but for the
+// OpenAI dialect, each event is exactly one "data: <json>" line followed
+// by a blank line, so we treat each data: line as a complete event and
+// skip the blank.
+func (r *sseReader) Next() ([]byte, error) {
+	for r.scanner.Scan() {
+		line := r.scanner.Bytes()
+		// Skip blank lines (event separators) and SSE comments (":...").
+		if len(line) == 0 || line[0] == ':' {
+			continue
+		}
+		// Only data: lines carry the JSON payload. Skip event:/id:/retry:.
+		const dataPrefix = "data:"
+		if len(line) < len(dataPrefix) || string(line[:len(dataPrefix)]) != dataPrefix {
+			continue
+		}
+		payload := line[len(dataPrefix):]
+		// Trim a single leading space per the SSE spec ("data: <text>" vs "data:<text>").
+		if len(payload) > 0 && payload[0] == ' ' {
+			payload = payload[1:]
+		}
+		if string(payload) == "[DONE]" {
+			return nil, errStreamDone
+		}
+		// Copy: scanner.Bytes() may be reused on the next call.
+		out := make([]byte, len(payload))
+		copy(out, payload)
+		return out, nil
+	}
+	if err := r.scanner.Err(); err != nil {
+		return nil, fmt.Errorf("openaicompat: sse read: %w", err)
+	}
+	return nil, errStreamDone
+}
+
+// Close closes the underlying response body. Safe to call multiple times.
+func (r *sseReader) Close() error {
+	return r.body.Close()
+}

--- a/provider/openaicompat/types.go
+++ b/provider/openaicompat/types.go
@@ -43,6 +43,7 @@ type chatFunction struct {
 
 // chatToolCall is one tool-call entry inside an assistant message.
 type chatToolCall struct {
+	Index    *int                 `json:"index,omitempty"` // present on streaming deltas
 	ID       string               `json:"id,omitempty"`
 	Type     string               `json:"type"` // "function"
 	Function chatToolCallFunction `json:"function"`

--- a/provider/openaicompat/types.go
+++ b/provider/openaicompat/types.go
@@ -42,17 +42,32 @@ type chatFunction struct {
 }
 
 // chatToolCall is one tool-call entry inside an assistant message.
+//
+// Index is a pointer-with-omitempty for two reasons: OpenAI's streaming
+// deltas include it to correlate arg fragments across chunks (the
+// streamToolCallAccumulator depends on this for fragmented assembly),
+// but outbound requests MUST NOT carry it — `index` is a response-only
+// field in OpenAI's spec, and strict server-side schema validators may
+// reject requests that include it. Nil pointer + omitempty produces the
+// correct shape in both directions; toWireToolCalls deliberately never
+// sets Index when converting provider.ToolCall back to the wire form.
 type chatToolCall struct {
-	Index    *int                 `json:"index,omitempty"` // present on streaming deltas
+	Index    *int                 `json:"index,omitempty"` // response-only; see type doc
 	ID       string               `json:"id,omitempty"`
 	Type     string               `json:"type"` // "function"
 	Function chatToolCallFunction `json:"function"`
 }
 
 // chatToolCallFunction is the function descriptor inside a tool_calls entry.
-// Arguments is preserved as raw JSON. OpenAI canonically returns it as a
-// JSON-encoded string; we forward whatever the server returned without
-// re-stringifying (same transparency tradeoff documented in compat/).
+//
+// Arguments is OpenAI's JSON-string envelope around the actual tool-call
+// payload (e.g. the wire carries `"arguments": "{\"q\":\"go\"}"` for a
+// search-style tool). On INBOUND we normalize via
+// normalizeToolCallArguments — object/array literals are unwrapped to the
+// canonical raw-JSON tool-call shape, scalar string literals stay wrapped
+// to preserve type. On OUTBOUND we re-encode via encodeToolCallArguments
+// so the wire shape matches OpenAI's canonical form regardless of which
+// representation a caller passed in.
 type chatToolCallFunction struct {
 	Name      string          `json:"name"`
 	Arguments json.RawMessage `json:"arguments,omitempty"`

--- a/provider/openaicompat/types.go
+++ b/provider/openaicompat/types.go
@@ -1,0 +1,209 @@
+package openaicompat
+
+import "encoding/json"
+
+// ---------------------------------------------------------------------------
+// Chat completion wire types (/v1/chat/completions)
+// ---------------------------------------------------------------------------
+
+// chatRequest is the outbound shape for POST /v1/chat/completions. Only the
+// fields go-llm sends are declared; OpenAI ignores unknown request fields.
+type chatRequest struct {
+	Model       string        `json:"model"`
+	Messages    []chatMessage `json:"messages"`
+	Stream      bool          `json:"stream,omitempty"`
+	Temperature *float64      `json:"temperature,omitempty"`
+	TopP        *float64      `json:"top_p,omitempty"`
+	MaxTokens   int           `json:"max_tokens,omitempty"`
+	Stop        []string      `json:"stop,omitempty"`
+	Tools       []chatTool    `json:"tools,omitempty"`
+}
+
+// chatMessage is the wire shape of one message in a chat request or response.
+type chatMessage struct {
+	Role       string         `json:"role"`
+	Content    string         `json:"content"`
+	Name       string         `json:"name,omitempty"`
+	ToolCallID string         `json:"tool_call_id,omitempty"`
+	ToolCalls  []chatToolCall `json:"tool_calls,omitempty"`
+}
+
+// chatTool is the OpenAI function-calling tool descriptor.
+type chatTool struct {
+	Type     string       `json:"type"` // always "function"
+	Function chatFunction `json:"function"`
+}
+
+// chatFunction describes a callable function.
+type chatFunction struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+}
+
+// chatToolCall is one tool-call entry inside an assistant message.
+type chatToolCall struct {
+	ID       string               `json:"id,omitempty"`
+	Type     string               `json:"type"` // "function"
+	Function chatToolCallFunction `json:"function"`
+}
+
+// chatToolCallFunction is the function descriptor inside a tool_calls entry.
+// Arguments is preserved as raw JSON. OpenAI canonically returns it as a
+// JSON-encoded string; we forward whatever the server returned without
+// re-stringifying (same transparency tradeoff documented in compat/).
+type chatToolCallFunction struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+}
+
+// chatResponse is the non-streaming /v1/chat/completions response body.
+type chatResponse struct {
+	ID      string       `json:"id"`
+	Model   string       `json:"model"`
+	Choices []chatChoice `json:"choices"`
+	Usage   usage        `json:"usage"`
+}
+
+// chatChoice is one completion choice in a chat response. The first choice
+// (index 0) is consumed; multi-choice responses are not exposed to the
+// provider-level API.
+type chatChoice struct {
+	Index        int         `json:"index"`
+	Message      chatMessage `json:"message"`
+	FinishReason string      `json:"finish_reason"`
+}
+
+// chatChunk is one frame of a streaming /v1/chat/completions response.
+type chatChunk struct {
+	ID      string            `json:"id"`
+	Model   string            `json:"model"`
+	Choices []chatChunkChoice `json:"choices"`
+	Usage   *usage            `json:"usage,omitempty"` // present on final chunk when stream_options.include_usage is set
+}
+
+// chatChunkChoice is one streaming-chunk choice. FinishReason is a pointer
+// so interim chunks deserialize without spuriously matching the zero value
+// — the final chunk is the one with a non-nil FinishReason.
+type chatChunkChoice struct {
+	Index        int         `json:"index"`
+	Delta        chatMessage `json:"delta"`
+	FinishReason *string     `json:"finish_reason"`
+}
+
+// ---------------------------------------------------------------------------
+// Completion wire types (/v1/completions, used for FIM via suffix)
+// ---------------------------------------------------------------------------
+
+// completionRequest is POST /v1/completions. The Suffix field is what makes
+// this distinct from chat: when set, vLLM and llama.cpp run native FIM.
+type completionRequest struct {
+	Model       string   `json:"model"`
+	Prompt      string   `json:"prompt"`
+	Suffix      string   `json:"suffix,omitempty"`
+	Stream      bool     `json:"stream,omitempty"`
+	Temperature *float64 `json:"temperature,omitempty"`
+	TopP        *float64 `json:"top_p,omitempty"`
+	MaxTokens   int      `json:"max_tokens,omitempty"`
+	Stop        []string `json:"stop,omitempty"`
+}
+
+// completionResponse is the non-streaming /v1/completions response body.
+type completionResponse struct {
+	ID      string             `json:"id"`
+	Model   string             `json:"model"`
+	Choices []completionChoice `json:"choices"`
+	Usage   usage              `json:"usage"`
+}
+
+// completionChoice is one choice in a completion response.
+type completionChoice struct {
+	Index        int    `json:"index"`
+	Text         string `json:"text"`
+	FinishReason string `json:"finish_reason"`
+}
+
+// completionChunk is one frame of a streaming /v1/completions response.
+type completionChunk struct {
+	ID      string                  `json:"id"`
+	Model   string                  `json:"model"`
+	Choices []completionChunkChoice `json:"choices"`
+	Usage   *usage                  `json:"usage,omitempty"`
+}
+
+// completionChunkChoice is one streaming-chunk choice. Same FinishReason
+// pointer convention as chatChunkChoice.
+type completionChunkChoice struct {
+	Index        int     `json:"index"`
+	Text         string  `json:"text"`
+	FinishReason *string `json:"finish_reason"`
+}
+
+// ---------------------------------------------------------------------------
+// Embedding wire types (/v1/embeddings)
+// ---------------------------------------------------------------------------
+
+// embedRequest is POST /v1/embeddings. Input accepts either a single string
+// or an array of strings on the wire; we always send an array for uniform
+// response handling.
+type embedRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+// embedResponse is the /v1/embeddings response body.
+type embedResponse struct {
+	Model string         `json:"model"`
+	Data  []embeddingDoc `json:"data"`
+	Usage usage          `json:"usage"`
+}
+
+// embeddingDoc is one entry in the response data array. Index correlates
+// the embedding back to its position in the request Input array.
+type embeddingDoc struct {
+	Index     int       `json:"index"`
+	Embedding []float64 `json:"embedding"`
+}
+
+// ---------------------------------------------------------------------------
+// Models wire types (/v1/models)
+// ---------------------------------------------------------------------------
+
+// modelsResponse is the GET /v1/models response body.
+type modelsResponse struct {
+	Data []modelEntry `json:"data"`
+}
+
+// modelEntry is one model in the /v1/models listing. OpenAI-compat servers
+// expose only the ID reliably; family/quant/context-window are NOT in the
+// spec and would have to be inferred per-server.
+type modelEntry struct {
+	ID      string `json:"id"`
+	OwnedBy string `json:"owned_by,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// Shared subtypes
+// ---------------------------------------------------------------------------
+
+// usage is OpenAI's token accounting shape. Embedding responses omit
+// completion_tokens; chat/completion responses populate all three.
+type usage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+// errorEnvelope is the OpenAI-shape error response body. Servers return
+// this with non-2xx HTTP statuses to surface model/auth/format problems.
+type errorEnvelope struct {
+	Error errorPayload `json:"error"`
+}
+
+// errorPayload is the nested error object inside errorEnvelope.
+type errorPayload struct {
+	Message string `json:"message"`
+	Type    string `json:"type,omitempty"`
+	Code    string `json:"code,omitempty"`
+	Param   string `json:"param,omitempty"`
+}


### PR DESCRIPTION
## Summary

PR2 of the 4-PR #81 rollout. Adds `provider/openaicompat/` — a `provider.Provider` implementation backed by OpenAI-compatible local model servers (LM Studio, llama.cpp `--api`, vLLM, text-generation-inference). Builds on PR1's instance-naming + per-model `Capabilities` overlay.

This is the **inbound** client-side complement to the existing `compat/` package (which is the **outbound** server exposing go-llm AS an OpenAI server). The two share no types by design: `compat/` depends on `provider/`, so importing it from a provider sub-package would invert the layering.

## Scope (IN)

All 7 `provider.Provider` methods over the OpenAI wire format:

| Method | Endpoint | Notes |
|---|---|---|
| Name / Capabilities | — | Default name `openai-compat`; `WithProviderName` overrides (panics on empty, matching OllamaProvider) |
| Health | GET /v1/models | Uses the spec's only mandatory GET as the liveness probe |
| Models | GET /v1/models | ID-only listing (spec doesn't expose family/quant/template — fed via models.json upstream) |
| Chat / ChatStream | POST /v1/chat/completions | SSE streaming, ThinkParser reuse for inline `<think>` tags, tool-call deltas, graceful cancellation with Done+Partial chunk |
| Generate / GenerateStream | POST /v1/completions | FIM via `suffix` field (vLLM + llama.cpp `--api` both support this); `System` prepended to `Prompt` since /v1/completions has no system field |
| Embed | POST /v1/embeddings | Singleflight dedup matching OllamaProvider; defensive reorder-by-Index (spec says order is unspecified) |

**Defaults:** `CapChat | CapGenerate | CapStream | CapEmbed | CapToolCall`. **`CapInsert` is intentionally NOT in the default set** — OpenAI-compat servers vary on FIM support and there's no probe equivalent to Ollama's template inspection. Opt in via `WithCapabilities(...)` when the target server is known to support native FIM.

## Scope (OUT, deferred)

- MCP `server.go` wiring — **PR4**
- `models.json` sample provider entries — **PR3**
- Per-model capability auto-detection — issue #81 calls this out as heuristic; users carve down via `config.ModelConfig.Capabilities` overlay (PR1)
- DeepSeek-R1 `reasoning_content` field — separate concern
- Real-server integration tests — out of scope for the unit-test cycle

## Commit roll-up

| Commit | Purpose |
|---|---|
| `1b704e4` feat(provider/openaicompat): scaffold package with OpenAI wire types | Package skeleton + wire shapes (only fields the client consumes) |
| `4f0d3e4` feat(provider/openaicompat): HTTP client + SSE reader | Bearer auth, JSON helpers, error-envelope unwrap, 1 MiB SSE buffer (default 64 KiB chokes on tool-call payloads) |
| `379daa3` feat(provider/openaicompat): implement provider.Provider against OpenAI-compat servers | All 7 Provider methods, ThinkParser reuse, singleflight dedup, graceful cancellation parity with OllamaProvider |
| `fb714f5` test(provider/openaicompat): httptest mock coverage for every wire path | 27 tests across construction, client transport, every endpoint, streaming, FIM, cancellation, singleflight dedup, SSE reader |
| `848f764` chore(provider/openaicompat): wrap defer Close() with _ = to satisfy errcheck | Lint cleanup |

## Test plan

- [x] `go test ./provider/openaicompat/ -count=1 -race` — 27 tests pass clean
- [x] `go test ./... -count=1 -race` — full module green
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./provider/openaicompat/` — 0 issues

Generated with [Claude Code](https://claude.com/claude-code)