### PR TITLE
fix(llm-bench): resolve judge digest with native Ollama model

### DIFF
--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -146,7 +146,7 @@ type judgeModelChecker interface {
 // Errors from /api/show are deliberately swallowed: a missing digest is
 // degraded R1 mitigation, not a hard failure.
 func resolveJudgeDigest(ctx context.Context, checker judgeModelChecker, judgeModel string) (string, error) {
-	info, err := checker.ShowModel(ctx, judgeModel)
+	info, err := checker.ShowModel(ctx, modelSelectorWithoutBenchProvider(judgeModel))
 	if err != nil {
 		return "", nil
 	}

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -510,9 +510,11 @@ func TestValidateJudgeModelPreservesNamespacedModelIDs(t *testing.T) {
 }
 
 func TestResolveJudgeDigest_ReturnsDigestWhenAvailable(t *testing.T) {
+	var gotName string
 	checker := &fakeJudgeChecker{
 		available: []string{"ollama/gemma4:31b"},
 		showFn: func(name string) (*ollama.ModelInfo, error) {
+			gotName = name
 			return &ollama.ModelInfo{Name: name, Digest: "sha256:deadbeef"}, nil
 		},
 	}
@@ -522,6 +524,29 @@ func TestResolveJudgeDigest_ReturnsDigestWhenAvailable(t *testing.T) {
 	}
 	if digest != "sha256:deadbeef" {
 		t.Fatalf("digest = %q; want sha256:deadbeef", digest)
+	}
+	if gotName != "gemma4:31b" {
+		t.Fatalf("ShowModel name = %q; want gemma4:31b", gotName)
+	}
+}
+
+func TestResolveJudgeDigest_StripsOnlyBenchProvider(t *testing.T) {
+	var gotName string
+	checker := &fakeJudgeChecker{
+		showFn: func(name string) (*ollama.ModelInfo, error) {
+			gotName = name
+			return &ollama.ModelInfo{Name: name, Digest: "sha256:namespaced"}, nil
+		},
+	}
+	digest, err := resolveJudgeDigest(context.Background(), checker, "ollama/hf.co/org/model:tag")
+	if err != nil {
+		t.Fatalf("resolveJudgeDigest: %v", err)
+	}
+	if digest != "sha256:namespaced" {
+		t.Fatalf("digest = %q; want sha256:namespaced", digest)
+	}
+	if gotName != "hf.co/org/model:tag" {
+		t.Fatalf("ShowModel name = %q; want hf.co/org/model:tag", gotName)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Strip the benchmark provider prefix before resolving the judge model digest through /api/show
- Add regression coverage for provider-qualified and namespaced judge selectors

## Test plan
- [x] GOCACHE=/private/tmp/go-llm-pr123-gocache go test ./cmd/llm-bench -run 'Test(ResolveJudgeDigest_|BuildJudgeCall_StripsBenchProviderFromJudgeRequestModel|ValidateJudgeModelAcceptsProviderQualifiedSelector)' -count=1 -v\n- [x] GOCACHE=/private/tmp/go-llm-pr123-gocache GOLANGCI_LINT_CACHE=/private/tmp/go-llm-pr123-golangci-cache golangci-lint run\n- [x] GOCACHE=/private/tmp/go-llm-pr123-gocache go vet ./...\n- [x] GOCACHE=/private/tmp/go-llm-pr123-gocache go test ./cmd/llm-bench/... -race\n- [x] GOCACHE=/private/tmp/go-llm-pr123-gocache go test -race ./...\n- [x] GOCACHE=/private/tmp/go-llm-pr123-gocache go test ./cmd/llm-bench -tags llmbench_integration -run TestCalibrateAgainstLiveOllama -count=1 -v