### PR TITLE
feat(provider): RoutingFeedback seam (Epic #48 Phase 5 PR1)

### DIFF
--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -12,6 +12,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 )
 
 // ---------------------------------------------------------------------------
@@ -477,13 +478,18 @@ func hasVisibleContent(content, thinking string, toolCalls []ToolCall) bool {
 	return content != "" || thinking != "" || len(toolCalls) > 0
 }
 
+// routeIDRand is the entropy source for newRouteID. It is a package-level
+// variable so tests can substitute a failing reader and exercise the
+// empty-string-on-error branch.
+var routeIDRand io.Reader = rand.Reader
+
 // newRouteID returns a 16-byte random hex string (32 chars) suitable as an
 // opaque correlation ID on RouteOutcome.RouteID. crypto/rand failures are
 // silently coerced to an empty string — RouteID is informational; we do
 // not want routing paths to fail because the OS RNG returned an error.
 func newRouteID() string {
 	var b [16]byte
-	if _, err := rand.Read(b[:]); err != nil {
+	if _, err := routeIDRand.Read(b[:]); err != nil {
 		return ""
 	}
 	return hex.EncodeToString(b[:])

--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -8,6 +8,8 @@ package provider
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 )
@@ -43,7 +45,7 @@ type RoutePlan struct {
 	Fallbacks []RoutePlan
 	Reason    string
 	Degraded  bool
-	wasSticky bool         // internal: propagated to RouteOutcome
+	wasSticky bool          // internal: propagated to RouteOutcome
 	recorder  RouteRecorder // internal: set by Router
 }
 
@@ -402,6 +404,8 @@ func (rp *RoutePlan) buildOutcome(fallbacksUsed int) *RouteOutcome {
 		WasSticky:     rp.wasSticky,
 		Score:         rp.Score,
 		Reason:        rp.Reason,
+		RouteID:       newRouteID(),
+		// Attempts: nil — PR2 will populate from handleResult.
 	}
 }
 
@@ -471,4 +475,16 @@ func (rp *RoutePlan) recordWarmthUse(key ModelKey) {
 // emitted, provider fallback is no longer safe.
 func hasVisibleContent(content, thinking string, toolCalls []ToolCall) bool {
 	return content != "" || thinking != "" || len(toolCalls) > 0
+}
+
+// newRouteID returns a 16-byte random hex string (32 chars) suitable as an
+// opaque correlation ID on RouteOutcome.RouteID. crypto/rand failures are
+// silently coerced to an empty string — RouteID is informational; we do
+// not want routing paths to fail because the OS RNG returned an error.
+func newRouteID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(b[:])
 }

