### PR TITLE
feat(provider): provider-instance-aware routing (#81 PR3/4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,11 @@ model names will observe different models at runtime.**
   keep independent sticky entries. Empty `Provider` produces byte-identical
   keys to pre-change behavior, preserving existing affinity warmth.
 - **JSON wire** — unset `provider` fields are omitted on the wire
-  (`omitempty`). Keyed Go struct literals are additive-compatible.
-  Unkeyed composite literals of the exported request structs would need
-  positional adjustment — none observed in the in-tree consumers.
+  (`omitempty`). Keyed Go struct literals (`provider.ChatRequest{Model: ...,
+  Messages: ...}`) are additive-compatible. Unkeyed composite literals
+  (`provider.ChatRequest{"qwen3:8b", []ChatMessage{...}, ...}`) will fail
+  to compile because positional arguments now shift by one slot; convert
+  to keyed literals (recommended) or insert an explicit empty `Provider`
+  positional value. None of the in-tree consumers (Firn IDE, Flux ML,
+  Quantum Trader call sites observed in this repo) use unkeyed literals
+  for these structs; external consumers should audit their call sites.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,3 +55,34 @@ model names will observe different models at runtime.**
 
 - Catalog: `qwen3-coder-next` gains a `latest` variant alias kept in
   sync with `80b` (guarded by test).
+
+### Router: provider-instance pinning (#81)
+
+- **`provider.RoutingRequest.Provider`** — new optional `string` field that
+  hard-scopes routing to a specific provider *instance* (the config-time
+  name, e.g. `ollama-local-a`, `vllm-prod-1`). Acts as a pre-score filter:
+  empty `Model` + `Provider` scopes `Recommend`; unqualified `Model` +
+  `Provider` pins `ModelKey{Provider, Model}` via `Lookup`; qualified
+  `Model` (`provider/model`) + non-empty `Provider` must agree on identity
+  or `Router.Route` returns the new `ErrProviderMismatch` sentinel before
+  candidate resolution. `PreferredChain` is authoritative when set —
+  chain selectors carry their own provider identity and the per-request
+  `Provider` hint is ignored under chain routing.
+- **`provider.ChatRequest.Provider`, `GenerateRequest.Provider`,
+  `EmbedRequest.Provider`** — optional `string` fields (`json:"provider,omitempty"`)
+  forwarded by `Router.Chat / ChatStream / Generate / GenerateStream / Embed`
+  into `RoutingRequest.Provider`. Router selection metadata only; not
+  forwarded to the concrete provider's execution call (the provider already
+  knows its own identity).
+- **`provider.RecommendOpts.RestrictToProvider`** — single-string hard
+  filter on the recommendation path. Distinct from the still-unused soft
+  `PreferredProviders`. An unknown provider name surfaces as a provider
+  resolution error rather than degrading to a silent empty result.
+- **Sticky-key derivation** — `RoutingRequest.Provider` participates in
+  `StickyKey` so two scoped requests with identical affinity/model/use-case
+  keep independent sticky entries. Empty `Provider` produces byte-identical
+  keys to pre-change behavior, preserving existing affinity warmth.
+- **JSON wire** — unset `provider` fields are omitted on the wire
+  (`omitempty`). Keyed Go struct literals are additive-compatible.
+  Unkeyed composite literals of the exported request structs would need
+  positional adjustment — none observed in the in-tree consumers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,10 +82,12 @@ model names will observe different models at runtime.**
   `StickyKey` so two scoped requests with identical affinity/model/use-case
   keep independent sticky entries. Empty `Provider` produces byte-identical
   keys to pre-change behavior, preserving existing affinity warmth.
