### PR TITLE
[codex] implement local llm-bench judge scorer

### DIFF
--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -20,8 +20,11 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
+
+	"github.com/kstruzzieri/go-llm/config"
 )
 
 func main() {
@@ -34,9 +37,12 @@ func main() {
 	tracesGlob := flag.String("traces", "", "Glob pattern for trace JSON files (required)")
 	modelsArg := flag.String("models", "", "Comma-separated model selectors (provider/model or bare model name; required)")
 	scorerName := flag.String("scorer", "exact-match", "Scoring strategy: exact-match, llm-judge, manual")
+	judgeModel := flag.String("judge-model", "", "Ollama model used by -scorer llm-judge; default uses models.json role judge or gemma4:31b")
+	judgeOllamaURL := flag.String("judge-ollama-url", "", "Ollama base URL for -scorer llm-judge (default: -ollama-url)")
+	judgeTimeout := flag.Duration("judge-timeout", 5*time.Minute, "Timeout for each llm-judge scoring request")
 	reportPath := flag.String("report", "", "Output report path (default: stdout)")
 	ollamaURL := flag.String("ollama-url", "http://localhost:11434", "Ollama base URL")
-	timeout := flag.Duration("timeout", 5*time.Minute, "Per-trace timeout")
+	timeout := flag.Duration("timeout", 5*time.Minute, "Per-replay timeout for candidate model calls")
 	flag.Parse()
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -86,7 +92,20 @@ func main() {
 		log.Fatalf("llm-bench: load traces: %v", err)
 	}
 
-	scorer, err := newScorer(*scorerName)
+	resolvedJudgeModel := strings.TrimSpace(*judgeModel)
+	if *scorerName == "llm-judge" && resolvedJudgeModel == "" {
+		resolvedJudgeModel = defaultJudgeModelName()
+	}
+	resolvedJudgeURL := strings.TrimSpace(*judgeOllamaURL)
+	if *scorerName == "llm-judge" && resolvedJudgeURL == "" {
+		resolvedJudgeURL = *ollamaURL
+	}
+
+	scorer, err := newScorer(ctx, *scorerName, scorerOptions{
+		ollamaURL:    resolvedJudgeURL,
+		judgeModel:   resolvedJudgeModel,
+		judgeTimeout: *judgeTimeout,
+	})
 	if err != nil {
 		log.Fatalf("llm-bench: scorer: %v", err)
 	}
@@ -107,7 +126,10 @@ func main() {
 		modelNames = append(modelNames, target.Display)
 	}
 
-	report := formatReport(modelNames, results)
+	report := formatReport(modelNames, results, reportOptions{
+		Scorer:     *scorerName,
+		JudgeModel: resolvedJudgeModel,
+	})
 
 	if *reportPath == "" {
 		fmt.Print(report)
@@ -118,4 +140,14 @@ func main() {
 		log.Fatalf("llm-bench: write report: %v", err)
 	}
 	fmt.Fprintf(os.Stderr, "llm-bench: report written to %s\n", *reportPath)
+}
+
+func defaultJudgeModelName() string {
+	cfg, err := config.Default()
+	if err == nil {
+		if m := cfg.RoleConfig("judge"); m != nil && strings.TrimSpace(m.Name) != "" {
+			return strings.TrimSpace(m.Name)
+		}
+	}
+	return fallbackJudgeModel
 }

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -8,7 +8,7 @@ import (
 )
 
 // formatReport renders per-model aggregates as a Markdown table.
-func formatReport(models []string, results []Result) string {
+func formatReport(models []string, results []Result, opts reportOptions) string {
 	byModel := make(map[string][]Result, len(models))
 	for _, r := range results {
 		byModel[r.Model] = append(byModel[r.Model], r)
@@ -17,33 +17,41 @@ func formatReport(models []string, results []Result) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "# llm-bench report\n\n")
 	fmt.Fprintf(&b, "Generated: %s\n\n", time.Now().UTC().Format(time.RFC3339))
+	if opts.Scorer != "" {
+		fmt.Fprintf(&b, "Scorer: `%s`\n\n", markdownCell(opts.Scorer))
+	}
+	if opts.Scorer == "llm-judge" && opts.JudgeModel != "" {
+		fmt.Fprintf(&b, "Judge model: `%s`\n\n", markdownCell(opts.JudgeModel))
+	}
 
 	fmt.Fprintf(&b, "## Summary\n\n")
-	fmt.Fprintf(&b, "| Model | Traces | Errors | Mean Quality | Mean ToolSeq | Mean Latency (ms) |\n")
-	fmt.Fprintf(&b, "|---|---|---|---|---|---|\n")
+	fmt.Fprintf(&b, "| Model | Traces | Errors | Mean Quality | Mean ToolSeq | Mean Replay Latency (ms) | Mean Scorer Latency (ms) |\n")
+	fmt.Fprintf(&b, "|---|---|---|---|---|---|---|\n")
 	for _, m := range models {
 		rs := byModel[m]
 		agg := aggregate(rs)
-		fmt.Fprintf(&b, "| %s | %d | %d | %.2f | %.2f | %d |\n",
-			m, len(rs), agg.errors, agg.meanQuality, agg.meanToolSeq, agg.meanLatencyMs)
+		fmt.Fprintf(&b, "| %s | %d | %d | %.2f | %.2f | %d | %d |\n",
+			markdownCell(m), len(rs), agg.errors, agg.meanQuality, agg.meanToolSeq, agg.meanLatencyMs, agg.meanScorerLatencyMs)
 	}
 
 	fmt.Fprintf(&b, "\n## Per-trace detail\n\n")
 	for _, m := range models {
-		fmt.Fprintf(&b, "### %s\n\n", m)
-		fmt.Fprintf(&b, "| Trace | Quality | ToolSeq | Latency (ms) | Error |\n")
-		fmt.Fprintf(&b, "|---|---|---|---|---|\n")
+		fmt.Fprintf(&b, "### %s\n\n", markdownCell(m))
+		fmt.Fprintf(&b, "| Trace | Quality | ToolSeq | Replay Latency (ms) | Scorer Latency (ms) | Notes | Error |\n")
+		fmt.Fprintf(&b, "|---|---|---|---|---|---|---|\n")
 		rs := byModel[m]
 		sort.Slice(rs, func(i, j int) bool { return rs[i].TraceID < rs[j].TraceID })
 		for _, r := range rs {
 			if r.Err != nil {
 				// Errored runs: render em-dash in metric cells so a reader
 				// never confuses an error with a genuine zero score.
-				fmt.Fprintf(&b, "| %s | — | — | — | %s |\n", r.TraceID, r.Err.Error())
+				fmt.Fprintf(&b, "| %s | — | — | — | — |  | %s |\n",
+					markdownCell(r.TraceID), markdownCell(r.Err.Error()))
 				continue
 			}
-			fmt.Fprintf(&b, "| %s | %.2f | %.2f | %d | |\n",
-				r.TraceID, r.Score.AnswerQuality, r.Score.ToolSequenceMatch, r.Score.LatencyMs)
+			fmt.Fprintf(&b, "| %s | %.2f | %.2f | %d | %d | %s |  |\n",
+				markdownCell(r.TraceID), r.Score.AnswerQuality, r.Score.ToolSequenceMatch,
+				r.Score.LatencyMs, r.Score.ScorerLatencyMs, markdownCell(r.Score.Notes))
 		}
 		fmt.Fprintln(&b)
 	}
@@ -51,11 +59,17 @@ func formatReport(models []string, results []Result) string {
 	return b.String()
 }
 
+type reportOptions struct {
+	Scorer     string
+	JudgeModel string
+}
+
 type modelAggregate struct {
-	errors         int
-	meanQuality    float64
-	meanToolSeq    float64
-	meanLatencyMs  int64
+	errors              int
+	meanQuality         float64
+	meanToolSeq         float64
+	meanLatencyMs       int64
+	meanScorerLatencyMs int64
 }
 
 func aggregate(rs []Result) modelAggregate {
@@ -64,7 +78,7 @@ func aggregate(rs []Result) modelAggregate {
 	}
 	var a modelAggregate
 	var qSum, tsSum float64
-	var latSum int64
+	var latSum, scorerLatSum int64
 	var scored int
 	for _, r := range rs {
 		if r.Err != nil {
@@ -74,12 +88,23 @@ func aggregate(rs []Result) modelAggregate {
 		qSum += r.Score.AnswerQuality
 		tsSum += r.Score.ToolSequenceMatch
 		latSum += r.Score.LatencyMs
+		scorerLatSum += r.Score.ScorerLatencyMs
 		scored++
 	}
 	if scored > 0 {
 		a.meanQuality = qSum / float64(scored)
 		a.meanToolSeq = tsSum / float64(scored)
 		a.meanLatencyMs = latSum / int64(scored)
+		a.meanScorerLatencyMs = scorerLatSum / int64(scored)
 	}
 	return a
+}
+
+func markdownCell(s string) string {
+	s = strings.Join(strings.Fields(s), " ")
+	s = strings.ReplaceAll(s, "|", `\|`)
+	if s == "" {
+		return ""
+	}
+	return s
 }

--- a/cmd/llm-bench/run_all_test.go
+++ b/cmd/llm-bench/run_all_test.go
@@ -113,3 +113,47 @@ func TestRunAllSucceedsEndToEnd(t *testing.T) {
 		t.Errorf("AnswerQuality = %f, want 1.0", r.Score.AnswerQuality)
 	}
 }
+
+type latencyPoisonScorer struct{}
+
+func (s latencyPoisonScorer) Score(context.Context, Trace, Result) (Score, error) {
+	time.Sleep(20 * time.Millisecond)
+	return Score{
+		AnswerQuality: 1.0,
+		LatencyMs:     int64((24 * time.Hour) / time.Millisecond),
+	}, nil
+}
+
+func TestRunAllLatencyExcludesScorerWork(t *testing.T) {
+	srv := newFakeChatServer(t, "answer")
+	runner := &Runner{
+		OllamaURL: srv.URL,
+		Timeout:   5 * time.Second,
+		Scorer:    latencyPoisonScorer{},
+	}
+
+	targets := []ModelTarget{{Display: "m1", Provider: "ollama", Model: "m1"}}
+	traces := []Trace{{
+		ID:     "t1",
+		System: "sys",
+		Turns:  []Turn{{Role: "user", Content: "q"}},
+		Golden: Golden{FinalAnswerSubstring: "answer"},
+	}}
+
+	results, err := runner.RunAll(context.Background(), targets, traces)
+	if err != nil {
+		t.Fatalf("RunAll() error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Err != nil {
+		t.Fatalf("unexpected result error: %v", results[0].Err)
+	}
+	if results[0].Score.LatencyMs >= int64(time.Hour/time.Millisecond) {
+		t.Fatalf("LatencyMs = %d, scorer latency leaked into replay latency", results[0].Score.LatencyMs)
+	}
+	if results[0].Score.ScorerLatencyMs <= 0 {
+		t.Fatalf("ScorerLatencyMs = %d, want scorer work to be visible", results[0].Score.ScorerLatencyMs)
+	}
+}

--- a/cmd/llm-bench/runner.go
+++ b/cmd/llm-bench/runner.go
@@ -30,6 +30,11 @@ var (
 	errUnsupportedTurns         = errors.New("trace has unsupported extra turns")
 	errEmptyAssistantReply      = errors.New("candidate returned empty assistant reply (no content, no tool calls)")
 	errUnsupportedProv          = errors.New("unsupported provider")
+	errEmptyJudgeModel          = errors.New("empty judge model")
+	errMissingJudgeCriteria     = errors.New("judge scorer requires golden.final_answer_criteria or golden.final_answer_substring")
+	errJudgeSelfPreference      = errors.New("judge model must differ from candidate model")
+	errMalformedJudgeResponse   = errors.New("malformed judge response")
+	errNoAssistantFinalAnswer   = errors.New("judge scorer requires an assistant final answer")
 )
 
 // Runner executes traces against a list of candidate models and collects
@@ -94,20 +99,22 @@ func (r *Runner) RunAll(ctx context.Context, targets []ModelTarget, traces []Tra
 }
 
 func (r *Runner) runOne(ctx context.Context, client *ollama.Client, target ModelTarget, trace Trace) Result {
-	runCtx, cancel := context.WithTimeout(ctx, r.Timeout)
-	defer cancel()
+	replayCtx, cancel := context.WithTimeout(ctx, r.Timeout)
 
 	opts := replayOptions{PerTurnTimeout: r.PerTurnTimeout, NumCtx: r.NumCtx}
-	out, err := replayWith(runCtx, client, target.Model, trace, opts)
+	out, err := replayWith(replayCtx, client, target.Model, trace, opts)
+	cancel()
 	if err != nil {
 		return Result{Model: target.Display, TraceID: trace.ID, Err: err, Transcript: out.Transcript}
 	}
 
-	score, err := r.Scorer.Score(runCtx, trace, Result{
+	scoreStart := time.Now()
+	score, err := r.Scorer.Score(ctx, trace, Result{
 		Model:      target.Display,
 		TraceID:    trace.ID,
 		Transcript: out.Transcript,
 	})
+	scorerMs := time.Since(scoreStart).Milliseconds()
 	if err != nil {
 		return Result{Model: target.Display, TraceID: trace.ID, Err: err, Transcript: out.Transcript}
 	}
@@ -121,6 +128,9 @@ func (r *Runner) runOne(ctx context.Context, client *ollama.Client, target Model
 	if len(out.Notes) > 0 {
 		score.Notes = appendNotes(score.Notes, out.Notes)
 	}
+	// Latency reflects replay only; ScorerLatencyMs keeps judge/scorer work visible
+	// without polluting the target model latency metric.
+	score.ScorerLatencyMs = scorerMs
 
 	return Result{
 		Model:      target.Display,

--- a/cmd/llm-bench/runner.go
+++ b/cmd/llm-bench/runner.go
@@ -479,11 +479,12 @@ func assistantTurnFromMessage(msg ollama.ChatMessage) (Turn, error) {
 // newOllamaClient constructs an ollama.Client targeting the configured URL.
 // Multi-provider routing (e.g. LM Studio at a different port) is a
 // follow-up that will introduce a client factory keyed by target.Provider.
-func newOllamaClient(baseURL string) (*ollama.Client, error) {
+func newOllamaClient(baseURL string, opts ...ollama.Option) (*ollama.Client, error) {
 	if strings.TrimSpace(baseURL) == "" {
 		return nil, errEmptyBaseURL
 	}
-	return ollama.NewClient(ollama.WithBaseURL(baseURL)), nil
+	clientOpts := append([]ollama.Option{ollama.WithBaseURL(baseURL)}, opts...)
+	return ollama.NewClient(clientOpts...), nil
 }
 
 func sumInt64(xs []int64) int64 {

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -2,8 +2,21 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+const (
+	fallbackJudgeModel       = "gemma4:31b"
+	judgeTemperature         = 0.1
+	judgeTokenBudget         = 512
+	maxJudgeTurnContentBytes = 8192
+	maxJudgeAnswerBytes      = 32768
 )
 
 // Score captures the evaluation dimensions for a single (model, trace) run.
@@ -14,6 +27,7 @@ type Score struct {
 	AnswerQuality     float64 // [0,1] — final-answer quality per the active Scorer
 	LatencyMs         int64   // sum of all chat round-trips for this replay
 	TurnLatenciesMs   []int64 // per-turn breakdown; len == number of chat round-trips
+	ScorerLatencyMs   int64   // wall-clock time spent in the active scorer
 	TotalTokens       int
 	Notes             string
 }
@@ -28,13 +42,30 @@ type Scorer interface {
 	Score(ctx context.Context, trace Trace, actual Result) (Score, error)
 }
 
+type scorerOptions struct {
+	ollamaURL    string
+	judgeModel   string
+	judgeTimeout time.Duration
+}
+
 // newScorer returns the Scorer matching the given name.
-func newScorer(name string) (Scorer, error) {
+func newScorer(ctx context.Context, name string, opts scorerOptions) (Scorer, error) {
 	switch name {
 	case "exact-match":
 		return &ExactMatchScorer{}, nil
 	case "llm-judge":
-		return nil, fmt.Errorf("llm-judge scorer not yet implemented (see docs/llm/benchmark-plan.md Phase 3)")
+		client, err := newOllamaClient(opts.ollamaURL)
+		if err != nil {
+			return nil, fmt.Errorf("llm-judge client: %w", err)
+		}
+		scorer, err := newLLMJudgeScorer(client, opts.judgeModel, opts.judgeTimeout)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateJudgeModel(ctx, client, scorer.JudgeModel); err != nil {
+			return nil, err
+		}
+		return scorer, nil
 	case "manual":
 		return nil, fmt.Errorf("manual scorer not yet implemented")
 	default:
@@ -71,6 +102,348 @@ func (s *ExactMatchScorer) Score(_ context.Context, trace Trace, actual Result) 
 	}
 
 	return score, nil
+}
+
+type judgeChatClient interface {
+	Chat(ctx context.Context, req ollama.ChatRequest) (*ollama.ChatResponse, error)
+}
+
+type judgeModelChecker interface {
+	AvailableModels(ctx context.Context) ([]string, error)
+}
+
+// LLMJudgeScorer asks a separate local Ollama model to score final-answer
+// quality against the trace's golden rubric. Replay latency and target-model
+// tokens remain owned by Runner.runOne.
+type LLMJudgeScorer struct {
+	Client       judgeChatClient
+	JudgeModel   string
+	JudgeTimeout time.Duration
+}
+
+func newLLMJudgeScorer(client judgeChatClient, judgeModel string, judgeTimeout time.Duration) (*LLMJudgeScorer, error) {
+	if client == nil {
+		return nil, fmt.Errorf("nil judge client")
+	}
+	judgeModel = strings.TrimSpace(judgeModel)
+	if judgeModel == "" {
+		return nil, errEmptyJudgeModel
+	}
+	if judgeTimeout < 0 {
+		return nil, fmt.Errorf("negative judge timeout %s", judgeTimeout)
+	}
+	return &LLMJudgeScorer{
+		Client:       client,
+		JudgeModel:   judgeModel,
+		JudgeTimeout: judgeTimeout,
+	}, nil
+}
+
+func validateJudgeModel(ctx context.Context, checker judgeModelChecker, judgeModel string) error {
+	if checker == nil {
+		return fmt.Errorf("llm-judge model validation requires a model checker")
+	}
+	models, err := checker.AvailableModels(ctx)
+	if err != nil {
+		return fmt.Errorf("validate judge model %q: %w", judgeModel, err)
+	}
+	for _, model := range models {
+		if sameModelSelector(judgeModel, model) {
+			return nil
+		}
+	}
+	return fmt.Errorf("judge model %q is not available from the configured Ollama server; pull it or pass -judge-model/-judge-ollama-url", judgeModel)
+}
+
+func (s *LLMJudgeScorer) Score(ctx context.Context, trace Trace, actual Result) (Score, error) {
+	if sameModelSelector(s.JudgeModel, actual.Model) {
+		return Score{}, fmt.Errorf("trace %q model %q: %w", trace.ID, actual.Model, errJudgeSelfPreference)
+	}
+
+	criteria := strings.TrimSpace(trace.Golden.FinalAnswerCriteria)
+	substring := strings.TrimSpace(trace.Golden.FinalAnswerSubstring)
+	if criteria == "" && substring == "" {
+		return Score{}, fmt.Errorf("trace %q: %w", trace.ID, errMissingJudgeCriteria)
+	}
+
+	score := Score{
+		ToolSequenceMatch: toolSequenceScore(trace.Golden.ToolCalls, extractToolNames(actual.Transcript)),
+		Notes:             "ToolArgsValid not computed (schema validation pending; see benchmark-plan.md metrics)",
+	}
+
+	if strings.TrimSpace(lastAssistantContent(actual.Transcript)) == "" {
+		return Score{}, fmt.Errorf("trace %q: %w", trace.ID, errNoAssistantFinalAnswer)
+	}
+
+	prompt, err := buildJudgePrompt(trace, actual)
+	if err != nil {
+		return Score{}, fmt.Errorf("trace %q: build judge prompt: %w", trace.ID, err)
+	}
+
+	judgeCtx := ctx
+	var cancel context.CancelFunc
+	if s.JudgeTimeout > 0 {
+		judgeCtx, cancel = context.WithTimeout(ctx, s.JudgeTimeout)
+		defer cancel()
+	}
+
+	resp, err := s.Client.Chat(judgeCtx, ollama.ChatRequest{
+		Model: s.JudgeModel,
+		Messages: []ollama.ChatMessage{
+			{Role: "system", Content: judgeSystemPrompt},
+			{Role: "user", Content: prompt},
+		},
+		Format: "json",
+		Options: &ollama.ModelOptions{
+			Temperature: judgeTemperature,
+			NumPredict:  judgeTokenBudget,
+		},
+		KeepAlive: benchKeepAlive,
+	})
+	if err != nil {
+		return Score{}, fmt.Errorf("judge model %q: %w", s.JudgeModel, err)
+	}
+	if resp == nil {
+		return Score{}, fmt.Errorf("judge model %q: %w: nil response", s.JudgeModel, errMalformedJudgeResponse)
+	}
+
+	judgment, err := parseJudgeResponse(resp.Message.Content)
+	if err != nil {
+		return Score{}, fmt.Errorf("judge model %q: %w", s.JudgeModel, err)
+	}
+	score.AnswerQuality = judgment.AnswerQuality
+	score.Notes = joinScoreNotes(score.Notes, fmt.Sprintf("llm-judge=%s: %s", s.JudgeModel, judgment.Justification))
+	return score, nil
+}
+
+const judgeSystemPrompt = `You are an impartial evaluator for local LLM benchmark replays.
+Score only the candidate assistant's final answer against the golden rubric.
+Return only valid JSON with this schema:
+{"answer_quality":0.5,"justification":"short reason"}
+
+answer_quality must be a number from 0 to 1:
+0.0 means the answer is wrong or absent.
+0.5 means the answer is partially correct but misses important requirements.
+1.0 means the answer fully satisfies the rubric.
+Penalize unsupported claims, missing requested details, and contradictions.
+Do not reward style, verbosity, or model identity.`
+
+type judgePromptPayload struct {
+	TraceID                       string      `json:"trace_id"`
+	CandidateModel                string      `json:"candidate_model"`
+	System                        string      `json:"system"`
+	SystemTruncated               bool        `json:"system_truncated,omitempty"`
+	PromptTurns                   []judgeTurn `json:"prompt_turns"`
+	GoldenToolCalls               []string    `json:"golden_tool_calls,omitempty"`
+	ActualToolCalls               []string    `json:"actual_tool_calls,omitempty"`
+	FinalAnswerCriteria           string      `json:"final_answer_criteria,omitempty"`
+	FinalAnswerSubstring          string      `json:"final_answer_substring,omitempty"`
+	FinalAnswerSubstringTruncated bool        `json:"final_answer_substring_truncated,omitempty"`
+	ActualFinalAnswer             string      `json:"actual_final_answer"`
+	ActualFinalAnswerTruncated    bool        `json:"actual_final_answer_truncated,omitempty"`
+	ActualReplayTranscript        []judgeTurn `json:"actual_replay_transcript"`
+}
+
+type judgeTurn struct {
+	Role             string   `json:"role"`
+	Content          string   `json:"content,omitempty"`
+	ContentTruncated bool     `json:"content_truncated,omitempty"`
+	ToolCalls        []string `json:"tool_calls,omitempty"`
+	ToolCallID       string   `json:"tool_call_id,omitempty"`
+	Name             string   `json:"name,omitempty"`
+}
+
+func buildJudgePrompt(trace Trace, actual Result) (string, error) {
+	finalAnswer, finalAnswerTruncated := truncateForJudge(lastAssistantContent(actual.Transcript), maxJudgeAnswerBytes)
+	system, systemTruncated := truncateForJudge(trace.System, maxJudgeTurnContentBytes)
+	finalAnswerSubstring, finalAnswerSubstringTruncated := truncateForJudge(strings.TrimSpace(trace.Golden.FinalAnswerSubstring), maxJudgeAnswerBytes)
+	payload := judgePromptPayload{
+		TraceID:                       trace.ID,
+		CandidateModel:                actual.Model,
+		System:                        system,
+		SystemTruncated:               systemTruncated,
+		PromptTurns:                   compactTurnsForJudge(trace.Turns),
+		GoldenToolCalls:               trace.Golden.ToolCalls,
+		ActualToolCalls:               extractToolNames(actual.Transcript),
+		FinalAnswerCriteria:           strings.TrimSpace(trace.Golden.FinalAnswerCriteria),
+		FinalAnswerSubstring:          finalAnswerSubstring,
+		FinalAnswerSubstringTruncated: finalAnswerSubstringTruncated,
+		ActualFinalAnswer:             finalAnswer,
+		ActualFinalAnswerTruncated:    finalAnswerTruncated,
+		ActualReplayTranscript:        compactTurnsForJudge(actual.Transcript),
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	var b strings.Builder
+	b.WriteString("Evaluate this benchmark replay. Use final_answer_criteria when present; ")
+	b.WriteString("otherwise use final_answer_substring as the expected answer excerpt. ")
+	b.WriteString("Score the final answer only; tool-call quality is scored separately and is included only as context.\n\n")
+	b.Write(data)
+	return b.String(), nil
+}
+
+func compactTurnsForJudge(turns []Turn) []judgeTurn {
+	if len(turns) == 0 {
+		return nil
+	}
+	out := make([]judgeTurn, 0, len(turns))
+	for _, turn := range turns {
+		content, truncated := truncateForJudge(turn.Content, maxJudgeTurnContentBytes)
+		out = append(out, judgeTurn{
+			Role:             turn.Role,
+			Content:          content,
+			ContentTruncated: truncated,
+			ToolCalls:        extractToolNames([]Turn{turn}),
+			ToolCallID:       turn.ToolCallID,
+			Name:             turn.Name,
+		})
+	}
+	return out
+}
+
+func truncateForJudge(s string, limit int) (string, bool) {
+	if limit <= 0 || len(s) <= limit {
+		return s, false
+	}
+	cut := limit
+	for cut > 0 && cut < len(s) && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	if cut <= 0 {
+		cut = limit
+	}
+	return s[:cut] + "\n[truncated for judge prompt]", true
+}
+
+type judgeResponse struct {
+	AnswerQuality float64
+	Justification string
+}
+
+func parseJudgeResponse(content string) (judgeResponse, error) {
+	raw := strings.TrimSpace(content)
+	if raw == "" {
+		return judgeResponse{}, fmt.Errorf("%w: empty response", errMalformedJudgeResponse)
+	}
+	raw = firstJSONObject(raw)
+	if raw == "" {
+		return judgeResponse{}, fmt.Errorf("%w: missing JSON object", errMalformedJudgeResponse)
+	}
+
+	var parsed struct {
+		AnswerQuality *float64 `json:"answer_quality"`
+		Score         *float64 `json:"score"`
+		Justification string   `json:"justification"`
+		Notes         string   `json:"notes"`
+	}
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return judgeResponse{}, fmt.Errorf("%w: %v", errMalformedJudgeResponse, err)
+	}
+	quality := parsed.AnswerQuality
+	if quality == nil {
+		quality = parsed.Score
+	}
+	if quality == nil {
+		return judgeResponse{}, fmt.Errorf("%w: missing answer_quality", errMalformedJudgeResponse)
+	}
+	if *quality < 0 || *quality > 1 {
+		return judgeResponse{}, fmt.Errorf("%w: answer_quality %.3f outside [0,1]", errMalformedJudgeResponse, *quality)
+	}
+
+	justification := strings.TrimSpace(parsed.Justification)
+	if justification == "" {
+		justification = strings.TrimSpace(parsed.Notes)
+	}
+	if justification == "" {
+		justification = "no justification returned"
+	}
+
+	return judgeResponse{
+		AnswerQuality: *quality,
+		Justification: normalizeNote(justification),
+	}, nil
+}
+
+func firstJSONObject(s string) string {
+	start := strings.IndexByte(s, '{')
+	if start < 0 {
+		return ""
+	}
+
+	depth := 0
+	inString := false
+	escaped := false
+	for i := start; i < len(s); i++ {
+		ch := s[i]
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			switch ch {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+
+		switch ch {
+		case '"':
+			inString = true
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return s[start : i+1]
+			}
+		}
+	}
+	return ""
+}
+
+func sameModelSelector(a, b string) bool {
+	a = normalizeModelSelector(a)
+	b = normalizeModelSelector(b)
+	if a == "" || b == "" {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	return modelSelectorWithoutBenchProvider(a) == modelSelectorWithoutBenchProvider(b)
+}
+
+func normalizeModelSelector(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+func modelSelectorWithoutBenchProvider(s string) string {
+	prefix := defaultBenchProvider + "/"
+	if strings.HasPrefix(s, prefix) {
+		return strings.TrimSpace(strings.TrimPrefix(s, prefix))
+	}
+	return s
+}
+
+func joinScoreNotes(parts ...string) string {
+	var cleaned []string
+	for _, part := range parts {
+		part = normalizeNote(part)
+		if part != "" {
+			cleaned = append(cleaned, part)
+		}
+	}
+	return strings.Join(cleaned, "; ")
+}
+
+func normalizeNote(s string) string {
+	return strings.Join(strings.Fields(s), " ")
 }
 
 // toolSequenceScore computes a simple Jaccard overlap between the expected

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -54,7 +54,10 @@ func newScorer(ctx context.Context, name string, opts scorerOptions) (Scorer, er
 	case "exact-match":
 		return &ExactMatchScorer{}, nil
 	case "llm-judge":
-		client, err := newOllamaClient(opts.ollamaURL)
+		if opts.judgeTimeout < 0 {
+			return nil, fmt.Errorf("negative judge timeout %s", opts.judgeTimeout)
+		}
+		client, err := newOllamaClient(opts.ollamaURL, ollama.WithTimeout(opts.judgeTimeout))
 		if err != nil {
 			return nil, fmt.Errorf("llm-judge client: %w", err)
 		}

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -2,9 +2,41 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
+
+	"github.com/kstruzzieri/go-llm/ollama"
 )
+
+type fakeJudgeClient struct {
+	req    ollama.ChatRequest
+	resp   *ollama.ChatResponse
+	err    error
+	called int
+}
+
+func (f *fakeJudgeClient) Chat(_ context.Context, req ollama.ChatRequest) (*ollama.ChatResponse, error) {
+	f.called++
+	f.req = req
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.resp, nil
+}
+
+type fakeJudgeModelChecker struct {
+	models []string
+	err    error
+}
+
+func (f fakeJudgeModelChecker) AvailableModels(context.Context) ([]string, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.models, nil
+}
 
 func TestExactMatchScorerRequiresGoldenSubstring(t *testing.T) {
 	s := &ExactMatchScorer{}
@@ -64,5 +96,285 @@ func TestToolSequenceScoreDeduplicatesActualToolNames(t *testing.T) {
 	score := toolSequenceScore([]string{"read_file"}, []string{"read_file", "read_file"})
 	if score != 1.0 {
 		t.Fatalf("toolSequenceScore() = %f, want 1.0", score)
+	}
+}
+
+func TestLLMJudgeScorerScoresFromJSON(t *testing.T) {
+	client := &fakeJudgeClient{
+		resp: &ollama.ChatResponse{
+			Message: ollama.ChatMessage{
+				Role:    "assistant",
+				Content: `{"answer_quality":0.75,"justification":"Identifies the main issue but misses the fallback detail."}`,
+			},
+		},
+	}
+	s, err := newLLMJudgeScorer(client, "gemma4:31b", 0)
+	if err != nil {
+		t.Fatalf("newLLMJudgeScorer() error: %v", err)
+	}
+
+	trace := Trace{
+		ID:     "judge-hit",
+		System: "review code",
+		Turns:  []Turn{{Role: "user", Content: "Find the bug"}},
+		Golden: Golden{
+			ToolCalls:           []string{"read_file"},
+			FinalAnswerCriteria: "Identifies the circular fallback bug",
+		},
+	}
+	actual := Result{
+		Model: "qwen3-coder-next:latest",
+		Transcript: []Turn{{
+			Role:    "assistant",
+			Content: "There is a circular fallback between router candidates.",
+			ToolCalls: []ToolCall{{
+				Name: "read_file",
+			}},
+		}},
+	}
+
+	score, err := s.Score(context.Background(), trace, actual)
+	if err != nil {
+		t.Fatalf("Score() error: %v", err)
+	}
+	if score.AnswerQuality != 0.75 {
+		t.Fatalf("AnswerQuality = %f, want 0.75", score.AnswerQuality)
+	}
+	if score.ToolSequenceMatch != 1.0 {
+		t.Fatalf("ToolSequenceMatch = %f, want 1.0", score.ToolSequenceMatch)
+	}
+	if !strings.Contains(score.Notes, "llm-judge=gemma4:31b") {
+		t.Fatalf("Notes = %q, want judge model note", score.Notes)
+	}
+	if client.called != 1 {
+		t.Fatalf("judge client called %d times, want 1", client.called)
+	}
+	if client.req.Model != "gemma4:31b" {
+		t.Fatalf("judge model = %q, want gemma4:31b", client.req.Model)
+	}
+	if client.req.Format != "json" {
+		t.Fatalf("judge format = %q, want json", client.req.Format)
+	}
+	if client.req.Options == nil {
+		t.Fatal("judge options = nil, want deterministic-ish judge options")
+	}
+	if client.req.Options.Temperature != judgeTemperature {
+		t.Fatalf("judge temperature = %f, want %f", client.req.Options.Temperature, judgeTemperature)
+	}
+	if client.req.Options.NumPredict != judgeTokenBudget {
+		t.Fatalf("judge num_predict = %d, want %d", client.req.Options.NumPredict, judgeTokenBudget)
+	}
+	if client.req.KeepAlive != benchKeepAlive {
+		t.Fatalf("judge keep_alive = %q, want %q", client.req.KeepAlive, benchKeepAlive)
+	}
+}
+
+func TestLLMJudgeScorerRejectsSelfJudging(t *testing.T) {
+	client := &fakeJudgeClient{
+		resp: &ollama.ChatResponse{Message: ollama.ChatMessage{Content: `{"answer_quality":1,"justification":"ok"}`}},
+	}
+	s, err := newLLMJudgeScorer(client, "gemma4:31b", 0)
+	if err != nil {
+		t.Fatalf("newLLMJudgeScorer() error: %v", err)
+	}
+
+	trace := Trace{
+		ID:     "self-judge",
+		System: "sys",
+		Turns:  []Turn{{Role: "user", Content: "q"}},
+		Golden: Golden{FinalAnswerCriteria: "answer correctly"},
+	}
+	actual := Result{
+		Model:      "ollama/gemma4:31b",
+		Transcript: []Turn{{Role: "assistant", Content: "answer"}},
+	}
+
+	_, err = s.Score(context.Background(), trace, actual)
+	if !errors.Is(err, errJudgeSelfPreference) {
+		t.Fatalf("err = %v, want errJudgeSelfPreference", err)
+	}
+	if client.called != 0 {
+		t.Fatalf("judge client called despite self-judging guard")
+	}
+}
+
+func TestLLMJudgeScorerRejectsNamespacedSelfJudging(t *testing.T) {
+	client := &fakeJudgeClient{
+		resp: &ollama.ChatResponse{Message: ollama.ChatMessage{Content: `{"answer_quality":1,"justification":"ok"}`}},
+	}
+	s, err := newLLMJudgeScorer(client, "hf.co/org/model:tag", 0)
+	if err != nil {
+		t.Fatalf("newLLMJudgeScorer() error: %v", err)
+	}
+
+	trace := Trace{
+		ID:     "namespaced-self-judge",
+		System: "sys",
+		Turns:  []Turn{{Role: "user", Content: "q"}},
+		Golden: Golden{FinalAnswerCriteria: "answer correctly"},
+	}
+	actual := Result{
+		Model:      "ollama/hf.co/org/model:tag",
+		Transcript: []Turn{{Role: "assistant", Content: "answer"}},
+	}
+
+	_, err = s.Score(context.Background(), trace, actual)
+	if !errors.Is(err, errJudgeSelfPreference) {
+		t.Fatalf("err = %v, want errJudgeSelfPreference", err)
+	}
+	if client.called != 0 {
+		t.Fatalf("judge client called despite namespaced self-judging guard")
+	}
+}
+
+func TestLLMJudgeScorerRequiresRubric(t *testing.T) {
+	s, err := newLLMJudgeScorer(&fakeJudgeClient{}, "gemma4:31b", 0)
+	if err != nil {
+		t.Fatalf("newLLMJudgeScorer() error: %v", err)
+	}
+
+	trace := Trace{
+		ID:     "missing-rubric",
+		System: "sys",
+		Turns:  []Turn{{Role: "user", Content: "q"}},
+	}
+	actual := Result{
+		Model:      "qwen3:8b",
+		Transcript: []Turn{{Role: "assistant", Content: "answer"}},
+	}
+
+	_, err = s.Score(context.Background(), trace, actual)
+	if !errors.Is(err, errMissingJudgeCriteria) {
+		t.Fatalf("err = %v, want errMissingJudgeCriteria", err)
+	}
+}
+
+func TestLLMJudgeScorerErrorsOnEmptyFinalAnswer(t *testing.T) {
+	client := &fakeJudgeClient{}
+	s, err := newLLMJudgeScorer(client, "gemma4:31b", 0)
+	if err != nil {
+		t.Fatalf("newLLMJudgeScorer() error: %v", err)
+	}
+
+	trace := Trace{
+		ID:     "empty-answer",
+		System: "sys",
+		Turns:  []Turn{{Role: "user", Content: "q"}},
+		Golden: Golden{FinalAnswerCriteria: "answer correctly"},
+	}
+	actual := Result{
+		Model:      "qwen3:8b",
+		Transcript: []Turn{{Role: "assistant", ToolCalls: []ToolCall{{Name: "read_file"}}}},
+	}
+
+	_, err = s.Score(context.Background(), trace, actual)
+	if !errors.Is(err, errNoAssistantFinalAnswer) {
+		t.Fatalf("err = %v, want errNoAssistantFinalAnswer", err)
+	}
+	if client.called != 0 {
+		t.Fatalf("judge client called for empty answer")
+	}
+}
+
+func TestValidateJudgeModelRequiresAvailableModel(t *testing.T) {
+	err := validateJudgeModel(context.Background(), fakeJudgeModelChecker{
+		models: []string{"qwen3:8b"},
+	}, "gemma4:31b")
+	if err == nil {
+		t.Fatal("validateJudgeModel() error = nil, want unavailable model error")
+	}
+	if !strings.Contains(err.Error(), "not available") {
+		t.Fatalf("error = %q, want not available", err.Error())
+	}
+}
+
+func TestValidateJudgeModelAcceptsProviderQualifiedSelector(t *testing.T) {
+	err := validateJudgeModel(context.Background(), fakeJudgeModelChecker{
+		models: []string{"gemma4:31b"},
+	}, "ollama/gemma4:31b")
+	if err != nil {
+		t.Fatalf("validateJudgeModel() error: %v", err)
+	}
+}
+
+func TestValidateJudgeModelPreservesNamespacedModelIDs(t *testing.T) {
+	err := validateJudgeModel(context.Background(), fakeJudgeModelChecker{
+		models: []string{"hf.co/org/model:tag"},
+	}, "ollama/hf.co/org/model:tag")
+	if err != nil {
+		t.Fatalf("validateJudgeModel() error: %v", err)
+	}
+
+	err = validateJudgeModel(context.Background(), fakeJudgeModelChecker{
+		models: []string{"hf.co/other/model:tag"},
+	}, "ollama/hf.co/org/model:tag")
+	if err == nil {
+		t.Fatal("validateJudgeModel() error = nil, want distinct namespaced model rejection")
+	}
+}
+
+func TestBuildJudgePromptStripsRawAndTruncatesLargeTurns(t *testing.T) {
+	large := strings.Repeat("x", maxJudgeTurnContentBytes+100)
+	trace := Trace{
+		ID:     "large-trace",
+		System: "sys",
+		Turns: []Turn{{
+			Role:    "tool",
+			Content: large,
+			Raw:     json.RawMessage(`{"large":"raw payload should not be included"}`),
+		}},
+		Golden: Golden{FinalAnswerCriteria: "answer correctly"},
+	}
+	actual := Result{
+		Model:      "qwen3:8b",
+		Transcript: []Turn{{Role: "assistant", Content: "final"}},
+	}
+
+	prompt, err := buildJudgePrompt(trace, actual)
+	if err != nil {
+		t.Fatalf("buildJudgePrompt() error: %v", err)
+	}
+	if strings.Contains(prompt, "raw payload should not be included") {
+		t.Fatalf("judge prompt includes raw payload: %s", prompt)
+	}
+	if !strings.Contains(prompt, `"content_truncated": true`) {
+		t.Fatalf("judge prompt does not mark truncated content: %s", prompt)
+	}
+}
+
+func TestParseJudgeResponseExtractsJSON(t *testing.T) {
+	got, err := parseJudgeResponse("```json\n{\"answer_quality\":0.5,\"justification\":\"partly correct\"}\n```")
+	if err != nil {
+		t.Fatalf("parseJudgeResponse() error: %v", err)
+	}
+	if got.AnswerQuality != 0.5 {
+		t.Fatalf("AnswerQuality = %f, want 0.5", got.AnswerQuality)
+	}
+	if got.Justification != "partly correct" {
+		t.Fatalf("Justification = %q, want partly correct", got.Justification)
+	}
+}
+
+func TestParseJudgeResponseIgnoresTrailingText(t *testing.T) {
+	got, err := parseJudgeResponse("{\"answer_quality\":0.25,\"justification\":\"weak\"}\nextra text")
+	if err != nil {
+		t.Fatalf("parseJudgeResponse() error: %v", err)
+	}
+	if got.AnswerQuality != 0.25 {
+		t.Fatalf("AnswerQuality = %f, want 0.25", got.AnswerQuality)
+	}
+}
+
+func TestParseJudgeResponseRejectsOutOfRangeScore(t *testing.T) {
+	_, err := parseJudgeResponse(`{"answer_quality":1.2,"justification":"too high"}`)
+	if !errors.Is(err, errMalformedJudgeResponse) {
+		t.Fatalf("err = %v, want errMalformedJudgeResponse", err)
+	}
+}
+
+func TestParseJudgeResponseRejectsNegativeScore(t *testing.T) {
+	_, err := parseJudgeResponse(`{"answer_quality":-0.1,"justification":"too low"}`)
+	if !errors.Is(err, errMalformedJudgeResponse) {
+		t.Fatalf("err = %v, want errMalformedJudgeResponse", err)
 	}
 }

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kstruzzieri/go-llm/ollama"
 )
@@ -36,6 +39,41 @@ func (f fakeJudgeModelChecker) AvailableModels(context.Context) ([]string, error
 		return nil, f.err
 	}
 	return f.models, nil
+}
+
+func TestNewScorerAppliesJudgeTimeoutToHTTPClient(t *testing.T) {
+	const judgeTimeout = 25 * time.Millisecond
+	const serverDelay = 250 * time.Millisecond
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/tags" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		select {
+		case <-r.Context().Done():
+			return
+		case <-time.After(serverDelay):
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"models": []map[string]any{{"name": "gemma4:31b"}},
+		})
+	}))
+	defer srv.Close()
+
+	start := time.Now()
+	_, err := newScorer(context.Background(), "llm-judge", scorerOptions{
+		ollamaURL:    srv.URL,
+		judgeModel:   "gemma4:31b",
+		judgeTimeout: judgeTimeout,
+	})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("newScorer() error = nil, want timeout from judge HTTP client")
+	}
+	if elapsed >= serverDelay/2 {
+		t.Fatalf("newScorer() returned after %s, want HTTP client timeout near %s", elapsed, judgeTimeout)
+	}
 }
 
 func TestExactMatchScorerRequiresGoldenSubstring(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -864,7 +864,7 @@ func TestLoad_RootModelsJSON(t *testing.T) {
 	if cfg.ModelFor("chat") == "" {
 		t.Error("expected chat model from root models.json")
 	}
-	if len(cfg.Models) != 6 {
-		t.Errorf("expected 6 models, got %d", len(cfg.Models))
+	if len(cfg.Models) != 7 {
+		t.Errorf("expected 7 models, got %d", len(cfg.Models))
 	}
 }

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -19,7 +19,7 @@ go get github.com/kstruzzieri/go-llm
 These pulls match the current reference lineup checked into `models.json`:
 
 ```bash
-# General / agent / analysis (reasoning, multimodal chat, tool use)
+# General / agent / judge / analysis (reasoning, multimodal chat, tool use)
 ollama pull gemma4:31b
 
 # Fast fallback / lower-latency chat
@@ -76,14 +76,17 @@ Consumer applications (Firn IDE, Flux ML) can also use `config.Default()` to dis
 |------|-------|-------------|
 | `general` | `gemma4:31b` (~20GB) | Complex reasoning, multimodal chat, long conversations |
 | `agent` | `gemma4:31b` (~20GB) | Tool use, agent loops, function calling |
+| `judge` | `gemma4:31b` (~20GB) | Local LLM-as-judge scoring for captured trace replays |
 | `fast` | `qwen3.6:35b-a3b` (~28GB) | Lower-latency chat and strong fallback path |
 | `coding` | `qwen3-coder-next:latest` (~46GB) | Code generation, review, FIM completions |
 | `lightweight` | `qwen3:8b` (~6GB) | Quick answers, classification, low-stakes tasks |
 | `embedding` | `qwen3-embedding:8b` (~5GB) | Vector embeddings for RAG search |
 
-The `analysis` use-case currently maps to the `general` role in
-`models.json`, so it also resolves to `gemma4:31b` unless you customize
-the defaults.
+The `analysis` use-case currently maps to the `general` role, so it also
+resolves to `gemma4:31b` unless you customize the defaults. The `judge`
+role is present for `cmd/llm-bench -scorer llm-judge`, but it is not in
+`defaults` because consumer apps should not expose it as a normal runtime
+use-case.
 
 ### Swapping Models
 

--- a/docs/llm/README.md
+++ b/docs/llm/README.md
@@ -39,7 +39,7 @@ not "what `go-llm` requires."
 
 - **`qwen3-coder-next`** — primary code generation (80B / 3.9B active MoE)
 - **`qwen3-embedding:8b`** — embeddings (#1 MTEB multilingual)
-- **`gemma4:31b`** (dense) — agent / tool-use / reasoning (86.4% τ2-bench,
+- **`gemma4:31b`** (dense) — agent / judge / reasoning (86.4% τ2-bench,
   80.0% LiveCodeBench, native function calling)
 - **`qwen3.6:35b-a3b`** — fast MoE (73.4% SWE-bench, 3B active)
 - **`qwen3:8b`** — lightweight / FIM
@@ -70,6 +70,27 @@ the command exits `0`, writes `/tmp/llm-bench-smoke.md`, and the report
 shows `Errors = 0` with `Mean Quality = 1.00` for each model on the
 `smoke-minimal-001` trace. This only verifies harness plumbing and basic
 model reachability, not real MCP-agent quality.
+
+To score free-form answers with the local judge model instead of the
+substring baseline, switch the scorer and keep the judge model separate
+from the candidate under test:
+
+```bash
+go run ./cmd/llm-bench \
+  -traces 'cmd/llm-bench/testdata/smoke/*.json' \
+  -models 'ollama/qwen3.6:35b-a3b' \
+  -scorer llm-judge \
+  -judge-model gemma4:31b \
+  -judge-timeout 5m \
+  -report /tmp/llm-bench-judge-smoke.md
+```
+
+`llm-judge` records an error instead of scoring a trace when the candidate
+model and judge model are the same, which avoids self-preference in
+calibration runs. Judge latency is excluded from the model latency metric
+in the report and shown separately as scorer latency. Use
+`-judge-ollama-url` when the judge should run on a different Ollama
+instance than the candidate models.
 
 ## Local trace capture
 

--- a/docs/llm/benchmark-plan.md
+++ b/docs/llm/benchmark-plan.md
@@ -82,8 +82,8 @@ the existing `feedback/` and `conversation/` SQLite stores.
 2. **Tool argument validity** — JSON schema validation against the
    declared tool schemas. Binary pass/fail per call, averaged.
 3. **Final answer quality** — *User-selected scoring strategy*:
-   - `llm-judge` — Claude API scores response against
-     `final_answer_criteria` on a 0–1 rubric.
+   - `llm-judge` — a separate local Ollama judge model scores the
+     response against `final_answer_criteria` on a 0–1 rubric.
    - `exact-match` — substring match (cheap, brittle).
    - `manual` — dump to CSV for human rating.
 4. **Latency** — end-to-end wall time + per-token throughput.
@@ -110,6 +110,7 @@ type Score struct {
     ToolArgsValid       float64 // [0,1]
     AnswerQuality       float64 // [0,1]
     LatencyMs           int64
+    ScorerLatencyMs     int64
     TotalTokens         int
     Notes               string
 }
@@ -165,10 +166,22 @@ First implementation slice:
   to conversations; today `feedback_retrievals` and `feedback_signals`
   do not carry a conversation id.
 
-### Phase 3 — LLM-as-judge scorer (follow-up PR)
+### Phase 3 — LLM-as-judge scorer
 
-- Optional integration with Claude API for `AnswerQuality`
-- Careful prompt engineering + cache the judgments
+- Local Ollama-backed `llm-judge` scorer for `AnswerQuality`
+- Dedicated `-judge-model` selection. When omitted, `cmd/llm-bench`
+  reads the reference `models.json` `judge` role when available, then
+  falls back to `gemma4:31b`.
+- Optional `-judge-ollama-url` and `-judge-timeout` keep judge placement
+  and timeout budget separate from candidate replay.
+- Anti-self-preference guard: a candidate model is skipped rather than
+  judged by itself
+- Judge latency is excluded from `Score.LatencyMs`; that metric remains
+  replay-only. Scorer latency is reported separately.
+- Judge prompts compact trace turns before scoring so stored raw payloads
+  and oversized tool results do not silently dominate the context window.
+- Follow-up: persistent cache keyed by `(judge_model, trace_id,
+  transcript_hash)` so re-running over the same corpus is cheap
 
 ### Phase 4 — Live comparison runs
 
@@ -192,13 +205,12 @@ distinct tradeoffs:
 | Strategy | Cost per trace | Quality of judgment | Reproducibility |
 |---|---|---|---|
 | `exact-match` | ~0 | Low (brittle) | High |
-| `llm-judge` (Claude) | $0.01–0.05 | High | Moderate (varies with Claude updates) |
+| `llm-judge` (local Ollama) | Local inference time | High | Moderate (varies with judge model updates) |
 | `manual` | ~5 min of human time | Highest | Low (rater variance) |
 
-**TODO for Keith**: decide which Scorer ships in Phase 1. The skeleton
-assumes `exact-match` because it has no external dependencies, but for
-the actual comparison runs (Phase 4) we likely want `llm-judge` as the
-primary with `manual` spot-checks.
+The skeleton shipped with `exact-match` because it has no external
+dependencies. For actual comparison runs (Phase 4), use `llm-judge` as
+the primary scorer with `manual` spot-checks.
 
 This is a real decision point, not busywork — the scorer choice
 determines whether the harness is trustworthy enough to override the

--- a/models.json
+++ b/models.json
@@ -24,6 +24,15 @@
       "context_window": 256000,
       "fallbacks": ["fast", "lightweight"]
     },
+    "judge": {
+      "name": "gemma4:31b",
+      "provider": "ollama",
+      "description": "Local LLM-as-judge for trace replay scoring; must not score itself in llm-bench",
+      "type": "dense",
+      "parameters": "31B",
+      "context_window": 256000,
+      "fallbacks": ["fast", "lightweight"]
+    },
     "fast": {
       "name": "qwen3.6:35b-a3b",
       "provider": "ollama",

--- a/ollama/types.go
+++ b/ollama/types.go
@@ -9,7 +9,7 @@ import (
 
 // Tool defines a tool the model may call during chat.
 type Tool struct {
-	Type     string       `json:"type"`     // always "function"
+	Type     string       `json:"type"` // always "function"
 	Function ToolFunction `json:"function"`
 }
 
@@ -38,11 +38,11 @@ type ToolCallFunction struct {
 
 // ChatMessage represents a single message in a chat conversation.
 type ChatMessage struct {
-	Role       string     `json:"role"`                    // system, user, assistant, tool
+	Role       string     `json:"role"` // system, user, assistant, tool
 	Content    string     `json:"content"`
-	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`    // present when assistant invokes tools
-	ToolName   string     `json:"tool_name,omitempty"`     // set when role="tool" (result)
-	ToolCallID string     `json:"tool_call_id,omitempty"`  // correlates result with originating call
+	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`   // present when assistant invokes tools
+	ToolName   string     `json:"tool_name,omitempty"`    // set when role="tool" (result)
+	ToolCallID string     `json:"tool_call_id,omitempty"` // correlates result with originating call
 }
 
 // ChatRequest is the request body for the /api/chat endpoint.
@@ -50,6 +50,7 @@ type ChatRequest struct {
 	Model     string        `json:"model"`
 	Messages  []ChatMessage `json:"messages"`
 	Stream    bool          `json:"stream"`
+	Format    string        `json:"format,omitempty"` // e.g. "json" for structured output
 	Options   *ModelOptions `json:"options,omitempty"`
 	Tools     []Tool        `json:"tools,omitempty"`      // available tools
 	KeepAlive string        `json:"keep_alive,omitempty"` // e.g. "5m", "30m", "-1" (keep forever); empty = Ollama default
@@ -73,8 +74,8 @@ type ChatResponse struct {
 type ModelOptions struct {
 	Temperature   float64  `json:"temperature,omitempty"`
 	TopP          float64  `json:"top_p,omitempty"`
-	NumPredict    int      `json:"num_predict,omitempty"`    // max tokens to generate
-	NumCtx        int      `json:"num_ctx,omitempty"`        // context window size
+	NumPredict    int      `json:"num_predict,omitempty"` // max tokens to generate
+	NumCtx        int      `json:"num_ctx,omitempty"`     // context window size
 	Stop          []string `json:"stop,omitempty"`
 	RepeatPenalty float64  `json:"repeat_penalty,omitempty"`
 }
@@ -118,9 +119,9 @@ type ModelInfo struct {
 	ParamSize    string   `json:"parameter_size"`
 	QuantLevel   string   `json:"quantization_level"`
 	Digest       string   `json:"digest"`       // model version hash from /api/show
-	Family       string   `json:"family"`        // model family (e.g. "qwen2", "llama")
-	Template     string   `json:"template"`      // prompt template; non-empty for chat models
-	Capabilities []string `json:"capabilities"`  // e.g. ["completion","tools"]; nil if not reported
+	Family       string   `json:"family"`       // model family (e.g. "qwen2", "llama")
+	Template     string   `json:"template"`     // prompt template; non-empty for chat models
+	Capabilities []string `json:"capabilities"` // e.g. ["completion","tools"]; nil if not reported
 }
 
 // modelDetails is used when parsing /api/show responses.


### PR DESCRIPTION
## Summary

- Implements the `llm-judge` scorer for `cmd/llm-bench` using a separate local Ollama judge model.
- Adds `-judge-model` CLI wiring, JSON rubric parsing, self-judging protection, and tests for scorer behavior.
- Adds a `judge` role to `models.json` and updates the benchmark docs around local judge-backed validation.

## Why

#48 Phase 5 needs trace and judge-backed validation data before provider-intelligence feedback routing work. #56 had capture landed, but `llm-judge` was still a hard error, so the harness could not score free-form answers qualitatively.

## Validation

- `go test ./cmd/llm-bench`
- `go test ./...`
- Pre-push hook: lint, race tests, compile smoke

## Follow-up

Persistent judge-response caching remains a follow-up for #56, keyed by judge model, trace id, and transcript hash.