--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -489,7 +489,7 @@ var routeIDRand io.Reader = rand.Reader
 // not want routing paths to fail because the OS RNG returned an error.
 func newRouteID() string {
 	var b [16]byte
-	if _, err := routeIDRand.Read(b[:]); err != nil {
+	if _, err := io.ReadFull(routeIDRand, b[:]); err != nil {
 		return ""
 	}
 	return hex.EncodeToString(b[:])

--- a/provider/routing_feedback.go
+++ b/provider/routing_feedback.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"reflect"
 	"time"
 )
 
@@ -105,9 +106,10 @@ type RoutingFeedback struct {
 	store RoutingFeedbackStore
 }
 
-// NewRoutingFeedback wraps a store; the name avoids the too-vague
-// provider.New(...) that conflicts with other constructible types in this
-// package.
+// NewRoutingFeedback wraps a store; methods return ErrNilRoutingFeedbackStore
+// if store is nil so wiring mistakes fail without panicking request paths.
+// The name avoids the too-vague provider.New(...) that conflicts with other
+// constructible types in this package.
 func NewRoutingFeedback(store RoutingFeedbackStore) *RoutingFeedback {
 	return &RoutingFeedback{store: store}
 }
@@ -118,14 +120,22 @@ func NewRoutingFeedback(store RoutingFeedbackStore) *RoutingFeedback {
 // expected to wrap this call with fail-open behavior so a store failure
 // never blocks routing decisions.
 func (rf *RoutingFeedback) Score(ctx context.Context, key FeedbackKey) (Aggregate, error) {
-	return rf.store.Get(ctx, key)
+	store, err := rf.requireStore()
+	if err != nil {
+		return Aggregate{}, err
+	}
+	return store.Get(ctx, key)
 }
 
 // Record persists a single signal via the underlying store. Validation
 // happens inside the store implementation, so error sentinels match
 // (ErrInvalidFeedbackKey, ErrUnknownSignalKind, ...).
 func (rf *RoutingFeedback) Record(ctx context.Context, key FeedbackKey, sig FeedbackSignal) error {
-	return rf.store.Record(ctx, key, sig)
+	store, err := rf.requireStore()
+	if err != nil {
+		return err
+	}
+	return store.Record(ctx, key, sig)
 }
 
 // RecordOutcome decomposes out.Attempts into typed per-attempt signals and
@@ -153,6 +163,10 @@ func (rf *RoutingFeedback) Record(ctx context.Context, key FeedbackKey, sig Feed
 // If out.Attempts is empty or nil, RecordOutcome is a no-op and returns
 // nil — the seam's pre-PR2 zero-value-safe property.
 func (rf *RoutingFeedback) RecordOutcome(ctx context.Context, useCase string, out RouteOutcome) error {
+	store, err := rf.requireStore()
+	if err != nil {
+		return err
+	}
 	if len(out.Attempts) == 0 {
 		return nil
 	}
@@ -215,13 +229,37 @@ func (rf *RoutingFeedback) RecordOutcome(ctx context.Context, useCase string, ou
 		// All attempts were AttemptStatusUnknown.
 		return nil
 	}
-	return rf.store.RecordBatch(ctx, items)
+	return store.RecordBatch(ctx, items)
+}
+
+func (rf *RoutingFeedback) requireStore() (RoutingFeedbackStore, error) {
+	if rf == nil || isNilRoutingFeedbackStore(rf.store) {
+		return nil, ErrNilRoutingFeedbackStore
+	}
+	return rf.store, nil
+}
+
+func isNilRoutingFeedbackStore(store RoutingFeedbackStore) bool {
+	if store == nil {
+		return true
+	}
+	v := reflect.ValueOf(store)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
 }
 
 // ErrInvalidFeedbackKey is returned when a FeedbackKey has an empty
 // Provider, Model, or UseCase field, or when RoutingFeedback.RecordOutcome
 // is called with an empty useCase argument.
 var ErrInvalidFeedbackKey = errors.New("provider: invalid feedback key")
+
+// ErrNilRoutingFeedbackStore is returned when RoutingFeedback is constructed
+// without a usable store or a method is called on a nil RoutingFeedback.
+var ErrNilRoutingFeedbackStore = errors.New("provider: nil routing feedback store")
 
 // ErrUnknownSignalKind is returned when a FeedbackSignal carries a Kind
 // that is not one of the declared RoutingSignalKind constants.

--- a/provider/routing_feedback.go
+++ b/provider/routing_feedback.go
@@ -1,0 +1,111 @@
+// Package provider — routing_feedback.go defines the RoutingFeedback seam:
+// a provider/model/use-case keyed signal store distinct from the chunk-key
+// oriented feedback.SignalStore. PR1 (Epic #48 Phase 5) ships types,
+// interface, in-memory wiring, and the RouteAttempt model; subsequent PRs
+// wire outcomes, persist signals, and read scores into routing decisions.
+package provider
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// FeedbackKey identifies a routing-feedback aggregation bucket. Provider is
+// the configured instance name (e.g. "ollama-local-a", "vllm-prod-1") —
+// matching ModelKey.Provider after #117/#118 — not the API kind.
+type FeedbackKey struct {
+	Provider string
+	Model    string
+	UseCase  string
+}
+
+// RoutingSignalKind enumerates the routing-owned signal kinds emitted in PR1.
+// FallbackUsed/CircuitOpened/Canceled were considered and deferred; see the
+// design spec for the rationale.
+type RoutingSignalKind string
+
+const (
+	RoutingSignalSuccess RoutingSignalKind = "success"
+	RoutingSignalFailure RoutingSignalKind = "failure"
+	RoutingSignalLatency RoutingSignalKind = "latency"
+)
+
+// defaultStrength maps each kind to its built-in strength contribution.
+// Latency defaults to 0.0 so latency signals count toward SampleCount but
+// not toward Score in PR1 (PR3 supplies latency-to-score policy).
+var defaultStrength = map[RoutingSignalKind]float64{
+	RoutingSignalSuccess: +0.5,
+	RoutingSignalFailure: -0.7,
+	RoutingSignalLatency: 0.0,
+}
+
+// DefaultStrength returns the default strength for kind, or 0 when kind is
+// not a known RoutingSignalKind.
+func DefaultStrength(kind RoutingSignalKind) float64 {
+	return defaultStrength[kind]
+}
+
+// FeedbackSignal is the typed routing-feedback payload. Strength uses
+// pointer-nil semantics so callers can distinguish "use the kind default"
+// (nil) from "explicit, including zero" (non-nil pointer).
+type FeedbackSignal struct {
+	Kind         RoutingSignalKind
+	Strength     *float64
+	At           time.Time
+	LatencyMs    int64
+	ErrorClass   string
+	RouteID      string
+	CompletionID string
+	Meta         map[string]string
+}
+
+// Aggregate is the read-side view of accumulated routing feedback. Score is
+// in [0, 1] with 0.5 neutral. ScoredCount is the subset of SampleCount with
+// non-zero effective strength.
+type Aggregate struct {
+	Score       float64
+	SampleCount int
+	ScoredCount int
+	UpdatedAt   time.Time
+}
+
+// FeedbackItem pairs a key with a signal for batch ingestion.
+type FeedbackItem struct {
+	Key    FeedbackKey
+	Signal FeedbackSignal
+}
+
+// RoutingFeedbackStore is the persistence boundary for the seam. PR3 swaps
+// the in-memory implementation for a SQLite-backed one without touching the
+// interface.
+type RoutingFeedbackStore interface {
+	Get(ctx context.Context, key FeedbackKey) (Aggregate, error)
+	Record(ctx context.Context, key FeedbackKey, sig FeedbackSignal) error
+	RecordBatch(ctx context.Context, items []FeedbackItem) error
+}
+
+// RoutingFeedback is the ergonomic public wrapper around a
+// RoutingFeedbackStore. RecordOutcome decomposes per-attempt route results
+// into typed signals; producers can't supply a FeedbackKey directly to
+// avoid misattribution.
+type RoutingFeedback struct {
+	store RoutingFeedbackStore
+}
+
+// NewRoutingFeedback wraps a store; the name avoids the too-vague
+// provider.New(...) that conflicts with other constructible types in this
+// package.
+func NewRoutingFeedback(store RoutingFeedbackStore) *RoutingFeedback {
+	return &RoutingFeedback{store: store}
+}
+
+// Sentinel errors returned by the seam.
+var (
+	ErrInvalidFeedbackKey    = errors.New("provider: invalid feedback key")
+	ErrUnknownSignalKind     = errors.New("provider: unknown routing signal kind")
+	ErrInvalidSignalStrength = errors.New("provider: invalid signal strength")
+	ErrInvalidSignalPayload  = errors.New("provider: invalid signal payload")
+	ErrMetaTooLarge          = errors.New("provider: signal meta too large")
+	ErrUnknownAttemptStatus  = errors.New("provider: unknown attempt status")
+)

--- a/provider/routing_feedback.go
+++ b/provider/routing_feedback.go
@@ -141,6 +141,7 @@ func (rf *RoutingFeedback) Record(ctx context.Context, key FeedbackKey, sig Feed
 //   - Any other AttemptStatus value: return ErrUnknownAttemptStatus and
 //     persist no signals from this outcome.
 //   - LatencyMs > 0: additionally emit a Latency signal at the same key.
+//   - LatencyMs < 0: return ErrInvalidSignalPayload (no signals persisted).
 //
 // All emitted signals share a single sampled-once-up-front timestamp and
 // the same RouteID copied from out.RouteID, so decomposition order has no
@@ -165,6 +166,9 @@ func (rf *RoutingFeedback) RecordOutcome(ctx context.Context, useCase string, ou
 			Provider: attempt.Key.Provider,
 			Model:    attempt.Key.Model,
 			UseCase:  useCase,
+		}
+		if attempt.LatencyMs < 0 {
+			return fmt.Errorf("%w: attempt[%d].LatencyMs=%d", ErrInvalidSignalPayload, i, attempt.LatencyMs)
 		}
 		switch attempt.Status {
 		case AttemptStatusUnknown:

--- a/provider/routing_feedback.go
+++ b/provider/routing_feedback.go
@@ -112,6 +112,22 @@ func NewRoutingFeedback(store RoutingFeedbackStore) *RoutingFeedback {
 	return &RoutingFeedback{store: store}
 }
 
+// Score returns the aggregate for key. If the underlying store has no
+// signals for key, returns the store's configured neutral aggregate.
+// Store read errors are returned to the caller; the PR3 scoring path is
+// expected to wrap this call with fail-open behavior so a store failure
+// never blocks routing decisions.
+func (rf *RoutingFeedback) Score(ctx context.Context, key FeedbackKey) (Aggregate, error) {
+	return rf.store.Get(ctx, key)
+}
+
+// Record persists a single signal via the underlying store. Validation
+// happens inside the store implementation, so error sentinels match
+// (ErrInvalidFeedbackKey, ErrUnknownSignalKind, ...).
+func (rf *RoutingFeedback) Record(ctx context.Context, key FeedbackKey, sig FeedbackSignal) error {
+	return rf.store.Record(ctx, key, sig)
+}
+
 // ErrInvalidFeedbackKey is returned when a FeedbackKey has an empty
 // Provider, Model, or UseCase field, or when RoutingFeedback.RecordOutcome
 // is called with an empty useCase argument.

--- a/provider/routing_feedback.go
+++ b/provider/routing_feedback.go
@@ -8,6 +8,8 @@ package provider
 import (
 	"context"
 	"errors"
+	"fmt"
+	"math"
 	"time"
 )
 
@@ -136,3 +138,82 @@ var ErrMetaTooLarge = errors.New("provider: signal meta too large")
 // when a RouteAttempt.Status (introduced in Task 2 / provider/types.go)
 // holds a value outside the declared AttemptStatus constants.
 var ErrUnknownAttemptStatus = errors.New("provider: unknown attempt status")
+
+// validateKey enforces non-empty key triple semantics.
+func validateKey(k FeedbackKey) error {
+	if k.Provider == "" || k.Model == "" || k.UseCase == "" {
+		return fmt.Errorf("%w: %+v", ErrInvalidFeedbackKey, k)
+	}
+	return nil
+}
+
+// validateSignal enforces shape/payload invariants:
+//   - Kind is one of the known constants.
+//   - Strength, if non-nil, is finite (no NaN/Inf).
+//   - LatencyMs is positive iff Kind is Latency.
+//   - ErrorClass is set iff Kind is Failure.
+//   - Meta does not exceed maxKeys keys or maxValBytes bytes per value.
+func validateSignal(sig FeedbackSignal, maxKeys, maxValBytes int) error {
+	switch sig.Kind {
+	case RoutingSignalSuccess, RoutingSignalFailure, RoutingSignalLatency:
+		// ok
+	default:
+		return fmt.Errorf("%w: %q", ErrUnknownSignalKind, sig.Kind)
+	}
+	if sig.Strength != nil {
+		v := *sig.Strength
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return fmt.Errorf("%w: %v", ErrInvalidSignalStrength, v)
+		}
+	}
+	switch sig.Kind {
+	case RoutingSignalLatency:
+		if sig.LatencyMs <= 0 {
+			return fmt.Errorf("%w: latency signal requires LatencyMs > 0", ErrInvalidSignalPayload)
+		}
+	default:
+		if sig.LatencyMs != 0 {
+			return fmt.Errorf("%w: non-latency signal must not carry LatencyMs", ErrInvalidSignalPayload)
+		}
+	}
+	switch sig.Kind {
+	case RoutingSignalFailure:
+		if sig.ErrorClass == "" {
+			return fmt.Errorf("%w: failure signal requires ErrorClass", ErrInvalidSignalPayload)
+		}
+	default:
+		if sig.ErrorClass != "" {
+			return fmt.Errorf("%w: non-failure signal must not carry ErrorClass", ErrInvalidSignalPayload)
+		}
+	}
+	if maxKeys > 0 && len(sig.Meta) > maxKeys {
+		return fmt.Errorf("%w: %d meta keys exceeds limit %d", ErrMetaTooLarge, len(sig.Meta), maxKeys)
+	}
+	if maxValBytes > 0 {
+		for k, v := range sig.Meta {
+			if len(v) > maxValBytes {
+				return fmt.Errorf("%w: meta[%q] %d bytes exceeds limit %d",
+					ErrMetaTooLarge, k, len(v), maxValBytes)
+			}
+		}
+	}
+	return nil
+}
+
+// cloneSignal returns a deep copy with store-owned Strength and Meta
+// memory so callers cannot retroactively mutate stored signals.
+func cloneSignal(sig FeedbackSignal) FeedbackSignal {
+	out := sig
+	if sig.Strength != nil {
+		v := *sig.Strength
+		out.Strength = &v
+	}
+	if sig.Meta != nil {
+		m := make(map[string]string, len(sig.Meta))
+		for k, v := range sig.Meta {
+			m[k] = v
+		}
+		out.Meta = m
+	}
+	return out
+}

--- a/provider/routing_feedback.go
+++ b/provider/routing_feedback.go
@@ -1,8 +1,8 @@
-// Package provider — routing_feedback.go defines the RoutingFeedback seam:
-// a provider/model/use-case keyed signal store distinct from the chunk-key
-// oriented feedback.SignalStore. PR1 (Epic #48 Phase 5) ships types,
-// interface, in-memory wiring, and the RouteAttempt model; subsequent PRs
-// wire outcomes, persist signals, and read scores into routing decisions.
+// routing_feedback.go defines the RoutingFeedback seam: a provider/model/
+// use-case keyed signal store distinct from the chunk-key oriented
+// feedback.SignalStore. PR1 (Epic #48 Phase 5) ships types, interface, and
+// the in-memory wiring; subsequent PRs persist signals and read scores into
+// routing decisions.
 package provider
 
 import (
@@ -60,10 +60,12 @@ type FeedbackSignal struct {
 	Meta         map[string]string
 }
 
-// Aggregate is the read-side view of accumulated routing feedback. Score is
-// in [0, 1] with 0.5 neutral. ScoredCount is the subset of SampleCount with
-// non-zero effective strength.
+// Aggregate is the read-side view of accumulated routing feedback. ScoredCount
+// is the subset of SampleCount with non-zero effective strength.
 type Aggregate struct {
+	// Score in [0, 1]; neutral is store-configured (default 0.5). Computed
+	// from signals whose effective strength is non-zero. Returns the
+	// configured neutral value when ScoredCount == 0.
 	Score       float64
 	SampleCount int
 	ScoredCount int
@@ -80,8 +82,16 @@ type FeedbackItem struct {
 // the in-memory implementation for a SQLite-backed one without touching the
 // interface.
 type RoutingFeedbackStore interface {
+	// Get returns the current aggregate for key, or a neutral aggregate
+	// when no signals are stored under it.
 	Get(ctx context.Context, key FeedbackKey) (Aggregate, error)
+
+	// Record persists a single signal. Implementations must validate the
+	// key and signal against the same rules enforced by RoutingFeedback.
 	Record(ctx context.Context, key FeedbackKey, sig FeedbackSignal) error
+
+	// RecordBatch persists multiple signals as a single atomic state
+	// transition: if any item fails validation, no item is persisted.
 	RecordBatch(ctx context.Context, items []FeedbackItem) error
 }
 
@@ -100,12 +110,29 @@ func NewRoutingFeedback(store RoutingFeedbackStore) *RoutingFeedback {
 	return &RoutingFeedback{store: store}
 }
 
-// Sentinel errors returned by the seam.
-var (
-	ErrInvalidFeedbackKey    = errors.New("provider: invalid feedback key")
-	ErrUnknownSignalKind     = errors.New("provider: unknown routing signal kind")
-	ErrInvalidSignalStrength = errors.New("provider: invalid signal strength")
-	ErrInvalidSignalPayload  = errors.New("provider: invalid signal payload")
-	ErrMetaTooLarge          = errors.New("provider: signal meta too large")
-	ErrUnknownAttemptStatus  = errors.New("provider: unknown attempt status")
-)
+// ErrInvalidFeedbackKey is returned when a FeedbackKey has an empty
+// Provider, Model, or UseCase field, or when RoutingFeedback.RecordOutcome
+// is called with an empty useCase argument.
+var ErrInvalidFeedbackKey = errors.New("provider: invalid feedback key")
+
+// ErrUnknownSignalKind is returned when a FeedbackSignal carries a Kind
+// that is not one of the declared RoutingSignalKind constants.
+var ErrUnknownSignalKind = errors.New("provider: unknown routing signal kind")
+
+// ErrInvalidSignalStrength is returned when a non-nil FeedbackSignal.Strength
+// holds a NaN or infinite value.
+var ErrInvalidSignalStrength = errors.New("provider: invalid signal strength")
+
+// ErrInvalidSignalPayload is returned when a FeedbackSignal's payload
+// fields violate kind-specific invariants — e.g. a Latency signal without
+// a positive LatencyMs, or a non-Failure signal carrying an ErrorClass.
+var ErrInvalidSignalPayload = errors.New("provider: invalid signal payload")
+
+// ErrMetaTooLarge is returned when a FeedbackSignal.Meta exceeds the
+// store's configured key count or per-value byte limits.
+var ErrMetaTooLarge = errors.New("provider: signal meta too large")
+
+// ErrUnknownAttemptStatus is returned by RoutingFeedback.RecordOutcome
+// when a RouteAttempt.Status (introduced in Task 2 / provider/types.go)
+// holds a value outside the declared AttemptStatus constants.
+var ErrUnknownAttemptStatus = errors.New("provider: unknown attempt status")

--- a/provider/routing_feedback.go
+++ b/provider/routing_feedback.go
@@ -153,11 +153,11 @@ func (rf *RoutingFeedback) Record(ctx context.Context, key FeedbackKey, sig Feed
 // If out.Attempts is empty or nil, RecordOutcome is a no-op and returns
 // nil — the seam's pre-PR2 zero-value-safe property.
 func (rf *RoutingFeedback) RecordOutcome(ctx context.Context, useCase string, out RouteOutcome) error {
-	if useCase == "" {
-		return fmt.Errorf("%w: useCase is required", ErrInvalidFeedbackKey)
-	}
 	if len(out.Attempts) == 0 {
 		return nil
+	}
+	if useCase == "" {
+		return fmt.Errorf("%w: useCase is required", ErrInvalidFeedbackKey)
 	}
 	now := time.Now()
 	items := make([]FeedbackItem, 0, len(out.Attempts)*2)

--- a/provider/routing_feedback.go
+++ b/provider/routing_feedback.go
@@ -128,6 +128,92 @@ func (rf *RoutingFeedback) Record(ctx context.Context, key FeedbackKey, sig Feed
 	return rf.store.Record(ctx, key, sig)
 }
 
+// RecordOutcome decomposes out.Attempts into typed per-attempt signals and
+// persists them atomically via the underlying store's RecordBatch.
+//
+// Decomposition rules (see spec § "Decomposition rules — worked examples"):
+//   - One signal pass per attempt in out.Attempts (in order).
+//   - AttemptStatusSucceeded: emit Success at key derived from
+//     attempt.Key + useCase.
+//   - AttemptStatusFailed:    emit Failure (carrying ErrorClass; empty
+//     normalizes to "unknown") at the same key.
+//   - AttemptStatusUnknown:   skip (no signal emitted).
+//   - Any other AttemptStatus value: return ErrUnknownAttemptStatus and
+//     persist no signals from this outcome.
+//   - LatencyMs > 0: additionally emit a Latency signal at the same key.
+//
+// All emitted signals share a single sampled-once-up-front timestamp and
+// the same RouteID copied from out.RouteID, so decomposition order has no
+// effect on UpdatedAt or route correlation.
+//
+// useCase must be non-empty; an empty useCase cannot form a FeedbackKey
+// and returns ErrInvalidFeedbackKey.
+//
+// If out.Attempts is empty or nil, RecordOutcome is a no-op and returns
+// nil — the seam's pre-PR2 zero-value-safe property.
+func (rf *RoutingFeedback) RecordOutcome(ctx context.Context, useCase string, out RouteOutcome) error {
+	if useCase == "" {
+		return fmt.Errorf("%w: useCase is required", ErrInvalidFeedbackKey)
+	}
+	if len(out.Attempts) == 0 {
+		return nil
+	}
+	now := time.Now()
+	items := make([]FeedbackItem, 0, len(out.Attempts)*2)
+	for i, attempt := range out.Attempts {
+		key := FeedbackKey{
+			Provider: attempt.Key.Provider,
+			Model:    attempt.Key.Model,
+			UseCase:  useCase,
+		}
+		switch attempt.Status {
+		case AttemptStatusUnknown:
+			continue
+		case AttemptStatusSucceeded:
+			items = append(items, FeedbackItem{
+				Key: key,
+				Signal: FeedbackSignal{
+					Kind:    RoutingSignalSuccess,
+					At:      now,
+					RouteID: out.RouteID,
+				},
+			})
+		case AttemptStatusFailed:
+			errClass := attempt.ErrorClass
+			if errClass == "" {
+				errClass = "unknown"
+			}
+			items = append(items, FeedbackItem{
+				Key: key,
+				Signal: FeedbackSignal{
+					Kind:       RoutingSignalFailure,
+					ErrorClass: errClass,
+					At:         now,
+					RouteID:    out.RouteID,
+				},
+			})
+		default:
+			return fmt.Errorf("%w: attempt[%d].Status=%d", ErrUnknownAttemptStatus, i, attempt.Status)
+		}
+		if attempt.LatencyMs > 0 {
+			items = append(items, FeedbackItem{
+				Key: key,
+				Signal: FeedbackSignal{
+					Kind:      RoutingSignalLatency,
+					LatencyMs: attempt.LatencyMs,
+					At:        now,
+					RouteID:   out.RouteID,
+				},
+			})
+		}
+	}
+	if len(items) == 0 {
+		// All attempts were AttemptStatusUnknown.
+		return nil
+	}
+	return rf.store.RecordBatch(ctx, items)
+}
+
 // ErrInvalidFeedbackKey is returned when a FeedbackKey has an empty
 // Provider, Model, or UseCase field, or when RoutingFeedback.RecordOutcome
 // is called with an empty useCase argument.

--- a/provider/routing_feedback_memory.go
+++ b/provider/routing_feedback_memory.go
@@ -179,7 +179,39 @@ func (s *MemoryStore) Record(_ context.Context, key FeedbackKey, sig FeedbackSig
 	return nil
 }
 
-// RecordBatch is implemented in a subsequent task.
-func (s *MemoryStore) RecordBatch(_ context.Context, _ []FeedbackItem) error {
-	return fmt.Errorf("provider: MemoryStore.RecordBatch not yet implemented")
+// RecordBatch persists multiple signals as a single atomic state transition.
+// All items are validated up front; if any item fails validation, no item
+// is persisted. Defaulting of At (when zero) uses a single time.Now() value
+// sampled at the start of the call so all items in the batch share a
+// timestamp. Per-key FIFO retention is applied inside the same lock so
+// readers never observe a partially-applied batch.
+func (s *MemoryStore) RecordBatch(_ context.Context, items []FeedbackItem) error {
+	if len(items) == 0 {
+		return nil
+	}
+	cloned := make([]FeedbackItem, len(items))
+	for i, item := range items {
+		if err := validateKey(item.Key); err != nil {
+			return err
+		}
+		if err := validateSignal(item.Signal, s.cfg.maxMetaKeys, s.cfg.maxMetaValueBytes); err != nil {
+			return err
+		}
+		cloned[i] = FeedbackItem{Key: item.Key, Signal: cloneSignal(item.Signal)}
+	}
+	now := time.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i := range cloned {
+		if cloned[i].Signal.At.IsZero() {
+			cloned[i].Signal.At = now
+		}
+		k := cloned[i].Key
+		s.signals[k] = append(s.signals[k], cloned[i].Signal)
+		if s.cfg.maxRetainedSamples > 0 && len(s.signals[k]) > s.cfg.maxRetainedSamples {
+			drop := len(s.signals[k]) - s.cfg.maxRetainedSamples
+			s.signals[k] = s.signals[k][drop:]
+		}
+	}
+	return nil
 }

--- a/provider/routing_feedback_memory.go
+++ b/provider/routing_feedback_memory.go
@@ -88,28 +88,70 @@ func NewMemoryStore(cfg MemoryStoreConfig) (*MemoryStore, error) {
 	}, nil
 }
 
-// Get returns the aggregate for key. Until Task 6 lands the full formula,
-// this returns SampleCount = len(signals[key]), UpdatedAt = latest At, and
-// Score = configured neutral. The Get-side formula upgrade lands in Task 6.
+// Get returns the aggregate for key. If no signals are stored, returns a
+// neutral aggregate (Score == cfg.neutralScore, other fields zero).
+// Otherwise computes Score from the score-bearing subset of signals
+// (effective strength != 0) using a [-1,+1]-clipped mean mapped to [0,1].
+// Latency signals (default strength 0) contribute to SampleCount only.
 func (s *MemoryStore) Get(_ context.Context, key FeedbackKey) (Aggregate, error) {
 	s.mu.Lock()
-	sigs := s.signals[key]
-	count := len(sigs)
-	var latestAt time.Time
+	sigs := append([]FeedbackSignal(nil), s.signals[key]...)
+	s.mu.Unlock()
+
+	if len(sigs) == 0 {
+		return Aggregate{Score: s.cfg.neutralScore}, nil
+	}
+
+	var (
+		sum      float64
+		scored   int
+		latestAt time.Time
+	)
 	for _, sig := range sigs {
+		strength := effectiveStrength(sig)
 		if sig.At.After(latestAt) {
 			latestAt = sig.At
 		}
+		if strength == 0 {
+			continue
+		}
+		sum += clip(strength, -1, +1)
+		scored++
 	}
-	s.mu.Unlock()
-	if count == 0 {
-		return Aggregate{Score: s.cfg.neutralScore}, nil
+	if scored == 0 {
+		return Aggregate{
+			Score:       s.cfg.neutralScore,
+			SampleCount: len(sigs),
+			UpdatedAt:   latestAt,
+		}, nil
 	}
+	mean := sum / float64(scored)
 	return Aggregate{
-		Score:       s.cfg.neutralScore,
-		SampleCount: count,
+		Score:       0.5 + 0.5*mean,
+		SampleCount: len(sigs),
+		ScoredCount: scored,
 		UpdatedAt:   latestAt,
 	}, nil
+}
+
+// effectiveStrength returns the signal's strength, falling back to the
+// default for its kind when Strength is nil. An unknown kind returns 0.
+func effectiveStrength(sig FeedbackSignal) float64 {
+	if sig.Strength != nil {
+		return *sig.Strength
+	}
+	return defaultStrength[sig.Kind]
+}
+
+// clip returns x clamped to the closed interval [lo, hi].
+func clip(x, lo, hi float64) float64 {
+	if x < lo {
+		return lo
+	}
+	if x > hi {
+		return hi
+	}
+	return x
 }
 
 // Record persists a single signal. Validates the key and signal, defaults

--- a/provider/routing_feedback_memory.go
+++ b/provider/routing_feedback_memory.go
@@ -1,0 +1,107 @@
+// routing_feedback_memory.go provides an in-memory RoutingFeedbackStore.
+// It implements bounded per-key retention with FIFO eviction, all-or-nothing
+// RecordBatch semantics, and defensive copies of caller-owned Meta and
+// Strength on Record. PR3 replaces it with a SQLite-backed store.
+package provider
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// Defaults applied by NewMemoryStore when MemoryStoreConfig fields are
+// zero-valued. See MemoryStoreConfig field docs for semantics.
+const (
+	DefaultMaxRetainedSamples = 1000
+	DefaultMaxMetaKeys        = 32
+	DefaultMaxMetaValueBytes  = 256
+	DefaultNeutralScore       = 0.5
+)
+
+// MemoryStoreConfig tunes MemoryStore. All zero-valued fields fall back to
+// the documented Default* constants.
+type MemoryStoreConfig struct {
+	// NeutralScore is returned by Get() when ScoredCount == 0. Must be in
+	// [0, 1] after default application. Zero value selects
+	// DefaultNeutralScore (0.5).
+	NeutralScore float64
+
+	// MaxRetainedSamples bounds per-key signal retention:
+	//   0  → use DefaultMaxRetainedSamples (1000)
+	//  -1  → unbounded (use only in tests and short-lived processes)
+	//  >0  → explicit cap; oldest entries dropped FIFO on overflow
+	MaxRetainedSamples int
+
+	// MaxMetaKeys / MaxMetaValueBytes bound Meta size per signal. Zero
+	// values select the Default* constants.
+	MaxMetaKeys       int
+	MaxMetaValueBytes int
+}
+
+// resolvedConfig holds post-default values so the hot path does not re-
+// resolve defaults on each call.
+type resolvedConfig struct {
+	neutralScore       float64
+	maxRetainedSamples int // -1 means unbounded
+	maxMetaKeys        int
+	maxMetaValueBytes  int
+}
+
+// MemoryStore is the in-memory RoutingFeedbackStore. Safe for concurrent
+// use via a single sync.Mutex; SQLite (PR3) will manage its own concurrency.
+type MemoryStore struct {
+	mu      sync.Mutex
+	cfg     resolvedConfig
+	signals map[FeedbackKey][]FeedbackSignal
+}
+
+// NewMemoryStore validates the config and returns an initialized store.
+// Out-of-range NeutralScore (after default application) returns an error
+// at construction so misconfiguration cannot silently move Get results.
+func NewMemoryStore(cfg MemoryStoreConfig) (*MemoryStore, error) {
+	resolved := resolvedConfig{
+		neutralScore:       cfg.NeutralScore,
+		maxRetainedSamples: cfg.MaxRetainedSamples,
+		maxMetaKeys:        cfg.MaxMetaKeys,
+		maxMetaValueBytes:  cfg.MaxMetaValueBytes,
+	}
+	if resolved.neutralScore == 0 {
+		resolved.neutralScore = DefaultNeutralScore
+	}
+	if resolved.maxRetainedSamples == 0 {
+		resolved.maxRetainedSamples = DefaultMaxRetainedSamples
+	}
+	if resolved.maxMetaKeys == 0 {
+		resolved.maxMetaKeys = DefaultMaxMetaKeys
+	}
+	if resolved.maxMetaValueBytes == 0 {
+		resolved.maxMetaValueBytes = DefaultMaxMetaValueBytes
+	}
+	if resolved.neutralScore < 0 || resolved.neutralScore > 1 {
+		return nil, fmt.Errorf("provider: NeutralScore %v out of range [0,1]", resolved.neutralScore)
+	}
+	return &MemoryStore{
+		cfg:     resolved,
+		signals: make(map[FeedbackKey][]FeedbackSignal),
+	}, nil
+}
+
+// Get returns the aggregate for key. Empty keys yield a neutral aggregate
+// (Score == cfg.NeutralScore, all other fields zero). Full aggregation logic
+// is implemented in a subsequent task; this skeleton returns neutral.
+func (s *MemoryStore) Get(_ context.Context, _ FeedbackKey) (Aggregate, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return Aggregate{Score: s.cfg.neutralScore}, nil
+}
+
+// Record / RecordBatch are implemented in subsequent tasks.
+func (s *MemoryStore) Record(_ context.Context, _ FeedbackKey, _ FeedbackSignal) error {
+	return fmt.Errorf("provider: MemoryStore.Record not yet implemented")
+}
+
+// RecordBatch is implemented in a subsequent task.
+func (s *MemoryStore) RecordBatch(_ context.Context, _ []FeedbackItem) error {
+	return fmt.Errorf("provider: MemoryStore.RecordBatch not yet implemented")
+}

--- a/provider/routing_feedback_memory.go
+++ b/provider/routing_feedback_memory.go
@@ -82,6 +82,15 @@ func NewMemoryStore(cfg MemoryStoreConfig) (*MemoryStore, error) {
 	if resolved.neutralScore < 0 || resolved.neutralScore > 1 {
 		return nil, fmt.Errorf("provider: NeutralScore %v out of range [0,1]", resolved.neutralScore)
 	}
+	if resolved.maxRetainedSamples < -1 {
+		return nil, fmt.Errorf("provider: MaxRetainedSamples %d out of range; use -1 for unbounded", resolved.maxRetainedSamples)
+	}
+	if resolved.maxMetaKeys < 0 {
+		return nil, fmt.Errorf("provider: MaxMetaKeys %d out of range", resolved.maxMetaKeys)
+	}
+	if resolved.maxMetaValueBytes < 0 {
+		return nil, fmt.Errorf("provider: MaxMetaValueBytes %d out of range", resolved.maxMetaValueBytes)
+	}
 	return &MemoryStore{
 		cfg:     resolved,
 		signals: make(map[FeedbackKey][]FeedbackSignal),

--- a/provider/routing_feedback_memory.go
+++ b/provider/routing_feedback_memory.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 )
 
 // Defaults applied by NewMemoryStore when MemoryStoreConfig fields are
@@ -87,18 +88,53 @@ func NewMemoryStore(cfg MemoryStoreConfig) (*MemoryStore, error) {
 	}, nil
 }
 
-// Get returns the aggregate for key. Empty keys yield a neutral aggregate
-// (Score == cfg.NeutralScore, all other fields zero). Full aggregation logic
-// is implemented in a subsequent task; this skeleton returns neutral.
-func (s *MemoryStore) Get(_ context.Context, _ FeedbackKey) (Aggregate, error) {
+// Get returns the aggregate for key. Until Task 6 lands the full formula,
+// this returns SampleCount = len(signals[key]), UpdatedAt = latest At, and
+// Score = configured neutral. The Get-side formula upgrade lands in Task 6.
+func (s *MemoryStore) Get(_ context.Context, key FeedbackKey) (Aggregate, error) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	return Aggregate{Score: s.cfg.neutralScore}, nil
+	sigs := s.signals[key]
+	count := len(sigs)
+	var latestAt time.Time
+	for _, sig := range sigs {
+		if sig.At.After(latestAt) {
+			latestAt = sig.At
+		}
+	}
+	s.mu.Unlock()
+	if count == 0 {
+		return Aggregate{Score: s.cfg.neutralScore}, nil
+	}
+	return Aggregate{
+		Score:       s.cfg.neutralScore,
+		SampleCount: count,
+		UpdatedAt:   latestAt,
+	}, nil
 }
 
-// Record / RecordBatch are implemented in subsequent tasks.
-func (s *MemoryStore) Record(_ context.Context, _ FeedbackKey, _ FeedbackSignal) error {
-	return fmt.Errorf("provider: MemoryStore.Record not yet implemented")
+// Record persists a single signal. Validates the key and signal, defaults
+// At to time.Now when zero, deep-copies caller-owned Strength and Meta,
+// appends under lock, and applies FIFO retention when the per-key bound
+// is finite.
+func (s *MemoryStore) Record(_ context.Context, key FeedbackKey, sig FeedbackSignal) error {
+	if err := validateKey(key); err != nil {
+		return err
+	}
+	if err := validateSignal(sig, s.cfg.maxMetaKeys, s.cfg.maxMetaValueBytes); err != nil {
+		return err
+	}
+	stored := cloneSignal(sig)
+	if stored.At.IsZero() {
+		stored.At = time.Now()
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.signals[key] = append(s.signals[key], stored)
+	if s.cfg.maxRetainedSamples > 0 && len(s.signals[key]) > s.cfg.maxRetainedSamples {
+		drop := len(s.signals[key]) - s.cfg.maxRetainedSamples
+		s.signals[key] = s.signals[key][drop:]
+	}
+	return nil
 }
 
 // RecordBatch is implemented in a subsequent task.

--- a/provider/routing_feedback_test.go
+++ b/provider/routing_feedback_test.go
@@ -620,3 +620,34 @@ func TestRecordBatchTinyCapKeepsAtomicity(t *testing.T) {
 		t.Fatalf("SampleCount = %d, want 1 (tiny cap retains newest only)", agg.SampleCount)
 	}
 }
+
+func TestRoutingFeedbackScoreDelegates(t *testing.T) {
+	store := mustStore(t, MemoryStoreConfig{})
+	rf := NewRoutingFeedback(store)
+
+	agg, err := rf.Score(context.Background(), validKey())
+	if err != nil {
+		t.Fatalf("Score: %v", err)
+	}
+	if agg.Score != DefaultNeutralScore {
+		t.Fatalf("Score = %v, want %v", agg.Score, DefaultNeutralScore)
+	}
+
+	if err := rf.Record(context.Background(), validKey(),
+		FeedbackSignal{Kind: RoutingSignalSuccess}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	agg, _ = rf.Score(context.Background(), validKey())
+	if agg.Score != 0.75 {
+		t.Fatalf("after Record Score = %v, want 0.75", agg.Score)
+	}
+}
+
+func TestRoutingFeedbackRecordPropagatesValidationErrors(t *testing.T) {
+	rf := NewRoutingFeedback(mustStore(t, MemoryStoreConfig{}))
+	err := rf.Record(context.Background(), FeedbackKey{},
+		FeedbackSignal{Kind: RoutingSignalSuccess})
+	if !errors.Is(err, ErrInvalidFeedbackKey) {
+		t.Fatalf("err = %v, want ErrInvalidFeedbackKey", err)
+	}
+}

--- a/provider/routing_feedback_test.go
+++ b/provider/routing_feedback_test.go
@@ -231,8 +231,9 @@ func TestRecordRejectsUnknownKind(t *testing.T) {
 func TestRecordRejectsBadStrength(t *testing.T) {
 	s, _ := NewMemoryStore(MemoryStoreConfig{})
 	nan := math.NaN()
-	inf := math.Inf(1)
-	cases := []*float64{&nan, &inf}
+	posInf := math.Inf(1)
+	negInf := math.Inf(-1)
+	cases := []*float64{&nan, &posInf, &negInf}
 	for _, sp := range cases {
 		err := s.Record(context.Background(), validKey(),
 			FeedbackSignal{Kind: RoutingSignalSuccess, Strength: sp})
@@ -251,6 +252,7 @@ func TestRecordRejectsBadPayload(t *testing.T) {
 		{"latency-without-positive-ms", FeedbackSignal{Kind: RoutingSignalLatency, LatencyMs: 0}},
 		{"latency-with-negative-ms", FeedbackSignal{Kind: RoutingSignalLatency, LatencyMs: -1}},
 		{"success-with-latency-ms", FeedbackSignal{Kind: RoutingSignalSuccess, LatencyMs: 100}},
+		{"failure-with-latency-ms", FeedbackSignal{Kind: RoutingSignalFailure, ErrorClass: "5xx", LatencyMs: 100}},
 		{"failure-without-class", FeedbackSignal{Kind: RoutingSignalFailure}},
 		{"success-with-error-class", FeedbackSignal{Kind: RoutingSignalSuccess, ErrorClass: "5xx"}},
 	}
@@ -285,17 +287,17 @@ func TestRecordAcceptsValidSignalAndDefaultsAt(t *testing.T) {
 		FeedbackSignal{Kind: RoutingSignalSuccess}); err != nil {
 		t.Fatalf("Record: %v", err)
 	}
-	after := time.Now()
+	// Add a small slack to upper bound for CI clock skew.
+	after := time.Now().Add(time.Second)
 	agg, _ := s.Get(context.Background(), validKey())
 	if agg.SampleCount != 1 {
 		t.Fatalf("SampleCount = %d, want 1", agg.SampleCount)
 	}
-	// UpdatedAt may or may not be exposed depending on the Get formula
-	// in Task 5's intermediate state; only assert if it's non-zero.
-	if !agg.UpdatedAt.IsZero() {
-		if agg.UpdatedAt.Before(before) || agg.UpdatedAt.After(after.Add(time.Second)) {
-			t.Fatalf("UpdatedAt %v outside [%v, %v]", agg.UpdatedAt, before, after)
-		}
+	if agg.UpdatedAt.IsZero() {
+		t.Fatal("UpdatedAt is zero; Record should have defaulted At to time.Now()")
+	}
+	if agg.UpdatedAt.Before(before) || agg.UpdatedAt.After(after) {
+		t.Fatalf("UpdatedAt %v outside [%v, %v]", agg.UpdatedAt, before, after)
 	}
 }
 
@@ -312,17 +314,37 @@ func TestRecordDefensiveCopiesStrengthAndMeta(t *testing.T) {
 		t.Fatalf("Record: %v", err)
 	}
 	// Mutate caller-owned values after Record returns; stored data must
-	// not change.
+	// not change. The store is an in-package neighbor, so we can lock
+	// and inspect s.signals directly — that is what actually proves the
+	// deep-copy worked.
 	strength = -1.0
 	meta["key"] = "v2"
 	meta["extra"] = "v3"
 
-	// We cannot directly read internal signals (no exported accessor); the
-	// canonical assertion is via Get once Task 6 lands the formula. For
-	// Task 5 we assert SampleCount is still 1 and Get does not panic.
-	agg, _ := s.Get(context.Background(), validKey())
-	if agg.SampleCount != 1 {
-		t.Fatalf("SampleCount = %d, want 1", agg.SampleCount)
+	s.mu.Lock()
+	storedSignals := s.signals[validKey()]
+	if len(storedSignals) != 1 {
+		s.mu.Unlock()
+		t.Fatalf("stored signals = %d, want 1", len(storedSignals))
+	}
+	stored := storedSignals[0]
+	if stored.Strength == nil {
+		s.mu.Unlock()
+		t.Fatal("stored Strength is nil")
+	}
+	storedStrength := *stored.Strength
+	storedMetaKey := stored.Meta["key"]
+	_, storedMetaHasExtra := stored.Meta["extra"]
+	s.mu.Unlock()
+
+	if storedStrength != 0.9 {
+		t.Errorf("stored Strength = %v, want 0.9", storedStrength)
+	}
+	if storedMetaKey != "v1" {
+		t.Errorf("stored Meta[key] = %q, want \"v1\"", storedMetaKey)
+	}
+	if storedMetaHasExtra {
+		t.Error("stored Meta unexpectedly saw caller mutation (extra key present)")
 	}
 }
 

--- a/provider/routing_feedback_test.go
+++ b/provider/routing_feedback_test.go
@@ -651,3 +651,179 @@ func TestRoutingFeedbackRecordPropagatesValidationErrors(t *testing.T) {
 		t.Fatalf("err = %v, want ErrInvalidFeedbackKey", err)
 	}
 }
+
+func mkAttempt(provider, model string, status AttemptStatus, latencyMs int64, errClass string) RouteAttempt {
+	return RouteAttempt{
+		Key:        ModelKey{Provider: provider, Model: model},
+		Status:     status,
+		LatencyMs:  latencyMs,
+		ErrorClass: errClass,
+	}
+}
+
+func TestRecordOutcomeNilAttemptsIsNoOp(t *testing.T) {
+	rf := NewRoutingFeedback(mustStore(t, MemoryStoreConfig{}))
+	if err := rf.RecordOutcome(context.Background(), "chat", RouteOutcome{}); err != nil {
+		t.Fatalf("nil Attempts: %v", err)
+	}
+}
+
+func TestRecordOutcomeAllUnknownIsNoOp(t *testing.T) {
+	store := mustStore(t, MemoryStoreConfig{})
+	rf := NewRoutingFeedback(store)
+	out := RouteOutcome{
+		Attempts: []RouteAttempt{
+			mkAttempt("p", "m", AttemptStatusUnknown, 100, ""),
+		},
+	}
+	if err := rf.RecordOutcome(context.Background(), "chat", out); err != nil {
+		t.Fatalf("all-Unknown: %v", err)
+	}
+	agg, _ := store.Get(context.Background(), FeedbackKey{Provider: "p", Model: "m", UseCase: "chat"})
+	if agg.SampleCount != 0 {
+		t.Fatalf("SampleCount = %d, want 0", agg.SampleCount)
+	}
+}
+
+func TestRecordOutcomeRejectsEmptyUseCase(t *testing.T) {
+	rf := NewRoutingFeedback(mustStore(t, MemoryStoreConfig{}))
+	out := RouteOutcome{
+		Attempts: []RouteAttempt{mkAttempt("p", "m", AttemptStatusSucceeded, 100, "")},
+	}
+	err := rf.RecordOutcome(context.Background(), "", out)
+	if !errors.Is(err, ErrInvalidFeedbackKey) {
+		t.Fatalf("err = %v, want ErrInvalidFeedbackKey", err)
+	}
+}
+
+func TestRecordOutcomeRejectsInvalidAttemptStatusAtomically(t *testing.T) {
+	store := mustStore(t, MemoryStoreConfig{})
+	rf := NewRoutingFeedback(store)
+	out := RouteOutcome{
+		Attempts: []RouteAttempt{
+			mkAttempt("p", "m", AttemptStatusSucceeded, 100, ""),
+			mkAttempt("p2", "m2", AttemptStatus(99), 100, ""),
+		},
+	}
+	err := rf.RecordOutcome(context.Background(), "chat", out)
+	if !errors.Is(err, ErrUnknownAttemptStatus) {
+		t.Fatalf("err = %v, want ErrUnknownAttemptStatus", err)
+	}
+	// Neither attempt should have produced signals — atomic rejection.
+	for _, k := range []FeedbackKey{
+		{Provider: "p", Model: "m", UseCase: "chat"},
+		{Provider: "p2", Model: "m2", UseCase: "chat"},
+	} {
+		agg, _ := store.Get(context.Background(), k)
+		if agg.SampleCount != 0 {
+			t.Fatalf("key %+v SampleCount = %d, want 0", k, agg.SampleCount)
+		}
+	}
+}
+
+func TestRecordOutcomeSuccessOnlyEmitsSuccessAndLatency(t *testing.T) {
+	store := mustStore(t, MemoryStoreConfig{})
+	rf := NewRoutingFeedback(store)
+	out := RouteOutcome{
+		Attempts: []RouteAttempt{mkAttempt("p", "m", AttemptStatusSucceeded, 820, "")},
+		RouteID:  "route-1",
+	}
+	if err := rf.RecordOutcome(context.Background(), "chat", out); err != nil {
+		t.Fatalf("RecordOutcome: %v", err)
+	}
+	key := FeedbackKey{Provider: "p", Model: "m", UseCase: "chat"}
+	agg, _ := store.Get(context.Background(), key)
+	if agg.SampleCount != 2 {
+		t.Fatalf("SampleCount = %d, want 2", agg.SampleCount)
+	}
+	if agg.ScoredCount != 1 {
+		t.Fatalf("ScoredCount = %d, want 1", agg.ScoredCount)
+	}
+}
+
+func TestRecordOutcomeFailureCarriesErrorClass(t *testing.T) {
+	store := mustStore(t, MemoryStoreConfig{})
+	rf := NewRoutingFeedback(store)
+	out := RouteOutcome{
+		Attempts: []RouteAttempt{mkAttempt("p", "m", AttemptStatusFailed, 30000, "timeout")},
+	}
+	if err := rf.RecordOutcome(context.Background(), "chat", out); err != nil {
+		t.Fatalf("RecordOutcome: %v", err)
+	}
+	key := FeedbackKey{Provider: "p", Model: "m", UseCase: "chat"}
+	agg, _ := store.Get(context.Background(), key)
+	// Failure (-0.7) + Latency (0): scoredCount = 1, mean = -0.7, score = 0.15.
+	if math.Abs(agg.Score-0.15) > 1e-15 {
+		t.Fatalf("Score = %v, want 0.15", agg.Score)
+	}
+}
+
+func TestRecordOutcomeFailedAttemptEmptyErrorClassNormalizesToUnknown(t *testing.T) {
+	store := mustStore(t, MemoryStoreConfig{})
+	rf := NewRoutingFeedback(store)
+	out := RouteOutcome{
+		Attempts: []RouteAttempt{mkAttempt("p", "m", AttemptStatusFailed, 100, "")},
+	}
+	if err := rf.RecordOutcome(context.Background(), "chat", out); err != nil {
+		t.Fatalf("RecordOutcome: %v", err)
+	}
+	// Decomposition emitted Failure + Latency at the same key. Failure
+	// must have been recorded with ErrorClass="unknown" (otherwise
+	// validateSignal would have rejected it).
+	key := FeedbackKey{Provider: "p", Model: "m", UseCase: "chat"}
+	agg, _ := store.Get(context.Background(), key)
+	if agg.SampleCount != 2 || agg.ScoredCount != 1 {
+		t.Fatalf("counts = (sample=%d, scored=%d), want (2,1)", agg.SampleCount, agg.ScoredCount)
+	}
+}
+
+func TestRecordOutcomePrimaryFailFallbackSucceedKeysSeparately(t *testing.T) {
+	// This is the design-review fix test: a primary failure followed by a
+	// fallback success debits the primary and credits the fallback —
+	// rather than crediting the planned model for a rescued request.
+	store := mustStore(t, MemoryStoreConfig{})
+	rf := NewRoutingFeedback(store)
+	out := RouteOutcome{
+		Attempts: []RouteAttempt{
+			mkAttempt("ollama-a", "qwen3:8b", AttemptStatusFailed, 200, "5xx"),
+			mkAttempt("ollama-b", "qwen3:8b", AttemptStatusSucceeded, 900, ""),
+		},
+	}
+	if err := rf.RecordOutcome(context.Background(), "chat", out); err != nil {
+		t.Fatalf("RecordOutcome: %v", err)
+	}
+	primary := FeedbackKey{Provider: "ollama-a", Model: "qwen3:8b", UseCase: "chat"}
+	fallback := FeedbackKey{Provider: "ollama-b", Model: "qwen3:8b", UseCase: "chat"}
+
+	primaryAgg, _ := store.Get(context.Background(), primary)
+	if math.Abs(primaryAgg.Score-0.15) > 1e-15 {
+		t.Errorf("primary.Score = %v, want 0.15 (Failure)", primaryAgg.Score)
+	}
+	if primaryAgg.SampleCount != 2 {
+		t.Errorf("primary.SampleCount = %d, want 2", primaryAgg.SampleCount)
+	}
+
+	fallbackAgg, _ := store.Get(context.Background(), fallback)
+	if fallbackAgg.Score != 0.75 {
+		t.Errorf("fallback.Score = %v, want 0.75 (Success)", fallbackAgg.Score)
+	}
+	if fallbackAgg.SampleCount != 2 {
+		t.Errorf("fallback.SampleCount = %d, want 2", fallbackAgg.SampleCount)
+	}
+}
+
+func TestRecordOutcomeLatencyOmittedWhenNotMeasured(t *testing.T) {
+	store := mustStore(t, MemoryStoreConfig{})
+	rf := NewRoutingFeedback(store)
+	out := RouteOutcome{
+		Attempts: []RouteAttempt{mkAttempt("p", "m", AttemptStatusSucceeded, 0, "")},
+	}
+	if err := rf.RecordOutcome(context.Background(), "chat", out); err != nil {
+		t.Fatalf("RecordOutcome: %v", err)
+	}
+	key := FeedbackKey{Provider: "p", Model: "m", UseCase: "chat"}
+	agg, _ := store.Get(context.Background(), key)
+	if agg.SampleCount != 1 {
+		t.Fatalf("SampleCount = %d, want 1 (no Latency emitted when LatencyMs <= 0)", agg.SampleCount)
+	}
+}

--- a/provider/routing_feedback_test.go
+++ b/provider/routing_feedback_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"math"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -865,5 +866,64 @@ func TestRecordOutcomeRejectsNegativeLatencyAtomically(t *testing.T) {
 		if agg.SampleCount != 0 {
 			t.Fatalf("key %+v SampleCount = %d, want 0 (atomic rejection)", k, agg.SampleCount)
 		}
+	}
+}
+
+func TestMemoryStoreConcurrentRecordAndGet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping concurrency stress under -short")
+	}
+	store := mustStore(t, MemoryStoreConfig{MaxRetainedSamples: -1})
+	const goroutines = 8
+	const iterations = 200
+
+	keys := []FeedbackKey{
+		{Provider: "p1", Model: "m1", UseCase: "chat"},
+		{Provider: "p1", Model: "m2", UseCase: "chat"},
+		{Provider: "p2", Model: "m1", UseCase: "fim"},
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(gid int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				k := keys[(gid+i)%len(keys)]
+				switch i % 3 {
+				case 0:
+					_ = store.Record(context.Background(), k,
+						FeedbackSignal{Kind: RoutingSignalSuccess})
+				case 1:
+					_ = store.RecordBatch(context.Background(), []FeedbackItem{
+						{Key: k, Signal: FeedbackSignal{Kind: RoutingSignalSuccess}},
+						{Key: k, Signal: FeedbackSignal{Kind: RoutingSignalLatency, LatencyMs: 100}},
+					})
+				case 2:
+					_, _ = store.Get(context.Background(), k)
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	// Final invariants: every Record adds exactly 1 sample; every
+	// RecordBatch with 2 items adds exactly 2 samples; Get adds 0. So
+	// total samples across all keys == sum over goroutines of:
+	//   (iterations/3 + 1 if iterations%3 > 0)  *  1     (Record)
+	// + (iterations/3 + 1 if iterations%3 > 1)  *  2     (RecordBatch)
+	// + (iterations/3)                          *  0     (Get)
+	// For iterations=200: 200%3 == 2, so:
+	//   record_calls = 67, batch_calls = 67, get_calls = 66.
+	// Per goroutine samples = 67 + 67*2 = 201.
+	// Total = 8 * 201 = 1608.
+	const wantTotal = 1608
+	var got int
+	for _, k := range keys {
+		agg, _ := store.Get(context.Background(), k)
+		got += agg.SampleCount
+	}
+	if got != wantTotal {
+		t.Fatalf("total samples = %d, want %d (key distribution may have drifted)", got, wantTotal)
 	}
 }

--- a/provider/routing_feedback_test.go
+++ b/provider/routing_feedback_test.go
@@ -1,0 +1,22 @@
+package provider
+
+import "testing"
+
+func TestDefaultStrength(t *testing.T) {
+	cases := []struct {
+		kind RoutingSignalKind
+		want float64
+	}{
+		{RoutingSignalSuccess, +0.5},
+		{RoutingSignalFailure, -0.7},
+		{RoutingSignalLatency, 0.0},
+		{RoutingSignalKind("unknown"), 0.0},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.kind), func(t *testing.T) {
+			if got := DefaultStrength(tc.kind); got != tc.want {
+				t.Fatalf("DefaultStrength(%q) = %v, want %v", tc.kind, got, tc.want)
+			}
+		})
+	}
+}

--- a/provider/routing_feedback_test.go
+++ b/provider/routing_feedback_test.go
@@ -88,3 +88,40 @@ func TestRouteOutcomeJSONOmitsEmptyNewFields(t *testing.T) {
 		}
 	}
 }
+
+func TestNewRouteIDProducesDistinct32CharHex(t *testing.T) {
+	id1 := newRouteID()
+	id2 := newRouteID()
+	if len(id1) != 32 {
+		t.Fatalf("newRouteID() length = %d, want 32", len(id1))
+	}
+	if id1 == id2 {
+		t.Fatalf("two consecutive newRouteID() values collided: %q", id1)
+	}
+	for _, c := range id1 {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			t.Fatalf("newRouteID() returned non-hex char %q in %q", c, id1)
+		}
+	}
+}
+
+func TestBuildOutcomePopulatesRouteID(t *testing.T) {
+	rp := &RoutePlan{
+		Profile: &ModelProfile{Key: ModelKey{Provider: "p", Model: "m"}},
+		Score:   0.42,
+		Reason:  "test",
+	}
+	out := rp.buildOutcome(0)
+	if out == nil {
+		t.Fatal("buildOutcome returned nil")
+	}
+	if out.RouteID == "" {
+		t.Fatal("buildOutcome did not set RouteID")
+	}
+	if len(out.RouteID) != 32 {
+		t.Fatalf("RouteID length = %d, want 32", len(out.RouteID))
+	}
+	if len(out.Attempts) != 0 {
+		t.Fatalf("Attempts populated by buildOutcome (len=%d); PR2 owns this", len(out.Attempts))
+	}
+}

--- a/provider/routing_feedback_test.go
+++ b/provider/routing_feedback_test.go
@@ -566,9 +566,43 @@ func TestRecordBatchSharesTimestampDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 	after := time.Now()
-	agg, _ := s.Get(context.Background(), validKey())
-	if agg.UpdatedAt.Before(before) || agg.UpdatedAt.After(after.Add(time.Second)) {
-		t.Fatalf("UpdatedAt %v outside [%v, %v]", agg.UpdatedAt, before, after)
+
+	// The "shared" property is the one that matters: both signals in the
+	// batch must carry the same `At`. UpdatedAt alone could pass even if
+	// RecordBatch internally re-sampled time.Now() between items.
+	s.mu.Lock()
+	sigs := s.signals[validKey()]
+	s.mu.Unlock()
+	if len(sigs) != 2 {
+		t.Fatalf("stored signals = %d, want 2", len(sigs))
+	}
+	if !sigs[0].At.Equal(sigs[1].At) {
+		t.Fatalf("signals[0].At = %v, signals[1].At = %v; want equal (shared now)", sigs[0].At, sigs[1].At)
+	}
+	if sigs[0].At.Before(before) || sigs[0].At.After(after) {
+		t.Fatalf("At %v outside [%v, %v]", sigs[0].At, before, after)
+	}
+}
+
+func TestRecordBatchDistinctKeys(t *testing.T) {
+	// Exercises the per-key map-insertion path that single-key batches do
+	// not — RecordOutcome (Task 9) produces batches keyed by attempt.Key,
+	// so distinct keys are the primary use case.
+	s := mustStore(t, MemoryStoreConfig{})
+	keyA := FeedbackKey{Provider: "a", Model: "m", UseCase: "c"}
+	keyB := FeedbackKey{Provider: "b", Model: "m", UseCase: "c"}
+	items := []FeedbackItem{
+		{Key: keyA, Signal: FeedbackSignal{Kind: RoutingSignalSuccess}},
+		{Key: keyB, Signal: FeedbackSignal{Kind: RoutingSignalFailure, ErrorClass: "timeout"}},
+	}
+	if err := s.RecordBatch(context.Background(), items); err != nil {
+		t.Fatalf("RecordBatch: %v", err)
+	}
+	for _, k := range []FeedbackKey{keyA, keyB} {
+		agg, _ := s.Get(context.Background(), k)
+		if agg.SampleCount != 1 {
+			t.Fatalf("key %+v SampleCount = %d, want 1", k, agg.SampleCount)
+		}
 	}
 }
 

--- a/provider/routing_feedback_test.go
+++ b/provider/routing_feedback_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"strings"
@@ -145,5 +146,50 @@ func TestNewRouteIDReturnsEmptyOnRandFailure(t *testing.T) {
 
 	if got := newRouteID(); got != "" {
 		t.Fatalf("newRouteID() = %q, want empty string on RNG failure", got)
+	}
+}
+
+func TestNewMemoryStoreAppliesDefaults(t *testing.T) {
+	s, err := NewMemoryStore(MemoryStoreConfig{})
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+	if s == nil {
+		t.Fatal("NewMemoryStore returned nil store")
+	}
+	// Zero values must resolve to the documented defaults. We verify
+	// indirectly through Get on an empty key (Score == DefaultNeutralScore).
+	agg, err := s.Get(context.Background(), FeedbackKey{Provider: "p", Model: "m", UseCase: "c"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if agg.Score != DefaultNeutralScore {
+		t.Fatalf("Score = %v, want %v", agg.Score, DefaultNeutralScore)
+	}
+}
+
+func TestNewMemoryStoreRejectsOutOfRangeNeutralScore(t *testing.T) {
+	cases := []float64{-0.01, 1.01, -1.0, 2.0}
+	for _, n := range cases {
+		t.Run("", func(t *testing.T) {
+			_, err := NewMemoryStore(MemoryStoreConfig{NeutralScore: n})
+			if err == nil {
+				t.Fatalf("NewMemoryStore(NeutralScore=%v) returned nil error", n)
+			}
+		})
+	}
+}
+
+func TestNewMemoryStoreCustomNeutralScore(t *testing.T) {
+	s, err := NewMemoryStore(MemoryStoreConfig{NeutralScore: 0.42})
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+	agg, err := s.Get(context.Background(), FeedbackKey{Provider: "p", Model: "m", UseCase: "c"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if agg.Score != 0.42 {
+		t.Fatalf("Score = %v, want 0.42", agg.Score)
 	}
 }

--- a/provider/routing_feedback_test.go
+++ b/provider/routing_feedback_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -26,16 +27,17 @@ func TestDefaultStrength(t *testing.T) {
 
 func TestAttemptStatusString(t *testing.T) {
 	cases := []struct {
+		name string
 		s    AttemptStatus
 		want string
 	}{
-		{AttemptStatusUnknown, "unknown"},
-		{AttemptStatusSucceeded, "succeeded"},
-		{AttemptStatusFailed, "failed"},
-		{AttemptStatus(99), "unknown"},
+		{"unknown", AttemptStatusUnknown, "unknown"},
+		{"succeeded", AttemptStatusSucceeded, "succeeded"},
+		{"failed", AttemptStatusFailed, "failed"},
+		{"out_of_range", AttemptStatus(99), "unknown"},
 	}
 	for _, tc := range cases {
-		t.Run(tc.want, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			if got := tc.s.String(); got != tc.want {
 				t.Fatalf("String() = %q, want %q", got, tc.want)
 			}
@@ -75,27 +77,14 @@ func TestRouteOutcomeJSONOmitsEmptyNewFields(t *testing.T) {
 		t.Fatalf("Marshal: %v", err)
 	}
 	s := string(b)
-	if got := s; got == "" {
+	if s == "" {
 		t.Fatalf("empty marshal")
 	}
 	// Forward-compatible expectation: zero-value Attempts/RouteID must be
 	// absent from the JSON output so existing consumers see no new keys.
 	for _, key := range []string{`"attempts"`, `"route_id"`} {
-		if contains(s, key) {
+		if strings.Contains(s, key) {
 			t.Errorf("RouteOutcome JSON %s unexpectedly contains %s", s, key)
 		}
 	}
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || indexOf(s, substr) >= 0)
-}
-
-func indexOf(s, substr string) int {
-	for i := 0; i+len(substr) <= len(s); i++ {
-		if s[i:i+len(substr)] == substr {
-			return i
-		}
-	}
-	return -1
 }

--- a/provider/routing_feedback_test.go
+++ b/provider/routing_feedback_test.go
@@ -693,6 +693,35 @@ func TestRoutingFeedbackRecordPropagatesValidationErrors(t *testing.T) {
 	}
 }
 
+func TestRoutingFeedbackRejectsNilStore(t *testing.T) {
+	rf := NewRoutingFeedback(nil)
+	if _, err := rf.Score(context.Background(), validKey()); !errors.Is(err, ErrNilRoutingFeedbackStore) {
+		t.Fatalf("Score err = %v, want ErrNilRoutingFeedbackStore", err)
+	}
+	if err := rf.Record(context.Background(), validKey(),
+		FeedbackSignal{Kind: RoutingSignalSuccess}); !errors.Is(err, ErrNilRoutingFeedbackStore) {
+		t.Fatalf("Record err = %v, want ErrNilRoutingFeedbackStore", err)
+	}
+	if err := rf.RecordOutcome(context.Background(), "chat", RouteOutcome{}); !errors.Is(err, ErrNilRoutingFeedbackStore) {
+		t.Fatalf("RecordOutcome err = %v, want ErrNilRoutingFeedbackStore", err)
+	}
+}
+
+func TestRoutingFeedbackRejectsTypedNilStore(t *testing.T) {
+	var store *MemoryStore
+	rf := NewRoutingFeedback(store)
+	if _, err := rf.Score(context.Background(), validKey()); !errors.Is(err, ErrNilRoutingFeedbackStore) {
+		t.Fatalf("Score err = %v, want ErrNilRoutingFeedbackStore", err)
+	}
+}
+
+func TestRoutingFeedbackRejectsNilReceiver(t *testing.T) {
+	var rf *RoutingFeedback
+	if _, err := rf.Score(context.Background(), validKey()); !errors.Is(err, ErrNilRoutingFeedbackStore) {
+		t.Fatalf("Score err = %v, want ErrNilRoutingFeedbackStore", err)
+	}
+}
+
 func mkAttempt(provider, model string, status AttemptStatus, latencyMs int64, errClass string) RouteAttempt {
 	return RouteAttempt{
 		Key:        ModelKey{Provider: provider, Model: model},

--- a/provider/routing_feedback_test.go
+++ b/provider/routing_feedback_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestDefaultStrength(t *testing.T) {
@@ -191,5 +193,163 @@ func TestNewMemoryStoreCustomNeutralScore(t *testing.T) {
 	}
 	if agg.Score != 0.42 {
 		t.Fatalf("Score = %v, want 0.42", agg.Score)
+	}
+}
+
+func validKey() FeedbackKey {
+	return FeedbackKey{Provider: "p", Model: "m", UseCase: "c"}
+}
+
+func TestRecordRejectsInvalidKeyFields(t *testing.T) {
+	s, err := NewMemoryStore(MemoryStoreConfig{})
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+	cases := []FeedbackKey{
+		{Provider: "", Model: "m", UseCase: "c"},
+		{Provider: "p", Model: "", UseCase: "c"},
+		{Provider: "p", Model: "m", UseCase: ""},
+	}
+	for _, k := range cases {
+		t.Run("", func(t *testing.T) {
+			err := s.Record(context.Background(), k, FeedbackSignal{Kind: RoutingSignalSuccess})
+			if !errors.Is(err, ErrInvalidFeedbackKey) {
+				t.Fatalf("Record err = %v, want ErrInvalidFeedbackKey", err)
+			}
+		})
+	}
+}
+
+func TestRecordRejectsUnknownKind(t *testing.T) {
+	s, _ := NewMemoryStore(MemoryStoreConfig{})
+	err := s.Record(context.Background(), validKey(), FeedbackSignal{Kind: RoutingSignalKind("nope")})
+	if !errors.Is(err, ErrUnknownSignalKind) {
+		t.Fatalf("err = %v, want ErrUnknownSignalKind", err)
+	}
+}
+
+func TestRecordRejectsBadStrength(t *testing.T) {
+	s, _ := NewMemoryStore(MemoryStoreConfig{})
+	nan := math.NaN()
+	inf := math.Inf(1)
+	cases := []*float64{&nan, &inf}
+	for _, sp := range cases {
+		err := s.Record(context.Background(), validKey(),
+			FeedbackSignal{Kind: RoutingSignalSuccess, Strength: sp})
+		if !errors.Is(err, ErrInvalidSignalStrength) {
+			t.Fatalf("Strength=%v err = %v, want ErrInvalidSignalStrength", *sp, err)
+		}
+	}
+}
+
+func TestRecordRejectsBadPayload(t *testing.T) {
+	s, _ := NewMemoryStore(MemoryStoreConfig{})
+	cases := []struct {
+		name string
+		sig  FeedbackSignal
+	}{
+		{"latency-without-positive-ms", FeedbackSignal{Kind: RoutingSignalLatency, LatencyMs: 0}},
+		{"latency-with-negative-ms", FeedbackSignal{Kind: RoutingSignalLatency, LatencyMs: -1}},
+		{"success-with-latency-ms", FeedbackSignal{Kind: RoutingSignalSuccess, LatencyMs: 100}},
+		{"failure-without-class", FeedbackSignal{Kind: RoutingSignalFailure}},
+		{"success-with-error-class", FeedbackSignal{Kind: RoutingSignalSuccess, ErrorClass: "5xx"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := s.Record(context.Background(), validKey(), tc.sig)
+			if !errors.Is(err, ErrInvalidSignalPayload) {
+				t.Fatalf("err = %v, want ErrInvalidSignalPayload", err)
+			}
+		})
+	}
+}
+
+func TestRecordRejectsOversizedMeta(t *testing.T) {
+	s, _ := NewMemoryStore(MemoryStoreConfig{MaxMetaKeys: 2, MaxMetaValueBytes: 3})
+	too := map[string]string{"a": "1", "b": "2", "c": "3"}
+	if err := s.Record(context.Background(), validKey(),
+		FeedbackSignal{Kind: RoutingSignalSuccess, Meta: too}); !errors.Is(err, ErrMetaTooLarge) {
+		t.Fatalf("too-many-keys err = %v, want ErrMetaTooLarge", err)
+	}
+	big := map[string]string{"a": strings.Repeat("x", 4)}
+	if err := s.Record(context.Background(), validKey(),
+		FeedbackSignal{Kind: RoutingSignalSuccess, Meta: big}); !errors.Is(err, ErrMetaTooLarge) {
+		t.Fatalf("oversize-value err = %v, want ErrMetaTooLarge", err)
+	}
+}
+
+func TestRecordAcceptsValidSignalAndDefaultsAt(t *testing.T) {
+	s, _ := NewMemoryStore(MemoryStoreConfig{})
+	before := time.Now()
+	if err := s.Record(context.Background(), validKey(),
+		FeedbackSignal{Kind: RoutingSignalSuccess}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	after := time.Now()
+	agg, _ := s.Get(context.Background(), validKey())
+	if agg.SampleCount != 1 {
+		t.Fatalf("SampleCount = %d, want 1", agg.SampleCount)
+	}
+	// UpdatedAt may or may not be exposed depending on the Get formula
+	// in Task 5's intermediate state; only assert if it's non-zero.
+	if !agg.UpdatedAt.IsZero() {
+		if agg.UpdatedAt.Before(before) || agg.UpdatedAt.After(after.Add(time.Second)) {
+			t.Fatalf("UpdatedAt %v outside [%v, %v]", agg.UpdatedAt, before, after)
+		}
+	}
+}
+
+func TestRecordDefensiveCopiesStrengthAndMeta(t *testing.T) {
+	s, _ := NewMemoryStore(MemoryStoreConfig{})
+	strength := +0.9
+	meta := map[string]string{"key": "v1"}
+	sig := FeedbackSignal{
+		Kind:     RoutingSignalSuccess,
+		Strength: &strength,
+		Meta:     meta,
+	}
+	if err := s.Record(context.Background(), validKey(), sig); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	// Mutate caller-owned values after Record returns; stored data must
+	// not change.
+	strength = -1.0
+	meta["key"] = "v2"
+	meta["extra"] = "v3"
+
+	// We cannot directly read internal signals (no exported accessor); the
+	// canonical assertion is via Get once Task 6 lands the formula. For
+	// Task 5 we assert SampleCount is still 1 and Get does not panic.
+	agg, _ := s.Get(context.Background(), validKey())
+	if agg.SampleCount != 1 {
+		t.Fatalf("SampleCount = %d, want 1", agg.SampleCount)
+	}
+}
+
+func TestRecordFIFOBound(t *testing.T) {
+	s, _ := NewMemoryStore(MemoryStoreConfig{MaxRetainedSamples: 3})
+	for i := 0; i < 5; i++ {
+		if err := s.Record(context.Background(), validKey(),
+			FeedbackSignal{Kind: RoutingSignalSuccess}); err != nil {
+			t.Fatalf("Record %d: %v", i, err)
+		}
+	}
+	agg, _ := s.Get(context.Background(), validKey())
+	if agg.SampleCount != 3 {
+		t.Fatalf("SampleCount = %d, want 3 (FIFO-capped)", agg.SampleCount)
+	}
+}
+
+func TestRecordUnboundedMode(t *testing.T) {
+	s, _ := NewMemoryStore(MemoryStoreConfig{MaxRetainedSamples: -1})
+	for i := 0; i < 50; i++ {
+		if err := s.Record(context.Background(), validKey(),
+			FeedbackSignal{Kind: RoutingSignalSuccess}); err != nil {
+			t.Fatalf("Record %d: %v", i, err)
+		}
+	}
+	agg, _ := s.Get(context.Background(), validKey())
+	if agg.SampleCount != 50 {
+		t.Fatalf("SampleCount = %d, want 50", agg.SampleCount)
 	}
 }

--- a/provider/routing_feedback_test.go
+++ b/provider/routing_feedback_test.go
@@ -375,3 +375,124 @@ func TestRecordUnboundedMode(t *testing.T) {
 		t.Fatalf("SampleCount = %d, want 50", agg.SampleCount)
 	}
 }
+
+func mustStore(t *testing.T, cfg MemoryStoreConfig) *MemoryStore {
+	t.Helper()
+	s, err := NewMemoryStore(cfg)
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+	return s
+}
+
+func TestGetSingleSuccess(t *testing.T) {
+	s := mustStore(t, MemoryStoreConfig{})
+	if err := s.Record(context.Background(), validKey(),
+		FeedbackSignal{Kind: RoutingSignalSuccess}); err != nil {
+		t.Fatal(err)
+	}
+	agg, _ := s.Get(context.Background(), validKey())
+	if agg.Score != 0.75 {
+		t.Fatalf("Score = %v, want 0.75", agg.Score)
+	}
+	if agg.SampleCount != 1 || agg.ScoredCount != 1 {
+		t.Fatalf("counts = (sample=%d, scored=%d), want (1,1)", agg.SampleCount, agg.ScoredCount)
+	}
+}
+
+func TestGetSingleFailure(t *testing.T) {
+	s := mustStore(t, MemoryStoreConfig{})
+	if err := s.Record(context.Background(), validKey(),
+		FeedbackSignal{Kind: RoutingSignalFailure, ErrorClass: "5xx"}); err != nil {
+		t.Fatal(err)
+	}
+	agg, _ := s.Get(context.Background(), validKey())
+	// 0.5 + 0.5*(-0.7) = 0.15; allow 1 ULP of float64 rounding.
+	const want = 0.15
+	if math.Abs(agg.Score-want) > 1e-15 {
+		t.Fatalf("Score = %v, want %v", agg.Score, want)
+	}
+	if agg.ScoredCount != 1 {
+		t.Fatalf("ScoredCount = %d, want 1", agg.ScoredCount)
+	}
+}
+
+func TestGetLatencyDoesNotShiftScore(t *testing.T) {
+	s := mustStore(t, MemoryStoreConfig{})
+	mustRecord(t, s, RoutingSignalSuccess, "", 0)
+	mustRecord(t, s, RoutingSignalLatency, "", 820)
+	agg, _ := s.Get(context.Background(), validKey())
+	if agg.Score != 0.75 {
+		t.Fatalf("Score = %v, want 0.75 (Latency must not dilute)", agg.Score)
+	}
+	if agg.SampleCount != 2 || agg.ScoredCount != 1 {
+		t.Fatalf("counts = (sample=%d, scored=%d), want (2,1)", agg.SampleCount, agg.ScoredCount)
+	}
+}
+
+func TestGetAllLatencyIsNeutralWithSampleCount(t *testing.T) {
+	s := mustStore(t, MemoryStoreConfig{})
+	for i := 0; i < 3; i++ {
+		mustRecord(t, s, RoutingSignalLatency, "", 100)
+	}
+	agg, _ := s.Get(context.Background(), validKey())
+	if agg.Score != 0.5 {
+		t.Fatalf("Score = %v, want 0.5", agg.Score)
+	}
+	if agg.SampleCount != 3 || agg.ScoredCount != 0 {
+		t.Fatalf("counts = (sample=%d, scored=%d), want (3,0)", agg.SampleCount, agg.ScoredCount)
+	}
+}
+
+func TestGetExplicitNeutralStrengthCountsAsSampleOnly(t *testing.T) {
+	s := mustStore(t, MemoryStoreConfig{})
+	zero := 0.0
+	if err := s.Record(context.Background(), validKey(),
+		FeedbackSignal{Kind: RoutingSignalSuccess, Strength: &zero}); err != nil {
+		t.Fatal(err)
+	}
+	agg, _ := s.Get(context.Background(), validKey())
+	if agg.Score != 0.5 {
+		t.Fatalf("Score = %v, want 0.5 (explicit-neutral Success is sample-only)", agg.Score)
+	}
+	if agg.SampleCount != 1 || agg.ScoredCount != 0 {
+		t.Fatalf("counts = (sample=%d, scored=%d), want (1,0)", agg.SampleCount, agg.ScoredCount)
+	}
+}
+
+func TestGetStrengthClipping(t *testing.T) {
+	s := mustStore(t, MemoryStoreConfig{})
+	too := -5.0
+	if err := s.Record(context.Background(), validKey(),
+		FeedbackSignal{Kind: RoutingSignalSuccess, Strength: &too}); err != nil {
+		t.Fatal(err)
+	}
+	agg, _ := s.Get(context.Background(), validKey())
+	// Clipping at -1.0 → mean = -1.0 → score = 0.0.
+	if agg.Score != 0.0 {
+		t.Fatalf("Score = %v, want 0.0 (clipped at -1)", agg.Score)
+	}
+}
+
+// mustRecord is a helper that records a well-formed signal of the given
+// kind and fails the test on error. ErrorClass and LatencyMs are
+// auto-applied based on kind so payload validation is satisfied.
+func mustRecord(t *testing.T, s *MemoryStore, kind RoutingSignalKind, errorClass string, latencyMs int64) {
+	t.Helper()
+	sig := FeedbackSignal{Kind: kind}
+	switch kind {
+	case RoutingSignalFailure:
+		if errorClass == "" {
+			errorClass = "5xx"
+		}
+		sig.ErrorClass = errorClass
+	case RoutingSignalLatency:
+		if latencyMs == 0 {
+			latencyMs = 100
+		}
+		sig.LatencyMs = latencyMs
+	}
+	if err := s.Record(context.Background(), validKey(), sig); err != nil {
+		t.Fatalf("Record(%s): %v", kind, err)
+	}
+}

--- a/provider/routing_feedback_test.go
+++ b/provider/routing_feedback_test.go
@@ -514,3 +514,75 @@ func TestGetMixedSuccessAndFailure(t *testing.T) {
 		t.Fatalf("counts = (sample=%d, scored=%d), want (2,2)", agg.SampleCount, agg.ScoredCount)
 	}
 }
+
+func TestRecordBatchAppliesValidItems(t *testing.T) {
+	s := mustStore(t, MemoryStoreConfig{})
+	items := []FeedbackItem{
+		{Key: validKey(), Signal: FeedbackSignal{Kind: RoutingSignalSuccess}},
+		{Key: validKey(), Signal: FeedbackSignal{Kind: RoutingSignalLatency, LatencyMs: 100}},
+	}
+	if err := s.RecordBatch(context.Background(), items); err != nil {
+		t.Fatalf("RecordBatch: %v", err)
+	}
+	agg, _ := s.Get(context.Background(), validKey())
+	if agg.SampleCount != 2 || agg.ScoredCount != 1 {
+		t.Fatalf("counts = (sample=%d, scored=%d), want (2,1)", agg.SampleCount, agg.ScoredCount)
+	}
+}
+
+func TestRecordBatchRejectsAnyInvalidItemAtomically(t *testing.T) {
+	s := mustStore(t, MemoryStoreConfig{})
+	items := []FeedbackItem{
+		{Key: validKey(), Signal: FeedbackSignal{Kind: RoutingSignalSuccess}},
+		{Key: FeedbackKey{}, Signal: FeedbackSignal{Kind: RoutingSignalSuccess}}, // invalid key
+	}
+	if err := s.RecordBatch(context.Background(), items); !errors.Is(err, ErrInvalidFeedbackKey) {
+		t.Fatalf("err = %v, want ErrInvalidFeedbackKey", err)
+	}
+	agg, _ := s.Get(context.Background(), validKey())
+	if agg.SampleCount != 0 {
+		t.Fatalf("SampleCount = %d, want 0 (no item should have been persisted)", agg.SampleCount)
+	}
+}
+
+func TestRecordBatchEmptyIsNoOp(t *testing.T) {
+	s := mustStore(t, MemoryStoreConfig{})
+	if err := s.RecordBatch(context.Background(), nil); err != nil {
+		t.Fatalf("nil items: %v", err)
+	}
+	if err := s.RecordBatch(context.Background(), []FeedbackItem{}); err != nil {
+		t.Fatalf("empty items: %v", err)
+	}
+}
+
+func TestRecordBatchSharesTimestampDefault(t *testing.T) {
+	s := mustStore(t, MemoryStoreConfig{})
+	items := []FeedbackItem{
+		{Key: validKey(), Signal: FeedbackSignal{Kind: RoutingSignalSuccess}},
+		{Key: validKey(), Signal: FeedbackSignal{Kind: RoutingSignalLatency, LatencyMs: 100}},
+	}
+	before := time.Now()
+	if err := s.RecordBatch(context.Background(), items); err != nil {
+		t.Fatal(err)
+	}
+	after := time.Now()
+	agg, _ := s.Get(context.Background(), validKey())
+	if agg.UpdatedAt.Before(before) || agg.UpdatedAt.After(after.Add(time.Second)) {
+		t.Fatalf("UpdatedAt %v outside [%v, %v]", agg.UpdatedAt, before, after)
+	}
+}
+
+func TestRecordBatchTinyCapKeepsAtomicity(t *testing.T) {
+	s := mustStore(t, MemoryStoreConfig{MaxRetainedSamples: 1})
+	items := []FeedbackItem{
+		{Key: validKey(), Signal: FeedbackSignal{Kind: RoutingSignalSuccess}},
+		{Key: validKey(), Signal: FeedbackSignal{Kind: RoutingSignalLatency, LatencyMs: 100}},
+	}
+	if err := s.RecordBatch(context.Background(), items); err != nil {
+		t.Fatal(err)
+	}
+	agg, _ := s.Get(context.Background(), validKey())
+	if agg.SampleCount != 1 {
+		t.Fatalf("SampleCount = %d, want 1 (tiny cap retains newest only)", agg.SampleCount)
+	}
+}

--- a/provider/routing_feedback_test.go
+++ b/provider/routing_feedback_test.go
@@ -104,7 +104,7 @@ func TestNewRouteIDProducesDistinct32CharHex(t *testing.T) {
 		t.Fatalf("two consecutive newRouteID() values collided: %q", id1)
 	}
 	for _, c := range id1 {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
 			t.Fatalf("newRouteID() returned non-hex char %q in %q", c, id1)
 		}
 	}
@@ -178,6 +178,24 @@ func TestNewMemoryStoreRejectsOutOfRangeNeutralScore(t *testing.T) {
 			_, err := NewMemoryStore(MemoryStoreConfig{NeutralScore: n})
 			if err == nil {
 				t.Fatalf("NewMemoryStore(NeutralScore=%v) returned nil error", n)
+			}
+		})
+	}
+}
+
+func TestNewMemoryStoreRejectsInvalidLimits(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  MemoryStoreConfig
+	}{
+		{"retained-less-than-negative-one", MemoryStoreConfig{MaxRetainedSamples: -2}},
+		{"negative-meta-keys", MemoryStoreConfig{MaxMetaKeys: -1}},
+		{"negative-meta-value-bytes", MemoryStoreConfig{MaxMetaValueBytes: -1}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := NewMemoryStore(tc.cfg); err == nil {
+				t.Fatal("NewMemoryStore returned nil error")
 			}
 		})
 	}
@@ -666,6 +684,9 @@ func TestRecordOutcomeNilAttemptsIsNoOp(t *testing.T) {
 	rf := NewRoutingFeedback(mustStore(t, MemoryStoreConfig{}))
 	if err := rf.RecordOutcome(context.Background(), "chat", RouteOutcome{}); err != nil {
 		t.Fatalf("nil Attempts: %v", err)
+	}
+	if err := rf.RecordOutcome(context.Background(), "", RouteOutcome{}); err != nil {
+		t.Fatalf("nil Attempts with empty useCase: %v", err)
 	}
 }
 

--- a/provider/routing_feedback_test.go
+++ b/provider/routing_feedback_test.go
@@ -200,6 +200,38 @@ func validKey() FeedbackKey {
 	return FeedbackKey{Provider: "p", Model: "m", UseCase: "c"}
 }
 
+func mustStore(t *testing.T, cfg MemoryStoreConfig) *MemoryStore {
+	t.Helper()
+	s, err := NewMemoryStore(cfg)
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+	return s
+}
+
+// mustRecord is a helper that records a well-formed signal of the given
+// kind and fails the test on error. ErrorClass and LatencyMs are
+// auto-applied based on kind so payload validation is satisfied.
+func mustRecord(t *testing.T, s *MemoryStore, kind RoutingSignalKind, errorClass string, latencyMs int64) {
+	t.Helper()
+	sig := FeedbackSignal{Kind: kind}
+	switch kind {
+	case RoutingSignalFailure:
+		if errorClass == "" {
+			errorClass = "5xx"
+		}
+		sig.ErrorClass = errorClass
+	case RoutingSignalLatency:
+		if latencyMs == 0 {
+			latencyMs = 100
+		}
+		sig.LatencyMs = latencyMs
+	}
+	if err := s.Record(context.Background(), validKey(), sig); err != nil {
+		t.Fatalf("Record(%s): %v", kind, err)
+	}
+}
+
 func TestRecordRejectsInvalidKeyFields(t *testing.T) {
 	s, err := NewMemoryStore(MemoryStoreConfig{})
 	if err != nil {
@@ -376,15 +408,6 @@ func TestRecordUnboundedMode(t *testing.T) {
 	}
 }
 
-func mustStore(t *testing.T, cfg MemoryStoreConfig) *MemoryStore {
-	t.Helper()
-	s, err := NewMemoryStore(cfg)
-	if err != nil {
-		t.Fatalf("NewMemoryStore: %v", err)
-	}
-	return s
-}
-
 func TestGetSingleSuccess(t *testing.T) {
 	s := mustStore(t, MemoryStoreConfig{})
 	if err := s.Record(context.Background(), validKey(),
@@ -474,25 +497,20 @@ func TestGetStrengthClipping(t *testing.T) {
 	}
 }
 
-// mustRecord is a helper that records a well-formed signal of the given
-// kind and fails the test on error. ErrorClass and LatencyMs are
-// auto-applied based on kind so payload validation is satisfied.
-func mustRecord(t *testing.T, s *MemoryStore, kind RoutingSignalKind, errorClass string, latencyMs int64) {
-	t.Helper()
-	sig := FeedbackSignal{Kind: kind}
-	switch kind {
-	case RoutingSignalFailure:
-		if errorClass == "" {
-			errorClass = "5xx"
-		}
-		sig.ErrorClass = errorClass
-	case RoutingSignalLatency:
-		if latencyMs == 0 {
-			latencyMs = 100
-		}
-		sig.LatencyMs = latencyMs
+func TestGetMixedSuccessAndFailure(t *testing.T) {
+	// Exercises the multi-scored division path: two score-bearing signals
+	// with opposite signs. Without this case, the formula could regress
+	// into scored==1 special-casing without any TestGet* failure.
+	s := mustStore(t, MemoryStoreConfig{})
+	mustRecord(t, s, RoutingSignalSuccess, "", 0) // +0.5
+	mustRecord(t, s, RoutingSignalFailure, "", 0) // -0.7 (5xx)
+	agg, _ := s.Get(context.Background(), validKey())
+	// mean = (0.5 + (-0.7)) / 2 = -0.1; score = 0.5 + 0.5 * -0.1 = 0.45.
+	const want = 0.45
+	if math.Abs(agg.Score-want) > 1e-15 {
+		t.Fatalf("Score = %v, want %v (within 1e-15)", agg.Score, want)
 	}
-	if err := s.Record(context.Background(), validKey(), sig); err != nil {
-		t.Fatalf("Record(%s): %v", kind, err)
+	if agg.SampleCount != 2 || agg.ScoredCount != 2 {
+		t.Fatalf("counts = (sample=%d, scored=%d), want (2,2)", agg.SampleCount, agg.ScoredCount)
 	}
 }

--- a/provider/routing_feedback_test.go
+++ b/provider/routing_feedback_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -123,5 +124,26 @@ func TestBuildOutcomePopulatesRouteID(t *testing.T) {
 	}
 	if len(out.Attempts) != 0 {
 		t.Fatalf("Attempts populated by buildOutcome (len=%d); PR2 owns this", len(out.Attempts))
+	}
+}
+
+// routeIDFailingReader is an io.Reader stub for TestNewRouteIDReturnsEmptyOnRandFailure;
+// every Read returns an error so newRouteID exercises its empty-string-on-error
+// branch deterministically.
+type routeIDFailingReader struct{}
+
+func (routeIDFailingReader) Read(_ []byte) (int, error) {
+	return 0, errRouteIDForcedFailure
+}
+
+var errRouteIDForcedFailure = errors.New("forced route id read failure")
+
+func TestNewRouteIDReturnsEmptyOnRandFailure(t *testing.T) {
+	orig := routeIDRand
+	routeIDRand = routeIDFailingReader{}
+	t.Cleanup(func() { routeIDRand = orig })
+
+	if got := newRouteID(); got != "" {
+		t.Fatalf("newRouteID() = %q, want empty string on RNG failure", got)
 	}
 }

--- a/provider/routing_feedback_test.go
+++ b/provider/routing_feedback_test.go
@@ -140,6 +140,18 @@ func (routeIDFailingReader) Read(_ []byte) (int, error) {
 	return 0, errRouteIDForcedFailure
 }
 
+type routeIDShortReader struct {
+	read bool
+}
+
+func (r *routeIDShortReader) Read(p []byte) (int, error) {
+	if r.read {
+		return 0, errRouteIDForcedFailure
+	}
+	r.read = true
+	return copy(p, []byte{1, 2, 3, 4}), nil
+}
+
 var errRouteIDForcedFailure = errors.New("forced route id read failure")
 
 func TestNewRouteIDReturnsEmptyOnRandFailure(t *testing.T) {
@@ -149,6 +161,16 @@ func TestNewRouteIDReturnsEmptyOnRandFailure(t *testing.T) {
 
 	if got := newRouteID(); got != "" {
 		t.Fatalf("newRouteID() = %q, want empty string on RNG failure", got)
+	}
+}
+
+func TestNewRouteIDReturnsEmptyOnShortRandRead(t *testing.T) {
+	orig := routeIDRand
+	routeIDRand = &routeIDShortReader{}
+	t.Cleanup(func() { routeIDRand = orig })
+
+	if got := newRouteID(); got != "" {
+		t.Fatalf("newRouteID() = %q, want empty string on short RNG read", got)
 	}
 }
 

--- a/provider/routing_feedback_test.go
+++ b/provider/routing_feedback_test.go
@@ -739,6 +739,20 @@ func TestRecordOutcomeSuccessOnlyEmitsSuccessAndLatency(t *testing.T) {
 	if agg.ScoredCount != 1 {
 		t.Fatalf("ScoredCount = %d, want 1", agg.ScoredCount)
 	}
+	// Verify RouteID propagation: every emitted signal must carry the
+	// outcome's RouteID. Aggregate has no RouteID field, so we inspect
+	// store.signals directly.
+	store.mu.Lock()
+	sigs := store.signals[key]
+	store.mu.Unlock()
+	if len(sigs) != 2 {
+		t.Fatalf("stored signals = %d, want 2", len(sigs))
+	}
+	for i, sig := range sigs {
+		if sig.RouteID != "route-1" {
+			t.Errorf("sigs[%d].RouteID = %q, want \"route-1\"", i, sig.RouteID)
+		}
+	}
 }
 
 func TestRecordOutcomeFailureCarriesErrorClass(t *testing.T) {
@@ -825,5 +839,31 @@ func TestRecordOutcomeLatencyOmittedWhenNotMeasured(t *testing.T) {
 	agg, _ := store.Get(context.Background(), key)
 	if agg.SampleCount != 1 {
 		t.Fatalf("SampleCount = %d, want 1 (no Latency emitted when LatencyMs <= 0)", agg.SampleCount)
+	}
+}
+
+func TestRecordOutcomeRejectsNegativeLatencyAtomically(t *testing.T) {
+	store := mustStore(t, MemoryStoreConfig{})
+	rf := NewRoutingFeedback(store)
+	out := RouteOutcome{
+		Attempts: []RouteAttempt{
+			mkAttempt("p", "m", AttemptStatusSucceeded, 100, ""),
+			mkAttempt("p2", "m2", AttemptStatusSucceeded, -1, ""),
+		},
+	}
+	err := rf.RecordOutcome(context.Background(), "chat", out)
+	if !errors.Is(err, ErrInvalidSignalPayload) {
+		t.Fatalf("err = %v, want ErrInvalidSignalPayload", err)
+	}
+	// Atomicity: neither attempt's signals should have been persisted,
+	// even though the first attempt was valid.
+	for _, k := range []FeedbackKey{
+		{Provider: "p", Model: "m", UseCase: "chat"},
+		{Provider: "p2", Model: "m2", UseCase: "chat"},
+	} {
+		agg, _ := store.Get(context.Background(), k)
+		if agg.SampleCount != 0 {
+			t.Fatalf("key %+v SampleCount = %d, want 0 (atomic rejection)", k, agg.SampleCount)
+		}
 	}
 }

--- a/provider/routing_feedback_test.go
+++ b/provider/routing_feedback_test.go
@@ -1,6 +1,9 @@
 package provider
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestDefaultStrength(t *testing.T) {
 	cases := []struct {
@@ -19,4 +22,80 @@ func TestDefaultStrength(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAttemptStatusString(t *testing.T) {
+	cases := []struct {
+		s    AttemptStatus
+		want string
+	}{
+		{AttemptStatusUnknown, "unknown"},
+		{AttemptStatusSucceeded, "succeeded"},
+		{AttemptStatusFailed, "failed"},
+		{AttemptStatus(99), "unknown"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			if got := tc.s.String(); got != tc.want {
+				t.Fatalf("String() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAttemptStatusJSON(t *testing.T) {
+	type wrap struct {
+		S AttemptStatus `json:"s"`
+	}
+	cases := []struct {
+		in   AttemptStatus
+		want string
+	}{
+		{AttemptStatusUnknown, `{"s":"unknown"}`},
+		{AttemptStatusSucceeded, `{"s":"succeeded"}`},
+		{AttemptStatusFailed, `{"s":"failed"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in.String(), func(t *testing.T) {
+			got, err := json.Marshal(wrap{S: tc.in})
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Fatalf("got %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRouteOutcomeJSONOmitsEmptyNewFields(t *testing.T) {
+	out := RouteOutcome{} // zero-valued
+	b, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	s := string(b)
+	if got := s; got == "" {
+		t.Fatalf("empty marshal")
+	}
+	// Forward-compatible expectation: zero-value Attempts/RouteID must be
+	// absent from the JSON output so existing consumers see no new keys.
+	for _, key := range []string{`"attempts"`, `"route_id"`} {
+		if contains(s, key) {
+			t.Errorf("RouteOutcome JSON %s unexpectedly contains %s", s, key)
+		}
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || indexOf(s, substr) >= 0)
+}
+
+func indexOf(s, substr string) int {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
 }

--- a/provider/types.go
+++ b/provider/types.go
@@ -417,10 +417,54 @@ type CompletionConfidence struct {
 // Route outcome
 // ---------------------------------------------------------------------------
 
+// AttemptStatus encodes the outcome of a single execution attempt within a
+// RoutePlan. AttemptStatusUnknown (the zero value) signals "no information"
+// and is treated by the RoutingFeedback seam as a no-op rather than as a
+// failure. AttemptStatus values out of range serialize as "unknown" but are
+// rejected by the seam's validation.
+type AttemptStatus int
+
+const (
+	AttemptStatusUnknown AttemptStatus = iota
+	AttemptStatusSucceeded
+	AttemptStatusFailed
+)
+
+// String returns the lowercase tag for this status. Out-of-range values
+// stringify as "unknown" so accidental logging is harmless; seam-level
+// validation still rejects them.
+func (s AttemptStatus) String() string {
+	switch s {
+	case AttemptStatusSucceeded:
+		return "succeeded"
+	case AttemptStatusFailed:
+		return "failed"
+	default:
+		return "unknown"
+	}
+}
+
+// MarshalJSON encodes AttemptStatus as its String() tag for human-readable
+// diagnostics in serialized RouteOutcome.Attempts.
+func (s AttemptStatus) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + s.String() + `"`), nil
+}
+
+// RouteAttempt records one execution attempt against a specific
+// provider/model. PR2's RoutePlan.handleResult populates these per attempt;
+// PR1 only declares the type.
+type RouteAttempt struct {
+	Key        ModelKey      `json:"key"`
+	Status     AttemptStatus `json:"status"`
+	LatencyMs  int64         `json:"latency_ms,omitempty"`
+	ErrorClass string        `json:"error_class,omitempty"`
+}
+
 // RouteOutcome captures the Router's decision metadata for a request.
-// It records which model was originally planned, which model actually served
-// the request (after any fallbacks), and scoring information. This is attached
-// to response types so callers can observe routing decisions.
+// Provider responses copy a pointer to a RouteOutcome onto Chat/Generate/
+// Embed responses so callers can observe planned vs actual model, sticky
+// state, score, fallback usage, the per-attempt trace, and a route-scoped
+// correlation ID.
 type RouteOutcome struct {
 	PlannedModel  ModelKey `json:"planned_model"`
 	ActualModel   ModelKey `json:"actual_model"`
@@ -428,6 +472,18 @@ type RouteOutcome struct {
 	WasSticky     bool     `json:"was_sticky"`
 	Score         float64  `json:"score"`
 	Reason        string   `json:"reason"`
+
+	// Attempts is the ordered list of execution attempts (primary first).
+	// Nil/empty pre-PR2 because nothing populates it yet; the
+	// RoutingFeedback seam treats nil as "no per-attempt data" and is a
+	// no-op. Post-PR2, len(Attempts) >= 1 on every executed plan.
+	Attempts []RouteAttempt `json:"attempts,omitempty"`
+
+	// RouteID is an opaque correlation ID generated at plan execution. The
+	// RoutingFeedback seam copies it into FeedbackSignal.RouteID; the
+	// future /v1/completions/feedback endpoint may attach a distinct
+	// client-visible CompletionID without conflating the two.
+	RouteID string `json:"route_id,omitempty"`
 }
 
 // ---------------------------------------------------------------------------

--- a/provider/types.go
+++ b/provider/types.go
@@ -425,9 +425,9 @@ type CompletionConfidence struct {
 type AttemptStatus int
 
 const (
-	AttemptStatusUnknown AttemptStatus = iota
-	AttemptStatusSucceeded
-	AttemptStatusFailed
+	AttemptStatusUnknown   AttemptStatus = iota // zero value: no info; skipped by feedback seam
+	AttemptStatusSucceeded                      // attempt completed without error
+	AttemptStatusFailed                         // attempt failed; see RouteAttempt.ErrorClass
 )
 
 // String returns the lowercase tag for this status. Out-of-range values


### PR DESCRIPTION
## Summary

Smallest first PR of Epic #48 Phase 5: introduces the `RoutingFeedback` seam — a provider/model/use-case keyed signal store distinct from the chunk-key-oriented `feedback.SignalStore` — and ships an in-memory implementation. PR2 will wire `RoutePlan.handleResult` to populate `RouteOutcome.Attempts` and call `RecordOutcome`; PR3 adds SQLite persistence and the scoring read in both `scoreAll` and `scoreChainStep`.

The seam's attribution is **per-attempt**, not per-request: a primary 5xx followed by a successful fallback debits the primary and credits the fallback. Locked in by `TestRecordOutcomePrimaryFailFallbackSucceedKeysSeparately`.

## What's in this PR

- `provider/routing_feedback.go` — `FeedbackKey`, `RoutingSignalKind` (Success/Failure/Latency), `FeedbackSignal` (with `Strength *float64`, `RouteID`, `CompletionID`), `Aggregate{Score, SampleCount, ScoredCount, UpdatedAt}`, `RoutingFeedbackStore` interface (`Get`/`Record`/`RecordBatch`), `RoutingFeedback` wrapper (`Score`, `Record`, `RecordOutcome`), six error sentinels, default-strength map.
- `provider/routing_feedback_memory.go` — `MemoryStore` with config-default resolution, validation, defensive copies of `Strength` pointer + `Meta` map, all-or-nothing `RecordBatch`, bounded per-key FIFO retention.
- `provider/types.go` — `AttemptStatus` enum (Unknown/Succeeded/Failed) with `String()`/`MarshalJSON()` emitting lowercase tags; `RouteAttempt` struct; `RouteOutcome += {Attempts []RouteAttempt, RouteID string}` with `omitempty` tags.
- `provider/route_plan.go` — `newRouteID()` helper (16-byte hex from `crypto/rand` with injectable seam for testability); `buildOutcome` populates `RouteID` (the only behavioral change to pre-existing code in PR1).

## What's NOT in this PR

- No `RoutingFeedback` field on `Router`, no SQLite store, no scoring read in `scoreCandidate`, no latency measurement, no error classification, no `Attempts` population (field exists; PR2 fills it), no `compat/chat.go:routeInfoFrom` change (`x_route_info` unchanged on the wire).

## Test plan

- [x] `go test ./provider/ -race -count=1` — 30+ new tests + existing suite green
- [x] `go test ./... -race -count=1` — all 15 module packages green
- [x] `go build ./... && go vet ./...` — clean (downstream packages unaffected by additive `RouteOutcome` fields)
- [x] `git diff --name-only develop..HEAD` — exactly 5 files modified, matching the spec's "Files touched" table
- [x] `TestRecordOutcomePrimaryFailFallbackSucceedKeysSeparately` — demonstrates per-attempt attribution (primary failed → Score 0.15 at primary key; fallback succeeded → Score 0.75 at fallback key)
- [x] `TestMemoryStoreConcurrentRecordAndGet` — 8 goroutines × 200 iterations under `-race`, sample-count invariant verified (1608 total)

## Sequencing

```
PR1 (this) ── seam + RouteAttempt + in-memory store
PR2        ── handleResult populates Attempts; ErrorClass classifier; RecordOutcome wiring
PR3        ── SQLite store; Router field; scoreCandidate context plumbing; opt-in scoring read; score-breakdown visibility
PR4        ── Harness #56 before/after comparison
PR5+       ── Epsilon-greedy; latency prediction; KV-cache routing; /v1/completions/feedback; FIM thread state
```

Generated with [Claude Code](https://claude.com/claude-code)