### PR TITLE
[codex] feat(mcp): wire OpenAI-compatible provider config

### DIFF
--- a/config/candidates.go
+++ b/config/candidates.go
@@ -10,6 +10,7 @@ import (
 // CandidateModel is one entry in a fully enumerated list of all available
 // models for a use-case, ordered by config preference.
 type CandidateModel struct {
+	Provider   string // the provider instance owning the model
 	Name       string // the model name (e.g. "qwen3.5:27b")
 	Role       string // the config role this model belongs to (e.g. "general")
 	IsFallback bool   // true if reached via fallback chain, not the primary role
@@ -33,12 +34,11 @@ func (c *Config) ResolveCandidates(ctx context.Context, checker ModelChecker, us
 		return nil, fmt.Errorf("config: unknown use-case %q", useCase)
 	}
 
-	models, err := checker.AvailableModels(ctx)
+	available, err := availableModels(ctx, checker)
 	if err != nil {
 		return nil, fmt.Errorf("config: checking available models: %w", err)
 	}
 
-	available := toSet(models)
 	visited := make(map[string]bool)
 	candidates := make([]CandidateModel, 0)
 	if err := c.collectCandidates(role, available, visited, false, &candidates); err != nil {
@@ -52,7 +52,7 @@ func (c *Config) ResolveCandidates(ctx context.Context, checker ModelChecker, us
 // matches (unlike resolveRole which short-circuits). The visited set prevents
 // both circular fallbacks and duplicate entries in diamond-shaped graphs
 // (e.g. a→b→d, a→c→d — d appears once, from whichever branch reaches it first).
-func (c *Config) collectCandidates(role string, available, visited map[string]bool, isFallback bool, candidates *[]CandidateModel) error {
+func (c *Config) collectCandidates(role string, available modelAvailability, visited map[string]bool, isFallback bool, candidates *[]CandidateModel) error {
 	if visited[role] {
 		return nil // already visited (cycle or diamond) — skip
 	}
@@ -63,8 +63,13 @@ func (c *Config) collectCandidates(role string, available, visited map[string]bo
 	}
 	visited[role] = true
 
-	if available[m.Name] {
+	if m.Provider == "" {
+		return fmt.Errorf("config: role %q has empty provider; use config.Load to materialize defaults or set ModelConfig.Provider explicitly", role)
+	}
+
+	if available.has(m.Provider, m.Name) {
 		*candidates = append(*candidates, CandidateModel{
+			Provider:   m.Provider,
 			Name:       m.Name,
 			Role:       role,
 			IsFallback: isFallback,

--- a/config/candidates_test.go
+++ b/config/candidates_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"testing"
+
+	"github.com/kstruzzieri/go-llm/provider"
 )
 
 func TestResolveCandidates_PrimaryOnly(t *testing.T) {
@@ -20,6 +22,9 @@ func TestResolveCandidates_PrimaryOnly(t *testing.T) {
 	}
 	if got[0].Name != "qwen3-embedding:8b" {
 		t.Errorf("Name = %q, want %q", got[0].Name, "qwen3-embedding:8b")
+	}
+	if got[0].Provider != "ollama" {
+		t.Errorf("Provider = %q, want %q", got[0].Provider, "ollama")
 	}
 	if got[0].Role != "embedding" {
 		t.Errorf("Role = %q, want %q", got[0].Role, "embedding")
@@ -155,7 +160,7 @@ func TestResolveCandidates_UnknownUseCase(t *testing.T) {
 func TestResolveCandidates_UnknownDefaultRole(t *testing.T) {
 	cfg := &Config{
 		Models: map[string]ModelConfig{
-			"a": {Name: "model-a"},
+			"a": {Name: "model-a", Provider: "ollama"},
 		},
 		Defaults: map[string]string{
 			"test": "missing",
@@ -175,7 +180,7 @@ func TestResolveCandidates_UnknownDefaultRole(t *testing.T) {
 func TestResolveCandidates_UnknownFallbackRole(t *testing.T) {
 	cfg := &Config{
 		Models: map[string]ModelConfig{
-			"a": {Name: "model-a", Fallbacks: []string{"missing"}},
+			"a": {Name: "model-a", Provider: "ollama", Fallbacks: []string{"missing"}},
 		},
 		Defaults: map[string]string{
 			"test": "a",
@@ -216,8 +221,8 @@ func TestResolveCandidates_CheckerError(t *testing.T) {
 func TestResolveCandidates_CircularFallback(t *testing.T) {
 	cfg := &Config{
 		Models: map[string]ModelConfig{
-			"a": {Name: "model-a", Fallbacks: []string{"b"}},
-			"b": {Name: "model-b", Fallbacks: []string{"a"}}, // cycle: a → b → a
+			"a": {Name: "model-a", Provider: "ollama", Fallbacks: []string{"b"}},
+			"b": {Name: "model-b", Provider: "ollama", Fallbacks: []string{"a"}}, // cycle: a → b → a
 		},
 		Defaults: map[string]string{
 			"test": "a",
@@ -253,10 +258,10 @@ func TestResolveCandidates_DiamondNoDuplicates(t *testing.T) {
 	// d should appear only once in candidates.
 	cfg := &Config{
 		Models: map[string]ModelConfig{
-			"a": {Name: "model-a", Fallbacks: []string{"b", "c"}},
-			"b": {Name: "model-b", Fallbacks: []string{"d"}},
-			"c": {Name: "model-c", Fallbacks: []string{"d"}},
-			"d": {Name: "model-d"},
+			"a": {Name: "model-a", Provider: "ollama", Fallbacks: []string{"b", "c"}},
+			"b": {Name: "model-b", Provider: "ollama", Fallbacks: []string{"d"}},
+			"c": {Name: "model-c", Provider: "ollama", Fallbacks: []string{"d"}},
+			"d": {Name: "model-d", Provider: "ollama"},
 		},
 		Defaults: map[string]string{
 			"test": "a",
@@ -319,10 +324,49 @@ func TestResolveCandidates_ConsistentWithResolve(t *testing.T) {
 			if candidates[0].Role != resolved.Role {
 				t.Errorf("first candidate Role = %q, Resolve Role = %q", candidates[0].Role, resolved.Role)
 			}
+			if candidates[0].Provider != resolved.Provider {
+				t.Errorf("first candidate Provider = %q, Resolve Provider = %q", candidates[0].Provider, resolved.Provider)
+			}
 			if candidates[0].IsFallback != resolved.IsFallback {
 				t.Errorf("first candidate IsFallback = %v, Resolve IsFallback = %v", candidates[0].IsFallback, resolved.IsFallback)
 			}
 		})
+	}
+}
+
+func TestResolveCandidates_ProviderAwareAvailability(t *testing.T) {
+	cfg := &Config{
+		Providers: map[string]ProviderConfig{
+			"ollama": {BaseURL: "http://localhost:11434"},
+			"vllm":   {BaseURL: "http://localhost:8080", APIFormat: "openai-compat"},
+		},
+		Models: map[string]ModelConfig{
+			"chat": {Name: "shared-model", Provider: "vllm", Type: "dense"},
+		},
+		Defaults: map[string]string{"chat": "chat"},
+	}
+	checker := &mockProviderChecker{keys: []provider.ModelKey{
+		{Provider: "ollama", Model: "shared-model"},
+	}}
+
+	got, err := cfg.ResolveCandidates(context.Background(), checker, "chat")
+	if err != nil {
+		t.Fatalf("ResolveCandidates() error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("len(candidates) = %d, want 0 for provider-specific miss", len(got))
+	}
+
+	checker.keys = append(checker.keys, provider.ModelKey{Provider: "vllm", Model: "shared-model"})
+	got, err = cfg.ResolveCandidates(context.Background(), checker, "chat")
+	if err != nil {
+		t.Fatalf("ResolveCandidates() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(candidates) = %d, want 1", len(got))
+	}
+	if got[0].Provider != "vllm" || got[0].Name != "shared-model" {
+		t.Fatalf("candidate = %+v, want vllm/shared-model", got[0])
 	}
 }
 
@@ -331,8 +375,8 @@ func TestResolveCandidates_DuplicateModelNames(t *testing.T) {
 	// since the orchestration layer cares about roles, not just model names.
 	cfg := &Config{
 		Models: map[string]ModelConfig{
-			"primary": {Name: "shared-model", Fallbacks: []string{"backup"}},
-			"backup":  {Name: "shared-model"},
+			"primary": {Name: "shared-model", Provider: "ollama", Fallbacks: []string{"backup"}},
+			"backup":  {Name: "shared-model", Provider: "ollama"},
 		},
 		Defaults: map[string]string{
 			"test": "primary",

--- a/config/config.go
+++ b/config/config.go
@@ -102,6 +102,18 @@ var validAPIFormats = map[string]bool{
 	"openai-compat": true,
 }
 
+// ValidateProviderName verifies that a configured provider key is safe to use
+// as a registry identity and in provider/model selectors.
+func ValidateProviderName(name string) error {
+	if name == "" {
+		return fmt.Errorf("provider name must not be empty")
+	}
+	if strings.Contains(name, "/") {
+		return fmt.Errorf("provider name %q must not contain %q", name, "/")
+	}
+	return nil
+}
+
 // validCapabilityNames is the schema vocabulary for ModelConfig.Capabilities,
 // derived from provider.CanonicalCapabilityNames so the two never drift.
 // User config accepts ONLY canonical single-bit names; catalog aliases like
@@ -363,6 +375,9 @@ func (cfg *Config) validate() error {
 	}
 	sort.Strings(providerKeys)
 	for _, key := range providerKeys {
+		if err := ValidateProviderName(key); err != nil {
+			return fmt.Errorf("config: %w", err)
+		}
 		p := cfg.Providers[key]
 		if p.BaseURL == "" {
 			return fmt.Errorf("config: provider %q: base_url is required", key)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -510,6 +510,16 @@ func TestLoad_Validation(t *testing.T) {
 			wantErr: "config: at least one provider is required",
 		},
 		{
+			name:    "empty provider name",
+			json:    `{"providers": {"": {"base_url": "http://localhost:11434"}}, "models": {"m": {"name": "x", "type": "dense"}}, "defaults": {}}`,
+			wantErr: "config: provider name must not be empty",
+		},
+		{
+			name:    "provider name contains slash",
+			json:    `{"providers": {"team/local": {"base_url": "http://localhost:11434"}}, "models": {"m": {"name": "x", "type": "dense", "provider": "team/local"}}, "defaults": {}}`,
+			wantErr: `config: provider name "team/local" must not contain "/"`,
+		},
+		{
 			name:    "empty base_url",
 			json:    `{"providers": {"ollama": {"base_url": ""}}, "models": {"m": {"name": "x", "type": "dense"}}, "defaults": {}}`,
 			wantErr: `config: provider "ollama": base_url is required`,

--- a/config/resolve.go
+++ b/config/resolve.go
@@ -5,11 +5,50 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/kstruzzieri/go-llm/provider"
 )
 
 // ModelChecker abstracts checking model availability against a backend.
 type ModelChecker interface {
 	AvailableModels(ctx context.Context) ([]string, error)
+}
+
+// ProviderModelChecker is an optional provider-aware extension for callers
+// that can report model availability per configured provider instance.
+type ProviderModelChecker interface {
+	AvailableModelKeys(ctx context.Context) ([]provider.ModelKey, error)
+}
+
+type modelAvailability struct {
+	names map[string]bool
+	keys  map[provider.ModelKey]bool
+}
+
+func availabilityFromNames(names []string) modelAvailability {
+	return modelAvailability{names: toSet(names)}
+}
+
+func availabilityFromKeys(keys []provider.ModelKey) modelAvailability {
+	available := modelAvailability{
+		names: make(map[string]bool, len(keys)),
+		keys:  make(map[provider.ModelKey]bool, len(keys)),
+	}
+	for _, key := range keys {
+		if key.Provider == "" || key.Model == "" {
+			continue
+		}
+		available.names[key.Model] = true
+		available.keys[key] = true
+	}
+	return available
+}
+
+func (a modelAvailability) has(providerName, model string) bool {
+	if a.keys != nil {
+		return a.keys[provider.ModelKey{Provider: providerName, Model: model}]
+	}
+	return a.names[model]
 }
 
 // ResolvedModel is the result of resolving a role to an available model.
@@ -37,12 +76,11 @@ func (c *Config) Resolve(ctx context.Context, checker ModelChecker, useCase stri
 		return ResolvedModel{}, fmt.Errorf("config: unknown use-case %q", useCase)
 	}
 
-	models, err := checker.AvailableModels(ctx)
+	available, err := availableModels(ctx, checker)
 	if err != nil {
 		return ResolvedModel{}, fmt.Errorf("config: checking available models: %w", err)
 	}
 
-	available := toSet(models)
 	return c.resolveRole(role, available, nil)
 }
 
@@ -52,12 +90,11 @@ func (c *Config) ResolveAll(ctx context.Context, checker ModelChecker) (map[stri
 	if checker == nil {
 		return nil, fmt.Errorf("config: model checker is required")
 	}
-	models, err := checker.AvailableModels(ctx)
+	available, err := availableModels(ctx, checker)
 	if err != nil {
 		return nil, fmt.Errorf("config: checking available models: %w", err)
 	}
 
-	available := toSet(models)
 	results := make(map[string]ResolvedModel, len(c.Defaults))
 	var errs []string
 
@@ -84,13 +121,28 @@ func (c *Config) ResolveAll(ctx context.Context, checker ModelChecker) (map[stri
 	return results, nil
 }
 
+func availableModels(ctx context.Context, checker ModelChecker) (modelAvailability, error) {
+	if keyed, ok := checker.(ProviderModelChecker); ok {
+		keys, err := keyed.AvailableModelKeys(ctx)
+		if err != nil {
+			return modelAvailability{}, err
+		}
+		return availabilityFromKeys(keys), nil
+	}
+	models, err := checker.AvailableModels(ctx)
+	if err != nil {
+		return modelAvailability{}, err
+	}
+	return availabilityFromNames(models), nil
+}
+
 // resolveRole tries the primary model for the given role, then walks its
 // Fallbacks slice, returning the first model found in the available set.
 // The onStack set tracks the current DFS path to detect circular fallbacks
 // while allowing diamond-shaped shared fallback nodes to be visited from
 // multiple parents (defensive — Load validates against cycles, but this
 // protects programmatic use).
-func (c *Config) resolveRole(role string, available map[string]bool, onStack map[string]bool) (ResolvedModel, error) {
+func (c *Config) resolveRole(role string, available modelAvailability, onStack map[string]bool) (ResolvedModel, error) {
 	if onStack == nil {
 		onStack = make(map[string]bool)
 	}
@@ -116,7 +168,7 @@ func (c *Config) resolveRole(role string, available map[string]bool, onStack map
 	}
 
 	// Try primary model.
-	if available[m.Name] {
+	if available.has(m.Provider, m.Name) {
 		return ResolvedModel{Name: m.Name, Role: role, Provider: m.Provider, IsFallback: false}, nil
 	}
 

--- a/config/resolve_test.go
+++ b/config/resolve_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/kstruzzieri/go-llm/provider"
 )
 
 type mockChecker struct {
@@ -14,6 +16,28 @@ type mockChecker struct {
 
 func (m *mockChecker) AvailableModels(_ context.Context) ([]string, error) {
 	return m.models, m.err
+}
+
+type mockProviderChecker struct {
+	keys []provider.ModelKey
+	err  error
+}
+
+func (m *mockProviderChecker) AvailableModels(_ context.Context) ([]string, error) {
+	seen := map[string]bool{}
+	var models []string
+	for _, key := range m.keys {
+		if key.Model == "" || seen[key.Model] {
+			continue
+		}
+		seen[key.Model] = true
+		models = append(models, key.Model)
+	}
+	return models, m.err
+}
+
+func (m *mockProviderChecker) AvailableModelKeys(_ context.Context) ([]provider.ModelKey, error) {
+	return m.keys, m.err
 }
 
 func loadTestConfig(t *testing.T) *Config {
@@ -134,6 +158,39 @@ func TestResolve_FallbackCrossProvider(t *testing.T) {
 	}
 	if !got.IsFallback {
 		t.Error("IsFallback = false, want true")
+	}
+}
+
+func TestResolve_ProviderAwareAvailability(t *testing.T) {
+	cfg := &Config{
+		Providers: map[string]ProviderConfig{
+			"ollama": {BaseURL: "http://localhost:11434"},
+			"vllm":   {BaseURL: "http://localhost:8080", APIFormat: "openai-compat"},
+		},
+		Models: map[string]ModelConfig{
+			"chat": {Name: "shared-model", Provider: "vllm", Type: "dense"},
+		},
+		Defaults: map[string]string{"chat": "chat"},
+	}
+	checker := &mockProviderChecker{keys: []provider.ModelKey{
+		{Provider: "ollama", Model: "shared-model"},
+	}}
+
+	_, err := cfg.Resolve(context.Background(), checker, "chat")
+	if err == nil {
+		t.Fatal("Resolve() error = nil, want provider-specific miss")
+	}
+	if !strings.Contains(err.Error(), `role "chat"`) {
+		t.Fatalf("error = %q, want unresolved chat role", err)
+	}
+
+	checker.keys = append(checker.keys, provider.ModelKey{Provider: "vllm", Model: "shared-model"})
+	got, err := cfg.Resolve(context.Background(), checker, "chat")
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if got.Provider != "vllm" || got.Name != "shared-model" {
+		t.Fatalf("Resolve() = %+v, want vllm/shared-model", got)
 	}
 }
 
@@ -420,4 +477,3 @@ func TestConfig_RoleFallbackChain_UnknownRole(t *testing.T) {
 		t.Fatal("expected unknown-role error, got nil")
 	}
 }
-

--- a/mcp/embed_helper.go
+++ b/mcp/embed_helper.go
@@ -62,8 +62,12 @@ func (s *Server) routedEmbed(ctx context.Context, model string, inputs []string,
 	if router == nil {
 		return nil, routedEmbedError{category: embedToolConfig, err: fmt.Errorf("router unavailable")}
 	}
+	selector, err := s.routeModelSelector(ctx, model, "embedding")
+	if err != nil {
+		return nil, routedEmbedError{category: embedToolConfig, err: err}
+	}
 	rr := provider.RoutingRequest{
-		Model:          model,
+		Model:          selector,
 		UseCase:        "embedding",
 		RequiredCaps:   provider.CapEmbed,
 		Input:          inputs,

--- a/mcp/fim_via_router_integration_test.go
+++ b/mcp/fim_via_router_integration_test.go
@@ -63,7 +63,7 @@ func TestFIMViaRouter_Smoke(t *testing.T) {
 	s.router = rec
 	s.mu.Unlock()
 
-	p, err := s.newCompletionProvider(ctx, model)
+	p, err := s.newCompletionProvider(ctx, model, "ollama")
 	if err != nil {
 		t.Fatalf("newCompletionProvider: %v", err)
 	}
@@ -89,8 +89,8 @@ func TestFIMViaRouter_Smoke(t *testing.T) {
 	if rec.last.RequiredCaps != wantCaps {
 		t.Errorf("RequiredCaps = %v, want %v", rec.last.RequiredCaps, wantCaps)
 	}
-	if rec.last.Model != model {
-		t.Errorf("Model = %q, want %q", rec.last.Model, model)
+	if want := "ollama/" + model; rec.last.Model != want {
+		t.Errorf("Model = %q, want %q", rec.last.Model, want)
 	}
 	if rec.last.Priority != provider.PriorityHigh {
 		t.Errorf("Priority = %v, want %v", rec.last.Priority, provider.PriorityHigh)

--- a/mcp/resolve.go
+++ b/mcp/resolve.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/kstruzzieri/go-llm/config"
@@ -31,15 +32,30 @@ func (s *Server) resolveModel(ctx context.Context, explicit, useCase string) (st
 	return target.Name, nil
 }
 
+func (s *Server) routeModelSelector(ctx context.Context, explicit, useCase string) (string, error) {
+	if explicit == "" {
+		return "", nil
+	}
+	target, err := s.resolveModelTarget(ctx, explicit, useCase)
+	if err != nil {
+		return "", err
+	}
+	return target.selector(), nil
+}
+
 // resolveModelTarget is resolveModel's provider-aware sibling. Explicit
 // qualified selectors preserve their provider component; configured defaults
 // return the provider instance captured by config.ResolvedModel.
 func (s *Server) resolveModelTarget(ctx context.Context, explicit, useCase string) (resolvedModelTarget, error) {
 	if explicit != "" {
-		if key, ok := parseModelSelector(explicit); ok {
+		if key, ok := s.parseKnownModelSelector(explicit); ok {
 			return resolvedModelTarget{Name: key.Model, Provider: key.Provider}, nil
 		}
-		return resolvedModelTarget{Name: explicit}, nil
+		providerName, err := s.inferProviderForExplicitModel(ctx, explicit)
+		if err != nil {
+			return resolvedModelTarget{}, err
+		}
+		return resolvedModelTarget{Name: explicit, Provider: providerName}, nil
 	}
 
 	// No config available — model must be provided explicitly.
@@ -205,6 +221,99 @@ func parseModelSelector(selector string) (provider.ModelKey, bool) {
 		return provider.ModelKey{}, false
 	}
 	return provider.ModelKey{Provider: providerName, Model: model}, true
+}
+
+func (s *Server) parseKnownModelSelector(selector string) (provider.ModelKey, bool) {
+	key, ok := parseModelSelector(selector)
+	if !ok || !s.providerKnown(key.Provider) {
+		return provider.ModelKey{}, false
+	}
+	return key, true
+}
+
+func (s *Server) providerKnown(providerName string) bool {
+	if providerName == "" {
+		return false
+	}
+	if pReg := s.providerRegistrySnapshot(); pReg != nil {
+		if _, ok := pReg.Get(providerName); ok {
+			return true
+		}
+	}
+	if s.cfg != nil {
+		_, ok := s.cfg.Providers[providerName]
+		return ok
+	}
+	return false
+}
+
+func (s *Server) inferProviderForExplicitModel(ctx context.Context, model string) (string, error) {
+	if providerName, ok, err := s.inferProviderFromConfig(model); ok || err != nil {
+		return providerName, err
+	}
+
+	pReg := s.providerRegistrySnapshot()
+	if pReg == nil {
+		return "", nil
+	}
+	if providerName, ok, err := inferProviderFromRegistryIndex(pReg, model); ok || err != nil {
+		return providerName, err
+	}
+
+	for _, name := range pReg.Names() {
+		_ = pReg.RefreshModels(ctx, name)
+	}
+	if providerName, ok, err := inferProviderFromRegistryIndex(pReg, model); ok || err != nil {
+		return providerName, err
+	}
+
+	names := pReg.Names()
+	if len(names) == 1 {
+		return names[0], nil
+	}
+	return "", nil
+}
+
+func (s *Server) inferProviderFromConfig(model string) (string, bool, error) {
+	if s.cfg == nil {
+		return "", false, nil
+	}
+	providers := make(map[string]bool)
+	for _, m := range s.cfg.Models {
+		if m.Name == model && m.Provider != "" {
+			providers[m.Provider] = true
+		}
+	}
+	return singleProvider(model, providers)
+}
+
+func inferProviderFromRegistryIndex(pReg *provider.Registry, model string) (string, bool, error) {
+	providers, err := pReg.ProvidersForModel(model)
+	if err != nil {
+		return "", false, nil
+	}
+	names := make(map[string]bool, len(providers))
+	for _, p := range providers {
+		names[p.Name()] = true
+	}
+	return singleProvider(model, names)
+}
+
+func singleProvider(model string, providers map[string]bool) (string, bool, error) {
+	switch len(providers) {
+	case 0:
+		return "", false, nil
+	case 1:
+		for providerName := range providers {
+			return providerName, true, nil
+		}
+	}
+	names := make([]string, 0, len(providers))
+	for providerName := range providers {
+		names = append(names, providerName)
+	}
+	sort.Strings(names)
+	return "", false, fmt.Errorf("mcp: provider required for ambiguous model %q (available from: %s)", model, strings.Join(names, ", "))
 }
 
 func modelSelector(providerName, model string) string {

--- a/mcp/resolve.go
+++ b/mcp/resolve.go
@@ -3,9 +3,20 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/kstruzzieri/go-llm/config"
+	"github.com/kstruzzieri/go-llm/provider"
 )
+
+type resolvedModelTarget struct {
+	Name     string
+	Provider string
+}
+
+func (t resolvedModelTarget) selector() string {
+	return modelSelector(t.Provider, t.Name)
+}
 
 // resolveModel resolves a model name for a given use-case.
 // If explicit is non-empty, it is returned directly.
@@ -13,13 +24,27 @@ import (
 // Use-case keys match config.Defaults (e.g., "chat", "completion",
 // "embedding", "analysis"), not role names.
 func (s *Server) resolveModel(ctx context.Context, explicit, useCase string) (string, error) {
+	target, err := s.resolveModelTarget(ctx, explicit, useCase)
+	if err != nil {
+		return "", err
+	}
+	return target.Name, nil
+}
+
+// resolveModelTarget is resolveModel's provider-aware sibling. Explicit
+// qualified selectors preserve their provider component; configured defaults
+// return the provider instance captured by config.ResolvedModel.
+func (s *Server) resolveModelTarget(ctx context.Context, explicit, useCase string) (resolvedModelTarget, error) {
 	if explicit != "" {
-		return explicit, nil
+		if key, ok := parseModelSelector(explicit); ok {
+			return resolvedModelTarget{Name: key.Model, Provider: key.Provider}, nil
+		}
+		return resolvedModelTarget{Name: explicit}, nil
 	}
 
 	// No config available — model must be provided explicitly.
 	if s.cfg == nil {
-		return "", fmt.Errorf("model parameter required (no models.json configured)")
+		return resolvedModelTarget{}, fmt.Errorf("model parameter required (no models.json configured)")
 	}
 
 	resolved := s.snapshotResolved()
@@ -35,31 +60,32 @@ func (s *Server) resolveModel(ctx context.Context, explicit, useCase string) (st
 
 	// Config exists but resolved map is empty (Ollama was unavailable).
 	if len(resolved) == 0 {
-		return "", fmt.Errorf("defaults unavailable; provide model explicitly")
+		return resolvedModelTarget{}, fmt.Errorf("defaults unavailable; provide model explicitly")
 	}
 
 	rm, ok := resolved[useCase]
 	if !ok {
-		return "", fmt.Errorf("no model configured for use-case %q", useCase)
+		return resolvedModelTarget{}, fmt.Errorf("no model configured for use-case %q", useCase)
 	}
 	if rm.Name == "" {
-		return "", fmt.Errorf("default for use-case %q did not resolve", useCase)
+		return resolvedModelTarget{}, fmt.Errorf("default for use-case %q did not resolve", useCase)
 	}
 
-	return rm.Name, nil
+	return resolvedModelTarget{Name: rm.Name, Provider: rm.Provider}, nil
 }
 
-// refreshResolved re-resolves all models against the running Ollama instance
+// refreshResolved re-resolves all models against registered provider instances
 // and rebuilds derived clients. Partial results are stored even on error.
 func (s *Server) refreshResolved(ctx context.Context) error {
 	if s.cfg == nil {
 		return fmt.Errorf("mcp: refresh models: no configuration loaded")
 	}
-	if s.client == nil {
+	checker := s.modelChecker()
+	if checker == nil {
 		return fmt.Errorf("mcp: refresh models: client unavailable")
 	}
 
-	resolved, err := s.cfg.ResolveAll(ctx, s.client)
+	resolved, err := s.cfg.ResolveAll(ctx, checker)
 
 	// Store partial results and rebuild derived clients under the write lock
 	// so future requests see the freshest resolved defaults. Derived clients
@@ -79,7 +105,7 @@ func (s *Server) refreshResolved(ctx context.Context) error {
 }
 
 func (s *Server) maybeRefreshResolved(ctx context.Context) {
-	if s.client == nil {
+	if s.modelChecker() == nil {
 		return
 	}
 	_ = s.refreshResolved(ctx)
@@ -111,4 +137,79 @@ func (s *Server) chainFor(useCase string) ([]string, error) {
 		return nil, fmt.Errorf("no model configured for use-case %q", useCase)
 	}
 	return chain, nil
+}
+
+func (s *Server) modelChecker() config.ModelChecker {
+	if pReg := s.providerRegistrySnapshot(); pReg != nil {
+		return providerRegistryModelChecker{registry: pReg}
+	}
+	if s.client != nil {
+		return s.client
+	}
+	return nil
+}
+
+type providerRegistryModelChecker struct {
+	registry *provider.Registry
+}
+
+func (c providerRegistryModelChecker) AvailableModels(ctx context.Context) ([]string, error) {
+	keys, err := c.AvailableModelKeys(ctx)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]bool, len(keys))
+	models := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if key.Model == "" || seen[key.Model] {
+			continue
+		}
+		seen[key.Model] = true
+		models = append(models, key.Model)
+	}
+	return models, nil
+}
+
+func (c providerRegistryModelChecker) AvailableModelKeys(ctx context.Context) ([]provider.ModelKey, error) {
+	if c.registry == nil {
+		return nil, fmt.Errorf("mcp: provider registry unavailable")
+	}
+	var keys []provider.ModelKey
+	var firstErr error
+	for _, p := range c.registry.All() {
+		models, err := p.Models(ctx)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("mcp: list models for provider %q: %w", p.Name(), err)
+			}
+			continue
+		}
+		for _, model := range models {
+			if model.Name == "" {
+				continue
+			}
+			key := provider.ModelKey{Provider: p.Name(), Model: model.Name}
+			keys = append(keys, key)
+			_ = c.registry.AddModelToIndex(model.Name, p.Name())
+		}
+	}
+	if len(keys) == 0 && firstErr != nil {
+		return nil, firstErr
+	}
+	return keys, nil
+}
+
+func parseModelSelector(selector string) (provider.ModelKey, bool) {
+	providerName, model, ok := strings.Cut(selector, "/")
+	if !ok || providerName == "" || model == "" {
+		return provider.ModelKey{}, false
+	}
+	return provider.ModelKey{Provider: providerName, Model: model}, true
+}
+
+func modelSelector(providerName, model string) string {
+	if providerName == "" || model == "" {
+		return model
+	}
+	return providerName + "/" + model
 }

--- a/mcp/resolve.go
+++ b/mcp/resolve.go
@@ -193,7 +193,7 @@ func (c providerRegistryModelChecker) AvailableModelKeys(ctx context.Context) ([
 	var keys []provider.ModelKey
 	var firstErr error
 	for _, p := range c.registry.All() {
-		models, err := p.Models(ctx)
+		models, err := c.registry.RefreshModelsAndList(ctx, p.Name())
 		if err != nil {
 			if firstErr == nil {
 				firstErr = fmt.Errorf("mcp: list models for provider %q: %w", p.Name(), err)
@@ -206,7 +206,6 @@ func (c providerRegistryModelChecker) AvailableModelKeys(ctx context.Context) ([
 			}
 			key := provider.ModelKey{Provider: p.Name(), Model: model.Name}
 			keys = append(keys, key)
-			_ = c.registry.AddModelToIndex(model.Name, p.Name())
 		}
 	}
 	if len(keys) == 0 && firstErr != nil {

--- a/mcp/resolve_test.go
+++ b/mcp/resolve_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kstruzzieri/go-llm/config"
 	"github.com/kstruzzieri/go-llm/ollama"
+	"github.com/kstruzzieri/go-llm/provider"
 )
 
 func TestResolveModelExplicit(t *testing.T) {
@@ -49,6 +50,56 @@ func TestResolveModelTargetDoesNotTreatUnknownSlashPrefixAsProvider(t *testing.T
 	if got.Provider != "vllm-local" {
 		t.Fatalf("Provider = %q, want vllm-local", got.Provider)
 	}
+}
+
+func TestProviderRegistryModelCheckerRefreshesModelIndex(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := &mutableModelProvider{
+		fakeRouteProvider: &fakeRouteProvider{name: "vllm-local"},
+		models:            []provider.ModelInfo{{Name: "old-model"}},
+	}
+	if err := reg.Register(p); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	checker := providerRegistryModelChecker{registry: reg}
+
+	keys, err := checker.AvailableModelKeys(context.Background())
+	if err != nil {
+		t.Fatalf("AvailableModelKeys() error = %v", err)
+	}
+	if len(keys) != 1 || keys[0].Model != "old-model" {
+		t.Fatalf("initial keys = %+v, want old-model", keys)
+	}
+
+	p.models = []provider.ModelInfo{{Name: "new-model"}}
+	keys, err = checker.AvailableModelKeys(context.Background())
+	if err != nil {
+		t.Fatalf("AvailableModelKeys() after update error = %v", err)
+	}
+	if len(keys) != 1 || keys[0].Model != "new-model" {
+		t.Fatalf("updated keys = %+v, want new-model", keys)
+	}
+	if _, err := reg.ProvidersForModel("old-model"); err == nil {
+		t.Fatal("ProvidersForModel(old-model) error = nil, want stale entry removed")
+	}
+	providers, err := reg.ProvidersForModel("new-model")
+	if err != nil {
+		t.Fatalf("ProvidersForModel(new-model) error = %v", err)
+	}
+	if len(providers) != 1 || providers[0].Name() != "vllm-local" {
+		t.Fatalf("ProvidersForModel(new-model) = %+v, want vllm-local", providers)
+	}
+}
+
+type mutableModelProvider struct {
+	*fakeRouteProvider
+	models []provider.ModelInfo
+}
+
+func (p *mutableModelProvider) Models(context.Context) ([]provider.ModelInfo, error) {
+	out := make([]provider.ModelInfo, len(p.models))
+	copy(out, p.models)
+	return out, nil
 }
 
 func TestResolveModelFromCache(t *testing.T) {

--- a/mcp/resolve_test.go
+++ b/mcp/resolve_test.go
@@ -25,6 +25,32 @@ func TestResolveModelExplicit(t *testing.T) {
 	}
 }
 
+func TestResolveModelTargetDoesNotTreatUnknownSlashPrefixAsProvider(t *testing.T) {
+	s := &Server{
+		cfg: &config.Config{
+			Providers: map[string]config.ProviderConfig{
+				"vllm-local": {BaseURL: "http://localhost:8080", APIFormat: "openai-compat"},
+			},
+			Models: map[string]config.ModelConfig{
+				"completion": {Name: "org/local-fim", Provider: "vllm-local", Type: "dense"},
+			},
+			Defaults: map[string]string{"completion": "completion"},
+		},
+		resolved: make(map[string]config.ResolvedModel),
+	}
+
+	got, err := s.resolveModelTarget(context.Background(), "org/local-fim", "completion")
+	if err != nil {
+		t.Fatalf("resolveModelTarget() error = %v", err)
+	}
+	if got.Name != "org/local-fim" {
+		t.Fatalf("Name = %q, want org/local-fim", got.Name)
+	}
+	if got.Provider != "vllm-local" {
+		t.Fatalf("Provider = %q, want vllm-local", got.Provider)
+	}
+}
+
 func TestResolveModelFromCache(t *testing.T) {
 	s := &Server{
 		cfg: &config.Config{}, // non-nil config

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -453,12 +453,30 @@ func (s *Server) installCapabilityOverrides(mr *provider.ModelRegistry) {
 	sort.Strings(roles)
 	for _, role := range roles {
 		m := s.cfg.Models[role]
-		if len(m.Capabilities) == 0 || m.Provider == "" || m.Name == "" {
+		if m.Provider == "" || m.Name == "" {
 			continue
 		}
-		caps := make([]string, len(m.Capabilities))
-		copy(caps, m.Capabilities)
-		overrides[provider.ModelKey{Provider: m.Provider, Model: m.Name}] = caps
+		caps := m.Capabilities
+		if len(caps) == 0 {
+			pCfg, ok := s.cfg.Providers[m.Provider]
+			if !ok {
+				continue
+			}
+			apiFormat := pCfg.APIFormat
+			if apiFormat == "" {
+				apiFormat = "ollama"
+			}
+			if apiFormat != "openai-compat" {
+				continue
+			}
+			caps = m.ResolvedCapabilities()
+		}
+		if len(caps) == 0 {
+			continue
+		}
+		copied := make([]string, len(caps))
+		copy(copied, caps)
+		overrides[provider.ModelKey{Provider: m.Provider, Model: m.Name}] = copied
 	}
 	if len(overrides) == 0 {
 		return

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -392,6 +392,9 @@ func (s *Server) configuredProviders() ([]provider.Provider, provider.Provider, 
 	registered := make([]provider.Provider, 0, len(keys))
 	var ollamaProv provider.Provider
 	for _, key := range keys {
+		if err := config.ValidateProviderName(key); err != nil {
+			return nil, nil, fmt.Errorf("mcp: provider config: %w", err)
+		}
 		cfg := providerConfigs[key]
 		if cfg.APIFormat == "" {
 			cfg.APIFormat = "ollama"

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -18,6 +19,7 @@ import (
 	"github.com/kstruzzieri/go-llm/config"
 	"github.com/kstruzzieri/go-llm/ollama"
 	"github.com/kstruzzieri/go-llm/provider"
+	"github.com/kstruzzieri/go-llm/provider/openaicompat"
 	"github.com/kstruzzieri/go-llm/rag"
 )
 
@@ -181,13 +183,13 @@ func NewServer(ctx context.Context, opts ...Option) (*Server, error) {
 	// unless the caller explicitly overrode the base URL.
 	clientOpts := []ollama.Option{ollama.WithBaseURL(s.ollamaURL)}
 	if s.cfg != nil {
-		if provider := s.cfg.Provider("ollama"); provider != nil {
-			if !s.ollamaURLExplicit && provider.BaseURL != "" {
-				s.ollamaURL = provider.BaseURL
+		if cfgProvider := s.cfg.Provider("ollama"); cfgProvider != nil && (cfgProvider.APIFormat == "" || cfgProvider.APIFormat == "ollama") {
+			if !s.ollamaURLExplicit && cfgProvider.BaseURL != "" {
+				s.ollamaURL = cfgProvider.BaseURL
 				clientOpts[0] = ollama.WithBaseURL(s.ollamaURL)
 			}
-			if provider.Timeout.Duration > 0 {
-				clientOpts = append(clientOpts, ollama.WithTimeout(provider.Timeout.Duration))
+			if cfgProvider.Timeout.Duration > 0 {
+				clientOpts = append(clientOpts, ollama.WithTimeout(cfgProvider.Timeout.Duration))
 			}
 		}
 	}
@@ -216,22 +218,26 @@ func NewServer(ctx context.Context, opts ...Option) (*Server, error) {
 
 	// Step 4b: build warmth source and Router after fallible store setup.
 	// NewRouter does not perform network I/O, so this is safe even when
-	// Ollama is unreachable. The warmth source's polling goroutine starts
-	// immediately and is fail-open.
+	// local providers are unreachable. The warmth source's polling goroutine
+	// starts immediately and is fail-open when the default Ollama instance
+	// is registered.
 	if s.modelRegistry != nil && s.providerRegistry != nil {
-		s.warmthSource = provider.NewOllamaWarmthSource(s.ollamaURL, "ollama")
-		s.router = provider.NewRouter(s.modelRegistry, s.providerRegistry,
-			provider.WithWarmthSource(s.warmthSource),
-		)
-		// Best-effort: populate the providerRegistry's model index so the
-		// Recommend safety-net tail can produce candidates. Failures are
-		// tolerated; handleListModels self-heals on the next call.
-		_ = s.providerRegistry.RefreshModels(ctx, "ollama")
+		opts := []provider.RouterOption{}
+		if s.ollamaProv != nil && s.ollamaProv.Name() == "ollama" {
+			s.warmthSource = provider.NewOllamaWarmthSource(s.ollamaURL, "ollama")
+			opts = append(opts, provider.WithWarmthSource(s.warmthSource))
+		}
+		s.router = provider.NewRouter(s.modelRegistry, s.providerRegistry, opts...)
+		// Best-effort: populate the providerRegistry's model index for every
+		// registered provider so model-name lookup and Recommend can produce
+		// candidates. Failures are tolerated; refreshResolved and list_models
+		// also self-heal on later calls.
+		s.refreshProviderModelIndexes(ctx)
 	}
 
 	// Step 5: Resolve models and rebuild derived clients (non-fatal).
 	// Uses refreshResolved which stores partial results and calls rebuildDerivedClients.
-	if s.cfg != nil && s.ollamaAvailable {
+	if s.cfg != nil {
 		_ = s.refreshResolved(ctx) // non-fatal: partial results are kept
 	} else {
 		// No resolution possible — still build derived clients with defaults.
@@ -278,7 +284,7 @@ func (s *Server) rebuildDerivedClients(ctx context.Context) {
 	// Rebuild completer from resolved "completion" model.
 	var completer *completion.Provider
 	if rm, ok := resolved["completion"]; ok && rm.Name != "" {
-		if c, err := s.newCompletionProvider(ctx, rm.Name); err == nil {
+		if c, err := s.newCompletionProvider(ctx, rm.Name, rm.Provider); err == nil {
 			completer = c
 		}
 	}
@@ -288,7 +294,7 @@ func (s *Server) rebuildDerivedClients(ctx context.Context) {
 	// callers do not discover the outage only on first use.
 	embeddingModel := ""
 	if rm, ok := resolved["embedding"]; ok && rm.Name != "" {
-		embeddingModel = rm.Name
+		embeddingModel = modelSelector(rm.Provider, rm.Name)
 	}
 
 	var indexer *rag.Indexer
@@ -325,26 +331,27 @@ func (s *Server) rebuildDerivedClients(ctx context.Context) {
 
 func (s *Server) ensureModelRegistry() error {
 	s.mu.RLock()
-	if s.modelRegistry != nil && s.ollamaProv != nil && s.providerRegistry != nil {
+	if s.modelRegistry != nil && s.providerRegistry != nil {
 		s.mu.RUnlock()
 		return nil
 	}
-	client := s.client
 	s.mu.RUnlock()
 
-	if client == nil {
-		return fmt.Errorf("mcp: model registry unavailable")
-	}
-
-	ollamaProv := provider.NewOllamaProvider(client)
 	pReg := provider.NewRegistry()
-	if err := pReg.Register(ollamaProv); err != nil {
-		return fmt.Errorf("mcp: model registry unavailable: %w", err)
+	registered, ollamaProv, err := s.configuredProviders()
+	if err != nil {
+		return err
+	}
+	for _, p := range registered {
+		if err := pReg.Register(p); err != nil {
+			return fmt.Errorf("mcp: model registry unavailable: %w", err)
+		}
 	}
 	mr, err := provider.NewModelRegistry(pReg, nil)
 	if err != nil {
 		return fmt.Errorf("mcp: model registry unavailable: %w", err)
 	}
+	s.installCapabilityOverrides(mr)
 
 	s.mu.Lock()
 	if s.ollamaProv == nil {
@@ -360,6 +367,114 @@ func (s *Server) ensureModelRegistry() error {
 	return nil
 }
 
+func (s *Server) configuredProviders() ([]provider.Provider, provider.Provider, error) {
+	providerConfigs := map[string]config.ProviderConfig{}
+	if s.cfg == nil {
+		providerConfigs["ollama"] = config.ProviderConfig{
+			BaseURL:   s.ollamaURL,
+			APIFormat: "ollama",
+		}
+	} else {
+		if len(s.cfg.Providers) == 0 {
+			return nil, nil, fmt.Errorf("mcp: model registry unavailable: no providers configured")
+		}
+		for key, cfg := range s.cfg.Providers {
+			providerConfigs[key] = cfg
+		}
+	}
+
+	keys := make([]string, 0, len(providerConfigs))
+	for key := range providerConfigs {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	registered := make([]provider.Provider, 0, len(keys))
+	var ollamaProv provider.Provider
+	for _, key := range keys {
+		cfg := providerConfigs[key]
+		if cfg.APIFormat == "" {
+			cfg.APIFormat = "ollama"
+		}
+		if key == "ollama" && s.ollamaURLExplicit {
+			cfg.BaseURL = s.ollamaURL
+		}
+
+		prov, err := configuredProvider(key, cfg)
+		if err != nil {
+			return nil, nil, err
+		}
+		registered = append(registered, prov)
+		if cfg.APIFormat == "ollama" && key == "ollama" {
+			ollamaProv = prov
+		}
+	}
+	return registered, ollamaProv, nil
+}
+
+func configuredProvider(key string, cfg config.ProviderConfig) (provider.Provider, error) {
+	switch cfg.APIFormat {
+	case "", "ollama":
+		opts := []ollama.Option{ollama.WithBaseURL(cfg.BaseURL)}
+		if cfg.Timeout.Duration > 0 {
+			opts = append(opts, ollama.WithTimeout(cfg.Timeout.Duration))
+		}
+		return provider.NewOllamaProvider(
+			ollama.NewClient(opts...),
+			provider.WithProviderName(key),
+		), nil
+	case "openai-compat":
+		opts := []openaicompat.ClientOption{}
+		if cfg.Timeout.Duration > 0 {
+			opts = append(opts, openaicompat.WithHTTPClient(&http.Client{Timeout: cfg.Timeout.Duration}))
+		}
+		if cfg.APIKey != "" {
+			opts = append(opts, openaicompat.WithAPIKey(cfg.APIKey))
+		}
+		return openaicompat.NewProvider(
+			openaicompat.NewClient(cfg.BaseURL, opts...),
+			openaicompat.WithProviderName(key),
+		), nil
+	default:
+		return nil, fmt.Errorf("mcp: provider %q: unsupported api_format %q", key, cfg.APIFormat)
+	}
+}
+
+func (s *Server) installCapabilityOverrides(mr *provider.ModelRegistry) {
+	if mr == nil || s.cfg == nil {
+		return
+	}
+
+	overrides := make(map[provider.ModelKey][]string)
+	roles := make([]string, 0, len(s.cfg.Models))
+	for role := range s.cfg.Models {
+		roles = append(roles, role)
+	}
+	sort.Strings(roles)
+	for _, role := range roles {
+		m := s.cfg.Models[role]
+		if len(m.Capabilities) == 0 || m.Provider == "" || m.Name == "" {
+			continue
+		}
+		caps := make([]string, len(m.Capabilities))
+		copy(caps, m.Capabilities)
+		overrides[provider.ModelKey{Provider: m.Provider, Model: m.Name}] = caps
+	}
+	if len(overrides) == 0 {
+		return
+	}
+
+	mr.SetCapabilityOverride(func(key provider.ModelKey) []string {
+		caps, ok := overrides[key]
+		if !ok {
+			return nil
+		}
+		out := make([]string, len(caps))
+		copy(out, caps)
+		return out
+	})
+}
+
 // Completer returns the current FIM completion provider (may be nil).
 // Safe for concurrent use.
 func (s *Server) Completer() *completion.Provider {
@@ -372,20 +487,23 @@ func (s *Server) Completer() *completion.Provider {
 // looking up its merged ModelProfile via the model registry and deriving a
 // ProviderConfig. Returns an error when the registry is unavailable, the
 // lookup fails, or the model does not support native FIM at runtime.
-func (s *Server) newCompletionProvider(ctx context.Context, model string) (*completion.Provider, error) {
+func (s *Server) newCompletionProvider(ctx context.Context, model, providerName string) (*completion.Provider, error) {
 	if err := s.ensureModelRegistry(); err != nil {
 		return nil, err
 	}
 
 	s.mu.RLock()
 	modelRegistry := s.modelRegistry
-	ollamaProv := s.ollamaProv
+	providerRegistry := s.providerRegistry
 	s.mu.RUnlock()
-	if modelRegistry == nil || ollamaProv == nil {
+	if modelRegistry == nil || providerRegistry == nil {
 		return nil, fmt.Errorf("mcp: model registry unavailable")
 	}
 
-	key := provider.ModelKey{Provider: ollamaProv.Name(), Model: model}
+	key, err := s.modelKeyForCompletion(model, providerName)
+	if err != nil {
+		return nil, err
+	}
 	profile, err := modelRegistry.Lookup(ctx, key)
 	if err != nil {
 		return nil, fmt.Errorf("mcp: lookup profile %q: %w", model, err)
@@ -402,10 +520,45 @@ func (s *Server) newCompletionProvider(ctx context.Context, model string) (*comp
 	// non-fatal — Router's own ProvidersForModel error will surface
 	// naturally if the seed didn't take.
 	if pReg := s.providerRegistrySnapshot(); pReg != nil {
-		_ = pReg.AddModelToIndex(model, ollamaProv.Name())
+		_ = pReg.AddModelToIndex(key.Model, key.Provider)
 	}
 
-	return completion.NewProviderWithGenerator(s.fimGenerator(s.fimPriority()), model, cfg)
+	return completion.NewProviderWithGenerator(s.fimGenerator(s.fimPriority()), key.String(), cfg)
+}
+
+func (s *Server) modelKeyForCompletion(model, providerName string) (provider.ModelKey, error) {
+	if providerName != "" {
+		return provider.ModelKey{Provider: providerName, Model: model}, nil
+	}
+	if key, ok := parseModelSelector(model); ok {
+		return key, nil
+	}
+
+	s.mu.RLock()
+	ollamaProv := s.ollamaProv
+	providerRegistry := s.providerRegistry
+	s.mu.RUnlock()
+
+	if ollamaProv != nil {
+		return provider.ModelKey{Provider: ollamaProv.Name(), Model: model}, nil
+	}
+	if providerRegistry != nil {
+		names := providerRegistry.Names()
+		if len(names) == 1 {
+			return provider.ModelKey{Provider: names[0], Model: model}, nil
+		}
+	}
+	return provider.ModelKey{}, fmt.Errorf("mcp: provider required for model %q", model)
+}
+
+func (s *Server) refreshProviderModelIndexes(ctx context.Context) {
+	pReg := s.providerRegistrySnapshot()
+	if pReg == nil {
+		return
+	}
+	for _, name := range pReg.Names() {
+		_ = pReg.RefreshModels(ctx, name)
+	}
 }
 
 // Indexer returns the current RAG indexer (nil if RAG disabled).

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -518,7 +518,7 @@ func (s *Server) newCompletionProvider(ctx context.Context, model, providerName 
 		return nil, fmt.Errorf("mcp: model registry unavailable")
 	}
 
-	key, err := s.modelKeyForCompletion(model, providerName)
+	key, err := s.modelKeyForCompletion(ctx, model, providerName)
 	if err != nil {
 		return nil, err
 	}
@@ -531,8 +531,8 @@ func (s *Server) newCompletionProvider(ctx context.Context, model, providerName 
 		return nil, err
 	}
 
-	// modelRegistry.Lookup proved this model exists for ollamaProv via
-	// /api/show. Seed the providerRegistry's routing index so Router can
+	// modelRegistry.Lookup proved this model exists for its provider. Seed
+	// the providerRegistry's routing index so Router can
 	// dispatch to it even when the bulk /api/tags-based RefreshModels at
 	// startup failed (partial Ollama outage). Idempotent; failure here is
 	// non-fatal — Router's own ProvidersForModel error will surface
@@ -544,27 +544,20 @@ func (s *Server) newCompletionProvider(ctx context.Context, model, providerName 
 	return completion.NewProviderWithGenerator(s.fimGenerator(s.fimPriority()), key.String(), cfg)
 }
 
-func (s *Server) modelKeyForCompletion(model, providerName string) (provider.ModelKey, error) {
+func (s *Server) modelKeyForCompletion(ctx context.Context, model, providerName string) (provider.ModelKey, error) {
 	if providerName != "" {
 		return provider.ModelKey{Provider: providerName, Model: model}, nil
 	}
-	if key, ok := parseModelSelector(model); ok {
+	if key, ok := s.parseKnownModelSelector(model); ok {
 		return key, nil
 	}
 
-	s.mu.RLock()
-	ollamaProv := s.ollamaProv
-	providerRegistry := s.providerRegistry
-	s.mu.RUnlock()
-
-	if ollamaProv != nil {
-		return provider.ModelKey{Provider: ollamaProv.Name(), Model: model}, nil
+	inferredProvider, err := s.inferProviderForExplicitModel(ctx, model)
+	if err != nil {
+		return provider.ModelKey{}, err
 	}
-	if providerRegistry != nil {
-		names := providerRegistry.Names()
-		if len(names) == 1 {
-			return provider.ModelKey{Provider: names[0], Model: model}, nil
-		}
+	if inferredProvider != "" {
+		return provider.ModelKey{Provider: inferredProvider, Model: model}, nil
 	}
 	return provider.ModelKey{}, fmt.Errorf("mcp: provider required for model %q", model)
 }

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -396,7 +396,7 @@ func (s *Server) configuredProviders() ([]provider.Provider, provider.Provider, 
 		if cfg.APIFormat == "" {
 			cfg.APIFormat = "ollama"
 		}
-		if key == "ollama" && s.ollamaURLExplicit {
+		if key == "ollama" && cfg.APIFormat == "ollama" && s.ollamaURLExplicit {
 			cfg.BaseURL = s.ollamaURL
 		}
 

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -183,7 +183,7 @@ func NewServer(ctx context.Context, opts ...Option) (*Server, error) {
 	// unless the caller explicitly overrode the base URL.
 	clientOpts := []ollama.Option{ollama.WithBaseURL(s.ollamaURL)}
 	if s.cfg != nil {
-		if cfgProvider := s.cfg.Provider("ollama"); cfgProvider != nil && (cfgProvider.APIFormat == "" || cfgProvider.APIFormat == "ollama") {
+		if cfgProvider := s.legacyOllamaProviderConfig(); cfgProvider != nil {
 			if !s.ollamaURLExplicit && cfgProvider.BaseURL != "" {
 				s.ollamaURL = cfgProvider.BaseURL
 				clientOpts[0] = ollama.WithBaseURL(s.ollamaURL)
@@ -262,6 +262,35 @@ func NewServer(ctx context.Context, opts ...Option) (*Server, error) {
 	s.registerResources()
 
 	return s, nil
+}
+
+func (s *Server) legacyOllamaProviderConfig() *config.ProviderConfig {
+	if s.cfg == nil {
+		return nil
+	}
+	if cfgProvider := s.cfg.Provider("ollama"); cfgProvider != nil && providerConfigIsOllama(*cfgProvider) {
+		return cfgProvider
+	}
+
+	keys := make([]string, 0, len(s.cfg.Providers))
+	for key, cfgProvider := range s.cfg.Providers {
+		if key == "ollama" {
+			continue
+		}
+		if providerConfigIsOllama(cfgProvider) {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	if len(keys) != 1 {
+		return nil
+	}
+	cfgProvider := s.cfg.Providers[keys[0]]
+	return &cfgProvider
+}
+
+func providerConfigIsOllama(cfgProvider config.ProviderConfig) bool {
+	return cfgProvider.APIFormat == "" || cfgProvider.APIFormat == "ollama"
 }
 
 // rebuildDerivedClients rebuilds the completer, indexer, and retriever from

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -200,7 +200,9 @@ func NewServer(ctx context.Context, opts ...Option) (*Server, error) {
 
 	// Step 3b: Build the provider-level model registry even in degraded mode
 	// so explicit completion requests can recover once Ollama comes back.
-	_ = s.ensureModelRegistry()
+	if err := s.ensureModelRegistry(); err != nil {
+		return nil, err
+	}
 
 	// Step 4: Open RAG store if not disabled (before model resolution
 	// so that rebuildDerivedClients can wire up indexer/retriever).
@@ -380,7 +382,9 @@ func (s *Server) ensureModelRegistry() error {
 	if err != nil {
 		return fmt.Errorf("mcp: model registry unavailable: %w", err)
 	}
-	s.installCapabilityOverrides(mr)
+	if err := s.installCapabilityOverrides(mr); err != nil {
+		return err
+	}
 
 	s.mu.Lock()
 	if s.ollamaProv == nil {
@@ -472,12 +476,18 @@ func configuredProvider(key string, cfg config.ProviderConfig) (provider.Provide
 	}
 }
 
-func (s *Server) installCapabilityOverrides(mr *provider.ModelRegistry) {
+type capabilityOverrideEntry struct {
+	role   string
+	caps   []string
+	parsed provider.Capability
+}
+
+func (s *Server) installCapabilityOverrides(mr *provider.ModelRegistry) error {
 	if mr == nil || s.cfg == nil {
-		return
+		return nil
 	}
 
-	overrides := make(map[provider.ModelKey][]string)
+	overrides := make(map[provider.ModelKey]capabilityOverrideEntry)
 	roles := make([]string, 0, len(s.cfg.Models))
 	for role := range s.cfg.Models {
 		roles = append(roles, role)
@@ -506,23 +516,49 @@ func (s *Server) installCapabilityOverrides(mr *provider.ModelRegistry) {
 		if len(caps) == 0 {
 			continue
 		}
+		parsedCaps, err := provider.ParseCapsStrict(caps)
+		if err != nil {
+			return fmt.Errorf("mcp: model %q capability override for %s/%s: %w", role, m.Provider, m.Name, err)
+		}
+
+		key := provider.ModelKey{Provider: m.Provider, Model: m.Name}
+		if existing, ok := overrides[key]; ok {
+			if existing.parsed != parsedCaps {
+				return fmt.Errorf(
+					"mcp: conflicting capability overrides for %s/%s: model %q declares %v, model %q declares %v",
+					key.Provider,
+					key.Model,
+					existing.role,
+					existing.caps,
+					role,
+					caps,
+				)
+			}
+			continue
+		}
+
 		copied := make([]string, len(caps))
 		copy(copied, caps)
-		overrides[provider.ModelKey{Provider: m.Provider, Model: m.Name}] = copied
+		overrides[key] = capabilityOverrideEntry{
+			role:   role,
+			caps:   copied,
+			parsed: parsedCaps,
+		}
 	}
 	if len(overrides) == 0 {
-		return
+		return nil
 	}
 
 	mr.SetCapabilityOverride(func(key provider.ModelKey) []string {
-		caps, ok := overrides[key]
+		entry, ok := overrides[key]
 		if !ok {
 			return nil
 		}
-		out := make([]string, len(caps))
-		copy(out, caps)
+		out := make([]string, len(entry.caps))
+		copy(out, entry.caps)
 		return out
 	})
+	return nil
 }
 
 // Completer returns the current FIM completion provider (may be nil).

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -67,6 +67,62 @@ func TestNewServerWithOptions(t *testing.T) {
 	}
 }
 
+func TestConfiguredProvidersDoesNotOverrideOpenAICompatProviderNamedOllama(t *testing.T) {
+	var openAIHit atomic.Bool
+	openAIMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		openAIHit.Store(true)
+		switch r.URL.Path {
+		case "/v1/models":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"local-fim","object":"model"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer openAIMock.Close()
+
+	var overrideHit atomic.Bool
+	overrideMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		overrideHit.Store(true)
+		http.NotFound(w, r)
+	}))
+	defer overrideMock.Close()
+
+	s := &Server{
+		ollamaURL:         overrideMock.URL,
+		ollamaURLExplicit: true,
+		cfg: &config.Config{
+			Providers: map[string]config.ProviderConfig{
+				"ollama": {BaseURL: openAIMock.URL, APIFormat: "openai-compat"},
+			},
+		},
+	}
+
+	registered, ollamaProv, err := s.configuredProviders()
+	if err != nil {
+		t.Fatalf("configuredProviders() error = %v", err)
+	}
+	if ollamaProv != nil {
+		t.Fatal("ollamaProv = non-nil, want nil for openai-compatible provider named ollama")
+	}
+	if len(registered) != 1 {
+		t.Fatalf("registered providers = %d, want 1", len(registered))
+	}
+	models, err := registered[0].Models(context.Background())
+	if err != nil {
+		t.Fatalf("Models() error = %v", err)
+	}
+	if len(models) != 1 || models[0].Name != "local-fim" {
+		t.Fatalf("Models() = %+v, want local-fim from openai-compatible endpoint", models)
+	}
+	if !openAIHit.Load() {
+		t.Fatal("openai-compatible base URL was not used")
+	}
+	if overrideHit.Load() {
+		t.Fatal("WithOllamaURL override was incorrectly applied to openai-compatible provider named ollama")
+	}
+}
+
 func TestNewServerUsesConfiguredOllamaProvider(t *testing.T) {
 	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -180,6 +180,50 @@ func TestNewServerRegistersConfiguredProvidersAndOverridesCapabilities(t *testin
 	}
 }
 
+func TestModelKeyForCompletionInfersConfiguredProvider(t *testing.T) {
+	ollamaMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/":
+			w.WriteHeader(http.StatusOK)
+		case "/api/tags":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"models":[{"name":"qwen3:8b"}]}`))
+		case "/api/show":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"details":{"family":"qwen3","parameter_size":"8B"},"capabilities":["embedding"]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollamaMock.Close()
+
+	openAIMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/models":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"local-chat","object":"model"},{"id":"local-carved","object":"model"},{"id":"local-fim","object":"model"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer openAIMock.Close()
+
+	cfgPath := writeProviderWiringConfig(t, t.TempDir(), ollamaMock.URL, openAIMock.URL)
+	s, err := NewServer(context.Background(), WithConfig(cfgPath), WithRAGDisabled())
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	key, err := s.modelKeyForCompletion(context.Background(), "local-fim", "")
+	if err != nil {
+		t.Fatalf("modelKeyForCompletion() error = %v", err)
+	}
+	if key.Provider != "vllm-local" || key.Model != "local-fim" {
+		t.Fatalf("modelKeyForCompletion() = %v, want vllm-local/local-fim", key)
+	}
+}
+
 func TestNewCompletionProviderPinsResolvedProvider(t *testing.T) {
 	openAIMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,8 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/kstruzzieri/go-llm/completion"
 	"github.com/kstruzzieri/go-llm/config"
@@ -195,6 +198,77 @@ func TestNewServerUsesConfiguredOllamaProvider(t *testing.T) {
 	}
 	if s.Completer() == nil {
 		t.Fatal("Completer() = nil, want resolved completion provider")
+	}
+}
+
+func TestNewServerUsesSingleNamedOllamaProviderForLegacyClient(t *testing.T) {
+	var pullHit atomic.Bool
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/":
+			w.WriteHeader(http.StatusOK)
+		case "/api/tags":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"models":[{"name":"local-model"}]}`))
+		case "/api/show":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"details":{"family":"qwen3","parameter_size":"8B"},"capabilities":["completion"]}`))
+		case "/api/pull":
+			pullHit.Store(true)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"success"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer mock.Close()
+
+	path := filepath.Join(t.TempDir(), "models.json")
+	data := `{
+  "providers": {
+    "local-ollama": {
+      "base_url": "` + mock.URL + `",
+      "timeout": "17s",
+      "api_format": "ollama"
+    }
+  },
+  "models": {
+    "general": {"name": "local-model", "provider": "local-ollama", "type": "dense"}
+  },
+  "defaults": {
+    "chat": "general"
+  }
+}`
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+
+	s, err := NewServer(context.Background(), WithConfig(path), WithRAGDisabled())
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	if s.ollamaURL != mock.URL {
+		t.Fatalf("ollamaURL = %q, want named Ollama provider URL %q", s.ollamaURL, mock.URL)
+	}
+	if !s.ollamaAvailable {
+		t.Fatal("ollamaAvailable = false, want true")
+	}
+
+	result, err := s.handlePullModel(context.Background(), &gomcp.CallToolRequest{
+		Params: &gomcp.CallToolParamsRaw{
+			Arguments: json.RawMessage(`{"name":"local-model"}`),
+		},
+	})
+	if err != nil {
+		t.Fatalf("handlePullModel() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handlePullModel() isError = true, content = %v", extractText(result))
+	}
+	if !pullHit.Load() {
+		t.Fatal("pull_model did not use the named Ollama provider URL")
 	}
 }
 

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -349,6 +349,42 @@ func TestNewServerRegistersConfiguredProvidersAndOverridesCapabilities(t *testin
 	}
 }
 
+func TestNewServerRejectsConflictingCapabilityOverrides(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "models.json")
+	data := `{
+  "providers": {
+    "vllm-local": {
+      "base_url": "http://127.0.0.1:1",
+      "timeout": "17s",
+      "api_format": "openai-compat"
+    }
+  },
+  "models": {
+    "chat": {"name": "shared-model", "provider": "vllm-local", "type": "dense", "capabilities": ["chat", "stream"]},
+    "completion": {"name": "shared-model", "provider": "vllm-local", "type": "dense", "capabilities": ["generate", "stream", "insert"]}
+  },
+  "defaults": {
+    "chat": "chat",
+    "completion": "completion"
+  }
+}`
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+
+	_, err := NewServer(context.Background(),
+		WithConfig(path),
+		WithOllamaURL("http://127.0.0.1:1"),
+		WithRAGDisabled(),
+	)
+	if err == nil {
+		t.Fatal("NewServer() error = nil, want conflicting capability override error")
+	}
+	if !strings.Contains(err.Error(), "conflicting capability overrides for vllm-local/shared-model") {
+		t.Fatalf("NewServer() error = %q, want conflicting capability override message", err)
+	}
+}
+
 func TestModelKeyForCompletionInfersConfiguredProvider(t *testing.T) {
 	ollamaMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -123,6 +123,45 @@ func TestConfiguredProvidersDoesNotOverrideOpenAICompatProviderNamedOllama(t *te
 	}
 }
 
+func TestConfiguredProvidersRejectsInvalidProviderKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		wantErr string
+	}{
+		{
+			name:    "empty",
+			key:     "",
+			wantErr: "provider name must not be empty",
+		},
+		{
+			name:    "slash",
+			key:     "team/local",
+			wantErr: `provider name "team/local" must not contain "/"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Server{
+				cfg: &config.Config{
+					Providers: map[string]config.ProviderConfig{
+						tt.key: {BaseURL: "http://localhost:11434", APIFormat: "ollama"},
+					},
+				},
+			}
+
+			_, _, err := s.configuredProviders()
+			if err == nil {
+				t.Fatal("configuredProviders() error = nil, want invalid provider key error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestNewServerUsesConfiguredOllamaProvider(t *testing.T) {
 	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -7,9 +7,12 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 
+	"github.com/kstruzzieri/go-llm/completion"
 	"github.com/kstruzzieri/go-llm/config"
 	"github.com/kstruzzieri/go-llm/ollama"
 	"github.com/kstruzzieri/go-llm/provider"
@@ -97,6 +100,121 @@ func TestNewServerUsesConfiguredOllamaProvider(t *testing.T) {
 	}
 	if s.Completer() == nil {
 		t.Fatal("Completer() = nil, want resolved completion provider")
+	}
+}
+
+func TestNewServerRegistersConfiguredProvidersAndOverridesCapabilities(t *testing.T) {
+	ollamaMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/":
+			w.WriteHeader(http.StatusOK)
+		case "/api/tags":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"models":[{"name":"qwen3:8b"}]}`))
+		case "/api/show":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"details":{"family":"qwen3","parameter_size":"8B"},"template":"{{ .Prompt }}{{ .Suffix }}","capabilities":["completion","insert"]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollamaMock.Close()
+
+	var sawBearer atomic.Bool
+	openAIMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "Bearer test-token" {
+			sawBearer.Store(true)
+		}
+		switch r.URL.Path {
+		case "/v1/models":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"local-chat","object":"model"},{"id":"local-fim","object":"model"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer openAIMock.Close()
+
+	cfgPath := writeProviderWiringConfig(t, t.TempDir(), ollamaMock.URL, openAIMock.URL)
+	s, err := NewServer(context.Background(), WithConfig(cfgPath), WithRAGDisabled())
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	if s.providerRegistry == nil {
+		t.Fatal("providerRegistry = nil")
+	}
+	if got, want := s.providerRegistry.Names(), []string{"ollama", "vllm-local"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("providerRegistry.Names() = %v, want %v", got, want)
+	}
+	if _, ok := s.providerRegistry.Get("vllm-local"); !ok {
+		t.Fatal("OpenAI-compatible provider instance vllm-local was not registered")
+	}
+	if !sawBearer.Load() {
+		t.Fatal("OpenAI-compatible provider did not use configured API key")
+	}
+
+	resolved := s.snapshotResolved()
+	if got := resolved["completion"].Provider; got != "vllm-local" {
+		t.Fatalf("resolved completion provider = %q, want vllm-local", got)
+	}
+
+	profile, err := s.modelRegistry.Lookup(context.Background(), provider.ModelKey{Provider: "vllm-local", Model: "local-chat"})
+	if err != nil {
+		t.Fatalf("Lookup(vllm-local/local-chat) error = %v", err)
+	}
+	if !profile.Caps.Has(provider.CapChat) || !profile.Caps.Has(provider.CapStream) {
+		t.Fatalf("local-chat caps = %v, want chat+stream override", profile.Caps)
+	}
+	if profile.Caps.Has(provider.CapGenerate) {
+		t.Fatalf("local-chat caps = %v, want config override to remove generate", profile.Caps)
+	}
+}
+
+func TestNewCompletionProviderPinsResolvedProvider(t *testing.T) {
+	openAIMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/models":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"local-fim","object":"model"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer openAIMock.Close()
+
+	cfgPath := writeOpenAICompatOnlyConfig(t, t.TempDir(), openAIMock.URL)
+	s, err := NewServer(context.Background(), WithConfig(cfgPath), WithRAGDisabled())
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	router := newRecordingRouteEngine("routed-fim")
+	s.mu.Lock()
+	s.router = router
+	s.mu.Unlock()
+
+	p, err := s.newCompletionProvider(context.Background(), "local-fim", "vllm-local")
+	if err != nil {
+		t.Fatalf("newCompletionProvider() error = %v", err)
+	}
+	resp, err := p.Complete(context.Background(), completion.FIMRequest{
+		Prefix: "func f() int { return ",
+		Suffix: " }",
+	})
+	if err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if resp.Completion != "routed-fim" {
+		t.Fatalf("Completion = %q, want routed-fim", resp.Completion)
+	}
+	if router.last.Model != "vllm-local/local-fim" {
+		t.Fatalf("RoutingRequest.Model = %q, want vllm-local/local-fim", router.last.Model)
+	}
+	if router.last.Provider != "" {
+		t.Fatalf("RoutingRequest.Provider = %q, want empty because qualified Model is authoritative", router.last.Provider)
 	}
 }
 
@@ -285,6 +403,66 @@ func writeTestConfig(t *testing.T, dir, baseURL string) string {
     "embedding": "embedding",
     "agent": "fast",
     "analysis": "general"
+  }
+}`
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+	return path
+}
+
+func writeProviderWiringConfig(t *testing.T, dir, ollamaURL, openAIURL string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, "models.json")
+	data := `{
+  "providers": {
+    "ollama": {
+      "base_url": "` + ollamaURL + `",
+      "timeout": "17s",
+      "api_format": "ollama"
+    },
+    "vllm-local": {
+      "base_url": "` + openAIURL + `",
+      "timeout": "17s",
+      "api_format": "openai-compat",
+      "api_key": "test-token"
+    }
+  },
+  "models": {
+    "general": {"name": "local-chat", "provider": "vllm-local", "type": "dense", "capabilities": ["chat", "stream"]},
+    "completion": {"name": "local-fim", "provider": "vllm-local", "type": "dense", "capabilities": ["generate", "stream", "insert"]},
+    "embedding": {"name": "qwen3:8b", "provider": "ollama", "type": "embedding"}
+  },
+  "defaults": {
+    "chat": "general",
+    "completion": "completion",
+    "embedding": "embedding"
+  }
+}`
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+	return path
+}
+
+func writeOpenAICompatOnlyConfig(t *testing.T, dir, openAIURL string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, "models.json")
+	data := `{
+  "providers": {
+    "vllm-local": {
+      "base_url": "` + openAIURL + `",
+      "timeout": "17s",
+      "api_format": "openai-compat"
+    }
+  },
+  "models": {
+    "completion": {"name": "local-fim", "provider": "vllm-local", "type": "dense", "capabilities": ["generate", "stream", "insert"]}
+  },
+  "defaults": {
+    "completion": "completion"
   }
 }`
 	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -128,7 +128,7 @@ func TestNewServerRegistersConfiguredProvidersAndOverridesCapabilities(t *testin
 		switch r.URL.Path {
 		case "/v1/models":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"local-chat","object":"model"},{"id":"local-fim","object":"model"}]}`))
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"local-chat","object":"model"},{"id":"local-carved","object":"model"},{"id":"local-fim","object":"model"}]}`))
 		default:
 			http.NotFound(w, r)
 		}
@@ -164,11 +164,19 @@ func TestNewServerRegistersConfiguredProvidersAndOverridesCapabilities(t *testin
 	if err != nil {
 		t.Fatalf("Lookup(vllm-local/local-chat) error = %v", err)
 	}
+	if !profile.Caps.Has(provider.CapChat | provider.CapGenerate | provider.CapStream) {
+		t.Fatalf("local-chat caps = %v, want openai-compatible type-derived chat+generate+stream override", profile.Caps)
+	}
+
+	profile, err = s.modelRegistry.Lookup(context.Background(), provider.ModelKey{Provider: "vllm-local", Model: "local-carved"})
+	if err != nil {
+		t.Fatalf("Lookup(vllm-local/local-carved) error = %v", err)
+	}
 	if !profile.Caps.Has(provider.CapChat) || !profile.Caps.Has(provider.CapStream) {
-		t.Fatalf("local-chat caps = %v, want chat+stream override", profile.Caps)
+		t.Fatalf("local-carved caps = %v, want chat+stream override", profile.Caps)
 	}
 	if profile.Caps.Has(provider.CapGenerate) {
-		t.Fatalf("local-chat caps = %v, want config override to remove generate", profile.Caps)
+		t.Fatalf("local-carved caps = %v, want config override to remove generate", profile.Caps)
 	}
 }
 
@@ -430,7 +438,8 @@ func writeProviderWiringConfig(t *testing.T, dir, ollamaURL, openAIURL string) s
     }
   },
   "models": {
-    "general": {"name": "local-chat", "provider": "vllm-local", "type": "dense", "capabilities": ["chat", "stream"]},
+    "general": {"name": "local-chat", "provider": "vllm-local", "type": "dense"},
+    "carved": {"name": "local-carved", "provider": "vllm-local", "type": "dense", "capabilities": ["chat", "stream"]},
     "completion": {"name": "local-fim", "provider": "vllm-local", "type": "dense", "capabilities": ["generate", "stream", "insert"]},
     "embedding": {"name": "qwen3:8b", "provider": "ollama", "type": "embedding"}
   },

--- a/mcp/tools_chat.go
+++ b/mcp/tools_chat.go
@@ -116,9 +116,13 @@ func (s *Server) handleChat(ctx context.Context, req *gomcp.CallToolRequest) (*g
 	if args.Temperature != nil {
 		opts.Temperature = args.Temperature
 	}
+	model, err := s.routeModelSelector(ctx, args.Model, "chat")
+	if err != nil {
+		return toolError("config", "%v", err), nil
+	}
 
 	rr := provider.RoutingRequest{
-		Model:          args.Model,
+		Model:          model,
 		UseCase:        "chat",
 		RequiredCaps:   provider.CapChat,
 		Messages:       pmsgs,

--- a/mcp/tools_completion.go
+++ b/mcp/tools_completion.go
@@ -44,7 +44,7 @@ func (s *Server) handleCompletion(ctx context.Context, req *gomcp.CallToolReques
 		return toolError("validation", "invalid arguments: %v", err), nil
 	}
 
-	model, err := s.resolveModel(ctx, args.Model, "completion")
+	target, err := s.resolveModelTarget(ctx, args.Model, "completion")
 	if err != nil {
 		return toolError("config", "%v", err), nil
 	}
@@ -52,7 +52,7 @@ func (s *Server) handleCompletion(ctx context.Context, req *gomcp.CallToolReques
 	// Build a provider for this specific model via the MCP server's registry
 	// so ProviderConfig (FIM tokens, context window, quality tier) reflects
 	// the resolved ModelProfile rather than hardcoded defaults.
-	provider, err := s.newCompletionProvider(ctx, model)
+	provider, err := s.newCompletionProvider(ctx, target.Name, target.Provider)
 	if err != nil {
 		return toolError("config", "%v", err), nil
 	}

--- a/mcp/tools_generate.go
+++ b/mcp/tools_generate.go
@@ -60,9 +60,13 @@ func (s *Server) handleGenerate(ctx context.Context, req *gomcp.CallToolRequest)
 	if args.MaxTokens > 0 {
 		expectedOutput = args.MaxTokens
 	}
+	model, err := s.routeModelSelector(ctx, args.Model, "chat")
+	if err != nil {
+		return toolError("config", "%v", err), nil
+	}
 
 	rr := provider.RoutingRequest{
-		Model:          args.Model,
+		Model:          model,
 		UseCase:        "chat", // generate routes via the chat use-case
 		RequiredCaps:   provider.CapGenerate,
 		Prompt:         args.Prompt,

--- a/mcp/tools_models.go
+++ b/mcp/tools_models.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -33,6 +34,10 @@ func (s *Server) registerModelTools() {
 			"type": "object",
 			"properties": map[string]any{
 				"name": map[string]any{"type": "string", "description": "Model name (e.g. qwen3:8b)"},
+				"provider": map[string]any{
+					"type":        "string",
+					"description": "Provider instance name when the model name is ambiguous",
+				},
 			},
 			"required": []string{"name"},
 		},
@@ -138,7 +143,8 @@ func (s *Server) listLegacyOllamaModels(ctx context.Context) ([]listedModelInfo,
 
 func (s *Server) handleShowModel(ctx context.Context, req *gomcp.CallToolRequest) (*gomcp.CallToolResult, error) {
 	var args struct {
-		Name string `json:"name"`
+		Name     string `json:"name"`
+		Provider string `json:"provider,omitempty"`
 	}
 	if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
 		return toolError("validation", "invalid arguments: %v", err), nil
@@ -147,16 +153,111 @@ func (s *Server) handleShowModel(ctx context.Context, req *gomcp.CallToolRequest
 		return toolError("validation", "name must not be empty"), nil
 	}
 
-	info, err := s.client.ShowModel(ctx, args.Name)
+	info, err := s.showModel(ctx, args.Name, args.Provider)
 	if err != nil {
-		return toolError("ollama", "%v", err), nil
+		return toolError("provider", "%v", err), nil
 	}
 
 	data, err := json.Marshal(info)
 	if err != nil {
-		return toolError("ollama", "marshal model info: %v", err), nil
+		return toolError("provider", "marshal model info: %v", err), nil
 	}
 	return toolResult(string(data)), nil
+}
+
+func (s *Server) showModel(ctx context.Context, name, providerName string) (any, error) {
+	key, ok, err := s.modelKeyForShowModel(ctx, name, providerName)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		return s.lookupProviderModelInfo(ctx, key)
+	}
+
+	info, err := s.client.ShowModel(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
+func (s *Server) modelKeyForShowModel(ctx context.Context, name, providerName string) (provider.ModelKey, bool, error) {
+	if providerName != "" {
+		return provider.ModelKey{Provider: providerName, Model: name}, true, nil
+	}
+	if key, ok := s.parseKnownModelSelector(name); ok {
+		return key, true, nil
+	}
+
+	inferredProvider, err := s.inferProviderForExplicitModel(ctx, name)
+	if err != nil {
+		return provider.ModelKey{}, false, err
+	}
+	if inferredProvider != "" {
+		return provider.ModelKey{Provider: inferredProvider, Model: name}, true, nil
+	}
+	return provider.ModelKey{}, false, nil
+}
+
+func (s *Server) lookupProviderModelInfo(ctx context.Context, key provider.ModelKey) (listedModelInfo, error) {
+	s.mu.RLock()
+	modelRegistry := s.modelRegistry
+	s.mu.RUnlock()
+	if modelRegistry != nil {
+		profile, err := modelRegistry.Lookup(ctx, key)
+		if err == nil {
+			return listedModelInfo{
+				ModelInfo: modelInfoFromProfile(profile),
+				Provider:  key.Provider,
+			}, nil
+		}
+	}
+
+	pReg := s.providerRegistrySnapshot()
+	if pReg == nil {
+		return listedModelInfo{}, fmt.Errorf("provider registry unavailable")
+	}
+	p, ok := pReg.Get(key.Provider)
+	if !ok {
+		return listedModelInfo{}, fmt.Errorf("provider %q not found", key.Provider)
+	}
+
+	models, err := p.Models(ctx)
+	if err != nil {
+		return listedModelInfo{}, err
+	}
+	for _, model := range models {
+		if model.Name == key.Model {
+			return listedModelInfo{
+				ModelInfo: model,
+				Provider:  key.Provider,
+			}, nil
+		}
+	}
+	return listedModelInfo{}, fmt.Errorf("model %q not found on provider %q", key.Model, key.Provider)
+}
+
+func modelInfoFromProfile(profile *provider.ModelProfile) provider.ModelInfo {
+	if profile == nil {
+		return provider.ModelInfo{}
+	}
+	return provider.ModelInfo{
+		Name:          profile.Key.Model,
+		Family:        profile.Family,
+		ParameterSize: profile.Resources.ParameterSize,
+		QuantLevel:    profile.Resources.QuantLevel,
+		Template:      profile.Template,
+		Capabilities:  capabilityNames(profile.Caps),
+		ContextWindow: profile.ContextWindow,
+		Digest:        profile.Digest,
+	}
+}
+
+func capabilityNames(caps provider.Capability) []string {
+	if caps == 0 {
+		return nil
+	}
+	return strings.Split(caps.String(), "|")
 }
 
 func (s *Server) handlePullModel(ctx context.Context, req *gomcp.CallToolRequest) (*gomcp.CallToolResult, error) {

--- a/mcp/tools_models.go
+++ b/mcp/tools_models.go
@@ -85,7 +85,7 @@ func listProviderRegistryModels(ctx context.Context, pReg *provider.Registry) ([
 	var out []listedModelInfo
 	var firstErr error
 	for _, p := range pReg.All() {
-		models, err := p.Models(ctx)
+		models, err := pReg.RefreshModelsAndList(ctx, p.Name())
 		if err != nil {
 			if firstErr == nil {
 				firstErr = fmt.Errorf("list models for provider %q: %w", p.Name(), err)
@@ -100,7 +100,6 @@ func listProviderRegistryModels(ctx context.Context, pReg *provider.Registry) ([
 				ModelInfo: model,
 				Provider:  p.Name(),
 			})
-			_ = pReg.AddModelToIndex(model.Name, p.Name())
 		}
 	}
 	sort.SliceStable(out, func(i, j int) bool {

--- a/mcp/tools_models.go
+++ b/mcp/tools_models.go
@@ -199,39 +199,37 @@ func (s *Server) modelKeyForShowModel(ctx context.Context, name, providerName st
 }
 
 func (s *Server) lookupProviderModelInfo(ctx context.Context, key provider.ModelKey) (listedModelInfo, error) {
-	s.mu.RLock()
-	modelRegistry := s.modelRegistry
-	s.mu.RUnlock()
-	if modelRegistry != nil {
-		profile, err := modelRegistry.Lookup(ctx, key)
-		if err == nil {
-			return listedModelInfo{
-				ModelInfo: modelInfoFromProfile(profile),
-				Provider:  key.Provider,
-			}, nil
-		}
-	}
-
 	pReg := s.providerRegistrySnapshot()
 	if pReg == nil {
 		return listedModelInfo{}, fmt.Errorf("provider registry unavailable")
 	}
-	p, ok := pReg.Get(key.Provider)
-	if !ok {
-		return listedModelInfo{}, fmt.Errorf("provider %q not found", key.Provider)
-	}
 
-	models, err := p.Models(ctx)
+	models, err := pReg.RefreshModelsAndList(ctx, key.Provider)
 	if err != nil {
 		return listedModelInfo{}, err
 	}
-	for _, model := range models {
-		if model.Name == key.Model {
-			return listedModelInfo{
-				ModelInfo: model,
-				Provider:  key.Provider,
-			}, nil
+	for i := range models {
+		if models[i].Name != key.Model {
+			continue
 		}
+
+		s.mu.RLock()
+		modelRegistry := s.modelRegistry
+		s.mu.RUnlock()
+		if modelRegistry != nil {
+			profile, err := modelRegistry.Refresh(ctx, key)
+			if err == nil {
+				return listedModelInfo{
+					ModelInfo: modelInfoFromProfile(profile),
+					Provider:  key.Provider,
+				}, nil
+			}
+		}
+
+		return listedModelInfo{
+			ModelInfo: models[i],
+			Provider:  key.Provider,
+		}, nil
 	}
 	return listedModelInfo{}, fmt.Errorf("model %q not found on provider %q", key.Model, key.Provider)
 }

--- a/mcp/tools_models.go
+++ b/mcp/tools_models.go
@@ -4,14 +4,22 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/kstruzzieri/go-llm/provider"
 )
+
+type listedModelInfo struct {
+	provider.ModelInfo
+	Provider string `json:"provider,omitempty"`
+}
 
 func (s *Server) registerModelTools() {
 	s.mcpServer.AddTool(&gomcp.Tool{
 		Name:        "list_models",
-		Description: "List all available Ollama models. Also refreshes the model resolution cache.",
+		Description: "List all available provider models. Also refreshes the model resolution cache.",
 		InputSchema: map[string]any{
 			"type":       "object",
 			"properties": map[string]any{},
@@ -44,24 +52,88 @@ func (s *Server) registerModelTools() {
 }
 
 func (s *Server) handleListModels(ctx context.Context, req *gomcp.CallToolRequest) (*gomcp.CallToolResult, error) {
-	models, err := s.client.ListModels(ctx)
-	if err != nil {
-		return toolError("ollama", "%v", err), nil
-	}
-
 	// Refresh model resolution cache since model availability may have changed.
 	if s.cfg != nil {
 		_ = s.refreshResolved(ctx) // non-fatal: partial results kept
 	}
-	// Self-heal the providerRegistry's model index so the Recommend safety-net
-	// tail works after providers recover from boot-time unreachability.
-	s.refreshProviderModelIndexes(ctx)
+
+	models, err := s.listModels(ctx)
+	if err != nil {
+		return toolError("provider", "%v", err), nil
+	}
 
 	data, err := json.Marshal(models)
 	if err != nil {
-		return toolError("ollama", "marshal models: %v", err), nil
+		return toolError("provider", "marshal models: %v", err), nil
 	}
 	return toolResult(string(data)), nil
+}
+
+func (s *Server) listModels(ctx context.Context) ([]listedModelInfo, error) {
+	if pReg := s.providerRegistrySnapshot(); pReg != nil {
+		return listProviderRegistryModels(ctx, pReg)
+	}
+	return s.listLegacyOllamaModels(ctx)
+}
+
+func listProviderRegistryModels(ctx context.Context, pReg *provider.Registry) ([]listedModelInfo, error) {
+	var out []listedModelInfo
+	var firstErr error
+	for _, p := range pReg.All() {
+		models, err := p.Models(ctx)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("list models for provider %q: %w", p.Name(), err)
+			}
+			continue
+		}
+		for _, model := range models {
+			if model.Name == "" {
+				continue
+			}
+			out = append(out, listedModelInfo{
+				ModelInfo: model,
+				Provider:  p.Name(),
+			})
+			_ = pReg.AddModelToIndex(model.Name, p.Name())
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Provider == out[j].Provider {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].Provider < out[j].Provider
+	})
+	if len(out) == 0 && firstErr != nil {
+		return nil, firstErr
+	}
+	return out, nil
+}
+
+func (s *Server) listLegacyOllamaModels(ctx context.Context) ([]listedModelInfo, error) {
+	models, err := s.client.ListModels(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]listedModelInfo, 0, len(models))
+	for _, model := range models {
+		if model.Name == "" {
+			continue
+		}
+		out = append(out, listedModelInfo{
+			ModelInfo: provider.ModelInfo{
+				Name:          model.Name,
+				Family:        model.Family,
+				ParameterSize: model.ParamSize,
+				QuantLevel:    model.QuantLevel,
+				Template:      model.Template,
+				Capabilities:  model.Capabilities,
+				Digest:        model.Digest,
+			},
+			Provider: "ollama",
+		})
+	}
+	return out, nil
 }
 
 func (s *Server) handleShowModel(ctx context.Context, req *gomcp.CallToolRequest) (*gomcp.CallToolResult, error) {

--- a/mcp/tools_models.go
+++ b/mcp/tools_models.go
@@ -54,10 +54,8 @@ func (s *Server) handleListModels(ctx context.Context, req *gomcp.CallToolReques
 		_ = s.refreshResolved(ctx) // non-fatal: partial results kept
 	}
 	// Self-heal the providerRegistry's model index so the Recommend safety-net
-	// tail works after Ollama recovers from boot-time unreachability.
-	if providerRegistry := s.providerRegistrySnapshot(); providerRegistry != nil {
-		_ = providerRegistry.RefreshModels(ctx, "ollama") // non-fatal
-	}
+	// tail works after providers recover from boot-time unreachability.
+	s.refreshProviderModelIndexes(ctx)
 
 	data, err := json.Marshal(models)
 	if err != nil {
@@ -111,9 +109,7 @@ func (s *Server) handlePullModel(ctx context.Context, req *gomcp.CallToolRequest
 	}
 	// Self-heal the providerRegistry's model index so the freshly pulled
 	// model becomes routable immediately.
-	if providerRegistry := s.providerRegistrySnapshot(); providerRegistry != nil {
-		_ = providerRegistry.RefreshModels(ctx, "ollama") // non-fatal
-	}
+	s.refreshProviderModelIndexes(ctx)
 
 	return toolResult(fmt.Sprintf("model %q pulled successfully", args.Name)), nil
 }

--- a/mcp/tools_models_test.go
+++ b/mcp/tools_models_test.go
@@ -131,6 +131,66 @@ func TestShowModelToolBasic(t *testing.T) {
 	}
 }
 
+func TestShowModelToolUsesProviderRegistry(t *testing.T) {
+	openAIMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/models":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"local-fim","object":"model"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer openAIMock.Close()
+
+	cfgPath := writeOpenAICompatOnlyConfig(t, t.TempDir(), openAIMock.URL)
+	s, err := NewServer(context.Background(), WithConfig(cfgPath), WithRAGDisabled())
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	result, err := s.handleShowModel(context.Background(), &gomcp.CallToolRequest{
+		Params: &gomcp.CallToolParamsRaw{
+			Arguments: json.RawMessage(`{"name":"local-fim"}`),
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleShowModel() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleShowModel() isError = true, content = %v", extractText(result))
+	}
+
+	var info struct {
+		Provider     string   `json:"provider"`
+		Name         string   `json:"name"`
+		Capabilities []string `json:"capabilities"`
+	}
+	if err := json.Unmarshal([]byte(extractText(result)), &info); err != nil {
+		t.Fatalf("unmarshal model info: %v", err)
+	}
+	if info.Provider != "vllm-local" || info.Name != "local-fim" {
+		t.Fatalf("model info = %+v, want vllm-local/local-fim", info)
+	}
+	if !containsAll(info.Capabilities, "generate", "stream", "insert") {
+		t.Fatalf("capabilities = %v, want generate, stream, insert", info.Capabilities)
+	}
+}
+
+func containsAll(got []string, want ...string) bool {
+	seen := make(map[string]bool, len(got))
+	for _, item := range got {
+		seen[item] = true
+	}
+	for _, item := range want {
+		if !seen[item] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestShowModelToolEmptyName(t *testing.T) {
 	mock := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/mcp/tools_models_test.go
+++ b/mcp/tools_models_test.go
@@ -11,6 +11,7 @@ import (
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/kstruzzieri/go-llm/ollama"
+	"github.com/kstruzzieri/go-llm/provider"
 )
 
 func TestListModelsToolBasic(t *testing.T) {
@@ -95,6 +96,9 @@ func TestShowModelToolBasic(t *testing.T) {
 		switch r.URL.Path {
 		case "/":
 			w.WriteHeader(http.StatusOK)
+		case "/api/tags":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"models":[{"name":"qwen3:8b"}]}`))
 		case "/api/show":
 			w.Header().Set("Content-Type", "application/json")
 			// Ollama's /api/show response nests model details under "details".
@@ -175,6 +179,39 @@ func TestShowModelToolUsesProviderRegistry(t *testing.T) {
 	}
 	if !containsAll(info.Capabilities, "generate", "stream", "insert") {
 		t.Fatalf("capabilities = %v, want generate, stream, insert", info.Capabilities)
+	}
+}
+
+func TestShowModelToolQueriesLiveInventoryBeforeCachedProfile(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := &mutableModelProvider{
+		fakeRouteProvider: &fakeRouteProvider{name: "vllm-local"},
+		models:            []provider.ModelInfo{{Name: "old-model"}},
+	}
+	if err := reg.Register(p); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	mr, err := provider.NewModelRegistry(reg, nil)
+	if err != nil {
+		t.Fatalf("NewModelRegistry() error = %v", err)
+	}
+	s := &Server{
+		providerRegistry: reg,
+		modelRegistry:    mr,
+	}
+
+	key := provider.ModelKey{Provider: "vllm-local", Model: "old-model"}
+	if _, err := s.lookupProviderModelInfo(context.Background(), key); err != nil {
+		t.Fatalf("initial lookupProviderModelInfo() error = %v", err)
+	}
+
+	p.models = []provider.ModelInfo{{Name: "new-model"}}
+	_, err = s.lookupProviderModelInfo(context.Background(), key)
+	if err == nil {
+		t.Fatal("lookupProviderModelInfo() error = nil, want stale cached model rejected")
+	}
+	if !strings.Contains(err.Error(), `model "old-model" not found`) {
+		t.Fatalf("lookupProviderModelInfo() error = %q, want stale model not found", err)
 	}
 }
 

--- a/mcp/tools_models_test.go
+++ b/mcp/tools_models_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -44,6 +45,48 @@ func TestListModelsToolBasic(t *testing.T) {
 	}
 	if len(models) != 2 {
 		t.Errorf("model count = %d, want 2", len(models))
+	}
+}
+
+func TestListModelsToolUsesProviderRegistryWhenOllamaUnavailable(t *testing.T) {
+	openAIMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/models":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"local-fim","object":"model"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer openAIMock.Close()
+
+	cfgPath := writeOpenAICompatOnlyConfig(t, t.TempDir(), openAIMock.URL)
+	s, err := NewServer(context.Background(), WithConfig(cfgPath), WithRAGDisabled())
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	result, err := s.handleListModels(context.Background(), &gomcp.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("handleListModels() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleListModels() isError = true, content = %v", extractText(result))
+	}
+
+	var models []struct {
+		Provider string `json:"provider"`
+		Name     string `json:"name"`
+	}
+	if err := json.Unmarshal([]byte(extractText(result)), &models); err != nil {
+		t.Fatalf("unmarshal models: %v", err)
+	}
+	if len(models) != 1 {
+		t.Fatalf("model count = %d, want 1", len(models))
+	}
+	if models[0].Provider != "vllm-local" || models[0].Name != "local-fim" {
+		t.Fatalf("model = %+v, want vllm-local/local-fim", models[0])
 	}
 }
 

--- a/provider/registry.go
+++ b/provider/registry.go
@@ -184,17 +184,27 @@ func (r *Registry) AddModelToIndex(model, providerName string) error {
 // the registry's model index. This must be called after registration to populate
 // the model index for ProvidersForModel lookups.
 func (r *Registry) RefreshModels(ctx context.Context, providerName string) error {
+	_, err := r.RefreshModelsAndList(ctx, providerName)
+	return err
+}
+
+// RefreshModelsAndList queries the named provider for its available models,
+// replaces that provider's model-index entries, and returns the fresh model
+// list. Callers that need both the current model list and a coherent registry
+// index should use this instead of calling Models followed by AddModelToIndex;
+// the latter is intentionally append-only for single-model recovery paths.
+func (r *Registry) RefreshModelsAndList(ctx context.Context, providerName string) ([]ModelInfo, error) {
 	r.mu.RLock()
 	p, ok := r.providers[providerName]
 	r.mu.RUnlock()
 
 	if !ok {
-		return fmt.Errorf("provider: refresh models: provider %q not found", providerName)
+		return nil, fmt.Errorf("provider: refresh models: provider %q not found", providerName)
 	}
 
 	models, err := p.Models(ctx)
 	if err != nil {
-		return fmt.Errorf("provider: refresh models for %q: %w", providerName, err)
+		return nil, fmt.Errorf("provider: refresh models for %q: %w", providerName, err)
 	}
 
 	r.mu.Lock()
@@ -217,8 +227,13 @@ func (r *Registry) RefreshModels(ctx context.Context, providerName string) error
 
 	// Add new entries.
 	for _, m := range models {
+		if m.Name == "" {
+			continue
+		}
 		r.modelIndex[m.Name] = append(r.modelIndex[m.Name], providerName)
 	}
 
-	return nil
+	out := make([]ModelInfo, len(models))
+	copy(out, models)
+	return out, nil
 }


### PR DESCRIPTION
## Summary

PR4 for #81. This wires the already-merged OpenAI-compatible provider backend into MCP/config startup so configured local provider instances are routable end-to-end.

- Register MCP provider instances from `models.json` provider config instead of hardcoding a single Ollama provider.
- Honor `api_format: "openai-compat"`, timeout, API key, and configured provider instance names when building providers.
- Refresh the provider model index for every registered provider on startup/self-heal paths.
- Install `ModelRegistry.SetCapabilityOverride` from explicit `ModelConfig.Capabilities` so user-declared per-model capabilities replace merged caps.
- Preserve provider identity for non-chain runtime paths by passing provider-qualified FIM and RAG embedding model selectors into Router.
- Add provider-aware config resolution so duplicate model names on different providers do not satisfy the wrong provider's role.

Closes #81.

## Validation

- `go test ./mcp ./config ./provider ./provider/openaicompat`
- `go test ./...`
- `go vet ./...`
- pre-push hook: lint, race tests, compile smoke