### PR TITLE
[codex] Add llm-bench conversation trace capture

### DIFF
--- a/cmd/llm-bench/capture.go
+++ b/cmd/llm-bench/capture.go
@@ -1,0 +1,518 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/conversation"
+
+	_ "modernc.org/sqlite"
+)
+
+const defaultCaptureSource = "conversation-store"
+
+var (
+	errConversationMissingID        = errors.New("conversation has empty id")
+	errConversationMissingSystem    = errors.New("conversation has no system message")
+	errConversationMissingUser      = errors.New("conversation has no user turn")
+	errConversationMissingAssistant = errors.New("conversation has no final assistant answer")
+	errConversationInvalidToolCall  = errors.New("conversation has invalid tool call")
+)
+
+type captureOptions struct {
+	DBPath         string
+	OutputDir      string
+	Limit          int
+	Source         string
+	FallbackSystem string
+}
+
+type captureResult struct {
+	Written []string
+	Skipped []string
+}
+
+type conversationStore interface {
+	List(ctx context.Context) ([]conversation.Summary, error)
+	Load(ctx context.Context, id string) (*conversation.Conversation, error)
+}
+
+func runCapture(ctx context.Context, opts captureOptions) (captureResult, error) {
+	if strings.TrimSpace(opts.DBPath) == "" {
+		return captureResult{}, fmt.Errorf("capture db path is required")
+	}
+	info, err := os.Stat(opts.DBPath)
+	if err != nil {
+		return captureResult{}, fmt.Errorf("stat capture db %q: %w", opts.DBPath, err)
+	}
+	if info.IsDir() {
+		return captureResult{}, fmt.Errorf("capture db %q is a directory", opts.DBPath)
+	}
+
+	db, err := openReadOnlySQLite(opts.DBPath)
+	if err != nil {
+		return captureResult{}, fmt.Errorf("open capture db %q: %w", opts.DBPath, err)
+	}
+	defer func() { _ = db.Close() }()
+
+	return captureConversations(ctx, &captureConversationReader{db: db}, opts)
+}
+
+func openReadOnlySQLite(path string) (*sql.DB, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+
+	u := url.URL{Scheme: "file", Path: abs}
+	q := u.Query()
+	q.Set("mode", "ro")
+	q.Add("_pragma", "query_only(1)")
+	u.RawQuery = q.Encode()
+
+	db, err := sql.Open("sqlite", u.String())
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(1)
+	return db, nil
+}
+
+type captureConversationReader struct {
+	db *sql.DB
+}
+
+func (r *captureConversationReader) List(ctx context.Context) ([]conversation.Summary, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id,
+		        title,
+		        CASE WHEN json_valid(messages) THEN json_array_length(messages) ELSE 0 END,
+		        created_at,
+		        updated_at
+		   FROM conversations
+		  ORDER BY updated_at DESC, id ASC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("capture: list conversations: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var summaries []conversation.Summary
+	for rows.Next() {
+		var s conversation.Summary
+		var createdMs, updatedMs int64
+		if err := rows.Scan(&s.ID, &s.Title, &s.MessageCount, &createdMs, &updatedMs); err != nil {
+			return nil, fmt.Errorf("capture: scan conversation summary: %w", err)
+		}
+		s.CreatedAt = time.UnixMilli(createdMs)
+		s.UpdatedAt = time.UnixMilli(updatedMs)
+		summaries = append(summaries, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("capture: iterate conversation summaries: %w", err)
+	}
+	if summaries == nil {
+		return []conversation.Summary{}, nil
+	}
+	return summaries, nil
+}
+
+func (r *captureConversationReader) Load(ctx context.Context, id string) (*conversation.Conversation, error) {
+	var conv conversation.Conversation
+	var messagesJSON string
+	var createdMs, updatedMs int64
+
+	err := r.db.QueryRowContext(ctx,
+		`SELECT id, title, messages, created_at, updated_at FROM conversations WHERE id = ?`,
+		id,
+	).Scan(&conv.ID, &conv.Title, &messagesJSON, &createdMs, &updatedMs)
+	if err != nil {
+		return nil, fmt.Errorf("capture: load conversation %q: %w", id, err)
+	}
+	if err := json.Unmarshal([]byte(messagesJSON), &conv.Messages); err != nil {
+		return nil, fmt.Errorf("capture: load conversation %q: unmarshal messages: %w", id, err)
+	}
+	conv.CreatedAt = time.UnixMilli(createdMs)
+	conv.UpdatedAt = time.UnixMilli(updatedMs)
+	return &conv, nil
+}
+
+func captureConversations(ctx context.Context, store conversationStore, opts captureOptions) (captureResult, error) {
+	outDir := strings.TrimSpace(opts.OutputDir)
+	if outDir == "" {
+		outDir = filepath.Join("docs", "llm", "traces")
+	}
+	source := strings.TrimSpace(opts.Source)
+	if source == "" {
+		source = defaultCaptureSource
+	}
+
+	summaries, err := store.List(ctx)
+	if err != nil {
+		return captureResult{}, err
+	}
+	sort.SliceStable(summaries, func(i, j int) bool {
+		if !summaries[i].UpdatedAt.Equal(summaries[j].UpdatedAt) {
+			return summaries[i].UpdatedAt.After(summaries[j].UpdatedAt)
+		}
+		return summaries[i].ID < summaries[j].ID
+	})
+	if err := os.MkdirAll(outDir, 0o700); err != nil {
+		return captureResult{}, fmt.Errorf("create trace dir %q: %w", outDir, err)
+	}
+
+	redactor := defaultRedactor()
+	var result captureResult
+	for _, summary := range summaries {
+		if opts.Limit > 0 && len(result.Written) >= opts.Limit {
+			break
+		}
+
+		conv, err := store.Load(ctx, summary.ID)
+		if err != nil {
+			result.Skipped = append(result.Skipped, fmt.Sprintf("%s: %v", summary.ID, err))
+			continue
+		}
+
+		trace, err := conversationToTrace(*conv, source, opts.FallbackSystem, redactor)
+		if err != nil {
+			result.Skipped = append(result.Skipped, fmt.Sprintf("%s: %v", summary.ID, err))
+			continue
+		}
+
+		path := filepath.Join(outDir, safeTraceFilename(trace.ID)+".json")
+		data, err := json.MarshalIndent(trace, "", "  ")
+		if err != nil {
+			return result, fmt.Errorf("marshal trace %q: %w", trace.ID, err)
+		}
+		data = append(data, '\n')
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			return result, fmt.Errorf("write trace %q: %w", path, err)
+		}
+		result.Written = append(result.Written, path)
+	}
+
+	return result, nil
+}
+
+func conversationToTrace(conv conversation.Conversation, source, fallbackSystem string, redactor redactor) (Trace, error) {
+	if strings.TrimSpace(conv.ID) == "" {
+		return Trace{}, errConversationMissingID
+	}
+
+	system, turns, finalAnswer, err := conversationTurns(conv.Messages, fallbackSystem, redactor)
+	if err != nil {
+		return Trace{}, err
+	}
+
+	trace := Trace{
+		ID:         "conversation-" + conv.ID,
+		Source:     source,
+		CapturedAt: captureTime(conv),
+		System:     system,
+		// conversation.Message persists tool calls and results, but not the
+		// tool schemas needed for future tool-loop replay. H2 will add a
+		// schema source; for now capture preserves expected call names only.
+		Tools: []json.RawMessage{},
+		Turns: turns,
+		Golden: Golden{
+			ToolCalls:            goldenToolCalls(turns),
+			FinalAnswerCriteria:  "Assistant answer should satisfy the captured final assistant response.",
+			FinalAnswerSubstring: finalAnswer,
+		},
+	}
+	if err := validateTrace(trace); err != nil {
+		return Trace{}, err
+	}
+	return trace, nil
+}
+
+func conversationTurns(messages []conversation.Message, fallbackSystem string, redactor redactor) (string, []Turn, string, error) {
+	var system string
+	var turns []Turn
+	sawUser := false
+	finalAssistantIndex, finalAnswer := capturedFinalAnswer(messages, redactor)
+
+	for i, msg := range messages {
+		role := strings.TrimSpace(msg.Role)
+		if role == "" {
+			continue
+		}
+
+		if role == "system" {
+			if system == "" {
+				system = redactor.Redact(msg.Content)
+			}
+			continue
+		}
+		if i == finalAssistantIndex {
+			continue
+		}
+
+		turn := Turn{
+			Role:       role,
+			Content:    redactor.Redact(msg.Content),
+			ToolCallID: redactor.Redact(msg.ToolCallID),
+			Name:       redactor.Redact(msg.ToolName),
+		}
+		if len(msg.ToolCalls) > 0 {
+			toolCalls, err := convertToolCalls(msg.ToolCalls, redactor)
+			if err != nil {
+				return "", nil, "", err
+			}
+			turn.ToolCalls = toolCalls
+		}
+		if role == "user" {
+			sawUser = true
+		}
+		turns = append(turns, turn)
+	}
+
+	if system == "" {
+		system = redactor.Redact(strings.TrimSpace(fallbackSystem))
+	}
+	if system == "" {
+		return "", nil, "", errConversationMissingSystem
+	}
+	if !sawUser {
+		return "", nil, "", errConversationMissingUser
+	}
+	if strings.TrimSpace(finalAnswer) == "" {
+		return "", nil, "", errConversationMissingAssistant
+	}
+
+	return system, turns, finalAnswer, nil
+}
+
+func capturedFinalAnswer(messages []conversation.Message, redactor redactor) (int, string) {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if strings.TrimSpace(messages[i].Role) == "assistant" && strings.TrimSpace(messages[i].Content) != "" {
+			return i, redactor.Redact(messages[i].Content)
+		}
+	}
+	return -1, ""
+}
+
+type storedToolCall struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+	Function  struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	} `json:"function"`
+}
+
+func convertToolCalls(raw json.RawMessage, redactor redactor) ([]ToolCall, error) {
+	var stored []storedToolCall
+	if err := json.Unmarshal(raw, &stored); err != nil {
+		return nil, fmt.Errorf("%w: %v", errConversationInvalidToolCall, err)
+	}
+
+	toolCalls := make([]ToolCall, 0, len(stored))
+	for _, call := range stored {
+		name := strings.TrimSpace(call.Name)
+		args := call.Arguments
+		if name == "" {
+			name = strings.TrimSpace(call.Function.Name)
+			args = call.Function.Arguments
+		}
+		if name == "" {
+			return nil, fmt.Errorf("%w: missing name", errConversationInvalidToolCall)
+		}
+
+		redactedArgs, err := redactRawJSON(args, redactor)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", errConversationInvalidToolCall, err)
+		}
+		toolCalls = append(toolCalls, ToolCall{
+			Name:      redactor.Redact(name),
+			Arguments: redactedArgs,
+		})
+	}
+
+	return toolCalls, nil
+}
+
+func redactRawJSON(raw json.RawMessage, redactor redactor) (json.RawMessage, error) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return json.RawMessage(`{}`), nil
+	}
+
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, err
+	}
+	value = redactJSONValue(value, redactor)
+
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(data), nil
+}
+
+func redactJSONValue(value any, redactor redactor) any {
+	switch v := value.(type) {
+	case map[string]any:
+		for key, nested := range v {
+			redacted := redactJSONValue(nested, redactor)
+			if _, ok := redacted.(string); ok && isSensitiveKey(key) {
+				v[key] = redactor.secretPlaceholder
+				continue
+			}
+			v[key] = redacted
+		}
+		return v
+	case []any:
+		for i, nested := range v {
+			v[i] = redactJSONValue(nested, redactor)
+		}
+		return v
+	case string:
+		return redactor.Redact(v)
+	default:
+		return value
+	}
+}
+
+func goldenToolCalls(turns []Turn) []string {
+	var names []string
+	for _, turn := range turns {
+		for _, call := range turn.ToolCalls {
+			names = append(names, call.Name)
+		}
+	}
+	if names == nil {
+		return []string{}
+	}
+	return names
+}
+
+func finalAssistantAnswer(turns []Turn) string {
+	for i := len(turns) - 1; i >= 0; i-- {
+		if turns[i].Role == "assistant" {
+			return turns[i].Content
+		}
+	}
+	return ""
+}
+
+func captureTime(conv conversation.Conversation) time.Time {
+	if !conv.UpdatedAt.IsZero() {
+		return conv.UpdatedAt.UTC()
+	}
+	if !conv.CreatedAt.IsZero() {
+		return conv.CreatedAt.UTC()
+	}
+	return time.Unix(0, 0).UTC()
+}
+
+func safeTraceFilename(id string) string {
+	var b strings.Builder
+	for _, r := range id {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-' || r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	name := strings.Trim(b.String(), "-")
+	if name == "" {
+		return "trace"
+	}
+	return name
+}
+
+type redactor struct {
+	pathPlaceholder   string
+	secretPlaceholder string
+	emailPlaceholder  string
+}
+
+func defaultRedactor() redactor {
+	return redactor{
+		pathPlaceholder:   "[REDACTED_PATH]",
+		secretPlaceholder: "[REDACTED_SECRET]",
+		emailPlaceholder:  "[REDACTED_EMAIL]",
+	}
+}
+
+var (
+	absolutePathPattern  = regexp.MustCompile(`(?i)(?:/(?:Users|home|private|var|tmp|Volumes|opt|etc|usr|workspace|mnt)/[^\s,'"()]+)|(?:[A-Z]:\\[^\s,'"()]+)`)
+	secretPattern        = regexp.MustCompile(`(?i)(["']?[A-Z0-9_./:-]*(?:api[_-]?key|apikey|auth[_-]?token|access[_-]?token|refresh[_-]?token|id[_-]?token|token|secret|password|passwd|private[_-]?key|authorization)["']?\s*[:=]\s*)(["']?)([^"',\s;&}]+)(["']?)`)
+	authHeaderPattern    = regexp.MustCompile(`(?i)\bAuthorization\s*:\s*[^\s,;&]+(?:\s+[^\s,;&]+)?`)
+	bearerPattern        = regexp.MustCompile(`(?i)\bBearer\s+[A-Za-z0-9._~+/-]+=*`)
+	tokenValuePattern    = regexp.MustCompile(`(?i)\b(?:sk-[A-Za-z0-9][A-Za-z0-9_-]{16,}|ghp_[A-Za-z0-9_]{16,}|github_pat_[A-Za-z0-9_]{16,}|glpat-[A-Za-z0-9_-]{16,}|xox[baprs]-[A-Za-z0-9-]{10,}|npm_[A-Za-z0-9]{16,})\b`)
+	urlCredentialPattern = regexp.MustCompile(`(?i)\b([a-z][a-z0-9+.-]*://)([^/\s:@]+):([^@\s/]+)@`)
+	privateKeyPattern    = regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----`)
+	emailPattern         = regexp.MustCompile(`(?i)\b[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}\b`)
+)
+
+func (r redactor) Redact(s string) string {
+	if s == "" {
+		return ""
+	}
+	s = privateKeyPattern.ReplaceAllString(s, r.secretPlaceholder)
+	s = absolutePathPattern.ReplaceAllStringFunc(s, func(match string) string {
+		base := pathBase(match)
+		if base == "" {
+			return r.pathPlaceholder
+		}
+		return r.pathPlaceholder + "/" + base
+	})
+	s = urlCredentialPattern.ReplaceAllString(s, "${1}"+r.secretPlaceholder+"@")
+	s = authHeaderPattern.ReplaceAllString(s, "Authorization: "+r.secretPlaceholder)
+	s = bearerPattern.ReplaceAllString(s, "Bearer "+r.secretPlaceholder)
+	s = secretPattern.ReplaceAllStringFunc(s, func(match string) string {
+		parts := secretPattern.FindStringSubmatch(match)
+		if len(parts) != 5 {
+			return r.secretPlaceholder
+		}
+		return parts[1] + parts[2] + r.secretPlaceholder + parts[4]
+	})
+	s = tokenValuePattern.ReplaceAllString(s, r.secretPlaceholder)
+	s = emailPattern.ReplaceAllString(s, r.emailPlaceholder)
+	return s
+}
+
+func pathBase(path string) string {
+	path = strings.TrimRight(path, `.,;:`)
+	idx := strings.LastIndexAny(path, `/\`)
+	if idx < 0 || idx == len(path)-1 {
+		return ""
+	}
+	return path[idx+1:]
+}
+
+func isSensitiveKey(key string) bool {
+	k := strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(key, "-", "_"), " ", "_"))
+	return strings.Contains(k, "token") ||
+		strings.Contains(k, "secret") ||
+		strings.Contains(k, "password") ||
+		strings.Contains(k, "passwd") ||
+		strings.Contains(k, "private_key") ||
+		strings.Contains(k, "privatekey") ||
+		strings.Contains(k, "api_key") ||
+		(strings.Contains(k, "api") && strings.Contains(k, "key")) ||
+		(strings.Contains(k, "access") && strings.Contains(k, "key")) ||
+		k == "apikey" ||
+		k == "authorization"
+}

--- a/cmd/llm-bench/capture_test.go
+++ b/cmd/llm-bench/capture_test.go
@@ -1,0 +1,428 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/conversation"
+)
+
+type fakeConversationStore struct {
+	summaries     []conversation.Summary
+	conversations map[string]conversation.Conversation
+}
+
+func (s fakeConversationStore) List(context.Context) ([]conversation.Summary, error) {
+	out := make([]conversation.Summary, len(s.summaries))
+	copy(out, s.summaries)
+	return out, nil
+}
+
+func (s fakeConversationStore) Load(_ context.Context, id string) (*conversation.Conversation, error) {
+	conv, ok := s.conversations[id]
+	if !ok {
+		return nil, errors.New("missing conversation")
+	}
+	return &conv, nil
+}
+
+func TestConversationToTraceRedactsAndConvertsToolCalls(t *testing.T) {
+	conv := conversation.Conversation{
+		ID:        "abc-123",
+		CreatedAt: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 5, 1, 12, 5, 0, 0, time.UTC),
+		Messages: []conversation.Message{
+			{Role: "system", Content: "Use workspace /Users/keith/project and token=system-secret."},
+			{Role: "user", Content: "Read /Users/keith/project/secret.go for user@example.com"},
+			{
+				Role: "assistant",
+				ToolCalls: json.RawMessage(`[
+					{
+						"id": "call_1",
+						"type": "function",
+						"function": {
+							"name": "read_file",
+							"arguments": {
+								"path": "/Users/keith/project/secret.go",
+								"api_key": "abc123",
+								"notes": ["email user@example.com"]
+							}
+						}
+					}
+				]`),
+			},
+			{
+				Role:       "tool",
+				ToolName:   "read_file",
+				ToolCallID: "call_1",
+				Content:    `{"path":"/Users/keith/project/secret.go","token":"tool-secret"}`,
+			},
+			{Role: "assistant", Content: "Done from /tmp/out.txt with password=hunter2."},
+		},
+	}
+
+	trace, err := conversationToTrace(conv, "test-source", "", defaultRedactor())
+	if err != nil {
+		t.Fatalf("conversationToTrace() error: %v", err)
+	}
+
+	if trace.ID != "conversation-abc-123" {
+		t.Fatalf("trace ID = %q", trace.ID)
+	}
+	if trace.Source != "test-source" {
+		t.Fatalf("trace source = %q", trace.Source)
+	}
+	assertClean(t, trace.System)
+	if strings.Contains(trace.System, "system-secret") {
+		t.Fatalf("system was not redacted: %q", trace.System)
+	}
+	if len(trace.Turns) != 3 {
+		t.Fatalf("turn count = %d, want 3", len(trace.Turns))
+	}
+	assertClean(t, trace.Turns[0].Content)
+	assertClean(t, trace.Turns[2].Content)
+	assertClean(t, trace.Golden.FinalAnswerSubstring)
+
+	if len(trace.Turns[1].ToolCalls) != 1 {
+		t.Fatalf("tool calls = %#v", trace.Turns[1].ToolCalls)
+	}
+	call := trace.Turns[1].ToolCalls[0]
+	if call.Name != "read_file" {
+		t.Fatalf("tool name = %q", call.Name)
+	}
+	var args map[string]any
+	if err := json.Unmarshal(call.Arguments, &args); err != nil {
+		t.Fatalf("unmarshal args: %v", err)
+	}
+	if args["path"] != "[REDACTED_PATH]/secret.go" {
+		t.Fatalf("path arg = %#v", args["path"])
+	}
+	if args["api_key"] != "[REDACTED_SECRET]" {
+		t.Fatalf("api_key arg = %#v", args["api_key"])
+	}
+	notes := args["notes"].([]any)
+	if notes[0] != "email [REDACTED_EMAIL]" {
+		t.Fatalf("notes = %#v", notes)
+	}
+	if len(trace.Golden.ToolCalls) != 1 || trace.Golden.ToolCalls[0] != "read_file" {
+		t.Fatalf("golden tool calls = %#v", trace.Golden.ToolCalls)
+	}
+}
+
+func TestConversationToTraceUsesFallbackSystem(t *testing.T) {
+	conv := conversation.Conversation{
+		ID: "no-system",
+		Messages: []conversation.Message{
+			{Role: "user", Content: "hello"},
+			{Role: "assistant", Content: "hi"},
+		},
+	}
+
+	trace, err := conversationToTrace(conv, "test-source", "Fallback system", defaultRedactor())
+	if err != nil {
+		t.Fatalf("conversationToTrace() error: %v", err)
+	}
+	if trace.System != "Fallback system" {
+		t.Fatalf("system = %q", trace.System)
+	}
+}
+
+func TestConversationToTraceRejectsMalformedConversations(t *testing.T) {
+	tests := []struct {
+		name    string
+		conv    conversation.Conversation
+		wantErr error
+	}{
+		{
+			name:    "missing id",
+			conv:    conversation.Conversation{Messages: []conversation.Message{{Role: "system", Content: "sys"}}},
+			wantErr: errConversationMissingID,
+		},
+		{
+			name: "missing system",
+			conv: conversation.Conversation{
+				ID:       "missing-system",
+				Messages: []conversation.Message{{Role: "user", Content: "hi"}, {Role: "assistant", Content: "hello"}},
+			},
+			wantErr: errConversationMissingSystem,
+		},
+		{
+			name: "missing user",
+			conv: conversation.Conversation{
+				ID:       "missing-user",
+				Messages: []conversation.Message{{Role: "system", Content: "sys"}, {Role: "assistant", Content: "hello"}},
+			},
+			wantErr: errConversationMissingUser,
+		},
+		{
+			name: "missing assistant",
+			conv: conversation.Conversation{
+				ID:       "missing-assistant",
+				Messages: []conversation.Message{{Role: "system", Content: "sys"}, {Role: "user", Content: "hi"}},
+			},
+			wantErr: errConversationMissingAssistant,
+		},
+		{
+			name: "invalid tool calls",
+			conv: conversation.Conversation{
+				ID: "bad-tool",
+				Messages: []conversation.Message{
+					{Role: "system", Content: "sys"},
+					{Role: "user", Content: "hi"},
+					{Role: "assistant", ToolCalls: json.RawMessage(`{"not":"an array"}`)},
+					{Role: "assistant", Content: "done"},
+				},
+			},
+			wantErr: errConversationInvalidToolCall,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := conversationToTrace(tt.conv, "source", "", defaultRedactor())
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCaptureConversationsSkipsMalformedAndWritesDeterministicOutput(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	store := fakeConversationStore{
+		summaries: []conversation.Summary{
+			{ID: "bad", UpdatedAt: now.Add(2 * time.Minute)},
+			{ID: "good", UpdatedAt: now.Add(time.Minute)},
+		},
+		conversations: map[string]conversation.Conversation{
+			"bad": {
+				ID:       "bad",
+				Messages: []conversation.Message{{Role: "user", Content: "hi"}},
+			},
+			"good": {
+				ID:        "good",
+				UpdatedAt: now,
+				Messages: []conversation.Message{
+					{Role: "system", Content: "sys"},
+					{Role: "user", Content: "hello"},
+					{Role: "assistant", Content: "world"},
+				},
+			},
+		},
+	}
+
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+	result1, err := captureConversations(context.Background(), store, captureOptions{OutputDir: dir1, Source: "test"})
+	if err != nil {
+		t.Fatalf("captureConversations first run: %v", err)
+	}
+	result2, err := captureConversations(context.Background(), store, captureOptions{OutputDir: dir2, Source: "test"})
+	if err != nil {
+		t.Fatalf("captureConversations second run: %v", err)
+	}
+
+	if len(result1.Written) != 1 || len(result1.Skipped) != 1 {
+		t.Fatalf("first result = %#v", result1)
+	}
+	if len(result2.Written) != 1 || len(result2.Skipped) != 1 {
+		t.Fatalf("second result = %#v", result2)
+	}
+
+	file1 := filepath.Join(dir1, "conversation-good.json")
+	file2 := filepath.Join(dir2, "conversation-good.json")
+	data1, err := os.ReadFile(file1)
+	if err != nil {
+		t.Fatalf("read first trace: %v", err)
+	}
+	data2, err := os.ReadFile(file2)
+	if err != nil {
+		t.Fatalf("read second trace: %v", err)
+	}
+	if string(data1) != string(data2) {
+		t.Fatalf("capture output differed:\n%s\n---\n%s", data1, data2)
+	}
+}
+
+func TestCaptureLimitCountsWrittenTraces(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	store := fakeConversationStore{
+		summaries: []conversation.Summary{
+			{ID: "bad", UpdatedAt: now.Add(3 * time.Minute)},
+			{ID: "good-1", UpdatedAt: now.Add(2 * time.Minute)},
+			{ID: "good-2", UpdatedAt: now.Add(time.Minute)},
+		},
+		conversations: map[string]conversation.Conversation{
+			"bad": {
+				ID:       "bad",
+				Messages: []conversation.Message{{Role: "user", Content: "hi"}},
+			},
+			"good-1": validTestConversation("good-1", "first", now),
+			"good-2": validTestConversation("good-2", "second", now),
+		},
+	}
+
+	dir := t.TempDir()
+	result, err := captureConversations(context.Background(), store, captureOptions{
+		OutputDir: dir,
+		Source:    "test",
+		Limit:     1,
+	})
+	if err != nil {
+		t.Fatalf("captureConversations: %v", err)
+	}
+	if len(result.Written) != 1 {
+		t.Fatalf("written = %#v, want 1 trace", result.Written)
+	}
+	if len(result.Skipped) != 1 {
+		t.Fatalf("skipped = %#v, want 1 skipped malformed conversation", result.Skipped)
+	}
+	if filepath.Base(result.Written[0]) != "conversation-good-1.json" {
+		t.Fatalf("written file = %q", result.Written[0])
+	}
+	if _, err := os.Stat(filepath.Join(dir, "conversation-good-2.json")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("good-2 should not be written after limit, stat err=%v", err)
+	}
+}
+
+func TestRunCaptureDoesNotMigrateSourceDB(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "source.sqlite")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open source db: %v", err)
+	}
+	if _, err := db.Exec(`
+		CREATE TABLE conversations (
+			id         TEXT PRIMARY KEY,
+			title      TEXT NOT NULL DEFAULT '',
+			messages   TEXT NOT NULL,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		)`,
+	); err != nil {
+		t.Fatalf("create conversations table: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO conversations (id, title, messages, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?)`,
+		"conv-1",
+		"test",
+		`[
+			{"role":"system","content":"sys"},
+			{"role":"user","content":"hello"},
+			{"role":"assistant","content":"world"}
+		]`,
+		int64(1000),
+		int64(2000),
+	); err != nil {
+		t.Fatalf("insert conversation: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close source db: %v", err)
+	}
+
+	result, err := runCapture(context.Background(), captureOptions{
+		DBPath:    dbPath,
+		OutputDir: t.TempDir(),
+		Source:    "test",
+	})
+	if err != nil {
+		t.Fatalf("runCapture: %v", err)
+	}
+	if len(result.Written) != 1 {
+		t.Fatalf("written = %#v, want 1 trace", result.Written)
+	}
+
+	db, err = sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("reopen source db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var versionTables int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'conversation_schema_version'`,
+	).Scan(&versionTables); err != nil {
+		t.Fatalf("query schema version table: %v", err)
+	}
+	if versionTables != 0 {
+		t.Fatalf("capture created conversation_schema_version table")
+	}
+}
+
+func TestRedactorRedactsObviousSensitiveValues(t *testing.T) {
+	input := `Path /Users/keith/src/private.txt token=abc123 Authorization: Bearer bearer-secret user@example.com
+OPENAI_API_KEY=sk-1234567890abcdefghi GITHUB_TOKEN=ghp_1234567890abcdefABCD ANTHROPIC_API_KEY='sk-ant-1234567890abcdef'
+{"apiKey":"json-secret","authToken":"json-token","privateKey":"json-private-key"}
+//registry.npmjs.org/:_authToken=npm_1234567890abcdef
+https://user:pass@example.com
+-----BEGIN OPENSSH PRIVATE KEY-----
+private key body
+-----END OPENSSH PRIVATE KEY-----`
+	got := defaultRedactor().Redact(input)
+
+	assertClean(t, got)
+	for _, want := range []string{
+		"[REDACTED_PATH]/private.txt",
+		"token=[REDACTED_SECRET]",
+		"Authorization: [REDACTED_SECRET]",
+		"[REDACTED_EMAIL]",
+		"OPENAI_API_KEY=[REDACTED_SECRET]",
+		"GITHUB_TOKEN=[REDACTED_SECRET]",
+		`ANTHROPIC_API_KEY='[REDACTED_SECRET]'`,
+		`"apiKey":"[REDACTED_SECRET]"`,
+		`"authToken":"[REDACTED_SECRET]"`,
+		`"privateKey":"[REDACTED_SECRET]"`,
+		"//registry.npmjs.org/:_authToken=[REDACTED_SECRET]",
+		"https://[REDACTED_SECRET]@example.com",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("redacted text %q missing %q", got, want)
+		}
+	}
+}
+
+func validTestConversation(id, answer string, updatedAt time.Time) conversation.Conversation {
+	return conversation.Conversation{
+		ID:        id,
+		UpdatedAt: updatedAt,
+		Messages: []conversation.Message{
+			{Role: "system", Content: "sys"},
+			{Role: "user", Content: "hello"},
+			{Role: "assistant", Content: answer},
+		},
+	}
+}
+
+func assertClean(t *testing.T, text string) {
+	t.Helper()
+	for _, forbidden := range []string{
+		"/Users/keith",
+		"/tmp/",
+		"abc123",
+		"bearer-secret",
+		"sk-1234567890abcdefghi",
+		"ghp_1234567890abcdefABCD",
+		"sk-ant-1234567890abcdef",
+		"json-secret",
+		"json-token",
+		"json-private-key",
+		"npm_1234567890abcdef",
+		"user:pass@",
+		"private key body",
+		"hunter2",
+		"tool-secret",
+		"user@example.com",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("text %q still contains %q", text, forbidden)
+		}
+	}
+}

