### PR TITLE
feat(llm-bench): judge cache + calibration workflow (#56 PR A)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ docs/spikes/
 docs/superpowers/
 docs/llm/traces/
 .DS_Store
+
+# llm-bench harness — local artifacts
+/llm-bench
+docs/llm/calibration/labels.jsonl
+docs/llm/calibration/artifacts.jsonl
+docs/llm/calibration/reports/

--- a/cmd/llm-bench/calibration.go
+++ b/cmd/llm-bench/calibration.go
@@ -143,3 +143,76 @@ func runCalibrateCapture(ctx context.Context, opts calibrateCaptureOptions) erro
 	}
 	return nil
 }
+
+// matchedLabel pairs a Label with its current Artifact so the calibration
+// loop can re-score the frozen output without re-running the candidate.
+type matchedLabel struct {
+	Label    Label
+	Artifact Artifact
+}
+
+// loadLabelsMatchedAgainst loads both files and partitions labels into
+// (matched, stale). A label is "stale" iff its ArtifactHash is not present
+// in artifactsPath. Stale labels are not errors — they're reported and
+// excluded from agreement.
+func loadLabelsMatchedAgainst(labelsPath, artifactsPath string) ([]matchedLabel, []Label, error) {
+	arts, err := loadArtifacts(artifactsPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load artifacts: %w", err)
+	}
+	byHash := make(map[string]Artifact, len(arts))
+	for _, a := range arts {
+		byHash[a.ArtifactHash] = a
+	}
+	labels, err := loadLabels(labelsPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load labels: %w", err)
+	}
+	var matched []matchedLabel
+	var stale []Label
+	for _, l := range labels {
+		a, ok := byHash[l.ArtifactHash]
+		if !ok {
+			stale = append(stale, l)
+			continue
+		}
+		matched = append(matched, matchedLabel{Label: l, Artifact: a})
+	}
+	return matched, stale, nil
+}
+
+func loadArtifacts(path string) ([]Artifact, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open %q: %w", path, err)
+	}
+	defer f.Close()
+	var out []Artifact
+	dec := json.NewDecoder(f)
+	for dec.More() {
+		var a Artifact
+		if err := dec.Decode(&a); err != nil {
+			return nil, fmt.Errorf("decode artifact: %w", err)
+		}
+		out = append(out, a)
+	}
+	return out, nil
+}
+
+func loadLabels(path string) ([]Label, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open %q: %w", path, err)
+	}
+	defer f.Close()
+	var out []Label
+	dec := json.NewDecoder(f)
+	for dec.More() {
+		var l Label
+		if err := dec.Decode(&l); err != nil {
+			return nil, fmt.Errorf("decode label: %w", err)
+		}
+		out = append(out, l)
+	}
+	return out, nil
+}