-- **JSON wire** — unset `provider` fields are omitted on the wire
-  (`omitempty`). Keyed Go struct literals (`provider.ChatRequest{Model: ...,
-  Messages: ...}`) are additive-compatible. Unkeyed composite literals
-  (`provider.ChatRequest{"qwen3:8b", []ChatMessage{...}, ...}`) will fail
+- **JSON wire / Go literals** — unset request-level `provider` fields are
+  omitted on the wire (`omitempty`). Keyed Go struct literals
+  (`provider.ChatRequest{Model: ..., Messages: ...}`) are
+  additive-compatible. Unkeyed composite literals for the changed exported
+  structs (`provider.RoutingRequest{...}`, `provider.ChatRequest{...}`,
+  `provider.GenerateRequest{...}`, `provider.EmbedRequest{...}`) will fail
   to compile because positional arguments now shift by one slot; convert
   to keyed literals (recommended) or insert an explicit empty `Provider`
   positional value. All call sites within this repo (`analysis/*`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,9 @@ model names will observe different models at runtime.**
   (`provider.ChatRequest{"qwen3:8b", []ChatMessage{...}, ...}`) will fail
   to compile because positional arguments now shift by one slot; convert
   to keyed literals (recommended) or insert an explicit empty `Provider`
-  positional value. None of the in-tree consumers (Firn IDE, Flux ML,
-  Quantum Trader call sites observed in this repo) use unkeyed literals
-  for these structs; external consumers should audit their call sites.
+  positional value. All call sites within this repo (`analysis/*`,
+  `provider/route_plan.go`, `provider/router.go`, etc.) use keyed
+  literals and are unaffected. External consumers — Firn IDE, Flux ML,
+  Quantum Trader — live in separate repos and should audit their own
+  call sites; they will get a compile error rather than silent
+  misbehavior on `go get -u`.

--- a/provider/model_profile.go
+++ b/provider/model_profile.go
@@ -224,6 +224,16 @@ type RecommendOpts struct {
 	// Reserved for Phase 2 — not yet used by Recommend.
 	PreferredProviders []string
 
+	// RestrictToProvider, when non-empty, is a HARD filter limiting Recommend
+	// results to profiles whose Key.Provider matches exactly. Distinct from
+	// PreferredProviders (a soft preference): RestrictToProvider produces no
+	// cross-provider degradation when no candidate matches, and an unknown
+	// provider name surfaces as a provider resolution error rather than a
+	// silent empty result. Used by Router.resolveCandidates to thread
+	// RoutingRequest.Provider through the recommend path without rewriting
+	// the ranking pipeline.
+	RestrictToProvider string
+
 	// RequiredCaps is a bitmask of capabilities the model must support.
 	// Models missing any of the required capabilities are filtered out.
 	RequiredCaps Capability

--- a/provider/model_registry.go
+++ b/provider/model_registry.go
@@ -258,8 +258,14 @@ func (r *ModelRegistry) All(ctx context.Context) ([]*ModelProfile, error) {
 // criteria. Results are filtered by required capabilities and available
 // RAM, then sorted by quality tier descending. The Router makes the
 // final selection from this candidate list.
+//
+// When opts.RestrictToProvider is non-empty, Recommend builds the initial
+// candidate set from only the named provider (via recommendSourceProfiles)
+// rather than walking All() and filtering after probing unrelated providers.
+// An unknown RestrictToProvider value surfaces as a provider resolution
+// error rather than degrading silently to an empty result.
 func (r *ModelRegistry) Recommend(ctx context.Context, opts RecommendOpts) ([]*ModelProfile, error) {
-	all, err := r.All(ctx)
+	all, err := r.recommendSourceProfiles(ctx, opts.RestrictToProvider)
 	if err != nil {
 		return nil, fmt.Errorf("provider: recommend: %w", err)
 	}
@@ -295,6 +301,38 @@ func (r *ModelRegistry) Recommend(ctx context.Context, opts RecommendOpts) ([]*M
 	sortProfiles(candidates)
 
 	return candidates, nil
+}
+
+// recommendSourceProfiles produces the initial profile set Recommend will
+// filter and rank. When providerName is empty, it returns the cross-provider
+// All() view. When non-empty, it scopes to that single provider instance —
+// resolving and probing only that provider, so unrelated provider outages
+// cannot break a scoped recommendation. An unknown providerName surfaces
+// as a provider resolution error.
+func (r *ModelRegistry) recommendSourceProfiles(ctx context.Context, providerName string) ([]*ModelProfile, error) {
+	if providerName == "" {
+		return r.All(ctx)
+	}
+
+	prov, err := r.providers.Resolve(ModelKey{Provider: providerName})
+	if err != nil {
+		return nil, fmt.Errorf("restricted provider %q: %w", providerName, err)
+	}
+
+	models, err := prov.Models(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("query models from restricted provider %q: %w", providerName, err)
+	}
+
+	profiles := make([]*ModelProfile, 0, len(models))
+	for _, mi := range models {
+		profile, lookupErr := r.Lookup(ctx, ModelKey{Provider: providerName, Model: mi.Name})
+		if lookupErr != nil {
+			continue
+		}
+		profiles = append(profiles, profile)
+	}
+	return profiles, nil
 }
 
 // FIMConfigFor returns the local FIM policy for a given model, or nil if no

--- a/provider/model_registry_test.go
+++ b/provider/model_registry_test.go
@@ -1459,8 +1459,8 @@ func TestModelRegistry_OverrideRejectionHook_FiresOnNonCanonicalToken(t *testing
 		err    error
 	}
 	var (
-		mu          sync.Mutex
-		rejections  []rejection
+		mu         sync.Mutex
+		rejections []rejection
 	)
 	mr.SetOverrideRejectionHook(func(k ModelKey, tokens []string, err error) {
 		mu.Lock()
@@ -1919,13 +1919,13 @@ func TestModelRegistry_CapabilityOverride_NilSkipped(t *testing.T) {
 // empty candidate set.
 func TestRecommend_RestrictToProvider(t *testing.T) {
 	provA := &mrMockProvider{
-		name: "ollama-a",
-		caps: CapChat | CapGenerate,
+		name:   "ollama-a",
+		caps:   CapChat | CapGenerate,
 		models: []ModelInfo{{Name: "qwen3:8b", Family: "qwen3", ParameterSize: "8B", QuantLevel: "Q4_K_M", ContextWindow: 32768, Capabilities: []string{"completion"}}},
 	}
 	provB := &mrMockProvider{
-		name: "ollama-b",
-		caps: CapChat | CapGenerate,
+		name:   "ollama-b",
+		caps:   CapChat | CapGenerate,
 		models: []ModelInfo{{Name: "qwen3:8b", Family: "qwen3", ParameterSize: "8B", QuantLevel: "Q4_K_M", ContextWindow: 32768, Capabilities: []string{"completion"}}},
 	}
 

--- a/provider/model_registry_test.go
+++ b/provider/model_registry_test.go
@@ -1906,3 +1906,74 @@ func TestModelRegistry_CapabilityOverride_NilSkipped(t *testing.T) {
 		t.Errorf("Caps with nil-returning override = %v, want %v (must match baseline)", overrideProfile.Caps, baselineProfile.Caps)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// TestRecommend_RestrictToProvider
+// ---------------------------------------------------------------------------
+
+// TestRecommend_RestrictToProvider verifies that RecommendOpts.RestrictToProvider
+// hard-filters candidates to a single provider instance, even when multiple
+// providers advertise capable models. Distinct from PreferredProviders (which
+// is currently a soft preference and remains unused). Unknown provider names
+// surface as provider resolution errors rather than degrading silently to an
+// empty candidate set.
+func TestRecommend_RestrictToProvider(t *testing.T) {
+	provA := &mrMockProvider{
+		name: "ollama-a",
+		caps: CapChat | CapGenerate,
+		models: []ModelInfo{{Name: "qwen3:8b", Family: "qwen3", ParameterSize: "8B", QuantLevel: "Q4_K_M", ContextWindow: 32768, Capabilities: []string{"completion"}}},
+	}
+	provB := &mrMockProvider{
+		name: "ollama-b",
+		caps: CapChat | CapGenerate,
+		models: []ModelInfo{{Name: "qwen3:8b", Family: "qwen3", ParameterSize: "8B", QuantLevel: "Q4_K_M", ContextWindow: 32768, Capabilities: []string{"completion"}}},
+	}
+
+	reg := NewRegistry()
+	if err := reg.Register(provA); err != nil {
+		t.Fatalf("Register provA: %v", err)
+	}
+	if err := reg.Register(provB); err != nil {
+		t.Fatalf("Register provB: %v", err)
+	}
+	ctx := context.Background()
+	if err := reg.RefreshModels(ctx, "ollama-a"); err != nil {
+		t.Fatalf("RefreshModels a: %v", err)
+	}
+	if err := reg.RefreshModels(ctx, "ollama-b"); err != nil {
+		t.Fatalf("RefreshModels b: %v", err)
+	}
+
+	mr, err := NewModelRegistry(reg, nil)
+	if err != nil {
+		t.Fatalf("NewModelRegistry: %v", err)
+	}
+
+	// Unscoped: both providers' profiles appear.
+	all, err := mr.Recommend(ctx, RecommendOpts{RequiredCaps: CapChat})
+	if err != nil {
+		t.Fatalf("Recommend (unscoped): %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("unscoped len = %d, want 2", len(all))
+	}
+
+	// Scoped to ollama-a: only ollama-a's profile appears.
+	scoped, err := mr.Recommend(ctx, RecommendOpts{RequiredCaps: CapChat, RestrictToProvider: "ollama-a"})
+	if err != nil {
+		t.Fatalf("Recommend (scoped): %v", err)
+	}
+	if len(scoped) != 1 {
+		t.Fatalf("scoped len = %d, want 1", len(scoped))
+	}
+	if scoped[0].Key.Provider != "ollama-a" {
+		t.Errorf("scoped[0].Provider = %q, want ollama-a", scoped[0].Key.Provider)
+	}
+
+	// Scoped to a non-existent provider: surface the typo as a provider
+	// resolution error instead of silently degrading to an empty candidate set.
+	_, err = mr.Recommend(ctx, RecommendOpts{RequiredCaps: CapChat, RestrictToProvider: "nonexistent"})
+	if err == nil {
+		t.Fatal("Recommend (nonexistent) returned nil error, want provider resolution error")
+	}
+}

--- a/provider/router.go
+++ b/provider/router.go
@@ -403,6 +403,7 @@ func (r *Router) RecordWarmthUse(key ModelKey) {
 func (r *Router) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error) {
 	rr := RoutingRequest{
 		Model:    req.Model,
+		Provider: req.Provider,
 		UseCase:  "chat",
 		Messages: req.Messages,
 		Options:  req.Options,
@@ -426,6 +427,7 @@ func (r *Router) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, erro
 func (r *Router) ChatStream(ctx context.Context, req ChatRequest, fn func(ChatResponse) error) error {
 	rr := RoutingRequest{
 		Model:    req.Model,
+		Provider: req.Provider,
 		UseCase:  "chat",
 		Messages: req.Messages,
 		Options:  req.Options,
@@ -451,6 +453,7 @@ func (r *Router) ChatStream(ctx context.Context, req ChatRequest, fn func(ChatRe
 func (r *Router) Generate(ctx context.Context, req GenerateRequest) (*GenerateResponse, error) {
 	rr := RoutingRequest{
 		Model:        req.Model,
+		Provider:     req.Provider,
 		UseCase:      "generate",
 		Prompt:       req.Prompt,
 		System:       req.System,
@@ -476,6 +479,7 @@ func (r *Router) Generate(ctx context.Context, req GenerateRequest) (*GenerateRe
 func (r *Router) GenerateStream(ctx context.Context, req GenerateRequest, fn func(GenerateResponse) error) error {
 	rr := RoutingRequest{
 		Model:        req.Model,
+		Provider:     req.Provider,
 		UseCase:      "generate",
 		Prompt:       req.Prompt,
 		System:       req.System,
@@ -501,6 +505,7 @@ func (r *Router) GenerateStream(ctx context.Context, req GenerateRequest, fn fun
 func (r *Router) Embed(ctx context.Context, req EmbedRequest) (*EmbedResponse, error) {
 	rr := RoutingRequest{
 		Model:        req.Model,
+		Provider:     req.Provider,
 		UseCase:      "embedding",
 		Input:        req.Input,
 		RequiredCaps: CapEmbed,

--- a/provider/router.go
+++ b/provider/router.go
@@ -221,6 +221,20 @@ func (r *Router) Route(ctx context.Context, req RoutingRequest) (*RoutePlan, err
 	}
 	r.mu.RUnlock()
 
+	// Invariant: when PreferredChain is empty and the caller supplies BOTH
+	// a qualified Model ("provider/model") and a Provider field, the two
+	// must agree on provider identity. Mismatch is a caller-side bug — we
+	// reject loudly with ErrProviderMismatch rather than silently routing
+	// to one or the other. Under PreferredChain the chain selectors are
+	// authoritative and Provider is suppressed; see RoutingRequest.Provider
+	// docs and feedback_invariants_at_provider.
+	if len(req.PreferredChain) == 0 && req.Provider != "" {
+		if key, ok := parseModelSelector(req.Model); ok && key.Provider != req.Provider {
+			return nil, fmt.Errorf("%w: model selector %q conflicts with Provider %q",
+				ErrProviderMismatch, req.Model, req.Provider)
+		}
+	}
+
 	if len(req.PreferredChain) > 0 {
 		return r.routeChain(ctx, req)
 	}
@@ -533,6 +547,18 @@ func (r *Router) WarmthSnapshot() []WarmModel {
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
+
+// parseModelSelector parses a "provider/model" string into a ModelKey,
+// returning ok=false when the input is unqualified (no "/" separator).
+// Shared by Router.Route, Router.resolveCandidates, and the chain-routing
+// path so selector semantics cannot drift between them.
+func parseModelSelector(selector string) (ModelKey, bool) {
+	providerName, model, ok := strings.Cut(selector, "/")
+	if !ok {
+		return ModelKey{}, false
+	}
+	return ModelKey{Provider: providerName, Model: model}, true
+}
 
 // resolveCandidates resolves model profiles from the request's Model field.
 //   - Empty model: use Recommend with RequiredCaps and AvailableRAM

--- a/provider/router.go
+++ b/provider/router.go
@@ -560,22 +560,28 @@ func parseModelSelector(selector string) (ModelKey, bool) {
 	return ModelKey{Provider: providerName, Model: model}, true
 }
 
-// resolveCandidates resolves model profiles from the request's Model field.
-//   - Empty model: use Recommend with RequiredCaps and AvailableRAM
-//   - Contains "/": qualified lookup via ModelRegistry.Lookup
-//   - Otherwise: unqualified lookup via ModelRegistry.LookupAny
+// resolveCandidates resolves model profiles from the request's Model field,
+// optionally scoped by req.Provider to a specific provider instance:
+//   - Empty Model: use Recommend (scoped by Provider when non-empty)
+//   - Qualified Model ("provider/model"): Lookup by ModelKey
+//   - Unqualified Model + Provider set: Lookup by ModelKey{Provider, Model}
+//   - Unqualified Model + Provider empty: LookupAny across all providers
+//
+// The qualified-Model + non-empty Provider conflict case is rejected upstream
+// in Router.Route before this is called; by the time we reach the qualified
+// branch here, either req.Provider is empty or it agrees with the qualified
+// prefix, so we do not need to re-read req.Provider in that branch.
 func (r *Router) resolveCandidates(ctx context.Context, req RoutingRequest) ([]*ModelProfile, error) {
 	if req.Model == "" {
 		return r.registry.Recommend(ctx, RecommendOpts{
-			RequiredCaps: req.RequiredCaps,
-			AvailableRAM: r.availableRAM,
-			PreferWarm:   req.PreferWarm,
+			RequiredCaps:       req.RequiredCaps,
+			AvailableRAM:       r.availableRAM,
+			PreferWarm:         req.PreferWarm,
+			RestrictToProvider: req.Provider, // empty == unrestricted
 		})
 	}
 
-	if strings.Contains(req.Model, "/") {
-		parts := strings.SplitN(req.Model, "/", 2)
-		key := ModelKey{Provider: parts[0], Model: parts[1]}
+	if key, ok := parseModelSelector(req.Model); ok {
 		profile, err := r.registry.Lookup(ctx, key)
 		if err != nil {
 			return nil, err
@@ -583,6 +589,14 @@ func (r *Router) resolveCandidates(ctx context.Context, req RoutingRequest) ([]*
 		return []*ModelProfile{profile}, nil
 	}
 
+	if req.Provider != "" {
+		key := ModelKey{Provider: req.Provider, Model: req.Model}
+		profile, err := r.registry.Lookup(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+		return []*ModelProfile{profile}, nil
+	}
 	return r.registry.LookupAny(ctx, req.Model)
 }
 

--- a/provider/router_chain.go
+++ b/provider/router_chain.go
@@ -172,6 +172,14 @@ func (r *Router) recordChainLookupFailure(selector string, err error) {
 	if !ok {
 		return
 	}
+	// Guard against selectors like "/qwen3:8b" where parseModelSelector
+	// succeeds but the provider half is empty. Without this we would
+	// create and persist a breaker named "" in the breakers map — a
+	// phantom entry that surfaces in observability dumps and that no
+	// legitimate route could ever match.
+	if key.Provider == "" {
+		return
+	}
 	cb := r.getOrCreateBreaker(key.Provider)
 	cb.RecordFailure(err)
 }

--- a/provider/router_chain.go
+++ b/provider/router_chain.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"strings"
 )
 
 // routeChain is the chain-first counterpart to the global-scoring branch in
@@ -115,9 +114,7 @@ func (r *Router) routeChain(ctx context.Context, req RoutingRequest) (*RoutePlan
 // existing ModelRegistry.Lookup / LookupAny paths, mirroring the selector
 // semantics already implemented in Router.resolveCandidates.
 func (r *Router) resolveChainEntry(ctx context.Context, selector string) ([]*ModelProfile, error) {
-	if strings.Contains(selector, "/") {
-		parts := strings.SplitN(selector, "/", 2)
-		key := ModelKey{Provider: parts[0], Model: parts[1]}
+	if key, ok := parseModelSelector(selector); ok {
 		profile, err := r.registry.Lookup(ctx, key)
 		if err != nil {
 			return nil, err
@@ -171,11 +168,11 @@ func (r *Router) recordChainLookupFailure(selector string, err error) {
 	if !IsInfrastructureError(err) {
 		return
 	}
-	if !strings.Contains(selector, "/") {
+	key, ok := parseModelSelector(selector)
+	if !ok {
 		return
 	}
-	parts := strings.SplitN(selector, "/", 2)
-	cb := r.getOrCreateBreaker(parts[0])
+	cb := r.getOrCreateBreaker(key.Provider)
 	cb.RecordFailure(err)
 }
 

--- a/provider/router_errors.go
+++ b/provider/router_errors.go
@@ -35,6 +35,13 @@ var ErrBudgetExceeded = errors.New("router: budget exceeded")
 // ErrRouterClosed is returned when Route is called on a shut-down router.
 var ErrRouterClosed = errors.New("router: router is closed")
 
+// ErrProviderMismatch is returned when a RoutingRequest sets both a
+// provider-qualified Model (e.g. "ollama-a/qwen3:8b") and a Provider field
+// ("ollama-b") that disagree. This is a caller-side invariant violation and
+// is detected inside Router.Route before any candidate resolution to prevent
+// silently routing to the wrong provider instance.
+var ErrProviderMismatch = errors.New("router: provider mismatch between qualified model and Provider field")
+
 // ---------------------------------------------------------------------------
 // BreakerState
 // ---------------------------------------------------------------------------

--- a/provider/router_provider_aware_test.go
+++ b/provider/router_provider_aware_test.go
@@ -2,8 +2,107 @@ package provider
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 )
+
+// setupTwoProviderRouter wires a Router with two distinct provider instances,
+// each advertising overlapping model names so the Provider field is the only
+// thing that distinguishes them. Returns the router and both mock providers.
+func setupTwoProviderRouter(t *testing.T) (*Router, *rtMockProvider, *rtMockProvider) {
+	t.Helper()
+
+	provA := &rtMockProvider{
+		name: "ollama-a",
+		caps: CapChat | CapGenerate | CapEmbed | CapStream,
+		models: []ModelInfo{
+			{Name: "qwen3:8b", Family: "qwen3", ParameterSize: "8B", QuantLevel: "Q4_K_M", ContextWindow: 32768, Capabilities: []string{"completion"}},
+		},
+		chatResp:  &ChatResponse{Model: "qwen3:8b", Content: "from A", Done: true},
+		genResp:   &GenerateResponse{Model: "qwen3:8b", Response: "gen-from-A", Done: true},
+		embedResp: &EmbedResponse{Model: "qwen3:8b", Embeddings: [][]float64{{0.1, 0.2, 0.3}}, Provider: "ollama-a"},
+	}
+	provB := &rtMockProvider{
+		name: "ollama-b",
+		caps: CapChat | CapGenerate | CapEmbed | CapStream,
+		models: []ModelInfo{
+			{Name: "qwen3:8b", Family: "qwen3", ParameterSize: "8B", QuantLevel: "Q4_K_M", ContextWindow: 32768, Capabilities: []string{"completion"}},
+		},
+		chatResp:  &ChatResponse{Model: "qwen3:8b", Content: "from B", Done: true},
+		genResp:   &GenerateResponse{Model: "qwen3:8b", Response: "gen-from-B", Done: true},
+		embedResp: &EmbedResponse{Model: "qwen3:8b", Embeddings: [][]float64{{0.4, 0.5, 0.6}}, Provider: "ollama-b"},
+	}
+
+	reg := NewRegistry()
+	if err := reg.Register(provA); err != nil {
+		t.Fatalf("Register provA: %v", err)
+	}
+	if err := reg.Register(provB); err != nil {
+		t.Fatalf("Register provB: %v", err)
+	}
+	ctx := context.Background()
+	if err := reg.RefreshModels(ctx, "ollama-a"); err != nil {
+		t.Fatalf("RefreshModels a: %v", err)
+	}
+	if err := reg.RefreshModels(ctx, "ollama-b"); err != nil {
+		t.Fatalf("RefreshModels b: %v", err)
+	}
+
+	mr, err := NewModelRegistry(reg, nil)
+	if err != nil {
+		t.Fatalf("NewModelRegistry: %v", err)
+	}
+
+	router := NewRouter(mr, reg)
+	t.Cleanup(func() { _ = router.Close() })
+	return router, provA, provB
+}
+
+// TestRoute_QualifiedModel_ConflictingProviderRejected verifies that a
+// qualified Model whose provider prefix disagrees with the Provider field
+// returns ErrProviderMismatch with a message that names both identifiers,
+// rejected BEFORE candidate resolution. Uses "missing/..." as the qualified
+// prefix so any leak past the invariant check would surface as a Lookup
+// error rather than this specific sentinel.
+func TestRoute_QualifiedModel_ConflictingProviderRejected(t *testing.T) {
+	router, _, _ := setupTwoProviderRouter(t)
+
+	_, err := router.Route(context.Background(), RoutingRequest{
+		Model:        "missing/qwen3:8b",
+		Provider:     "ollama-b",
+		UseCase:      "chat",
+		RequiredCaps: CapChat,
+	})
+	if !errors.Is(err, ErrProviderMismatch) {
+		t.Fatalf("err = %v, want ErrProviderMismatch", err)
+	}
+	if !strings.Contains(err.Error(), "missing") || !strings.Contains(err.Error(), "ollama-b") {
+		t.Errorf("err message %q must name both provider identifiers", err.Error())
+	}
+}
+
+// TestRoute_PreferredChain_SuppressesProviderFilter verifies that a non-empty
+// PreferredChain makes the Provider field a no-op for conflict checking. The
+// chain selectors own provider identity; the per-request Provider hint must
+// not silently filter chain candidates.
+func TestRoute_PreferredChain_SuppressesProviderFilter(t *testing.T) {
+	router, _, _ := setupTwoProviderRouter(t)
+
+	plan, err := router.Route(context.Background(), RoutingRequest{
+		Model:          "ollama-a/qwen3:8b",
+		PreferredChain: []string{"ollama-a/qwen3:8b"},
+		Provider:       "ollama-b", // would conflict if checked, but chain wins
+		UseCase:        "chat",
+		RequiredCaps:   CapChat,
+	})
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if plan.Profile.Key.Provider != "ollama-a" {
+		t.Errorf("plan.Profile.Key.Provider = %q, want ollama-a", plan.Profile.Key.Provider)
+	}
+}
 
 // TestRoutingRequest_ProviderField_Preserved asserts that a RoutingRequest
 // carrying a Provider that matches the qualified Model routes successfully

--- a/provider/router_provider_aware_test.go
+++ b/provider/router_provider_aware_test.go
@@ -104,6 +104,69 @@ func TestRoute_PreferredChain_SuppressesProviderFilter(t *testing.T) {
 	}
 }
 
+// TestRoute_EmptyModel_ProviderScopesRecommend verifies that an empty Model
+// with a non-empty Provider restricts the Recommend candidate set to that
+// provider, even when another provider has capable models too.
+func TestRoute_EmptyModel_ProviderScopesRecommend(t *testing.T) {
+	router, _, _ := setupTwoProviderRouter(t)
+
+	plan, err := router.Route(context.Background(), RoutingRequest{
+		UseCase:      "chat",
+		Provider:     "ollama-b",
+		RequiredCaps: CapChat,
+	})
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if plan.Profile.Key.Provider != "ollama-b" {
+		t.Errorf("plan.Profile.Key.Provider = %q, want ollama-b", plan.Profile.Key.Provider)
+	}
+}
+
+// TestRoute_UnqualifiedModel_ProviderResolvesByKey verifies that an
+// unqualified Model with a Provider pins resolution to ModelKey{Provider,
+// Model} via Lookup, bypassing LookupAny's multi-provider scan. Pins
+// ollama-b specifically so it fails clearly before the provider-aware
+// implementation if Lookup-by-key is not used.
+func TestRoute_UnqualifiedModel_ProviderResolvesByKey(t *testing.T) {
+	router, _, _ := setupTwoProviderRouter(t)
+
+	plan, err := router.Route(context.Background(), RoutingRequest{
+		Model:        "qwen3:8b",
+		Provider:     "ollama-b",
+		UseCase:      "chat",
+		RequiredCaps: CapChat,
+	})
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if plan.Profile.Key.Provider != "ollama-b" {
+		t.Errorf("plan.Profile.Key.Provider = %q, want ollama-b", plan.Profile.Key.Provider)
+	}
+	if plan.Model != "qwen3:8b" {
+		t.Errorf("plan.Model = %q, want qwen3:8b", plan.Model)
+	}
+}
+
+// TestRoute_QualifiedModel_MatchingProviderAccepted verifies that a Provider
+// matching the qualified Model prefix is accepted (parity with qualified-only).
+func TestRoute_QualifiedModel_MatchingProviderAccepted(t *testing.T) {
+	router, _, _ := setupTwoProviderRouter(t)
+
+	plan, err := router.Route(context.Background(), RoutingRequest{
+		Model:        "ollama-a/qwen3:8b",
+		Provider:     "ollama-a",
+		UseCase:      "chat",
+		RequiredCaps: CapChat,
+	})
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if plan.Profile.Key.Provider != "ollama-a" {
+		t.Errorf("plan.Profile.Key.Provider = %q, want ollama-a", plan.Profile.Key.Provider)
+	}
+}
+
 // TestRoutingRequest_ProviderField_Preserved asserts that a RoutingRequest
 // carrying a Provider that matches the qualified Model routes successfully
 // (no error, no behavior change) — the field exists, is wired through, and

--- a/provider/router_provider_aware_test.go
+++ b/provider/router_provider_aware_test.go
@@ -188,14 +188,19 @@ func TestRecordChainLookupFailure_EmptyProviderSelectorIsNoOp(t *testing.T) {
 }
 
 // TestStickyKey_IncludesProvider verifies that two provider-scoped requests
-// with the same affinity/model/use-case get distinct sticky slots. Candidate
-// filtering prevents wrong routing either way, but without Provider in the
+// with the same affinity/model/use-case get distinct sticky slots, AND that
+// each slot's cached provider matches what the request pinned. Candidate
+// filtering alone prevents wrong routing, but without Provider in the
 // sticky key these requests churn the same sticky cache entry and lose
-// per-provider affinity.
+// per-provider affinity. Asserting both providers appear (not just that
+// the count is 2) catches the case where StickyKey starts separating
+// entries by something OTHER than Provider — a future regression that a
+// count-only check would miss.
 func TestStickyKey_IncludesProvider(t *testing.T) {
 	router, _, _ := setupTwoProviderRouter(t)
 
-	for _, providerName := range []string{"ollama-a", "ollama-b"} {
+	want := []string{"ollama-a", "ollama-b"}
+	for _, providerName := range want {
 		_, err := router.Route(context.Background(), RoutingRequest{
 			Model:        "qwen3:8b",
 			Provider:     providerName,
@@ -208,8 +213,19 @@ func TestStickyKey_IncludesProvider(t *testing.T) {
 		}
 	}
 
-	if got := len(router.StickyRoutes()); got != 2 {
+	routes := router.StickyRoutes()
+	if got := len(routes); got != 2 {
 		t.Fatalf("sticky route count = %d, want 2 provider-scoped entries", got)
+	}
+
+	seen := make(map[string]int, len(want))
+	for _, info := range routes {
+		seen[info.Key.Provider]++
+	}
+	for _, name := range want {
+		if seen[name] != 1 {
+			t.Errorf("sticky entry for provider %q: observed %d, want 1", name, seen[name])
+		}
 	}
 }
 

--- a/provider/router_provider_aware_test.go
+++ b/provider/router_provider_aware_test.go
@@ -167,6 +167,26 @@ func TestRoute_QualifiedModel_MatchingProviderAccepted(t *testing.T) {
 	}
 }
 
+// TestRecordChainLookupFailure_EmptyProviderSelectorIsNoOp verifies that a
+// malformed chain selector like "/qwen3:8b" — where parseModelSelector
+// succeeds but the provider half is empty — does NOT create a phantom
+// breaker named "" in the breakers map. The infrastructure-error path
+// that would reach this guard is not currently triggered by chain routing
+// (Registry.Register rejects providers with empty names, so Resolve always
+// returns a non-infrastructure "not found" error for empty Provider), but
+// the guard documents the invariant "no breakers keyed by empty strings"
+// and prevents a regression if the upstream error-classification changes.
+func TestRecordChainLookupFailure_EmptyProviderSelectorIsNoOp(t *testing.T) {
+	router, _, _ := setupTwoProviderRouter(t)
+
+	infra := &HTTPStatusError{StatusCode: 503, Status: "503 Service Unavailable"}
+	router.recordChainLookupFailure("/qwen3:8b", infra)
+
+	if _, ok := router.BreakerInfo(""); ok {
+		t.Errorf("phantom breaker created for empty provider name; want no entry")
+	}
+}
+
 // TestStickyKey_IncludesProvider verifies that two provider-scoped requests
 // with the same affinity/model/use-case get distinct sticky slots. Candidate
 // filtering prevents wrong routing either way, but without Provider in the

--- a/provider/router_provider_aware_test.go
+++ b/provider/router_provider_aware_test.go
@@ -167,6 +167,32 @@ func TestRoute_QualifiedModel_MatchingProviderAccepted(t *testing.T) {
 	}
 }
 
+// TestStickyKey_IncludesProvider verifies that two provider-scoped requests
+// with the same affinity/model/use-case get distinct sticky slots. Candidate
+// filtering prevents wrong routing either way, but without Provider in the
+// sticky key these requests churn the same sticky cache entry and lose
+// per-provider affinity.
+func TestStickyKey_IncludesProvider(t *testing.T) {
+	router, _, _ := setupTwoProviderRouter(t)
+
+	for _, providerName := range []string{"ollama-a", "ollama-b"} {
+		_, err := router.Route(context.Background(), RoutingRequest{
+			Model:        "qwen3:8b",
+			Provider:     providerName,
+			AffinityKey:  "session-1",
+			UseCase:      "chat",
+			RequiredCaps: CapChat,
+		})
+		if err != nil {
+			t.Fatalf("Route(%s): %v", providerName, err)
+		}
+	}
+
+	if got := len(router.StickyRoutes()); got != 2 {
+		t.Fatalf("sticky route count = %d, want 2 provider-scoped entries", got)
+	}
+}
+
 // TestRoutingRequest_ProviderField_Preserved asserts that a RoutingRequest
 // carrying a Provider that matches the qualified Model routes successfully
 // (no error, no behavior change) — the field exists, is wired through, and

--- a/provider/router_provider_aware_test.go
+++ b/provider/router_provider_aware_test.go
@@ -1,0 +1,26 @@
+package provider
+
+import (
+	"context"
+	"testing"
+)
+
+// TestRoutingRequest_ProviderField_Preserved asserts that a RoutingRequest
+// carrying a Provider that matches the qualified Model routes successfully
+// (no error, no behavior change) — the field exists, is wired through, and
+// does not break the existing qualified-Model path.
+func TestRoutingRequest_ProviderField_Preserved(t *testing.T) {
+	router, _ := setupTestRouter(t)
+
+	plan, err := router.Route(context.Background(), RoutingRequest{
+		Model:    "test/qwen3:8b",
+		Provider: "test",
+		UseCase:  "chat",
+	})
+	if err != nil {
+		t.Fatalf("Route returned error: %v", err)
+	}
+	if plan.Profile.Key.Provider != "test" {
+		t.Errorf("plan.Profile.Key.Provider = %q, want %q", plan.Profile.Key.Provider, "test")
+	}
+}

--- a/provider/router_provider_aware_test.go
+++ b/provider/router_provider_aware_test.go
@@ -324,6 +324,108 @@ func TestEmbed_ProviderForwarded(t *testing.T) {
 	}
 }
 
+// TestRoute_ProviderMatrix is the table-driven contract test consolidating
+// every (Model × Provider × PreferredChain) combination Router.Route must
+// honor. New scoping cases land here, not in scattered tests.
+func TestRoute_ProviderMatrix(t *testing.T) {
+	cases := []struct {
+		name        string
+		model       string
+		provider    string
+		chain       []string
+		wantProv    string
+		wantErrSent error // nil for success, otherwise errors.Is target
+	}{
+		{
+			name:     "empty_model_empty_provider_picks_any",
+			model:    "",
+			provider: "",
+			wantProv: "", // either; assert via err==nil only
+		},
+		{
+			name:     "empty_model_provider_set_scopes_recommend",
+			model:    "",
+			provider: "ollama-b",
+			wantProv: "ollama-b",
+		},
+		{
+			name:     "unqualified_model_empty_provider_lookupany",
+			model:    "qwen3:8b",
+			provider: "",
+			wantProv: "", // either; assert via err==nil only
+		},
+		{
+			name:     "unqualified_model_provider_set_pins_lookup",
+			model:    "qwen3:8b",
+			provider: "ollama-a",
+			wantProv: "ollama-a",
+		},
+		{
+			name:     "qualified_model_empty_provider_unchanged",
+			model:    "ollama-b/qwen3:8b",
+			provider: "",
+			wantProv: "ollama-b",
+		},
+		{
+			name:     "qualified_model_matching_provider_accepted",
+			model:    "ollama-a/qwen3:8b",
+			provider: "ollama-a",
+			wantProv: "ollama-a",
+		},
+		{
+			name:        "qualified_model_conflicting_provider_rejected",
+			model:       "ollama-a/qwen3:8b",
+			provider:    "ollama-b",
+			wantErrSent: ErrProviderMismatch,
+		},
+		{
+			name:     "chain_set_provider_ignored_no_conflict_error",
+			model:    "ollama-a/qwen3:8b",
+			provider: "ollama-b",
+			chain:    []string{"ollama-a/qwen3:8b"},
+			wantProv: "ollama-a",
+		},
+		{
+			name:     "chain_set_empty_model_provider_still_ignored",
+			model:    "",
+			provider: "ollama-b",
+			chain:    []string{"ollama-a/qwen3:8b"},
+			wantProv: "ollama-a",
+		},
+		{
+			name:     "chain_recommend_tail_ignores_provider",
+			model:    "",
+			provider: "nonexistent",
+			chain:    []string{"missing/qwen3:8b"},
+			wantProv: "ollama-a", // non-strict tail is unrestricted by Provider
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			router, _, _ := setupTwoProviderRouter(t)
+			plan, err := router.Route(context.Background(), RoutingRequest{
+				Model:          tc.model,
+				Provider:       tc.provider,
+				PreferredChain: tc.chain,
+				UseCase:        "chat",
+				RequiredCaps:   CapChat,
+			})
+			if tc.wantErrSent != nil {
+				if !errors.Is(err, tc.wantErrSent) {
+					t.Fatalf("err = %v, want errors.Is(%v)", err, tc.wantErrSent)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Route: %v", err)
+			}
+			if tc.wantProv != "" && plan.Profile.Key.Provider != tc.wantProv {
+				t.Errorf("plan.Profile.Key.Provider = %q, want %q", plan.Profile.Key.Provider, tc.wantProv)
+			}
+		})
+	}
+}
+
 // TestRoutingRequest_ProviderField_Preserved asserts that a RoutingRequest
 // carrying a Provider that matches the qualified Model routes successfully
 // (no error, no behavior change) — the field exists, is wired through, and

--- a/provider/router_provider_aware_test.go
+++ b/provider/router_provider_aware_test.go
@@ -17,7 +17,7 @@ func setupTwoProviderRouter(t *testing.T) (*Router, *rtMockProvider, *rtMockProv
 		name: "ollama-a",
 		caps: CapChat | CapGenerate | CapEmbed | CapStream,
 		models: []ModelInfo{
-			{Name: "qwen3:8b", Family: "qwen3", ParameterSize: "8B", QuantLevel: "Q4_K_M", ContextWindow: 32768, Capabilities: []string{"completion"}},
+			{Name: "qwen3:8b", Family: "qwen3", ParameterSize: "8B", QuantLevel: "Q4_K_M", ContextWindow: 32768, Capabilities: []string{"completion", "embedding"}},
 		},
 		chatResp:  &ChatResponse{Model: "qwen3:8b", Content: "from A", Done: true},
 		genResp:   &GenerateResponse{Model: "qwen3:8b", Response: "gen-from-A", Done: true},
@@ -27,7 +27,7 @@ func setupTwoProviderRouter(t *testing.T) (*Router, *rtMockProvider, *rtMockProv
 		name: "ollama-b",
 		caps: CapChat | CapGenerate | CapEmbed | CapStream,
 		models: []ModelInfo{
-			{Name: "qwen3:8b", Family: "qwen3", ParameterSize: "8B", QuantLevel: "Q4_K_M", ContextWindow: 32768, Capabilities: []string{"completion"}},
+			{Name: "qwen3:8b", Family: "qwen3", ParameterSize: "8B", QuantLevel: "Q4_K_M", ContextWindow: 32768, Capabilities: []string{"completion", "embedding"}},
 		},
 		chatResp:  &ChatResponse{Model: "qwen3:8b", Content: "from B", Done: true},
 		genResp:   &GenerateResponse{Model: "qwen3:8b", Response: "gen-from-B", Done: true},
@@ -190,6 +190,137 @@ func TestStickyKey_IncludesProvider(t *testing.T) {
 
 	if got := len(router.StickyRoutes()); got != 2 {
 		t.Fatalf("sticky route count = %d, want 2 provider-scoped entries", got)
+	}
+}
+
+// TestChat_ProviderForwarded verifies that ChatRequest.Provider is forwarded
+// into the routing request so that the Chat convenience method honors the
+// per-request provider pin. Uses two providers with the same model name and
+// asserts the response content matches the pinned provider's mock content
+// AND that Provider was NOT stamped onto the concrete execution request
+// (the provider already knows its identity by the time Chat is called).
+func TestChat_ProviderForwarded(t *testing.T) {
+	router, _, provB := setupTwoProviderRouter(t)
+
+	resp, err := router.Chat(context.Background(), ChatRequest{
+		Model:    "qwen3:8b",
+		Provider: "ollama-b",
+		Messages: []ChatMessage{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Content != "from B" {
+		t.Errorf("resp.Content = %q, want %q (provB pinned)", resp.Content, "from B")
+	}
+	if provB.getChatCalls() != 1 {
+		t.Errorf("provB.chatCalls = %d, want 1", provB.getChatCalls())
+	}
+	if got := provB.getLastChatRequest().Provider; got != "" {
+		t.Errorf("executed ChatRequest.Provider = %q, want empty (selection metadata must not be forwarded)", got)
+	}
+}
+
+// TestChatStream_ProviderForwarded mirrors TestChat_ProviderForwarded for
+// the streaming Chat convenience method.
+func TestChatStream_ProviderForwarded(t *testing.T) {
+	router, _, provB := setupTwoProviderRouter(t)
+
+	var got ChatResponse
+	err := router.ChatStream(context.Background(), ChatRequest{
+		Model:    "qwen3:8b",
+		Provider: "ollama-b",
+		Messages: []ChatMessage{{Role: "user", Content: "hi"}},
+	}, func(resp ChatResponse) error {
+		got = resp
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ChatStream: %v", err)
+	}
+	if got.Content != "from B" {
+		t.Errorf("stream content = %q, want %q", got.Content, "from B")
+	}
+	if provB.getChatCalls() != 1 {
+		t.Errorf("provB.chatCalls = %d, want 1", provB.getChatCalls())
+	}
+	if got := provB.getLastChatRequest().Provider; got != "" {
+		t.Errorf("executed ChatStream request Provider = %q, want empty", got)
+	}
+}
+
+// TestGenerate_ProviderForwarded mirrors TestChat_ProviderForwarded for
+// the Generate convenience method.
+func TestGenerate_ProviderForwarded(t *testing.T) {
+	router, _, provB := setupTwoProviderRouter(t)
+
+	resp, err := router.Generate(context.Background(), GenerateRequest{
+		Model:    "qwen3:8b",
+		Provider: "ollama-b",
+		Prompt:   "hi",
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if resp.Response != "gen-from-B" {
+		t.Errorf("resp.Response = %q, want %q", resp.Response, "gen-from-B")
+	}
+	if provB.getGenCalls() != 1 {
+		t.Errorf("provB.genCalls = %d, want 1", provB.getGenCalls())
+	}
+	if got := provB.getLastGenerateRequest().Provider; got != "" {
+		t.Errorf("executed GenerateRequest.Provider = %q, want empty (selection metadata must not be forwarded)", got)
+	}
+}
+
+// TestGenerateStream_ProviderForwarded mirrors TestGenerate_ProviderForwarded
+// for the streaming Generate convenience method.
+func TestGenerateStream_ProviderForwarded(t *testing.T) {
+	router, _, provB := setupTwoProviderRouter(t)
+
+	var got GenerateResponse
+	err := router.GenerateStream(context.Background(), GenerateRequest{
+		Model:    "qwen3:8b",
+		Provider: "ollama-b",
+		Prompt:   "hi",
+	}, func(resp GenerateResponse) error {
+		got = resp
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("GenerateStream: %v", err)
+	}
+	if got.Response != "gen-from-B" {
+		t.Errorf("stream response = %q, want %q", got.Response, "gen-from-B")
+	}
+	if provB.getGenCalls() != 1 {
+		t.Errorf("provB.genCalls = %d, want 1", provB.getGenCalls())
+	}
+	if got := provB.getLastGenerateRequest().Provider; got != "" {
+		t.Errorf("executed GenerateStream request Provider = %q, want empty", got)
+	}
+}
+
+// TestEmbed_ProviderForwarded mirrors the others for Embed.
+func TestEmbed_ProviderForwarded(t *testing.T) {
+	router, _, provB := setupTwoProviderRouter(t)
+
+	resp, err := router.Embed(context.Background(), EmbedRequest{
+		Model:    "qwen3:8b",
+		Provider: "ollama-b",
+		Input:    []string{"x"},
+	})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if resp.Provider != "ollama-b" {
+		t.Errorf("resp.Provider = %q, want ollama-b", resp.Provider)
+	}
+	if provB.getEmbedCalls() != 1 {
+		t.Errorf("provB.embedCalls = %d, want 1", provB.getEmbedCalls())
+	}
+	if got := provB.getLastEmbedRequest().Provider; got != "" {
+		t.Errorf("executed EmbedRequest.Provider = %q, want empty (selection metadata must not be forwarded)", got)
 	}
 }
 

--- a/provider/router_test.go
+++ b/provider/router_test.go
@@ -28,10 +28,13 @@ type rtMockProvider struct {
 	embedErr  error
 	healthErr error
 
-	mu        sync.Mutex
-	chatCalls int
-	genCalls  int
-	embedCalls int
+	mu           sync.Mutex
+	chatCalls    int
+	genCalls     int
+	embedCalls   int
+	lastChatReq  ChatRequest
+	lastGenReq   GenerateRequest
+	lastEmbedReq EmbedRequest
 }
 
 func (m *rtMockProvider) Name() string             { return m.name }
@@ -41,9 +44,10 @@ func (m *rtMockProvider) Models(_ context.Context) ([]ModelInfo, error) {
 	return m.models, nil
 }
 
-func (m *rtMockProvider) Chat(_ context.Context, _ ChatRequest) (*ChatResponse, error) {
+func (m *rtMockProvider) Chat(_ context.Context, req ChatRequest) (*ChatResponse, error) {
 	m.mu.Lock()
 	m.chatCalls++
+	m.lastChatReq = req
 	m.mu.Unlock()
 	if m.chatErr != nil {
 		return nil, m.chatErr
@@ -52,9 +56,10 @@ func (m *rtMockProvider) Chat(_ context.Context, _ ChatRequest) (*ChatResponse, 
 	return &resp, nil
 }
 
-func (m *rtMockProvider) ChatStream(_ context.Context, _ ChatRequest, fn func(ChatResponse) error) error {
+func (m *rtMockProvider) ChatStream(_ context.Context, req ChatRequest, fn func(ChatResponse) error) error {
 	m.mu.Lock()
 	m.chatCalls++
+	m.lastChatReq = req
 	m.mu.Unlock()
 	if m.chatErr != nil {
 		return m.chatErr
@@ -62,9 +67,10 @@ func (m *rtMockProvider) ChatStream(_ context.Context, _ ChatRequest, fn func(Ch
 	return fn(ChatResponse{Model: m.chatResp.Model, Content: m.chatResp.Content, Done: true})
 }
 
-func (m *rtMockProvider) Generate(_ context.Context, _ GenerateRequest) (*GenerateResponse, error) {
+func (m *rtMockProvider) Generate(_ context.Context, req GenerateRequest) (*GenerateResponse, error) {
 	m.mu.Lock()
 	m.genCalls++
+	m.lastGenReq = req
 	m.mu.Unlock()
 	if m.genErr != nil {
 		return nil, m.genErr
@@ -73,9 +79,10 @@ func (m *rtMockProvider) Generate(_ context.Context, _ GenerateRequest) (*Genera
 	return &resp, nil
 }
 
-func (m *rtMockProvider) GenerateStream(_ context.Context, _ GenerateRequest, fn func(GenerateResponse) error) error {
+func (m *rtMockProvider) GenerateStream(_ context.Context, req GenerateRequest, fn func(GenerateResponse) error) error {
 	m.mu.Lock()
 	m.genCalls++
+	m.lastGenReq = req
 	m.mu.Unlock()
 	if m.genErr != nil {
 		return m.genErr
@@ -83,9 +90,10 @@ func (m *rtMockProvider) GenerateStream(_ context.Context, _ GenerateRequest, fn
 	return fn(GenerateResponse{Model: m.genResp.Model, Response: m.genResp.Response, Done: true})
 }
 
-func (m *rtMockProvider) Embed(_ context.Context, _ EmbedRequest) (*EmbedResponse, error) {
+func (m *rtMockProvider) Embed(_ context.Context, req EmbedRequest) (*EmbedResponse, error) {
 	m.mu.Lock()
 	m.embedCalls++
+	m.lastEmbedReq = req
 	m.mu.Unlock()
 	if m.embedErr != nil {
 		return nil, m.embedErr
@@ -98,6 +106,36 @@ func (m *rtMockProvider) getChatCalls() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.chatCalls
+}
+
+func (m *rtMockProvider) getGenCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.genCalls
+}
+
+func (m *rtMockProvider) getEmbedCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.embedCalls
+}
+
+func (m *rtMockProvider) getLastChatRequest() ChatRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastChatReq
+}
+
+func (m *rtMockProvider) getLastGenerateRequest() GenerateRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastGenReq
+}
+
+func (m *rtMockProvider) getLastEmbedRequest() EmbedRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastEmbedReq
 }
 
 // ---------------------------------------------------------------------------

--- a/provider/router_test.go
+++ b/provider/router_test.go
@@ -37,8 +37,8 @@ type rtMockProvider struct {
 	lastEmbedReq EmbedRequest
 }
 
-func (m *rtMockProvider) Name() string             { return m.name }
-func (m *rtMockProvider) Capabilities() Capability { return m.caps }
+func (m *rtMockProvider) Name() string                   { return m.name }
+func (m *rtMockProvider) Capabilities() Capability       { return m.caps }
 func (m *rtMockProvider) Health(_ context.Context) error { return m.healthErr }
 func (m *rtMockProvider) Models(_ context.Context) ([]ModelInfo, error) {
 	return m.models, nil

--- a/provider/routing_request.go
+++ b/provider/routing_request.go
@@ -125,6 +125,32 @@ type RoutingRequest struct {
 	// the chain-first router otherwise appends when every chain entry is
 	// gated out. Has no effect when PreferredChain is empty.
 	StrictChain bool
+	// Provider scopes routing to a specific provider *instance* (the
+	// config-time name, e.g. "ollama-local-a", "vllm-prod-1"), enforced as
+	// a hard pre-score filter rather than a scoring boost:
+	//
+	//   Model == "" && Provider != ""        → Recommend is restricted to
+	//                                           profiles owned by Provider.
+	//   unqualified Model && Provider != ""  → Lookup uses ModelKey{Provider,
+	//                                           Model} directly.
+	//   qualified Model && Provider == ""    → unchanged (current behavior).
+	//   qualified Model && Provider != ""    → must agree with the qualified
+	//                                           prefix; mismatch returns
+	//                                           ErrProviderMismatch from
+	//                                           Router.Route before candidate
+	//                                           resolution.
+	//
+	// When PreferredChain is non-empty, Provider is IGNORED: chain selectors
+	// carry their own provider identity and authoritative ordering, and the
+	// chain-first path (including its non-strict Recommend tail) must not be
+	// silently scope-narrowed by a per-request hint. This matches the
+	// "invariants enforced inside Router, not via caller convention" pattern
+	// from feedback_invariants_at_provider.
+	//
+	// Provider also participates in StickyKey derivation so two scoped
+	// requests with identical affinity/model/use-case keep independent
+	// sticky entries (scoping by Provider implies separate affinity slots).
+	Provider string
 	// DryRun, when true, returns the routing decision without executing the request.
 	DryRun bool
 }

--- a/provider/routing_request.go
+++ b/provider/routing_request.go
@@ -147,9 +147,12 @@ type RoutingRequest struct {
 	// "invariants enforced inside Router, not via caller convention" pattern
 	// from feedback_invariants_at_provider.
 	//
-	// Provider also participates in StickyKey derivation so two scoped
-	// requests with identical affinity/model/use-case keep independent
-	// sticky entries (scoping by Provider implies separate affinity slots).
+	// Provider participates in StickyKey derivation on the non-chain path
+	// so two scoped requests with identical affinity/model/use-case keep
+	// independent sticky entries (scoping by Provider implies separate
+	// affinity slots). Chain routes are unconditionally non-sticky (see
+	// router_chain.go), so StickyKey is not invoked under PreferredChain
+	// regardless of whether Provider is set.
 	Provider string
 	// DryRun, when true, returns the routing decision without executing the request.
 	DryRun bool

--- a/provider/routing_request.go
+++ b/provider/routing_request.go
@@ -225,6 +225,16 @@ func outputBudgetClass(tokens int) string {
 // Including Provider ensures that scoped requests (RoutingRequest.Provider
 // pinning two distinct instances with the same model name) keep independent
 // sticky entries rather than churning a shared slot.
+//
+// The Provider segment uses a NUL byte separator rather than the "|" used
+// for legacy fields. Provider names come from unvalidated config map keys
+// and could in principle contain "|"; NUL ("\x00") cannot appear in a Go
+// string typed by a user and so cannot collide with future "|"-delimited
+// segments. AffinityKey, Model, UseCase, and budget classes share the same
+// "|"-delimited risk; their collision surface is bounded by Go's string
+// type accepting NUL but config and user input rarely producing it. The
+// Provider-segment hardening is the cheap win where the threat model has
+// shifted with the new code path.
 func StickyKey(req RoutingRequest) string {
 	expectedOut := req.ExpectedOutput
 	if expectedOut == 0 {
@@ -248,7 +258,11 @@ func StickyKey(req RoutingRequest) string {
 		// Appended conditionally so requests that do not set Provider keep
 		// byte-identical sticky keys to the pre-Provider behavior — this
 		// preserves any existing affinity warmth from prior sessions.
-		data += "|provider=" + req.Provider
+		//
+		// "\x00provider=" prevents a future appended segment from sharing
+		// a separator with a user-supplied Provider name that happens to
+		// contain "|" or "provider=".
+		data += "\x00provider=" + req.Provider
 	}
 
 	hash := sha256.Sum256([]byte(data))

--- a/provider/routing_request.go
+++ b/provider/routing_request.go
@@ -218,7 +218,10 @@ func outputBudgetClass(tokens int) string {
 // session affinity and cache reuse.
 //
 // The key is derived from: affinity_key, model, use_case, required_caps,
-// priority, input budget class, and output budget class.
+// priority, input budget class, output budget class, and Provider when set.
+// Including Provider ensures that scoped requests (RoutingRequest.Provider
+// pinning two distinct instances with the same model name) keep independent
+// sticky entries rather than churning a shared slot.
 func StickyKey(req RoutingRequest) string {
 	expectedOut := req.ExpectedOutput
 	if expectedOut == 0 {
@@ -238,6 +241,12 @@ func StickyKey(req RoutingRequest) string {
 		inClass,
 		outClass,
 	)
+	if req.Provider != "" {
+		// Appended conditionally so requests that do not set Provider keep
+		// byte-identical sticky keys to the pre-Provider behavior — this
+		// preserves any existing affinity warmth from prior sessions.
+		data += "|provider=" + req.Provider
+	}
 
 	hash := sha256.Sum256([]byte(data))
 	// Return first 128 bits (16 bytes) as hex.

--- a/provider/types.go
+++ b/provider/types.go
@@ -171,8 +171,16 @@ type ToolCallFunction struct {
 }
 
 // ChatRequest is the provider-agnostic request for a chat completion.
+//
+// Provider, when non-empty, pins router selection to a specific provider
+// *instance*. It is router selection metadata only: Router.Chat / ChatStream
+// copy it into RoutingRequest.Provider and do NOT forward it to the
+// concrete provider's execution call (the provider already knows its own
+// identity by the time it is invoked). Empty preserves today's behavior and
+// is omitted from JSON.
 type ChatRequest struct {
 	Model    string        `json:"model"`
+	Provider string        `json:"provider,omitempty"`
 	Messages []ChatMessage `json:"messages"`
 	Options  ModelOptions  `json:"options,omitempty"`
 	Tools    []Tool        `json:"tools,omitempty"`
@@ -198,13 +206,18 @@ type ChatResponse struct {
 // ---------------------------------------------------------------------------
 
 // GenerateRequest is the provider-agnostic request for raw text generation.
+//
+// Provider, when non-empty, pins router selection to a specific provider
+// *instance*. Router selection metadata only — see ChatRequest.Provider for
+// the contract; behavior is identical for Generate / GenerateStream.
 type GenerateRequest struct {
-	Model   string       `json:"model"`
-	Prompt  string       `json:"prompt"`
-	System  string       `json:"system,omitempty"`
-	Suffix  string       `json:"suffix,omitempty"` // presence triggers FIM mode
-	Options ModelOptions `json:"options,omitempty"`
-	Stream  bool         `json:"stream"`
+	Model    string       `json:"model"`
+	Provider string       `json:"provider,omitempty"`
+	Prompt   string       `json:"prompt"`
+	System   string       `json:"system,omitempty"`
+	Suffix   string       `json:"suffix,omitempty"` // presence triggers FIM mode
+	Options  ModelOptions `json:"options,omitempty"`
+	Stream   bool         `json:"stream"`
 }
 
 // GenerateResponse is the provider-agnostic response from text generation.
@@ -225,9 +238,13 @@ type GenerateResponse struct {
 // ---------------------------------------------------------------------------
 
 // EmbedRequest is the provider-agnostic request for embedding generation.
+//
+// Provider, when non-empty, pins router selection to a specific provider
+// *instance*. Router selection metadata only — see ChatRequest.Provider.
 type EmbedRequest struct {
-	Model string   `json:"model"`
-	Input []string `json:"input"`
+	Model    string   `json:"model"`
+	Provider string   `json:"provider,omitempty"`
+	Input    []string `json:"input"`
 }
 
 // EmbedResponse is the provider-agnostic response from embedding generation.


### PR DESCRIPTION
## Summary

- Adds `RoutingRequest.Provider` as a structured pre-score filter that hard-scopes routing to a specific provider *instance* (e.g. `ollama-local-a`, `vllm-prod-1`), with four documented permutations against `Model` and a strict conflict invariant for qualified-`Model` + non-matching `Provider` (new `ErrProviderMismatch` sentinel).
- Adds matching `Provider` fields on `ChatRequest` / `GenerateRequest` / `EmbedRequest` (JSON `provider,omitempty`) so callers holding a `config.ResolvedModel` can pin both `Name` and `Provider` through the convenience methods without dropping down to `RoutingRequest`. The field is router selection metadata only — never stamped onto the concrete provider's execution call.
- Adds `RecommendOpts.RestrictToProvider` as a hard filter that builds candidate profiles from the named provider only (does not probe unrelated providers), distinct from the still-unused soft `PreferredProviders`. Unknown provider names surface as resolution errors, not silent empty results.
- Separates `StickyKey` derivation by `Provider` (with `\x00` separator) so scoped requests targeting two instances of the same model keep independent affinity slots. Empty `Provider` produces byte-identical keys to the pre-change behavior.
- Centralises selector parsing into a shared `parseModelSelector` used by `Router.Route`, `Router.resolveCandidates`, and the chain-routing path so semantics cannot drift; closes a latent phantom-breaker leak in `recordChainLookupFailure` for malformed `"/model"` selectors.

Closes PR3 of the four-PR `#81` series (PR1 = `WithProviderName` + `ModelConfig.Capabilities` + `ResolvedModel.Provider`; PR2 = `provider/openaicompat`; PR3 = this; PR4 = MCP wiring of the non-chain explicit-model code paths).

## Test plan

- [x] `go test -race ./...` — all packages pass
- [x] `go vet ./...` — no warnings
- [x] `gofmt -l` on all modified Go files — clean
- [x] `TestRoute_ProviderMatrix` exercises the full 10-cell `(Model × Provider × PreferredChain)` matrix as a single table-driven contract test
- [x] `TestStickyKey_IncludesProvider` asserts both pinned providers appear in `StickyRoutes()` (not merely a count of 2) to guard against future regressions where sticky entries get separated by something other than `Provider`
- [x] `TestRecordChainLookupFailure_EmptyProviderSelectorIsNoOp` regression test confirmed catches the phantom-breaker leak by temporarily reverting the guard
- [x] Five convenience-method forwarding tests verify the pinned provider receives the call AND that `Provider` is NOT stamped onto the executed request
- [x] Reviewer: spot-check `CHANGELOG.md` migration guidance for external consumers (Firn IDE, Flux ML, Quantum Trader) — keyed literals are additive-compatible, unkeyed positional literals fail to compile and need adjustment
- [x] Reviewer: confirm `Provider` field placement after `Model` matches the existing `ChatResponse.Provider` convention

## Commit shape

12 atomic commits — 7 implementation, 3 from `/code-review` (doc clarity + gofmt cleanup), 2 from `/criticize-review` (breaker-name guard + StickyKey NUL separator hardening). Each commit is green on its own; bisect-safe.