--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -25,6 +25,12 @@ import (
 )
 
 func main() {
+	capture := flag.Bool("capture", false, "Export persisted conversations as redacted benchmark traces and exit")
+	captureDB := flag.String("capture-db", "", "SQLite database path containing conversation tables (required with -capture)")
+	captureOut := flag.String("capture-out", filepath.Join("docs", "llm", "traces"), "Directory for captured trace JSON files")
+	captureLimit := flag.Int("capture-limit", 0, "Maximum conversations to export in capture mode (0 = all)")
+	captureSource := flag.String("capture-source", defaultCaptureSource, "Trace source label for captured conversations")
+	captureSystem := flag.String("capture-system", "", "Fallback system prompt when a conversation has no stored system message")
 	tracesGlob := flag.String("traces", "", "Glob pattern for trace JSON files (required)")
 	modelsArg := flag.String("models", "", "Comma-separated model selectors (provider/model or bare model name; required)")
 	scorerName := flag.String("scorer", "exact-match", "Scoring strategy: exact-match, llm-judge, manual")
@@ -32,6 +38,30 @@ func main() {
 	ollamaURL := flag.String("ollama-url", "http://localhost:11434", "Ollama base URL")
 	timeout := flag.Duration("timeout", 5*time.Minute, "Per-trace timeout")
 	flag.Parse()
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	if *capture {
+		result, err := runCapture(ctx, captureOptions{
+			DBPath:         *captureDB,
+			OutputDir:      *captureOut,
+			Limit:          *captureLimit,
+			Source:         *captureSource,
+			FallbackSystem: *captureSystem,
+		})
+		if err != nil {
+			log.Fatalf("llm-bench: capture: %v", err)
+		}
+		for _, skipped := range result.Skipped {
+			fmt.Fprintf(os.Stderr, "llm-bench: capture skipped %s\n", skipped)
+		}
+		if len(result.Written) == 0 {
+			log.Fatalf("llm-bench: capture wrote no traces")
+		}
+		fmt.Fprintf(os.Stderr, "llm-bench: capture wrote %d trace(s) to %s\n", len(result.Written), *captureOut)
+		return
+	}
 
 	if *tracesGlob == "" || *modelsArg == "" {
 		flag.Usage()
@@ -50,9 +80,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("llm-bench: parse models: %v", err)
 	}
-
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer cancel()
 
 	traces, err := loadTraces(tracePaths)
 	if err != nil {

--- a/docs/llm/README.md
+++ b/docs/llm/README.md
@@ -71,6 +71,45 @@ shows `Errors = 0` with `Mean Quality = 1.00` for each model on the
 `smoke-minimal-001` trace. This only verifies harness plumbing and basic
 model reachability, not real MCP-agent quality.
 
+## Local trace capture
+
+Captured traces are written under `docs/llm/traces/`, which is gitignored
+because traces can contain local paths, prompts, and tool results. Export
+from a SQLite database that contains the `conversation/` tables with:
+
+```bash
+go run ./cmd/llm-bench \
+  -capture \
+  -capture-db /path/to/go-llm.sqlite \
+  -capture-out docs/llm/traces \
+  -capture-source firn-ide
+```
+
+If older conversations do not include a persisted system message, provide
+the exact prompt used by that app:
+
+```bash
+go run ./cmd/llm-bench \
+  -capture \
+  -capture-db /path/to/go-llm.sqlite \
+  -capture-system 'You are the local coding assistant...' \
+  -capture-limit 50
+```
+
+The capture pass exports one JSON trace per valid conversation, moves the
+captured final assistant answer into `golden.final_answer_substring`,
+redacts absolute local paths, obvious secret values, bearer tokens,
+authorization headers, URL credentials, private key blocks, and email
+addresses, and skips conversations that cannot form a replayable trace.
+The first capture PR uses `conversation/` as the source of truth;
+feedback-linked sampling comes later because the current `feedback/`
+schema does not store a conversation id.
+
+Tool-call names and tool-result turns are preserved, but tool schemas are
+not exported yet because the current `conversation/` records do not store
+them. Multi-turn/tool-use traces are useful calibration fixtures now;
+full replay of those traces requires the Phase 2 tool-loop/schema work.
+
 ## Date stamp
 
 Research was conducted April 16, 2026 and refreshed against the live

--- a/docs/llm/benchmark-plan.md
+++ b/docs/llm/benchmark-plan.md
@@ -22,6 +22,7 @@ MCP protocol handshake or picks the wrong tool 10% of the time.
 ```
 cmd/llm-bench/
 ├── main.go           # CLI entry point
+├── capture.go        # Conversation-store trace export + redaction
 ├── trace.go          # Trace loading + validation
 ├── runner.go         # Per-model replay loop
 ├── scorer.go         # Pluggable scoring strategies
@@ -132,6 +133,28 @@ manual review because the "right answer" is domain-specific.
 - Extend `feedback/` or `conversation/` store to export replayable traces
 - Redaction pass for sensitive data (paths, tokens, customer info)
 - Initial capture target: 20–30 traces spanning all three consumer apps
+
+First implementation slice:
+
+- `go run ./cmd/llm-bench -capture -capture-db <sqlite-db>` exports
+  persisted `conversation/` rows into one JSON trace per conversation
+  using a read-only SQLite connection and no store migrations.
+- Output defaults to `docs/llm/traces/`, which is gitignored and should
+  remain local unless explicitly reviewed and exported.
+- The captured final assistant answer is stored as
+  `golden.final_answer_substring`; prompt turns stop before that answer
+  so simple one-user-turn traces can replay against the current harness.
+- Capture redacts absolute local paths, obvious secret assignments,
+  bearer tokens, authorization headers, URL credentials, private key
+  blocks, and email addresses before files are written.
+- Conversations without a system prompt, user turn, final assistant
+  answer, or parseable tool-call JSON are skipped with a warning.
+- Tool-call names and tool-result turns are captured, but tool schemas are
+  not recoverable from `conversation/` today; full replay of tool-use
+  traces requires the follow-up schema/tool-loop work.
+- Feedback-driven sampling is deferred until feedback rows can be tied
+  to conversations; today `feedback_retrievals` and `feedback_signals`
+  do not carry a conversation id.
 
 ### Phase 3 — LLM-as-judge scorer (follow-up PR)
 


### PR DESCRIPTION
## Summary

Adds the first focused #56 benchmark-harness slice: local conversation trace capture/export for `cmd/llm-bench`.

- Adds `llm-bench -capture` flags for exporting persisted `conversation/` rows into local JSON traces.
- Uses a read-only SQLite connection and a SELECT-only reader so capture does not migrate or mutate source databases.
- Moves captured final assistant output into `golden.final_answer_substring` and preserves prompt turns before the final answer.
- Adds conservative redaction for local paths, obvious secrets, bearer/auth headers, provider token prefixes, URL credentials, private key blocks, and email addresses.
- Documents local trace capture and the current tool-schema limitation.

Refs #56. This does not close #56; multi-turn replay, feedback-linked sampling, tool-schema capture, judge scoring, and calibration remain follow-up work.

## Validation

- `go test ./cmd/llm-bench`
- `go test ./cmd/llm-bench ./conversation ./feedback`
- `go test ./...`
- Pre-push hook: lint, race tests, compile smoke