--- a/cmd/llm-bench/calibration.go
+++ b/cmd/llm-bench/calibration.go
@@ -226,9 +226,10 @@ const (
 // calibrateOptions configures runCalibrate.
 //
 // MinLabels defaults to calibrationDefaultMinLabels (50) when zero so a
-// sufficient sample backs the agreement verdict. StabilityRuns is reserved
-// for Task 20 (judge stability spread) and currently ignored. Clock is an
-// optional time source for deterministic report filenames.
+// sufficient sample backs the agreement verdict. StabilityRuns, when >1,
+// runs the judge N times per artifact and reports the max-min agreement
+// spread as a diagnostic; it does NOT gate the PASS/FAIL verdict. Clock is
+// an optional time source for deterministic report filenames.
 type calibrateOptions struct {
 	LabelsPath    string
 	ArtifactsPath string

--- a/cmd/llm-bench/calibration.go
+++ b/cmd/llm-bench/calibration.go
@@ -333,7 +333,13 @@ func runCalibrate(ctx context.Context, opts calibrateOptions) (CalibrationResult
 		if opts.StabilityRuns > 1 {
 			scores := []float64{score.AnswerQuality}
 			for i := 1; i < opts.StabilityRuns; i++ {
-				extra, sErr := opts.Scorer.Score(ctx, trace, actual)
+				bypassScorer := opts.Scorer
+				if cs, ok := opts.Scorer.(*LLMJudgeScorer); ok {
+					clone := *cs
+					clone.BypassCache = true
+					bypassScorer = &clone
+				}
+				extra, sErr := bypassScorer.Score(ctx, trace, actual)
 				if sErr != nil {
 					return CalibrationResult{}, fmt.Errorf("calibrate: stability run %d for %s/%s: %w",
 						i, m.Artifact.TraceID, m.Artifact.CandidateModel, sErr)

--- a/cmd/llm-bench/calibration.go
+++ b/cmd/llm-bench/calibration.go
@@ -109,6 +109,13 @@ func runCalibrateCapture(ctx context.Context, opts calibrateCaptureOptions) (ret
 	if len(opts.Targets) == 0 {
 		return errors.New("calibrate-capture: no targets")
 	}
+	traceByID := make(map[string]Trace, len(opts.Traces))
+	for _, trace := range opts.Traces {
+		if _, ok := traceByID[trace.ID]; ok {
+			return fmt.Errorf("calibrate-capture: duplicate trace ID %q", trace.ID)
+		}
+		traceByID[trace.ID] = trace
+	}
 	results, err := opts.Runner.RunAll(ctx, opts.Targets, opts.Traces)
 	if err != nil {
 		return fmt.Errorf("calibrate-capture: run: %w", err)
@@ -117,11 +124,6 @@ func runCalibrateCapture(ctx context.Context, opts calibrateCaptureOptions) (ret
 	if opts.Clock != nil {
 		now = opts.Clock
 	}
-	traceByID := make(map[string]Trace, len(opts.Traces))
-	for _, trace := range opts.Traces {
-		traceByID[trace.ID] = trace
-	}
-
 	var artifacts []Artifact
 	failed := 0
 	for _, r := range results {

--- a/cmd/llm-bench/calibration.go
+++ b/cmd/llm-bench/calibration.go
@@ -216,3 +216,197 @@ func loadLabels(path string) ([]Label, error) {
 	}
 	return out, nil
 }
+
+const (
+	calibrationAgreementDelta   = 0.25
+	calibrationPassThreshold    = 0.85
+	calibrationDefaultMinLabels = 50
+)
+
+// calibrateOptions configures runCalibrate.
+//
+// MinLabels defaults to calibrationDefaultMinLabels (50) when zero so a
+// sufficient sample backs the agreement verdict. StabilityRuns is reserved
+// for Task 20 (judge stability spread) and currently ignored. Clock is an
+// optional time source for deterministic report filenames.
+type calibrateOptions struct {
+	LabelsPath    string
+	ArtifactsPath string
+	Scorer        Scorer
+	JudgeModel    string
+	ReportDir     string
+	MinLabels     int // defaults to calibrationDefaultMinLabels when zero
+	StabilityRuns int // when >1, runs judge that many times with bypass-cache (Task 20)
+	Clock         func() time.Time
+}
+
+// CalibrationResult is the in-memory summary returned by runCalibrate. The
+// markdown report contains the same data plus per-label rows.
+type CalibrationResult struct {
+	JudgeModel    string
+	MatchedCount  int
+	StaleCount    int
+	AgreeCount    int
+	AgreementRate float64
+	MinLabels     int
+	Verdict       string // PASS / FAIL / INSUFFICIENT_LABELS
+	ReportPath    string
+	PerLabel      []perLabelOutcome
+}
+
+// perLabelOutcome is one row of the calibration report: a label paired with
+// the judge's verdict on the same frozen artifact. StabilitySpread is
+// reserved for Task 20 (multi-run judge spread) and zero otherwise.
+type perLabelOutcome struct {
+	TraceID         string
+	CandidateModel  string
+	Expected        float64
+	Judge           float64
+	Delta           float64
+	Agree           bool
+	StabilitySpread float64
+}
+
+// runCalibrate loads (labels, artifacts), invokes the scorer once per
+// matched (label, artifact) pair, and computes the agreement rate against
+// human ExpectedAnswerQuality values. The verdict is INSUFFICIENT_LABELS
+// when MatchedCount < MinLabels, otherwise PASS when AgreementRate is at
+// least calibrationPassThreshold (0.85), else FAIL.
+//
+// The synthesized Trace inside the loop uses a placeholder System and a
+// single empty user turn so Scorer.Score's signature is satisfied. The
+// frozen ActualTranscript from the Artifact is what the scorer actually
+// reads from; live LLMJudgeScorer would need a transcript with an
+// assistant final answer, which the captured Artifact provides.
+//
+// When ReportDir is non-empty the markdown report is written and its path
+// stored on the returned result; otherwise no report is emitted.
+func runCalibrate(ctx context.Context, opts calibrateOptions) (CalibrationResult, error) {
+	if opts.Scorer == nil {
+		return CalibrationResult{}, errors.New("calibrate: nil scorer")
+	}
+	if opts.MinLabels == 0 {
+		opts.MinLabels = calibrationDefaultMinLabels
+	}
+	matched, stale, err := loadLabelsMatchedAgainst(opts.LabelsPath, opts.ArtifactsPath)
+	if err != nil {
+		return CalibrationResult{}, err
+	}
+	res := CalibrationResult{
+		JudgeModel:   opts.JudgeModel,
+		MatchedCount: len(matched),
+		StaleCount:   len(stale),
+		MinLabels:    opts.MinLabels,
+	}
+	for _, m := range matched {
+		// Construct a synthetic Trace and Result from the Label+Artifact
+		// so we can call Scorer.Score against the frozen output.
+		trace := Trace{
+			ID:     m.Artifact.TraceID,
+			System: "calibration",
+			Turns:  []Turn{{Role: "user", Content: ""}},
+			Golden: Golden{FinalAnswerCriteria: "frozen calibration artifact"},
+		}
+		actual := Result{
+			Model:      m.Artifact.CandidateModel,
+			TraceID:    m.Artifact.TraceID,
+			Transcript: m.Artifact.ActualTranscript,
+		}
+		score, scoreErr := opts.Scorer.Score(ctx, trace, actual)
+		if scoreErr != nil {
+			return CalibrationResult{}, fmt.Errorf("calibrate: scorer for %s/%s: %w",
+				m.Artifact.TraceID, m.Artifact.CandidateModel, scoreErr)
+		}
+		delta := score.AnswerQuality - m.Label.ExpectedAnswerQuality
+		if delta < 0 {
+			delta = -delta
+		}
+		outcome := perLabelOutcome{
+			TraceID:        m.Artifact.TraceID,
+			CandidateModel: m.Artifact.CandidateModel,
+			Expected:       m.Label.ExpectedAnswerQuality,
+			Judge:          score.AnswerQuality,
+			Delta:          delta,
+			Agree:          delta <= calibrationAgreementDelta,
+		}
+		res.PerLabel = append(res.PerLabel, outcome)
+		if outcome.Agree {
+			res.AgreeCount++
+		}
+	}
+	if res.MatchedCount > 0 {
+		res.AgreementRate = float64(res.AgreeCount) / float64(res.MatchedCount)
+	}
+	switch {
+	case res.MatchedCount < opts.MinLabels:
+		res.Verdict = "INSUFFICIENT_LABELS"
+	case res.AgreementRate >= calibrationPassThreshold:
+		res.Verdict = "PASS"
+	default:
+		res.Verdict = "FAIL"
+	}
+	if opts.ReportDir != "" {
+		path, writeErr := writeCalibrationReport(opts.ReportDir, opts.JudgeModel, res, opts.Clock)
+		if writeErr != nil {
+			return res, fmt.Errorf("calibrate: write report: %w", writeErr)
+		}
+		res.ReportPath = path
+	}
+	return res, nil
+}
+
+// slugifyModel makes a path-safe slug from a model selector by replacing
+// '/' and ':' with '_'. Example: "ollama/gemma4:31b" -> "ollama_gemma4_31b".
+func slugifyModel(s string) string {
+	out := strings.ReplaceAll(s, "/", "_")
+	return strings.ReplaceAll(out, ":", "_")
+}
+
+// writeCalibrationReport emits a markdown calibration report to dir with a
+// slugified, dated filename and returns the absolute path. Clock is the
+// time source used to stamp the filename and report header; defaults to
+// time.Now().UTC() when nil.
+func writeCalibrationReport(dir, judgeModel string, res CalibrationResult, clock func() time.Time) (string, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir %q: %w", dir, err)
+	}
+	now := time.Now().UTC()
+	if clock != nil {
+		now = clock()
+	}
+	path := fmt.Sprintf("%s/%s-%s.md", dir, now.Format("2006-01-02"), slugifyModel(judgeModel))
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return "", fmt.Errorf("open %q: %w", path, err)
+	}
+	defer f.Close()
+	fmt.Fprintf(f, "# Judge calibration — %s — %s\n\n", judgeModel, now.Format("2006-01-02"))
+	fmt.Fprintf(f, "Matched labels: %d / %d required → %s\n", res.MatchedCount, res.MinLabels, sufficiencyLabel(res))
+	fmt.Fprintf(f, "Stale labels: %d\n", res.StaleCount)
+	fmt.Fprintf(f, "Agreement: %d / %d (%.0f%%) → **%s**\n\n",
+		res.AgreeCount, res.MatchedCount, res.AgreementRate*100, res.Verdict)
+	fmt.Fprintln(f, "| trace_id | candidate | expected | judge | Δ | agree | stability |")
+	fmt.Fprintln(f, "|---|---|---|---|---|---|---|")
+	for _, p := range res.PerLabel {
+		agree := "✗"
+		if p.Agree {
+			agree = "✓"
+		}
+		stability := "n/a"
+		if p.StabilitySpread > 0 {
+			stability = fmt.Sprintf("spread=%.2f", p.StabilitySpread)
+		}
+		fmt.Fprintf(f, "| %s | %s | %.2f | %.2f | %.2f | %s | %s |\n",
+			p.TraceID, p.CandidateModel, p.Expected, p.Judge, p.Delta, agree, stability)
+	}
+	return path, nil
+}
+
+// sufficiencyLabel renders the matched-vs-required label-count state as a
+// short string for the report header.
+func sufficiencyLabel(res CalibrationResult) string {
+	if res.MatchedCount >= res.MinLabels {
+		return "SUFFICIENT"
+	}
+	return "INSUFFICIENT"
+}

--- a/cmd/llm-bench/calibration.go
+++ b/cmd/llm-bench/calibration.go
@@ -21,6 +21,7 @@ type Artifact struct {
 	TraceID           string    `json:"trace_id"`
 	CandidateModel    string    `json:"candidate_model"`
 	ArtifactHash      string    `json:"artifact_hash"`
+	Trace             Trace     `json:"trace"`
 	ActualFinalAnswer string    `json:"actual_final_answer"`
 	ActualToolCalls   []string  `json:"actual_tool_calls"`
 	ActualTranscript  []Turn    `json:"actual_transcript"`
@@ -49,6 +50,7 @@ type Label struct {
 type artifactHashInput struct {
 	TraceID           string   `json:"trace_id"`
 	CandidateModel    string   `json:"candidate_model"`
+	Trace             Trace    `json:"trace"`
 	ActualFinalAnswer string   `json:"actual_final_answer"`
 	ActualToolCalls   []string `json:"actual_tool_calls"`
 	ActualTranscript  []Turn   `json:"actual_transcript"`
@@ -61,6 +63,7 @@ func artifactHash(a Artifact) string {
 	raw, _ := json.Marshal(artifactHashInput{
 		TraceID:           normalizeModelSelector(a.TraceID),
 		CandidateModel:    normalizeModelSelector(a.CandidateModel),
+		Trace:             a.Trace,
 		ActualFinalAnswer: a.ActualFinalAnswer,
 		ActualToolCalls:   a.ActualToolCalls,
 		ActualTranscript:  a.ActualTranscript,
@@ -113,6 +116,10 @@ func runCalibrateCapture(ctx context.Context, opts calibrateCaptureOptions) (ret
 	if opts.Clock != nil {
 		now = opts.Clock
 	}
+	traceByID := make(map[string]Trace, len(opts.Traces))
+	for _, trace := range opts.Traces {
+		traceByID[trace.ID] = trace
+	}
 
 	if err := os.MkdirAll(filepath.Dir(opts.OutputPath), 0o755); err != nil {
 		return fmt.Errorf("calibrate-capture: mkdir: %w", err)
@@ -132,9 +139,14 @@ func runCalibrateCapture(ctx context.Context, opts calibrateCaptureOptions) (ret
 			// Skip failed runs — they cannot be labeled coherently.
 			continue
 		}
+		trace, ok := traceByID[r.TraceID]
+		if !ok {
+			return fmt.Errorf("calibrate-capture: result %s/%s has no matching trace context", r.TraceID, r.Model)
+		}
 		artifact := Artifact{
 			TraceID:           r.TraceID,
 			CandidateModel:    r.Model,
+			Trace:             trace,
 			ActualFinalAnswer: lastAssistantContent(r.Transcript),
 			ActualToolCalls:   extractToolNames(r.Transcript),
 			ActualTranscript:  r.Transcript,
@@ -306,13 +318,9 @@ func runCalibrate(ctx context.Context, opts calibrateOptions) (CalibrationResult
 		StabilityRuns: opts.StabilityRuns,
 	}
 	for _, m := range matched {
-		// Construct a synthetic Trace and Result from the Label+Artifact
-		// so we can call Scorer.Score against the frozen output.
-		trace := Trace{
-			ID:     m.Artifact.TraceID,
-			System: "calibration",
-			Turns:  []Turn{{Role: "user", Content: ""}},
-			Golden: Golden{FinalAnswerCriteria: "frozen calibration artifact"},
+		trace, traceErr := calibrationTraceFromArtifact(m.Artifact)
+		if traceErr != nil {
+			return CalibrationResult{}, traceErr
 		}
 		actual := Result{
 			Model:      m.Artifact.CandidateModel,
@@ -378,6 +386,26 @@ func runCalibrate(ctx context.Context, opts calibrateOptions) (CalibrationResult
 		res.ReportPath = path
 	}
 	return res, nil
+}
+
+func calibrationTraceFromArtifact(a Artifact) (Trace, error) {
+	trace := a.Trace
+	if strings.TrimSpace(trace.ID) == "" {
+		return Trace{}, fmt.Errorf("calibrate: artifact %s/%s missing original trace context", a.TraceID, a.CandidateModel)
+	}
+	if trace.ID != a.TraceID {
+		return Trace{}, fmt.Errorf("calibrate: artifact %s/%s trace ID mismatch: %q", a.TraceID, a.CandidateModel, trace.ID)
+	}
+	if strings.TrimSpace(trace.System) == "" {
+		return Trace{}, fmt.Errorf("calibrate: artifact %s/%s missing original trace system prompt", a.TraceID, a.CandidateModel)
+	}
+	if len(trace.Turns) == 0 {
+		return Trace{}, fmt.Errorf("calibrate: artifact %s/%s missing original trace turns", a.TraceID, a.CandidateModel)
+	}
+	if strings.TrimSpace(trace.Golden.FinalAnswerCriteria) == "" && strings.TrimSpace(trace.Golden.FinalAnswerSubstring) == "" {
+		return Trace{}, fmt.Errorf("calibrate: artifact %s/%s missing original trace golden rubric", a.TraceID, a.CandidateModel)
+	}
+	return trace, nil
 }
 
 // slugifyModel makes a path-safe slug from a model selector by replacing

--- a/cmd/llm-bench/calibration.go
+++ b/cmd/llm-bench/calibration.go
@@ -286,16 +286,17 @@ type calibrateOptions struct {
 // CalibrationResult is the in-memory summary returned by runCalibrate. The
 // markdown report contains the same data plus per-label rows.
 type CalibrationResult struct {
-	JudgeModel    string
-	MatchedCount  int
-	StaleCount    int
-	AgreeCount    int
-	AgreementRate float64
-	MinLabels     int
-	StabilityRuns int
-	Verdict       string // PASS / FAIL / INSUFFICIENT_LABELS
-	ReportPath    string
-	PerLabel      []perLabelOutcome
+	JudgeModel          string
+	MatchedCount        int
+	StaleCount          int
+	SelfJudgedSkipCount int
+	AgreeCount          int
+	AgreementRate       float64
+	MinLabels           int
+	StabilityRuns       int
+	Verdict             string // PASS / FAIL / INSUFFICIENT_LABELS
+	ReportPath          string
+	PerLabel            []perLabelOutcome
 }
 
 // perLabelOutcome is one row of the calibration report: a label paired with
@@ -338,12 +339,15 @@ func runCalibrate(ctx context.Context, opts calibrateOptions) (CalibrationResult
 	}
 	res := CalibrationResult{
 		JudgeModel:    opts.JudgeModel,
-		MatchedCount:  len(matched),
 		StaleCount:    len(stale),
 		MinLabels:     opts.MinLabels,
 		StabilityRuns: opts.StabilityRuns,
 	}
 	for _, m := range matched {
+		if sameModelSelector(opts.JudgeModel, m.Artifact.CandidateModel) {
+			res.SelfJudgedSkipCount++
+			continue
+		}
 		trace, traceErr := calibrationTraceFromArtifact(m.Artifact)
 		if traceErr != nil {
 			return CalibrationResult{}, traceErr
@@ -387,6 +391,7 @@ func runCalibrate(ctx context.Context, opts calibrateOptions) (CalibrationResult
 		if outcome.Agree {
 			res.AgreeCount++
 		}
+		res.MatchedCount++
 	}
 	if res.MatchedCount > 0 {
 		res.AgreementRate = float64(res.AgreeCount) / float64(res.MatchedCount)
@@ -464,6 +469,7 @@ func writeCalibrationReport(dir, judgeModel string, res CalibrationResult, clock
 	fmt.Fprintf(&b, "# Judge calibration — %s — %s\n\n", judgeModel, now.Format("2006-01-02"))
 	fmt.Fprintf(&b, "Matched labels: %d / %d required → %s\n", res.MatchedCount, res.MinLabels, sufficiencyLabel(res))
 	fmt.Fprintf(&b, "Stale labels: %d\n", res.StaleCount)
+	fmt.Fprintf(&b, "Self-judged labels skipped: %d\n", res.SelfJudgedSkipCount)
 	fmt.Fprintf(&b, "Agreement: %d / %d (%.0f%%) → **%s**\n\n",
 		res.AgreeCount, res.MatchedCount, res.AgreementRate*100, res.Verdict)
 	fmt.Fprintln(&b, "| trace_id | candidate | expected | judge | Δ | agree | stability |")

--- a/cmd/llm-bench/calibration.go
+++ b/cmd/llm-bench/calibration.go
@@ -1,10 +1,15 @@
 package main
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -62,4 +67,79 @@ func artifactHash(a Artifact) string {
 	})
 	sum := sha256.Sum256(raw)
 	return fmt.Sprintf("sha256:%s", hex.EncodeToString(sum[:]))
+}
+
+// calibrationRunner abstracts Runner.RunAll so calibration tests can
+// inject canned Results without needing a live Ollama.
+type calibrationRunner interface {
+	RunAll(ctx context.Context, targets []ModelTarget, traces []Trace) ([]Result, error)
+}
+
+// calibrateCaptureOptions configures runCalibrateCapture. Runner is the
+// (typically *Runner) replayer; Targets and Traces are forwarded to it;
+// OutputPath receives one JSONL Artifact per non-failed Result. Clock is
+// an optional time source for deterministic tests; defaults to time.Now
+// in UTC.
+type calibrateCaptureOptions struct {
+	Runner     calibrationRunner
+	Targets    []ModelTarget
+	Traces     []Trace
+	OutputPath string
+	Clock      func() time.Time
+}
+
+// runCalibrateCapture replays each (trace, candidate) and writes one
+// Artifact per non-failed Result to OutputPath as JSONL. Artifacts have
+// no ExpectedAnswerQuality — labels are a separate file the operator
+// hand-edits.
+func runCalibrateCapture(ctx context.Context, opts calibrateCaptureOptions) error {
+	if opts.Runner == nil {
+		return fmt.Errorf("calibrate-capture: nil runner")
+	}
+	if strings.TrimSpace(opts.OutputPath) == "" {
+		return fmt.Errorf("calibrate-capture: empty output path")
+	}
+	if len(opts.Traces) == 0 {
+		return errors.New("calibrate-capture: no traces")
+	}
+	if len(opts.Targets) == 0 {
+		return errors.New("calibrate-capture: no targets")
+	}
+	results, err := opts.Runner.RunAll(ctx, opts.Targets, opts.Traces)
+	if err != nil {
+		return fmt.Errorf("calibrate-capture: run: %w", err)
+	}
+	now := func() time.Time { return time.Now().UTC() }
+	if opts.Clock != nil {
+		now = opts.Clock
+	}
+
+	if err := os.MkdirAll(filepath.Dir(opts.OutputPath), 0o755); err != nil {
+		return fmt.Errorf("calibrate-capture: mkdir: %w", err)
+	}
+	f, err := os.OpenFile(opts.OutputPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("calibrate-capture: open output: %w", err)
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for _, r := range results {
+		if r.Err != nil {
+			// Skip failed runs — they cannot be labeled coherently.
+			continue
+		}
+		artifact := Artifact{
+			TraceID:           r.TraceID,
+			CandidateModel:    r.Model,
+			ActualFinalAnswer: lastAssistantContent(r.Transcript),
+			ActualToolCalls:   extractToolNames(r.Transcript),
+			ActualTranscript:  r.Transcript,
+			CapturedAt:        now(),
+		}
+		artifact.ArtifactHash = artifactHash(artifact)
+		if err := enc.Encode(artifact); err != nil {
+			return fmt.Errorf("calibrate-capture: encode artifact %s/%s: %w", artifact.TraceID, artifact.CandidateModel, err)
+		}
+	}
+	return nil
 }

--- a/cmd/llm-bench/calibration.go
+++ b/cmd/llm-bench/calibration.go
@@ -46,8 +46,8 @@ type Label struct {
 }
 
 // artifactHashInput is the canonical struct hashed to produce ArtifactHash.
-// Order-sensitive on tool calls and transcript turns; ID and candidate
-// model normalized to lowercase to avoid spurious mismatch from case.
+// Order-sensitive on trace IDs, tool calls, and transcript turns; candidate
+// model is normalized to lowercase to avoid spurious mismatch from case.
 type artifactHashInput struct {
 	TraceID           string   `json:"trace_id"`
 	CandidateModel    string   `json:"candidate_model"`
@@ -62,7 +62,7 @@ type artifactHashInput struct {
 // tool-call sequence order.
 func artifactHash(a Artifact) string {
 	raw, _ := json.Marshal(artifactHashInput{
-		TraceID:           normalizeModelSelector(a.TraceID),
+		TraceID:           a.TraceID,
 		CandidateModel:    normalizeModelSelector(a.CandidateModel),
 		Trace:             a.Trace,
 		ActualFinalAnswer: a.ActualFinalAnswer,
@@ -244,9 +244,17 @@ func loadLabels(path string) ([]Label, error) {
 		if err := dec.Decode(&l); err != nil {
 			return nil, fmt.Errorf("decode label: %w", err)
 		}
+		if !validExpectedAnswerQuality(l.ExpectedAnswerQuality) {
+			return nil, fmt.Errorf("invalid expected_answer_quality for label %s/%s: %.2f (want one of 0.0, 0.5, 1.0)",
+				l.TraceID, l.CandidateModel, l.ExpectedAnswerQuality)
+		}
 		out = append(out, l)
 	}
 	return out, nil
+}
+
+func validExpectedAnswerQuality(v float64) bool {
+	return v == 0 || v == 0.5 || v == 1
 }
 
 const (

--- a/cmd/llm-bench/calibration.go
+++ b/cmd/llm-bench/calibration.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Artifact is one frozen candidate output for a (trace, candidate model)
+// pair. Written by -calibrate-capture; consumed by -calibrate and by the
+// labeling workflow (humans add expected_answer_quality to corresponding
+// Label rows).
+type Artifact struct {
+	TraceID           string    `json:"trace_id"`
+	CandidateModel    string    `json:"candidate_model"`
+	ArtifactHash      string    `json:"artifact_hash"`
+	ActualFinalAnswer string    `json:"actual_final_answer"`
+	ActualToolCalls   []string  `json:"actual_tool_calls"`
+	ActualTranscript  []Turn    `json:"actual_transcript"`
+	CapturedAt        time.Time `json:"captured_at"`
+}
+
+// Label is the human-supplied truth for one frozen Artifact. ArtifactHash
+// links them: a Label with a hash that doesn't match any current Artifact
+// is "stale" and excluded from agreement.
+type Label struct {
+	TraceID               string    `json:"trace_id"`
+	CandidateModel        string    `json:"candidate_model"`
+	ArtifactHash          string    `json:"artifact_hash"`
+	ActualFinalAnswer     string    `json:"actual_final_answer,omitempty"`
+	ActualToolCalls       []string  `json:"actual_tool_calls,omitempty"`
+	ActualTranscript      []Turn    `json:"actual_transcript,omitempty"`
+	ExpectedAnswerQuality float64   `json:"expected_answer_quality"`
+	LabelNotes            string    `json:"label_notes,omitempty"`
+	LabeledAt             time.Time `json:"labeled_at"`
+	Labeler               string    `json:"labeler"`
+}
+
+// artifactHashInput is the canonical struct hashed to produce ArtifactHash.
+// Order-sensitive on tool calls and transcript turns; ID and candidate
+// model normalized to lowercase to avoid spurious mismatch from case.
+type artifactHashInput struct {
+	TraceID           string   `json:"trace_id"`
+	CandidateModel    string   `json:"candidate_model"`
+	ActualFinalAnswer string   `json:"actual_final_answer"`
+	ActualToolCalls   []string `json:"actual_tool_calls"`
+	ActualTranscript  []Turn   `json:"actual_transcript"`
+}
+
+// artifactHash returns the canonical sha256 hash for an Artifact. Stable
+// under JSON struct-tag ordering; sensitive to every input including
+// tool-call sequence order.
+func artifactHash(a Artifact) string {
+	raw, _ := json.Marshal(artifactHashInput{
+		TraceID:           normalizeModelSelector(a.TraceID),
+		CandidateModel:    normalizeModelSelector(a.CandidateModel),
+		ActualFinalAnswer: a.ActualFinalAnswer,
+		ActualToolCalls:   a.ActualToolCalls,
+		ActualTranscript:  a.ActualTranscript,
+	})
+	sum := sha256.Sum256(raw)
+	return fmt.Sprintf("sha256:%s", hex.EncodeToString(sum[:]))
+}

--- a/cmd/llm-bench/calibration.go
+++ b/cmd/llm-bench/calibration.go
@@ -30,7 +30,8 @@ type Artifact struct {
 
 // Label is the human-supplied truth for one frozen Artifact. ArtifactHash
 // links them: a Label with a hash that doesn't match any current Artifact
-// is "stale" and excluded from agreement.
+// is "stale" and excluded from agreement. Duplicate matched ArtifactHash
+// values are rejected so each artifact contributes at most once.
 type Label struct {
 	TraceID               string    `json:"trace_id"`
 	CandidateModel        string    `json:"candidate_model"`
@@ -186,12 +187,17 @@ func loadLabelsMatchedAgainst(labelsPath, artifactsPath string) ([]matchedLabel,
 	}
 	var matched []matchedLabel
 	var stale []Label
+	seenMatched := make(map[string]struct{}, len(labels))
 	for _, l := range labels {
 		a, ok := byHash[l.ArtifactHash]
 		if !ok {
 			stale = append(stale, l)
 			continue
 		}
+		if _, ok := seenMatched[l.ArtifactHash]; ok {
+			return nil, nil, fmt.Errorf("duplicate label for artifact_hash %q", l.ArtifactHash)
+		}
+		seenMatched[l.ArtifactHash] = struct{}{}
 		matched = append(matched, matchedLabel{Label: l, Artifact: a})
 	}
 	return matched, stale, nil
@@ -243,7 +249,7 @@ const (
 //
 // MinLabels defaults to calibrationDefaultMinLabels (50) when zero so a
 // sufficient sample backs the agreement verdict. StabilityRuns, when >1,
-// runs the judge N times per artifact and reports the max-min agreement
+// runs the judge exactly N times per artifact and reports the max-min agreement
 // spread as a diagnostic; it does NOT gate the PASS/FAIL verdict. Clock is
 // an optional time source for deterministic report filenames.
 type calibrateOptions struct {
@@ -253,7 +259,7 @@ type calibrateOptions struct {
 	JudgeModel    string
 	ReportDir     string
 	MinLabels     int // defaults to calibrationDefaultMinLabels when zero
-	StabilityRuns int // when >1, runs the judge N times per artifact and reports max-min spread as a diagnostic (does NOT gate the PASS/FAIL verdict); uses bypass-cache (Task 23)
+	StabilityRuns int // when >1, runs the judge exactly N times per artifact and reports max-min spread as a diagnostic (does NOT gate the PASS/FAIL verdict); uses bypass-cache (Task 23)
 	Clock         func() time.Time
 }
 
@@ -327,7 +333,8 @@ func runCalibrate(ctx context.Context, opts calibrateOptions) (CalibrationResult
 			TraceID:    m.Artifact.TraceID,
 			Transcript: m.Artifact.ActualTranscript,
 		}
-		score, scoreErr := opts.Scorer.Score(ctx, trace, actual)
+		scorer := calibrationScorer(opts.Scorer, opts.StabilityRuns)
+		score, scoreErr := scorer.Score(ctx, trace, actual)
 		if scoreErr != nil {
 			return CalibrationResult{}, fmt.Errorf("calibrate: scorer for %s/%s: %w",
 				m.Artifact.TraceID, m.Artifact.CandidateModel, scoreErr)
@@ -345,15 +352,9 @@ func runCalibrate(ctx context.Context, opts calibrateOptions) (CalibrationResult
 			Agree:          delta <= calibrationAgreementDelta,
 		}
 		if opts.StabilityRuns > 1 {
-			scores := make([]float64, 0, opts.StabilityRuns)
-			for i := 0; i < opts.StabilityRuns; i++ {
-				bypassScorer := opts.Scorer
-				if cs, ok := opts.Scorer.(*LLMJudgeScorer); ok {
-					clone := *cs
-					clone.BypassCache = true
-					bypassScorer = &clone
-				}
-				extra, sErr := bypassScorer.Score(ctx, trace, actual)
+			scores := []float64{score.AnswerQuality}
+			for i := 1; i < opts.StabilityRuns; i++ {
+				extra, sErr := scorer.Score(ctx, trace, actual)
 				if sErr != nil {
 					return CalibrationResult{}, fmt.Errorf("calibrate: stability run %d for %s/%s: %w",
 						i+1, m.Artifact.TraceID, m.Artifact.CandidateModel, sErr)
@@ -386,6 +387,18 @@ func runCalibrate(ctx context.Context, opts calibrateOptions) (CalibrationResult
 		res.ReportPath = path
 	}
 	return res, nil
+}
+
+func calibrationScorer(s Scorer, stabilityRuns int) Scorer {
+	if stabilityRuns <= 1 {
+		return s
+	}
+	if cs, ok := s.(*LLMJudgeScorer); ok {
+		clone := *cs
+		clone.BypassCache = true
+		return &clone
+	}
+	return s
 }
 
 func calibrationTraceFromArtifact(a Artifact) (Trace, error) {

--- a/cmd/llm-bench/calibration.go
+++ b/cmd/llm-bench/calibration.go
@@ -237,7 +237,7 @@ type calibrateOptions struct {
 	JudgeModel    string
 	ReportDir     string
 	MinLabels     int // defaults to calibrationDefaultMinLabels when zero
-	StabilityRuns int // when >1, runs judge that many times with bypass-cache (Task 20)
+	StabilityRuns int // when >1, runs the judge N times per artifact and reports max-min spread as a diagnostic (does NOT gate the PASS/FAIL verdict); uses bypass-cache (Task 23)
 	Clock         func() time.Time
 }
 

--- a/cmd/llm-bench/calibration.go
+++ b/cmd/llm-bench/calibration.go
@@ -122,22 +122,12 @@ func runCalibrateCapture(ctx context.Context, opts calibrateCaptureOptions) (ret
 		traceByID[trace.ID] = trace
 	}
 
-	if err := os.MkdirAll(filepath.Dir(opts.OutputPath), 0o755); err != nil {
-		return fmt.Errorf("calibrate-capture: mkdir: %w", err)
-	}
-	f, err := os.OpenFile(opts.OutputPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
-	if err != nil {
-		return fmt.Errorf("calibrate-capture: open output: %w", err)
-	}
-	defer func() {
-		if closeErr := f.Close(); retErr == nil && closeErr != nil {
-			retErr = fmt.Errorf("calibrate-capture: close output: %w", closeErr)
-		}
-	}()
-	enc := json.NewEncoder(f)
+	var artifacts []Artifact
+	failed := 0
 	for _, r := range results {
 		if r.Err != nil {
 			// Skip failed runs — they cannot be labeled coherently.
+			failed++
 			continue
 		}
 		trace, ok := traceByID[r.TraceID]
@@ -154,6 +144,26 @@ func runCalibrateCapture(ctx context.Context, opts calibrateCaptureOptions) (ret
 			CapturedAt:        now(),
 		}
 		artifact.ArtifactHash = artifactHash(artifact)
+		artifacts = append(artifacts, artifact)
+	}
+	if len(artifacts) == 0 {
+		return fmt.Errorf("calibrate-capture: no artifacts written; %d results returned, %d failed", len(results), failed)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(opts.OutputPath), 0o755); err != nil {
+		return fmt.Errorf("calibrate-capture: mkdir: %w", err)
+	}
+	f, err := os.OpenFile(opts.OutputPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("calibrate-capture: open output: %w", err)
+	}
+	defer func() {
+		if closeErr := f.Close(); retErr == nil && closeErr != nil {
+			retErr = fmt.Errorf("calibrate-capture: close output: %w", closeErr)
+		}
+	}()
+	enc := json.NewEncoder(f)
+	for _, artifact := range artifacts {
 		if err := enc.Encode(artifact); err != nil {
 			return fmt.Errorf("calibrate-capture: encode artifact %s/%s: %w", artifact.TraceID, artifact.CandidateModel, err)
 		}
@@ -429,8 +439,8 @@ func slugifyModel(s string) string {
 }
 
 // writeCalibrationReport emits a markdown calibration report to dir with a
-// slugified, dated filename and returns the report path. Clock is the time
-// source used to stamp the filename and report header; defaults to
+// slugified, timestamped filename and returns the report path. Clock is the
+// time source used to stamp the filename and report header; defaults to
 // time.Now().UTC() when nil.
 func writeCalibrationReport(dir, judgeModel string, res CalibrationResult, clock func() time.Time) (string, error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -438,9 +448,8 @@ func writeCalibrationReport(dir, judgeModel string, res CalibrationResult, clock
 	}
 	now := time.Now().UTC()
 	if clock != nil {
-		now = clock()
+		now = clock().UTC()
 	}
-	path := filepath.Join(dir, fmt.Sprintf("%s-%s.md", now.Format("2006-01-02"), slugifyModel(judgeModel)))
 	var b strings.Builder
 	fmt.Fprintf(&b, "# Judge calibration — %s — %s\n\n", judgeModel, now.Format("2006-01-02"))
 	fmt.Fprintf(&b, "Matched labels: %d / %d required → %s\n", res.MatchedCount, res.MinLabels, sufficiencyLabel(res))
@@ -461,10 +470,40 @@ func writeCalibrationReport(dir, judgeModel string, res CalibrationResult, clock
 		fmt.Fprintf(&b, "| %s | %s | %.2f | %.2f | %.2f | %s | %s |\n",
 			p.TraceID, p.CandidateModel, p.Expected, p.Judge, p.Delta, agree, stability)
 	}
-	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
+	f, path, err := createCalibrationReportFile(dir, judgeModel, now)
+	if err != nil {
+		return "", err
+	}
+	if _, err := f.WriteString(b.String()); err != nil {
+		_ = f.Close()
 		return "", fmt.Errorf("write %q: %w", path, err)
 	}
+	if err := f.Close(); err != nil {
+		return "", fmt.Errorf("close %q: %w", path, err)
+	}
 	return path, nil
+}
+
+func createCalibrationReportFile(dir, judgeModel string, now time.Time) (*os.File, string, error) {
+	for attempt := 0; ; attempt++ {
+		path := calibrationReportPath(dir, judgeModel, now, attempt)
+		f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if err == nil {
+			return f, path, nil
+		}
+		if errors.Is(err, os.ErrExist) {
+			continue
+		}
+		return nil, "", fmt.Errorf("create %q: %w", path, err)
+	}
+}
+
+func calibrationReportPath(dir, judgeModel string, now time.Time, attempt int) string {
+	stem := fmt.Sprintf("%s-%s", now.Format("2006-01-02T150405Z"), slugifyModel(judgeModel))
+	if attempt > 0 {
+		stem = fmt.Sprintf("%s-%d", stem, attempt+1)
+	}
+	return filepath.Join(dir, stem+".md")
 }
 
 // sufficiencyLabel renders the matched-vs-required label-count state as a

--- a/cmd/llm-bench/calibration.go
+++ b/cmd/llm-bench/calibration.go
@@ -329,6 +329,18 @@ func runCalibrate(ctx context.Context, opts calibrateOptions) (CalibrationResult
 			Delta:          delta,
 			Agree:          delta <= calibrationAgreementDelta,
 		}
+		if opts.StabilityRuns > 1 {
+			scores := []float64{score.AnswerQuality}
+			for i := 1; i < opts.StabilityRuns; i++ {
+				extra, sErr := opts.Scorer.Score(ctx, trace, actual)
+				if sErr != nil {
+					return CalibrationResult{}, fmt.Errorf("calibrate: stability run %d for %s/%s: %w",
+						i, m.Artifact.TraceID, m.Artifact.CandidateModel, sErr)
+				}
+				scores = append(scores, extra.AnswerQuality)
+			}
+			outcome.StabilitySpread = maxFloat(scores) - minFloat(scores)
+		}
 		res.PerLabel = append(res.PerLabel, outcome)
 		if outcome.Agree {
 			res.AgreeCount++
@@ -409,4 +421,24 @@ func sufficiencyLabel(res CalibrationResult) string {
 		return "SUFFICIENT"
 	}
 	return "INSUFFICIENT"
+}
+
+func maxFloat(vs []float64) float64 {
+	m := vs[0]
+	for _, v := range vs[1:] {
+		if v > m {
+			m = v
+		}
+	}
+	return m
+}
+
+func minFloat(vs []float64) float64 {
+	m := vs[0]
+	for _, v := range vs[1:] {
+		if v < m {
+			m = v
+		}
+	}
+	return m
 }

--- a/cmd/llm-bench/calibration.go
+++ b/cmd/llm-bench/calibration.go
@@ -92,7 +92,7 @@ type calibrateCaptureOptions struct {
 // Artifact per non-failed Result to OutputPath as JSONL. Artifacts have
 // no ExpectedAnswerQuality — labels are a separate file the operator
 // hand-edits.
-func runCalibrateCapture(ctx context.Context, opts calibrateCaptureOptions) error {
+func runCalibrateCapture(ctx context.Context, opts calibrateCaptureOptions) (retErr error) {
 	if opts.Runner == nil {
 		return fmt.Errorf("calibrate-capture: nil runner")
 	}
@@ -121,7 +121,11 @@ func runCalibrateCapture(ctx context.Context, opts calibrateCaptureOptions) erro
 	if err != nil {
 		return fmt.Errorf("calibrate-capture: open output: %w", err)
 	}
-	defer f.Close()
+	defer func() {
+		if closeErr := f.Close(); retErr == nil && closeErr != nil {
+			retErr = fmt.Errorf("calibrate-capture: close output: %w", closeErr)
+		}
+	}()
 	enc := json.NewEncoder(f)
 	for _, r := range results {
 		if r.Err != nil {
@@ -186,7 +190,7 @@ func loadArtifacts(path string) ([]Artifact, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open %q: %w", path, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	var out []Artifact
 	dec := json.NewDecoder(f)
 	for dec.More() {
@@ -204,7 +208,7 @@ func loadLabels(path string) ([]Label, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open %q: %w", path, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	var out []Label
 	dec := json.NewDecoder(f)
 	for dec.More() {
@@ -250,6 +254,7 @@ type CalibrationResult struct {
 	AgreeCount    int
 	AgreementRate float64
 	MinLabels     int
+	StabilityRuns int
 	Verdict       string // PASS / FAIL / INSUFFICIENT_LABELS
 	ReportPath    string
 	PerLabel      []perLabelOutcome
@@ -294,10 +299,11 @@ func runCalibrate(ctx context.Context, opts calibrateOptions) (CalibrationResult
 		return CalibrationResult{}, err
 	}
 	res := CalibrationResult{
-		JudgeModel:   opts.JudgeModel,
-		MatchedCount: len(matched),
-		StaleCount:   len(stale),
-		MinLabels:    opts.MinLabels,
+		JudgeModel:    opts.JudgeModel,
+		MatchedCount:  len(matched),
+		StaleCount:    len(stale),
+		MinLabels:     opts.MinLabels,
+		StabilityRuns: opts.StabilityRuns,
 	}
 	for _, m := range matched {
 		// Construct a synthetic Trace and Result from the Label+Artifact
@@ -331,8 +337,8 @@ func runCalibrate(ctx context.Context, opts calibrateOptions) (CalibrationResult
 			Agree:          delta <= calibrationAgreementDelta,
 		}
 		if opts.StabilityRuns > 1 {
-			scores := []float64{score.AnswerQuality}
-			for i := 1; i < opts.StabilityRuns; i++ {
+			scores := make([]float64, 0, opts.StabilityRuns)
+			for i := 0; i < opts.StabilityRuns; i++ {
 				bypassScorer := opts.Scorer
 				if cs, ok := opts.Scorer.(*LLMJudgeScorer); ok {
 					clone := *cs
@@ -342,7 +348,7 @@ func runCalibrate(ctx context.Context, opts calibrateOptions) (CalibrationResult
 				extra, sErr := bypassScorer.Score(ctx, trace, actual)
 				if sErr != nil {
 					return CalibrationResult{}, fmt.Errorf("calibrate: stability run %d for %s/%s: %w",
-						i, m.Artifact.TraceID, m.Artifact.CandidateModel, sErr)
+						i+1, m.Artifact.TraceID, m.Artifact.CandidateModel, sErr)
 				}
 				scores = append(scores, extra.AnswerQuality)
 			}
@@ -382,8 +388,8 @@ func slugifyModel(s string) string {
 }
 
 // writeCalibrationReport emits a markdown calibration report to dir with a
-// slugified, dated filename and returns the absolute path. Clock is the
-// time source used to stamp the filename and report header; defaults to
+// slugified, dated filename and returns the report path. Clock is the time
+// source used to stamp the filename and report header; defaults to
 // time.Now().UTC() when nil.
 func writeCalibrationReport(dir, judgeModel string, res CalibrationResult, clock func() time.Time) (string, error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -393,30 +399,29 @@ func writeCalibrationReport(dir, judgeModel string, res CalibrationResult, clock
 	if clock != nil {
 		now = clock()
 	}
-	path := fmt.Sprintf("%s/%s-%s.md", dir, now.Format("2006-01-02"), slugifyModel(judgeModel))
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
-	if err != nil {
-		return "", fmt.Errorf("open %q: %w", path, err)
-	}
-	defer f.Close()
-	fmt.Fprintf(f, "# Judge calibration — %s — %s\n\n", judgeModel, now.Format("2006-01-02"))
-	fmt.Fprintf(f, "Matched labels: %d / %d required → %s\n", res.MatchedCount, res.MinLabels, sufficiencyLabel(res))
-	fmt.Fprintf(f, "Stale labels: %d\n", res.StaleCount)
-	fmt.Fprintf(f, "Agreement: %d / %d (%.0f%%) → **%s**\n\n",
+	path := filepath.Join(dir, fmt.Sprintf("%s-%s.md", now.Format("2006-01-02"), slugifyModel(judgeModel)))
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Judge calibration — %s — %s\n\n", judgeModel, now.Format("2006-01-02"))
+	fmt.Fprintf(&b, "Matched labels: %d / %d required → %s\n", res.MatchedCount, res.MinLabels, sufficiencyLabel(res))
+	fmt.Fprintf(&b, "Stale labels: %d\n", res.StaleCount)
+	fmt.Fprintf(&b, "Agreement: %d / %d (%.0f%%) → **%s**\n\n",
 		res.AgreeCount, res.MatchedCount, res.AgreementRate*100, res.Verdict)
-	fmt.Fprintln(f, "| trace_id | candidate | expected | judge | Δ | agree | stability |")
-	fmt.Fprintln(f, "|---|---|---|---|---|---|---|")
+	fmt.Fprintln(&b, "| trace_id | candidate | expected | judge | Δ | agree | stability |")
+	fmt.Fprintln(&b, "|---|---|---|---|---|---|---|")
 	for _, p := range res.PerLabel {
 		agree := "✗"
 		if p.Agree {
 			agree = "✓"
 		}
 		stability := "n/a"
-		if p.StabilitySpread > 0 {
+		if res.StabilityRuns > 1 {
 			stability = fmt.Sprintf("spread=%.2f", p.StabilitySpread)
 		}
-		fmt.Fprintf(f, "| %s | %s | %.2f | %.2f | %.2f | %s | %s |\n",
+		fmt.Fprintf(&b, "| %s | %s | %.2f | %.2f | %.2f | %s | %s |\n",
 			p.TraceID, p.CandidateModel, p.Expected, p.Judge, p.Delta, agree, stability)
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
+		return "", fmt.Errorf("write %q: %w", path, err)
 	}
 	return path, nil
 }

--- a/cmd/llm-bench/calibration_test.go
+++ b/cmd/llm-bench/calibration_test.go
@@ -130,6 +130,16 @@ func TestArtifactHash_SensitiveToFinalAnswer(t *testing.T) {
 	}
 }
 
+func TestArtifactHash_SensitiveToTraceIDCase(t *testing.T) {
+	base := Artifact{TraceID: "Foo", CandidateModel: "c"}
+	h1 := artifactHash(base)
+	base.TraceID = "foo"
+	h2 := artifactHash(base)
+	if h1 == h2 {
+		t.Fatalf("artifactHash should preserve TraceID case")
+	}
+}
+
 func TestArtifactHash_SensitiveToToolCallSequence(t *testing.T) {
 	base := Artifact{TraceID: "t", CandidateModel: "c"}
 	base.ActualToolCalls = []string{"a", "b"}
@@ -215,6 +225,21 @@ func TestLoadLabelsAndArtifacts_DuplicateMatchedLabelRejected(t *testing.T) {
 	_, _, err := loadLabelsMatchedAgainst(labels, arts)
 	if err == nil || !strings.Contains(err.Error(), "duplicate label for artifact_hash") {
 		t.Fatalf("loadLabelsMatchedAgainst err = %v; want duplicate label error", err)
+	}
+}
+
+func TestLoadLabels_InvalidExpectedAnswerQualityRejected(t *testing.T) {
+	dir := t.TempDir()
+	labels := filepath.Join(dir, "labels.jsonl")
+	if err := writeJSONL(labels, []any{
+		Label{TraceID: "t1", CandidateModel: "ollama/c", ArtifactHash: "sha256:h", ExpectedAnswerQuality: 2.0, Labeler: "manual"},
+	}); err != nil {
+		t.Fatalf("seed labels: %v", err)
+	}
+
+	_, err := loadLabels(labels)
+	if err == nil || !strings.Contains(err.Error(), "invalid expected_answer_quality") {
+		t.Fatalf("loadLabels err = %v; want invalid expected_answer_quality", err)
 	}
 }
 

--- a/cmd/llm-bench/calibration_test.go
+++ b/cmd/llm-bench/calibration_test.go
@@ -1,9 +1,81 @@
 package main
 
 import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// fakeRunner implements calibrationRunner with canned Results so we don't
+// need a live Ollama for the capture test.
+type fakeRunner struct {
+	results []Result
+}
+
+func (f *fakeRunner) RunAll(ctx context.Context, targets []ModelTarget, traces []Trace) ([]Result, error) {
+	return f.results, nil
+}
+
+func TestRunCalibrateCapture_WritesOneArtifactPerResult(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "artifacts.jsonl")
+	runner := &fakeRunner{results: []Result{
+		{Model: "ollama/cand", TraceID: "t1", Transcript: []Turn{
+			{Role: "assistant", ToolCalls: []ToolCall{{Name: "read_file"}}},
+			{Role: "assistant", Content: "answer one"},
+		}},
+		{Model: "ollama/cand", TraceID: "t2", Transcript: []Turn{
+			{Role: "assistant", Content: "answer two"},
+		}},
+	}}
+	traces := []Trace{
+		{ID: "t1", System: "s", Turns: []Turn{{Role: "user", Content: "u1"}}, Golden: Golden{FinalAnswerCriteria: "c"}},
+		{ID: "t2", System: "s", Turns: []Turn{{Role: "user", Content: "u2"}}, Golden: Golden{FinalAnswerCriteria: "c"}},
+	}
+	targets := []ModelTarget{{Display: "ollama/cand", Provider: "ollama", Model: "cand"}}
+
+	if err := runCalibrateCapture(context.Background(), calibrateCaptureOptions{
+		Runner: runner, Targets: targets, Traces: traces, OutputPath: out,
+	}); err != nil {
+		t.Fatalf("runCalibrateCapture: %v", err)
+	}
+
+	// Read back artifacts.jsonl: expect 2 records, each with non-empty
+	// ArtifactHash, no ExpectedAnswerQuality field set (labels are
+	// separate), and ActualFinalAnswer matching the transcript.
+	f, err := os.Open(out)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	var artifacts []Artifact
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var a Artifact
+		if err := json.Unmarshal(scanner.Bytes(), &a); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		artifacts = append(artifacts, a)
+	}
+	if len(artifacts) != 2 {
+		t.Fatalf("got %d artifacts; want 2", len(artifacts))
+	}
+	for i, a := range artifacts {
+		if a.ArtifactHash == "" {
+			t.Fatalf("artifact %d missing hash", i)
+		}
+		if a.CandidateModel != "ollama/cand" {
+			t.Fatalf("artifact %d candidate = %q", i, a.CandidateModel)
+		}
+	}
+	if artifacts[0].ActualFinalAnswer != "answer one" {
+		t.Fatalf("artifact[0].ActualFinalAnswer = %q", artifacts[0].ActualFinalAnswer)
+	}
+}
 
 func TestArtifactHash_DeterministicAcrossInvocations(t *testing.T) {
 	a := Artifact{

--- a/cmd/llm-bench/calibration_test.go
+++ b/cmd/llm-bench/calibration_test.go
@@ -4,10 +4,12 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // fakeRunner implements calibrationRunner with canned Results so we don't
@@ -148,6 +150,73 @@ func TestLoadLabelsAndArtifacts_MatchAndStale(t *testing.T) {
 	}
 	if len(stale) != 1 || stale[0].ArtifactHash != "sha256:stale" {
 		t.Fatalf("stale = %+v; want 1 stale label", stale)
+	}
+}
+
+// fakeScorer returns canned answer-quality values per (trace, candidate).
+type fakeScorer struct {
+	judgeByTrace map[string]float64
+	called       int
+}
+
+func (s *fakeScorer) Score(ctx context.Context, t Trace, r Result) (Score, error) {
+	s.called++
+	return Score{AnswerQuality: s.judgeByTrace[t.ID]}, nil
+}
+
+func TestRunCalibrate_AgreementMatchesByHand(t *testing.T) {
+	dir := t.TempDir()
+	arts := filepath.Join(dir, "artifacts.jsonl")
+	labels := filepath.Join(dir, "labels.jsonl")
+	reportDir := filepath.Join(dir, "reports")
+
+	// 4 artifacts, 4 labels:
+	// - label 0: expected 1.0, judge 1.0 → agree (Δ=0)
+	// - label 1: expected 1.0, judge 0.6 → disagree (Δ=0.4 > 0.25)
+	// - label 2: expected 0.5, judge 0.7 → agree (Δ=0.2 ≤ 0.25)
+	// - label 3: expected 0.0, judge 0.25 → agree (Δ=0.25 == 0.25)
+	var artifacts []any
+	var labelRecs []any
+	judge := map[string]float64{}
+	expected := []float64{1.0, 1.0, 0.5, 0.0}
+	judged := []float64{1.0, 0.6, 0.7, 0.25}
+	for i := 0; i < 4; i++ {
+		traceID := fmt.Sprintf("t%d", i)
+		a := Artifact{TraceID: traceID, CandidateModel: "ollama/c", ActualFinalAnswer: traceID}
+		a.ArtifactHash = artifactHash(a)
+		artifacts = append(artifacts, a)
+		labelRecs = append(labelRecs, Label{
+			TraceID: traceID, CandidateModel: "ollama/c", ArtifactHash: a.ArtifactHash,
+			ExpectedAnswerQuality: expected[i], Labeler: "manual",
+		})
+		judge[traceID] = judged[i]
+	}
+	if err := writeJSONL(arts, artifacts); err != nil {
+		t.Fatalf("seed arts: %v", err)
+	}
+	if err := writeJSONL(labels, labelRecs); err != nil {
+		t.Fatalf("seed labels: %v", err)
+	}
+
+	fs := &fakeScorer{judgeByTrace: judge}
+	res, err := runCalibrate(context.Background(), calibrateOptions{
+		LabelsPath:    labels,
+		ArtifactsPath: arts,
+		Scorer:        fs,
+		JudgeModel:    "ollama/judge",
+		ReportDir:     reportDir,
+		MinLabels:     2, // lower threshold for the test
+		Clock:         func() time.Time { return time.Date(2026, 5, 25, 0, 0, 0, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatalf("runCalibrate: %v", err)
+	}
+	if res.MatchedCount != 4 || res.AgreeCount != 3 {
+		t.Fatalf("MatchedCount=%d AgreeCount=%d; want 4 / 3", res.MatchedCount, res.AgreeCount)
+	}
+	// 3 of 4 agreed = 75% < 85% threshold → FAIL.
+	if res.Verdict != "FAIL" {
+		t.Fatalf("Verdict=%q; want FAIL (3/4 = 75%% below 85%% threshold)", res.Verdict)
 	}
 }
 

--- a/cmd/llm-bench/calibration_test.go
+++ b/cmd/llm-bench/calibration_test.go
@@ -122,3 +122,47 @@ func TestArtifactHash_PrefixIsSha256(t *testing.T) {
 		t.Fatalf("artifactHash length = %d; want 71", len(h))
 	}
 }
+
+func TestLoadLabelsAndArtifacts_MatchAndStale(t *testing.T) {
+	dir := t.TempDir()
+	labels := filepath.Join(dir, "labels.jsonl")
+	arts := filepath.Join(dir, "artifacts.jsonl")
+	art := Artifact{TraceID: "t1", CandidateModel: "ollama/c", ActualFinalAnswer: "x"}
+	art.ArtifactHash = artifactHash(art)
+	if err := writeJSONL(arts, []any{art}); err != nil {
+		t.Fatalf("seed arts: %v", err)
+	}
+	if err := writeJSONL(labels, []any{
+		Label{TraceID: "t1", CandidateModel: "ollama/c", ArtifactHash: art.ArtifactHash, ExpectedAnswerQuality: 1.0, Labeler: "manual"},
+		Label{TraceID: "t1", CandidateModel: "ollama/c", ArtifactHash: "sha256:stale", ExpectedAnswerQuality: 0.5, Labeler: "manual"},
+	}); err != nil {
+		t.Fatalf("seed labels: %v", err)
+	}
+
+	matched, stale, err := loadLabelsMatchedAgainst(labels, arts)
+	if err != nil {
+		t.Fatalf("loadLabelsMatchedAgainst: %v", err)
+	}
+	if len(matched) != 1 || matched[0].Label.ArtifactHash != art.ArtifactHash {
+		t.Fatalf("matched = %+v; want 1 entry with art.ArtifactHash", matched)
+	}
+	if len(stale) != 1 || stale[0].ArtifactHash != "sha256:stale" {
+		t.Fatalf("stale = %+v; want 1 stale label", stale)
+	}
+}
+
+// writeJSONL is a tiny test helper local to calibration_test.go.
+func writeJSONL(path string, records []any) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for _, r := range records {
+		if err := enc.Encode(r); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/llm-bench/calibration_test.go
+++ b/cmd/llm-bench/calibration_test.go
@@ -393,6 +393,58 @@ func TestRunCalibrate_AgreementMatchesByHand(t *testing.T) {
 	}
 }
 
+func TestRunCalibrate_SkipsSelfJudgedArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	arts := filepath.Join(dir, "artifacts.jsonl")
+	labels := filepath.Join(dir, "labels.jsonl")
+	reportDir := filepath.Join(dir, "reports")
+
+	self := testCalibrationArtifact("self", "self answer")
+	self.CandidateModel = "ollama/judge"
+	self.ArtifactHash = artifactHash(self)
+	other := testCalibrationArtifact("other", "other answer")
+	if err := writeJSONL(arts, []any{self, other}); err != nil {
+		t.Fatalf("seed arts: %v", err)
+	}
+	if err := writeJSONL(labels, []any{
+		Label{TraceID: "self", CandidateModel: self.CandidateModel, ArtifactHash: self.ArtifactHash, ExpectedAnswerQuality: 1.0, Labeler: "manual"},
+		Label{TraceID: "other", CandidateModel: other.CandidateModel, ArtifactHash: other.ArtifactHash, ExpectedAnswerQuality: 1.0, Labeler: "manual"},
+	}); err != nil {
+		t.Fatalf("seed labels: %v", err)
+	}
+
+	fs := &fakeScorer{judgeByTrace: map[string]float64{"other": 1.0}}
+	res, err := runCalibrate(context.Background(), calibrateOptions{
+		LabelsPath:    labels,
+		ArtifactsPath: arts,
+		Scorer:        fs,
+		JudgeModel:    "judge",
+		ReportDir:     reportDir,
+		MinLabels:     1,
+		Clock:         func() time.Time { return time.Date(2026, 5, 25, 0, 0, 0, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatalf("runCalibrate: %v", err)
+	}
+	if res.MatchedCount != 1 || res.SelfJudgedSkipCount != 1 || res.AgreeCount != 1 {
+		t.Fatalf("MatchedCount=%d SelfJudgedSkipCount=%d AgreeCount=%d; want 1 / 1 / 1",
+			res.MatchedCount, res.SelfJudgedSkipCount, res.AgreeCount)
+	}
+	if fs.called != 1 {
+		t.Fatalf("Score calls=%d; want 1", fs.called)
+	}
+	if len(res.PerLabel) != 1 || res.PerLabel[0].TraceID != "other" {
+		t.Fatalf("PerLabel=%+v; want only non-self artifact", res.PerLabel)
+	}
+	report, err := os.ReadFile(res.ReportPath)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	if !strings.Contains(string(report), "Self-judged labels skipped: 1") {
+		t.Fatalf("report missing self-judged skip count:\n%s", report)
+	}
+}
+
 func TestRunCalibrate_InsufficientLabelsNeverPasses(t *testing.T) {
 	dir := t.TempDir()
 	arts := filepath.Join(dir, "artifacts.jsonl")

--- a/cmd/llm-bench/calibration_test.go
+++ b/cmd/llm-bench/calibration_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/kstruzzieri/go-llm/ollama"
 )
 
 // fakeRunner implements calibrationRunner with canned Results so we don't
@@ -351,6 +353,47 @@ func TestRunCalibrate_StabilityRunsReportSpread(t *testing.T) {
 	// Stability runs do NOT affect agreement (primary calls were already cached/Counted).
 	if res.AgreeCount != 1 {
 		t.Fatalf("AgreeCount=%d; want 1 (stability runs are diagnostic only)", res.AgreeCount)
+	}
+}
+
+func TestRunCalibrate_StabilityRunsDoNotPersistJudgeCache(t *testing.T) {
+	dir := t.TempDir()
+	arts := filepath.Join(dir, "artifacts.jsonl")
+	labels := filepath.Join(dir, "labels.jsonl")
+	a := Artifact{
+		TraceID: "t", CandidateModel: "ollama/c",
+		ActualFinalAnswer: "x",
+		ActualTranscript:  []Turn{{Role: "user", Content: "ask"}, {Role: "assistant", Content: "x"}},
+	}
+	a.ArtifactHash = artifactHash(a)
+	if err := writeJSONL(arts, []any{a}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONL(labels, []any{Label{
+		TraceID: "t", CandidateModel: "ollama/c", ArtifactHash: a.ArtifactHash,
+		ExpectedAnswerQuality: 1.0, Labeler: "manual",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	c, _ := newTestCache(t)
+	judge := &fakeJudgeClient{resp: &ollama.ChatResponse{Message: ollama.ChatMessage{
+		Content: `{"answer_quality":1.0,"justification":"j"}`,
+	}}}
+	scorer := &LLMJudgeScorer{Client: judge, JudgeModel: "ollama/judge", Cache: c, BypassCache: false}
+	_, err := runCalibrate(context.Background(), calibrateOptions{
+		LabelsPath: labels, ArtifactsPath: arts, Scorer: scorer,
+		JudgeModel: "ollama/judge", MinLabels: 1, StabilityRuns: 3,
+	})
+	if err != nil {
+		t.Fatalf("runCalibrate: %v", err)
+	}
+	// Primary run wrote 1 row; stability runs (M-1 = 2 extra calls) must NOT write rows.
+	var count int
+	if err := c.db.QueryRow(`SELECT COUNT(*) FROM judge_cache`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("cache row count = %d; want 1 (stability runs must bypass write)", count)
 	}
 }
 

--- a/cmd/llm-bench/calibration_test.go
+++ b/cmd/llm-bench/calibration_test.go
@@ -220,6 +220,44 @@ func TestRunCalibrate_AgreementMatchesByHand(t *testing.T) {
 	}
 }
 
+func TestRunCalibrate_InsufficientLabelsNeverPasses(t *testing.T) {
+	dir := t.TempDir()
+	arts := filepath.Join(dir, "artifacts.jsonl")
+	labels := filepath.Join(dir, "labels.jsonl")
+
+	// Seed only 3 matched artifacts/labels, all perfect agreement.
+	var artifacts, labelRecs []any
+	for i := 0; i < 3; i++ {
+		traceID := fmt.Sprintf("t%d", i)
+		a := Artifact{TraceID: traceID, CandidateModel: "ollama/c", ActualFinalAnswer: traceID}
+		a.ArtifactHash = artifactHash(a)
+		artifacts = append(artifacts, a)
+		labelRecs = append(labelRecs, Label{
+			TraceID: traceID, CandidateModel: "ollama/c", ArtifactHash: a.ArtifactHash,
+			ExpectedAnswerQuality: 1.0, Labeler: "manual",
+		})
+	}
+	if err := writeJSONL(arts, artifacts); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONL(labels, labelRecs); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := &fakeScorer{judgeByTrace: map[string]float64{"t0": 1, "t1": 1, "t2": 1}}
+	res, err := runCalibrate(context.Background(), calibrateOptions{
+		LabelsPath: labels, ArtifactsPath: arts, Scorer: fs,
+		JudgeModel: "ollama/judge",
+		// Use default MinLabels=50; we only have 3.
+	})
+	if err != nil {
+		t.Fatalf("runCalibrate: %v", err)
+	}
+	if res.Verdict != "INSUFFICIENT_LABELS" {
+		t.Fatalf("Verdict=%q; want INSUFFICIENT_LABELS even at 100%% agreement on 3 matched", res.Verdict)
+	}
+}
+
 // writeJSONL is a tiny test helper local to calibration_test.go.
 func writeJSONL(path string, records []any) error {
 	f, err := os.Create(path)

--- a/cmd/llm-bench/calibration_test.go
+++ b/cmd/llm-bench/calibration_test.go
@@ -258,6 +258,51 @@ func TestRunCalibrate_InsufficientLabelsNeverPasses(t *testing.T) {
 	}
 }
 
+func TestSlugifyModel_ReplacesSlashAndColon(t *testing.T) {
+	cases := map[string]string{
+		"ollama/gemma4:31b":              "ollama_gemma4_31b",
+		"ollama/qwen3-coder-next:latest": "ollama_qwen3-coder-next_latest",
+		"bare-name":                      "bare-name",
+	}
+	for in, want := range cases {
+		if got := slugifyModel(in); got != want {
+			t.Errorf("slugifyModel(%q) = %q; want %q", in, got, want)
+		}
+	}
+}
+
+func TestRunCalibrate_ReportFilenameIsSlugified(t *testing.T) {
+	dir := t.TempDir()
+	arts := filepath.Join(dir, "artifacts.jsonl")
+	labels := filepath.Join(dir, "labels.jsonl")
+	reportDir := filepath.Join(dir, "reports")
+	a := Artifact{TraceID: "t", CandidateModel: "ollama/c", ActualFinalAnswer: "x"}
+	a.ArtifactHash = artifactHash(a)
+	if err := writeJSONL(arts, []any{a}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONL(labels, []any{Label{
+		TraceID: "t", CandidateModel: "ollama/c", ArtifactHash: a.ArtifactHash,
+		ExpectedAnswerQuality: 1.0, Labeler: "manual",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	res, err := runCalibrate(context.Background(), calibrateOptions{
+		LabelsPath: labels, ArtifactsPath: arts,
+		Scorer:     &fakeScorer{judgeByTrace: map[string]float64{"t": 1.0}},
+		JudgeModel: "ollama/gemma4:31b",
+		MinLabels:  1,
+		ReportDir:  reportDir,
+		Clock:      func() time.Time { return time.Date(2026, 5, 25, 0, 0, 0, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatalf("runCalibrate: %v", err)
+	}
+	if !strings.HasSuffix(res.ReportPath, "2026-05-25-ollama_gemma4_31b.md") {
+		t.Fatalf("ReportPath=%q; want suffix 2026-05-25-ollama_gemma4_31b.md", res.ReportPath)
+	}
+}
+
 // writeJSONL is a tiny test helper local to calibration_test.go.
 func writeJSONL(path string, records []any) error {
 	f, err := os.Create(path)

--- a/cmd/llm-bench/calibration_test.go
+++ b/cmd/llm-bench/calibration_test.go
@@ -175,6 +175,27 @@ func TestLoadLabelsAndArtifacts_MatchAndStale(t *testing.T) {
 	}
 }
 
+func TestLoadLabelsAndArtifacts_DuplicateMatchedLabelRejected(t *testing.T) {
+	dir := t.TempDir()
+	labels := filepath.Join(dir, "labels.jsonl")
+	arts := filepath.Join(dir, "artifacts.jsonl")
+	art := testCalibrationArtifact("t1", "x")
+	if err := writeJSONL(arts, []any{art}); err != nil {
+		t.Fatalf("seed arts: %v", err)
+	}
+	if err := writeJSONL(labels, []any{
+		Label{TraceID: "t1", CandidateModel: "ollama/c", ArtifactHash: art.ArtifactHash, ExpectedAnswerQuality: 1.0, Labeler: "manual"},
+		Label{TraceID: "t1", CandidateModel: "ollama/c", ArtifactHash: art.ArtifactHash, ExpectedAnswerQuality: 0.5, Labeler: "manual"},
+	}); err != nil {
+		t.Fatalf("seed labels: %v", err)
+	}
+
+	_, _, err := loadLabelsMatchedAgainst(labels, arts)
+	if err == nil || !strings.Contains(err.Error(), "duplicate label for artifact_hash") {
+		t.Fatalf("loadLabelsMatchedAgainst err = %v; want duplicate label error", err)
+	}
+}
+
 // fakeScorer returns canned answer-quality values per (trace, candidate).
 type fakeScorer struct {
 	judgeByTrace map[string]float64
@@ -420,7 +441,7 @@ func TestRunCalibrate_StabilityRunsReportSpread(t *testing.T) {
 	}}); err != nil {
 		t.Fatal(err)
 	}
-	fs := &fakeStabilityScorer{sequence: []float64{0.8, 1.0, 0.6, 0.7}} // primary=0.8, stability spread = 0.4
+	fs := &fakeStabilityScorer{sequence: []float64{0.8, 1.0, 0.6}} // primary=0.8, spread across 3 runs = 0.4
 	res, err := runCalibrate(context.Background(), calibrateOptions{
 		LabelsPath: labels, ArtifactsPath: arts, Scorer: fs,
 		JudgeModel: "ollama/judge", MinLabels: 1, StabilityRuns: 3,
@@ -434,10 +455,10 @@ func TestRunCalibrate_StabilityRunsReportSpread(t *testing.T) {
 	if res.PerLabel[0].StabilitySpread != 0.4 {
 		t.Fatalf("StabilitySpread=%v; want 0.4", res.PerLabel[0].StabilitySpread)
 	}
-	if fs.callCount != 4 {
-		t.Fatalf("Score calls=%d; want 4 (1 primary + 3 stability)", fs.callCount)
+	if fs.callCount != 3 {
+		t.Fatalf("Score calls=%d; want 3 total stability samples", fs.callCount)
 	}
-	// Stability runs do NOT affect agreement (primary call is counted).
+	// Stability spread does NOT affect agreement (primary sample is counted).
 	if res.AgreeCount != 1 {
 		t.Fatalf("AgreeCount=%d; want 1 (stability runs are diagnostic only)", res.AgreeCount)
 	}
@@ -471,16 +492,16 @@ func TestRunCalibrate_StabilityRunsDoNotPersistJudgeCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runCalibrate: %v", err)
 	}
-	if judge.called != 4 {
-		t.Fatalf("judge called %d times; want 4 (1 primary + 3 bypassed stability runs)", judge.called)
+	if judge.called != 3 {
+		t.Fatalf("judge called %d times; want 3 total bypassed stability samples", judge.called)
 	}
-	// Primary run wrote 1 row; stability runs must NOT write rows.
+	// Stability mode bypasses cache for all samples and must NOT write rows.
 	var count int
 	if err := c.db.QueryRow(`SELECT COUNT(*) FROM judge_cache`).Scan(&count); err != nil {
 		t.Fatal(err)
 	}
-	if count != 1 {
-		t.Fatalf("cache row count = %d; want 1 (stability runs must bypass write)", count)
+	if count != 0 {
+		t.Fatalf("cache row count = %d; want 0 (stability runs must bypass write)", count)
 	}
 }
 

--- a/cmd/llm-bench/calibration_test.go
+++ b/cmd/llm-bench/calibration_test.go
@@ -55,7 +55,7 @@ func TestRunCalibrateCapture_WritesOneArtifactPerResult(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	var artifacts []Artifact
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
@@ -260,6 +260,18 @@ func TestRunCalibrate_InsufficientLabelsNeverPasses(t *testing.T) {
 	}
 }
 
+func TestCalibrationExitCodeFailsClosedOnInsufficientLabels(t *testing.T) {
+	if got := calibrationExitCode("PASS"); got != 0 {
+		t.Fatalf("PASS exit code = %d; want 0", got)
+	}
+	if got := calibrationExitCode("FAIL"); got == 0 {
+		t.Fatalf("FAIL exit code = %d; want non-zero", got)
+	}
+	if got := calibrationExitCode("INSUFFICIENT_LABELS"); got == 0 {
+		t.Fatalf("INSUFFICIENT_LABELS exit code = %d; want non-zero", got)
+	}
+}
+
 func TestSlugifyModel_ReplacesSlashAndColon(t *testing.T) {
 	cases := map[string]string{
 		"ollama/gemma4:31b":              "ollama_gemma4_31b",
@@ -336,7 +348,7 @@ func TestRunCalibrate_StabilityRunsReportSpread(t *testing.T) {
 	}}); err != nil {
 		t.Fatal(err)
 	}
-	fs := &fakeStabilityScorer{sequence: []float64{0.8, 1.0, 0.6}} // spread = 0.4
+	fs := &fakeStabilityScorer{sequence: []float64{0.8, 1.0, 0.6, 0.7}} // primary=0.8, stability spread = 0.4
 	res, err := runCalibrate(context.Background(), calibrateOptions{
 		LabelsPath: labels, ArtifactsPath: arts, Scorer: fs,
 		JudgeModel: "ollama/judge", MinLabels: 1, StabilityRuns: 3,
@@ -350,7 +362,10 @@ func TestRunCalibrate_StabilityRunsReportSpread(t *testing.T) {
 	if res.PerLabel[0].StabilitySpread != 0.4 {
 		t.Fatalf("StabilitySpread=%v; want 0.4", res.PerLabel[0].StabilitySpread)
 	}
-	// Stability runs do NOT affect agreement (primary calls were already cached/Counted).
+	if fs.callCount != 4 {
+		t.Fatalf("Score calls=%d; want 4 (1 primary + 3 stability)", fs.callCount)
+	}
+	// Stability runs do NOT affect agreement (primary call is counted).
 	if res.AgreeCount != 1 {
 		t.Fatalf("AgreeCount=%d; want 1 (stability runs are diagnostic only)", res.AgreeCount)
 	}
@@ -387,7 +402,10 @@ func TestRunCalibrate_StabilityRunsDoNotPersistJudgeCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runCalibrate: %v", err)
 	}
-	// Primary run wrote 1 row; stability runs (M-1 = 2 extra calls) must NOT write rows.
+	if judge.called != 4 {
+		t.Fatalf("judge called %d times; want 4 (1 primary + 3 bypassed stability runs)", judge.called)
+	}
+	// Primary run wrote 1 row; stability runs must NOT write rows.
 	var count int
 	if err := c.db.QueryRow(`SELECT COUNT(*) FROM judge_cache`).Scan(&count); err != nil {
 		t.Fatal(err)
@@ -403,7 +421,7 @@ func writeJSONL(path string, records []any) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	enc := json.NewEncoder(f)
 	for _, r := range records {
 		if err := enc.Encode(r); err != nil {

--- a/cmd/llm-bench/calibration_test.go
+++ b/cmd/llm-bench/calibration_test.go
@@ -18,9 +18,11 @@ import (
 // need a live Ollama for the capture test.
 type fakeRunner struct {
 	results []Result
+	calls   int
 }
 
 func (f *fakeRunner) RunAll(ctx context.Context, targets []ModelTarget, traces []Trace) ([]Result, error) {
+	f.calls++
 	return f.results, nil
 }
 
@@ -100,6 +102,32 @@ func TestRunCalibrateCapture_FailsWhenNoArtifactsWritten(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "no artifacts written") {
 		t.Fatalf("runCalibrateCapture err = %v; want no artifacts written", err)
+	}
+	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+		t.Fatalf("output stat err = %v; want file not created", statErr)
+	}
+}
+
+func TestRunCalibrateCapture_DuplicateTraceIDRejectedBeforeReplay(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "artifacts.jsonl")
+	runner := &fakeRunner{results: []Result{
+		{Model: "ollama/cand", TraceID: "dup", Transcript: []Turn{{Role: "assistant", Content: "answer"}}},
+	}}
+	traces := []Trace{
+		{ID: "dup", System: "s1", Turns: []Turn{{Role: "user", Content: "u1"}}, Golden: Golden{FinalAnswerCriteria: "c1"}},
+		{ID: "dup", System: "s2", Turns: []Turn{{Role: "user", Content: "u2"}}, Golden: Golden{FinalAnswerCriteria: "c2"}},
+	}
+	targets := []ModelTarget{{Display: "ollama/cand", Provider: "ollama", Model: "cand"}}
+
+	err := runCalibrateCapture(context.Background(), calibrateCaptureOptions{
+		Runner: runner, Targets: targets, Traces: traces, OutputPath: out,
+	})
+	if err == nil || !strings.Contains(err.Error(), `duplicate trace ID "dup"`) {
+		t.Fatalf("runCalibrateCapture err = %v; want duplicate trace ID", err)
+	}
+	if runner.calls != 0 {
+		t.Fatalf("RunAll calls = %d; want 0", runner.calls)
 	}
 	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
 		t.Fatalf("output stat err = %v; want file not created", statErr)

--- a/cmd/llm-bench/calibration_test.go
+++ b/cmd/llm-bench/calibration_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestArtifactHash_DeterministicAcrossInvocations(t *testing.T) {
+	a := Artifact{
+		TraceID: "t1", CandidateModel: "ollama/cand",
+		ActualFinalAnswer: "the answer is 4",
+		ActualToolCalls:   []string{"read_file"},
+		ActualTranscript:  []Turn{{Role: "assistant", Content: "the answer is 4"}},
+	}
+	b := a
+	if artifactHash(a) != artifactHash(b) {
+		t.Fatalf("artifactHash not deterministic for identical Artifact")
+	}
+}
+
+func TestArtifactHash_SensitiveToFinalAnswer(t *testing.T) {
+	base := Artifact{TraceID: "t", CandidateModel: "c"}
+	base.ActualFinalAnswer = "v1"
+	h1 := artifactHash(base)
+	base.ActualFinalAnswer = "v2"
+	h2 := artifactHash(base)
+	if h1 == h2 {
+		t.Fatalf("artifactHash not sensitive to ActualFinalAnswer")
+	}
+}
+
+func TestArtifactHash_SensitiveToToolCallSequence(t *testing.T) {
+	base := Artifact{TraceID: "t", CandidateModel: "c"}
+	base.ActualToolCalls = []string{"a", "b"}
+	h1 := artifactHash(base)
+	base.ActualToolCalls = []string{"b", "a"}
+	h2 := artifactHash(base)
+	if h1 == h2 {
+		t.Fatalf("artifactHash should be order-sensitive on ActualToolCalls")
+	}
+}
+
+func TestArtifactHash_PrefixIsSha256(t *testing.T) {
+	h := artifactHash(Artifact{TraceID: "t", CandidateModel: "c"})
+	if !strings.HasPrefix(h, "sha256:") {
+		t.Fatalf("artifactHash %q does not start with sha256:", h)
+	}
+	// sha256: + 64 hex chars = 71 total
+	if len(h) != 71 {
+		t.Fatalf("artifactHash length = %d; want 71", len(h))
+	}
+}

--- a/cmd/llm-bench/calibration_test.go
+++ b/cmd/llm-bench/calibration_test.go
@@ -84,6 +84,28 @@ func TestRunCalibrateCapture_WritesOneArtifactPerResult(t *testing.T) {
 	}
 }
 
+func TestRunCalibrateCapture_FailsWhenNoArtifactsWritten(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "artifacts.jsonl")
+	runner := &fakeRunner{results: []Result{
+		{Model: "ollama/cand", TraceID: "t1", Err: fmt.Errorf("model unavailable")},
+	}}
+	traces := []Trace{
+		{ID: "t1", System: "s", Turns: []Turn{{Role: "user", Content: "u1"}}, Golden: Golden{FinalAnswerCriteria: "c"}},
+	}
+	targets := []ModelTarget{{Display: "ollama/cand", Provider: "ollama", Model: "cand"}}
+
+	err := runCalibrateCapture(context.Background(), calibrateCaptureOptions{
+		Runner: runner, Targets: targets, Traces: traces, OutputPath: out,
+	})
+	if err == nil || !strings.Contains(err.Error(), "no artifacts written") {
+		t.Fatalf("runCalibrateCapture err = %v; want no artifacts written", err)
+	}
+	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+		t.Fatalf("output stat err = %v; want file not created", statErr)
+	}
+}
+
 func TestArtifactHash_DeterministicAcrossInvocations(t *testing.T) {
 	a := Artifact{
 		TraceID: "t1", CandidateModel: "ollama/cand",
@@ -401,13 +423,64 @@ func TestRunCalibrate_ReportFilenameIsSlugified(t *testing.T) {
 		JudgeModel: "ollama/gemma4:31b",
 		MinLabels:  1,
 		ReportDir:  reportDir,
-		Clock:      func() time.Time { return time.Date(2026, 5, 25, 0, 0, 0, 0, time.UTC) },
+		Clock:      func() time.Time { return time.Date(2026, 5, 25, 13, 14, 15, 0, time.UTC) },
 	})
 	if err != nil {
 		t.Fatalf("runCalibrate: %v", err)
 	}
-	if !strings.HasSuffix(res.ReportPath, "2026-05-25-ollama_gemma4_31b.md") {
-		t.Fatalf("ReportPath=%q; want suffix 2026-05-25-ollama_gemma4_31b.md", res.ReportPath)
+	if !strings.HasSuffix(res.ReportPath, "2026-05-25T131415Z-ollama_gemma4_31b.md") {
+		t.Fatalf("ReportPath=%q; want suffix 2026-05-25T131415Z-ollama_gemma4_31b.md", res.ReportPath)
+	}
+}
+
+func TestRunCalibrate_ReportFilenameDoesNotOverwriteSameTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	arts := filepath.Join(dir, "artifacts.jsonl")
+	labels := filepath.Join(dir, "labels.jsonl")
+	reportDir := filepath.Join(dir, "reports")
+	a := testCalibrationArtifact("t", "x")
+	if err := writeJSONL(arts, []any{a}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONL(labels, []any{Label{
+		TraceID: "t", CandidateModel: "ollama/c", ArtifactHash: a.ArtifactHash,
+		ExpectedAnswerQuality: 1.0, Labeler: "manual",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	run := func() CalibrationResult {
+		t.Helper()
+		res, err := runCalibrate(context.Background(), calibrateOptions{
+			LabelsPath: labels, ArtifactsPath: arts,
+			Scorer:     &fakeScorer{judgeByTrace: map[string]float64{"t": 1.0}},
+			JudgeModel: "ollama/gemma4:31b",
+			MinLabels:  1,
+			ReportDir:  reportDir,
+			Clock:      func() time.Time { return time.Date(2026, 5, 25, 13, 14, 15, 0, time.UTC) },
+		})
+		if err != nil {
+			t.Fatalf("runCalibrate: %v", err)
+		}
+		return res
+	}
+
+	first := run()
+	if err := os.WriteFile(first.ReportPath, []byte("sentinel"), 0o600); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+	second := run()
+	if first.ReportPath == second.ReportPath {
+		t.Fatalf("ReportPath reused %q; want unique path", first.ReportPath)
+	}
+	if !strings.HasSuffix(second.ReportPath, "2026-05-25T131415Z-ollama_gemma4_31b-2.md") {
+		t.Fatalf("second ReportPath=%q; want -2 suffix", second.ReportPath)
+	}
+	got, err := os.ReadFile(first.ReportPath)
+	if err != nil {
+		t.Fatalf("read first report: %v", err)
+	}
+	if string(got) != "sentinel" {
+		t.Fatalf("first report was overwritten: %q", got)
 	}
 }
 

--- a/cmd/llm-bench/calibration_test.go
+++ b/cmd/llm-bench/calibration_test.go
@@ -75,6 +75,9 @@ func TestRunCalibrateCapture_WritesOneArtifactPerResult(t *testing.T) {
 		if a.CandidateModel != "ollama/cand" {
 			t.Fatalf("artifact %d candidate = %q", i, a.CandidateModel)
 		}
+		if a.Trace.ID != a.TraceID {
+			t.Fatalf("artifact %d trace context ID = %q; want %q", i, a.Trace.ID, a.TraceID)
+		}
 	}
 	if artifacts[0].ActualFinalAnswer != "answer one" {
 		t.Fatalf("artifact[0].ActualFinalAnswer = %q", artifacts[0].ActualFinalAnswer)
@@ -116,6 +119,16 @@ func TestArtifactHash_SensitiveToToolCallSequence(t *testing.T) {
 	}
 }
 
+func TestArtifactHash_SensitiveToGoldenRubric(t *testing.T) {
+	base := testCalibrationArtifact("t", "answer")
+	h1 := artifactHash(base)
+	base.Trace.Golden.FinalAnswerCriteria = "different rubric"
+	h2 := artifactHash(base)
+	if h1 == h2 {
+		t.Fatalf("artifactHash not sensitive to original trace rubric")
+	}
+}
+
 func TestArtifactHash_PrefixIsSha256(t *testing.T) {
 	h := artifactHash(Artifact{TraceID: "t", CandidateModel: "c"})
 	if !strings.HasPrefix(h, "sha256:") {
@@ -127,12 +140,19 @@ func TestArtifactHash_PrefixIsSha256(t *testing.T) {
 	}
 }
 
+func TestCalibrationTraceFromArtifactRequiresOriginalRubric(t *testing.T) {
+	artifact := Artifact{TraceID: "t", CandidateModel: "ollama/c"}
+	_, err := calibrationTraceFromArtifact(artifact)
+	if err == nil || !strings.Contains(err.Error(), "missing original trace context") {
+		t.Fatalf("calibrationTraceFromArtifact err = %v; want missing trace context", err)
+	}
+}
+
 func TestLoadLabelsAndArtifacts_MatchAndStale(t *testing.T) {
 	dir := t.TempDir()
 	labels := filepath.Join(dir, "labels.jsonl")
 	arts := filepath.Join(dir, "artifacts.jsonl")
-	art := Artifact{TraceID: "t1", CandidateModel: "ollama/c", ActualFinalAnswer: "x"}
-	art.ArtifactHash = artifactHash(art)
+	art := testCalibrationArtifact("t1", "x")
 	if err := writeJSONL(arts, []any{art}); err != nil {
 		t.Fatalf("seed arts: %v", err)
 	}
@@ -166,6 +186,62 @@ func (s *fakeScorer) Score(ctx context.Context, t Trace, r Result) (Score, error
 	return Score{AnswerQuality: s.judgeByTrace[t.ID]}, nil
 }
 
+func testCalibrationArtifact(traceID, answer string) Artifact {
+	trace := Trace{
+		ID:     traceID,
+		System: "system for " + traceID,
+		Turns:  []Turn{{Role: "user", Content: "question for " + traceID}},
+		Golden: Golden{FinalAnswerCriteria: "rubric for " + traceID},
+	}
+	artifact := Artifact{
+		TraceID:           traceID,
+		CandidateModel:    "ollama/c",
+		Trace:             trace,
+		ActualFinalAnswer: answer,
+		ActualTranscript:  []Turn{{Role: "assistant", Content: answer}},
+	}
+	artifact.ArtifactHash = artifactHash(artifact)
+	return artifact
+}
+
+type recordingScorer struct {
+	trace Trace
+}
+
+func (s *recordingScorer) Score(ctx context.Context, t Trace, r Result) (Score, error) {
+	s.trace = t
+	return Score{AnswerQuality: 1.0}, nil
+}
+
+func TestRunCalibrate_UsesArtifactTraceRubric(t *testing.T) {
+	dir := t.TempDir()
+	arts := filepath.Join(dir, "artifacts.jsonl")
+	labels := filepath.Join(dir, "labels.jsonl")
+	artifact := testCalibrationArtifact("trace-rubric", "answer")
+	artifact.Trace.Golden.FinalAnswerCriteria = "trace-specific rubric"
+	artifact.ArtifactHash = artifactHash(artifact)
+	if err := writeJSONL(arts, []any{artifact}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONL(labels, []any{Label{
+		TraceID: artifact.TraceID, CandidateModel: artifact.CandidateModel, ArtifactHash: artifact.ArtifactHash,
+		ExpectedAnswerQuality: 1.0, Labeler: "manual",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	scorer := &recordingScorer{}
+	_, err := runCalibrate(context.Background(), calibrateOptions{
+		LabelsPath: labels, ArtifactsPath: arts, Scorer: scorer,
+		JudgeModel: "ollama/judge", MinLabels: 1,
+	})
+	if err != nil {
+		t.Fatalf("runCalibrate: %v", err)
+	}
+	if scorer.trace.Golden.FinalAnswerCriteria != "trace-specific rubric" {
+		t.Fatalf("scored rubric = %q; want original trace rubric", scorer.trace.Golden.FinalAnswerCriteria)
+	}
+}
+
 func TestRunCalibrate_AgreementMatchesByHand(t *testing.T) {
 	dir := t.TempDir()
 	arts := filepath.Join(dir, "artifacts.jsonl")
@@ -184,8 +260,7 @@ func TestRunCalibrate_AgreementMatchesByHand(t *testing.T) {
 	judged := []float64{1.0, 0.6, 0.7, 0.25}
 	for i := 0; i < 4; i++ {
 		traceID := fmt.Sprintf("t%d", i)
-		a := Artifact{TraceID: traceID, CandidateModel: "ollama/c", ActualFinalAnswer: traceID}
-		a.ArtifactHash = artifactHash(a)
+		a := testCalibrationArtifact(traceID, traceID)
 		artifacts = append(artifacts, a)
 		labelRecs = append(labelRecs, Label{
 			TraceID: traceID, CandidateModel: "ollama/c", ArtifactHash: a.ArtifactHash,
@@ -231,8 +306,7 @@ func TestRunCalibrate_InsufficientLabelsNeverPasses(t *testing.T) {
 	var artifacts, labelRecs []any
 	for i := 0; i < 3; i++ {
 		traceID := fmt.Sprintf("t%d", i)
-		a := Artifact{TraceID: traceID, CandidateModel: "ollama/c", ActualFinalAnswer: traceID}
-		a.ArtifactHash = artifactHash(a)
+		a := testCalibrationArtifact(traceID, traceID)
 		artifacts = append(artifacts, a)
 		labelRecs = append(labelRecs, Label{
 			TraceID: traceID, CandidateModel: "ollama/c", ArtifactHash: a.ArtifactHash,
@@ -290,8 +364,7 @@ func TestRunCalibrate_ReportFilenameIsSlugified(t *testing.T) {
 	arts := filepath.Join(dir, "artifacts.jsonl")
 	labels := filepath.Join(dir, "labels.jsonl")
 	reportDir := filepath.Join(dir, "reports")
-	a := Artifact{TraceID: "t", CandidateModel: "ollama/c", ActualFinalAnswer: "x"}
-	a.ArtifactHash = artifactHash(a)
+	a := testCalibrationArtifact("t", "x")
 	if err := writeJSONL(arts, []any{a}); err != nil {
 		t.Fatal(err)
 	}
@@ -337,8 +410,7 @@ func TestRunCalibrate_StabilityRunsReportSpread(t *testing.T) {
 	dir := t.TempDir()
 	arts := filepath.Join(dir, "artifacts.jsonl")
 	labels := filepath.Join(dir, "labels.jsonl")
-	a := Artifact{TraceID: "t", CandidateModel: "ollama/c", ActualFinalAnswer: "x"}
-	a.ArtifactHash = artifactHash(a)
+	a := testCalibrationArtifact("t", "x")
 	if err := writeJSONL(arts, []any{a}); err != nil {
 		t.Fatal(err)
 	}
@@ -375,11 +447,8 @@ func TestRunCalibrate_StabilityRunsDoNotPersistJudgeCache(t *testing.T) {
 	dir := t.TempDir()
 	arts := filepath.Join(dir, "artifacts.jsonl")
 	labels := filepath.Join(dir, "labels.jsonl")
-	a := Artifact{
-		TraceID: "t", CandidateModel: "ollama/c",
-		ActualFinalAnswer: "x",
-		ActualTranscript:  []Turn{{Role: "user", Content: "ask"}, {Role: "assistant", Content: "x"}},
-	}
+	a := testCalibrationArtifact("t", "x")
+	a.ActualTranscript = []Turn{{Role: "user", Content: "ask"}, {Role: "assistant", Content: "x"}}
 	a.ArtifactHash = artifactHash(a)
 	if err := writeJSONL(arts, []any{a}); err != nil {
 		t.Fatal(err)

--- a/cmd/llm-bench/calibration_test.go
+++ b/cmd/llm-bench/calibration_test.go
@@ -303,6 +303,57 @@ func TestRunCalibrate_ReportFilenameIsSlugified(t *testing.T) {
 	}
 }
 
+// fakeStabilityScorer returns a sequence of scores per Score() call.
+type fakeStabilityScorer struct {
+	callCount int
+	sequence  []float64
+}
+
+func (s *fakeStabilityScorer) Score(ctx context.Context, t Trace, r Result) (Score, error) {
+	if s.callCount >= len(s.sequence) {
+		s.callCount++
+		return Score{AnswerQuality: s.sequence[len(s.sequence)-1]}, nil
+	}
+	v := s.sequence[s.callCount]
+	s.callCount++
+	return Score{AnswerQuality: v}, nil
+}
+
+func TestRunCalibrate_StabilityRunsReportSpread(t *testing.T) {
+	dir := t.TempDir()
+	arts := filepath.Join(dir, "artifacts.jsonl")
+	labels := filepath.Join(dir, "labels.jsonl")
+	a := Artifact{TraceID: "t", CandidateModel: "ollama/c", ActualFinalAnswer: "x"}
+	a.ArtifactHash = artifactHash(a)
+	if err := writeJSONL(arts, []any{a}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONL(labels, []any{Label{
+		TraceID: "t", CandidateModel: "ollama/c", ArtifactHash: a.ArtifactHash,
+		ExpectedAnswerQuality: 1.0, Labeler: "manual",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	fs := &fakeStabilityScorer{sequence: []float64{0.8, 1.0, 0.6}} // spread = 0.4
+	res, err := runCalibrate(context.Background(), calibrateOptions{
+		LabelsPath: labels, ArtifactsPath: arts, Scorer: fs,
+		JudgeModel: "ollama/judge", MinLabels: 1, StabilityRuns: 3,
+	})
+	if err != nil {
+		t.Fatalf("runCalibrate: %v", err)
+	}
+	if len(res.PerLabel) != 1 {
+		t.Fatalf("PerLabel=%d; want 1", len(res.PerLabel))
+	}
+	if res.PerLabel[0].StabilitySpread != 0.4 {
+		t.Fatalf("StabilitySpread=%v; want 0.4", res.PerLabel[0].StabilitySpread)
+	}
+	// Stability runs do NOT affect agreement (primary calls were already cached/Counted).
+	if res.AgreeCount != 1 {
+		t.Fatalf("AgreeCount=%d; want 1 (stability runs are diagnostic only)", res.AgreeCount)
+	}
+}
+
 // writeJSONL is a tiny test helper local to calibration_test.go.
 func writeJSONL(path string, records []any) error {
 	f, err := os.Create(path)

--- a/cmd/llm-bench/judge_cache.go
+++ b/cmd/llm-bench/judge_cache.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+)
+
+// judgeCacheKeyVersion is bumped to force-invalidate every entry. Increment
+// when changing the canonical request shape (new field, semantic shift).
+const judgeCacheKeyVersion = 1
+
+// judgeCacheRequest is the canonical envelope hashed to produce the cache
+// key. Fields here MUST be limited to inputs that affect judgment semantics.
+// KeepAlive, JudgeTimeout, OllamaURL are deliberately excluded — they
+// affect execution, not the judge's verdict.
+type judgeCacheRequest struct {
+	Version          int     `json:"version"`
+	JudgeModel       string  `json:"judge_model"`
+	JudgeModelDigest string  `json:"judge_model_digest"`
+	SystemPrompt     string  `json:"system_prompt"`
+	UserPrompt       string  `json:"user_prompt"`
+	Format           string  `json:"format"`
+	Temperature      float64 `json:"temperature"`
+	NumPredict       int     `json:"num_predict"`
+}
+
+// canonicalCacheKey hashes the envelope deterministically. Uses
+// encoding/json's stable struct-tag ordering (Go's encoding/json marshals
+// struct fields in declaration order), then SHA-256s the bytes.
+func canonicalCacheKey(r judgeCacheRequest) string {
+	raw, _ := json.Marshal(r) // marshaling a fixed-shape struct cannot fail
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}

--- a/cmd/llm-bench/judge_cache.go
+++ b/cmd/llm-bench/judge_cache.go
@@ -3,9 +3,15 @@ package main
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
 	"time"
+
+	_ "modernc.org/sqlite"
 )
 
 // judgeCacheKeyVersion is bumped to force-invalidate every entry. Increment
@@ -62,4 +68,187 @@ type judgeCacheStore interface {
 	Get(ctx context.Context, key string) (judgeCacheEntry, bool, error)
 	Put(ctx context.Context, e judgeCacheEntry) error
 	Close() error
+}
+
+// Sentinel errors so callers can distinguish the four failure modes per
+// feedback_error_granularity. All four are non-fatal: callers log + bypass
+// to a direct judge call.
+var (
+	errJudgeCacheOpen    = errors.New("judge cache: open")
+	errJudgeCacheMigrate = errors.New("judge cache: migrate schema")
+	errJudgeCacheGet     = errors.New("judge cache: get")
+	errJudgeCachePut     = errors.New("judge cache: put")
+)
+
+// sqliteJudgeCache is the SQLite-backed judgeCacheStore. Use openJudgeCache
+// to construct one (it handles migrations); callers MUST treat all returned
+// errors as non-fatal and degrade to an uncached judge call.
+type sqliteJudgeCache struct {
+	db *sql.DB
+}
+
+// openJudgeCache opens (and migrates) the judge cache DB at path. Empty
+// path returns (nil, nil) so callers can disable the cache by passing "".
+// Callers MUST check for a nil concrete pointer before assigning to a
+// judgeCacheStore interface variable to avoid the typed-nil interface trap.
+func openJudgeCache(path string) (*sqliteJudgeCache, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, nil
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("%w %q: %v", errJudgeCacheOpen, path, err)
+	}
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("%w %q: %v", errJudgeCacheOpen, path, err)
+	}
+	if err := migrateJudgeCache(db); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("%w: %v", errJudgeCacheMigrate, err)
+	}
+	return &sqliteJudgeCache{db: db}, nil
+}
+
+// migrateJudgeCache applies pending DDL migrations using the
+// judge_cache_schema_version table to track applied versions. The pattern
+// matches feedback/migration.go and rag/migration.go: each migration runs
+// in its own transaction so a mid-list failure leaves the DB in a known
+// state.
+func migrateJudgeCache(db *sql.DB) error {
+	const createVersionTable = `CREATE TABLE IF NOT EXISTS judge_cache_schema_version (
+        version     INTEGER PRIMARY KEY,
+        description TEXT    NOT NULL,
+        applied_at  INTEGER NOT NULL
+    );`
+	if _, err := db.Exec(createVersionTable); err != nil {
+		return fmt.Errorf("create version table: %w", err)
+	}
+	var current int
+	if err := db.QueryRow(`SELECT COALESCE(MAX(version),0) FROM judge_cache_schema_version`).Scan(&current); err != nil {
+		return fmt.Errorf("read schema version: %w", err)
+	}
+	migrations := []struct {
+		version     int
+		description string
+		ddl         string
+	}{
+		{
+			version:     1,
+			description: "initial judge_cache table",
+			ddl: `
+            CREATE TABLE judge_cache (
+                cache_key          TEXT PRIMARY KEY,
+                judge_model        TEXT NOT NULL,
+                judge_model_digest TEXT NOT NULL DEFAULT '',
+                trace_id           TEXT NOT NULL,
+                candidate_model    TEXT NOT NULL,
+                prompt_hash        TEXT NOT NULL,
+                request_json       TEXT NOT NULL,
+                response_content   TEXT NOT NULL,
+                answer_quality     REAL NOT NULL,
+                justification      TEXT NOT NULL,
+                created_at         INTEGER NOT NULL,
+                last_used_at       INTEGER NOT NULL,
+                hit_count          INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE INDEX idx_judge_cache_model_trace ON judge_cache(judge_model, trace_id);
+            `,
+		},
+	}
+	for _, m := range migrations {
+		if m.version <= current {
+			continue
+		}
+		tx, err := db.Begin()
+		if err != nil {
+			return fmt.Errorf("begin tx for v%d: %w", m.version, err)
+		}
+		if _, err := tx.Exec(m.ddl); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("apply v%d: %w", m.version, err)
+		}
+		if _, err := tx.Exec(
+			`INSERT INTO judge_cache_schema_version (version, description, applied_at) VALUES (?, ?, ?)`,
+			m.version, m.description, time.Now().UnixNano(),
+		); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("record v%d: %w", m.version, err)
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit v%d: %w", m.version, err)
+		}
+	}
+	return nil
+}
+
+// Get returns the entry for key plus ok=true on hit, ok=false on miss.
+// On a hit, hit_count is bumped and last_used_at is set to now; the
+// returned entry reflects the post-bump values so caller telemetry sees
+// the same state the DB now holds.
+func (c *sqliteJudgeCache) Get(ctx context.Context, key string) (judgeCacheEntry, bool, error) {
+	var e judgeCacheEntry
+	var createdNs, lastUsedNs int64
+	err := c.db.QueryRowContext(ctx, `
+        SELECT cache_key, judge_model, judge_model_digest, trace_id, candidate_model,
+               prompt_hash, request_json, response_content, answer_quality, justification,
+               created_at, last_used_at, hit_count
+        FROM judge_cache WHERE cache_key = ?`, key,
+	).Scan(
+		&e.CacheKey, &e.JudgeModel, &e.JudgeModelDigest, &e.TraceID, &e.CandidateModel,
+		&e.PromptHash, &e.RequestJSON, &e.ResponseContent, &e.AnswerQuality, &e.Justification,
+		&createdNs, &lastUsedNs, &e.HitCount,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return judgeCacheEntry{}, false, nil
+	}
+	if err != nil {
+		return judgeCacheEntry{}, false, fmt.Errorf("%w key %s: %v", errJudgeCacheGet, key, err)
+	}
+	e.CreatedAt = time.Unix(0, createdNs).UTC()
+	e.LastUsedAt = time.Unix(0, lastUsedNs).UTC()
+
+	nowNs := time.Now().UTC().UnixNano()
+	if _, err := c.db.ExecContext(ctx,
+		`UPDATE judge_cache SET hit_count = hit_count + 1, last_used_at = ? WHERE cache_key = ?`,
+		nowNs, key,
+	); err != nil {
+		return judgeCacheEntry{}, false, fmt.Errorf("%w hit-count for key %s: %v", errJudgeCacheGet, key, err)
+	}
+	e.HitCount++
+	e.LastUsedAt = time.Unix(0, nowNs).UTC()
+	return e, true, nil
+}
+
+// Put upserts e by cache_key. On conflict, only last_used_at and hit_count
+// are updated — the original verdict (answer_quality, justification,
+// response_content) is preserved so a re-Put of the same key behaves like
+// a Get-hit.
+func (c *sqliteJudgeCache) Put(ctx context.Context, e judgeCacheEntry) error {
+	_, err := c.db.ExecContext(ctx, `
+        INSERT INTO judge_cache (cache_key, judge_model, judge_model_digest, trace_id, candidate_model,
+            prompt_hash, request_json, response_content, answer_quality, justification,
+            created_at, last_used_at, hit_count)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+        ON CONFLICT(cache_key) DO UPDATE SET
+            last_used_at = excluded.last_used_at,
+            hit_count    = judge_cache.hit_count + 1`,
+		e.CacheKey, e.JudgeModel, e.JudgeModelDigest, e.TraceID, e.CandidateModel,
+		e.PromptHash, e.RequestJSON, e.ResponseContent, e.AnswerQuality, e.Justification,
+		e.CreatedAt.UnixNano(), e.LastUsedAt.UnixNano(), e.HitCount,
+	)
+	if err != nil {
+		return fmt.Errorf("%w key %s: %v", errJudgeCachePut, e.CacheKey, err)
+	}
+	return nil
+}
+
+// Close releases the underlying DB handle. Safe to call on a nil receiver
+// so callers can defer cache.Close() even when openJudgeCache("") returned
+// (nil, nil).
+func (c *sqliteJudgeCache) Close() error {
+	if c == nil || c.db == nil {
+		return nil
+	}
+	return c.db.Close()
 }

--- a/cmd/llm-bench/judge_cache.go
+++ b/cmd/llm-bench/judge_cache.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -95,6 +97,11 @@ type sqliteJudgeCache struct {
 func openJudgeCache(path string) (*sqliteJudgeCache, error) {
 	if strings.TrimSpace(path) == "" {
 		return nil, nil
+	}
+	if dir := filepath.Dir(path); dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, fmt.Errorf("%w %q: mkdir parent: %v", errJudgeCacheOpen, path, err)
+		}
 	}
 	db, err := sql.Open("sqlite", path)
 	if err != nil {

--- a/cmd/llm-bench/judge_cache.go
+++ b/cmd/llm-bench/judge_cache.go
@@ -16,7 +16,7 @@ import (
 
 // judgeCacheKeyVersion is bumped to force-invalidate every entry. Increment
 // when changing the canonical request shape (new field, semantic shift).
-const judgeCacheKeyVersion = 1
+const judgeCacheKeyVersion = 2
 
 // judgeCacheRequest is the canonical envelope hashed to produce the cache
 // key. Fields here MUST be limited to inputs that affect judgment semantics.
@@ -29,6 +29,7 @@ type judgeCacheRequest struct {
 	SystemPrompt     string  `json:"system_prompt"`
 	UserPrompt       string  `json:"user_prompt"`
 	Format           string  `json:"format"`
+	Think            *bool   `json:"think,omitempty"`
 	Temperature      float64 `json:"temperature"`
 	NumPredict       int     `json:"num_predict"`
 }

--- a/cmd/llm-bench/judge_cache.go
+++ b/cmd/llm-bench/judge_cache.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"time"
 )
 
 // judgeCacheKeyVersion is bumped to force-invalidate every entry. Increment
@@ -32,4 +34,32 @@ func canonicalCacheKey(r judgeCacheRequest) string {
 	raw, _ := json.Marshal(r) // marshaling a fixed-shape struct cannot fail
 	sum := sha256.Sum256(raw)
 	return hex.EncodeToString(sum[:])
+}
+
+// judgeCacheEntry is the value half of a cache row. ResponseContent is the
+// raw judge Message.Content; AnswerQuality and Justification are the
+// parsed verdict (denormalized so cache audits don't need to re-parse).
+type judgeCacheEntry struct {
+	CacheKey         string
+	JudgeModel       string
+	JudgeModelDigest string
+	TraceID          string
+	CandidateModel   string
+	PromptHash       string // sha256 of UserPrompt only, for audit grouping
+	RequestJSON      string // canonical request envelope, pretty-printed
+	ResponseContent  string
+	AnswerQuality    float64
+	Justification    string
+	CreatedAt        time.Time
+	LastUsedAt       time.Time
+	HitCount         int64
+}
+
+// judgeCacheStore is the abstraction used by LLMJudgeScorer. A nil store is
+// a valid "no cache" signal; the SQLite-backed concrete type is constructed
+// by openJudgeCache.
+type judgeCacheStore interface {
+	Get(ctx context.Context, key string) (judgeCacheEntry, bool, error)
+	Put(ctx context.Context, e judgeCacheEntry) error
+	Close() error
 }

--- a/cmd/llm-bench/judge_cache_test.go
+++ b/cmd/llm-bench/judge_cache_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -116,4 +118,34 @@ func TestSQLiteJudgeCache_MigrationIdempotent(t *testing.T) {
 		t.Fatalf("re-open: %v", err)
 	}
 	defer c2.Close()
+}
+
+func TestOpenJudgeCache_CorruptDBReturnsWrappedErrorNoAutoRepair(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "corrupt.db")
+	// Write garbage bytes to the file before opening.
+	if err := os.WriteFile(path, []byte("not a sqlite file"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	_, err := openJudgeCache(path)
+	if err == nil {
+		t.Fatalf("openJudgeCache(corrupt) returned nil error; want wrapped open or migrate error")
+	}
+	if !errors.Is(err, errJudgeCacheOpen) && !errors.Is(err, errJudgeCacheMigrate) {
+		t.Fatalf("openJudgeCache(corrupt) returned %v; want errJudgeCacheOpen or errJudgeCacheMigrate", err)
+	}
+	// The file must still be on disk (no auto-repair / auto-delete).
+	if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+		t.Fatalf("openJudgeCache deleted the corrupt file; expected no auto-repair")
+	}
+}
+
+func TestOpenJudgeCache_EmptyPathReturnsNilCache(t *testing.T) {
+	c, err := openJudgeCache("")
+	if err != nil {
+		t.Fatalf("openJudgeCache(\"\"): %v", err)
+	}
+	if c != nil {
+		t.Fatalf("openJudgeCache(\"\") returned non-nil cache; want nil (disabled)")
+	}
 }

--- a/cmd/llm-bench/judge_cache_test.go
+++ b/cmd/llm-bench/judge_cache_test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -148,4 +150,31 @@ func TestOpenJudgeCache_EmptyPathReturnsNilCache(t *testing.T) {
 	if c != nil {
 		t.Fatalf("openJudgeCache(\"\") returned non-nil cache; want nil (disabled)")
 	}
+}
+
+func TestSQLiteJudgeCache_ConcurrentGetPut_NoRace(t *testing.T) {
+	c, _ := newTestCache(t)
+	ctx := context.Background()
+	const workers = 8
+	const iters = 50
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				key := fmt.Sprintf("k-%d-%d", id, i%10) // intentional collisions across workers
+				now := time.Now().UTC()
+				_ = c.Put(ctx, judgeCacheEntry{
+					CacheKey: key, JudgeModel: "m", JudgeModelDigest: "d",
+					TraceID: "t", CandidateModel: "cand",
+					PromptHash: "ph", RequestJSON: "{}", ResponseContent: "{}",
+					AnswerQuality: 0.5, Justification: "j",
+					CreatedAt: now, LastUsedAt: now,
+				})
+				_, _, _ = c.Get(ctx, key)
+			}
+		}(w)
+	}
+	wg.Wait()
 }

--- a/cmd/llm-bench/judge_cache_test.go
+++ b/cmd/llm-bench/judge_cache_test.go
@@ -132,6 +132,18 @@ func TestSQLiteJudgeCache_MigrationIdempotent(t *testing.T) {
 	defer func() { _ = c2.Close() }()
 }
 
+func TestOpenJudgeCache_CreatesParentDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing", "nested", "judge.db")
+	c, err := openJudgeCache(path)
+	if err != nil {
+		t.Fatalf("openJudgeCache: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("cache file stat: %v", err)
+	}
+}
+
 func TestOpenJudgeCache_CorruptDBReturnsWrappedErrorNoAutoRepair(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "corrupt.db")

--- a/cmd/llm-bench/judge_cache_test.go
+++ b/cmd/llm-bench/judge_cache_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCanonicalCacheKey_StableUnderFieldReordering(t *testing.T) {
+	a := judgeCacheRequest{
+		Version: 1, JudgeModel: "ollama/gemma4:31b", JudgeModelDigest: "sha256:abc",
+		SystemPrompt: "sys", UserPrompt: "u",
+		Format: "json", Temperature: 0.1, NumPredict: 512,
+	}
+	b := a
+	k1 := canonicalCacheKey(a)
+	k2 := canonicalCacheKey(b)
+	if k1 != k2 {
+		t.Fatalf("same inputs produced different keys: %s vs %s", k1, k2)
+	}
+	if len(k1) != 64 {
+		t.Fatalf("key length %d; want 64 hex chars", len(k1))
+	}
+}
+
+func TestCanonicalCacheKey_VersionBumpInvalidates(t *testing.T) {
+	base := judgeCacheRequest{Version: 1, JudgeModel: "m", SystemPrompt: "s", UserPrompt: "u", Format: "json", Temperature: 0.1, NumPredict: 100}
+	bumped := base
+	bumped.Version = 2
+	if canonicalCacheKey(base) == canonicalCacheKey(bumped) {
+		t.Fatalf("version bump did not invalidate key")
+	}
+}
+
+func TestCanonicalCacheKey_DigestSensitive(t *testing.T) {
+	base := judgeCacheRequest{Version: 1, JudgeModel: "m", JudgeModelDigest: "sha256:aaa", SystemPrompt: "s", UserPrompt: "u", Format: "json", Temperature: 0.1, NumPredict: 100}
+	diff := base
+	diff.JudgeModelDigest = "sha256:bbb"
+	if canonicalCacheKey(base) == canonicalCacheKey(diff) {
+		t.Fatalf("digest change did not invalidate key")
+	}
+}
+
+func TestCanonicalCacheKey_ExcludesExecutionOnlyFields(t *testing.T) {
+	// Sanity: judgeCacheRequest is the cache key envelope. If anyone adds
+	// KeepAlive / JudgeTimeout / OllamaURL to it, this test will be deleted
+	// intentionally — keep it as a guard until then.
+	s := canonicalCacheKey(judgeCacheRequest{Version: 1, JudgeModel: "m", SystemPrompt: "s", UserPrompt: "u", Format: "json", Temperature: 0.1, NumPredict: 100})
+	if strings.TrimSpace(s) == "" {
+		t.Fatalf("empty key")
+	}
+}

--- a/cmd/llm-bench/judge_cache_test.go
+++ b/cmd/llm-bench/judge_cache_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"context"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestCanonicalCacheKey_StableUnderFieldReordering(t *testing.T) {
@@ -48,4 +51,69 @@ func TestCanonicalCacheKey_ExcludesExecutionOnlyFields(t *testing.T) {
 	if strings.TrimSpace(s) == "" {
 		t.Fatalf("empty key")
 	}
+}
+
+func newTestCache(t *testing.T) (*sqliteJudgeCache, string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "judge.db")
+	c, err := openJudgeCache(path)
+	if err != nil {
+		t.Fatalf("openJudgeCache: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+	return c, path
+}
+
+func TestSQLiteJudgeCache_PutThenGetReturnsEntry(t *testing.T) {
+	c, _ := newTestCache(t)
+	ctx := context.Background()
+	now := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	entry := judgeCacheEntry{
+		CacheKey: "abc", JudgeModel: "ollama/gemma4:31b",
+		JudgeModelDigest: "sha256:deadbeef",
+		TraceID:          "t1", CandidateModel: "ollama/cand",
+		PromptHash:      "ph",
+		RequestJSON:     `{"v":1}`,
+		ResponseContent: `{"answer_quality":0.5,"justification":"ok"}`,
+		AnswerQuality:   0.5, Justification: "ok",
+		CreatedAt: now, LastUsedAt: now, HitCount: 0,
+	}
+	if err := c.Put(ctx, entry); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, ok, err := c.Get(ctx, "abc")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !ok {
+		t.Fatalf("Get returned ok=false for present key")
+	}
+	if got.ResponseContent != entry.ResponseContent || got.AnswerQuality != 0.5 {
+		t.Fatalf("Get returned wrong entry: %+v", got)
+	}
+	if got.HitCount != 1 {
+		t.Fatalf("HitCount not bumped: %d", got.HitCount)
+	}
+}
+
+func TestSQLiteJudgeCache_GetMissingReturnsOkFalse(t *testing.T) {
+	c, _ := newTestCache(t)
+	_, ok, err := c.Get(context.Background(), "does-not-exist")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if ok {
+		t.Fatalf("Get returned ok=true for missing key")
+	}
+}
+
+func TestSQLiteJudgeCache_MigrationIdempotent(t *testing.T) {
+	_, path := newTestCache(t)
+	// Reopen same path; migration must not error or duplicate version row.
+	c2, err := openJudgeCache(path)
+	if err != nil {
+		t.Fatalf("re-open: %v", err)
+	}
+	defer c2.Close()
 }

--- a/cmd/llm-bench/judge_cache_test.go
+++ b/cmd/llm-bench/judge_cache_test.go
@@ -163,7 +163,7 @@ func TestSQLiteJudgeCache_ConcurrentGetPut_NoRace(t *testing.T) {
 		go func(id int) {
 			defer wg.Done()
 			for i := 0; i < iters; i++ {
-				key := fmt.Sprintf("k-%d-%d", id, i%10) // intentional collisions across workers
+				key := fmt.Sprintf("k-%d-%d", id, i%10) // each worker re-touches its own 10-key window
 				now := time.Now().UTC()
 				_ = c.Put(ctx, judgeCacheEntry{
 					CacheKey: key, JudgeModel: "m", JudgeModelDigest: "d",

--- a/cmd/llm-bench/judge_cache_test.go
+++ b/cmd/llm-bench/judge_cache_test.go
@@ -47,6 +47,16 @@ func TestCanonicalCacheKey_DigestSensitive(t *testing.T) {
 	}
 }
 
+func TestCanonicalCacheKey_ThinkSensitive(t *testing.T) {
+	base := judgeCacheRequest{Version: judgeCacheKeyVersion, JudgeModel: "m", SystemPrompt: "s", UserPrompt: "u", Format: "json", Temperature: 0.1, NumPredict: 100}
+	thinkFalse := false
+	noThink := base
+	noThink.Think = &thinkFalse
+	if canonicalCacheKey(base) == canonicalCacheKey(noThink) {
+		t.Fatalf("think mode change did not invalidate key")
+	}
+}
+
 func TestCanonicalCacheKey_ExcludesExecutionOnlyFields(t *testing.T) {
 	// Sanity: judgeCacheRequest is the cache key envelope. If anyone adds
 	// KeepAlive / JudgeTimeout / OllamaURL to it, this test will be deleted
@@ -119,7 +129,7 @@ func TestSQLiteJudgeCache_MigrationIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("re-open: %v", err)
 	}
-	defer c2.Close()
+	defer func() { _ = c2.Close() }()
 }
 
 func TestOpenJudgeCache_CorruptDBReturnsWrappedErrorNoAutoRepair(t *testing.T) {

--- a/cmd/llm-bench/judge_integration_test.go
+++ b/cmd/llm-bench/judge_integration_test.go
@@ -34,9 +34,17 @@ func TestCalibrateAgainstLiveOllama(t *testing.T) {
 	// Build a tiny 10-artifact micro-set with hand-crafted easy correctness.
 	var artifacts, labelRecs []any
 	for i := 0; i < 10; i++ {
+		traceID := "easy-" + strings.Repeat("a", i+1)
+		trace := Trace{
+			ID:     traceID,
+			System: "answer arithmetic questions exactly",
+			Turns:  []Turn{{Role: "user", Content: "what is 2+2?"}},
+			Golden: Golden{FinalAnswerCriteria: "answer exactly 4"},
+		}
 		a := Artifact{
-			TraceID:           "easy-" + strings.Repeat("a", i+1),
+			TraceID:           traceID,
 			CandidateModel:    "ollama/probe-candidate",
+			Trace:             trace,
 			ActualFinalAnswer: "4",
 			ActualToolCalls:   nil,
 			ActualTranscript: []Turn{

--- a/cmd/llm-bench/judge_integration_test.go
+++ b/cmd/llm-bench/judge_integration_test.go
@@ -57,7 +57,7 @@ func TestCalibrateAgainstLiveOllama(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 		enc := json.NewEncoder(f)
 		for _, r := range recs {
 			if err := enc.Encode(r); err != nil {
@@ -71,7 +71,7 @@ func TestCalibrateAgainstLiveOllama(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 	cache, _ := openJudgeCache(filepath.Join(dir, "judge.db"))
-	defer cache.Close()
+	defer func() { _ = cache.Close() }()
 
 	scorer, err := newScorer(ctx, "llm-judge", scorerOptions{
 		ollamaURL:    ollamaURL,

--- a/cmd/llm-bench/judge_integration_test.go
+++ b/cmd/llm-bench/judge_integration_test.go
@@ -1,0 +1,103 @@
+//go:build llmbench_integration
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestCalibrateAgainstLiveOllama exercises the full calibrate pipeline against
+// a live local Ollama. Skipped unless built with -tags llmbench_integration.
+// Set LLM_BENCH_JUDGE_MODEL (default "gemma4:31b") and LLM_BENCH_OLLAMA_URL
+// (default http://localhost:11434).
+func TestCalibrateAgainstLiveOllama(t *testing.T) {
+	judgeModel := os.Getenv("LLM_BENCH_JUDGE_MODEL")
+	if judgeModel == "" {
+		judgeModel = "gemma4:31b"
+	}
+	ollamaURL := os.Getenv("LLM_BENCH_OLLAMA_URL")
+	if ollamaURL == "" {
+		ollamaURL = "http://localhost:11434"
+	}
+
+	dir := t.TempDir()
+	arts := filepath.Join(dir, "artifacts.jsonl")
+	labels := filepath.Join(dir, "labels.jsonl")
+	reports := filepath.Join(dir, "reports")
+
+	// Build a tiny 10-artifact micro-set with hand-crafted easy correctness.
+	var artifacts, labelRecs []any
+	for i := 0; i < 10; i++ {
+		a := Artifact{
+			TraceID:           "easy-" + strings.Repeat("a", i+1),
+			CandidateModel:    "ollama/probe-candidate",
+			ActualFinalAnswer: "4",
+			ActualToolCalls:   nil,
+			ActualTranscript: []Turn{
+				{Role: "user", Content: "what is 2+2?"},
+				{Role: "assistant", Content: "4"},
+			},
+			CapturedAt: time.Now().UTC(),
+		}
+		a.ArtifactHash = artifactHash(a)
+		artifacts = append(artifacts, a)
+		labelRecs = append(labelRecs, Label{
+			TraceID: a.TraceID, CandidateModel: a.CandidateModel, ArtifactHash: a.ArtifactHash,
+			ExpectedAnswerQuality: 1.0, Labeler: "integration",
+		})
+	}
+	seed := func(path string, recs []any) {
+		f, err := os.Create(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+		enc := json.NewEncoder(f)
+		for _, r := range recs {
+			if err := enc.Encode(r); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	seed(arts, artifacts)
+	seed(labels, labelRecs)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	cache, _ := openJudgeCache(filepath.Join(dir, "judge.db"))
+	defer cache.Close()
+
+	scorer, err := newScorer(ctx, "llm-judge", scorerOptions{
+		ollamaURL:    ollamaURL,
+		judgeModel:   judgeModel,
+		judgeTimeout: 90 * time.Second,
+		judgeCache:   cache,
+	})
+	if err != nil {
+		t.Fatalf("newScorer: %v", err)
+	}
+	res, err := runCalibrate(ctx, calibrateOptions{
+		LabelsPath:    labels,
+		ArtifactsPath: arts,
+		Scorer:        scorer,
+		JudgeModel:    judgeModel,
+		ReportDir:     reports,
+		MinLabels:     10,
+	})
+	if err != nil {
+		t.Fatalf("runCalibrate: %v", err)
+	}
+	if res.Verdict == "" {
+		t.Fatalf("no verdict produced")
+	}
+	if res.MatchedCount != 10 {
+		t.Fatalf("MatchedCount=%d; want 10", res.MatchedCount)
+	}
+	t.Logf("integration calibrate: %d/%d (%.0f%%) → %s", res.AgreeCount, res.MatchedCount, res.AgreementRate*100, res.Verdict)
+}

--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -175,8 +175,8 @@ func main() {
 		}
 		fmt.Fprintf(os.Stderr, "llm-bench: calibrate verdict=%s agreement=%d/%d report=%s\n",
 			res.Verdict, res.AgreeCount, res.MatchedCount, res.ReportPath)
-		if res.Verdict == "FAIL" {
-			os.Exit(3)
+		if code := calibrationExitCode(res.Verdict); code != 0 {
+			os.Exit(code)
 		}
 		return
 	}
@@ -276,6 +276,13 @@ func defaultJudgeModelName() string {
 		}
 	}
 	return fallbackJudgeModel
+}
+
+func calibrationExitCode(verdict string) int {
+	if verdict == "PASS" {
+		return 0
+	}
+	return 3
 }
 
 // defaultJudgeCachePath returns the platform-appropriate location for the

--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -112,10 +112,7 @@ func main() {
 		runner := &Runner{
 			OllamaURL: *ollamaURL,
 			Timeout:   *timeout,
-			// ExactMatchScorer is unused by capture (we only need
-			// Runner.RunAll to produce Results); Runner currently
-			// requires a non-nil Scorer.
-			Scorer: &ExactMatchScorer{},
+			Scorer:    &CaptureScorer{},
 		}
 		if err := runCalibrateCapture(ctx, calibrateCaptureOptions{
 			Runner:     runner,

--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -34,16 +34,46 @@ func main() {
 	captureLimit := flag.Int("capture-limit", 0, "Maximum conversations to export in capture mode (0 = all)")
 	captureSource := flag.String("capture-source", defaultCaptureSource, "Trace source label for captured conversations")
 	captureSystem := flag.String("capture-system", "", "Fallback system prompt when a conversation has no stored system message")
-	tracesGlob := flag.String("traces", "", "Glob pattern for trace JSON files (required)")
+
+	calibrateCapture := flag.Bool("calibrate-capture", false, "Phase 1: replay candidates and write frozen artifacts.jsonl")
+	calibrate := flag.Bool("calibrate", false, "Phase 2: re-score frozen labeled artifacts with the judge model")
+	labelsPath := flag.String("labels", filepath.Join("docs", "llm", "calibration", "labels.jsonl"), "Path to labels.jsonl (Phase 2)")
+	labelsOut := flag.String("labels-out", filepath.Join("docs", "llm", "calibration", "artifacts.jsonl"), "Output path for -calibrate-capture artifacts.jsonl")
+	artifactsPath := flag.String("artifacts", filepath.Join("docs", "llm", "calibration", "artifacts.jsonl"), "Path to artifacts.jsonl (Phase 2)")
+	calibrateReportDir := flag.String("calibrate-report-dir", filepath.Join("docs", "llm", "calibration", "reports"), "Directory for calibration reports")
+	judgeStabilityRuns := flag.Int("judge-stability-runs", 0, "When >1, run the judge that many times per artifact (cache bypassed) and report spread as a diagnostic")
+
+	tracesGlob := flag.String("traces", "", "Glob pattern for trace JSON files (required for normal runs and -calibrate-capture)")
 	modelsArg := flag.String("models", "", "Comma-separated model selectors (provider/model or bare model name; required)")
 	scorerName := flag.String("scorer", "exact-match", "Scoring strategy: exact-match, llm-judge, manual")
 	judgeModel := flag.String("judge-model", "", "Ollama model used by -scorer llm-judge; default uses models.json role judge or gemma4:31b")
 	judgeOllamaURL := flag.String("judge-ollama-url", "", "Ollama base URL for -scorer llm-judge (default: -ollama-url)")
 	judgeTimeout := flag.Duration("judge-timeout", 5*time.Minute, "Timeout for each llm-judge scoring request")
+	judgeCachePath := flag.String("judge-cache", defaultJudgeCachePath(), "SQLite path for judge response cache; empty disables")
 	reportPath := flag.String("report", "", "Output report path (default: stdout)")
 	ollamaURL := flag.String("ollama-url", "http://localhost:11434", "Ollama base URL")
 	timeout := flag.Duration("timeout", 5*time.Minute, "Per-replay timeout for candidate model calls")
 	flag.Parse()
+
+	modes := 0
+	if *capture {
+		modes++
+	}
+	if *calibrateCapture {
+		modes++
+	}
+	if *calibrate {
+		modes++
+	}
+	if modes > 1 {
+		log.Fatalf("llm-bench: -capture, -calibrate-capture, -calibrate are mutually exclusive")
+	}
+	_ = labelsPath
+	_ = labelsOut
+	_ = artifactsPath
+	_ = calibrateReportDir
+	_ = judgeStabilityRuns
+	_ = judgeCachePath
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
@@ -150,4 +180,15 @@ func defaultJudgeModelName() string {
 		}
 	}
 	return fallbackJudgeModel
+}
+
+// defaultJudgeCachePath returns the platform-appropriate location for the
+// judge response cache. Falls back to "" (cache disabled) if the user
+// cache dir cannot be resolved.
+func defaultJudgeCachePath() string {
+	base, err := os.UserCacheDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(base, "go-llm", "judge-cache.db")
 }

--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -68,12 +68,6 @@ func main() {
 	if modes > 1 {
 		log.Fatalf("llm-bench: -capture, -calibrate-capture, -calibrate are mutually exclusive")
 	}
-	_ = labelsPath
-	_ = labelsOut
-	_ = artifactsPath
-	_ = calibrateReportDir
-	_ = judgeStabilityRuns
-	_ = judgeCachePath
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
@@ -96,6 +90,94 @@ func main() {
 			log.Fatalf("llm-bench: capture wrote no traces")
 		}
 		fmt.Fprintf(os.Stderr, "llm-bench: capture wrote %d trace(s) to %s\n", len(result.Written), *captureOut)
+		return
+	}
+
+	if *calibrateCapture {
+		if *tracesGlob == "" || *modelsArg == "" {
+			log.Fatalf("llm-bench: -calibrate-capture requires -traces and -models")
+		}
+		tracePaths, err := filepath.Glob(*tracesGlob)
+		if err != nil {
+			log.Fatalf("llm-bench: glob: %v", err)
+		}
+		traces, err := loadTraces(tracePaths)
+		if err != nil {
+			log.Fatalf("llm-bench: load traces: %v", err)
+		}
+		targets, err := parseModelTargets(*modelsArg)
+		if err != nil {
+			log.Fatalf("llm-bench: parse models: %v", err)
+		}
+		runner := &Runner{
+			OllamaURL: *ollamaURL,
+			Timeout:   *timeout,
+			// ExactMatchScorer is unused by capture (we only need
+			// Runner.RunAll to produce Results); Runner currently
+			// requires a non-nil Scorer.
+			Scorer: &ExactMatchScorer{},
+		}
+		if err := runCalibrateCapture(ctx, calibrateCaptureOptions{
+			Runner:     runner,
+			Targets:    targets,
+			Traces:     traces,
+			OutputPath: *labelsOut,
+		}); err != nil {
+			log.Fatalf("llm-bench: calibrate-capture: %v", err)
+		}
+		fmt.Fprintf(os.Stderr, "llm-bench: calibrate-capture wrote artifacts to %s\n", *labelsOut)
+		return
+	}
+
+	if *calibrate {
+		judgeURL := strings.TrimSpace(*judgeOllamaURL)
+		if judgeURL == "" {
+			judgeURL = *ollamaURL
+		}
+		judgeName := strings.TrimSpace(*judgeModel)
+		if judgeName == "" {
+			judgeName = defaultJudgeModelName()
+		}
+		// Typed-nil interface trap: openJudgeCache may return
+		// (*sqliteJudgeCache)(nil), which would still satisfy the
+		// judgeCacheStore interface as a non-nil interface value.
+		// Only assign the interface variable when the concrete
+		// pointer is genuinely non-nil.
+		var cacheStore judgeCacheStore
+		if c, err := openJudgeCache(*judgeCachePath); err != nil {
+			fmt.Fprintf(os.Stderr, "llm-bench: judge cache disabled: %v\n", err)
+		} else if c != nil {
+			cacheStore = c
+			defer func() { _ = c.Close() }()
+		}
+		scorer, err := newScorer(ctx, "llm-judge", scorerOptions{
+			ollamaURL:    judgeURL,
+			judgeModel:   judgeName,
+			judgeTimeout: *judgeTimeout,
+			judgeCache:   cacheStore,
+			// Primary calibration run is cached; stability runs flip
+			// the flag internally (Task 23).
+			bypassCache: false,
+		})
+		if err != nil {
+			log.Fatalf("llm-bench: calibrate: %v", err)
+		}
+		res, err := runCalibrate(ctx, calibrateOptions{
+			LabelsPath:    *labelsPath,
+			ArtifactsPath: *artifactsPath,
+			Scorer:        scorer,
+			JudgeModel:    judgeName,
+			ReportDir:     *calibrateReportDir,
+			StabilityRuns: *judgeStabilityRuns,
+		})
+		if err != nil {
+			log.Fatalf("llm-bench: calibrate: %v", err)
+		}
+		fmt.Fprintf(os.Stderr, "llm-bench: calibrate verdict=%s agreement=%d/%d report=%s\n",
+			res.Verdict, res.AgreeCount, res.MatchedCount, res.ReportPath)
+		if res.Verdict == "FAIL" {
+			os.Exit(3)
+		}
 		return
 	}
 
@@ -131,10 +213,24 @@ func main() {
 		resolvedJudgeURL = *ollamaURL
 	}
 
+	// Typed-nil interface trap: openJudgeCache may return
+	// (*sqliteJudgeCache)(nil) for an empty path, which would still satisfy
+	// the judgeCacheStore interface as a non-nil interface value. Only
+	// assign the interface variable when the concrete pointer is genuinely
+	// non-nil.
+	var cacheStore judgeCacheStore
+	if c, err := openJudgeCache(*judgeCachePath); err != nil {
+		fmt.Fprintf(os.Stderr, "llm-bench: judge cache disabled: %v\n", err)
+	} else if c != nil {
+		cacheStore = c
+		defer func() { _ = c.Close() }()
+	}
+
 	scorer, err := newScorer(ctx, *scorerName, scorerOptions{
 		ollamaURL:    resolvedJudgeURL,
 		judgeModel:   resolvedJudgeModel,
 		judgeTimeout: *judgeTimeout,
+		judgeCache:   cacheStore,
 	})
 	if err != nil {
 		log.Fatalf("llm-bench: scorer: %v", err)

--- a/cmd/llm-bench/replay_test.go
+++ b/cmd/llm-bench/replay_test.go
@@ -381,8 +381,8 @@ func TestReplayErrorsWhenCandidateCallsToolForPlainTextScript(t *testing.T) {
 				Role: "assistant",
 				ToolCalls: []ollama.ToolCall{
 					{
-						ID:   "candidate-call",
-						Type: "function",
+						ID:       "candidate-call",
+						Type:     "function",
 						Function: ollama.ToolCallFunction{Name: "read_file", Arguments: map[string]any{}},
 					},
 				},
@@ -429,8 +429,8 @@ func TestReplayErrorsWhenCandidateCallsToolWithNoScriptedAssistant(t *testing.T)
 				Role: "assistant",
 				ToolCalls: []ollama.ToolCall{
 					{
-						ID:   "candidate-call",
-						Type: "function",
+						ID:       "candidate-call",
+						Type:     "function",
 						Function: ollama.ToolCallFunction{Name: "read_file", Arguments: map[string]any{}},
 					},
 				},

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -255,14 +255,20 @@ func (s *LLMJudgeScorer) callJudge(ctx context.Context, req ollama.ChatRequest) 
 // ToolSequenceMatch comes from baseScore (recomputed fresh each call).
 // Parse errors are wrapped with the judge model identity; callers MUST
 // NOT re-attribute.
-func materializeJudgement(base Score, judgeModel, rawContent string) (Score, error) {
+//
+// The parsed judgeResponse is returned alongside the merged Score so the
+// cache-put path can persist the verbatim justification without round-
+// tripping it through the joined Notes string (which uses "; " as a
+// separator and would silently truncate justifications that contain that
+// substring — common in real judge output like "covered A; missed B").
+func materializeJudgement(base Score, judgeModel, rawContent string) (Score, judgeResponse, error) {
 	judgement, err := parseJudgeResponse(rawContent)
 	if err != nil {
-		return Score{}, fmt.Errorf("judge model %q: %w", judgeModel, err)
+		return Score{}, judgeResponse{}, fmt.Errorf("judge model %q: %w", judgeModel, err)
 	}
 	base.AnswerQuality = judgement.AnswerQuality
 	base.Notes = joinScoreNotes(base.Notes, fmt.Sprintf("llm-judge=%s: %s", judgeModel, judgement.Justification))
-	return base, nil
+	return base, judgement, nil
 }
 
 // Score composes: build → check cache (if enabled) → callJudge or hit →
@@ -300,14 +306,18 @@ func (s *LLMJudgeScorer) Score(ctx context.Context, trace Trace, actual Result) 
 		if hit, ok, getErr := s.Cache.Get(ctx, cacheKey); getErr != nil {
 			fmt.Fprintf(os.Stderr, "llm-bench: judge cache get bypassed: %v\n", getErr)
 		} else if ok {
-			return materializeJudgement(base, s.JudgeModel, hit.ResponseContent)
+			matHit, _, hitErr := materializeJudgement(base, s.JudgeModel, hit.ResponseContent)
+			if hitErr != nil {
+				return Score{}, hitErr
+			}
+			return matHit, nil
 		}
 	}
 	content, err := s.callJudge(ctx, req)
 	if err != nil {
 		return Score{}, err
 	}
-	materialized, err := materializeJudgement(base, s.JudgeModel, content)
+	materialized, judgement, err := materializeJudgement(base, s.JudgeModel, content)
 	if err != nil {
 		return Score{}, err
 	}
@@ -324,7 +334,7 @@ func (s *LLMJudgeScorer) Score(ctx context.Context, trace Trace, actual Result) 
 			RequestJSON:      prettyRequestJSON(req),
 			ResponseContent:  content,
 			AnswerQuality:    materialized.AnswerQuality,
-			Justification:    judgeJustificationFromNotes(materialized.Notes),
+			Justification:    judgement.Justification,
 			CreatedAt:        now,
 			LastUsedAt:       now,
 		}); putErr != nil {
@@ -357,26 +367,6 @@ func prettyRequestJSON(req ollama.ChatRequest) string {
 		return ""
 	}
 	return string(raw)
-}
-
-// judgeJustificationFromNotes recovers the justification fragment that
-// materializeJudgement appended via joinScoreNotes. Mirror: the last note
-// segment that starts with "llm-judge=" carries the justification after a
-// colon-space delimiter. Returns "" if no such segment is present so the
-// cache row's justification column never carries the model-identity
-// prefix.
-func judgeJustificationFromNotes(notes string) string {
-	parts := strings.Split(notes, "; ")
-	for i := len(parts) - 1; i >= 0; i-- {
-		p := parts[i]
-		if !strings.HasPrefix(p, "llm-judge=") {
-			continue
-		}
-		if idx := strings.Index(p, ": "); idx >= 0 {
-			return p[idx+2:]
-		}
-	}
-	return ""
 }
 
 const judgeSystemPrompt = `You are an impartial evaluator for local LLM benchmark replays.

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -158,6 +158,52 @@ func validateJudgeModel(ctx context.Context, checker judgeModelChecker, judgeMod
 	return fmt.Errorf("judge model %q is not available from the configured Ollama server; pull it or pass -judge-model/-judge-ollama-url", judgeModel)
 }
 
+// buildJudgeCall produces the judge ChatRequest and the partial Score that
+// will be merged with the judge's verdict. Pure over (trace, actual): no I/O
+// and no mutation. The cache key is derived from req; baseScore carries the
+// freshly-computed ToolSequenceMatch/Notes that must be recomputed each run
+// even on a cache hit so tool-loop changes are not masked by stale cache.
+func (s *LLMJudgeScorer) buildJudgeCall(trace Trace, actual Result) (ollama.ChatRequest, Score, error) {
+	if sameModelSelector(s.JudgeModel, actual.Model) {
+		return ollama.ChatRequest{}, Score{}, fmt.Errorf("trace %q model %q: %w", trace.ID, actual.Model, errJudgeSelfPreference)
+	}
+
+	criteria := strings.TrimSpace(trace.Golden.FinalAnswerCriteria)
+	substring := strings.TrimSpace(trace.Golden.FinalAnswerSubstring)
+	if criteria == "" && substring == "" {
+		return ollama.ChatRequest{}, Score{}, fmt.Errorf("trace %q: %w", trace.ID, errMissingJudgeCriteria)
+	}
+
+	baseScore := Score{
+		ToolSequenceMatch: toolSequenceScore(trace.Golden.ToolCalls, extractToolNames(actual.Transcript)),
+		Notes:             "ToolArgsValid not computed (schema validation pending; see benchmark-plan.md metrics)",
+	}
+
+	if strings.TrimSpace(lastAssistantContent(actual.Transcript)) == "" {
+		return ollama.ChatRequest{}, Score{}, fmt.Errorf("trace %q: %w", trace.ID, errNoAssistantFinalAnswer)
+	}
+
+	prompt, err := buildJudgePrompt(trace, actual)
+	if err != nil {
+		return ollama.ChatRequest{}, Score{}, fmt.Errorf("trace %q: build judge prompt: %w", trace.ID, err)
+	}
+
+	req := ollama.ChatRequest{
+		Model: s.JudgeModel,
+		Messages: []ollama.ChatMessage{
+			{Role: "system", Content: judgeSystemPrompt},
+			{Role: "user", Content: prompt},
+		},
+		Format: "json",
+		Options: &ollama.ModelOptions{
+			Temperature: judgeTemperature,
+			NumPredict:  judgeTokenBudget,
+		},
+		KeepAlive: benchKeepAlive,
+	}
+	return req, baseScore, nil
+}
+
 func (s *LLMJudgeScorer) Score(ctx context.Context, trace Trace, actual Result) (Score, error) {
 	if sameModelSelector(s.JudgeModel, actual.Model) {
 		return Score{}, fmt.Errorf("trace %q model %q: %w", trace.ID, actual.Model, errJudgeSelfPreference)

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -251,7 +251,7 @@ func (s *LLMJudgeScorer) buildJudgeCall(trace Trace, actual Result) (ollama.Chat
 
 	think := false
 	req := ollama.ChatRequest{
-		Model: s.JudgeModel,
+		Model: modelSelectorWithoutBenchProvider(s.JudgeModel),
 		Messages: []ollama.ChatMessage{
 			{Role: "system", Content: judgeSystemPrompt},
 			{Role: "user", Content: prompt},
@@ -619,9 +619,10 @@ func normalizeModelSelector(s string) string {
 }
 
 func modelSelectorWithoutBenchProvider(s string) string {
+	s = strings.TrimSpace(s)
 	prefix := defaultBenchProvider + "/"
-	if strings.HasPrefix(s, prefix) {
-		return strings.TrimSpace(strings.TrimPrefix(s, prefix))
+	if strings.HasPrefix(strings.ToLower(s), prefix) {
+		return strings.TrimSpace(s[len(prefix):])
 	}
 	return s
 }

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -49,6 +49,13 @@ type scorerOptions struct {
 	ollamaURL    string
 	judgeModel   string
 	judgeTimeout time.Duration
+	// judgeCache is the optional judge response cache. Callers MUST avoid
+	// the typed-nil interface trap: assign only a non-nil concrete
+	// implementation (e.g. *sqliteJudgeCache) or leave this field unset.
+	// openJudgeCache("") returns a nil *sqliteJudgeCache by design so the
+	// caller can decide whether to wrap it in this interface field.
+	judgeCache  judgeCacheStore
+	bypassCache bool // when true, the scorer skips both cache Get and Put
 }
 
 // newScorer returns the Scorer matching the given name.
@@ -71,6 +78,10 @@ func newScorer(ctx context.Context, name string, opts scorerOptions) (Scorer, er
 		if err := validateJudgeModel(ctx, client, scorer.JudgeModel); err != nil {
 			return nil, err
 		}
+		digest, _ := resolveJudgeDigest(ctx, client, scorer.JudgeModel)
+		scorer.JudgeModelDigest = digest
+		scorer.Cache = opts.judgeCache
+		scorer.BypassCache = opts.bypassCache
 		return scorer, nil
 	case "manual":
 		return nil, fmt.Errorf("manual scorer not yet implemented")

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -204,65 +204,50 @@ func (s *LLMJudgeScorer) buildJudgeCall(trace Trace, actual Result) (ollama.Chat
 	return req, baseScore, nil
 }
 
-func (s *LLMJudgeScorer) Score(ctx context.Context, trace Trace, actual Result) (Score, error) {
-	if sameModelSelector(s.JudgeModel, actual.Model) {
-		return Score{}, fmt.Errorf("trace %q model %q: %w", trace.ID, actual.Model, errJudgeSelfPreference)
-	}
-
-	criteria := strings.TrimSpace(trace.Golden.FinalAnswerCriteria)
-	substring := strings.TrimSpace(trace.Golden.FinalAnswerSubstring)
-	if criteria == "" && substring == "" {
-		return Score{}, fmt.Errorf("trace %q: %w", trace.ID, errMissingJudgeCriteria)
-	}
-
-	score := Score{
-		ToolSequenceMatch: toolSequenceScore(trace.Golden.ToolCalls, extractToolNames(actual.Transcript)),
-		Notes:             "ToolArgsValid not computed (schema validation pending; see benchmark-plan.md metrics)",
-	}
-
-	if strings.TrimSpace(lastAssistantContent(actual.Transcript)) == "" {
-		return Score{}, fmt.Errorf("trace %q: %w", trace.ID, errNoAssistantFinalAnswer)
-	}
-
-	prompt, err := buildJudgePrompt(trace, actual)
-	if err != nil {
-		return Score{}, fmt.Errorf("trace %q: build judge prompt: %w", trace.ID, err)
-	}
-
+// callJudge issues the judge ChatRequest and returns the raw response
+// content. The only I/O step; honors JudgeTimeout. Errors are returned
+// unwrapped so callers can attribute model identity in their wrap.
+func (s *LLMJudgeScorer) callJudge(ctx context.Context, req ollama.ChatRequest) (string, error) {
 	judgeCtx := ctx
 	var cancel context.CancelFunc
 	if s.JudgeTimeout > 0 {
 		judgeCtx, cancel = context.WithTimeout(ctx, s.JudgeTimeout)
 		defer cancel()
 	}
-
-	resp, err := s.Client.Chat(judgeCtx, ollama.ChatRequest{
-		Model: s.JudgeModel,
-		Messages: []ollama.ChatMessage{
-			{Role: "system", Content: judgeSystemPrompt},
-			{Role: "user", Content: prompt},
-		},
-		Format: "json",
-		Options: &ollama.ModelOptions{
-			Temperature: judgeTemperature,
-			NumPredict:  judgeTokenBudget,
-		},
-		KeepAlive: benchKeepAlive,
-	})
+	resp, err := s.Client.Chat(judgeCtx, req)
 	if err != nil {
-		return Score{}, fmt.Errorf("judge model %q: %w", s.JudgeModel, err)
+		return "", fmt.Errorf("judge model %q: %w", s.JudgeModel, err)
 	}
 	if resp == nil {
-		return Score{}, fmt.Errorf("judge model %q: %w: nil response", s.JudgeModel, errMalformedJudgeResponse)
+		return "", fmt.Errorf("judge model %q: %w: nil response", s.JudgeModel, errMalformedJudgeResponse)
 	}
+	return resp.Message.Content, nil
+}
 
-	judgment, err := parseJudgeResponse(resp.Message.Content)
+// materializeJudgement parses raw judge response content and merges it
+// into baseScore. Pure; no I/O. Used identically by cache-hit and
+// cache-miss paths so AnswerQuality/Notes derive from the judge text but
+// ToolSequenceMatch comes from baseScore (recomputed fresh each call).
+func materializeJudgement(base Score, judgeModel, rawContent string) (Score, error) {
+	judgement, err := parseJudgeResponse(rawContent)
 	if err != nil {
-		return Score{}, fmt.Errorf("judge model %q: %w", s.JudgeModel, err)
+		return Score{}, fmt.Errorf("judge model %q: %w", judgeModel, err)
 	}
-	score.AnswerQuality = judgment.AnswerQuality
-	score.Notes = joinScoreNotes(score.Notes, fmt.Sprintf("llm-judge=%s: %s", s.JudgeModel, judgment.Justification))
-	return score, nil
+	base.AnswerQuality = judgement.AnswerQuality
+	base.Notes = joinScoreNotes(base.Notes, fmt.Sprintf("llm-judge=%s: %s", judgeModel, judgement.Justification))
+	return base, nil
+}
+
+func (s *LLMJudgeScorer) Score(ctx context.Context, trace Trace, actual Result) (Score, error) {
+	req, base, err := s.buildJudgeCall(trace, actual)
+	if err != nil {
+		return Score{}, err
+	}
+	content, err := s.callJudge(ctx, req)
+	if err != nil {
+		return Score{}, err
+	}
+	return materializeJudgement(base, s.JudgeModel, content)
 }
 
 const judgeSystemPrompt = `You are an impartial evaluator for local LLM benchmark replays.

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -118,10 +121,30 @@ type judgeModelChecker interface {
 // LLMJudgeScorer asks a separate local Ollama model to score final-answer
 // quality against the trace's golden rubric. Replay latency and target-model
 // tokens remain owned by Runner.runOne.
+//
+// Cache is the optional judge response cache. It is typed as the
+// judgeCacheStore interface so callers MUST assign only non-nil concrete
+// values; assigning a typed-nil pointer (e.g. the (*sqliteJudgeCache)(nil)
+// returned by openJudgeCache("")) produces a non-nil interface that will
+// panic on use. Wiring code is responsible for guarding against the
+// typed-nil interface trap before assignment.
 type LLMJudgeScorer struct {
-	Client       judgeChatClient
-	JudgeModel   string
-	JudgeTimeout time.Duration
+	Client           judgeChatClient
+	JudgeModel       string
+	JudgeModelDigest string // optional; empty when /api/show was unavailable
+	JudgeTimeout     time.Duration
+	Cache            judgeCacheStore  // optional; nil disables caching
+	BypassCache      bool             // when true, Score skips both Get and Put
+	Clock            func() time.Time // injectable; defaults to time.Now().UTC()
+}
+
+// now returns the scorer's notion of the current time. Injected via Clock
+// in tests so cache CreatedAt/LastUsedAt timestamps are deterministic.
+func (s *LLMJudgeScorer) now() time.Time {
+	if s.Clock != nil {
+		return s.Clock()
+	}
+	return time.Now().UTC()
 }
 
 func newLLMJudgeScorer(client judgeChatClient, judgeModel string, judgeTimeout time.Duration) (*LLMJudgeScorer, error) {
@@ -242,16 +265,118 @@ func materializeJudgement(base Score, judgeModel, rawContent string) (Score, err
 	return base, nil
 }
 
+// Score composes: build → check cache (if enabled) → callJudge or hit →
+// materialize → put-to-cache (if enabled).
+//
+// Cache-hit path MUST pass `base` (fresh from buildJudgeCall on THIS call's
+// trace + actual) into materializeJudgement — not a base reconstructed
+// from the cached entry. This is the load-bearing invariant covered by
+// TestLLMJudgeScorer_CacheHit_ReusesContentButRecomputesToolSequenceMatch:
+// AnswerQuality and the judge justification are reused from the cached
+// response content, but ToolSequenceMatch / Notes are always recomputed
+// from the current actual transcript so tool-loop regressions can never
+// be masked by a stale cache entry.
+//
+// Cache errors (Get and Put) are non-fatal: they are logged to stderr and
+// bypassed. The judge call still proceeds on a Get error; the result is
+// still returned on a Put error.
 func (s *LLMJudgeScorer) Score(ctx context.Context, trace Trace, actual Result) (Score, error) {
 	req, base, err := s.buildJudgeCall(trace, actual)
 	if err != nil {
 		return Score{}, err
 	}
+	var cacheKey string
+	if s.Cache != nil && !s.BypassCache {
+		cacheKey = canonicalCacheKey(judgeCacheRequest{
+			Version:          judgeCacheKeyVersion,
+			JudgeModel:       normalizeModelSelector(s.JudgeModel),
+			JudgeModelDigest: s.JudgeModelDigest,
+			SystemPrompt:     judgeSystemPrompt,
+			UserPrompt:       judgeUserPromptOf(req),
+			Format:           req.Format,
+			Temperature:      judgeTemperature,
+			NumPredict:       judgeTokenBudget,
+		})
+		if hit, ok, getErr := s.Cache.Get(ctx, cacheKey); getErr != nil {
+			fmt.Fprintf(os.Stderr, "llm-bench: judge cache get bypassed: %v\n", getErr)
+		} else if ok {
+			return materializeJudgement(base, s.JudgeModel, hit.ResponseContent)
+		}
+	}
 	content, err := s.callJudge(ctx, req)
 	if err != nil {
 		return Score{}, err
 	}
-	return materializeJudgement(base, s.JudgeModel, content)
+	materialized, err := materializeJudgement(base, s.JudgeModel, content)
+	if err != nil {
+		return Score{}, err
+	}
+	if s.Cache != nil && !s.BypassCache && cacheKey != "" {
+		sum := sha256.Sum256([]byte(judgeUserPromptOf(req)))
+		now := s.now()
+		if putErr := s.Cache.Put(ctx, judgeCacheEntry{
+			CacheKey:         cacheKey,
+			JudgeModel:       s.JudgeModel,
+			JudgeModelDigest: s.JudgeModelDigest,
+			TraceID:          trace.ID,
+			CandidateModel:   actual.Model,
+			PromptHash:       hex.EncodeToString(sum[:]),
+			RequestJSON:      prettyRequestJSON(req),
+			ResponseContent:  content,
+			AnswerQuality:    materialized.AnswerQuality,
+			Justification:    judgeJustificationFromNotes(materialized.Notes),
+			CreatedAt:        now,
+			LastUsedAt:       now,
+		}); putErr != nil {
+			fmt.Fprintf(os.Stderr, "llm-bench: judge cache put bypassed: %v\n", putErr)
+		}
+	}
+	return materialized, nil
+}
+
+// judgeUserPromptOf extracts the user prompt that buildJudgeCall composed.
+// We rely on the convention that buildJudgeCall always emits
+// [system, user] in that order; this helper returns the first message with
+// role "user" so a future ordering tweak surfaces obviously rather than
+// silently mixing system and user content into the cache key.
+func judgeUserPromptOf(req ollama.ChatRequest) string {
+	for _, m := range req.Messages {
+		if m.Role == "user" {
+			return m.Content
+		}
+	}
+	return ""
+}
+
+// prettyRequestJSON serializes the judge ChatRequest for cache-audit
+// inspection. Best-effort: returns "" on marshal failure rather than
+// failing the Score call, since the cache row is observational only.
+func prettyRequestJSON(req ollama.ChatRequest) string {
+	raw, err := json.MarshalIndent(req, "", "  ")
+	if err != nil {
+		return ""
+	}
+	return string(raw)
+}
+
+// judgeJustificationFromNotes recovers the justification fragment that
+// materializeJudgement appended via joinScoreNotes. Mirror: the last note
+// segment that starts with "llm-judge=" carries the justification after a
+// colon-space delimiter. Returns "" if no such segment is present so the
+// cache row's justification column never carries the model-identity
+// prefix.
+func judgeJustificationFromNotes(notes string) string {
+	parts := strings.Split(notes, "; ")
+	for i := len(parts) - 1; i >= 0; i-- {
+		p := parts[i]
+		if !strings.HasPrefix(p, "llm-judge=") {
+			continue
+		}
+		if idx := strings.Index(p, ": "); idx >= 0 {
+			return p[idx+2:]
+		}
+	}
+	return ""
 }
 
 const judgeSystemPrompt = `You are an impartial evaluator for local LLM benchmark replays.

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -323,9 +323,9 @@ func materializeJudgement(base Score, judgeModel, rawContent string) (Score, jud
 // from the current actual transcript so tool-loop regressions can never
 // be masked by a stale cache entry.
 //
-// Cache errors (Get and Put) are non-fatal: they are logged to stderr and
-// bypassed. The judge call still proceeds on a Get error; the result is
-// still returned on a Put error.
+// Cache errors (Get and Put) and malformed cache-hit payloads are non-fatal:
+// they are logged to stderr and bypassed. The judge call still proceeds on a
+// Get error or malformed hit; the result is still returned on a Put error.
 func (s *LLMJudgeScorer) Score(ctx context.Context, trace Trace, actual Result) (Score, error) {
 	req, base, err := s.buildJudgeCall(trace, actual)
 	if err != nil {
@@ -349,9 +349,10 @@ func (s *LLMJudgeScorer) Score(ctx context.Context, trace Trace, actual Result) 
 		} else if ok {
 			matHit, _, hitErr := materializeJudgement(base, s.JudgeModel, hit.ResponseContent)
 			if hitErr != nil {
-				return Score{}, hitErr
+				fmt.Fprintf(os.Stderr, "llm-bench: judge cache hit bypassed: %v\n", hitErr)
+			} else {
+				return matHit, nil
 			}
-			return matHit, nil
 		}
 	}
 	content, err := s.callJudge(ctx, req)

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -238,6 +238,7 @@ func (s *LLMJudgeScorer) buildJudgeCall(trace Trace, actual Result) (ollama.Chat
 		return ollama.ChatRequest{}, Score{}, fmt.Errorf("trace %q: build judge prompt: %w", trace.ID, err)
 	}
 
+	think := false
 	req := ollama.ChatRequest{
 		Model: s.JudgeModel,
 		Messages: []ollama.ChatMessage{
@@ -245,6 +246,7 @@ func (s *LLMJudgeScorer) buildJudgeCall(trace Trace, actual Result) (ollama.Chat
 			{Role: "user", Content: prompt},
 		},
 		Format: "json",
+		Think:  &think,
 		Options: &ollama.ModelOptions{
 			Temperature: judgeTemperature,
 			NumPredict:  judgeTokenBudget,
@@ -327,6 +329,7 @@ func (s *LLMJudgeScorer) Score(ctx context.Context, trace Trace, actual Result) 
 			SystemPrompt:     judgeSystemPrompt,
 			UserPrompt:       judgeUserPromptOf(req),
 			Format:           req.Format,
+			Think:            req.Think,
 			Temperature:      judgeTemperature,
 			NumPredict:       judgeTokenBudget,
 		})

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -205,8 +205,10 @@ func (s *LLMJudgeScorer) buildJudgeCall(trace Trace, actual Result) (ollama.Chat
 }
 
 // callJudge issues the judge ChatRequest and returns the raw response
-// content. The only I/O step; honors JudgeTimeout. Errors are returned
-// unwrapped so callers can attribute model identity in their wrap.
+// content. The only I/O step; honors JudgeTimeout. Errors are wrapped
+// with the judge model identity so callers (Score and the future cache
+// wrapper) MUST NOT re-attribute model identity in their own wraps —
+// doing so produces double-prefixed messages.
 func (s *LLMJudgeScorer) callJudge(ctx context.Context, req ollama.ChatRequest) (string, error) {
 	judgeCtx := ctx
 	var cancel context.CancelFunc
@@ -228,6 +230,8 @@ func (s *LLMJudgeScorer) callJudge(ctx context.Context, req ollama.ChatRequest) 
 // into baseScore. Pure; no I/O. Used identically by cache-hit and
 // cache-miss paths so AnswerQuality/Notes derive from the judge text but
 // ToolSequenceMatch comes from baseScore (recomputed fresh each call).
+// Parse errors are wrapped with the judge model identity; callers MUST
+// NOT re-attribute.
 func materializeJudgement(base Score, judgeModel, rawContent string) (Score, error) {
 	judgement, err := parseJudgeResponse(rawContent)
 	if err != nil {

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -116,6 +116,22 @@ type judgeChatClient interface {
 
 type judgeModelChecker interface {
 	AvailableModels(ctx context.Context) ([]string, error)
+	ShowModel(ctx context.Context, name string) (*ollama.ModelInfo, error)
+}
+
+// resolveJudgeDigest returns the judge model's content digest, or empty
+// string if the provider's /api/show response is unavailable or omits one.
+// Errors from /api/show are deliberately swallowed: a missing digest is
+// degraded R1 mitigation, not a hard failure.
+func resolveJudgeDigest(ctx context.Context, checker judgeModelChecker, judgeModel string) (string, error) {
+	info, err := checker.ShowModel(ctx, judgeModel)
+	if err != nil {
+		return "", nil
+	}
+	if info == nil {
+		return "", nil
+	}
+	return info.Digest, nil
 }
 
 // LLMJudgeScorer asks a separate local Ollama model to score final-answer

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -121,6 +121,17 @@ func (s *ExactMatchScorer) Score(_ context.Context, trace Trace, actual Result) 
 	return score, nil
 }
 
+// CaptureScorer lets capture-only flows replay candidates through Runner
+// without making scoring prerequisites part of artifact collection.
+type CaptureScorer struct{}
+
+func (s *CaptureScorer) Score(_ context.Context, trace Trace, actual Result) (Score, error) {
+	return Score{
+		ToolSequenceMatch: toolSequenceScore(trace.Golden.ToolCalls, extractToolNames(actual.Transcript)),
+		Notes:             "capture mode: scoring skipped",
+	}, nil
+}
+
 type judgeChatClient interface {
 	Chat(ctx context.Context, req ollama.ChatRequest) (*ollama.ChatResponse, error)
 }

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -183,6 +183,49 @@ func TestLLMJudgeScorer_HappyPath_PreRefactorBaseline(t *testing.T) {
 	}
 }
 
+func TestBuildJudgeCall_PopulatesBaseScoreAndRequest(t *testing.T) {
+	trace := Trace{
+		ID:     "t1",
+		System: "sys",
+		Turns:  []Turn{{Role: "user", Content: "hi"}},
+		Golden: Golden{
+			ToolCalls:           []string{"read_file"},
+			FinalAnswerCriteria: "fc",
+		},
+	}
+	actual := Result{
+		Model:   "ollama/cand",
+		TraceID: "t1",
+		Transcript: []Turn{
+			{Role: "assistant", ToolCalls: []ToolCall{{Name: "read_file"}}},
+			{Role: "assistant", Content: "done"},
+		},
+	}
+	scorer := &LLMJudgeScorer{Client: &fakeJudgeClient{}, JudgeModel: "ollama/judge"}
+	req, base, err := scorer.buildJudgeCall(trace, actual)
+	if err != nil {
+		t.Fatalf("buildJudgeCall: %v", err)
+	}
+	if req.Model != "ollama/judge" {
+		t.Fatalf("req.Model = %q; want ollama/judge", req.Model)
+	}
+	if req.Format != "json" {
+		t.Fatalf("req.Format = %q; want json", req.Format)
+	}
+	if base.ToolSequenceMatch != 1.0 {
+		t.Fatalf("baseScore.ToolSequenceMatch = %v; want 1.0", base.ToolSequenceMatch)
+	}
+}
+
+func TestBuildJudgeCall_SelfPreferenceGuard(t *testing.T) {
+	trace := Trace{ID: "t", System: "s", Turns: []Turn{{Role: "user", Content: "x"}}, Golden: Golden{FinalAnswerCriteria: "fc"}}
+	actual := Result{Model: "ollama/same", TraceID: "t", Transcript: []Turn{{Role: "assistant", Content: "y"}}}
+	scorer := &LLMJudgeScorer{Client: &fakeJudgeClient{}, JudgeModel: "ollama/same"}
+	if _, _, err := scorer.buildJudgeCall(trace, actual); !errors.Is(err, errJudgeSelfPreference) {
+		t.Fatalf("got %v; want errJudgeSelfPreference", err)
+	}
+}
+
 func TestLLMJudgeScorerScoresFromJSON(t *testing.T) {
 	client := &fakeJudgeClient{
 		resp: &ollama.ChatResponse{

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -41,6 +41,26 @@ func (f fakeJudgeModelChecker) AvailableModels(context.Context) ([]string, error
 	return f.models, nil
 }
 
+func (f fakeJudgeModelChecker) ShowModel(_ context.Context, name string) (*ollama.ModelInfo, error) {
+	return &ollama.ModelInfo{Name: name}, nil
+}
+
+type fakeJudgeChecker struct {
+	available []string
+	showFn    func(name string) (*ollama.ModelInfo, error)
+}
+
+func (f *fakeJudgeChecker) AvailableModels(_ context.Context) ([]string, error) {
+	return f.available, nil
+}
+
+func (f *fakeJudgeChecker) ShowModel(_ context.Context, name string) (*ollama.ModelInfo, error) {
+	if f.showFn == nil {
+		return &ollama.ModelInfo{Name: name, Digest: ""}, nil
+	}
+	return f.showFn(name)
+}
+
 func TestNewScorerAppliesJudgeTimeoutToHTTPClient(t *testing.T) {
 	const judgeTimeout = 25 * time.Millisecond
 	const serverDelay = 250 * time.Millisecond
@@ -454,6 +474,37 @@ func TestValidateJudgeModelPreservesNamespacedModelIDs(t *testing.T) {
 	}, "ollama/hf.co/org/model:tag")
 	if err == nil {
 		t.Fatal("validateJudgeModel() error = nil, want distinct namespaced model rejection")
+	}
+}
+
+func TestResolveJudgeDigest_ReturnsDigestWhenAvailable(t *testing.T) {
+	checker := &fakeJudgeChecker{
+		available: []string{"ollama/gemma4:31b"},
+		showFn: func(name string) (*ollama.ModelInfo, error) {
+			return &ollama.ModelInfo{Name: name, Digest: "sha256:deadbeef"}, nil
+		},
+	}
+	digest, err := resolveJudgeDigest(context.Background(), checker, "ollama/gemma4:31b")
+	if err != nil {
+		t.Fatalf("resolveJudgeDigest: %v", err)
+	}
+	if digest != "sha256:deadbeef" {
+		t.Fatalf("digest = %q; want sha256:deadbeef", digest)
+	}
+}
+
+func TestResolveJudgeDigest_EmptyOnError(t *testing.T) {
+	checker := &fakeJudgeChecker{
+		showFn: func(name string) (*ollama.ModelInfo, error) {
+			return nil, errors.New("api/show unavailable")
+		},
+	}
+	digest, err := resolveJudgeDigest(context.Background(), checker, "ollama/gemma4:31b")
+	if err != nil {
+		t.Fatalf("resolveJudgeDigest: %v", err) // expected to swallow and return empty
+	}
+	if digest != "" {
+		t.Fatalf("digest = %q; want empty on error", digest)
 	}
 }
 

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -213,6 +213,9 @@ func TestLLMJudgeScorer_HappyPath_PreRefactorBaseline(t *testing.T) {
 	if !strings.Contains(score.Notes, "correct") {
 		t.Fatalf("Notes missing justification: %q", score.Notes)
 	}
+	if judge.req.Model != "gemma4:31b" {
+		t.Fatalf("judge request model = %q; want gemma4:31b", judge.req.Model)
+	}
 }
 
 func TestBuildJudgeCall_PopulatesBaseScoreAndRequest(t *testing.T) {
@@ -238,8 +241,8 @@ func TestBuildJudgeCall_PopulatesBaseScoreAndRequest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildJudgeCall: %v", err)
 	}
-	if req.Model != "ollama/judge" {
-		t.Fatalf("req.Model = %q; want ollama/judge", req.Model)
+	if req.Model != "judge" {
+		t.Fatalf("req.Model = %q; want judge", req.Model)
 	}
 	if req.Format != "json" {
 		t.Fatalf("req.Format = %q; want json", req.Format)
@@ -249,6 +252,20 @@ func TestBuildJudgeCall_PopulatesBaseScoreAndRequest(t *testing.T) {
 	}
 	if base.ToolSequenceMatch != 1.0 {
 		t.Fatalf("baseScore.ToolSequenceMatch = %v; want 1.0", base.ToolSequenceMatch)
+	}
+}
+
+func TestBuildJudgeCall_StripsBenchProviderFromJudgeRequestModel(t *testing.T) {
+	trace := Trace{ID: "t", System: "s", Turns: []Turn{{Role: "user", Content: "x"}}, Golden: Golden{FinalAnswerCriteria: "fc"}}
+	actual := Result{Model: "ollama/cand", TraceID: "t", Transcript: []Turn{{Role: "assistant", Content: "y"}}}
+	scorer := &LLMJudgeScorer{Client: &fakeJudgeClient{}, JudgeModel: "ollama/hf.co/org/model:tag"}
+
+	req, _, err := scorer.buildJudgeCall(trace, actual)
+	if err != nil {
+		t.Fatalf("buildJudgeCall: %v", err)
+	}
+	if req.Model != "hf.co/org/model:tag" {
+		t.Fatalf("req.Model = %q; want hf.co/org/model:tag", req.Model)
 	}
 }
 

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -651,3 +651,63 @@ func TestLLMJudgeScorer_BypassCache_AlwaysCallsJudgeAndDoesNotPersist(t *testing
 		t.Fatalf("BypassCache=true persisted %d rows; want 0", count)
 	}
 }
+
+// TestLLMJudgeScorer_CacheHit_FreshToolSequenceMatch is the load-bearing
+// invariant of the judge-cache architecture: on a cache hit the judge MUST
+// NOT be re-invoked, but the returned Score's ToolSequenceMatch MUST come
+// from THIS call's baseScore (computed fresh from current trace+actual),
+// never from a cached judgement field. Without this contract, a future
+// refactor that accidentally caches the full Score could silently mask
+// tool-loop regressions, since the cached ToolSequenceMatch would be
+// returned even when the candidate's actual tool calls have changed.
+func TestLLMJudgeScorer_CacheHit_FreshToolSequenceMatch(t *testing.T) {
+	c, _ := newTestCache(t)
+	judge := &fakeJudgeClient{
+		resp: &ollama.ChatResponse{
+			Message: ollama.ChatMessage{
+				Content: `{"answer_quality":0.5,"justification":"j"}`,
+			},
+		},
+	}
+	scorer := &LLMJudgeScorer{
+		Client:     judge,
+		JudgeModel: "ollama/gemma4:31b",
+		Cache:      c,
+	}
+
+	// Trace whose golden expects a single tool call.
+	trace := Trace{
+		ID:     "t",
+		System: "s",
+		Turns:  []Turn{{Role: "user", Content: "hi"}},
+		Golden: Golden{ToolCalls: []string{"read_file"}, FinalAnswerCriteria: "c"},
+	}
+	// First call: actual matches golden → ToolSequenceMatch=1.0 baked into
+	// baseScore and the judgement is persisted to the cache.
+	actualMatch := Result{Model: "ollama/cand", Transcript: []Turn{
+		{Role: "assistant", ToolCalls: []ToolCall{{Name: "read_file"}}},
+		{Role: "assistant", Content: "answer"},
+	}}
+	if _, err := scorer.Score(context.Background(), trace, actualMatch); err != nil {
+		t.Fatalf("seed Score: %v", err)
+	}
+	if judge.called != 1 {
+		t.Fatalf("judge called %d; want 1", judge.called)
+	}
+
+	// Second call: same trace + same actual → CACHE HIT. judge NOT re-called.
+	// The ToolSequenceMatch in the returned Score must come from THIS call's
+	// recomputation (against current trace+actual), not from the cached
+	// judgement.
+	s2, err := scorer.Score(context.Background(), trace, actualMatch)
+	if err != nil {
+		t.Fatalf("hit Score: %v", err)
+	}
+	if judge.called != 1 {
+		t.Fatalf("judge re-called on cache hit; called=%d", judge.called)
+	}
+	// ToolSequenceMatch is computed fresh from current trace+actual:
+	if s2.ToolSequenceMatch != 1.0 {
+		t.Fatalf("cache-hit ToolSequenceMatch=%v; want 1.0 (recomputed fresh)", s2.ToolSequenceMatch)
+	}
+}

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -107,6 +107,18 @@ func TestExactMatchScorerRequiresGoldenSubstring(t *testing.T) {
 	}
 }
 
+func TestCaptureScorerAcceptsCriteriaOnlyTrace(t *testing.T) {
+	s := &CaptureScorer{}
+	trace := Trace{
+		ID:     "criteria-only",
+		Golden: Golden{FinalAnswerCriteria: "use the rubric, not a substring"},
+	}
+	actual := Result{Transcript: []Turn{{Role: "assistant", Content: "answer"}}}
+	if _, err := s.Score(context.Background(), trace, actual); err != nil {
+		t.Fatalf("CaptureScorer.Score() error = %v; want nil", err)
+	}
+}
+
 func TestExactMatchScorerSubstringHit(t *testing.T) {
 	s := &ExactMatchScorer{}
 	trace := Trace{

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -226,6 +226,23 @@ func TestBuildJudgeCall_SelfPreferenceGuard(t *testing.T) {
 	}
 }
 
+func TestMaterializeJudgement_AppendsJustificationToNotes(t *testing.T) {
+	base := Score{ToolSequenceMatch: 0.5, Notes: "pre-existing"}
+	got, err := materializeJudgement(base, "ollama/gemma4:31b", `{"answer_quality":0.5,"justification":"missed caveat"}`)
+	if err != nil {
+		t.Fatalf("materializeJudgement: %v", err)
+	}
+	if got.AnswerQuality != 0.5 {
+		t.Fatalf("AnswerQuality = %v; want 0.5", got.AnswerQuality)
+	}
+	if got.ToolSequenceMatch != 0.5 {
+		t.Fatalf("ToolSequenceMatch lost from base: %v", got.ToolSequenceMatch)
+	}
+	if !strings.Contains(got.Notes, "missed caveat") {
+		t.Fatalf("Notes missing justification: %q", got.Notes)
+	}
+}
+
 func TestLLMJudgeScorerScoresFromJSON(t *testing.T) {
 	client := &fakeJudgeClient{
 		resp: &ollama.ChatResponse{

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -614,3 +614,40 @@ func TestLLMJudgeScorer_CachePutPreservesSemicolonsInJustification(t *testing.T)
 		t.Fatalf("Justification truncated: got %q, want %q", stored, want)
 	}
 }
+
+// TestLLMJudgeScorer_BypassCache_AlwaysCallsJudgeAndDoesNotPersist pins the
+// BypassCache=true contract: every Score call must invoke the judge (Get is
+// skipped, so cached entries can never satisfy the call), and no row may
+// ever be written to the cache (Put is also skipped). This guards against
+// regressions where BypassCache short-circuits only one side of the cache.
+func TestLLMJudgeScorer_BypassCache_AlwaysCallsJudgeAndDoesNotPersist(t *testing.T) {
+	c, _ := newTestCache(t)
+	judge := &fakeJudgeClient{resp: &ollama.ChatResponse{Message: ollama.ChatMessage{
+		Content: `{"answer_quality":0.5,"justification":"x"}`,
+	}}}
+	scorer := &LLMJudgeScorer{
+		Client:      judge,
+		JudgeModel:  "ollama/gemma4:31b",
+		Cache:       c,
+		BypassCache: true,
+	}
+	trace := Trace{ID: "t", System: "s", Turns: []Turn{{Role: "user", Content: "h"}}, Golden: Golden{FinalAnswerCriteria: "c"}}
+	actual := Result{Model: "ollama/cand", Transcript: []Turn{{Role: "assistant", Content: "a"}}}
+
+	for i := 0; i < 3; i++ {
+		if _, err := scorer.Score(context.Background(), trace, actual); err != nil {
+			t.Fatalf("Score #%d: %v", i, err)
+		}
+	}
+	if judge.called != 3 {
+		t.Fatalf("BypassCache=true should call judge each time; called=%d", judge.called)
+	}
+	// Verify nothing was written to the cache by querying any row count.
+	var count int
+	if err := c.db.QueryRow(`SELECT COUNT(*) FROM judge_cache`).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("BypassCache=true persisted %d rows; want 0", count)
+	}
+}

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -232,6 +232,9 @@ func TestBuildJudgeCall_PopulatesBaseScoreAndRequest(t *testing.T) {
 	if req.Format != "json" {
 		t.Fatalf("req.Format = %q; want json", req.Format)
 	}
+	if req.Think == nil || *req.Think {
+		t.Fatalf("req.Think = %v; want explicit false", req.Think)
+	}
 	if base.ToolSequenceMatch != 1.0 {
 		t.Fatalf("baseScore.ToolSequenceMatch = %v; want 1.0", base.ToolSequenceMatch)
 	}

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -718,6 +718,60 @@ func TestLLMJudgeScorer_BypassCache_AlwaysCallsJudgeAndDoesNotPersist(t *testing
 	}
 }
 
+func TestLLMJudgeScorer_MalformedCacheHitFallsBackToJudge(t *testing.T) {
+	c, _ := newTestCache(t)
+	judge := &fakeJudgeClient{resp: &ollama.ChatResponse{Message: ollama.ChatMessage{
+		Content: `{"answer_quality":0.9,"justification":"fresh"}`,
+	}}}
+	scorer := &LLMJudgeScorer{
+		Client:     judge,
+		JudgeModel: "ollama/gemma4:31b",
+		Cache:      c,
+	}
+	trace := Trace{ID: "bad-cache", System: "s", Turns: []Turn{{Role: "user", Content: "h"}}, Golden: Golden{FinalAnswerCriteria: "c"}}
+	actual := Result{Model: "ollama/cand", TraceID: "bad-cache", Transcript: []Turn{{Role: "assistant", Content: "a"}}}
+	req, _, err := scorer.buildJudgeCall(trace, actual)
+	if err != nil {
+		t.Fatalf("buildJudgeCall: %v", err)
+	}
+	cacheKey := canonicalCacheKey(judgeCacheRequest{
+		Version:      judgeCacheKeyVersion,
+		JudgeModel:   normalizeModelSelector(scorer.JudgeModel),
+		SystemPrompt: judgeSystemPrompt,
+		UserPrompt:   judgeUserPromptOf(req),
+		Format:       req.Format,
+		Think:        req.Think,
+		Temperature:  judgeTemperature,
+		NumPredict:   judgeTokenBudget,
+	})
+	now := time.Date(2026, 5, 26, 0, 0, 0, 0, time.UTC)
+	if err := c.Put(context.Background(), judgeCacheEntry{
+		CacheKey:        cacheKey,
+		JudgeModel:      scorer.JudgeModel,
+		TraceID:         trace.ID,
+		CandidateModel:  actual.Model,
+		PromptHash:      "bad",
+		RequestJSON:     "{}",
+		ResponseContent: "not-json",
+		AnswerQuality:   0,
+		Justification:   "bad",
+		CreatedAt:       now,
+		LastUsedAt:      now,
+	}); err != nil {
+		t.Fatalf("seed bad cache row: %v", err)
+	}
+	score, err := scorer.Score(context.Background(), trace, actual)
+	if err != nil {
+		t.Fatalf("Score: %v", err)
+	}
+	if judge.called != 1 {
+		t.Fatalf("judge called %d times; want 1 fallback call", judge.called)
+	}
+	if score.AnswerQuality != 0.9 {
+		t.Fatalf("AnswerQuality = %v; want fresh judge score 0.9", score.AnswerQuality)
+	}
+}
+
 // TestLLMJudgeScorer_CacheHit_FreshToolSequenceMatch is the load-bearing
 // invariant of the judge-cache architecture: on a cache hit the judge MUST
 // NOT be re-invoked, but the returned Score's ToolSequenceMatch MUST come

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -522,3 +522,61 @@ func TestParseJudgeResponseRejectsNegativeScore(t *testing.T) {
 		t.Fatalf("err = %v, want errMalformedJudgeResponse", err)
 	}
 }
+
+// TestLLMJudgeScorer_CacheHit_ReusesContentButRecomputesToolSequenceMatch
+// pins the load-bearing invariant of the cache integration: a cache hit
+// reuses the judge's response content (so AnswerQuality and justification
+// are stable), but ToolSequenceMatch is recomputed fresh from the current
+// actual transcript so tool-loop changes can never be masked by a stale
+// cache entry.
+func TestLLMJudgeScorer_CacheHit_ReusesContentButRecomputesToolSequenceMatch(t *testing.T) {
+	c, _ := newTestCache(t)
+	judge := &fakeJudgeClient{
+		resp: &ollama.ChatResponse{
+			Message: ollama.ChatMessage{
+				Content: `{"answer_quality":0.7,"justification":"meh"}`,
+			},
+		},
+	}
+	scorer := &LLMJudgeScorer{
+		Client:           judge,
+		JudgeModel:       "ollama/gemma4:31b",
+		JudgeModelDigest: "sha256:abc",
+		Cache:            c,
+		Clock:            func() time.Time { return time.Date(2026, 5, 25, 0, 0, 0, 0, time.UTC) },
+	}
+	trace := Trace{
+		ID:     "tx",
+		System: "s",
+		Turns:  []Turn{{Role: "user", Content: "hi"}},
+		Golden: Golden{ToolCalls: []string{"read_file"}, FinalAnswerCriteria: "c"},
+	}
+	actualA := Result{Model: "ollama/cand", Transcript: []Turn{
+		{Role: "assistant", ToolCalls: []ToolCall{{Name: "read_file"}}},
+		{Role: "assistant", Content: "done"},
+	}}
+	s1, err := scorer.Score(context.Background(), trace, actualA)
+	if err != nil {
+		t.Fatalf("first Score: %v", err)
+	}
+	if s1.ToolSequenceMatch != 1.0 {
+		t.Fatalf("first ToolSequenceMatch=%v; want 1.0", s1.ToolSequenceMatch)
+	}
+	if judge.called != 1 {
+		t.Fatalf("judge called %d times; want 1", judge.called)
+	}
+
+	s2, err := scorer.Score(context.Background(), trace, actualA)
+	if err != nil {
+		t.Fatalf("second Score: %v", err)
+	}
+	if judge.called != 1 {
+		t.Fatalf("judge called %d times after cache-hit; want still 1", judge.called)
+	}
+	if s2.AnswerQuality != s1.AnswerQuality {
+		t.Fatalf("cache returned different AnswerQuality: %v vs %v", s2.AnswerQuality, s1.AnswerQuality)
+	}
+	if s2.ToolSequenceMatch != 1.0 {
+		t.Fatalf("cache-hit ToolSequenceMatch=%v; want 1.0 (recomputed fresh)", s2.ToolSequenceMatch)
+	}
+}

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -137,6 +137,52 @@ func TestToolSequenceScoreDeduplicatesActualToolNames(t *testing.T) {
 	}
 }
 
+// TestLLMJudgeScorer_HappyPath_PreRefactorBaseline pins the end-to-end happy
+// path behavior of LLMJudgeScorer.Score before the upcoming refactor splits
+// it into helpers. Keep this test green through the refactor as a regression
+// anchor.
+func TestLLMJudgeScorer_HappyPath_PreRefactorBaseline(t *testing.T) {
+	trace := Trace{
+		ID:     "baseline-trace",
+		System: "you are an assistant",
+		Turns: []Turn{
+			{Role: "user", Content: "what is 2+2?"},
+		},
+		Golden: Golden{
+			ToolCalls:           nil,
+			FinalAnswerCriteria: "exactly 4",
+		},
+	}
+	actual := Result{
+		Model:   "ollama/qwen3-coder-next:latest",
+		TraceID: "baseline-trace",
+		Transcript: []Turn{
+			{Role: "assistant", Content: "the answer is 4"},
+		},
+	}
+	judge := &fakeJudgeClient{
+		resp: &ollama.ChatResponse{
+			Message: ollama.ChatMessage{
+				Content: `{"answer_quality":1.0,"justification":"correct"}`,
+			},
+		},
+	}
+	scorer := &LLMJudgeScorer{
+		Client:     judge,
+		JudgeModel: "ollama/gemma4:31b",
+	}
+	score, err := scorer.Score(context.Background(), trace, actual)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if score.AnswerQuality != 1.0 {
+		t.Fatalf("AnswerQuality = %v; want 1.0", score.AnswerQuality)
+	}
+	if !strings.Contains(score.Notes, "correct") {
+		t.Fatalf("Notes missing justification: %q", score.Notes)
+	}
+}
+
 func TestLLMJudgeScorerScoresFromJSON(t *testing.T) {
 	client := &fakeJudgeClient{
 		resp: &ollama.ChatResponse{

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -228,7 +228,7 @@ func TestBuildJudgeCall_SelfPreferenceGuard(t *testing.T) {
 
 func TestMaterializeJudgement_AppendsJustificationToNotes(t *testing.T) {
 	base := Score{ToolSequenceMatch: 0.5, Notes: "pre-existing"}
-	got, err := materializeJudgement(base, "ollama/gemma4:31b", `{"answer_quality":0.5,"justification":"missed caveat"}`)
+	got, _, err := materializeJudgement(base, "ollama/gemma4:31b", `{"answer_quality":0.5,"justification":"missed caveat"}`)
 	if err != nil {
 		t.Fatalf("materializeJudgement: %v", err)
 	}
@@ -578,5 +578,39 @@ func TestLLMJudgeScorer_CacheHit_ReusesContentButRecomputesToolSequenceMatch(t *
 	}
 	if s2.ToolSequenceMatch != 1.0 {
 		t.Fatalf("cache-hit ToolSequenceMatch=%v; want 1.0 (recomputed fresh)", s2.ToolSequenceMatch)
+	}
+}
+
+// TestLLMJudgeScorer_CachePutPreservesSemicolonsInJustification pins the
+// fix for the brittle joined-Notes round-trip: a judge justification
+// containing "; " (very common in real model output) must be persisted
+// verbatim into the cache's justification column instead of being
+// silently truncated at the first "; " segment boundary.
+func TestLLMJudgeScorer_CachePutPreservesSemicolonsInJustification(t *testing.T) {
+	c, _ := newTestCache(t)
+	// Justification with embedded "; " — the kind that would have been
+	// truncated by the old judgeJustificationFromNotes round-trip.
+	judge := &fakeJudgeClient{resp: &ollama.ChatResponse{Message: ollama.ChatMessage{
+		Content: `{"answer_quality":0.5,"justification":"covered A; missed B; also dropped C"}`,
+	}}}
+	scorer := &LLMJudgeScorer{
+		Client:           judge,
+		JudgeModel:       "ollama/gemma4:31b",
+		JudgeModelDigest: "sha256:abc",
+		Cache:            c,
+	}
+	trace := Trace{ID: "t-semi", System: "s", Turns: []Turn{{Role: "user", Content: "u"}}, Golden: Golden{FinalAnswerCriteria: "c"}}
+	actual := Result{Model: "ollama/cand", Transcript: []Turn{{Role: "assistant", Content: "ans"}}}
+	if _, err := scorer.Score(context.Background(), trace, actual); err != nil {
+		t.Fatalf("Score: %v", err)
+	}
+	// Read the row back via the test cache's underlying db.
+	var stored string
+	if err := c.db.QueryRow(`SELECT justification FROM judge_cache WHERE trace_id = ?`, "t-semi").Scan(&stored); err != nil {
+		t.Fatalf("query justification: %v", err)
+	}
+	want := "covered A; missed B; also dropped C"
+	if stored != want {
+		t.Fatalf("Justification truncated: got %q, want %q", stored, want)
 	}
 }

--- a/docs/llm/CALIBRATION.md
+++ b/docs/llm/CALIBRATION.md
@@ -32,6 +32,12 @@ Writes one JSON object per line to `artifacts.jsonl`:
   "trace_id": "fim-go-handler-001",
   "candidate_model": "ollama/qwen3-coder-next:latest",
   "artifact_hash": "sha256:...",
+  "trace": {
+    "id": "fim-go-handler-001",
+    "system": "...",
+    "turns": [{"role": "user", "content": "..."}],
+    "golden": {"final_answer_criteria": "...", "tool_calls": ["read_file"]}
+  },
   "actual_final_answer": "...",
   "actual_tool_calls": ["read_file", "search_code"],
   "actual_transcript": [{"role": "...", "content": "..."}],

--- a/docs/llm/CALIBRATION.md
+++ b/docs/llm/CALIBRATION.md
@@ -66,6 +66,7 @@ The `artifact_hash` MUST match the corresponding artifact's hash — that's
 how the calibration loop knows the label is still valid for the frozen
 output. Each current artifact hash may appear only once in `labels.jsonl`;
 duplicate matched labels are rejected so one artifact cannot be double-counted.
+Labels with `expected_answer_quality` outside `{0.0, 0.5, 1.0}` are rejected.
 
 ### How to label
 

--- a/docs/llm/CALIBRATION.md
+++ b/docs/llm/CALIBRATION.md
@@ -1,0 +1,128 @@
+# Judge Calibration Workflow
+
+The `cmd/llm-bench` LLM-judge scorer needs periodic calibration against
+human-labeled ground truth before its agreement numbers can be trusted in
+[recommendation.md](recommendation.md). This doc describes the two-phase
+workflow.
+
+## Storage layout
+
+| Path | Checked in? | Purpose |
+|---|---|---|
+| `docs/llm/CALIBRATION.md` | ✅ this file | Format spec + workflow |
+| `docs/llm/calibration/artifacts.jsonl` | ❌ gitignored | Frozen candidate outputs (Phase 1 output) |
+| `docs/llm/calibration/labels.jsonl` | ❌ gitignored | Human labels (you hand-edit) |
+| `docs/llm/calibration/reports/*.md` | ❌ gitignored | Per-run calibration reports |
+
+## Phase 1 — Capture frozen artifacts
+
+Run this when you change the set of candidate models you care about.
+
+```
+llm-bench -calibrate-capture \
+  -traces 'docs/llm/traces/*.json' \
+  -models 'ollama/qwen3-coder-next:latest,ollama/gemma4:31b' \
+  -labels-out docs/llm/calibration/artifacts.jsonl
+```
+
+Writes one JSON object per line to `artifacts.jsonl`:
+
+```json
+{
+  "trace_id": "fim-go-handler-001",
+  "candidate_model": "ollama/qwen3-coder-next:latest",
+  "artifact_hash": "sha256:...",
+  "actual_final_answer": "...",
+  "actual_tool_calls": ["read_file", "search_code"],
+  "actual_transcript": [{"role": "...", "content": "..."}],
+  "captured_at": "2026-05-25T14:00:00Z"
+}
+```
+
+## Phase 2 — Label the artifacts
+
+Open `artifacts.jsonl` and create a parallel `labels.jsonl` where each line
+adds `expected_answer_quality` ∈ {0.0, 0.5, 1.0}:
+
+```json
+{
+  "trace_id": "fim-go-handler-001",
+  "candidate_model": "ollama/qwen3-coder-next:latest",
+  "artifact_hash": "sha256:...",
+  "expected_answer_quality": 0.5,
+  "label_notes": "correct high-level answer, missed required caveat",
+  "labeled_at": "2026-05-25T14:30:00Z",
+  "labeler": "manual"
+}
+```
+
+The `artifact_hash` MUST match the corresponding artifact's hash — that's
+how the calibration loop knows the label is still valid for the frozen
+output.
+
+### How to label
+
+- **1.0** — fully satisfies the rubric: every required element present, no
+  contradictions, no unsupported claims.
+- **0.5** — partially correct: gets the gist or some required elements
+  right but misses something material.
+- **0.0** — wrong or absent.
+
+## Phase 3 — Calibrate
+
+Run this when you change the judge model (or after material judge prompt
+changes).
+
+```
+llm-bench -calibrate \
+  -labels docs/llm/calibration/labels.jsonl \
+  -artifacts docs/llm/calibration/artifacts.jsonl \
+  -judge-model ollama/gemma4:31b
+```
+
+Writes a markdown report to
+`docs/llm/calibration/reports/YYYY-MM-DD-<slug>.md`. Verdict is one of:
+
+- **PASS** — agreement ≥85% on ≥50 matched non-stale labels.
+- **FAIL** — agreement <85% on ≥50 matched non-stale labels.
+- **INSUFFICIENT_LABELS** — fewer than 50 matched non-stale labels.
+  Never claims PASS. Label more artifacts and rerun.
+
+A label is "stale" iff its `artifact_hash` doesn't match the current
+`artifacts.jsonl`. Stale labels are listed in the report and excluded from
+agreement. Usual cause: candidate model upgraded silently (floating tag).
+Mitigation: pin candidates to non-floating tags or digests.
+
+### Stability runs (diagnostic)
+
+```
+llm-bench -calibrate ... -judge-stability-runs 3
+```
+
+Runs the judge `M=3` times per artifact (cache bypassed, results NOT
+persisted) and reports `max - min` spread per artifact. Does not affect
+the PASS/FAIL verdict — it's a separate "is the judge stable?" check.
+
+## Floating-tag caution
+
+Two distinct floating-tag risks:
+
+1. **Judge model drift** — `ollama pull gemma4:31b` may resolve to a
+   different digest. Mitigation: the judge cache key includes the model
+   digest when `/api/show` exposes one, so cached judgments from a
+   different digest miss instead of being reused incorrectly.
+2. **Candidate model drift** — `ollama pull qwen3-coder-next:latest` may
+   resolve to a different digest, producing different artifacts that no
+   longer match your old labels. Mitigation: `artifact_hash` mismatch
+   surfaces as "stale labels" in the report.
+
+For trustworthy accepted-run calibrations, pin both judge and candidate
+to non-floating tags or digests.
+
+## Active labeling loop (deferred)
+
+`-calibrate-suggest` (an "active learning" subcommand that highlights
+artifacts most worth labeling) is a planned follow-up. For now, label
+incrementally — start with 20 artifacts, run `-calibrate`, then label
+artifacts where the judge disagreed with your label or where the answer
+falls in the borderline 0.4–0.6 band.

--- a/docs/llm/CALIBRATION.md
+++ b/docs/llm/CALIBRATION.md
@@ -88,7 +88,9 @@ llm-bench -calibrate \
 ```
 
 Writes a markdown report to
-`docs/llm/calibration/reports/YYYY-MM-DD-<slug>.md`. Verdict is one of:
+`docs/llm/calibration/reports/YYYY-MM-DDTHHMMSSZ-<slug>.md`. If a report
+already exists for the same timestamp and judge model, a numeric suffix is
+added so prior reports are not overwritten. Verdict is one of:
 
 - **PASS** — agreement ≥85% on ≥50 matched non-stale labels.
 - **FAIL** — agreement <85% on ≥50 matched non-stale labels.

--- a/docs/llm/CALIBRATION.md
+++ b/docs/llm/CALIBRATION.md
@@ -64,7 +64,8 @@ adds `expected_answer_quality` ∈ {0.0, 0.5, 1.0}:
 
 The `artifact_hash` MUST match the corresponding artifact's hash — that's
 how the calibration loop knows the label is still valid for the frozen
-output.
+output. Each current artifact hash may appear only once in `labels.jsonl`;
+duplicate matched labels are rejected so one artifact cannot be double-counted.
 
 ### How to label
 
@@ -105,9 +106,10 @@ Mitigation: pin candidates to non-floating tags or digests.
 llm-bench -calibrate ... -judge-stability-runs 3
 ```
 
-Runs the judge `M=3` times per artifact (cache bypassed, results NOT
-persisted) and reports `max - min` spread per artifact. Does not affect
-the PASS/FAIL verdict — it's a separate "is the judge stable?" check.
+Runs the judge exactly `M=3` times per artifact (cache bypassed, results
+NOT persisted) and reports `max - min` spread across those samples. The
+first sample is also the score used for agreement. Does not affect the
+PASS/FAIL verdict — it's a separate "is the judge stable?" check.
 
 ## Floating-tag caution
 

--- a/docs/llm/CALIBRATION.md
+++ b/docs/llm/CALIBRATION.md
@@ -102,6 +102,9 @@ A label is "stale" iff its `artifact_hash` doesn't match the current
 `artifacts.jsonl`. Stale labels are listed in the report and excluded from
 agreement. Usual cause: candidate model upgraded silently (floating tag).
 Mitigation: pin candidates to non-floating tags or digests.
+Labels whose candidate model is the same selector as the judge model are also
+skipped and reported separately; they are excluded from agreement and label
+sufficiency math.
 
 ### Stability runs (diagnostic)
 

--- a/docs/llm/benchmark-plan.md
+++ b/docs/llm/benchmark-plan.md
@@ -183,6 +183,22 @@ First implementation slice:
 - Follow-up: persistent cache keyed by `(judge_model, trace_id,
   transcript_hash)` so re-running over the same corpus is cheap
 
+### Calibration
+
+The judge scorer is calibrated against human labels via a two-phase
+workflow documented in [CALIBRATION.md](CALIBRATION.md). Headline numbers:
+
+- Primary agreement criterion: `|judge - expected| ≤ 0.25`.
+- Pass threshold: ≥85% agreement on ≥50 matched non-stale labels.
+- Below 50 matched non-stale labels: verdict is `INSUFFICIENT_LABELS`
+  (never PASS).
+- Stale labels (label `artifact_hash` ≠ frozen `artifacts.jsonl` hash) are
+  listed in the report and excluded from agreement.
+- Stability runs (`-judge-stability-runs M`) are diagnostic only and do
+  not gate the verdict.
+
+Active labeling (`-calibrate-suggest`) is a planned follow-up.
+
 ### Phase 4 — Live comparison runs
 
 - **Currently-configured model vs candidate** on each role's captured

--- a/ollama/types.go
+++ b/ollama/types.go
@@ -51,6 +51,7 @@ type ChatRequest struct {
 	Messages  []ChatMessage `json:"messages"`
 	Stream    bool          `json:"stream"`
 	Format    string        `json:"format,omitempty"` // e.g. "json" for structured output
+	Think     *bool         `json:"think,omitempty"`  // controls reasoning models that support Ollama's thinking mode
 	Options   *ModelOptions `json:"options,omitempty"`
 	Tools     []Tool        `json:"tools,omitempty"`      // available tools
 	KeepAlive string        `json:"keep_alive,omitempty"` // e.g. "5m", "30m", "-1" (keep forever); empty = Ollama default


### PR DESCRIPTION
## Summary
- Persistent SQLite judge-response cache keyed on (judge model + digest, system+user prompt, format/temp/numpredict). Hits skip the judge call but recompute ToolSequenceMatch / Notes fresh so tool-loop changes are never masked.
- Two-phase calibration: `-calibrate-capture` freezes candidate outputs to `artifacts.jsonl`; `-calibrate` re-scores only labeled frozen artifacts and writes a slugified markdown report under `docs/llm/calibration/reports/`.
- Fails closed when fewer than 50 matched non-stale labels exist (`INSUFFICIENT_LABELS` — never PASS).
- `-judge-stability-runs M` runs the judge M times per artifact with cache bypassed; reports spread as diagnostic only.

## Background
- Closes part of #56 (Harness Track follow-ups).
- This is PR A of a planned multi-PR rollout. PR B (schema capture + ToolArgsValid) and PR C (citable recommendation) follow.
- See `docs/llm/benchmark-plan.md` Phase 3 and the new `docs/llm/CALIBRATION.md` for the calibration workflow.

## Test plan
- [x] `go test ./cmd/llm-bench/... -race` passes
- [x] Refactor regression baseline (`TestLLMJudgeScorer_HappyPath_PreRefactorBaseline`) passes
- [x] Corrupt-DB test asserts wrapped error + no auto-repair
- [x] Cache hit returns fresh ToolSequenceMatch (load-bearing invariant)
- [x] BypassCache=true never reads or writes cache
- [x] Insufficient-labels verdict is INSUFFICIENT_LABELS, not PASS, at 100% agreement on 3 matched
- [x] Slugified report filename: `ollama/gemma4:31b` → `ollama_gemma4_31b`
- [x] Stability runs do not persist cache rows
- [x] Optional: integration test against live Ollama with `-tags llmbench_integration`

## Out of scope (filed separately)
- Track B (schema capture + JSON Schema validation for real `ToolArgsValid`).
- Track C (citable recommendation docs, per-run benchmark artifacts).
- `-calibrate-suggest` active-labeling subcommand.
- `-judge-cache-prune` / `-judge-cache-reset` commands.
- Conversation↔feedback linkage.

Generated with [Claude Code](https://claude.com/claude-code)