### PR TITLE
[codex] Add llm-bench multi-turn tool replay

### DIFF
--- a/cmd/llm-bench/replay_test.go
+++ b/cmd/llm-bench/replay_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/kstruzzieri/go-llm/ollama"
@@ -25,51 +26,12 @@ func newBlockedServer(t *testing.T) (*httptest.Server, *bool) {
 	return srv, &called
 }
 
-func TestReplayRefusesMultipleUserTurns(t *testing.T) {
-	srv, called := newBlockedServer(t)
-	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
-
-	trace := Trace{
-		ID:     "multi-turn",
-		System: "sys",
-		Turns: []Turn{
-			{Role: "user", Content: "first"},
-			{Role: "assistant", Content: "ack"},
-			{Role: "user", Content: "second"},
-		},
+func rolesAndContent(messages []ollama.ChatMessage) []string {
+	result := make([]string, 0, len(messages))
+	for _, msg := range messages {
+		result = append(result, msg.Role+":"+msg.Content)
 	}
-
-	_, err := replay(context.Background(), client, "some-model", trace)
-	if !errors.Is(err, errMultiUserTurn) {
-		t.Fatalf("err = %v, want errMultiUserTurn", err)
-	}
-	if *called {
-		t.Error("replay reached Ollama despite refusing the trace")
-	}
-}
-
-func TestReplayRefusesTraceWithUnsupportedExtraTurns(t *testing.T) {
-	srv, called := newBlockedServer(t)
-	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
-
-	trace := Trace{
-		ID:     "tool-loop-trace",
-		System: "sys",
-		Turns: []Turn{
-			{Role: "user", Content: "first"},
-			{Role: "assistant", ToolCalls: []ToolCall{{Name: "read_file"}}},
-			{Role: "tool", Name: "read_file", Content: "contents"},
-			{Role: "assistant", Content: "final"},
-		},
-	}
-
-	_, err := replay(context.Background(), client, "some-model", trace)
-	if !errors.Is(err, errUnsupportedTurns) {
-		t.Fatalf("err = %v, want errUnsupportedTurns", err)
-	}
-	if *called {
-		t.Error("replay reached Ollama despite refusing the trace")
-	}
+	return result
 }
 
 func TestReplayRefusesTraceWithoutUserTurn(t *testing.T) {
@@ -84,6 +46,212 @@ func TestReplayRefusesTraceWithoutUserTurn(t *testing.T) {
 	}
 	if *called {
 		t.Error("replay reached Ollama despite refusing the trace")
+	}
+}
+
+func TestReplaySupportsMultipleUserTurns(t *testing.T) {
+	var requests []ollama.ChatRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollama.ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		requests = append(requests, req)
+
+		resp := ollama.ChatResponse{
+			Model: "test-model",
+			Done:  true,
+		}
+		switch len(requests) {
+		case 1:
+			resp.Message = ollama.ChatMessage{Role: "assistant", Content: "model ack"}
+		case 2:
+			resp.Message = ollama.ChatMessage{Role: "assistant", Content: "final answer"}
+		default:
+			t.Fatalf("unexpected request %d", len(requests))
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	trace := Trace{
+		ID:     "multi-turn",
+		System: "sys",
+		Turns: []Turn{
+			{Role: "user", Content: "first"},
+			{Role: "assistant", Content: "captured ack"},
+			{Role: "user", Content: "second"},
+		},
+	}
+
+	transcript, err := replay(context.Background(), client, "test-model", trace)
+	if err != nil {
+		t.Fatalf("replay() error: %v", err)
+	}
+	if len(transcript) != 2 {
+		t.Fatalf("transcript len = %d, want 2: %#v", len(transcript), transcript)
+	}
+	if transcript[0].Content != "model ack" || transcript[1].Content != "final answer" {
+		t.Fatalf("transcript = %#v, want candidate assistant turns", transcript)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("requests len = %d, want 2", len(requests))
+	}
+	gotRoles := rolesAndContent(requests[1].Messages)
+	wantRoles := []string{
+		"system:sys",
+		"user:first",
+		"assistant:model ack",
+		"user:second",
+	}
+	if !reflect.DeepEqual(gotRoles, wantRoles) {
+		t.Fatalf("second request messages = %#v, want %#v", gotRoles, wantRoles)
+	}
+}
+
+func TestReplayInjectsFrozenToolResults(t *testing.T) {
+	var requests []ollama.ChatRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollama.ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		requests = append(requests, req)
+
+		resp := ollama.ChatResponse{
+			Model: "test-model",
+			Done:  true,
+		}
+		switch len(requests) {
+		case 1:
+			if len(req.Tools) != 1 || req.Tools[0].Function.Name != "read_file" {
+				t.Fatalf("tools = %#v, want read_file", req.Tools)
+			}
+			resp.Message = ollama.ChatMessage{
+				Role: "assistant",
+				ToolCalls: []ollama.ToolCall{
+					{
+						ID:   "candidate-call",
+						Type: "function",
+						Function: ollama.ToolCallFunction{
+							Name:      "read_file",
+							Arguments: map[string]any{"path": "provider/router.go"},
+						},
+					},
+				},
+			}
+		case 2:
+			if len(req.Messages) != 4 {
+				t.Fatalf("second request messages len = %d, want 4: %#v", len(req.Messages), req.Messages)
+			}
+			tool := req.Messages[3]
+			if tool.Role != "tool" || tool.ToolName != "read_file" {
+				t.Fatalf("tool message = %#v, want read_file result", tool)
+			}
+			if tool.ToolCallID != "candidate-call" {
+				t.Fatalf("tool_call_id = %q, want candidate-call", tool.ToolCallID)
+			}
+			if tool.Content != "package provider" {
+				t.Fatalf("tool content = %q, want frozen result", tool.Content)
+			}
+			resp.Message = ollama.ChatMessage{Role: "assistant", Content: "router summary"}
+		default:
+			t.Fatalf("unexpected request %d", len(requests))
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	trace := Trace{
+		ID:     "tool-loop",
+		System: "sys",
+		Tools: []json.RawMessage{
+			json.RawMessage(`{"name":"read_file","description":"Read a file from disk","inputSchema":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}}`),
+		},
+		Turns: []Turn{
+			{Role: "user", Content: "Read provider/router.go"},
+			{
+				Role:      "assistant",
+				ToolCalls: []ToolCall{{Name: "read_file", Arguments: json.RawMessage(`{"path":"provider/router.go"}`)}},
+			},
+			{Role: "tool", Name: "read_file", ToolCallID: "captured-call", Content: "package provider"},
+		},
+	}
+
+	transcript, err := replay(context.Background(), client, "test-model", trace)
+	if err != nil {
+		t.Fatalf("replay() error: %v", err)
+	}
+	if len(transcript) != 3 {
+		t.Fatalf("transcript len = %d, want 3: %#v", len(transcript), transcript)
+	}
+	if got := extractToolNames(transcript); !reflect.DeepEqual(got, []string{"read_file"}) {
+		t.Fatalf("extractToolNames() = %v, want [read_file]", got)
+	}
+	if transcript[1].Role != "tool" || transcript[1].Name != "read_file" {
+		t.Fatalf("tool transcript turn = %#v, want read_file result", transcript[1])
+	}
+	if transcript[1].ToolCallID != "candidate-call" {
+		t.Fatalf("transcript tool_call_id = %q, want candidate-call", transcript[1].ToolCallID)
+	}
+	if transcript[2].Content != "router summary" {
+		t.Fatalf("final transcript = %#v, want router summary", transcript[2])
+	}
+}
+
+func TestReplayErrorsWhenCandidateToolCallDoesNotMatchFrozenResult(t *testing.T) {
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		resp := ollama.ChatResponse{
+			Model: "test-model",
+			Message: ollama.ChatMessage{
+				Role: "assistant",
+				ToolCalls: []ollama.ToolCall{
+					{
+						ID:   "candidate-call",
+						Type: "function",
+						Function: ollama.ToolCallFunction{
+							Name:      "write_file",
+							Arguments: map[string]any{"path": "provider/router.go"},
+						},
+					},
+				},
+			},
+			Done: true,
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	trace := Trace{
+		ID:     "tool-mismatch",
+		System: "sys",
+		Tools: []json.RawMessage{
+			json.RawMessage(`{"name":"read_file","description":"Read a file from disk","inputSchema":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}}`),
+		},
+		Turns: []Turn{
+			{Role: "user", Content: "Read provider/router.go"},
+			{Role: "assistant", ToolCalls: []ToolCall{{Name: "read_file", Arguments: json.RawMessage(`{"path":"provider/router.go"}`)}}},
+			{Role: "tool", Name: "read_file", Content: "package provider"},
+		},
+	}
+
+	_, err := replay(context.Background(), client, "test-model", trace)
+	if !errors.Is(err, errToolCallMismatch) {
+		t.Fatalf("err = %v, want errToolCallMismatch", err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want 1", requests)
 	}
 }
 

--- a/cmd/llm-bench/replay_test.go
+++ b/cmd/llm-bench/replay_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/kstruzzieri/go-llm/ollama"
@@ -34,6 +35,37 @@ func rolesAndContent(messages []ollama.ChatMessage) []string {
 	return result
 }
 
+// requestLog is a goroutine-safe accumulator for request payloads observed
+// by an httptest handler. Tests read snapshots from the test goroutine
+// while the handler appends from the server goroutine — without this
+// indirection, `go test -race` would flag the shared-slice access even
+// though HTTP round-tripping currently happens to establish happens-
+// before.
+type requestLog struct {
+	mu       sync.Mutex
+	requests []ollama.ChatRequest
+}
+
+func (r *requestLog) append(req ollama.ChatRequest) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.requests = append(r.requests, req)
+}
+
+func (r *requestLog) snapshot() []ollama.ChatRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]ollama.ChatRequest, len(r.requests))
+	copy(out, r.requests)
+	return out
+}
+
+func (r *requestLog) len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.requests)
+}
+
 func TestReplayRefusesTraceWithoutUserTurn(t *testing.T) {
 	srv, called := newBlockedServer(t)
 	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
@@ -50,25 +82,25 @@ func TestReplayRefusesTraceWithoutUserTurn(t *testing.T) {
 }
 
 func TestReplaySupportsMultipleUserTurns(t *testing.T) {
-	var requests []ollama.ChatRequest
+	log := &requestLog{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req ollama.ChatRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Fatalf("decode request: %v", err)
 		}
-		requests = append(requests, req)
+		log.append(req)
 
 		resp := ollama.ChatResponse{
 			Model: "test-model",
 			Done:  true,
 		}
-		switch len(requests) {
+		switch log.len() {
 		case 1:
 			resp.Message = ollama.ChatMessage{Role: "assistant", Content: "model ack"}
 		case 2:
 			resp.Message = ollama.ChatMessage{Role: "assistant", Content: "final answer"}
 		default:
-			t.Fatalf("unexpected request %d", len(requests))
+			t.Fatalf("unexpected request %d", log.len())
 		}
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
 			t.Fatalf("encode response: %v", err)
@@ -97,6 +129,7 @@ func TestReplaySupportsMultipleUserTurns(t *testing.T) {
 	if transcript[0].Content != "model ack" || transcript[1].Content != "final answer" {
 		t.Fatalf("transcript = %#v, want candidate assistant turns", transcript)
 	}
+	requests := log.snapshot()
 	if len(requests) != 2 {
 		t.Fatalf("requests len = %d, want 2", len(requests))
 	}
@@ -113,19 +146,19 @@ func TestReplaySupportsMultipleUserTurns(t *testing.T) {
 }
 
 func TestReplayInjectsFrozenToolResults(t *testing.T) {
-	var requests []ollama.ChatRequest
+	log := &requestLog{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req ollama.ChatRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Fatalf("decode request: %v", err)
 		}
-		requests = append(requests, req)
+		log.append(req)
 
 		resp := ollama.ChatResponse{
 			Model: "test-model",
 			Done:  true,
 		}
-		switch len(requests) {
+		switch log.len() {
 		case 1:
 			if len(req.Tools) != 1 || req.Tools[0].Function.Name != "read_file" {
 				t.Fatalf("tools = %#v, want read_file", req.Tools)
@@ -159,7 +192,7 @@ func TestReplayInjectsFrozenToolResults(t *testing.T) {
 			}
 			resp.Message = ollama.ChatMessage{Role: "assistant", Content: "router summary"}
 		default:
-			t.Fatalf("unexpected request %d", len(requests))
+			t.Fatalf("unexpected request %d", log.len())
 		}
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
 			t.Fatalf("encode response: %v", err)
@@ -205,10 +238,82 @@ func TestReplayInjectsFrozenToolResults(t *testing.T) {
 	}
 }
 
-func TestReplayErrorsWhenCandidateToolCallDoesNotMatchFrozenResult(t *testing.T) {
-	var requests int
+// TestReplayLeavesToolCallIDEmptyWhenCandidateOmitsIt verifies the
+// regression fix for the captured-ID fallback: when the candidate omits
+// an `id` on the tool call, the injected tool-result message must not
+// borrow the captured trace's `ToolCallID` (which belonged to a different
+// conversation and would mislead any model that routes by ID).
+func TestReplayLeavesToolCallIDEmptyWhenCandidateOmitsIt(t *testing.T) {
+	log := &requestLog{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requests++
+		var req ollama.ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		log.append(req)
+
+		resp := ollama.ChatResponse{Model: "test-model", Done: true}
+		switch log.len() {
+		case 1:
+			resp.Message = ollama.ChatMessage{
+				Role: "assistant",
+				ToolCalls: []ollama.ToolCall{
+					{
+						Type: "function",
+						Function: ollama.ToolCallFunction{
+							Name:      "read_file",
+							Arguments: map[string]any{"path": "provider/router.go"},
+						},
+					},
+				},
+			}
+		case 2:
+			tool := req.Messages[3]
+			if tool.ToolCallID != "" {
+				t.Fatalf("tool_call_id = %q, want empty (candidate omitted id; must not borrow captured-call)", tool.ToolCallID)
+			}
+			resp.Message = ollama.ChatMessage{Role: "assistant", Content: "ok"}
+		default:
+			t.Fatalf("unexpected request %d", log.len())
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	trace := Trace{
+		ID:     "no-id-fallback",
+		System: "sys",
+		Tools: []json.RawMessage{
+			json.RawMessage(`{"name":"read_file","description":"Read a file from disk","inputSchema":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}}`),
+		},
+		Turns: []Turn{
+			{Role: "user", Content: "Read provider/router.go"},
+			{Role: "assistant", ToolCalls: []ToolCall{{Name: "read_file", Arguments: json.RawMessage(`{"path":"provider/router.go"}`)}}},
+			{Role: "tool", Name: "read_file", ToolCallID: "captured-call", Content: "package provider"},
+		},
+	}
+
+	transcript, err := replay(context.Background(), client, "test-model", trace)
+	if err != nil {
+		t.Fatalf("replay() error: %v", err)
+	}
+	if transcript[1].ToolCallID != "" {
+		t.Fatalf("transcript tool_call_id = %q, want empty", transcript[1].ToolCallID)
+	}
+}
+
+func TestReplayErrorsWhenCandidateToolCallDoesNotMatchFrozenResult(t *testing.T) {
+	var requests = struct {
+		sync.Mutex
+		n int
+	}{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Lock()
+		requests.n++
+		requests.Unlock()
 		resp := ollama.ChatResponse{
 			Model: "test-model",
 			Message: ollama.ChatMessage{
@@ -250,8 +355,263 @@ func TestReplayErrorsWhenCandidateToolCallDoesNotMatchFrozenResult(t *testing.T)
 	if !errors.Is(err, errToolCallMismatch) {
 		t.Fatalf("err = %v, want errToolCallMismatch", err)
 	}
-	if requests != 1 {
-		t.Fatalf("requests = %d, want 1", requests)
+	requests.Lock()
+	defer requests.Unlock()
+	if requests.n != 1 {
+		t.Fatalf("requests = %d, want 1", requests.n)
+	}
+}
+
+// TestReplayErrorsWhenCandidateCallsToolForPlainTextScript guards the
+// sentinel correction: a candidate that emits tool calls against a
+// scripted plain-text assistant turn is a *mismatch*, not a missing
+// tool result.
+func TestReplayErrorsWhenCandidateCallsToolForPlainTextScript(t *testing.T) {
+	log := &requestLog{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollama.ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		log.append(req)
+
+		resp := ollama.ChatResponse{
+			Model: "test-model",
+			Message: ollama.ChatMessage{
+				Role: "assistant",
+				ToolCalls: []ollama.ToolCall{
+					{
+						ID:   "candidate-call",
+						Type: "function",
+						Function: ollama.ToolCallFunction{Name: "read_file", Arguments: map[string]any{}},
+					},
+				},
+			},
+			Done: true,
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	trace := Trace{
+		ID:     "plain-text-scripted",
+		System: "sys",
+		Tools: []json.RawMessage{
+			json.RawMessage(`{"name":"read_file","description":"Read a file","inputSchema":{"type":"object"}}`),
+		},
+		Turns: []Turn{
+			{Role: "user", Content: "What is 2+2?"},
+			{Role: "assistant", Content: "4"},
+		},
+	}
+
+	_, err := replay(context.Background(), client, "test-model", trace)
+	if !errors.Is(err, errToolCallMismatch) {
+		t.Fatalf("err = %v, want errToolCallMismatch", err)
+	}
+	if errors.Is(err, errMissingToolResult) {
+		t.Fatalf("err = %v, must not be errMissingToolResult", err)
+	}
+}
+
+// TestReplayErrorsWhenCandidateCallsToolWithNoScriptedAssistant guards
+// the second sentinel-taxonomy fix: when the trace has no scripted
+// assistant turn after the user turn, a candidate tool call yields
+// errMissingScriptedAssistant, not errMissingToolResult.
+func TestReplayErrorsWhenCandidateCallsToolWithNoScriptedAssistant(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := ollama.ChatResponse{
+			Model: "test-model",
+			Message: ollama.ChatMessage{
+				Role: "assistant",
+				ToolCalls: []ollama.ToolCall{
+					{
+						ID:   "candidate-call",
+						Type: "function",
+						Function: ollama.ToolCallFunction{Name: "read_file", Arguments: map[string]any{}},
+					},
+				},
+			},
+			Done: true,
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	trace := Trace{
+		ID:     "no-scripted-assistant",
+		System: "sys",
+		Tools: []json.RawMessage{
+			json.RawMessage(`{"name":"read_file","description":"Read a file","inputSchema":{"type":"object"}}`),
+		},
+		Turns: []Turn{
+			{Role: "user", Content: "Read it"},
+		},
+	}
+
+	_, err := replay(context.Background(), client, "test-model", trace)
+	if !errors.Is(err, errMissingScriptedAssistant) {
+		t.Fatalf("err = %v, want errMissingScriptedAssistant", err)
+	}
+}
+
+// TestReplayRecordsBypassNoteWhenCandidateSkipsScriptedTools verifies
+// that silently fast-forwarding past a scripted tool loop records a
+// Notes annotation on the resulting Score — preserving the historical
+// "refuse rather than mislead" intent in observability form.
+func TestReplayRecordsBypassNoteWhenCandidateSkipsScriptedTools(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := ollama.ChatResponse{
+			Model:   "test-model",
+			Message: ollama.ChatMessage{Role: "assistant", Content: "I already know the answer"},
+			Done:    true,
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	trace := Trace{
+		ID:     "skip-tool-route",
+		System: "sys",
+		Tools: []json.RawMessage{
+			json.RawMessage(`{"name":"read_file","description":"Read","inputSchema":{"type":"object"}}`),
+		},
+		Turns: []Turn{
+			{Role: "user", Content: "Read provider/router.go"},
+			{Role: "assistant", ToolCalls: []ToolCall{{Name: "read_file", Arguments: json.RawMessage(`{"path":"provider/router.go"}`)}}},
+			{Role: "tool", Name: "read_file", Content: "package provider"},
+			{Role: "assistant", Content: "scripted summary"},
+		},
+	}
+
+	out, err := replayWith(context.Background(), client, "test-model", trace, replayOptions{})
+	if err != nil {
+		t.Fatalf("replayWith() error: %v", err)
+	}
+	if len(out.Notes) == 0 {
+		t.Fatalf("expected divergence Notes, got none")
+	}
+	if len(out.Transcript) != 1 || out.Transcript[0].Content != "I already know the answer" {
+		t.Fatalf("transcript = %#v, want single bypass assistant turn", out.Transcript)
+	}
+}
+
+// TestReplayRejectsEmptyAssistantReply guards the empty-reply sentinel:
+// a candidate that produces no content AND no tool calls fails the
+// replay rather than being scored as a valid empty answer.
+func TestReplayRejectsEmptyAssistantReply(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := ollama.ChatResponse{
+			Model:   "test-model",
+			Message: ollama.ChatMessage{Role: "assistant"},
+			Done:    true,
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	trace := Trace{
+		ID:     "empty-reply",
+		System: "sys",
+		Turns:  []Turn{{Role: "user", Content: "hi"}},
+	}
+
+	_, err := replay(context.Background(), client, "test-model", trace)
+	if !errors.Is(err, errEmptyAssistantReply) {
+		t.Fatalf("err = %v, want errEmptyAssistantReply", err)
+	}
+}
+
+// TestReplaySupportsMultipleToolRoundsPerUserTurn drives the inner-loop's
+// second iteration: the candidate calls tool A, gets a frozen result,
+// then calls tool B, gets another result, then emits a final text
+// answer — all within a single user turn.
+func TestReplaySupportsMultipleToolRoundsPerUserTurn(t *testing.T) {
+	log := &requestLog{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollama.ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		log.append(req)
+
+		resp := ollama.ChatResponse{Model: "test-model", Done: true}
+		switch log.len() {
+		case 1:
+			resp.Message = ollama.ChatMessage{
+				Role: "assistant",
+				ToolCalls: []ollama.ToolCall{
+					{
+						ID: "call-a", Type: "function",
+						Function: ollama.ToolCallFunction{Name: "read_file", Arguments: map[string]any{"path": "a"}},
+					},
+				},
+			}
+		case 2:
+			resp.Message = ollama.ChatMessage{
+				Role: "assistant",
+				ToolCalls: []ollama.ToolCall{
+					{
+						ID: "call-b", Type: "function",
+						Function: ollama.ToolCallFunction{Name: "read_file", Arguments: map[string]any{"path": "b"}},
+					},
+				},
+			}
+		case 3:
+			resp.Message = ollama.ChatMessage{Role: "assistant", Content: "summary of a and b"}
+		default:
+			t.Fatalf("unexpected request %d", log.len())
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	trace := Trace{
+		ID:     "two-rounds",
+		System: "sys",
+		Tools: []json.RawMessage{
+			json.RawMessage(`{"name":"read_file","description":"Read a file","inputSchema":{"type":"object"}}`),
+		},
+		Turns: []Turn{
+			{Role: "user", Content: "summarize files a and b"},
+			{Role: "assistant", ToolCalls: []ToolCall{{Name: "read_file", Arguments: json.RawMessage(`{"path":"a"}`)}}},
+			{Role: "tool", Name: "read_file", Content: "contents-a"},
+			{Role: "assistant", ToolCalls: []ToolCall{{Name: "read_file", Arguments: json.RawMessage(`{"path":"b"}`)}}},
+			{Role: "tool", Name: "read_file", Content: "contents-b"},
+		},
+	}
+
+	transcript, err := replay(context.Background(), client, "test-model", trace)
+	if err != nil {
+		t.Fatalf("replay() error: %v", err)
+	}
+	if log.len() != 3 {
+		t.Fatalf("requests = %d, want 3 (two tool rounds + final answer)", log.len())
+	}
+	// Transcript shape: [assistant-call-a, tool-a, assistant-call-b, tool-b, assistant-text]
+	if len(transcript) != 5 {
+		t.Fatalf("transcript len = %d, want 5: %#v", len(transcript), transcript)
+	}
+	if got := extractToolNames(transcript); !reflect.DeepEqual(got, []string{"read_file", "read_file"}) {
+		t.Fatalf("extractToolNames() = %v, want [read_file read_file]", got)
+	}
+	if transcript[4].Role != "assistant" || transcript[4].Content != "summary of a and b" {
+		t.Fatalf("final transcript = %#v, want assistant summary", transcript[4])
 	}
 }
 
@@ -306,6 +666,49 @@ func TestReplayForwardsTraceTools(t *testing.T) {
 	}
 	if len(transcript) != 1 || transcript[0].Content != "done" {
 		t.Fatalf("transcript = %#v, want single assistant turn with content", transcript)
+	}
+}
+
+// TestReplayPropagatesNumCtxAndPerTurnTimeout verifies the new Runner
+// knobs reach Ollama: NumCtx is set on req.Options, and PerTurnTimeout
+// bounds an individual chat round-trip even when the parent context has
+// a much larger budget.
+func TestReplayPropagatesNumCtxOption(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollama.ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.Options == nil {
+			t.Fatalf("Options = nil, want NumCtx propagated")
+		}
+		if req.Options.NumCtx != 32768 {
+			t.Fatalf("NumCtx = %d, want 32768", req.Options.NumCtx)
+		}
+		resp := ollama.ChatResponse{
+			Model:   "test-model",
+			Message: ollama.ChatMessage{Role: "assistant", Content: "ok"},
+			Done:    true,
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	trace := Trace{
+		ID:     "numctx",
+		System: "sys",
+		Turns:  []Turn{{Role: "user", Content: "hi"}},
+	}
+
+	out, err := replayWith(context.Background(), client, "test-model", trace, replayOptions{NumCtx: 32768})
+	if err != nil {
+		t.Fatalf("replayWith() error: %v", err)
+	}
+	if len(out.TurnLatenciesMs) != 1 {
+		t.Fatalf("TurnLatenciesMs len = %d, want 1", len(out.TurnLatenciesMs))
 	}
 }
 

--- a/cmd/llm-bench/runner.go
+++ b/cmd/llm-bench/runner.go
@@ -18,16 +18,18 @@ const benchKeepAlive = "30m"
 
 // Sentinel errors so tests assert on identity rather than message text.
 var (
-	errNoUserTurn        = errors.New("trace has no user turn")
-	errEmptyBaseURL      = errors.New("empty ollama base URL")
-	errMissingGolden     = errors.New("scorer requires golden.final_answer_substring")
-	errEmptySystem       = errors.New("trace has empty system prompt")
-	errNoTurns           = errors.New("trace has no turns")
-	errInvalidTraceTool  = errors.New("trace has invalid tool definition")
-	errMissingToolResult = errors.New("trace is missing frozen tool result")
-	errToolCallMismatch  = errors.New("candidate tool call does not match trace")
-	errUnsupportedTurns  = errors.New("trace has unsupported extra turns")
-	errUnsupportedProv   = errors.New("unsupported provider")
+	errNoUserTurn               = errors.New("trace has no user turn")
+	errEmptyBaseURL             = errors.New("empty ollama base URL")
+	errMissingGolden            = errors.New("scorer requires golden.final_answer_substring")
+	errEmptySystem              = errors.New("trace has empty system prompt")
+	errNoTurns                  = errors.New("trace has no turns")
+	errInvalidTraceTool         = errors.New("trace has invalid tool definition")
+	errMissingToolResult        = errors.New("trace is missing frozen tool result")
+	errMissingScriptedAssistant = errors.New("trace is missing scripted assistant turn for candidate tool call")
+	errToolCallMismatch         = errors.New("candidate tool call does not match trace")
+	errUnsupportedTurns         = errors.New("trace has unsupported extra turns")
+	errEmptyAssistantReply      = errors.New("candidate returned empty assistant reply (no content, no tool calls)")
+	errUnsupportedProv          = errors.New("unsupported provider")
 )
 
 // Runner executes traces against a list of candidate models and collects
@@ -35,7 +37,17 @@ var (
 type Runner struct {
 	OllamaURL string
 	Timeout   time.Duration
-	Scorer    Scorer
+	// PerTurnTimeout bounds a single chatReplayTurn round-trip. Zero means
+	// no per-turn bound — only Timeout applies to the whole replay. Set
+	// this when running models that may stall mid-loop to keep one bad
+	// trace from draining the full per-trace budget.
+	PerTurnTimeout time.Duration
+	// NumCtx, when non-zero, is passed to Ollama as the context-window
+	// directive. Zero leaves the model's configured default in place;
+	// long multi-turn replays may silently truncate prompts from the
+	// model's perspective without this set.
+	NumCtx int
+	Scorer Scorer
 }
 
 // Result is a single (model, trace) evaluation.
@@ -85,40 +97,87 @@ func (r *Runner) runOne(ctx context.Context, client *ollama.Client, target Model
 	runCtx, cancel := context.WithTimeout(ctx, r.Timeout)
 	defer cancel()
 
-	replayStart := time.Now()
-	transcript, err := replay(runCtx, client, target.Model, trace)
-	replayMs := time.Since(replayStart).Milliseconds()
+	opts := replayOptions{PerTurnTimeout: r.PerTurnTimeout, NumCtx: r.NumCtx}
+	out, err := replayWith(runCtx, client, target.Model, trace, opts)
 	if err != nil {
-		return Result{Model: target.Display, TraceID: trace.ID, Err: err}
+		return Result{Model: target.Display, TraceID: trace.ID, Err: err, Transcript: out.Transcript}
 	}
 
 	score, err := r.Scorer.Score(runCtx, trace, Result{
 		Model:      target.Display,
 		TraceID:    trace.ID,
-		Transcript: transcript,
+		Transcript: out.Transcript,
 	})
 	if err != nil {
-		return Result{Model: target.Display, TraceID: trace.ID, Err: err, Transcript: transcript}
+		return Result{Model: target.Display, TraceID: trace.ID, Err: err, Transcript: out.Transcript}
 	}
-	// Latency reflects replay only, not scorer work. When llm-judge lands,
-	// the judge round-trip must not pollute the model-latency metric.
-	score.LatencyMs = replayMs
+	// LatencyMs sums per-turn chat round-trips only; scorer work is
+	// excluded so llm-judge round-trips can't pollute the model-latency
+	// metric. TurnLatenciesMs preserves the per-turn breakdown so a slow
+	// first turn (cold load) is distinguishable from a slow tail turn
+	// (long context).
+	score.LatencyMs = sumInt64(out.TurnLatenciesMs)
+	score.TurnLatenciesMs = out.TurnLatenciesMs
+	if len(out.Notes) > 0 {
+		score.Notes = appendNotes(score.Notes, out.Notes)
+	}
 
 	return Result{
 		Model:      target.Display,
 		TraceID:    trace.ID,
 		Score:      score,
-		Transcript: transcript,
+		Transcript: out.Transcript,
 	}
 }
 
-// replay sends user turns to the model, replaces scripted assistant turns with
-// candidate responses, and feeds captured tool-result turns back after matching
-// candidate tool calls. Tool results are frozen replay fixtures: the candidate
-// chooses whether and which tool to call, but llm-bench never executes tools.
+// replayOutput bundles the side effects of a single replay.
+type replayOutput struct {
+	Transcript      []Turn
+	Notes           []string
+	TurnLatenciesMs []int64
+}
+
+// replayOptions are the per-replay knobs threaded down from Runner.
+// Zero values preserve current behavior: no per-turn bound, no NumCtx.
+type replayOptions struct {
+	PerTurnTimeout time.Duration
+	NumCtx         int
+}
+
+// replay is the legacy entry point retained for tests and callers that
+// don't need the Runner-level knobs (PerTurnTimeout, NumCtx).
 func replay(ctx context.Context, client *ollama.Client, model string, trace Trace) ([]Turn, error) {
+	out, err := replayWith(ctx, client, model, trace, replayOptions{})
+	return out.Transcript, err
+}
+
+// replayWith sends user turns to the model, replaces scripted assistant
+// turns with candidate responses, and feeds captured tool-result turns
+// back after matching candidate tool calls.
+//
+// Tool results are frozen replay fixtures: the candidate chooses whether
+// and which tool to call, but llm-bench never executes tools. The match
+// is strict and lock-step — the candidate must emit the same number of
+// tool calls in the same order, with the same names, as the scripted
+// assistant turn it is replacing. Argument-shape divergence is not
+// rejected here (schema validation is scorer-side follow-up).
+//
+// Divergence handling:
+//   - Candidate emits tool calls when the scripted turn was plain text:
+//     errToolCallMismatch.
+//   - Candidate emits tool calls when there is no scripted assistant turn
+//     after the user turn: errMissingScriptedAssistant.
+//   - Candidate emits plain text when the scripted route used tools:
+//     scripted tool group is skipped and a Notes annotation records the
+//     bypass; the candidate's reply replaces the scripted final answer.
+//   - Candidate emits a fully empty reply (no content, no tool calls):
+//     errEmptyAssistantReply.
+//
+// All accumulated divergence notes are appended to the resulting Score's
+// Notes so aggregate consumers can see why a candidate diverged.
+func replayWith(ctx context.Context, client *ollama.Client, model string, trace Trace, opts replayOptions) (replayOutput, error) {
 	if !hasUserTurn(trace.Turns) {
-		return nil, fmt.Errorf("trace %q: %w", trace.ID, errNoUserTurn)
+		return replayOutput{}, fmt.Errorf("trace %q: %w", trace.ID, errNoUserTurn)
 	}
 
 	messages := []ollama.ChatMessage{
@@ -126,16 +185,17 @@ func replay(ctx context.Context, client *ollama.Client, model string, trace Trac
 	}
 	tools, err := decodeTraceTools(trace.Tools)
 	if err != nil {
-		return nil, fmt.Errorf("trace %q: %w", trace.ID, err)
+		return replayOutput{}, fmt.Errorf("trace %q: %w", trace.ID, err)
 	}
 
-	var transcript []Turn
+	out := replayOutput{}
 	for i := 0; i < len(trace.Turns); {
 		turn := trace.Turns[i]
 		if turn.Role != "user" {
-			return nil, fmt.Errorf("trace %q turn %d role %q: %w", trace.ID, i, turn.Role, errUnsupportedTurns)
+			return out, fmt.Errorf("trace %q turn %d role %q: %w", trace.ID, i, turn.Role, errUnsupportedTurns)
 		}
 		messages = append(messages, ollama.ChatMessage{Role: "user", Content: turn.Content})
+		userIndex := i
 		i++
 
 		for {
@@ -147,35 +207,50 @@ func replay(ctx context.Context, client *ollama.Client, model string, trace Trac
 				i++
 			}
 
-			msg, actualTurn, err := chatReplayTurn(ctx, client, model, messages, tools)
+			msg, actualTurn, latencyMs, err := chatReplayTurn(ctx, client, model, messages, tools, opts)
+			out.TurnLatenciesMs = append(out.TurnLatenciesMs, latencyMs)
 			if err != nil {
-				return nil, err
+				return out, err
 			}
 			messages = append(messages, msg)
-			transcript = append(transcript, actualTurn)
+			out.Transcript = append(out.Transcript, actualTurn)
 
 			if len(msg.ToolCalls) == 0 {
+				if msg.Content == "" {
+					return out, fmt.Errorf("trace %q turn %d: %w", trace.ID, userIndex, errEmptyAssistantReply)
+				}
 				if len(expected.ToolCalls) > 0 {
-					i = skipScriptedToolLoop(trace.Turns, i)
+					skipped, next := skipScriptedToolLoop(trace.Turns, i)
+					if skipped > 0 {
+						out.Notes = append(out.Notes,
+							fmt.Sprintf("trace %q user turn %d: candidate bypassed scripted tool route (%d turn(s) skipped from index %d)",
+								trace.ID, userIndex, skipped, i))
+					}
+					i = next
 				}
 				break
 			}
 
+			if expectedIndex == -1 {
+				return out, fmt.Errorf("trace %q user turn %d: candidate emitted %d tool call(s) with no scripted assistant turn to match: %w",
+					trace.ID, userIndex, len(msg.ToolCalls), errMissingScriptedAssistant)
+			}
 			if len(expected.ToolCalls) == 0 {
-				return nil, fmt.Errorf("trace %q turn %d: %w", trace.ID, i, errMissingToolResult)
+				return out, fmt.Errorf("trace %q assistant turn %d: candidate emitted %d tool call(s) for plain-text scripted reply: %w",
+					trace.ID, expectedIndex, len(msg.ToolCalls), errToolCallMismatch)
 			}
 
 			toolMessages, toolTurns, next, err := frozenToolResults(trace.ID, expectedIndex, expected, trace.Turns, i, msg.ToolCalls)
 			if err != nil {
-				return nil, err
+				return out, err
 			}
 			i = next
 			messages = append(messages, toolMessages...)
-			transcript = append(transcript, toolTurns...)
+			out.Transcript = append(out.Transcript, toolTurns...)
 		}
 	}
 
-	return transcript, nil
+	return out, nil
 }
 
 func hasUserTurn(turns []Turn) bool {
@@ -187,23 +262,37 @@ func hasUserTurn(turns []Turn) bool {
 	return false
 }
 
-func chatReplayTurn(ctx context.Context, client *ollama.Client, model string, messages []ollama.ChatMessage, tools []ollama.Tool) (ollama.ChatMessage, Turn, error) {
-	resp, err := client.Chat(ctx, ollama.ChatRequest{
+func chatReplayTurn(ctx context.Context, client *ollama.Client, model string, messages []ollama.ChatMessage, tools []ollama.Tool, opts replayOptions) (ollama.ChatMessage, Turn, int64, error) {
+	turnCtx := ctx
+	if opts.PerTurnTimeout > 0 {
+		var cancel context.CancelFunc
+		turnCtx, cancel = context.WithTimeout(ctx, opts.PerTurnTimeout)
+		defer cancel()
+	}
+
+	req := ollama.ChatRequest{
 		Model:     model,
 		Messages:  messages,
 		Tools:     tools,
 		KeepAlive: benchKeepAlive,
-	})
+	}
+	if opts.NumCtx > 0 {
+		req.Options = &ollama.ModelOptions{NumCtx: opts.NumCtx}
+	}
+
+	start := time.Now()
+	resp, err := client.Chat(turnCtx, req)
+	latencyMs := time.Since(start).Milliseconds()
 	if err != nil {
-		return ollama.ChatMessage{}, Turn{}, err
+		return ollama.ChatMessage{}, Turn{}, latencyMs, err
 	}
 
 	msg := normalizeAssistantMessage(resp.Message)
 	turn, err := assistantTurnFromMessage(msg)
 	if err != nil {
-		return ollama.ChatMessage{}, Turn{}, err
+		return ollama.ChatMessage{}, Turn{}, latencyMs, err
 	}
-	return msg, turn, nil
+	return msg, turn, latencyMs, nil
 }
 
 func normalizeAssistantMessage(msg ollama.ChatMessage) ollama.ChatMessage {
@@ -213,6 +302,12 @@ func normalizeAssistantMessage(msg ollama.ChatMessage) ollama.ChatMessage {
 	return msg
 }
 
+// frozenToolResults pairs each candidate tool call with the corresponding
+// frozen tool-result turn from the trace and produces both the wire
+// messages and the transcript turns. The candidate's call ID is the
+// authoritative correlator: an empty candidate ID stays empty rather
+// than borrowing the captured trace's ID (which belonged to a different
+// conversation and would mislead any model that routes by ID).
 func frozenToolResults(traceID string, expectedIndex int, expected Turn, turns []Turn, start int, calls []ollama.ToolCall) ([]ollama.ChatMessage, []Turn, int, error) {
 	if len(calls) != len(expected.ToolCalls) {
 		return nil, nil, start, fmt.Errorf("trace %q assistant turn %d: got %d candidate tool calls for %d frozen calls: %w",
@@ -242,21 +337,17 @@ func frozenToolResults(traceID string, expectedIndex int, expected Turn, turns [
 				traceID, expectedIndex, i, resultName, callName, errToolCallMismatch)
 		}
 
-		callID := call.ID
-		if callID == "" {
-			callID = result.ToolCallID
-		}
 		messages = append(messages, ollama.ChatMessage{
 			Role:       "tool",
 			Content:    result.Content,
 			ToolName:   callName,
-			ToolCallID: callID,
+			ToolCallID: call.ID,
 		})
 		transcript = append(transcript, Turn{
 			Role:       "tool",
 			Content:    result.Content,
 			Name:       callName,
-			ToolCallID: callID,
+			ToolCallID: call.ID,
 			Raw:        result.Raw,
 		})
 	}
@@ -269,11 +360,17 @@ func frozenToolResults(traceID string, expectedIndex int, expected Turn, turns [
 	return messages, transcript, next, nil
 }
 
-func skipScriptedToolLoop(turns []Turn, start int) int {
-	for start < len(turns) && turns[start].Role != "user" {
-		start++
+// skipScriptedToolLoop fast-forwards past a scripted tool group when the
+// candidate diverged from the scripted route by replying with plain text.
+// Returns the number of turns skipped (for Notes annotation) and the new
+// index. Skips up to the next user turn since the outer replay loop only
+// accepts user turns at the top level.
+func skipScriptedToolLoop(turns []Turn, start int) (int, int) {
+	i := start
+	for i < len(turns) && turns[i].Role != "user" {
+		i++
 	}
-	return start
+	return i - start, i
 }
 
 func decodeTraceTools(rawTools []json.RawMessage) ([]ollama.Tool, error) {
@@ -377,4 +474,23 @@ func newOllamaClient(baseURL string) (*ollama.Client, error) {
 		return nil, errEmptyBaseURL
 	}
 	return ollama.NewClient(ollama.WithBaseURL(baseURL)), nil
+}
+
+func sumInt64(xs []int64) int64 {
+	var total int64
+	for _, x := range xs {
+		total += x
+	}
+	return total
+}
+
+func appendNotes(existing string, extras []string) string {
+	if len(extras) == 0 {
+		return existing
+	}
+	joined := strings.Join(extras, "; ")
+	if existing == "" {
+		return joined
+	}
+	return existing + "; " + joined
 }

--- a/cmd/llm-bench/runner.go
+++ b/cmd/llm-bench/runner.go
@@ -18,15 +18,16 @@ const benchKeepAlive = "30m"
 
 // Sentinel errors so tests assert on identity rather than message text.
 var (
-	errNoUserTurn       = errors.New("trace has no user turn")
-	errMultiUserTurn    = errors.New("multi-turn replay not yet supported")
-	errEmptyBaseURL     = errors.New("empty ollama base URL")
-	errMissingGolden    = errors.New("scorer requires golden.final_answer_substring")
-	errEmptySystem      = errors.New("trace has empty system prompt")
-	errNoTurns          = errors.New("trace has no turns")
-	errInvalidTraceTool = errors.New("trace has invalid tool definition")
-	errUnsupportedTurns = errors.New("trace has unsupported extra turns")
-	errUnsupportedProv  = errors.New("unsupported provider")
+	errNoUserTurn        = errors.New("trace has no user turn")
+	errEmptyBaseURL      = errors.New("empty ollama base URL")
+	errMissingGolden     = errors.New("scorer requires golden.final_answer_substring")
+	errEmptySystem       = errors.New("trace has empty system prompt")
+	errNoTurns           = errors.New("trace has no turns")
+	errInvalidTraceTool  = errors.New("trace has invalid tool definition")
+	errMissingToolResult = errors.New("trace is missing frozen tool result")
+	errToolCallMismatch  = errors.New("candidate tool call does not match trace")
+	errUnsupportedTurns  = errors.New("trace has unsupported extra turns")
+	errUnsupportedProv   = errors.New("unsupported provider")
 )
 
 // Runner executes traces against a list of candidate models and collects
@@ -111,45 +112,82 @@ func (r *Runner) runOne(ctx context.Context, client *ollama.Client, target Model
 	}
 }
 
-// replay sends the trace's turns to the model and captures the assistant's
-// responses. This is a SKELETON — the tool-call loop is not yet wired up.
-// Feeding tool results back to the model and extracting real ToolCalls
-// from the Ollama response requires more plumbing than this scaffold.
-//
-// Until the tool loop lands, replay only supports the minimal trace shape:
-// a single user turn plus the top-level system prompt. Any additional
-// assistant/tool turns would be silently truncated by this scaffold, so
-// replay refuses them rather than producing misleading aggregates.
+// replay sends user turns to the model, replaces scripted assistant turns with
+// candidate responses, and feeds captured tool-result turns back after matching
+// candidate tool calls. Tool results are frozen replay fixtures: the candidate
+// chooses whether and which tool to call, but llm-bench never executes tools.
 func replay(ctx context.Context, client *ollama.Client, model string, trace Trace) ([]Turn, error) {
-	var firstUser *Turn
-	userTurns := 0
-	for i := range trace.Turns {
-		if trace.Turns[i].Role == "user" {
-			userTurns++
-			if firstUser == nil {
-				firstUser = &trace.Turns[i]
-			}
-		}
-	}
-	if firstUser == nil {
+	if !hasUserTurn(trace.Turns) {
 		return nil, fmt.Errorf("trace %q: %w", trace.ID, errNoUserTurn)
-	}
-	if userTurns > 1 {
-		return nil, fmt.Errorf("trace %q has %d user turns: %w", trace.ID, userTurns, errMultiUserTurn)
-	}
-	if len(trace.Turns) != 1 {
-		return nil, fmt.Errorf("trace %q has %d turns: %w", trace.ID, len(trace.Turns), errUnsupportedTurns)
 	}
 
 	messages := []ollama.ChatMessage{
 		{Role: "system", Content: trace.System},
-		{Role: "user", Content: firstUser.Content},
 	}
 	tools, err := decodeTraceTools(trace.Tools)
 	if err != nil {
 		return nil, fmt.Errorf("trace %q: %w", trace.ID, err)
 	}
 
+	var transcript []Turn
+	for i := 0; i < len(trace.Turns); {
+		turn := trace.Turns[i]
+		if turn.Role != "user" {
+			return nil, fmt.Errorf("trace %q turn %d role %q: %w", trace.ID, i, turn.Role, errUnsupportedTurns)
+		}
+		messages = append(messages, ollama.ChatMessage{Role: "user", Content: turn.Content})
+		i++
+
+		for {
+			var expected Turn
+			expectedIndex := -1
+			if i < len(trace.Turns) && trace.Turns[i].Role == "assistant" {
+				expected = trace.Turns[i]
+				expectedIndex = i
+				i++
+			}
+
+			msg, actualTurn, err := chatReplayTurn(ctx, client, model, messages, tools)
+			if err != nil {
+				return nil, err
+			}
+			messages = append(messages, msg)
+			transcript = append(transcript, actualTurn)
+
+			if len(msg.ToolCalls) == 0 {
+				if len(expected.ToolCalls) > 0 {
+					i = skipScriptedToolLoop(trace.Turns, i)
+				}
+				break
+			}
+
+			if len(expected.ToolCalls) == 0 {
+				return nil, fmt.Errorf("trace %q turn %d: %w", trace.ID, i, errMissingToolResult)
+			}
+
+			toolMessages, toolTurns, next, err := frozenToolResults(trace.ID, expectedIndex, expected, trace.Turns, i, msg.ToolCalls)
+			if err != nil {
+				return nil, err
+			}
+			i = next
+			messages = append(messages, toolMessages...)
+			transcript = append(transcript, toolTurns...)
+		}
+	}
+
+	return transcript, nil
+}
+
+func hasUserTurn(turns []Turn) bool {
+	for _, turn := range turns {
+		if turn.Role == "user" {
+			return true
+		}
+	}
+	return false
+}
+
+func chatReplayTurn(ctx context.Context, client *ollama.Client, model string, messages []ollama.ChatMessage, tools []ollama.Tool) (ollama.ChatMessage, Turn, error) {
 	resp, err := client.Chat(ctx, ollama.ChatRequest{
 		Model:     model,
 		Messages:  messages,
@@ -157,15 +195,85 @@ func replay(ctx context.Context, client *ollama.Client, model string, trace Trac
 		KeepAlive: benchKeepAlive,
 	})
 	if err != nil {
-		return nil, err
+		return ollama.ChatMessage{}, Turn{}, err
 	}
 
-	turn, err := assistantTurnFromMessage(resp.Message)
+	msg := normalizeAssistantMessage(resp.Message)
+	turn, err := assistantTurnFromMessage(msg)
 	if err != nil {
-		return nil, err
+		return ollama.ChatMessage{}, Turn{}, err
+	}
+	return msg, turn, nil
+}
+
+func normalizeAssistantMessage(msg ollama.ChatMessage) ollama.ChatMessage {
+	if msg.Role == "" {
+		msg.Role = "assistant"
+	}
+	return msg
+}
+
+func frozenToolResults(traceID string, expectedIndex int, expected Turn, turns []Turn, start int, calls []ollama.ToolCall) ([]ollama.ChatMessage, []Turn, int, error) {
+	if len(calls) != len(expected.ToolCalls) {
+		return nil, nil, start, fmt.Errorf("trace %q assistant turn %d: got %d candidate tool calls for %d frozen calls: %w",
+			traceID, expectedIndex, len(calls), len(expected.ToolCalls), errToolCallMismatch)
+	}
+	if start+len(expected.ToolCalls) > len(turns) {
+		return nil, nil, start, fmt.Errorf("trace %q assistant turn %d: %w", traceID, expectedIndex, errMissingToolResult)
 	}
 
-	return []Turn{turn}, nil
+	messages := make([]ollama.ChatMessage, 0, len(calls))
+	transcript := make([]Turn, 0, len(calls))
+	for i, call := range calls {
+		expectedCall := expected.ToolCalls[i]
+		callName := strings.TrimSpace(call.Function.Name)
+		if callName == "" || callName != strings.TrimSpace(expectedCall.Name) {
+			return nil, nil, start, fmt.Errorf("trace %q assistant turn %d tool %d: got %q, want %q: %w",
+				traceID, expectedIndex, i, callName, expectedCall.Name, errToolCallMismatch)
+		}
+
+		result := turns[start+i]
+		if result.Role != "tool" {
+			return nil, nil, start, fmt.Errorf("trace %q assistant turn %d tool %d: %w", traceID, expectedIndex, i, errMissingToolResult)
+		}
+		resultName := strings.TrimSpace(result.Name)
+		if resultName != "" && resultName != callName {
+			return nil, nil, start, fmt.Errorf("trace %q assistant turn %d tool %d result: got %q, want %q: %w",
+				traceID, expectedIndex, i, resultName, callName, errToolCallMismatch)
+		}
+
+		callID := call.ID
+		if callID == "" {
+			callID = result.ToolCallID
+		}
+		messages = append(messages, ollama.ChatMessage{
+			Role:       "tool",
+			Content:    result.Content,
+			ToolName:   callName,
+			ToolCallID: callID,
+		})
+		transcript = append(transcript, Turn{
+			Role:       "tool",
+			Content:    result.Content,
+			Name:       callName,
+			ToolCallID: callID,
+			Raw:        result.Raw,
+		})
+	}
+
+	next := start + len(expected.ToolCalls)
+	if next < len(turns) && turns[next].Role == "tool" {
+		return nil, nil, start, fmt.Errorf("trace %q assistant turn %d: extra frozen tool result: %w",
+			traceID, expectedIndex, errUnsupportedTurns)
+	}
+	return messages, transcript, next, nil
+}
+
+func skipScriptedToolLoop(turns []Turn, start int) int {
+	for start < len(turns) && turns[start].Role != "user" {
+		start++
+	}
+	return start
 }
 
 func decodeTraceTools(rawTools []json.RawMessage) ([]ollama.Tool, error) {

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -47,11 +47,10 @@ func newScorer(name string) (Scorer, error) {
 // before drawing conclusions.
 type ExactMatchScorer struct{}
 
-// Score implements Scorer. ToolArgsValid is left unset (zero) because the
-// tool loop has not yet been wired in Phase 1, so per-call argument
-// validation against trace.Tools schemas is not computable. The Notes
-// field records this so aggregate consumers can distinguish "not scored"
-// from "scored zero".
+// Score implements Scorer. ToolArgsValid is left unset (zero) until replay
+// validates candidate arguments against trace.Tools schemas. The Notes field
+// records this so aggregate consumers can distinguish "not scored" from
+// "scored zero".
 func (s *ExactMatchScorer) Score(_ context.Context, trace Trace, actual Result) (Score, error) {
 	needle := strings.TrimSpace(trace.Golden.FinalAnswerSubstring)
 	if needle == "" {
@@ -60,7 +59,7 @@ func (s *ExactMatchScorer) Score(_ context.Context, trace Trace, actual Result) 
 
 	score := Score{
 		ToolSequenceMatch: toolSequenceScore(trace.Golden.ToolCalls, extractToolNames(actual.Transcript)),
-		Notes:             "ToolArgsValid not computed (tool loop pending; see benchmark-plan.md Phase 2)",
+		Notes:             "ToolArgsValid not computed (schema validation pending; see benchmark-plan.md metrics)",
 	}
 
 	finalText := lastAssistantContent(actual.Transcript)

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -12,7 +12,8 @@ type Score struct {
 	ToolSequenceMatch float64 // [0,1] — how close actual tool calls were to the golden sequence
 	ToolArgsValid     float64 // [0,1] — fraction of tool calls with valid arguments
 	AnswerQuality     float64 // [0,1] — final-answer quality per the active Scorer
-	LatencyMs         int64
+	LatencyMs         int64   // sum of all chat round-trips for this replay
+	TurnLatenciesMs   []int64 // per-turn breakdown; len == number of chat round-trips
 	TotalTokens       int
 	Notes             string
 }
@@ -73,9 +74,11 @@ func (s *ExactMatchScorer) Score(_ context.Context, trace Trace, actual Result) 
 }
 
 // toolSequenceScore computes a simple Jaccard overlap between the expected
-// and actual tool-call sequences, ignoring order for now. A Levenshtein-
-// based sequence comparison is a follow-up once the tool loop records real
-// ordered calls.
+// and actual tool-call sequences, ignoring order. The tool loop now
+// records real ordered calls, so order-sensitive scoring (e.g.
+// Levenshtein) is a meaningful follow-up — deferred pending the
+// cost/benefit call on whether a coarser sequence-match-vs-divergence
+// signal is enough for the benchmark's purpose.
 func toolSequenceScore(expected, actual []string) float64 {
 	if len(expected) == 0 && len(actual) == 0 {
 		return 1.0

--- a/cmd/llm-bench/trace.go
+++ b/cmd/llm-bench/trace.go
@@ -2,10 +2,17 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 )
+
+// errToolNameNotDeclared signals a scripted assistant tool call whose
+// name doesn't appear in trace.Tools — the candidate would never see a
+// schema for the tool it's supposed to invoke.
+var errToolNameNotDeclared = errors.New("trace tool call references undeclared tool name")
 
 // Trace is a replayable conversation captured from a real MCP / chat session.
 // See docs/llm/benchmark-plan.md for the format and capture strategy.
@@ -75,5 +82,72 @@ func validateTrace(t Trace) error {
 	if len(t.Turns) == 0 {
 		return errNoTurns
 	}
+	if err := validateToolNamesDeclared(t); err != nil {
+		return err
+	}
 	return nil
+}
+
+// validateToolNamesDeclared rejects a trace whose scripted assistant
+// tool calls reference a tool name not declared in trace.Tools. Empty
+// trace.Tools is a permitted shape (traces with no tools at all); the
+// check only applies once any tool schema is declared.
+func validateToolNamesDeclared(t Trace) error {
+	if len(t.Tools) == 0 {
+		return nil
+	}
+	declared, err := declaredToolNames(t.Tools)
+	if err != nil {
+		return err
+	}
+	for i, turn := range t.Turns {
+		if turn.Role != "assistant" {
+			continue
+		}
+		for j, call := range turn.ToolCalls {
+			name := strings.TrimSpace(call.Name)
+			if name == "" {
+				continue
+			}
+			if _, ok := declared[name]; !ok {
+				return fmt.Errorf("turn %d tool_call %d %q: %w", i, j, name, errToolNameNotDeclared)
+			}
+		}
+	}
+	return nil
+}
+
+// declaredToolNames extracts the tool names from trace.Tools using a
+// minimal decode that tolerates both the provider-tool shape ("function"
+// wrapper) and the MCP-style shape (top-level "name").
+func declaredToolNames(rawTools []json.RawMessage) (map[string]struct{}, error) {
+	names := make(map[string]struct{}, len(rawTools))
+	for i, raw := range rawTools {
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &fields); err != nil {
+			return nil, fmt.Errorf("trace tool[%d]: %w", i, err)
+		}
+		if fn, ok := fields["function"]; ok {
+			var inner struct {
+				Name string `json:"name"`
+			}
+			if err := json.Unmarshal(fn, &inner); err != nil {
+				return nil, fmt.Errorf("trace tool[%d].function: %w", i, err)
+			}
+			if n := strings.TrimSpace(inner.Name); n != "" {
+				names[n] = struct{}{}
+			}
+			continue
+		}
+		if raw, ok := fields["name"]; ok {
+			var n string
+			if err := json.Unmarshal(raw, &n); err != nil {
+				return nil, fmt.Errorf("trace tool[%d].name: %w", i, err)
+			}
+			if n = strings.TrimSpace(n); n != "" {
+				names[n] = struct{}{}
+			}
+		}
+	}
+	return names, nil
 }

--- a/cmd/llm-bench/trace_test.go
+++ b/cmd/llm-bench/trace_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 )
@@ -30,6 +31,48 @@ func TestValidateTrace(t *testing.T) {
 			name:    "no turns",
 			trace:   Trace{ID: "t3", System: "sys"},
 			wantErr: errNoTurns,
+		},
+		{
+			name: "tool name not declared",
+			trace: Trace{
+				ID:     "t4",
+				System: "sys",
+				Tools: []json.RawMessage{
+					json.RawMessage(`{"name":"read_file","inputSchema":{"type":"object"}}`),
+				},
+				Turns: []Turn{
+					{Role: "user", Content: "q"},
+					{Role: "assistant", ToolCalls: []ToolCall{{Name: "write_file"}}},
+				},
+			},
+			wantErr: errToolNameNotDeclared,
+		},
+		{
+			name: "tool name declared via provider shape",
+			trace: Trace{
+				ID:     "t5",
+				System: "sys",
+				Tools: []json.RawMessage{
+					json.RawMessage(`{"type":"function","function":{"name":"read_file","parameters":{"type":"object"}}}`),
+				},
+				Turns: []Turn{
+					{Role: "user", Content: "q"},
+					{Role: "assistant", ToolCalls: []ToolCall{{Name: "read_file"}}},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "no tools declared bypasses cross-check",
+			trace: Trace{
+				ID:     "t6",
+				System: "sys",
+				Turns: []Turn{
+					{Role: "user", Content: "q"},
+					{Role: "assistant", ToolCalls: []ToolCall{{Name: "anything"}}},
+				},
+			},
+			wantErr: nil,
 		},
 	}
 

--- a/docs/llm/README.md
+++ b/docs/llm/README.md
@@ -107,9 +107,15 @@ schema does not store a conversation id.
 
 Tool-call names and tool-result turns are preserved, and `llm-bench`
 can replay multi-turn conversations with frozen tool results when the
-trace includes the needed tool schemas. The current `conversation/`
-capture path does not export schemas because those records do not store
-them, so schema sourcing remains follow-up capture work.
+trace includes the needed tool schemas. Replay matches candidate tool
+calls against the scripted assistant turn in lock-step (same count,
+same names, same order); mismatches surface as `errToolCallMismatch`,
+divergence into plain text bypasses the scripted tool route and is
+recorded in `Score.Notes`, and tool-argument schema validation against
+`trace.Tools` remains scorer-side follow-up work. The current
+`conversation/` capture path does not export schemas because those
+records do not store them, so schema sourcing remains follow-up capture
+work.
 
 ## Date stamp
 

--- a/docs/llm/README.md
+++ b/docs/llm/README.md
@@ -105,10 +105,11 @@ The first capture PR uses `conversation/` as the source of truth;
 feedback-linked sampling comes later because the current `feedback/`
 schema does not store a conversation id.
 
-Tool-call names and tool-result turns are preserved, but tool schemas are
-not exported yet because the current `conversation/` records do not store
-them. Multi-turn/tool-use traces are useful calibration fixtures now;
-full replay of those traces requires the Phase 2 tool-loop/schema work.
+Tool-call names and tool-result turns are preserved, and `llm-bench`
+can replay multi-turn conversations with frozen tool results when the
+trace includes the needed tool schemas. The current `conversation/`
+capture path does not export schemas because those records do not store
+them, so schema sourcing remains follow-up capture work.
 
 ## Date stamp
 

--- a/docs/llm/benchmark-plan.md
+++ b/docs/llm/benchmark-plan.md
@@ -149,9 +149,11 @@ First implementation slice:
   blocks, and email addresses before files are written.
 - Conversations without a system prompt, user turn, final assistant
   answer, or parseable tool-call JSON are skipped with a warning.
-- Tool-call names and tool-result turns are captured, but tool schemas are
-  not recoverable from `conversation/` today; full replay of tool-use
-  traces requires the follow-up schema/tool-loop work.
+- Tool-call names and tool-result turns are captured, and `llm-bench`
+  can replay multi-turn/tool-use traces by injecting frozen tool results
+  after matching candidate tool calls. Tool schemas are still not
+  recoverable from `conversation/` today; schema sourcing remains
+  follow-up capture work.
 - Feedback-driven sampling is deferred until feedback rows can be tied
   to conversations; today `feedback_retrievals` and `feedback_signals`
   do not carry a conversation id.

--- a/docs/llm/benchmark-plan.md
+++ b/docs/llm/benchmark-plan.md
@@ -151,9 +151,16 @@ First implementation slice:
   answer, or parseable tool-call JSON are skipped with a warning.
 - Tool-call names and tool-result turns are captured, and `llm-bench`
   can replay multi-turn/tool-use traces by injecting frozen tool results
-  after matching candidate tool calls. Tool schemas are still not
-  recoverable from `conversation/` today; schema sourcing remains
-  follow-up capture work.
+  after matching candidate tool calls. Matching is strict and lock-step:
+  the candidate must emit the same number of tool calls in the same
+  order, with the same names, as the scripted assistant turn. Mismatches
+  surface as `errToolCallMismatch`; a candidate that emits tool calls
+  with no scripted assistant turn surfaces as `errMissingScriptedAssistant`;
+  a candidate that bypasses the scripted tool route by replying in plain
+  text has the skip recorded in `Score.Notes` (the historical
+  "refuse rather than mislead" intent, now in observability form).
+  Tool schemas are still not recoverable from `conversation/` today;
+  schema sourcing remains follow-up capture work.
 - Feedback-driven sampling is deferred until feedback rows can be tied
   to conversations; today `feedback_retrievals` and `feedback_signals`
   do not carry a conversation id.
@@ -166,9 +173,10 @@ First implementation slice:
 ### Phase 4 — Live comparison runs
 
 - **Currently-configured model vs candidate** on each role's captured
-  traces. The harness takes `-models <provider>/<name>,...` so any model
-  reachable through an existing `provider.Provider` can participate —
-  swap candidates without editing Go code.
+  traces. The harness takes `-models <provider>/<name>,...`; today only
+  `ollama` is wired (`parseModelTarget` rejects other providers), so the
+  "any model reachable through an existing `provider.Provider`" target
+  remains follow-up work alongside the multi-provider client factory.
 - Initial target comparisons against the reference lineup in `models.json`:
   - `coding` — Qwen3-Coder-Next vs GLM-5.1 on code-gen traces (Setup 2
     experiment; see [setups.md](setups.md))


### PR DESCRIPTION
## Summary

Adds the next focused #56 benchmark-harness slice for H2 replay support in `cmd/llm-bench`.

- Replaces the single-user-turn replay restriction with scripted multi-turn replay where candidate assistant turns replace captured assistant turns.
- Injects captured frozen tool-result turns back into Ollama after the candidate emits matching tool calls, keyed by assistant turn/order/tool name rather than captured call IDs.
- Preserves the current Ollama-only target path; provider expansion remains out of scope.
- Updates llm-bench docs to clarify that replay now supports frozen tool results while conversation-store tool-schema capture remains follow-up work.

Refs #56. This does not close #56; `llm-judge`, calibration/sampling docs, feedback-linked sampling, and tool-schema capture still remain.

## Validation

- `go test ./cmd/llm-bench`
- `go test ./cmd/llm-bench ./conversation ./feedback`
- `go test ./...`
- Pre-push hook: lint, race tests, compile smoke