### PR TITLE
feat(provider): attempt attribution wiring (Epic #48 Phase 5 PR2)

### DIFF
--- a/ollama/types.go
+++ b/ollama/types.go
@@ -178,3 +178,12 @@ type APIError struct {
 func (e *APIError) Error() string {
 	return fmt.Sprintf("ollama: HTTP %d: %s", e.StatusCode, e.Message)
 }
+
+// HTTPStatusCode exposes the response status code for router classification
+// without requiring the routing layer to depend on Ollama-specific types.
+func (e *APIError) HTTPStatusCode() int {
+	if e == nil {
+		return 0
+	}
+	return e.StatusCode
+}

--- a/provider/openaicompat/client.go
+++ b/provider/openaicompat/client.go
@@ -180,10 +180,30 @@ func readErrorEnvelope(resp *http.Response) error {
 
 	var env errorEnvelope
 	if json.Unmarshal(body, &env) == nil && env.Error.Message != "" {
-		return fmt.Errorf("openaicompat: %s: %s", resp.Status, env.Error.Message)
+		return &statusError{statusCode: resp.StatusCode, status: resp.Status, message: env.Error.Message}
 	}
 	if len(body) > 0 {
-		return fmt.Errorf("openaicompat: %s: %s", resp.Status, string(body))
+		return &statusError{statusCode: resp.StatusCode, status: resp.Status, message: string(body)}
 	}
-	return fmt.Errorf("openaicompat: %s", resp.Status)
+	return &statusError{statusCode: resp.StatusCode, status: resp.Status}
+}
+
+type statusError struct {
+	statusCode int
+	status     string
+	message    string
+}
+
+func (e *statusError) Error() string {
+	if e.message != "" {
+		return fmt.Sprintf("openaicompat: %s: %s", e.status, e.message)
+	}
+	return fmt.Sprintf("openaicompat: %s", e.status)
+}
+
+func (e *statusError) HTTPStatusCode() int {
+	if e == nil {
+		return 0
+	}
+	return e.statusCode
 }

--- a/provider/openaicompat/openaicompat_test.go
+++ b/provider/openaicompat/openaicompat_test.go
@@ -3,6 +3,7 @@ package openaicompat
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -153,6 +154,9 @@ func TestClient_ErrorEnvelope_Unwrapped(t *testing.T) {
 	if !strings.Contains(err.Error(), "model not found") {
 		t.Errorf("error should surface the OpenAI message, got: %v", err)
 	}
+	if provider.IsInfrastructureError(err) {
+		t.Errorf("400 error should not be classified as infrastructure: %v", err)
+	}
 }
 
 func TestClient_NonJSONError_FallsBackToBody(t *testing.T) {
@@ -173,6 +177,16 @@ func TestClient_NonJSONError_FallsBackToBody(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "502") {
 		t.Errorf("error should mention status, got: %v", err)
+	}
+	if !provider.IsInfrastructureError(err) {
+		t.Errorf("502 error should be classified as infrastructure: %v", err)
+	}
+	var statusErr interface{ HTTPStatusCode() int }
+	if !errors.As(err, &statusErr) {
+		t.Fatalf("expected wrapped error to expose HTTPStatusCode: %v", err)
+	}
+	if got := statusErr.HTTPStatusCode(); got != http.StatusBadGateway {
+		t.Fatalf("HTTPStatusCode = %d, want %d", got, http.StatusBadGateway)
 	}
 }
 

--- a/provider/route_errors.go
+++ b/provider/route_errors.go
@@ -1,0 +1,98 @@
+// route_errors.go defines the bounded ErrorClass vocabulary used by the
+// RoutingFeedback seam to attribute per-attempt failures. classifyError is
+// a pure function over the error types already used by IsInfrastructureError
+// (net.OpError, net.DNSError, HTTPStatusError) plus context cancellation,
+// returning both the class and the corresponding AttemptStatus.
+package provider
+
+import (
+	"context"
+	"errors"
+	"net"
+)
+
+// ErrorClass is the bounded vocabulary of routing failure classes.
+// RoutingFeedback aggregates pivot by ErrorClass for fail-mode debugging.
+type ErrorClass string
+
+const (
+	// ErrorClassNetwork covers connection-level failures: refused, reset,
+	// DNS lookup failures, unreachable.
+	ErrorClassNetwork ErrorClass = "network"
+
+	// ErrorClassTimeout covers context.DeadlineExceeded — the caller's
+	// reasonable deadline was missed. Distinct from cancellation
+	// (caller-initiated abort) which gets AttemptStatusUnknown and no class.
+	ErrorClassTimeout ErrorClass = "timeout"
+
+	// ErrorClass4xx covers HTTP 400-499 except 429, which gets its own
+	// class. Typically caller-side issues (bad request, unauthorized,
+	// not found).
+	ErrorClass4xx ErrorClass = "4xx"
+
+	// ErrorClass5xx covers HTTP 500-599 — server-side failures.
+	ErrorClass5xx ErrorClass = "5xx"
+
+	// ErrorClassRateLimit covers HTTP 429. Semantically distinct from 5xx:
+	// rate limiting indicates load-shedding, not a server fault.
+	ErrorClassRateLimit ErrorClass = "rate_limit"
+
+	// ErrorClassModelUnloaded is reserved for Ollama-specific detection of
+	// the "model is not loaded" error. classifyError does not produce this
+	// class in PR2 — the producer is added in a later PR. Consumers may
+	// still match on the constant without a vocabulary change later.
+	ErrorClassModelUnloaded ErrorClass = "model_unloaded"
+
+	// ErrorClassUnknown is the fall-through for errors classifyError can't
+	// otherwise identify. Always paired with AttemptStatusFailed.
+	ErrorClassUnknown ErrorClass = "unknown"
+)
+
+// classifyError returns the ErrorClass and AttemptStatus for err.
+//
+// Mapping (first match wins):
+//
+//	nil err                                       → ("",            Succeeded)
+//	errors.Is(err, context.Canceled)              → ("",            Unknown)
+//	errors.Is(err, context.DeadlineExceeded)      → ("timeout",     Failed)
+//	*net.OpError / *net.DNSError                  → ("network",     Failed)
+//	*HTTPStatusError 429                          → ("rate_limit",  Failed)
+//	*HTTPStatusError 500..599                     → ("5xx",         Failed)
+//	*HTTPStatusError 400..499 (not 429)           → ("4xx",         Failed)
+//	any other err                                 → ("unknown",     Failed)
+//
+// model_unloaded is reserved but never returned in PR2.
+func classifyError(err error) (ErrorClass, AttemptStatus) {
+	if err == nil {
+		return "", AttemptStatusSucceeded
+	}
+	if errors.Is(err, context.Canceled) {
+		return "", AttemptStatusUnknown
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return ErrorClassTimeout, AttemptStatusFailed
+	}
+
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return ErrorClassNetwork, AttemptStatusFailed
+	}
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return ErrorClassNetwork, AttemptStatusFailed
+	}
+
+	var httpErr *HTTPStatusError
+	if errors.As(err, &httpErr) {
+		switch {
+		case httpErr.StatusCode == 429:
+			return ErrorClassRateLimit, AttemptStatusFailed
+		case httpErr.StatusCode >= 500 && httpErr.StatusCode <= 599:
+			return ErrorClass5xx, AttemptStatusFailed
+		case httpErr.StatusCode >= 400 && httpErr.StatusCode <= 499:
+			return ErrorClass4xx, AttemptStatusFailed
+		}
+	}
+
+	return ErrorClassUnknown, AttemptStatusFailed
+}

--- a/provider/route_errors.go
+++ b/provider/route_errors.go
@@ -56,9 +56,9 @@ const (
 //	errors.Is(err, context.Canceled)              → ("",            Unknown)
 //	errors.Is(err, context.DeadlineExceeded)      → ("timeout",     Failed)
 //	*net.OpError / *net.DNSError                  → ("network",     Failed)
-//	*HTTPStatusError 429                          → ("rate_limit",  Failed)
-//	*HTTPStatusError 500..599                     → ("5xx",         Failed)
-//	*HTTPStatusError 400..499 (not 429)           → ("4xx",         Failed)
+//	HTTPStatusCode() == 429                       → ("rate_limit",  Failed)
+//	HTTPStatusCode() == 500..599                  → ("5xx",         Failed)
+//	HTTPStatusCode() == 400..499 (not 429)        → ("4xx",         Failed)
 //	any other err                                 → ("unknown",     Failed)
 //
 // model_unloaded is reserved but never returned in PR2.
@@ -82,14 +82,13 @@ func classifyError(err error) (ErrorClass, AttemptStatus) {
 		return ErrorClassNetwork, AttemptStatusFailed
 	}
 
-	var httpErr *HTTPStatusError
-	if errors.As(err, &httpErr) {
+	if statusCode, ok := httpStatusCode(err); ok {
 		switch {
-		case httpErr.StatusCode == 429:
+		case statusCode == 429:
 			return ErrorClassRateLimit, AttemptStatusFailed
-		case httpErr.StatusCode >= 500 && httpErr.StatusCode <= 599:
+		case statusCode >= 500 && statusCode <= 599:
 			return ErrorClass5xx, AttemptStatusFailed
-		case httpErr.StatusCode >= 400 && httpErr.StatusCode <= 499:
+		case statusCode >= 400 && statusCode <= 499:
 			return ErrorClass4xx, AttemptStatusFailed
 		}
 	}

--- a/provider/route_errors_test.go
+++ b/provider/route_errors_test.go
@@ -1,0 +1,65 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+)
+
+func TestClassifyError(t *testing.T) {
+	cases := []struct {
+		name       string
+		err        error
+		wantClass  ErrorClass
+		wantStatus AttemptStatus
+	}{
+		{"nil", nil, "", AttemptStatusSucceeded},
+		{"canceled", context.Canceled, "", AttemptStatusUnknown},
+		{"deadline-exceeded", context.DeadlineExceeded, ErrorClassTimeout, AttemptStatusFailed},
+		{"net-op-error", &net.OpError{Op: "dial", Err: errors.New("refused")}, ErrorClassNetwork, AttemptStatusFailed},
+		{"net-dns-error", &net.DNSError{Err: "no such host"}, ErrorClassNetwork, AttemptStatusFailed},
+		{"http-429", &HTTPStatusError{StatusCode: 429, Status: "429 Too Many Requests"}, ErrorClassRateLimit, AttemptStatusFailed},
+		{"http-500", &HTTPStatusError{StatusCode: 500, Status: "500 Internal Server Error"}, ErrorClass5xx, AttemptStatusFailed},
+		{"http-503", &HTTPStatusError{StatusCode: 503, Status: "503 Service Unavailable"}, ErrorClass5xx, AttemptStatusFailed},
+		{"http-599", &HTTPStatusError{StatusCode: 599, Status: "599"}, ErrorClass5xx, AttemptStatusFailed},
+		{"http-400", &HTTPStatusError{StatusCode: 400, Status: "400 Bad Request"}, ErrorClass4xx, AttemptStatusFailed},
+		{"http-404", &HTTPStatusError{StatusCode: 404, Status: "404 Not Found"}, ErrorClass4xx, AttemptStatusFailed},
+		{"http-499", &HTTPStatusError{StatusCode: 499, Status: "499"}, ErrorClass4xx, AttemptStatusFailed},
+		{"unknown", errors.New("something else"), ErrorClassUnknown, AttemptStatusFailed},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotClass, gotStatus := classifyError(tc.err)
+			if gotClass != tc.wantClass {
+				t.Errorf("class = %q, want %q", gotClass, tc.wantClass)
+			}
+			if gotStatus != tc.wantStatus {
+				t.Errorf("status = %v, want %v", gotStatus, tc.wantStatus)
+			}
+		})
+	}
+}
+
+func TestErrorClassModelUnloadedReservedNotProduced(t *testing.T) {
+	// model_unloaded is reserved in the vocabulary but the PR2 classifier
+	// never produces it — Ollama-specific detection is deferred. Lock the
+	// invariant: no input to classifyError should currently return it.
+	cases := []error{
+		nil,
+		context.Canceled,
+		context.DeadlineExceeded,
+		&net.OpError{Op: "dial", Err: errors.New("refused")},
+		&net.DNSError{Err: "no such host"},
+		&HTTPStatusError{StatusCode: 429},
+		&HTTPStatusError{StatusCode: 500},
+		&HTTPStatusError{StatusCode: 404},
+		errors.New("something else"),
+	}
+	for _, err := range cases {
+		class, _ := classifyError(err)
+		if class == ErrorClassModelUnloaded {
+			t.Fatalf("classifyError(%v) returned reserved %q", err, class)
+		}
+	}
+}

--- a/provider/route_errors_test.go
+++ b/provider/route_errors_test.go
@@ -44,6 +44,16 @@ func TestClassifyError(t *testing.T) {
 		{"wrapped-status-code-interface-503", fmt.Errorf("wrapped: %w", testStatusCodeError(503)), ErrorClass5xx, AttemptStatusFailed},
 		{"status-code-interface-404", testStatusCodeError(404), ErrorClass4xx, AttemptStatusFailed},
 		{"wrapped-ollama-api-error-429", fmt.Errorf("provider: ollama: chat: %w", &ollama.APIError{StatusCode: 429}), ErrorClassRateLimit, AttemptStatusFailed},
+		// Wrapped *HTTPStatusError must also traverse the unwrap chain — guards
+		// against a future refactor that drops the errors.As path.
+		{"wrapped-http-503", fmt.Errorf("provider: %w", &HTTPStatusError{StatusCode: 503}), ErrorClass5xx, AttemptStatusFailed},
+		{"wrapped-net-error", fmt.Errorf("dial: %w", &net.OpError{Op: "dial", Err: errors.New("refused")}), ErrorClassNetwork, AttemptStatusFailed},
+		{"wrapped-canceled", fmt.Errorf("provider: %w", context.Canceled), "", AttemptStatusUnknown},
+		// Status codes outside [400,599] fall through to unknown — pins the
+		// vocabulary's deliberate gap so future refactors can't widen it
+		// silently.
+		{"http-200-unexpected", &HTTPStatusError{StatusCode: 200}, ErrorClassUnknown, AttemptStatusFailed},
+		{"http-301-unexpected", &HTTPStatusError{StatusCode: 301}, ErrorClassUnknown, AttemptStatusFailed},
 		{"unknown", errors.New("something else"), ErrorClassUnknown, AttemptStatusFailed},
 	}
 	for _, tc := range cases {

--- a/provider/route_errors_test.go
+++ b/provider/route_errors_test.go
@@ -3,10 +3,23 @@ package provider
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"testing"
 	"time"
+
+	"github.com/kstruzzieri/go-llm/ollama"
 )
+
+type testStatusCodeError int
+
+func (e testStatusCodeError) Error() string {
+	return fmt.Sprintf("HTTP %d", int(e))
+}
+
+func (e testStatusCodeError) HTTPStatusCode() int {
+	return int(e)
+}
 
 func TestClassifyError(t *testing.T) {
 	cases := []struct {
@@ -27,6 +40,10 @@ func TestClassifyError(t *testing.T) {
 		{"http-400", &HTTPStatusError{StatusCode: 400, Status: "400 Bad Request"}, ErrorClass4xx, AttemptStatusFailed},
 		{"http-404", &HTTPStatusError{StatusCode: 404, Status: "404 Not Found"}, ErrorClass4xx, AttemptStatusFailed},
 		{"http-499", &HTTPStatusError{StatusCode: 499, Status: "499"}, ErrorClass4xx, AttemptStatusFailed},
+		{"status-code-interface-429", testStatusCodeError(429), ErrorClassRateLimit, AttemptStatusFailed},
+		{"wrapped-status-code-interface-503", fmt.Errorf("wrapped: %w", testStatusCodeError(503)), ErrorClass5xx, AttemptStatusFailed},
+		{"status-code-interface-404", testStatusCodeError(404), ErrorClass4xx, AttemptStatusFailed},
+		{"wrapped-ollama-api-error-429", fmt.Errorf("provider: ollama: chat: %w", &ollama.APIError{StatusCode: 429}), ErrorClassRateLimit, AttemptStatusFailed},
 		{"unknown", errors.New("something else"), ErrorClassUnknown, AttemptStatusFailed},
 	}
 	for _, tc := range cases {

--- a/provider/route_errors_test.go
+++ b/provider/route_errors_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"testing"
+	"time"
 )
 
 func TestClassifyError(t *testing.T) {
@@ -61,5 +62,59 @@ func TestErrorClassModelUnloadedReservedNotProduced(t *testing.T) {
 		if class == ErrorClassModelUnloaded {
 			t.Fatalf("classifyError(%v) returned reserved %q", err, class)
 		}
+	}
+}
+
+func TestMakeAttemptHappyPath(t *testing.T) {
+	key := ModelKey{Provider: "ollama-a", Model: "qwen3:8b"}
+	got := makeAttempt(key, nil, 820*time.Millisecond)
+	if got.Key != key {
+		t.Errorf("Key = %v, want %v", got.Key, key)
+	}
+	if got.Status != AttemptStatusSucceeded {
+		t.Errorf("Status = %v, want Succeeded", got.Status)
+	}
+	if got.LatencyMs != 820 {
+		t.Errorf("LatencyMs = %d, want 820", got.LatencyMs)
+	}
+	if got.ErrorClass != "" {
+		t.Errorf("ErrorClass = %q, want empty", got.ErrorClass)
+	}
+}
+
+func TestMakeAttemptFailedNetwork(t *testing.T) {
+	key := ModelKey{Provider: "ollama-a", Model: "qwen3:8b"}
+	err := &net.OpError{Op: "dial", Err: errors.New("refused")}
+	got := makeAttempt(key, err, 200*time.Millisecond)
+	if got.Status != AttemptStatusFailed {
+		t.Errorf("Status = %v, want Failed", got.Status)
+	}
+	if got.LatencyMs != 200 {
+		t.Errorf("LatencyMs = %d, want 200", got.LatencyMs)
+	}
+	if got.ErrorClass != string(ErrorClassNetwork) {
+		t.Errorf("ErrorClass = %q, want %q", got.ErrorClass, ErrorClassNetwork)
+	}
+}
+
+func TestMakeAttemptCanceled(t *testing.T) {
+	key := ModelKey{Provider: "ollama-a", Model: "qwen3:8b"}
+	got := makeAttempt(key, context.Canceled, 100*time.Millisecond)
+	if got.Status != AttemptStatusUnknown {
+		t.Errorf("Status = %v, want Unknown", got.Status)
+	}
+	if got.LatencyMs != 100 {
+		t.Errorf("LatencyMs = %d, want 100", got.LatencyMs)
+	}
+	if got.ErrorClass != "" {
+		t.Errorf("ErrorClass = %q, want empty (Canceled gets no class)", got.ErrorClass)
+	}
+}
+
+func TestMakeAttemptClampsNegativeDuration(t *testing.T) {
+	key := ModelKey{Provider: "ollama-a", Model: "qwen3:8b"}
+	got := makeAttempt(key, nil, -1*time.Second)
+	if got.LatencyMs != 0 {
+		t.Errorf("LatencyMs = %d, want 0 (clamped)", got.LatencyMs)
 	}
 }

--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -225,8 +225,12 @@ func (rp *RoutePlan) ExecuteGenerate(ctx context.Context) (*GenerateResponse, er
 		return nil, ErrBudgetAdaptationRequired
 	}
 
+	var attempts []RouteAttempt
 	req := rp.buildGenerateRequest(false)
+
+	start := time.Now()
 	resp, err := rp.Provider.Generate(ctx, req)
+	attempts = append(attempts, makeAttempt(rp.Profile.Key, err, time.Since(start)))
 
 	fallbacksUsed := 0
 	if err != nil && IsInfrastructureError(err) {
@@ -234,7 +238,9 @@ func (rp *RoutePlan) ExecuteGenerate(ctx context.Context) (*GenerateResponse, er
 
 		for i, fb := range rp.Fallbacks {
 			fbReq := fb.buildGenerateRequest(false)
+			fbStart := time.Now()
 			resp, err = fb.Provider.Generate(ctx, fbReq)
+			attempts = append(attempts, makeAttempt(fb.Profile.Key, err, time.Since(fbStart)))
 			if err == nil {
 				fallbacksUsed = i + 1
 				break
@@ -247,7 +253,7 @@ func (rp *RoutePlan) ExecuteGenerate(ctx context.Context) (*GenerateResponse, er
 		}
 	}
 
-	outcome := rp.handleResult(err, fallbacksUsed, nil)
+	outcome := rp.handleResult(err, fallbacksUsed, attempts)
 	if resp != nil && outcome != nil {
 		resp.RouteOutcome = outcome
 	}

--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -141,10 +141,11 @@ func (rp *RoutePlan) ExecuteChat(ctx context.Context) (*ChatResponse, error) {
 // provider. Fallback is only attempted when the primary fails with an
 // infrastructure error AND no user-visible chunk has yet been delivered
 // (a chunk is "visible" when Content, Thinking, or ToolCalls is non-empty).
-// Each provider call produces exactly one RouteAttempt, finalized either by
-// the Done-chunk handler (when chunk.Partial == false) or by the post-stream
-// code (using the real stream-method error). User-callback errors are
-// captured separately and attributed as AttemptStatusUnknown.
+// Each provider call produces exactly one RouteAttempt. A terminal Done chunk
+// prepares the successful attempt and RouteOutcome, but feedback recording is
+// deferred until the provider stream returns so post-Done provider errors and
+// callback aborts are reconciled against the returned execution result. User-
+// callback errors are captured separately and attributed as AttemptStatusUnknown.
 //
 // Stream callback invocation:
 //   - fn is invoked once per chunk in the calling goroutine. Provider
@@ -197,7 +198,6 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 			attempts = pendingAttempts
 			streamDone = true
 			outcome = pendingOutcome
-			rp.recordResult(nil, attempts, outcome)
 			return nil
 		}
 		if e := fn(chunk); e != nil {
@@ -208,6 +208,13 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 	}
 
 	err := rp.Provider.ChatStream(ctx, req, wrappedFn)
+	if streamDone && err != nil && (callbackErr == nil || !errors.Is(err, callbackErr)) {
+		// A provider may still surface transport/read errors after it has
+		// delivered a final Done chunk accepted by the callback. Treat the
+		// accepted terminal chunk as authoritative so feedback and the returned
+		// execution result agree.
+		err = nil
+	}
 
 	if !streamDone {
 		if callbackErr != nil {
@@ -257,7 +264,6 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 						fallbacksUsed = pendingFallbacksUsed
 						fbStreamDone = true
 						outcome = pendingOutcome
-						rp.recordResult(nil, attempts, outcome)
 						return nil
 					}
 					if e := fn(chunk); e != nil {
@@ -268,6 +274,10 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 				}
 
 				err = fb.Provider.ChatStream(ctx, fbReq, wrappedFbFn)
+				if fbStreamDone && err != nil && (fbCallbackErr == nil || !errors.Is(err, fbCallbackErr)) {
+					// See primary streamDone handling above.
+					err = nil
+				}
 
 				if !fbStreamDone {
 					if fbCallbackErr != nil {
@@ -301,6 +311,8 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 	// that ended in a non-infrastructure error / cancellation.
 	if outcome == nil {
 		rp.handleResult(err, fallbacksUsed, attempts)
+	} else if err == nil {
+		rp.recordResult(nil, attempts, outcome)
 	}
 
 	return err
@@ -360,11 +372,12 @@ func (rp *RoutePlan) ExecuteGenerate(ctx context.Context) (*GenerateResponse, er
 // ExecuteGenerateStream dispatches a streaming generate request to the
 // selected provider. Fallback is only attempted when the primary fails with
 // an infrastructure error AND no user-visible Response chunk has yet been
-// delivered. Each provider call produces exactly one RouteAttempt,
-// finalized either by the Done-chunk handler (when chunk.Partial == false)
-// or by the post-stream code (using the real stream-method error). User-
-// callback errors are captured separately and attributed as
-// AttemptStatusUnknown.
+// delivered. Each provider call produces exactly one RouteAttempt. A terminal
+// Done chunk prepares the successful attempt and RouteOutcome, but feedback
+// recording is deferred until the provider stream returns so post-Done
+// provider errors and callback aborts are reconciled against the returned
+// execution result. User-callback errors are captured separately and
+// attributed as AttemptStatusUnknown.
 //
 // See ExecuteChatStream for the full stream callback contract — the
 // invariants are identical (serial-callback contract, Done-chunk
@@ -405,7 +418,6 @@ func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(Generate
 			attempts = pendingAttempts
 			streamDone = true
 			outcome = pendingOutcome
-			rp.recordResult(nil, attempts, outcome)
 			return nil
 		}
 		if e := fn(chunk); e != nil {
@@ -416,6 +428,13 @@ func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(Generate
 	}
 
 	err := rp.Provider.GenerateStream(ctx, req, wrappedFn)
+	if streamDone && err != nil && (callbackErr == nil || !errors.Is(err, callbackErr)) {
+		// A provider may still surface transport/read errors after it has
+		// delivered a final Done chunk accepted by the callback. Treat the
+		// accepted terminal chunk as authoritative so feedback and the returned
+		// execution result agree.
+		err = nil
+	}
 
 	if !streamDone {
 		if callbackErr != nil {
@@ -465,7 +484,6 @@ func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(Generate
 						fallbacksUsed = pendingFallbacksUsed
 						fbStreamDone = true
 						outcome = pendingOutcome
-						rp.recordResult(nil, attempts, outcome)
 						return nil
 					}
 					if e := fn(chunk); e != nil {
@@ -476,6 +494,10 @@ func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(Generate
 				}
 
 				err = fb.Provider.GenerateStream(ctx, fbReq, wrappedFbFn)
+				if fbStreamDone && err != nil && (fbCallbackErr == nil || !errors.Is(err, fbCallbackErr)) {
+					// See primary streamDone handling above.
+					err = nil
+				}
 
 				if !fbStreamDone {
 					if fbCallbackErr != nil {
@@ -509,6 +531,8 @@ func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(Generate
 	// that ended in a non-infrastructure error / cancellation.
 	if outcome == nil {
 		rp.handleResult(err, fallbacksUsed, attempts)
+	} else if err == nil {
+		rp.recordResult(nil, attempts, outcome)
 	}
 
 	return err

--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -321,32 +321,64 @@ func (rp *RoutePlan) ExecuteGenerate(ctx context.Context) (*GenerateResponse, er
 // ---------------------------------------------------------------------------
 
 // ExecuteGenerateStream dispatches a streaming generate request to the selected
-// provider. Fallback is only attempted before the first user-visible chunk.
+// provider. Fallback is only attempted before the first user-visible chunk
+// has been delivered. Each provider call produces exactly one RouteAttempt,
+// finalized either by the Done-chunk handler (when chunk.Partial == false)
+// or by the post-stream code (using the real stream-method error). User-
+// callback errors are captured separately and attributed as
+// AttemptStatusUnknown.
 func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(GenerateResponse) error) error {
 	if rp.Budget.Decision == BudgetTruncate {
 		return ErrBudgetAdaptationRequired
 	}
 
+	var attempts []RouteAttempt
 	req := rp.buildGenerateRequest(true)
 
 	delivered := false
 	fallbacksUsed := 0
 	var outcome *RouteOutcome
 
+	primaryStart := time.Now()
+	streamDone := false
+	var callbackErr error
+
 	wrappedFn := func(chunk GenerateResponse) error {
 		if !delivered && chunk.Response != "" {
 			delivered = true
 		}
-		if chunk.Done {
-			outcome = rp.handleResult(nil, fallbacksUsed, nil)
+		if chunk.Done && !chunk.Partial {
+			attempts = append(attempts,
+				makeAttempt(rp.Profile.Key, nil, time.Since(primaryStart)))
+			streamDone = true
+			outcome = rp.handleResult(nil, fallbacksUsed, attempts)
 			if outcome != nil {
 				chunk.RouteOutcome = outcome
 			}
 		}
-		return fn(chunk)
+		if e := fn(chunk); e != nil {
+			callbackErr = e
+			return e
+		}
+		return nil
 	}
 
 	err := rp.Provider.GenerateStream(ctx, req, wrappedFn)
+
+	if !streamDone {
+		if callbackErr != nil {
+			// User aborted via callback. Attribute as Unknown, not a
+			// provider failure.
+			attempts = append(attempts, RouteAttempt{
+				Key:       rp.Profile.Key,
+				Status:    AttemptStatusUnknown,
+				LatencyMs: time.Since(primaryStart).Milliseconds(),
+			})
+		} else {
+			attempts = append(attempts,
+				makeAttempt(rp.Profile.Key, err, time.Since(primaryStart)))
+		}
+	}
 
 	if err != nil && IsInfrastructureError(err) {
 		rp.recordFailure(rp.Profile.Key, err)
@@ -357,26 +389,51 @@ func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(Generate
 				fbReq := fb.buildGenerateRequest(true)
 				delivered = false
 				fallbacksUsed = i + 1
+				fbStart := time.Now()
+				fbStreamDone := false
+				var fbCallbackErr error
 
 				wrappedFbFn := func(chunk GenerateResponse) error {
 					if !delivered && chunk.Response != "" {
 						delivered = true
 					}
-					if chunk.Done {
-						outcome = rp.handleResult(nil, fallbacksUsed, nil)
+					if chunk.Done && !chunk.Partial {
+						attempts = append(attempts,
+							makeAttempt(fb.Profile.Key, nil, time.Since(fbStart)))
+						fbStreamDone = true
+						outcome = rp.handleResult(nil, fallbacksUsed, attempts)
 						if outcome != nil {
 							chunk.RouteOutcome = outcome
 						}
 					}
-					return fn(chunk)
+					if e := fn(chunk); e != nil {
+						fbCallbackErr = e
+						return e
+					}
+					return nil
 				}
 
 				err = fb.Provider.GenerateStream(ctx, fbReq, wrappedFbFn)
+
+				if !fbStreamDone {
+					if fbCallbackErr != nil {
+						attempts = append(attempts, RouteAttempt{
+							Key:       fb.Profile.Key,
+							Status:    AttemptStatusUnknown,
+							LatencyMs: time.Since(fbStart).Milliseconds(),
+						})
+					} else {
+						attempts = append(attempts,
+							makeAttempt(fb.Profile.Key, err, time.Since(fbStart)))
+					}
+				}
+
 				if err == nil {
-					return nil
+					break
 				}
 				if IsInfrastructureError(err) {
 					rp.recordFailure(fb.Profile.Key, err)
+					// Only continue to next fallback if this one did not deliver content.
 					if delivered {
 						break
 					}
@@ -390,7 +447,7 @@ func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(Generate
 	// Record signals for streams that completed without a Done chunk, or
 	// that ended in a non-infrastructure error / cancellation.
 	if outcome == nil {
-		rp.handleResult(err, fallbacksUsed, nil)
+		rp.handleResult(err, fallbacksUsed, attempts)
 	}
 
 	return err

--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"time"
 )
 
@@ -137,23 +138,29 @@ func (rp *RoutePlan) ExecuteChat(ctx context.Context) (*ChatResponse, error) {
 // ---------------------------------------------------------------------------
 
 // ExecuteChatStream dispatches a streaming chat request to the selected
-// provider. Fallback is only attempted before the first user-visible chunk
-// has been delivered. Each provider call produces exactly one RouteAttempt,
-// finalized either by the Done-chunk handler (when chunk.Partial == false)
-// or by the post-stream code (using the real stream-method error). User-
-// callback errors are captured separately and attributed as
-// AttemptStatusUnknown.
+// provider. Fallback is only attempted when the primary fails with an
+// infrastructure error AND no user-visible chunk has yet been delivered
+// (a chunk is "visible" when Content, Thinking, or ToolCalls is non-empty).
+// Each provider call produces exactly one RouteAttempt, finalized either by
+// the Done-chunk handler (when chunk.Partial == false) or by the post-stream
+// code (using the real stream-method error). User-callback errors are
+// captured separately and attributed as AttemptStatusUnknown.
 //
-// The user-supplied fn MUST be called serially in the calling goroutine —
-// closure-captured attempt state is mutated without synchronization. The
-// stock Provider implementations honor this; custom Provider implementations
-// that fan callbacks out to goroutines would race.
-//
-// When fallback occurs, fn may be invoked with chunks from multiple
-// providers (the failed primary's partial chunks AND the fallback's
-// chunks). Each Done chunk's RouteOutcome reflects the chain up to that
-// point; consumers that accumulate chunks across providers should treat
-// the Done chunk's RouteOutcome as authoritative for the final attribution.
+// Stream callback invocation:
+//   - fn is invoked once per chunk in the calling goroutine. Provider
+//     implementations are required to honor this contract (see
+//     Provider.ChatStream); custom providers that fan callbacks out to
+//     goroutines would race against the closure-captured attempt state.
+//   - If the primary emits chunks with no visible content (heartbeats,
+//     synthetic partial-Done) and then fails with infra error, fn first
+//     receives the primary's content-less chunks, then receives the
+//     fallback's chunks. Once any visible content reaches fn, fallback is
+//     suppressed for the rest of the request.
+//   - On a Done chunk, fn receives the chunk with RouteOutcome attached.
+//     Consumers that store the RouteOutcome (or its Attempts slice) should
+//     do so synchronously inside fn — the slice is cloned per Done chunk,
+//     so it remains valid after fn returns even if the callback errors and
+//     post-stream logic appends additional attempts.
 func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse) error) error {
 	if rp.Budget.Decision == BudgetTruncate {
 		return ErrBudgetAdaptationRequired
@@ -175,7 +182,11 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 			delivered = true
 		}
 		if chunk.Done && !chunk.Partial && !streamDone {
-			pendingAttempts := append(attempts,
+			// Clone attempts before appending so the chunk's outcome owns
+			// an independent slice. Otherwise a callback error would let a
+			// later iteration overwrite the success entry at index [n] of
+			// the shared underlying array.
+			pendingAttempts := append(slices.Clone(attempts),
 				makeAttempt(rp.Profile.Key, nil, time.Since(primaryStart)))
 			pendingOutcome := rp.buildOutcome(fallbacksUsed, pendingAttempts)
 			chunk.RouteOutcome = pendingOutcome
@@ -186,7 +197,7 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 			attempts = pendingAttempts
 			streamDone = true
 			outcome = pendingOutcome
-			rp.recordResult(nil, fallbacksUsed, attempts, outcome)
+			rp.recordResult(nil, attempts, outcome)
 			return nil
 		}
 		if e := fn(chunk); e != nil {
@@ -226,7 +237,10 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 						delivered = true
 					}
 					if chunk.Done && !chunk.Partial && !fbStreamDone {
-						pendingAttempts := append(attempts,
+						// Clone attempts before appending so the chunk's
+						// outcome owns an independent slice (see primary
+						// Done handler for rationale).
+						pendingAttempts := append(slices.Clone(attempts),
 							makeAttempt(fb.Profile.Key, nil, time.Since(fbStart)))
 						// Done implies this fallback served the request, so it
 						// is the SELECTED fallback. Pending-only until the
@@ -243,7 +257,7 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 						fallbacksUsed = pendingFallbacksUsed
 						fbStreamDone = true
 						outcome = pendingOutcome
-						rp.recordResult(nil, fallbacksUsed, attempts, outcome)
+						rp.recordResult(nil, attempts, outcome)
 						return nil
 					}
 					if e := fn(chunk); e != nil {
@@ -343,23 +357,18 @@ func (rp *RoutePlan) ExecuteGenerate(ctx context.Context) (*GenerateResponse, er
 // Execute — Generate stream
 // ---------------------------------------------------------------------------
 
-// ExecuteGenerateStream dispatches a streaming generate request to the selected
-// provider. Fallback is only attempted before the first user-visible chunk
-// has been delivered. Each provider call produces exactly one RouteAttempt,
+// ExecuteGenerateStream dispatches a streaming generate request to the
+// selected provider. Fallback is only attempted when the primary fails with
+// an infrastructure error AND no user-visible Response chunk has yet been
+// delivered. Each provider call produces exactly one RouteAttempt,
 // finalized either by the Done-chunk handler (when chunk.Partial == false)
 // or by the post-stream code (using the real stream-method error). User-
 // callback errors are captured separately and attributed as
 // AttemptStatusUnknown.
 //
-// The user-supplied fn MUST be called serially in the calling goroutine —
-// closure-captured attempt state is mutated without synchronization. The
-// stock Provider implementations honor this; custom Provider implementations
-// that fan callbacks out to goroutines would race.
-//
-// When fallback occurs, fn may be invoked with chunks from multiple
-// providers. Each Done chunk's RouteOutcome reflects the chain up to that
-// point; consumers that accumulate chunks across providers should treat
-// the Done chunk's RouteOutcome as authoritative for the final attribution.
+// See ExecuteChatStream for the full stream callback contract — the
+// invariants are identical (serial-callback contract, Done-chunk
+// RouteOutcome ownership, attempts slice clone-per-Done).
 func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(GenerateResponse) error) error {
 	if rp.Budget.Decision == BudgetTruncate {
 		return ErrBudgetAdaptationRequired
@@ -381,7 +390,11 @@ func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(Generate
 			delivered = true
 		}
 		if chunk.Done && !chunk.Partial && !streamDone {
-			pendingAttempts := append(attempts,
+			// Clone attempts before appending so the chunk's outcome owns
+			// an independent slice. Otherwise a callback error would let a
+			// later iteration overwrite the success entry at index [n] of
+			// the shared underlying array.
+			pendingAttempts := append(slices.Clone(attempts),
 				makeAttempt(rp.Profile.Key, nil, time.Since(primaryStart)))
 			pendingOutcome := rp.buildOutcome(fallbacksUsed, pendingAttempts)
 			chunk.RouteOutcome = pendingOutcome
@@ -392,7 +405,7 @@ func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(Generate
 			attempts = pendingAttempts
 			streamDone = true
 			outcome = pendingOutcome
-			rp.recordResult(nil, fallbacksUsed, attempts, outcome)
+			rp.recordResult(nil, attempts, outcome)
 			return nil
 		}
 		if e := fn(chunk); e != nil {
@@ -432,7 +445,10 @@ func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(Generate
 						delivered = true
 					}
 					if chunk.Done && !chunk.Partial && !fbStreamDone {
-						pendingAttempts := append(attempts,
+						// Clone attempts before appending so the chunk's
+						// outcome owns an independent slice (see primary
+						// Done handler for rationale).
+						pendingAttempts := append(slices.Clone(attempts),
 							makeAttempt(fb.Profile.Key, nil, time.Since(fbStart)))
 						// Done implies this fallback served the request, so it
 						// is the SELECTED fallback. Pending-only until the
@@ -449,7 +465,7 @@ func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(Generate
 						fallbacksUsed = pendingFallbacksUsed
 						fbStreamDone = true
 						outcome = pendingOutcome
-						rp.recordResult(nil, fallbacksUsed, attempts, outcome)
+						rp.recordResult(nil, attempts, outcome)
 						return nil
 					}
 					if e := fn(chunk); e != nil {
@@ -557,18 +573,19 @@ func (rp *RoutePlan) ExecuteEmbed(ctx context.Context) (*EmbedResponse, error) {
 // PR2 always returns non-nil.
 func (rp *RoutePlan) handleResult(err error, fallbacksUsed int, attempts []RouteAttempt) *RouteOutcome {
 	outcome := rp.buildOutcome(fallbacksUsed, attempts)
-	rp.recordResult(err, fallbacksUsed, attempts, outcome)
+	rp.recordResult(err, attempts, outcome)
 	return outcome
 }
 
 // recordResult attributes warmth and (on success) success signals against the
 // last-touched model, then forwards the prebuilt outcome to the feedback seam.
-// Warmth derives from attempts[last].Key when available — the last attempt is
-// always the most recently touched model regardless of outcome, so the OS page
-// cache is hot for that model whether it succeeded, failed, or was cancelled.
-// Falls back to rp.Profile.Key only when called directly by tests with a nil
-// attempts slice; production Execute* methods always populate it.
-func (rp *RoutePlan) recordResult(err error, fallbacksUsed int, attempts []RouteAttempt, outcome *RouteOutcome) {
+// Warmth derives from attempts[len(attempts)-1].Key when available — the last
+// attempt is the most recently touched model regardless of outcome, so the OS
+// page cache is hot for that model whether it succeeded, failed, or was
+// cancelled. Falls back to rp.Profile.Key when attempts is nil/empty (only
+// the unit tests for handleResult directly hit this branch; production
+// Execute* methods always populate attempts).
+func (rp *RoutePlan) recordResult(err error, attempts []RouteAttempt, outcome *RouteOutcome) {
 	actualKey := rp.Profile.Key
 	if len(attempts) > 0 {
 		actualKey = attempts[len(attempts)-1].Key
@@ -585,12 +602,19 @@ func (rp *RoutePlan) recordResult(err error, fallbacksUsed int, attempts []Route
 	rp.recordOutcomeFeedback(outcome)
 }
 
-// buildOutcome constructs a RouteOutcome from the plan, fallback index, and
-// per-attempt trace. ActualModel reflects the model whose response served
-// the request — the last attempt's key when it succeeded, otherwise the
-// planned (primary) model. This keeps ActualModel consistent across both
-// non-streaming and streaming Execute methods regardless of how the
-// fallbacksUsed counter was updated mid-stream.
+// buildOutcome constructs a RouteOutcome from the plan, the count of
+// fallbacks selected, and the per-attempt trace.
+//
+// ActualModel reflects the model whose response served the request — the
+// last attempt's key when it succeeded, otherwise the planned (primary)
+// model. ActualModel is derived from attempts alone, not from
+// fallbacksUsed, which keeps it consistent across non-streaming and
+// streaming Execute methods regardless of how mid-stream counter updates
+// were ordered.
+//
+// fallbacksUsed populates the RouteOutcome.FallbacksUsed output field only;
+// callers must pass the count of fallbacks that actually served (zero if
+// the primary served or if every attempt failed).
 func (rp *RoutePlan) buildOutcome(fallbacksUsed int, attempts []RouteAttempt) *RouteOutcome {
 	actualKey := rp.Profile.Key
 	if n := len(attempts); n > 0 && attempts[n-1].Status == AttemptStatusSucceeded {
@@ -686,8 +710,8 @@ var routeIDRand io.Reader = rand.Reader
 // silently coerced to an empty string — RouteID is informational; we do
 // not want routing paths to fail because the OS RNG returned an error.
 //
-// TODO(#48-phase5-pr3): once-logged warning on first RNG failure so
-// operators discover the cause when correlation IDs disappear.
+// TODO: once-logged warning on first RNG failure so operators discover the
+// cause when correlation IDs disappear.
 func newRouteID() string {
 	var b [16]byte
 	if _, err := io.ReadFull(routeIDRand, b[:]); err != nil {
@@ -742,7 +766,10 @@ func clampMs(duration time.Duration) int64 {
 // and survivable for a SQLite store under contention. Without this bound a
 // stuck store (locked WAL, frozen filesystem) would block every routed
 // request indefinitely.
-const feedbackWriteTimeout = 1 * time.Second
+//
+// Declared as a package-level var (not const) so tests can override it to
+// exercise the timeout path without burning real wall-clock seconds.
+var feedbackWriteTimeout = 1 * time.Second
 
 // recordOutcomeFeedback delegates to RoutingFeedback.RecordOutcome when a
 // feedback wrapper is configured AND the routing request has a non-empty
@@ -752,10 +779,10 @@ const feedbackWriteTimeout = 1 * time.Second
 // short the feedback write, and so a slow/stuck store does not block the
 // routing path indefinitely.
 //
-// TODO(#48-phase5-pr3): expose a counter or once-logged warning when the
-// store returns a non-nil error. Today's silent-swallow makes a broken
-// store look identical to a working empty store from the operator's view.
-// Tracked for the PR that adds the SQLite-backed store.
+// TODO: expose a counter or once-logged warning when the store returns a
+// non-nil error. Today's silent-swallow makes a broken store look identical
+// to a working empty store from the operator's view. Track in the PR that
+// adds the SQLite-backed store.
 func (rp *RoutePlan) recordOutcomeFeedback(outcome *RouteOutcome) {
 	if rp.feedback == nil || outcome == nil || rp.Request.UseCase == "" {
 		return

--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -164,13 +164,19 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 			delivered = true
 		}
 		if chunk.Done && !chunk.Partial && !streamDone {
-			attempts = append(attempts,
+			pendingAttempts := append(attempts,
 				makeAttempt(rp.Profile.Key, nil, time.Since(primaryStart)))
-			streamDone = true
-			outcome = rp.handleResult(nil, fallbacksUsed, attempts)
-			if outcome != nil {
-				chunk.RouteOutcome = outcome
+			pendingOutcome := rp.buildOutcome(fallbacksUsed, pendingAttempts)
+			chunk.RouteOutcome = pendingOutcome
+			if e := fn(chunk); e != nil {
+				callbackErr = e
+				return e
 			}
+			attempts = pendingAttempts
+			streamDone = true
+			outcome = pendingOutcome
+			rp.recordResult(nil, fallbacksUsed, attempts, outcome)
+			return nil
 		}
 		if e := fn(chunk); e != nil {
 			callbackErr = e
@@ -214,13 +220,19 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 						delivered = true
 					}
 					if chunk.Done && !chunk.Partial && !fbStreamDone {
-						attempts = append(attempts,
+						pendingAttempts := append(attempts,
 							makeAttempt(fb.Profile.Key, nil, time.Since(fbStart)))
-						fbStreamDone = true
-						outcome = rp.handleResult(nil, fallbacksUsed, attempts)
-						if outcome != nil {
-							chunk.RouteOutcome = outcome
+						pendingOutcome := rp.buildOutcome(fallbacksUsed, pendingAttempts)
+						chunk.RouteOutcome = pendingOutcome
+						if e := fn(chunk); e != nil {
+							fbCallbackErr = e
+							return e
 						}
+						attempts = pendingAttempts
+						fbStreamDone = true
+						outcome = pendingOutcome
+						rp.recordResult(nil, fallbacksUsed, attempts, outcome)
+						return nil
 					}
 					if e := fn(chunk); e != nil {
 						fbCallbackErr = e
@@ -348,13 +360,19 @@ func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(Generate
 			delivered = true
 		}
 		if chunk.Done && !chunk.Partial && !streamDone {
-			attempts = append(attempts,
+			pendingAttempts := append(attempts,
 				makeAttempt(rp.Profile.Key, nil, time.Since(primaryStart)))
-			streamDone = true
-			outcome = rp.handleResult(nil, fallbacksUsed, attempts)
-			if outcome != nil {
-				chunk.RouteOutcome = outcome
+			pendingOutcome := rp.buildOutcome(fallbacksUsed, pendingAttempts)
+			chunk.RouteOutcome = pendingOutcome
+			if e := fn(chunk); e != nil {
+				callbackErr = e
+				return e
 			}
+			attempts = pendingAttempts
+			streamDone = true
+			outcome = pendingOutcome
+			rp.recordResult(nil, fallbacksUsed, attempts, outcome)
+			return nil
 		}
 		if e := fn(chunk); e != nil {
 			callbackErr = e
@@ -398,13 +416,19 @@ func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(Generate
 						delivered = true
 					}
 					if chunk.Done && !chunk.Partial && !fbStreamDone {
-						attempts = append(attempts,
+						pendingAttempts := append(attempts,
 							makeAttempt(fb.Profile.Key, nil, time.Since(fbStart)))
-						fbStreamDone = true
-						outcome = rp.handleResult(nil, fallbacksUsed, attempts)
-						if outcome != nil {
-							chunk.RouteOutcome = outcome
+						pendingOutcome := rp.buildOutcome(fallbacksUsed, pendingAttempts)
+						chunk.RouteOutcome = pendingOutcome
+						if e := fn(chunk); e != nil {
+							fbCallbackErr = e
+							return e
 						}
+						attempts = pendingAttempts
+						fbStreamDone = true
+						outcome = pendingOutcome
+						rp.recordResult(nil, fallbacksUsed, attempts, outcome)
+						return nil
 					}
 					if e := fn(chunk); e != nil {
 						fbCallbackErr = e
@@ -511,6 +535,12 @@ func (rp *RoutePlan) ExecuteEmbed(ctx context.Context) (*EmbedResponse, error) {
 // recordOutcomeFeedback. Pre-PR2 returned nil on cancellation/failure;
 // PR2 always returns non-nil.
 func (rp *RoutePlan) handleResult(err error, fallbacksUsed int, attempts []RouteAttempt) *RouteOutcome {
+	outcome := rp.buildOutcome(fallbacksUsed, attempts)
+	rp.recordResult(err, fallbacksUsed, attempts, outcome)
+	return outcome
+}
+
+func (rp *RoutePlan) recordResult(err error, fallbacksUsed int, attempts []RouteAttempt, outcome *RouteOutcome) {
 	// Derive the most recently attempted key for warmth/success attribution.
 	// attempts[last].Key is correct in every case Execute* produces: success,
 	// infra failure, cancellation after a fallback was tried. The previous
@@ -536,9 +566,7 @@ func (rp *RoutePlan) handleResult(err error, fallbacksUsed int, attempts []Route
 	}
 	// Infrastructure failures continue to be recorded inline by Execute methods.
 
-	outcome := rp.buildOutcome(fallbacksUsed, attempts)
 	rp.recordOutcomeFeedback(outcome)
-	return outcome
 }
 
 // buildOutcome constructs a RouteOutcome from the plan, fallback index, and

--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -118,7 +118,7 @@ func (rp *RoutePlan) ExecuteChat(ctx context.Context) (*ChatResponse, error) {
 		}
 	}
 
-	outcome := rp.handleResult(err, fallbacksUsed)
+	outcome := rp.handleResult(err, fallbacksUsed, nil)
 	if resp != nil && outcome != nil {
 		resp.RouteOutcome = outcome
 	}
@@ -149,7 +149,7 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 			delivered = true
 		}
 		if chunk.Done {
-			outcome = rp.handleResult(nil, fallbacksUsed)
+			outcome = rp.handleResult(nil, fallbacksUsed, nil)
 			if outcome != nil {
 				chunk.RouteOutcome = outcome
 			}
@@ -174,7 +174,7 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 						delivered = true
 					}
 					if chunk.Done {
-						outcome = rp.handleResult(nil, fallbacksUsed)
+						outcome = rp.handleResult(nil, fallbacksUsed, nil)
 						if outcome != nil {
 							chunk.RouteOutcome = outcome
 						}
@@ -202,7 +202,7 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 	// Record signals for streams that completed without a Done chunk, or
 	// that ended in a non-infrastructure error / cancellation.
 	if outcome == nil {
-		rp.handleResult(err, fallbacksUsed)
+		rp.handleResult(err, fallbacksUsed, nil)
 	}
 
 	return err
@@ -241,7 +241,7 @@ func (rp *RoutePlan) ExecuteGenerate(ctx context.Context) (*GenerateResponse, er
 		}
 	}
 
-	outcome := rp.handleResult(err, fallbacksUsed)
+	outcome := rp.handleResult(err, fallbacksUsed, nil)
 	if resp != nil && outcome != nil {
 		resp.RouteOutcome = outcome
 	}
@@ -271,7 +271,7 @@ func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(Generate
 			delivered = true
 		}
 		if chunk.Done {
-			outcome = rp.handleResult(nil, fallbacksUsed)
+			outcome = rp.handleResult(nil, fallbacksUsed, nil)
 			if outcome != nil {
 				chunk.RouteOutcome = outcome
 			}
@@ -296,7 +296,7 @@ func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(Generate
 						delivered = true
 					}
 					if chunk.Done {
-						outcome = rp.handleResult(nil, fallbacksUsed)
+						outcome = rp.handleResult(nil, fallbacksUsed, nil)
 						if outcome != nil {
 							chunk.RouteOutcome = outcome
 						}
@@ -323,7 +323,7 @@ func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(Generate
 	// Record signals for streams that completed without a Done chunk, or
 	// that ended in a non-infrastructure error / cancellation.
 	if outcome == nil {
-		rp.handleResult(err, fallbacksUsed)
+		rp.handleResult(err, fallbacksUsed, nil)
 	}
 
 	return err
@@ -362,7 +362,7 @@ func (rp *RoutePlan) ExecuteEmbed(ctx context.Context) (*EmbedResponse, error) {
 		}
 	}
 
-	outcome := rp.handleResult(err, fallbacksUsed)
+	outcome := rp.handleResult(err, fallbacksUsed, nil)
 	if resp != nil && outcome != nil {
 		resp.RouteOutcome = outcome
 	}
@@ -374,39 +374,52 @@ func (rp *RoutePlan) ExecuteEmbed(ctx context.Context) (*EmbedResponse, error) {
 // handleResult — post-execution recorder + outcome builder
 // ---------------------------------------------------------------------------
 
-// handleResult records success/failure/cancellation signals and returns a
-// RouteOutcome for successful executions.
-func (rp *RoutePlan) handleResult(err error, fallbacksUsed int) *RouteOutcome {
+// handleResult records side-channel signals (breaker, warmth, feedback) and
+// returns a *RouteOutcome carrying the per-attempt trace. The outcome is
+// ALWAYS built, regardless of err — failure-path callers have no response
+// to attach the outcome to, but the feedback seam consumes it via
+// recordOutcomeFeedback. Pre-PR2 returned nil on cancellation/failure;
+// PR2 always returns non-nil.
+func (rp *RoutePlan) handleResult(err error, fallbacksUsed int, attempts []RouteAttempt) *RouteOutcome {
+	// Derive the most recently attempted key for warmth/success attribution.
+	// attempts[last].Key is correct in every case Execute* produces: success,
+	// infra failure, cancellation after a fallback was tried. The previous
+	// fallbacksUsed-arithmetic mis-attributed warmth to the primary when a
+	// fallback was attempted but never successfully selected.
+	//
+	// While the Execute* call sites still pass attempts=nil (Tasks 5-9 fill
+	// these in), fall back to the legacy fallbacksUsed-based derivation so
+	// existing tests and consumer behavior continue to observe RecordSuccess
+	// against the actually-selected fallback.
 	actualKey := rp.Profile.Key
-	if fallbacksUsed > 0 && fallbacksUsed <= len(rp.Fallbacks) {
+	if len(attempts) > 0 {
+		actualKey = attempts[len(attempts)-1].Key
+	} else if fallbacksUsed > 0 && fallbacksUsed <= len(rp.Fallbacks) {
 		actualKey = rp.Fallbacks[fallbacksUsed-1].Profile.Key
 	}
 
 	if err == nil {
 		rp.recordSuccess(actualKey, LatencyInfo{})
 		rp.recordWarmthUse(actualKey)
-		return rp.buildOutcome(fallbacksUsed)
+	} else if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		rp.recordWarmthUse(actualKey) // model IS warm even if caller bailed
 	}
+	// Infrastructure failures continue to be recorded inline by Execute methods.
 
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		rp.recordWarmthUse(actualKey) // model IS warm
-		return nil
-	}
-
-	// Infrastructure failures are recorded inline by the Execute methods
-	// (once per provider attempt) rather than here, to avoid double-counting
-	// the last-tried provider in the fallback chain.
-
-	return nil
+	outcome := rp.buildOutcome(fallbacksUsed, attempts)
+	rp.recordOutcomeFeedback(outcome)
+	return outcome
 }
 
-// buildOutcome constructs a RouteOutcome from the plan and fallback index.
-func (rp *RoutePlan) buildOutcome(fallbacksUsed int) *RouteOutcome {
+// buildOutcome constructs a RouteOutcome from the plan, fallback index, and
+// per-attempt trace. ActualModel reflects the *selected* fallback (the model
+// whose response is in the user's hand). Attempts records every provider
+// call that happened, in order.
+func (rp *RoutePlan) buildOutcome(fallbacksUsed int, attempts []RouteAttempt) *RouteOutcome {
 	actualKey := rp.Profile.Key
 	if fallbacksUsed > 0 && fallbacksUsed <= len(rp.Fallbacks) {
 		actualKey = rp.Fallbacks[fallbacksUsed-1].Profile.Key
 	}
-
 	return &RouteOutcome{
 		PlannedModel:  rp.Profile.Key,
 		ActualModel:   actualKey,
@@ -415,7 +428,7 @@ func (rp *RoutePlan) buildOutcome(fallbacksUsed int) *RouteOutcome {
 		Score:         rp.Score,
 		Reason:        rp.Reason,
 		RouteID:       newRouteID(),
-		// Attempts: nil — PR2 will populate from handleResult.
+		Attempts:      attempts,
 	}
 }
 

--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -47,8 +47,9 @@ type RoutePlan struct {
 	Fallbacks []RoutePlan
 	Reason    string
 	Degraded  bool
-	wasSticky bool          // internal: propagated to RouteOutcome
-	recorder  RouteRecorder // internal: set by Router
+	wasSticky bool             // internal: propagated to RouteOutcome
+	recorder  RouteRecorder    // internal: set by Router
+	feedback  *RoutingFeedback // internal: set by Router via SetFeedback; nil = no recording
 }
 
 // String returns a human-readable summary of the route plan.
@@ -62,6 +63,13 @@ func (rp *RoutePlan) String() string {
 // after constructing the plan.
 func (rp *RoutePlan) SetRecorder(r RouteRecorder) {
 	rp.recorder = r
+}
+
+// SetFeedback sets the RoutingFeedback wrapper used by handleResult to
+// record per-attempt outcomes. The Router calls this from buildPlan.
+// nil disables feedback recording for this plan (default).
+func (rp *RoutePlan) SetFeedback(rf *RoutingFeedback) {
+	rp.feedback = rf
 }
 
 // SetWasSticky marks the plan as having been selected via sticky routing.
@@ -515,4 +523,16 @@ func makeAttempt(key ModelKey, err error, duration time.Duration) RouteAttempt {
 		LatencyMs:  ms,
 		ErrorClass: string(class),
 	}
+}
+
+// recordOutcomeFeedback delegates to RoutingFeedback.RecordOutcome when a
+// feedback wrapper is configured AND the routing request has a non-empty
+// UseCase. Errors are swallowed — the seam is observational, never
+// load-bearing for routing. Uses context.Background() so cancellation of
+// the request's ctx does not cut short the feedback write.
+func (rp *RoutePlan) recordOutcomeFeedback(outcome *RouteOutcome) {
+	if rp.feedback == nil || outcome == nil || rp.Request.UseCase == "" {
+		return
+	}
+	_ = rp.feedback.RecordOutcome(context.Background(), rp.Request.UseCase, *outcome)
 }

--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -143,6 +143,17 @@ func (rp *RoutePlan) ExecuteChat(ctx context.Context) (*ChatResponse, error) {
 // or by the post-stream code (using the real stream-method error). User-
 // callback errors are captured separately and attributed as
 // AttemptStatusUnknown.
+//
+// The user-supplied fn MUST be called serially in the calling goroutine —
+// closure-captured attempt state is mutated without synchronization. The
+// stock Provider implementations honor this; custom Provider implementations
+// that fan callbacks out to goroutines would race.
+//
+// When fallback occurs, fn may be invoked with chunks from multiple
+// providers (the failed primary's partial chunks AND the fallback's
+// chunks). Each Done chunk's RouteOutcome reflects the chain up to that
+// point; consumers that accumulate chunks across providers should treat
+// the Done chunk's RouteOutcome as authoritative for the final attribution.
 func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse) error) error {
 	if rp.Budget.Decision == BudgetTruncate {
 		return ErrBudgetAdaptationRequired
@@ -191,11 +202,7 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 		if callbackErr != nil {
 			// User aborted via callback. Attribute as Unknown, not a
 			// provider failure.
-			attempts = append(attempts, RouteAttempt{
-				Key:       rp.Profile.Key,
-				Status:    AttemptStatusUnknown,
-				LatencyMs: time.Since(primaryStart).Milliseconds(),
-			})
+			attempts = append(attempts, makeUnknownAttempt(rp.Profile.Key, time.Since(primaryStart)))
 		} else {
 			attempts = append(attempts,
 				makeAttempt(rp.Profile.Key, err, time.Since(primaryStart)))
@@ -210,7 +217,6 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 			for i, fb := range rp.Fallbacks {
 				fbReq := fb.buildChatRequest(true)
 				delivered = false
-				fallbacksUsed = i + 1
 				fbStart := time.Now()
 				fbStreamDone := false
 				var fbCallbackErr error
@@ -222,13 +228,19 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 					if chunk.Done && !chunk.Partial && !fbStreamDone {
 						pendingAttempts := append(attempts,
 							makeAttempt(fb.Profile.Key, nil, time.Since(fbStart)))
-						pendingOutcome := rp.buildOutcome(fallbacksUsed, pendingAttempts)
+						// Done implies this fallback served the request, so it
+						// is the SELECTED fallback. Pending-only until the
+						// callback returns nil — keeps the idempotent
+						// finalization contract.
+						pendingFallbacksUsed := i + 1
+						pendingOutcome := rp.buildOutcome(pendingFallbacksUsed, pendingAttempts)
 						chunk.RouteOutcome = pendingOutcome
 						if e := fn(chunk); e != nil {
 							fbCallbackErr = e
 							return e
 						}
 						attempts = pendingAttempts
+						fallbacksUsed = pendingFallbacksUsed
 						fbStreamDone = true
 						outcome = pendingOutcome
 						rp.recordResult(nil, fallbacksUsed, attempts, outcome)
@@ -245,11 +257,7 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 
 				if !fbStreamDone {
 					if fbCallbackErr != nil {
-						attempts = append(attempts, RouteAttempt{
-							Key:       fb.Profile.Key,
-							Status:    AttemptStatusUnknown,
-							LatencyMs: time.Since(fbStart).Milliseconds(),
-						})
+						attempts = append(attempts, makeUnknownAttempt(fb.Profile.Key, time.Since(fbStart)))
 					} else {
 						attempts = append(attempts,
 							makeAttempt(fb.Profile.Key, err, time.Since(fbStart)))
@@ -257,6 +265,9 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 				}
 
 				if err == nil {
+					// Stream returned cleanly without a Done chunk; this
+					// fallback still served the (incomplete) response.
+					fallbacksUsed = i + 1
 					break
 				}
 				if IsInfrastructureError(err) {
@@ -339,6 +350,16 @@ func (rp *RoutePlan) ExecuteGenerate(ctx context.Context) (*GenerateResponse, er
 // or by the post-stream code (using the real stream-method error). User-
 // callback errors are captured separately and attributed as
 // AttemptStatusUnknown.
+//
+// The user-supplied fn MUST be called serially in the calling goroutine —
+// closure-captured attempt state is mutated without synchronization. The
+// stock Provider implementations honor this; custom Provider implementations
+// that fan callbacks out to goroutines would race.
+//
+// When fallback occurs, fn may be invoked with chunks from multiple
+// providers. Each Done chunk's RouteOutcome reflects the chain up to that
+// point; consumers that accumulate chunks across providers should treat
+// the Done chunk's RouteOutcome as authoritative for the final attribution.
 func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(GenerateResponse) error) error {
 	if rp.Budget.Decision == BudgetTruncate {
 		return ErrBudgetAdaptationRequired
@@ -387,11 +408,7 @@ func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(Generate
 		if callbackErr != nil {
 			// User aborted via callback. Attribute as Unknown, not a
 			// provider failure.
-			attempts = append(attempts, RouteAttempt{
-				Key:       rp.Profile.Key,
-				Status:    AttemptStatusUnknown,
-				LatencyMs: time.Since(primaryStart).Milliseconds(),
-			})
+			attempts = append(attempts, makeUnknownAttempt(rp.Profile.Key, time.Since(primaryStart)))
 		} else {
 			attempts = append(attempts,
 				makeAttempt(rp.Profile.Key, err, time.Since(primaryStart)))
@@ -406,7 +423,6 @@ func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(Generate
 			for i, fb := range rp.Fallbacks {
 				fbReq := fb.buildGenerateRequest(true)
 				delivered = false
-				fallbacksUsed = i + 1
 				fbStart := time.Now()
 				fbStreamDone := false
 				var fbCallbackErr error
@@ -418,13 +434,19 @@ func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(Generate
 					if chunk.Done && !chunk.Partial && !fbStreamDone {
 						pendingAttempts := append(attempts,
 							makeAttempt(fb.Profile.Key, nil, time.Since(fbStart)))
-						pendingOutcome := rp.buildOutcome(fallbacksUsed, pendingAttempts)
+						// Done implies this fallback served the request, so it
+						// is the SELECTED fallback. Pending-only until the
+						// callback returns nil — keeps the idempotent
+						// finalization contract.
+						pendingFallbacksUsed := i + 1
+						pendingOutcome := rp.buildOutcome(pendingFallbacksUsed, pendingAttempts)
 						chunk.RouteOutcome = pendingOutcome
 						if e := fn(chunk); e != nil {
 							fbCallbackErr = e
 							return e
 						}
 						attempts = pendingAttempts
+						fallbacksUsed = pendingFallbacksUsed
 						fbStreamDone = true
 						outcome = pendingOutcome
 						rp.recordResult(nil, fallbacksUsed, attempts, outcome)
@@ -441,11 +463,7 @@ func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(Generate
 
 				if !fbStreamDone {
 					if fbCallbackErr != nil {
-						attempts = append(attempts, RouteAttempt{
-							Key:       fb.Profile.Key,
-							Status:    AttemptStatusUnknown,
-							LatencyMs: time.Since(fbStart).Milliseconds(),
-						})
+						attempts = append(attempts, makeUnknownAttempt(fb.Profile.Key, time.Since(fbStart)))
 					} else {
 						attempts = append(attempts,
 							makeAttempt(fb.Profile.Key, err, time.Since(fbStart)))
@@ -453,6 +471,9 @@ func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(Generate
 				}
 
 				if err == nil {
+					// Stream returned cleanly without a Done chunk; this
+					// fallback still served the (incomplete) response.
+					fallbacksUsed = i + 1
 					break
 				}
 				if IsInfrastructureError(err) {
@@ -540,22 +561,17 @@ func (rp *RoutePlan) handleResult(err error, fallbacksUsed int, attempts []Route
 	return outcome
 }
 
+// recordResult attributes warmth and (on success) success signals against the
+// last-touched model, then forwards the prebuilt outcome to the feedback seam.
+// Warmth derives from attempts[last].Key when available — the last attempt is
+// always the most recently touched model regardless of outcome, so the OS page
+// cache is hot for that model whether it succeeded, failed, or was cancelled.
+// Falls back to rp.Profile.Key only when called directly by tests with a nil
+// attempts slice; production Execute* methods always populate it.
 func (rp *RoutePlan) recordResult(err error, fallbacksUsed int, attempts []RouteAttempt, outcome *RouteOutcome) {
-	// Derive the most recently attempted key for warmth/success attribution.
-	// attempts[last].Key is correct in every case Execute* produces: success,
-	// infra failure, cancellation after a fallback was tried. The previous
-	// fallbacksUsed-arithmetic mis-attributed warmth to the primary when a
-	// fallback was attempted but never successfully selected.
-	//
-	// While the Execute* call sites still pass attempts=nil (Tasks 5-9 fill
-	// these in), fall back to the legacy fallbacksUsed-based derivation so
-	// existing tests and consumer behavior continue to observe RecordSuccess
-	// against the actually-selected fallback.
 	actualKey := rp.Profile.Key
 	if len(attempts) > 0 {
 		actualKey = attempts[len(attempts)-1].Key
-	} else if fallbacksUsed > 0 && fallbacksUsed <= len(rp.Fallbacks) {
-		actualKey = rp.Fallbacks[fallbacksUsed-1].Profile.Key
 	}
 
 	if err == nil {
@@ -570,13 +586,15 @@ func (rp *RoutePlan) recordResult(err error, fallbacksUsed int, attempts []Route
 }
 
 // buildOutcome constructs a RouteOutcome from the plan, fallback index, and
-// per-attempt trace. ActualModel reflects the *selected* fallback (the model
-// whose response is in the user's hand). Attempts records every provider
-// call that happened, in order.
+// per-attempt trace. ActualModel reflects the model whose response served
+// the request — the last attempt's key when it succeeded, otherwise the
+// planned (primary) model. This keeps ActualModel consistent across both
+// non-streaming and streaming Execute methods regardless of how the
+// fallbacksUsed counter was updated mid-stream.
 func (rp *RoutePlan) buildOutcome(fallbacksUsed int, attempts []RouteAttempt) *RouteOutcome {
 	actualKey := rp.Profile.Key
-	if fallbacksUsed > 0 && fallbacksUsed <= len(rp.Fallbacks) {
-		actualKey = rp.Fallbacks[fallbacksUsed-1].Profile.Key
+	if n := len(attempts); n > 0 && attempts[n-1].Status == AttemptStatusSucceeded {
+		actualKey = attempts[n-1].Key
 	}
 	return &RouteOutcome{
 		PlannedModel:  rp.Profile.Key,
@@ -667,6 +685,9 @@ var routeIDRand io.Reader = rand.Reader
 // opaque correlation ID on RouteOutcome.RouteID. crypto/rand failures are
 // silently coerced to an empty string — RouteID is informational; we do
 // not want routing paths to fail because the OS RNG returned an error.
+//
+// TODO(#48-phase5-pr3): once-logged warning on first RNG failure so
+// operators discover the cause when correlation IDs disappear.
 func newRouteID() string {
 	var b [16]byte
 	if _, err := io.ReadFull(routeIDRand, b[:]); err != nil {
@@ -684,26 +705,62 @@ func newRouteID() string {
 //   - Negative duration clamps to LatencyMs=0.
 func makeAttempt(key ModelKey, err error, duration time.Duration) RouteAttempt {
 	class, status := classifyError(err)
-	ms := duration.Milliseconds()
-	if ms < 0 {
-		ms = 0
-	}
 	return RouteAttempt{
 		Key:        key,
 		Status:     status,
-		LatencyMs:  ms,
+		LatencyMs:  clampMs(duration),
 		ErrorClass: string(class),
 	}
 }
 
+// makeUnknownAttempt builds a RouteAttempt with AttemptStatusUnknown — used
+// by streaming Execute methods when a user-callback error aborts the stream
+// before a Done chunk. The attribution must NOT classify as a provider
+// failure (the provider may have been healthy), and Unknown signals are
+// no-ops in RoutingFeedback. Shares clampMs with makeAttempt so negative
+// monotonic-clock excursions can't produce negative LatencyMs.
+func makeUnknownAttempt(key ModelKey, duration time.Duration) RouteAttempt {
+	return RouteAttempt{
+		Key:       key,
+		Status:    AttemptStatusUnknown,
+		LatencyMs: clampMs(duration),
+	}
+}
+
+// clampMs converts a duration to milliseconds, clamping negative values to 0
+// to guard against non-monotonic clock excursions.
+func clampMs(duration time.Duration) int64 {
+	ms := duration.Milliseconds()
+	if ms < 0 {
+		return 0
+	}
+	return ms
+}
+
+// feedbackWriteTimeout bounds how long recordOutcomeFeedback will wait for
+// the store before giving up. Picked to be generous for an in-memory store
+// and survivable for a SQLite store under contention. Without this bound a
+// stuck store (locked WAL, frozen filesystem) would block every routed
+// request indefinitely.
+const feedbackWriteTimeout = 1 * time.Second
+
 // recordOutcomeFeedback delegates to RoutingFeedback.RecordOutcome when a
 // feedback wrapper is configured AND the routing request has a non-empty
 // UseCase. Errors are swallowed — the seam is observational, never
-// load-bearing for routing. Uses context.Background() so cancellation of
-// the request's ctx does not cut short the feedback write.
+// load-bearing for routing. Uses a fresh context with a bounded timeout
+// (not the request ctx) so cancellation of the caller's ctx does not cut
+// short the feedback write, and so a slow/stuck store does not block the
+// routing path indefinitely.
+//
+// TODO(#48-phase5-pr3): expose a counter or once-logged warning when the
+// store returns a non-nil error. Today's silent-swallow makes a broken
+// store look identical to a working empty store from the operator's view.
+// Tracked for the PR that adds the SQLite-backed store.
 func (rp *RoutePlan) recordOutcomeFeedback(outcome *RouteOutcome) {
 	if rp.feedback == nil || outcome == nil || rp.Request.UseCase == "" {
 		return
 	}
-	_ = rp.feedback.RecordOutcome(context.Background(), rp.Request.UseCase, *outcome)
+	ctx, cancel := context.WithTimeout(context.Background(), feedbackWriteTimeout)
+	defer cancel()
+	_ = rp.feedback.RecordOutcome(ctx, rp.Request.UseCase, *outcome)
 }

--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -245,7 +245,7 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 				}
 
 				if err == nil {
-					return nil
+					break
 				}
 				if IsInfrastructureError(err) {
 					rp.recordFailure(fb.Profile.Key, err)

--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
 )
 
 // ---------------------------------------------------------------------------
@@ -493,4 +494,25 @@ func newRouteID() string {
 		return ""
 	}
 	return hex.EncodeToString(b[:])
+}
+
+// makeAttempt builds a RouteAttempt for one provider call.
+//
+//   - err == nil: Status=Succeeded, no ErrorClass, LatencyMs from duration.
+//   - err != nil: Status and ErrorClass from classifyError(err); LatencyMs
+//     from duration regardless (latency-to-failure is informative for
+//     failure-mode pivots in PR3+).
+//   - Negative duration clamps to LatencyMs=0.
+func makeAttempt(key ModelKey, err error, duration time.Duration) RouteAttempt {
+	class, status := classifyError(err)
+	ms := duration.Milliseconds()
+	if ms < 0 {
+		ms = 0
+	}
+	return RouteAttempt{
+		Key:        key,
+		Status:     status,
+		LatencyMs:  ms,
+		ErrorClass: string(class),
+	}
 }

--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -138,32 +138,63 @@ func (rp *RoutePlan) ExecuteChat(ctx context.Context) (*ChatResponse, error) {
 
 // ExecuteChatStream dispatches a streaming chat request to the selected
 // provider. Fallback is only attempted before the first user-visible chunk
-// has been delivered.
+// has been delivered. Each provider call produces exactly one RouteAttempt,
+// finalized either by the Done-chunk handler (when chunk.Partial == false)
+// or by the post-stream code (using the real stream-method error). User-
+// callback errors are captured separately and attributed as
+// AttemptStatusUnknown.
 func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse) error) error {
 	if rp.Budget.Decision == BudgetTruncate {
 		return ErrBudgetAdaptationRequired
 	}
 
+	var attempts []RouteAttempt
 	req := rp.buildChatRequest(true)
 
 	delivered := false
 	fallbacksUsed := 0
 	var outcome *RouteOutcome
 
+	primaryStart := time.Now()
+	streamDone := false
+	var callbackErr error
+
 	wrappedFn := func(chunk ChatResponse) error {
 		if !delivered && hasVisibleContent(chunk.Content, chunk.Thinking, chunk.ToolCalls) {
 			delivered = true
 		}
-		if chunk.Done {
-			outcome = rp.handleResult(nil, fallbacksUsed, nil)
+		if chunk.Done && !chunk.Partial {
+			attempts = append(attempts,
+				makeAttempt(rp.Profile.Key, nil, time.Since(primaryStart)))
+			streamDone = true
+			outcome = rp.handleResult(nil, fallbacksUsed, attempts)
 			if outcome != nil {
 				chunk.RouteOutcome = outcome
 			}
 		}
-		return fn(chunk)
+		if e := fn(chunk); e != nil {
+			callbackErr = e
+			return e
+		}
+		return nil
 	}
 
 	err := rp.Provider.ChatStream(ctx, req, wrappedFn)
+
+	if !streamDone {
+		if callbackErr != nil {
+			// User aborted via callback. Attribute as Unknown, not a
+			// provider failure.
+			attempts = append(attempts, RouteAttempt{
+				Key:       rp.Profile.Key,
+				Status:    AttemptStatusUnknown,
+				LatencyMs: time.Since(primaryStart).Milliseconds(),
+			})
+		} else {
+			attempts = append(attempts,
+				makeAttempt(rp.Profile.Key, err, time.Since(primaryStart)))
+		}
+	}
 
 	if err != nil && IsInfrastructureError(err) {
 		rp.recordFailure(rp.Profile.Key, err)
@@ -174,21 +205,45 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 				fbReq := fb.buildChatRequest(true)
 				delivered = false
 				fallbacksUsed = i + 1
+				fbStart := time.Now()
+				fbStreamDone := false
+				var fbCallbackErr error
 
 				wrappedFbFn := func(chunk ChatResponse) error {
 					if !delivered && hasVisibleContent(chunk.Content, chunk.Thinking, chunk.ToolCalls) {
 						delivered = true
 					}
-					if chunk.Done {
-						outcome = rp.handleResult(nil, fallbacksUsed, nil)
+					if chunk.Done && !chunk.Partial {
+						attempts = append(attempts,
+							makeAttempt(fb.Profile.Key, nil, time.Since(fbStart)))
+						fbStreamDone = true
+						outcome = rp.handleResult(nil, fallbacksUsed, attempts)
 						if outcome != nil {
 							chunk.RouteOutcome = outcome
 						}
 					}
-					return fn(chunk)
+					if e := fn(chunk); e != nil {
+						fbCallbackErr = e
+						return e
+					}
+					return nil
 				}
 
 				err = fb.Provider.ChatStream(ctx, fbReq, wrappedFbFn)
+
+				if !fbStreamDone {
+					if fbCallbackErr != nil {
+						attempts = append(attempts, RouteAttempt{
+							Key:       fb.Profile.Key,
+							Status:    AttemptStatusUnknown,
+							LatencyMs: time.Since(fbStart).Milliseconds(),
+						})
+					} else {
+						attempts = append(attempts,
+							makeAttempt(fb.Profile.Key, err, time.Since(fbStart)))
+					}
+				}
+
 				if err == nil {
 					return nil
 				}
@@ -208,7 +263,7 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 	// Record signals for streams that completed without a Done chunk, or
 	// that ended in a non-infrastructure error / cancellation.
 	if outcome == nil {
-		rp.handleResult(err, fallbacksUsed, nil)
+		rp.handleResult(err, fallbacksUsed, attempts)
 	}
 
 	return err

--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -95,8 +95,12 @@ func (rp *RoutePlan) ExecuteChat(ctx context.Context) (*ChatResponse, error) {
 		return nil, ErrBudgetAdaptationRequired
 	}
 
+	var attempts []RouteAttempt
 	req := rp.buildChatRequest(false)
+
+	start := time.Now()
 	resp, err := rp.Provider.Chat(ctx, req)
+	attempts = append(attempts, makeAttempt(rp.Profile.Key, err, time.Since(start)))
 
 	fallbacksUsed := 0
 	if err != nil && IsInfrastructureError(err) {
@@ -104,7 +108,9 @@ func (rp *RoutePlan) ExecuteChat(ctx context.Context) (*ChatResponse, error) {
 
 		for i, fb := range rp.Fallbacks {
 			fbReq := fb.buildChatRequest(false)
+			fbStart := time.Now()
 			resp, err = fb.Provider.Chat(ctx, fbReq)
+			attempts = append(attempts, makeAttempt(fb.Profile.Key, err, time.Since(fbStart)))
 			if err == nil {
 				fallbacksUsed = i + 1
 				break
@@ -118,7 +124,7 @@ func (rp *RoutePlan) ExecuteChat(ctx context.Context) (*ChatResponse, error) {
 		}
 	}
 
-	outcome := rp.handleResult(err, fallbacksUsed, nil)
+	outcome := rp.handleResult(err, fallbacksUsed, attempts)
 	if resp != nil && outcome != nil {
 		resp.RouteOutcome = outcome
 	}

--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -352,8 +352,12 @@ func (rp *RoutePlan) ExecuteEmbed(ctx context.Context) (*EmbedResponse, error) {
 		return nil, ErrBudgetAdaptationRequired
 	}
 
+	var attempts []RouteAttempt
 	req := rp.buildEmbedRequest()
+
+	start := time.Now()
 	resp, err := rp.Provider.Embed(ctx, req)
+	attempts = append(attempts, makeAttempt(rp.Profile.Key, err, time.Since(start)))
 
 	fallbacksUsed := 0
 	if err != nil && IsInfrastructureError(err) {
@@ -361,7 +365,9 @@ func (rp *RoutePlan) ExecuteEmbed(ctx context.Context) (*EmbedResponse, error) {
 
 		for i, fb := range rp.Fallbacks {
 			fbReq := fb.buildEmbedRequest()
+			fbStart := time.Now()
 			resp, err = fb.Provider.Embed(ctx, fbReq)
+			attempts = append(attempts, makeAttempt(fb.Profile.Key, err, time.Since(fbStart)))
 			if err == nil {
 				fallbacksUsed = i + 1
 				break
@@ -374,7 +380,7 @@ func (rp *RoutePlan) ExecuteEmbed(ctx context.Context) (*EmbedResponse, error) {
 		}
 	}
 
-	outcome := rp.handleResult(err, fallbacksUsed, nil)
+	outcome := rp.handleResult(err, fallbacksUsed, attempts)
 	if resp != nil && outcome != nil {
 		resp.RouteOutcome = outcome
 	}

--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -163,7 +163,7 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 		if !delivered && hasVisibleContent(chunk.Content, chunk.Thinking, chunk.ToolCalls) {
 			delivered = true
 		}
-		if chunk.Done && !chunk.Partial {
+		if chunk.Done && !chunk.Partial && !streamDone {
 			attempts = append(attempts,
 				makeAttempt(rp.Profile.Key, nil, time.Since(primaryStart)))
 			streamDone = true
@@ -213,7 +213,7 @@ func (rp *RoutePlan) ExecuteChatStream(ctx context.Context, fn func(ChatResponse
 					if !delivered && hasVisibleContent(chunk.Content, chunk.Thinking, chunk.ToolCalls) {
 						delivered = true
 					}
-					if chunk.Done && !chunk.Partial {
+					if chunk.Done && !chunk.Partial && !fbStreamDone {
 						attempts = append(attempts,
 							makeAttempt(fb.Profile.Key, nil, time.Since(fbStart)))
 						fbStreamDone = true
@@ -347,7 +347,7 @@ func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(Generate
 		if !delivered && chunk.Response != "" {
 			delivered = true
 		}
-		if chunk.Done && !chunk.Partial {
+		if chunk.Done && !chunk.Partial && !streamDone {
 			attempts = append(attempts,
 				makeAttempt(rp.Profile.Key, nil, time.Since(primaryStart)))
 			streamDone = true
@@ -397,7 +397,7 @@ func (rp *RoutePlan) ExecuteGenerateStream(ctx context.Context, fn func(Generate
 					if !delivered && chunk.Response != "" {
 						delivered = true
 					}
-					if chunk.Done && !chunk.Partial {
+					if chunk.Done && !chunk.Partial && !fbStreamDone {
 						attempts = append(attempts,
 							makeAttempt(fb.Profile.Key, nil, time.Since(fbStart)))
 						fbStreamDone = true

--- a/provider/route_plan_test.go
+++ b/provider/route_plan_test.go
@@ -948,3 +948,40 @@ func TestExecuteGenerateTracksPrimaryFailFallbackSuccessAttempts(t *testing.T) {
 		t.Errorf("att[1].Status = %v, want Succeeded", att[1].Status)
 	}
 }
+
+func TestExecuteEmbedTracksPrimarySuccessAttempt(t *testing.T) {
+	prov := &rpMockProvider{name: "ollama", caps: CapEmbed, embedResp: &EmbedResponse{Embeddings: [][]float64{{0.1}}}}
+	plan := newTestPlan(prov, &rpMockRecorder{})
+	plan.Kind = RouteKindEmbed
+	resp, err := plan.ExecuteEmbed(context.Background())
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if resp.RouteOutcome == nil || len(resp.RouteOutcome.Attempts) != 1 {
+		t.Fatalf("Attempts len = %d, want 1", len(resp.RouteOutcome.Attempts))
+	}
+	if resp.RouteOutcome.Attempts[0].Status != AttemptStatusSucceeded {
+		t.Errorf("Status = %v, want Succeeded", resp.RouteOutcome.Attempts[0].Status)
+	}
+}
+
+func TestExecuteEmbedTracksPrimaryFailFallbackSuccessAttempts(t *testing.T) {
+	primary := &rpMockProvider{name: "ollama-a", caps: CapEmbed, embedErr: &HTTPStatusError{StatusCode: 500}}
+	fallback := &rpMockProvider{name: "ollama-b", caps: CapEmbed, embedResp: &EmbedResponse{Embeddings: [][]float64{{0.2}}}}
+	plan := newTestPlan(primary, &rpMockRecorder{})
+	plan.Kind = RouteKindEmbed
+	plan.Fallbacks = []RoutePlan{{
+		Profile:  &ModelProfile{Key: ModelKey{Provider: "ollama-b", Model: "embed-1"}},
+		Provider: fallback,
+		Model:    "embed-1",
+	}}
+
+	resp, err := plan.ExecuteEmbed(context.Background())
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	att := resp.RouteOutcome.Attempts
+	if len(att) != 2 || att[0].ErrorClass != string(ErrorClass5xx) || att[1].Status != AttemptStatusSucceeded {
+		t.Fatalf("attempts = %+v, want [Failed/5xx, Succeeded]", att)
+	}
+}

--- a/provider/route_plan_test.go
+++ b/provider/route_plan_test.go
@@ -748,6 +748,52 @@ func TestRoutePlanRecordOutcomeFeedbackSwallowsStoreErrors(t *testing.T) {
 	rp.recordOutcomeFeedback(outcome)
 }
 
+func TestHandleResultAlwaysBuildsOutcomeOnSuccess(t *testing.T) {
+	rp := newTestPlan(&rpMockProvider{name: "ollama", caps: CapChat}, &rpMockRecorder{})
+	out := rp.handleResult(nil, 0, nil)
+	if out == nil {
+		t.Fatal("outcome is nil; want non-nil on success")
+	}
+	if out.PlannedModel.Provider != "ollama" {
+		t.Errorf("PlannedModel.Provider = %q", out.PlannedModel.Provider)
+	}
+}
+
+func TestHandleResultAlwaysBuildsOutcomeOnCancellation(t *testing.T) {
+	rp := newTestPlan(&rpMockProvider{name: "ollama", caps: CapChat}, &rpMockRecorder{})
+	out := rp.handleResult(context.Canceled, 0, nil)
+	if out == nil {
+		t.Fatal("outcome is nil; want non-nil on cancellation (PR2 always builds)")
+	}
+}
+
+func TestHandleResultAlwaysBuildsOutcomeOnInfraFailure(t *testing.T) {
+	rp := newTestPlan(&rpMockProvider{name: "ollama", caps: CapChat}, &rpMockRecorder{})
+	out := rp.handleResult(&HTTPStatusError{StatusCode: 500}, 0, nil)
+	if out == nil {
+		t.Fatal("outcome is nil; want non-nil on infra failure")
+	}
+}
+
+func TestHandleResultUsesLastAttemptKeyForCancellationWarmth(t *testing.T) {
+	rec := &rpMockRecorder{}
+	rp := newTestPlan(&rpMockProvider{name: "ollama-a", caps: CapChat}, rec)
+	// Fabricate two attempts — primary failed (network), fallback canceled.
+	attempts := []RouteAttempt{
+		{Key: ModelKey{Provider: "ollama-a", Model: "qwen3:8b"}, Status: AttemptStatusFailed, ErrorClass: "network"},
+		{Key: ModelKey{Provider: "ollama-b", Model: "qwen3:8b"}, Status: AttemptStatusUnknown},
+	}
+	_ = rp.handleResult(context.Canceled, 0, attempts)
+
+	warmth := rec.getWarmthUses()
+	if len(warmth) != 1 {
+		t.Fatalf("warmthUses = %d, want 1", len(warmth))
+	}
+	if warmth[0].Provider != "ollama-b" {
+		t.Errorf("warmth target = %q, want ollama-b (last attempted key)", warmth[0].Provider)
+	}
+}
+
 func TestRoutePlanString(t *testing.T) {
 	plan := &RoutePlan{
 		Model: "qwen3:8b",

--- a/provider/route_plan_test.go
+++ b/provider/route_plan_test.go
@@ -36,8 +36,8 @@ type rpMockProvider struct {
 	mu               sync.Mutex
 }
 
-func (m *rpMockProvider) Name() string         { return m.name }
-func (m *rpMockProvider) Capabilities() Capability { return m.caps }
+func (m *rpMockProvider) Name() string                   { return m.name }
+func (m *rpMockProvider) Capabilities() Capability       { return m.caps }
 func (m *rpMockProvider) Health(_ context.Context) error { return m.healthErr }
 func (m *rpMockProvider) Models(_ context.Context) ([]ModelInfo, error) {
 	return m.models, nil
@@ -198,9 +198,9 @@ func newTestPlan(prov *rpMockProvider, rec *rpMockRecorder) *RoutePlan {
 			UseCase:  "chat",
 			Messages: []ChatMessage{{Role: "user", Content: "hello"}},
 		},
-		Score:  0.85,
-		Budget: BudgetResult{Decision: BudgetOK},
-		Reason: "best candidate",
+		Score:    0.85,
+		Budget:   BudgetResult{Decision: BudgetOK},
+		Reason:   "best candidate",
 		recorder: rec,
 	}
 }
@@ -1045,7 +1045,11 @@ func TestExecuteChatStreamDonePartialDefersToPostStream(t *testing.T) {
 	// is finalized as Unknown via a real RoutingFeedback store.
 }
 
-func TestExecuteChatStreamCallbackErrorAttributedAsUnknown(t *testing.T) {
+func TestExecuteChatStreamPropagatesCallbackError(t *testing.T) {
+	// Renamed from TestExecuteChatStreamCallbackErrorAttributedAsUnknown:
+	// this test only verifies error propagation. The Unknown-attribution
+	// invariant is verified end-to-end via the feedback store in
+	// TestExecuteChatStreamCallbackErrorDoesNotRecordProviderFailure.
 	prov := &rpMockProvider{
 		name: "ollama", caps: CapChat,
 		chatStreamChunks: []ChatResponse{
@@ -1067,10 +1071,6 @@ func TestExecuteChatStreamCallbackErrorAttributedAsUnknown(t *testing.T) {
 	if !errors.Is(err, callbackErr) {
 		t.Fatalf("err = %v, want callbackErr", err)
 	}
-	// We can't inspect attempts here; the load-bearing test is in Task 11's
-	// integration coverage with a real feedback store. The point of THIS
-	// test is to confirm the error path completes without panic and the
-	// callback error is propagated as-is.
 }
 
 func TestExecuteChatStreamFallbackOnPrimaryInfraError(t *testing.T) {
@@ -1112,6 +1112,44 @@ func TestExecuteChatStreamFallbackOnPrimaryInfraError(t *testing.T) {
 	}
 	if att[1].Status != AttemptStatusSucceeded || att[1].Key.Provider != "ollama-b" {
 		t.Errorf("att[1] = %+v, want Succeeded/ollama-b", att[1])
+	}
+}
+
+func TestBuildOutcomeActualModelOnAllFail(t *testing.T) {
+	// When every attempt failed, ActualModel must fall back to PlannedModel
+	// (primary), not to the last-tried fallback. This locks in the streaming
+	// fix where fallbacksUsed is no longer eagerly set at the top of each
+	// iteration — buildOutcome derives ActualModel from
+	// attempts[last].Status == Succeeded.
+	rp := newTestPlan(&rpMockProvider{name: "ollama-a", caps: CapChat}, &rpMockRecorder{})
+	rp.Profile.Key = ModelKey{Provider: "ollama-a", Model: "qwen3:8b"}
+	attempts := []RouteAttempt{
+		{Key: ModelKey{Provider: "ollama-a", Model: "qwen3:8b"}, Status: AttemptStatusFailed, ErrorClass: "5xx"},
+		{Key: ModelKey{Provider: "ollama-b", Model: "qwen3:8b"}, Status: AttemptStatusFailed, ErrorClass: "5xx"},
+	}
+	// fallbacksUsed=2 reflects "two fallbacks were tried" but none succeeded.
+	out := rp.buildOutcome(2, attempts)
+	if out.ActualModel != rp.Profile.Key {
+		t.Errorf("ActualModel = %+v, want PlannedModel %+v (no attempt succeeded)", out.ActualModel, rp.Profile.Key)
+	}
+	if out.PlannedModel != rp.Profile.Key {
+		t.Errorf("PlannedModel = %+v, want %+v", out.PlannedModel, rp.Profile.Key)
+	}
+}
+
+func TestBuildOutcomeActualModelOnFallbackSuccess(t *testing.T) {
+	// Inverse: when the last attempt succeeded, ActualModel reflects that
+	// model's key — regardless of fallbacksUsed counter value.
+	rp := newTestPlan(&rpMockProvider{name: "ollama-a", caps: CapChat}, &rpMockRecorder{})
+	rp.Profile.Key = ModelKey{Provider: "ollama-a", Model: "qwen3:8b"}
+	fbKey := ModelKey{Provider: "ollama-b", Model: "qwen3:8b"}
+	attempts := []RouteAttempt{
+		{Key: rp.Profile.Key, Status: AttemptStatusFailed, ErrorClass: "5xx"},
+		{Key: fbKey, Status: AttemptStatusSucceeded},
+	}
+	out := rp.buildOutcome(1, attempts)
+	if out.ActualModel != fbKey {
+		t.Errorf("ActualModel = %+v, want fallback %+v", out.ActualModel, fbKey)
 	}
 }
 
@@ -1330,8 +1368,10 @@ func TestExecuteChatEndToEndRecordsPerAttemptFeedback(t *testing.T) {
 
 	// Verify the stored signals carry the right ErrorClass for the
 	// primary failure. Inspect under lock since signals isn't exported.
+	// Copy under the lock to avoid aliasing the store's slice — matches
+	// the production MemoryStore.Get pattern.
 	store.mu.Lock()
-	pSigs := store.signals[primaryKey]
+	pSigs := append([]FeedbackSignal(nil), store.signals[primaryKey]...)
 	store.mu.Unlock()
 	var failureCount int
 	for _, sig := range pSigs {

--- a/provider/route_plan_test.go
+++ b/provider/route_plan_test.go
@@ -1153,6 +1153,76 @@ func TestBuildOutcomeActualModelOnFallbackSuccess(t *testing.T) {
 	}
 }
 
+func TestExecuteChatStreamPendingAttemptsClonedFromIteration(t *testing.T) {
+	// Regression test for the aliasing bug fixed in c7e6db1 / slices.Clone.
+	// Setup: primary + 3 fallbacks where the first two fail infra (driving
+	// `attempts` to len=3, cap=4 — Go's growth strategy gives spare
+	// capacity at this length) and the third emits a Done chunk. Without
+	// slices.Clone on pendingAttempts, the post-stream Unknown-attempt
+	// append (triggered when the user callback errors on Done) would
+	// overwrite the Succeeded entry in the captured RouteOutcome.Attempts.
+	primary := &rpMockProvider{
+		name: "ollama-a", caps: CapChat,
+		chatStreamErr: &HTTPStatusError{StatusCode: 500},
+	}
+	fb0 := &rpMockProvider{
+		name: "ollama-b", caps: CapChat,
+		chatStreamErr: &HTTPStatusError{StatusCode: 500},
+	}
+	fb1 := &rpMockProvider{
+		name: "ollama-c", caps: CapChat,
+		chatStreamErr: &HTTPStatusError{StatusCode: 500},
+	}
+	fb2 := &rpMockProvider{
+		name: "ollama-d", caps: CapChat,
+		chatStreamChunks: []ChatResponse{
+			// No visible content before Done so fallback isn't suppressed,
+			// and so this stream finalizes via the Done-chunk path that
+			// uses pendingAttempts.
+			{Done: true},
+		},
+	}
+	plan := newTestPlan(primary, &rpMockRecorder{})
+	plan.Fallbacks = []RoutePlan{
+		{Profile: &ModelProfile{Key: ModelKey{Provider: "ollama-b", Model: "qwen3:8b"}}, Provider: fb0, Model: "qwen3:8b"},
+		{Profile: &ModelProfile{Key: ModelKey{Provider: "ollama-c", Model: "qwen3:8b"}}, Provider: fb1, Model: "qwen3:8b"},
+		{Profile: &ModelProfile{Key: ModelKey{Provider: "ollama-d", Model: "qwen3:8b"}}, Provider: fb2, Model: "qwen3:8b"},
+	}
+
+	var capturedAttempts []RouteAttempt
+	var capturedKey ModelKey
+	callbackErr := errors.New("user abort on done")
+	err := plan.ExecuteChatStream(context.Background(), func(c ChatResponse) error {
+		if c.Done && c.RouteOutcome != nil {
+			capturedAttempts = c.RouteOutcome.Attempts
+			if n := len(capturedAttempts); n > 0 {
+				capturedKey = capturedAttempts[n-1].Key
+			}
+			return callbackErr
+		}
+		return nil
+	})
+	if !errors.Is(err, callbackErr) {
+		t.Fatalf("err = %v, want callbackErr", err)
+	}
+	if len(capturedAttempts) == 0 {
+		t.Fatal("Done chunk did not arrive with an outcome; test setup failed")
+	}
+	// The last entry of the captured slice must still be the Succeeded
+	// attempt for ollama-d. Without slices.Clone it would have been
+	// overwritten to AttemptStatusUnknown by the post-stream append.
+	last := capturedAttempts[len(capturedAttempts)-1]
+	if last.Status != AttemptStatusSucceeded {
+		t.Errorf("captured last attempt Status = %v, want Succeeded (aliasing corruption)", last.Status)
+	}
+	if last.Key.Provider != "ollama-d" {
+		t.Errorf("captured last attempt Key.Provider = %q, want ollama-d (corruption)", last.Key.Provider)
+	}
+	if capturedKey.Provider != "ollama-d" {
+		t.Errorf("captured Key.Provider at Done time = %q, want ollama-d", capturedKey.Provider)
+	}
+}
+
 func TestExecuteChatStreamFallbackSuccessWithoutDoneRecordsAttempt(t *testing.T) {
 	// A fallback provider that returns err==nil without emitting a Done
 	// chunk must still call handleResult so the feedback seam records the
@@ -1367,12 +1437,9 @@ func TestExecuteChatEndToEndRecordsPerAttemptFeedback(t *testing.T) {
 	}
 
 	// Verify the stored signals carry the right ErrorClass for the
-	// primary failure. Inspect under lock since signals isn't exported.
-	// Copy under the lock to avoid aliasing the store's slice — matches
-	// the production MemoryStore.Get pattern.
-	store.mu.Lock()
-	pSigs := append([]FeedbackSignal(nil), store.signals[primaryKey]...)
-	store.mu.Unlock()
+	// primary failure. Uses the public Signals accessor so the test
+	// doesn't depend on internal field names.
+	pSigs := store.Signals(primaryKey)
 	var failureCount int
 	for _, sig := range pSigs {
 		switch sig.Kind {

--- a/provider/route_plan_test.go
+++ b/provider/route_plan_test.go
@@ -985,3 +985,131 @@ func TestExecuteEmbedTracksPrimaryFailFallbackSuccessAttempts(t *testing.T) {
 		t.Fatalf("attempts = %+v, want [Failed/5xx, Succeeded]", att)
 	}
 }
+
+func TestExecuteChatStreamFinalizesOnNonPartialDone(t *testing.T) {
+	prov := &rpMockProvider{
+		name: "ollama", caps: CapChat,
+		chatStreamChunks: []ChatResponse{
+			{Content: "h"},
+			{Content: "i", Done: true}, // Partial defaults to false
+		},
+	}
+	plan := newTestPlan(prov, &rpMockRecorder{})
+	var got []ChatResponse
+	err := plan.ExecuteChatStream(context.Background(), func(c ChatResponse) error {
+		got = append(got, c)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	final := got[len(got)-1]
+	if final.RouteOutcome == nil {
+		t.Fatal("final chunk RouteOutcome nil")
+	}
+	att := final.RouteOutcome.Attempts
+	if len(att) != 1 || att[0].Status != AttemptStatusSucceeded {
+		t.Fatalf("attempts = %+v, want [Succeeded]", att)
+	}
+}
+
+func TestExecuteChatStreamDonePartialDefersToPostStream(t *testing.T) {
+	// Ollama emits {Done: true, Partial: true} on cancellation, then
+	// returns ctx.Err(). The handler must NOT finalize on partial-Done;
+	// post-stream code finalizes with the real error.
+	prov := &rpMockProvider{
+		name: "ollama", caps: CapChat,
+		chatStreamChunks: []ChatResponse{
+			{Content: "h"},
+			{Done: true, Partial: true}, // synthetic partial Done
+		},
+		chatStreamErr: context.Canceled,
+	}
+	plan := newTestPlan(prov, &rpMockRecorder{})
+	var lastChunk ChatResponse
+	err := plan.ExecuteChatStream(context.Background(), func(c ChatResponse) error {
+		lastChunk = c
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want Canceled", err)
+	}
+	// The partial-Done chunk must NOT have carried a RouteOutcome.
+	if lastChunk.RouteOutcome != nil {
+		t.Errorf("partial-Done chunk got RouteOutcome; want nil (post-stream finalizes)")
+	}
+	// We can't observe Attempts via the response (no resp returned for
+	// streams), but the test's purpose is the negative assertion above
+	// + ensuring no panic. Task 11 integration test asserts the attempt
+	// is finalized as Unknown via a real RoutingFeedback store.
+}
+
+func TestExecuteChatStreamCallbackErrorAttributedAsUnknown(t *testing.T) {
+	prov := &rpMockProvider{
+		name: "ollama", caps: CapChat,
+		chatStreamChunks: []ChatResponse{
+			{Content: "h"},
+			{Content: "i", Done: true},
+		},
+	}
+	plan := newTestPlan(prov, &rpMockRecorder{})
+
+	callbackErr := errors.New("user aborted")
+	gotCalls := 0
+	err := plan.ExecuteChatStream(context.Background(), func(c ChatResponse) error {
+		gotCalls++
+		if gotCalls == 1 {
+			return callbackErr // abort after first chunk
+		}
+		return nil
+	})
+	if !errors.Is(err, callbackErr) {
+		t.Fatalf("err = %v, want callbackErr", err)
+	}
+	// We can't inspect attempts here; the load-bearing test is in Task 11's
+	// integration coverage with a real feedback store. The point of THIS
+	// test is to confirm the error path completes without panic and the
+	// callback error is propagated as-is.
+}
+
+func TestExecuteChatStreamFallbackOnPrimaryInfraError(t *testing.T) {
+	primary := &rpMockProvider{
+		name: "ollama-a", caps: CapChat,
+		chatStreamErr: &HTTPStatusError{StatusCode: 500},
+	}
+	fallback := &rpMockProvider{
+		name: "ollama-b", caps: CapChat,
+		chatStreamChunks: []ChatResponse{
+			{Content: "ok"},
+			{Content: "", Done: true},
+		},
+	}
+	plan := newTestPlan(primary, &rpMockRecorder{})
+	plan.Fallbacks = []RoutePlan{{
+		Profile:  &ModelProfile{Key: ModelKey{Provider: "ollama-b", Model: "qwen3:8b"}},
+		Provider: fallback,
+		Model:    "qwen3:8b",
+	}}
+
+	var lastChunk ChatResponse
+	err := plan.ExecuteChatStream(context.Background(), func(c ChatResponse) error {
+		lastChunk = c
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil after fallback success", err)
+	}
+	if lastChunk.RouteOutcome == nil {
+		t.Fatal("final-chunk outcome nil")
+	}
+	att := lastChunk.RouteOutcome.Attempts
+	if len(att) != 2 {
+		t.Fatalf("attempts len = %d, want 2 (primary Failed + fallback Succeeded)", len(att))
+	}
+	if att[0].Status != AttemptStatusFailed || att[0].ErrorClass != string(ErrorClass5xx) {
+		t.Errorf("att[0] = %+v, want Failed/5xx", att[0])
+	}
+	if att[1].Status != AttemptStatusSucceeded || att[1].Key.Provider != "ollama-b" {
+		t.Errorf("att[1] = %+v, want Succeeded/ollama-b", att[1])
+	}
+}

--- a/provider/route_plan_test.go
+++ b/provider/route_plan_test.go
@@ -905,3 +905,46 @@ func TestRoutePlanString(t *testing.T) {
 		t.Errorf("String() = %q, want %q", got, want)
 	}
 }
+
+func TestExecuteGenerateTracksPrimarySuccessAttempt(t *testing.T) {
+	prov := &rpMockProvider{name: "ollama", caps: CapGenerate, genResp: &GenerateResponse{Response: "hi", Done: true}}
+	plan := newTestPlan(prov, &rpMockRecorder{})
+	plan.Kind = RouteKindGenerate
+	resp, err := plan.ExecuteGenerate(context.Background())
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if resp.RouteOutcome == nil || len(resp.RouteOutcome.Attempts) != 1 {
+		t.Fatalf("Attempts len = %d, want 1", len(resp.RouteOutcome.Attempts))
+	}
+	if resp.RouteOutcome.Attempts[0].Status != AttemptStatusSucceeded {
+		t.Errorf("Status = %v, want Succeeded", resp.RouteOutcome.Attempts[0].Status)
+	}
+}
+
+func TestExecuteGenerateTracksPrimaryFailFallbackSuccessAttempts(t *testing.T) {
+	primary := &rpMockProvider{name: "ollama-a", caps: CapGenerate, genErr: &HTTPStatusError{StatusCode: 500}}
+	fallback := &rpMockProvider{name: "ollama-b", caps: CapGenerate, genResp: &GenerateResponse{Response: "ok", Done: true}}
+	plan := newTestPlan(primary, &rpMockRecorder{})
+	plan.Kind = RouteKindGenerate
+	plan.Fallbacks = []RoutePlan{{
+		Profile:  &ModelProfile{Key: ModelKey{Provider: "ollama-b", Model: "qwen3:8b"}},
+		Provider: fallback,
+		Model:    "qwen3:8b",
+	}}
+
+	resp, err := plan.ExecuteGenerate(context.Background())
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	att := resp.RouteOutcome.Attempts
+	if len(att) != 2 {
+		t.Fatalf("Attempts len = %d, want 2", len(att))
+	}
+	if att[0].ErrorClass != string(ErrorClass5xx) {
+		t.Errorf("att[0].ErrorClass = %q, want 5xx", att[0].ErrorClass)
+	}
+	if att[1].Status != AttemptStatusSucceeded {
+		t.Errorf("att[1].Status = %v, want Succeeded", att[1].Status)
+	}
+}

--- a/provider/route_plan_test.go
+++ b/provider/route_plan_test.go
@@ -1417,6 +1417,48 @@ func TestExecuteChatStreamCallbackErrorDoesNotRecordProviderFailure(t *testing.T
 	}
 }
 
+func TestExecuteChatStreamFinalDoneCallbackErrorDoesNotRecordSuccess(t *testing.T) {
+	store, err := NewMemoryStore(MemoryStoreConfig{})
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+	rf := NewRoutingFeedback(store)
+	rec := &rpMockRecorder{}
+
+	prov := &rpMockProvider{
+		name: "ollama", caps: CapChat,
+		chatStreamChunks: []ChatResponse{
+			{Content: "h"},
+			{Done: true},
+		},
+	}
+	plan := newTestPlan(prov, rec)
+	plan.SetFeedback(rf)
+
+	callbackErr := errors.New("client disconnected on final chunk")
+	err = plan.ExecuteChatStream(context.Background(), func(c ChatResponse) error {
+		if c.Done {
+			if c.RouteOutcome == nil {
+				t.Fatal("final Done chunk RouteOutcome nil")
+			}
+			return callbackErr
+		}
+		return nil
+	})
+	if !errors.Is(err, callbackErr) {
+		t.Fatalf("err = %v, want callbackErr", err)
+	}
+
+	key := FeedbackKey{Provider: "ollama", Model: "test-model", UseCase: "chat"}
+	agg, _ := store.Get(context.Background(), key)
+	if agg.SampleCount != 0 {
+		t.Fatalf("SampleCount = %d, want 0 (final callback abort is AttemptStatusUnknown)", agg.SampleCount)
+	}
+	if successes := rec.getSuccesses(); len(successes) != 0 {
+		t.Fatalf("successes = %d, want 0", len(successes))
+	}
+}
+
 func TestExecuteGenerateStreamFallbackSuccessWithoutDoneRecordsAttempt(t *testing.T) {
 	store, err := NewMemoryStore(MemoryStoreConfig{})
 	if err != nil {
@@ -1452,6 +1494,49 @@ func TestExecuteGenerateStreamFallbackSuccessWithoutDoneRecordsAttempt(t *testin
 	agg, _ := store.Get(context.Background(), key)
 	if agg.ScoredCount < 1 {
 		t.Errorf("fallback ScoredCount = %d, want >= 1 (Success signal should have been recorded)", agg.ScoredCount)
+	}
+}
+
+func TestExecuteGenerateStreamFinalDoneCallbackErrorDoesNotRecordSuccess(t *testing.T) {
+	store, err := NewMemoryStore(MemoryStoreConfig{})
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+	rf := NewRoutingFeedback(store)
+	rec := &rpMockRecorder{}
+
+	prov := &rpMockProvider{
+		name: "ollama", caps: CapGenerate,
+		genStreamChunks: []GenerateResponse{
+			{Response: "h"},
+			{Done: true},
+		},
+	}
+	plan := newTestPlan(prov, rec)
+	plan.Kind = RouteKindGenerate
+	plan.SetFeedback(rf)
+
+	callbackErr := errors.New("client disconnected on final chunk")
+	err = plan.ExecuteGenerateStream(context.Background(), func(c GenerateResponse) error {
+		if c.Done {
+			if c.RouteOutcome == nil {
+				t.Fatal("final Done chunk RouteOutcome nil")
+			}
+			return callbackErr
+		}
+		return nil
+	})
+	if !errors.Is(err, callbackErr) {
+		t.Fatalf("err = %v, want callbackErr", err)
+	}
+
+	key := FeedbackKey{Provider: "ollama", Model: "test-model", UseCase: "chat"}
+	agg, _ := store.Get(context.Background(), key)
+	if agg.SampleCount != 0 {
+		t.Fatalf("SampleCount = %d, want 0 (final callback abort is AttemptStatusUnknown)", agg.SampleCount)
+	}
+	if successes := rec.getSuccesses(); len(successes) != 0 {
+		t.Fatalf("successes = %d, want 0", len(successes))
 	}
 }
 

--- a/provider/route_plan_test.go
+++ b/provider/route_plan_test.go
@@ -1566,6 +1566,52 @@ func TestExecuteChatStreamFinalDoneCallbackErrorDoesNotRecordSuccess(t *testing.
 	}
 }
 
+func TestExecuteChatStreamPostDoneProviderErrorSuppressedAndRecordsSuccess(t *testing.T) {
+	store, err := NewMemoryStore(MemoryStoreConfig{})
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+	rf := NewRoutingFeedback(store)
+	rec := &rpMockRecorder{}
+
+	prov := &rpMockProvider{
+		name: "ollama", caps: CapChat,
+		chatStreamChunks: []ChatResponse{
+			{Content: "h"},
+			{Done: true},
+		},
+		chatStreamErr: &HTTPStatusError{StatusCode: 500},
+	}
+	plan := newTestPlan(prov, rec)
+	plan.SetFeedback(rf)
+
+	var final ChatResponse
+	err = plan.ExecuteChatStream(context.Background(), func(c ChatResponse) error {
+		if c.Done {
+			final = c
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil after accepted final Done", err)
+	}
+	if final.RouteOutcome == nil {
+		t.Fatal("final Done chunk RouteOutcome nil")
+	}
+
+	key := FeedbackKey{Provider: "ollama", Model: "test-model", UseCase: "chat"}
+	agg, _ := store.Get(context.Background(), key)
+	if agg.ScoredCount != 1 {
+		t.Fatalf("ScoredCount = %d, want 1 success", agg.ScoredCount)
+	}
+	if successes := rec.getSuccesses(); len(successes) != 1 {
+		t.Fatalf("successes = %d, want 1", len(successes))
+	}
+	if failures := rec.getFailures(); len(failures) != 0 {
+		t.Fatalf("failures = %d, want 0", len(failures))
+	}
+}
+
 func TestExecuteGenerateStreamFallbackSuccessWithoutDoneRecordsAttempt(t *testing.T) {
 	store, err := NewMemoryStore(MemoryStoreConfig{})
 	if err != nil {
@@ -1644,6 +1690,53 @@ func TestExecuteGenerateStreamFinalDoneCallbackErrorDoesNotRecordSuccess(t *test
 	}
 	if successes := rec.getSuccesses(); len(successes) != 0 {
 		t.Fatalf("successes = %d, want 0", len(successes))
+	}
+}
+
+func TestExecuteGenerateStreamPostDoneProviderErrorSuppressedAndRecordsSuccess(t *testing.T) {
+	store, err := NewMemoryStore(MemoryStoreConfig{})
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+	rf := NewRoutingFeedback(store)
+	rec := &rpMockRecorder{}
+
+	prov := &rpMockProvider{
+		name: "ollama", caps: CapGenerate,
+		genStreamChunks: []GenerateResponse{
+			{Response: "h"},
+			{Done: true},
+		},
+		genStreamErr: &HTTPStatusError{StatusCode: 500},
+	}
+	plan := newTestPlan(prov, rec)
+	plan.Kind = RouteKindGenerate
+	plan.SetFeedback(rf)
+
+	var final GenerateResponse
+	err = plan.ExecuteGenerateStream(context.Background(), func(c GenerateResponse) error {
+		if c.Done {
+			final = c
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil after accepted final Done", err)
+	}
+	if final.RouteOutcome == nil {
+		t.Fatal("final Done chunk RouteOutcome nil")
+	}
+
+	key := FeedbackKey{Provider: "ollama", Model: "test-model", UseCase: "chat"}
+	agg, _ := store.Get(context.Background(), key)
+	if agg.ScoredCount != 1 {
+		t.Fatalf("ScoredCount = %d, want 1 success", agg.ScoredCount)
+	}
+	if successes := rec.getSuccesses(); len(successes) != 1 {
+		t.Fatalf("successes = %d, want 1", len(successes))
+	}
+	if failures := rec.getFailures(); len(failures) != 0 {
+		t.Fatalf("failures = %d, want 0", len(failures))
 	}
 }
 

--- a/provider/route_plan_test.go
+++ b/provider/route_plan_test.go
@@ -1454,3 +1454,165 @@ func TestExecuteGenerateStreamFallbackSuccessWithoutDoneRecordsAttempt(t *testin
 		t.Errorf("fallback ScoredCount = %d, want >= 1 (Success signal should have been recorded)", agg.ScoredCount)
 	}
 }
+
+func TestExecuteChatStreamDuplicateDoneRecordsAttemptOnce(t *testing.T) {
+	store, err := NewMemoryStore(MemoryStoreConfig{})
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+	rf := NewRoutingFeedback(store)
+	rec := &rpMockRecorder{}
+
+	prov := &rpMockProvider{
+		name: "ollama", caps: CapChat,
+		chatStreamChunks: []ChatResponse{
+			{Done: true},
+			{Done: true},
+		},
+	}
+	plan := newTestPlan(prov, rec)
+	plan.SetFeedback(rf)
+
+	if err := plan.ExecuteChatStream(context.Background(), func(ChatResponse) error { return nil }); err != nil {
+		t.Fatalf("ExecuteChatStream: %v", err)
+	}
+
+	key := FeedbackKey{Provider: "ollama", Model: "test-model", UseCase: "chat"}
+	agg, _ := store.Get(context.Background(), key)
+	if agg.ScoredCount != 1 {
+		t.Fatalf("ScoredCount = %d, want 1 (duplicate Done must not replay outcome)", agg.ScoredCount)
+	}
+	if successes := rec.getSuccesses(); len(successes) != 1 {
+		t.Fatalf("successes = %d, want 1", len(successes))
+	}
+}
+
+func TestExecuteGenerateStreamDuplicateDoneRecordsAttemptOnce(t *testing.T) {
+	store, err := NewMemoryStore(MemoryStoreConfig{})
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+	rf := NewRoutingFeedback(store)
+	rec := &rpMockRecorder{}
+
+	prov := &rpMockProvider{
+		name: "ollama", caps: CapGenerate,
+		genStreamChunks: []GenerateResponse{
+			{Done: true},
+			{Done: true},
+		},
+	}
+	plan := newTestPlan(prov, rec)
+	plan.Kind = RouteKindGenerate
+	plan.SetFeedback(rf)
+
+	if err := plan.ExecuteGenerateStream(context.Background(), func(GenerateResponse) error { return nil }); err != nil {
+		t.Fatalf("ExecuteGenerateStream: %v", err)
+	}
+
+	key := FeedbackKey{Provider: "ollama", Model: "test-model", UseCase: "chat"}
+	agg, _ := store.Get(context.Background(), key)
+	if agg.ScoredCount != 1 {
+		t.Fatalf("ScoredCount = %d, want 1 (duplicate Done must not replay outcome)", agg.ScoredCount)
+	}
+	if successes := rec.getSuccesses(); len(successes) != 1 {
+		t.Fatalf("successes = %d, want 1", len(successes))
+	}
+}
+
+func TestExecuteChatStreamFallbackDuplicateDoneRecordsAttemptOnce(t *testing.T) {
+	store, err := NewMemoryStore(MemoryStoreConfig{})
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+	rf := NewRoutingFeedback(store)
+	rec := &rpMockRecorder{}
+
+	primary := &rpMockProvider{
+		name:          "ollama-a",
+		caps:          CapChat,
+		chatStreamErr: &HTTPStatusError{StatusCode: 500},
+	}
+	fallback := &rpMockProvider{
+		name: "ollama-b", caps: CapChat,
+		chatStreamChunks: []ChatResponse{
+			{Done: true},
+			{Done: true},
+		},
+	}
+	plan := newTestPlan(primary, rec)
+	plan.Profile.Key.Model = "qwen3:8b"
+	plan.SetFeedback(rf)
+	plan.Fallbacks = []RoutePlan{{
+		Profile:  &ModelProfile{Key: ModelKey{Provider: "ollama-b", Model: "qwen3:8b"}},
+		Provider: fallback,
+		Model:    "qwen3:8b",
+	}}
+
+	if err := plan.ExecuteChatStream(context.Background(), func(ChatResponse) error { return nil }); err != nil {
+		t.Fatalf("ExecuteChatStream: %v", err)
+	}
+
+	primaryKey := FeedbackKey{Provider: "ollama-a", Model: "qwen3:8b", UseCase: "chat"}
+	primaryAgg, _ := store.Get(context.Background(), primaryKey)
+	if primaryAgg.ScoredCount != 1 {
+		t.Fatalf("primary ScoredCount = %d, want 1", primaryAgg.ScoredCount)
+	}
+	fallbackKey := FeedbackKey{Provider: "ollama-b", Model: "qwen3:8b", UseCase: "chat"}
+	fallbackAgg, _ := store.Get(context.Background(), fallbackKey)
+	if fallbackAgg.ScoredCount != 1 {
+		t.Fatalf("fallback ScoredCount = %d, want 1", fallbackAgg.ScoredCount)
+	}
+	if successes := rec.getSuccesses(); len(successes) != 1 {
+		t.Fatalf("successes = %d, want 1", len(successes))
+	}
+}
+
+func TestExecuteGenerateStreamFallbackDuplicateDoneRecordsAttemptOnce(t *testing.T) {
+	store, err := NewMemoryStore(MemoryStoreConfig{})
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+	rf := NewRoutingFeedback(store)
+	rec := &rpMockRecorder{}
+
+	primary := &rpMockProvider{
+		name:         "ollama-a",
+		caps:         CapGenerate,
+		genStreamErr: &HTTPStatusError{StatusCode: 500},
+	}
+	fallback := &rpMockProvider{
+		name: "ollama-b", caps: CapGenerate,
+		genStreamChunks: []GenerateResponse{
+			{Done: true},
+			{Done: true},
+		},
+	}
+	plan := newTestPlan(primary, rec)
+	plan.Kind = RouteKindGenerate
+	plan.Profile.Key.Model = "qwen3:8b"
+	plan.SetFeedback(rf)
+	plan.Fallbacks = []RoutePlan{{
+		Profile:  &ModelProfile{Key: ModelKey{Provider: "ollama-b", Model: "qwen3:8b"}},
+		Provider: fallback,
+		Model:    "qwen3:8b",
+	}}
+
+	if err := plan.ExecuteGenerateStream(context.Background(), func(GenerateResponse) error { return nil }); err != nil {
+		t.Fatalf("ExecuteGenerateStream: %v", err)
+	}
+
+	primaryKey := FeedbackKey{Provider: "ollama-a", Model: "qwen3:8b", UseCase: "chat"}
+	primaryAgg, _ := store.Get(context.Background(), primaryKey)
+	if primaryAgg.ScoredCount != 1 {
+		t.Fatalf("primary ScoredCount = %d, want 1", primaryAgg.ScoredCount)
+	}
+	fallbackKey := FeedbackKey{Provider: "ollama-b", Model: "qwen3:8b", UseCase: "chat"}
+	fallbackAgg, _ := store.Get(context.Background(), fallbackKey)
+	if fallbackAgg.ScoredCount != 1 {
+		t.Fatalf("fallback ScoredCount = %d, want 1", fallbackAgg.ScoredCount)
+	}
+	if successes := rec.getSuccesses(); len(successes) != 1 {
+		t.Fatalf("successes = %d, want 1", len(successes))
+	}
+}

--- a/provider/route_plan_test.go
+++ b/provider/route_plan_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"errors"
+	"net"
 	"sync"
 	"testing"
 )
@@ -1259,5 +1260,197 @@ func TestExecuteGenerateStreamFallbackOnPrimaryInfraError(t *testing.T) {
 	att := lastChunk.RouteOutcome.Attempts
 	if len(att) != 2 || att[0].ErrorClass != string(ErrorClass5xx) || att[1].Status != AttemptStatusSucceeded {
 		t.Fatalf("attempts = %+v, want [Failed/5xx, Succeeded]", att)
+	}
+}
+
+func TestExecuteChatEndToEndRecordsPerAttemptFeedback(t *testing.T) {
+	store, err := NewMemoryStore(MemoryStoreConfig{})
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+	rf := NewRoutingFeedback(store)
+
+	primary := &rpMockProvider{
+		name: "ollama-a", caps: CapChat,
+		chatErr: &net.OpError{Op: "dial", Err: errors.New("refused")},
+	}
+	fallback := &rpMockProvider{
+		name: "ollama-b", caps: CapChat,
+		chatResp: &ChatResponse{Content: "hello", Done: true},
+	}
+	plan := newTestPlan(primary, &rpMockRecorder{})
+	plan.Request.UseCase = "chat"
+	plan.Model = "qwen3:8b"
+	plan.Profile.Key.Model = "qwen3:8b"
+	plan.SetFeedback(rf)
+	plan.Fallbacks = []RoutePlan{{
+		Profile:  &ModelProfile{Key: ModelKey{Provider: "ollama-b", Model: "qwen3:8b"}},
+		Provider: fallback,
+		Model:    "qwen3:8b",
+	}}
+
+	resp, err := plan.ExecuteChat(context.Background())
+	if err != nil {
+		t.Fatalf("ExecuteChat: %v", err)
+	}
+	if resp.RouteOutcome == nil {
+		t.Fatal("response RouteOutcome nil")
+	}
+
+	// Primary key should have one scored Failure (network). Latency is
+	// emitted only when elapsed wall-clock milliseconds are >0, so this
+	// test must not require it.
+	primaryKey := FeedbackKey{Provider: "ollama-a", Model: "qwen3:8b", UseCase: "chat"}
+	pa, _ := store.Get(context.Background(), primaryKey)
+	if pa.SampleCount < 1 || pa.SampleCount > 2 {
+		t.Errorf("primary SampleCount = %d, want 1 or 2 (Failure, optional Latency)", pa.SampleCount)
+	}
+	if pa.ScoredCount != 1 {
+		t.Errorf("primary ScoredCount = %d, want 1 (Failure scores; optional Latency doesn't)", pa.ScoredCount)
+	}
+	// Score for one Failure (-0.7) clipped = -0.7; mean = -0.7; score = 0.15.
+	const wantPrimaryScore = 0.15
+	if abs := pa.Score - wantPrimaryScore; abs > 1e-15 || abs < -1e-15 {
+		t.Errorf("primary Score = %v, want %v (within 1e-15)", pa.Score, wantPrimaryScore)
+	}
+
+	// Fallback key should have one scored Success (+0.5), plus optional
+	// Latency if elapsed milliseconds were measurable.
+	fallbackKey := FeedbackKey{Provider: "ollama-b", Model: "qwen3:8b", UseCase: "chat"}
+	fa, _ := store.Get(context.Background(), fallbackKey)
+	if fa.SampleCount < 1 || fa.SampleCount > 2 {
+		t.Errorf("fallback SampleCount = %d, want 1 or 2 (Success, optional Latency)", fa.SampleCount)
+	}
+	if fa.ScoredCount != 1 {
+		t.Errorf("fallback ScoredCount = %d, want 1", fa.ScoredCount)
+	}
+	if fa.Score != 0.75 {
+		t.Errorf("fallback Score = %v, want 0.75", fa.Score)
+	}
+
+	// Verify the stored signals carry the right ErrorClass for the
+	// primary failure. Inspect under lock since signals isn't exported.
+	store.mu.Lock()
+	pSigs := store.signals[primaryKey]
+	store.mu.Unlock()
+	var failureCount int
+	for _, sig := range pSigs {
+		switch sig.Kind {
+		case RoutingSignalFailure:
+			failureCount++
+			if sig.ErrorClass != "network" {
+				t.Errorf("primary Failure ErrorClass = %q, want %q", sig.ErrorClass, "network")
+			}
+		}
+	}
+	if failureCount != 1 {
+		t.Errorf("primary Failure signals = %d, want 1", failureCount)
+	}
+}
+
+func TestExecuteChatStreamPartialCanceledDoesNotRecordSuccess(t *testing.T) {
+	store, err := NewMemoryStore(MemoryStoreConfig{})
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+	rf := NewRoutingFeedback(store)
+
+	prov := &rpMockProvider{
+		name: "ollama", caps: CapChat,
+		chatStreamChunks: []ChatResponse{
+			{Content: "h"},
+			{Done: true, Partial: true},
+		},
+		chatStreamErr: context.Canceled,
+	}
+	plan := newTestPlan(prov, &rpMockRecorder{})
+	plan.SetFeedback(rf)
+
+	var last ChatResponse
+	err = plan.ExecuteChatStream(context.Background(), func(c ChatResponse) error {
+		last = c
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if last.RouteOutcome != nil {
+		t.Fatalf("partial Done chunk carried RouteOutcome; want nil")
+	}
+
+	key := FeedbackKey{Provider: "ollama", Model: "test-model", UseCase: "chat"}
+	agg, _ := store.Get(context.Background(), key)
+	if agg.SampleCount != 0 {
+		t.Fatalf("SampleCount = %d, want 0 (Canceled is AttemptStatusUnknown)", agg.SampleCount)
+	}
+}
+
+func TestExecuteChatStreamCallbackErrorDoesNotRecordProviderFailure(t *testing.T) {
+	store, err := NewMemoryStore(MemoryStoreConfig{})
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+	rf := NewRoutingFeedback(store)
+
+	prov := &rpMockProvider{
+		name: "ollama", caps: CapChat,
+		chatStreamChunks: []ChatResponse{
+			{Content: "h"},
+			{Content: "i", Done: true},
+		},
+	}
+	plan := newTestPlan(prov, &rpMockRecorder{})
+	plan.SetFeedback(rf)
+
+	callbackErr := errors.New("user aborted")
+	err = plan.ExecuteChatStream(context.Background(), func(ChatResponse) error {
+		return callbackErr
+	})
+	if !errors.Is(err, callbackErr) {
+		t.Fatalf("err = %v, want callbackErr", err)
+	}
+
+	key := FeedbackKey{Provider: "ollama", Model: "test-model", UseCase: "chat"}
+	agg, _ := store.Get(context.Background(), key)
+	if agg.SampleCount != 0 {
+		t.Fatalf("SampleCount = %d, want 0 (callback abort is AttemptStatusUnknown)", agg.SampleCount)
+	}
+}
+
+func TestExecuteGenerateStreamFallbackSuccessWithoutDoneRecordsAttempt(t *testing.T) {
+	store, err := NewMemoryStore(MemoryStoreConfig{})
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+	rf := NewRoutingFeedback(store)
+
+	primary := &rpMockProvider{
+		name: "ollama-a", caps: CapGenerate,
+		genStreamErr: &HTTPStatusError{StatusCode: 500},
+	}
+	fallback := &rpMockProvider{
+		name: "ollama-b", caps: CapGenerate,
+		genStreamChunks: []GenerateResponse{
+			{Response: "partial without Done"},
+		},
+	}
+	plan := newTestPlan(primary, &rpMockRecorder{})
+	plan.Kind = RouteKindGenerate
+	plan.Request.UseCase = "chat"
+	plan.SetFeedback(rf)
+	plan.Fallbacks = []RoutePlan{{
+		Profile:  &ModelProfile{Key: ModelKey{Provider: "ollama-b", Model: "qwen3:8b"}},
+		Provider: fallback,
+		Model:    "qwen3:8b",
+	}}
+
+	if err := plan.ExecuteGenerateStream(context.Background(), func(GenerateResponse) error { return nil }); err != nil {
+		t.Fatalf("ExecuteGenerateStream: %v", err)
+	}
+
+	key := FeedbackKey{Provider: "ollama-b", Model: "qwen3:8b", UseCase: "chat"}
+	agg, _ := store.Get(context.Background(), key)
+	if agg.ScoredCount < 1 {
+		t.Errorf("fallback ScoredCount = %d, want >= 1 (Success signal should have been recorded)", agg.ScoredCount)
 	}
 }

--- a/provider/route_plan_test.go
+++ b/provider/route_plan_test.go
@@ -1113,3 +1113,46 @@ func TestExecuteChatStreamFallbackOnPrimaryInfraError(t *testing.T) {
 		t.Errorf("att[1] = %+v, want Succeeded/ollama-b", att[1])
 	}
 }
+
+func TestExecuteChatStreamFallbackSuccessWithoutDoneRecordsAttempt(t *testing.T) {
+	// A fallback provider that returns err==nil without emitting a Done
+	// chunk must still call handleResult so the feedback seam records the
+	// success. Without the fix, return-nil-on-success short-circuited the
+	// post-stream finalization, leaving the feedback store empty.
+	store, err := NewMemoryStore(MemoryStoreConfig{})
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+	rf := NewRoutingFeedback(store)
+
+	primary := &rpMockProvider{
+		name: "ollama-a", caps: CapChat,
+		chatStreamErr: &HTTPStatusError{StatusCode: 500},
+	}
+	// Fallback emits one chunk but NO Done chunk, then returns nil.
+	fallback := &rpMockProvider{
+		name: "ollama-b", caps: CapChat,
+		chatStreamChunks: []ChatResponse{
+			{Content: "partial without Done"},
+		},
+	}
+	plan := newTestPlan(primary, &rpMockRecorder{})
+	plan.Request.UseCase = "chat"
+	plan.SetFeedback(rf)
+	plan.Fallbacks = []RoutePlan{{
+		Profile:  &ModelProfile{Key: ModelKey{Provider: "ollama-b", Model: "qwen3:8b"}},
+		Provider: fallback,
+		Model:    "qwen3:8b",
+	}}
+
+	if err := plan.ExecuteChatStream(context.Background(), func(ChatResponse) error { return nil }); err != nil {
+		t.Fatalf("ExecuteChatStream: %v", err)
+	}
+
+	// Fallback success should be recorded against ollama-b.
+	key := FeedbackKey{Provider: "ollama-b", Model: "qwen3:8b", UseCase: "chat"}
+	agg, _ := store.Get(context.Background(), key)
+	if agg.ScoredCount < 1 {
+		t.Errorf("fallback ScoredCount = %d, want >= 1 (Success signal should have been recorded)", agg.ScoredCount)
+	}
+}

--- a/provider/route_plan_test.go
+++ b/provider/route_plan_test.go
@@ -664,6 +664,90 @@ func TestRoutePlanExecuteEmbed(t *testing.T) {
 	}
 }
 
+func TestRoutePlanRecordOutcomeFeedbackNilSafe(t *testing.T) {
+	cases := []struct {
+		name    string
+		setup   func(*RoutePlan)
+		outcome *RouteOutcome
+	}{
+		{
+			name:    "nil-feedback",
+			setup:   func(rp *RoutePlan) { rp.SetFeedback(nil) },
+			outcome: &RouteOutcome{},
+		},
+		{
+			name:    "nil-outcome",
+			setup:   func(rp *RoutePlan) {},
+			outcome: nil,
+		},
+		{
+			name: "empty-usecase",
+			setup: func(rp *RoutePlan) {
+				rp.Request = RoutingRequest{UseCase: ""}
+				store, _ := NewMemoryStore(MemoryStoreConfig{})
+				rp.SetFeedback(NewRoutingFeedback(store))
+			},
+			outcome: &RouteOutcome{
+				PlannedModel: ModelKey{Provider: "p", Model: "m"},
+				Attempts: []RouteAttempt{
+					{Key: ModelKey{Provider: "p", Model: "m"}, Status: AttemptStatusSucceeded},
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rp := &RoutePlan{Profile: &ModelProfile{Key: ModelKey{Provider: "p", Model: "m"}}}
+			tc.setup(rp)
+			// Must not panic, must not return any error (helper returns void).
+			rp.recordOutcomeFeedback(tc.outcome)
+		})
+	}
+}
+
+func TestRoutePlanRecordOutcomeFeedbackDelegatesWhenConfigured(t *testing.T) {
+	store, _ := NewMemoryStore(MemoryStoreConfig{})
+	rf := NewRoutingFeedback(store)
+	rp := &RoutePlan{
+		Profile: &ModelProfile{Key: ModelKey{Provider: "p", Model: "m"}},
+		Request: RoutingRequest{UseCase: "chat"},
+	}
+	rp.SetFeedback(rf)
+
+	outcome := &RouteOutcome{
+		PlannedModel: ModelKey{Provider: "p", Model: "m"},
+		Attempts: []RouteAttempt{
+			// Keep LatencyMs at zero so this helper test only asserts
+			// delegation of the Success signal. Latency emission is covered
+			// by RecordOutcome tests and Task 11's end-to-end test.
+			{Key: ModelKey{Provider: "p", Model: "m"}, Status: AttemptStatusSucceeded},
+		},
+	}
+	rp.recordOutcomeFeedback(outcome)
+
+	agg, _ := store.Get(context.Background(), FeedbackKey{Provider: "p", Model: "m", UseCase: "chat"})
+	if agg.SampleCount != 1 {
+		t.Fatalf("SampleCount = %d, want 1 (helper should have recorded the success)", agg.SampleCount)
+	}
+}
+
+func TestRoutePlanRecordOutcomeFeedbackSwallowsStoreErrors(t *testing.T) {
+	// NewRoutingFeedback(nil) returns a wrapper that returns
+	// ErrNilRoutingFeedbackStore on every call. recordOutcomeFeedback must
+	// swallow that error rather than propagating.
+	rp := &RoutePlan{
+		Profile: &ModelProfile{Key: ModelKey{Provider: "p", Model: "m"}},
+		Request: RoutingRequest{UseCase: "chat"},
+	}
+	rp.SetFeedback(NewRoutingFeedback(nil))
+
+	outcome := &RouteOutcome{
+		Attempts: []RouteAttempt{{Key: ModelKey{Provider: "p", Model: "m"}, Status: AttemptStatusSucceeded}},
+	}
+	// Must not panic; must not log; must return void.
+	rp.recordOutcomeFeedback(outcome)
+}
+
 func TestRoutePlanString(t *testing.T) {
 	plan := &RoutePlan{
 		Model: "qwen3:8b",

--- a/provider/route_plan_test.go
+++ b/provider/route_plan_test.go
@@ -1156,3 +1156,108 @@ func TestExecuteChatStreamFallbackSuccessWithoutDoneRecordsAttempt(t *testing.T)
 		t.Errorf("fallback ScoredCount = %d, want >= 1 (Success signal should have been recorded)", agg.ScoredCount)
 	}
 }
+
+func TestExecuteGenerateStreamFinalizesOnNonPartialDone(t *testing.T) {
+	prov := &rpMockProvider{
+		name: "ollama", caps: CapGenerate,
+		genStreamChunks: []GenerateResponse{
+			{Response: "h"},
+			{Response: "i", Done: true},
+		},
+	}
+	plan := newTestPlan(prov, &rpMockRecorder{})
+	plan.Kind = RouteKindGenerate
+	var lastChunk GenerateResponse
+	err := plan.ExecuteGenerateStream(context.Background(), func(c GenerateResponse) error {
+		lastChunk = c
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if lastChunk.RouteOutcome == nil {
+		t.Fatal("outcome nil")
+	}
+	att := lastChunk.RouteOutcome.Attempts
+	if len(att) != 1 || att[0].Status != AttemptStatusSucceeded {
+		t.Fatalf("attempts = %+v, want [Succeeded]", att)
+	}
+}
+
+func TestExecuteGenerateStreamDonePartialDefersToPostStream(t *testing.T) {
+	prov := &rpMockProvider{
+		name: "ollama", caps: CapGenerate,
+		genStreamChunks: []GenerateResponse{
+			{Response: "h"},
+			{Done: true, Partial: true},
+		},
+		genStreamErr: context.Canceled,
+	}
+	plan := newTestPlan(prov, &rpMockRecorder{})
+	plan.Kind = RouteKindGenerate
+	var lastChunk GenerateResponse
+	err := plan.ExecuteGenerateStream(context.Background(), func(c GenerateResponse) error {
+		lastChunk = c
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want Canceled", err)
+	}
+	if lastChunk.RouteOutcome != nil {
+		t.Errorf("partial-Done chunk got RouteOutcome; want nil")
+	}
+}
+
+func TestExecuteGenerateStreamCallbackErrorAttributedAsUnknown(t *testing.T) {
+	prov := &rpMockProvider{
+		name: "ollama", caps: CapGenerate,
+		genStreamChunks: []GenerateResponse{
+			{Response: "h"},
+			{Response: "i", Done: true},
+		},
+	}
+	plan := newTestPlan(prov, &rpMockRecorder{})
+	plan.Kind = RouteKindGenerate
+
+	callbackErr := errors.New("user aborted")
+	err := plan.ExecuteGenerateStream(context.Background(), func(GenerateResponse) error {
+		return callbackErr
+	})
+	if !errors.Is(err, callbackErr) {
+		t.Fatalf("err = %v, want callbackErr", err)
+	}
+}
+
+func TestExecuteGenerateStreamFallbackOnPrimaryInfraError(t *testing.T) {
+	primary := &rpMockProvider{
+		name: "ollama-a", caps: CapGenerate,
+		genStreamErr: &HTTPStatusError{StatusCode: 500},
+	}
+	fallback := &rpMockProvider{
+		name: "ollama-b", caps: CapGenerate,
+		genStreamChunks: []GenerateResponse{
+			{Response: "ok"},
+			{Done: true},
+		},
+	}
+	plan := newTestPlan(primary, &rpMockRecorder{})
+	plan.Kind = RouteKindGenerate
+	plan.Fallbacks = []RoutePlan{{
+		Profile:  &ModelProfile{Key: ModelKey{Provider: "ollama-b", Model: "qwen3:8b"}},
+		Provider: fallback,
+		Model:    "qwen3:8b",
+	}}
+
+	var lastChunk GenerateResponse
+	err := plan.ExecuteGenerateStream(context.Background(), func(c GenerateResponse) error {
+		lastChunk = c
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	att := lastChunk.RouteOutcome.Attempts
+	if len(att) != 2 || att[0].ErrorClass != string(ErrorClass5xx) || att[1].Status != AttemptStatusSucceeded {
+		t.Fatalf("attempts = %+v, want [Failed/5xx, Succeeded]", att)
+	}
+}

--- a/provider/route_plan_test.go
+++ b/provider/route_plan_test.go
@@ -794,6 +794,97 @@ func TestHandleResultUsesLastAttemptKeyForCancellationWarmth(t *testing.T) {
 	}
 }
 
+func TestExecuteChatTracksPrimarySuccessAttempt(t *testing.T) {
+	prov := &rpMockProvider{name: "ollama", caps: CapChat, chatResp: &ChatResponse{Content: "hi", Done: true}}
+	plan := newTestPlan(prov, &rpMockRecorder{})
+	resp, err := plan.ExecuteChat(context.Background())
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if resp == nil || resp.RouteOutcome == nil {
+		t.Fatal("resp/outcome nil")
+	}
+	att := resp.RouteOutcome.Attempts
+	if len(att) != 1 {
+		t.Fatalf("Attempts len = %d, want 1", len(att))
+	}
+	if att[0].Status != AttemptStatusSucceeded {
+		t.Errorf("Status = %v, want Succeeded", att[0].Status)
+	}
+	if att[0].ErrorClass != "" {
+		t.Errorf("ErrorClass = %q, want empty on success", att[0].ErrorClass)
+	}
+}
+
+func TestExecuteChatTracksPrimaryFailFallbackSuccessAttempts(t *testing.T) {
+	primary := &rpMockProvider{name: "ollama-a", caps: CapChat, chatErr: &HTTPStatusError{StatusCode: 500}}
+	fallback := &rpMockProvider{name: "ollama-b", caps: CapChat, chatResp: &ChatResponse{Content: "ok", Done: true}}
+	plan := newTestPlan(primary, &rpMockRecorder{})
+	plan.Fallbacks = []RoutePlan{{
+		Profile:  &ModelProfile{Key: ModelKey{Provider: "ollama-b", Model: "qwen3:8b"}},
+		Provider: fallback,
+		Model:    "qwen3:8b",
+	}}
+
+	resp, err := plan.ExecuteChat(context.Background())
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if resp.RouteOutcome == nil {
+		t.Fatal("outcome nil")
+	}
+	att := resp.RouteOutcome.Attempts
+	if len(att) != 2 {
+		t.Fatalf("Attempts len = %d, want 2 (primary fail + fallback success)", len(att))
+	}
+	if att[0].Status != AttemptStatusFailed || att[0].ErrorClass != string(ErrorClass5xx) {
+		t.Errorf("att[0] = %+v, want Failed/5xx", att[0])
+	}
+	if att[1].Status != AttemptStatusSucceeded || att[1].Key.Provider != "ollama-b" {
+		t.Errorf("att[1] = %+v, want Succeeded for ollama-b", att[1])
+	}
+}
+
+func TestExecuteChatTracksAllFailAttempts(t *testing.T) {
+	prov := &rpMockProvider{name: "ollama-a", caps: CapChat, chatErr: &HTTPStatusError{StatusCode: 500}}
+	plan := newTestPlan(prov, &rpMockRecorder{})
+	plan.Fallbacks = []RoutePlan{{
+		Profile:  &ModelProfile{Key: ModelKey{Provider: "ollama-b", Model: "qwen3:8b"}},
+		Provider: &rpMockProvider{name: "ollama-b", caps: CapChat, chatErr: &HTTPStatusError{StatusCode: 503}},
+		Model:    "qwen3:8b",
+	}}
+
+	_, err := plan.ExecuteChat(context.Background())
+	if err == nil {
+		t.Fatal("err nil; want failure")
+	}
+	// resp is nil so we cannot read outcome via response. Instead, the
+	// outcome is built and consumed only by recordOutcomeFeedback (no-op
+	// here because feedback is nil). We verify by inspecting the plan via
+	// a future integration test (Task 11). For now we just assert no panic
+	// and the right error is surfaced.
+	if !errors.As(err, new(*HTTPStatusError)) {
+		t.Errorf("err type = %T, want *HTTPStatusError", err)
+	}
+}
+
+func TestExecuteChatCancellationProducesUnknownAttempt(t *testing.T) {
+	prov := &rpMockProvider{name: "ollama", caps: CapChat, chatErr: context.Canceled}
+	plan := newTestPlan(prov, &rpMockRecorder{})
+
+	resp, err := plan.ExecuteChat(context.Background())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if resp != nil {
+		t.Fatalf("resp = %+v, want nil on cancellation", resp)
+	}
+	// outcome is built but only consumed by the (nil) feedback seam.
+	// We can't observe Attempts from the test surface without integration
+	// wiring — Task 11 covers that. Here we just lock in that the path
+	// completes without panic.
+}
+
 func TestRoutePlanString(t *testing.T) {
 	plan := &RoutePlan{
 		Model: "qwen3:8b",

--- a/provider/router.go
+++ b/provider/router.go
@@ -48,18 +48,19 @@ type routerDefaults struct {
 // Router implements RouteRecorder so that RoutePlans can feed post-execution
 // signals back to the circuit breakers, warmth tracker, and sticky cache.
 type Router struct {
-	mu           sync.RWMutex
-	registry     *ModelRegistry
-	providers    *Registry
-	breakers     map[string]*CircuitBreaker
-	warmth       WarmthSource
-	tokenBudget  *TokenBudgetValidator
-	sticky       *stickyCache
-	availableRAM float64
-	defaultOpts  routerDefaults
-	closed       bool
-	done         chan struct{}
-	closeOnce    sync.Once
+	mu              sync.RWMutex
+	registry        *ModelRegistry
+	providers       *Registry
+	breakers        map[string]*CircuitBreaker
+	warmth          WarmthSource
+	tokenBudget     *TokenBudgetValidator
+	sticky          *stickyCache
+	availableRAM    float64
+	defaultOpts     routerDefaults
+	closed          bool
+	done            chan struct{}
+	closeOnce       sync.Once
+	routingFeedback *RoutingFeedback
 }
 
 // Compile-time assertion that Router implements RouteRecorder.
@@ -146,6 +147,15 @@ func WithTokenBudgetValidator(v *TokenBudgetValidator) RouterOption {
 	return func(r *Router) {
 		r.tokenBudget = v
 	}
+}
+
+// WithRoutingFeedback configures the router to record per-attempt
+// outcomes via the RoutingFeedback wrapper. Default is nil (no recording).
+// The wrapper itself is nil-safe — if a future caller passes a
+// *RoutingFeedback constructed with a nil store, RecordOutcome returns
+// ErrNilRoutingFeedbackStore which recordOutcomeFeedback swallows.
+func WithRoutingFeedback(rf *RoutingFeedback) RouterOption {
+	return func(r *Router) { r.routingFeedback = rf }
 }
 
 // ---------------------------------------------------------------------------
@@ -720,6 +730,7 @@ func (r *Router) buildPlan(winner scoredCandidate, fallbacks []scoredCandidate, 
 	}
 	plan.SetWasSticky(wasSticky)
 	plan.SetRecorder(r)
+	plan.SetFeedback(r.routingFeedback) // ← PR2 addition; nil is fine, SetFeedback handles it
 
 	// Build fallback chain.
 	for _, fb := range fallbacks {

--- a/provider/router_errors.go
+++ b/provider/router_errors.go
@@ -113,6 +113,28 @@ func (e *HTTPStatusError) Error() string {
 	return fmt.Sprintf("HTTP %d", e.StatusCode)
 }
 
+// HTTPStatusCode exposes the status code through the shared status-code error
+// contract used by routing classification. Built-in provider clients can
+// implement the same method without importing this package.
+func (e *HTTPStatusError) HTTPStatusCode() int {
+	if e == nil {
+		return 0
+	}
+	return e.StatusCode
+}
+
+type httpStatusCodeError interface {
+	HTTPStatusCode() int
+}
+
+func httpStatusCode(err error) (int, bool) {
+	var statusErr httpStatusCodeError
+	if errors.As(err, &statusErr) {
+		return statusErr.HTTPStatusCode(), true
+	}
+	return 0, false
+}
+
 // ---------------------------------------------------------------------------
 // Infrastructure error classification
 // ---------------------------------------------------------------------------
@@ -151,12 +173,12 @@ func IsInfrastructureError(err error) bool {
 	}
 
 	// HTTP status errors: 5xx and 429 are infrastructure, other 4xx are not.
-	var httpErr *HTTPStatusError
-	if errors.As(err, &httpErr) {
-		if httpErr.StatusCode >= 500 {
+	// Provider-specific wrappers expose their status through HTTPStatusCode.
+	if statusCode, ok := httpStatusCode(err); ok {
+		if statusCode >= 500 {
 			return true
 		}
-		if httpErr.StatusCode == 429 {
+		if statusCode == 429 {
 			return true
 		}
 		return false

--- a/provider/router_errors_test.go
+++ b/provider/router_errors_test.go
@@ -74,6 +74,16 @@ func TestIsInfrastructureError(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "wrapped status-code interface 429",
+			err:  fmt.Errorf("provider error: %w", testStatusCodeError(429)),
+			want: true,
+		},
+		{
+			name: "status-code interface 404",
+			err:  testStatusCodeError(404),
+			want: false,
+		},
+		{
 			name: "wrapped context.Canceled",
 			err:  fmt.Errorf("request failed: %w", context.Canceled),
 			want: false,

--- a/provider/router_test.go
+++ b/provider/router_test.go
@@ -835,3 +835,44 @@ func TestRouterBuildReason(t *testing.T) {
 		t.Errorf("reason = %q, should contain score", reason)
 	}
 }
+
+func TestRouterWithRoutingFeedbackPlumbsToPlan(t *testing.T) {
+	store, err := NewMemoryStore(MemoryStoreConfig{})
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+	rf := NewRoutingFeedback(store)
+
+	// Construct a router with the new option. setupTestRouter already
+	// accepts RouterOption values and registers the qwen3:8b fixture model.
+	r, _ := setupTestRouter(t, WithRoutingFeedback(rf))
+
+	// Drive a Route call that succeeds. The test fixture should already
+	// register a model that the router will select. Inspect the returned
+	// plan's feedback field via a small accessor or by behavior: execute
+	// the plan and check that store.Get returns a non-zero SampleCount.
+	plan, err := r.Route(context.Background(), RoutingRequest{
+		Model:   "qwen3:8b",
+		UseCase: "chat",
+	})
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if plan.feedback != rf {
+		t.Errorf("plan.feedback = %v, want injected rf", plan.feedback)
+	}
+}
+
+func TestRouterWithoutRoutingFeedbackProducesNilPlanFeedback(t *testing.T) {
+	r, _ := setupTestRouter(t)
+	plan, err := r.Route(context.Background(), RoutingRequest{
+		Model:   "qwen3:8b",
+		UseCase: "chat",
+	})
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if plan.feedback != nil {
+		t.Errorf("plan.feedback = %v, want nil (no option configured)", plan.feedback)
+	}
+}

--- a/provider/routing_feedback_memory.go
+++ b/provider/routing_feedback_memory.go
@@ -97,6 +97,21 @@ func NewMemoryStore(cfg MemoryStoreConfig) (*MemoryStore, error) {
 	}, nil
 }
 
+// Signals returns a snapshot copy of the raw signals stored for key, in
+// insertion order. Returns nil if no signals are stored. Tests and
+// diagnostic tools can use this to inspect individual signals (kind,
+// strength, error class) without computing an aggregate. The returned
+// slice is independent of the store's internal storage and safe to
+// retain across concurrent Record calls.
+func (s *MemoryStore) Signals(key FeedbackKey) []FeedbackSignal {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.signals[key]) == 0 {
+		return nil
+	}
+	return append([]FeedbackSignal(nil), s.signals[key]...)
+}
+
 // Get returns the aggregate for key. If no signals are stored, returns a
 // neutral aggregate (Score == cfg.neutralScore, other fields zero).
 // Otherwise computes Score from the score-bearing subset of signals

--- a/provider/routing_feedback_memory.go
+++ b/provider/routing_feedback_memory.go
@@ -106,10 +106,15 @@ func NewMemoryStore(cfg MemoryStoreConfig) (*MemoryStore, error) {
 func (s *MemoryStore) Signals(key FeedbackKey) []FeedbackSignal {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if len(s.signals[key]) == 0 {
+	signals := s.signals[key]
+	if len(signals) == 0 {
 		return nil
 	}
-	return append([]FeedbackSignal(nil), s.signals[key]...)
+	out := make([]FeedbackSignal, len(signals))
+	for i, sig := range signals {
+		out[i] = cloneSignal(sig)
+	}
+	return out
 }
 
 // Get returns the aggregate for key. If no signals are stored, returns a

--- a/provider/routing_feedback_test.go
+++ b/provider/routing_feedback_test.go
@@ -421,6 +421,47 @@ func TestRecordDefensiveCopiesStrengthAndMeta(t *testing.T) {
 	}
 }
 
+func TestSignalsDeepCopiesStrengthAndMeta(t *testing.T) {
+	s, _ := NewMemoryStore(MemoryStoreConfig{})
+	key := validKey()
+	strength := +0.9
+	if err := s.Record(context.Background(), key, FeedbackSignal{
+		Kind:     RoutingSignalSuccess,
+		Strength: &strength,
+		Meta:     map[string]string{"key": "v1"},
+	}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	snapshot := s.Signals(key)
+	if len(snapshot) != 1 {
+		t.Fatalf("Signals len = %d, want 1", len(snapshot))
+	}
+	if snapshot[0].Strength == nil {
+		t.Fatal("snapshot Strength is nil")
+	}
+	*snapshot[0].Strength = -1.0
+	snapshot[0].Meta["key"] = "redacted"
+	snapshot[0].Meta["extra"] = "caller-only"
+
+	next := s.Signals(key)
+	if len(next) != 1 {
+		t.Fatalf("Signals after mutation len = %d, want 1", len(next))
+	}
+	if next[0].Strength == nil {
+		t.Fatal("stored Strength is nil")
+	}
+	if got := *next[0].Strength; got != 0.9 {
+		t.Fatalf("stored Strength = %v, want 0.9", got)
+	}
+	if got := next[0].Meta["key"]; got != "v1" {
+		t.Fatalf("stored Meta[key] = %q, want \"v1\"", got)
+	}
+	if _, ok := next[0].Meta["extra"]; ok {
+		t.Fatal("stored Meta unexpectedly saw caller-only key")
+	}
+}
+
 func TestRecordFIFOBound(t *testing.T) {
 	s, _ := NewMemoryStore(MemoryStoreConfig{MaxRetainedSamples: 3})
 	for i := 0; i < 5; i++ {

--- a/provider/routing_feedback_test.go
+++ b/provider/routing_feedback_test.go
@@ -116,7 +116,7 @@ func TestBuildOutcomePopulatesRouteID(t *testing.T) {
 		Score:   0.42,
 		Reason:  "test",
 	}
-	out := rp.buildOutcome(0)
+	out := rp.buildOutcome(0, nil)
 	if out == nil {
 		t.Fatal("buildOutcome returned nil")
 	}

--- a/provider/types.go
+++ b/provider/types.go
@@ -117,6 +117,13 @@ type Provider interface {
 
 	// ChatStream sends a chat completion request and invokes fn for each
 	// partial response chunk. The final chunk has Done set to true.
+	//
+	// fn MUST be called serially in the calling goroutine, never from a
+	// separately-spawned goroutine. RoutePlan.ExecuteChatStream wraps fn
+	// with closure-captured attempt state that is mutated without
+	// synchronization; a Provider that fans callbacks out to goroutines
+	// would race against that state. Returning an error from fn must abort
+	// the stream and propagate the error from ChatStream's return value.
 	ChatStream(ctx context.Context, req ChatRequest, fn func(ChatResponse) error) error
 
 	// Generate sends a raw text generation request and returns the response.
@@ -124,6 +131,9 @@ type Provider interface {
 
 	// GenerateStream sends a generation request and invokes fn for each
 	// partial response chunk. The final chunk has Done set to true.
+	//
+	// The fn-invocation contract matches ChatStream's: serial, in the
+	// calling goroutine, errors abort and propagate.
 	GenerateStream(ctx context.Context, req GenerateRequest, fn func(GenerateResponse) error) error
 
 	// Embed generates vector embeddings for the given input texts.
@@ -466,12 +476,30 @@ type RouteAttempt struct {
 // state, score, fallback usage, the per-attempt trace, and a route-scoped
 // correlation ID.
 type RouteOutcome struct {
-	PlannedModel  ModelKey `json:"planned_model"`
-	ActualModel   ModelKey `json:"actual_model"`
-	FallbacksUsed int      `json:"fallbacks_used"`
-	WasSticky     bool     `json:"was_sticky"`
-	Score         float64  `json:"score"`
-	Reason        string   `json:"reason"`
+	// PlannedModel is the model the Router selected at plan time. Stable
+	// across the request: never updated by fallback execution.
+	PlannedModel ModelKey `json:"planned_model"`
+
+	// ActualModel is the model whose response served the request — the
+	// last attempt's key when it succeeded. When no attempt succeeded
+	// (every provider in the chain failed, was cancelled, or the request
+	// errored before any provider call), ActualModel equals PlannedModel
+	// as a defensive default; consumers should consult Attempts to learn
+	// what actually happened. Pre-PR2 semantics derived this field from
+	// FallbacksUsed alone, which produced inconsistent values between
+	// non-streaming and streaming Execute methods; PR2 derives it from
+	// the per-attempt trace for consistency.
+	ActualModel ModelKey `json:"actual_model"`
+
+	// FallbacksUsed counts the fallbacks promoted to "selected" before
+	// success. 0 means the primary served (or every attempt failed); 1
+	// means Fallbacks[0] served, and so on. Use len(Attempts) - 1 to
+	// learn how many fallbacks were tried (vs. how many served).
+	FallbacksUsed int `json:"fallbacks_used"`
+
+	WasSticky bool    `json:"was_sticky"`
+	Score     float64 `json:"score"`
+	Reason    string  `json:"reason"`
 
 	// Attempts is the ordered list of execution attempts (primary first).
 	// Nil/empty pre-PR2 because nothing populates it yet; the


### PR DESCRIPTION
## Summary

Second PR of Epic #48 Phase 5: wires `RoutePlan.handleResult`/`recordResult` and the five `Execute*` methods to populate `RouteOutcome.Attempts` per attempt, classify errors into a bounded `ErrorClass` vocabulary, construct `RouteOutcome` on every execution path (success / failure / cancellation), and call `RoutingFeedback.RecordOutcome` through a nil-safe / fail-open / bounded-timeout seam. After this PR, configuring a `*RoutingFeedback` on the router (via `WithRoutingFeedback`) causes every routed request to record per-attempt feedback signals into the underlying store.

PR3 adds the SQLite store, the scoring read, and the score-component breakdown.

## What's in this PR

- `provider/route_errors.go` — `ErrorClass` type (7 constants: `network` / `timeout` / `4xx` / `5xx` / `rate_limit` / `model_unloaded` reserved / `unknown`) + `classifyError(err) (ErrorClass, AttemptStatus)`. Pure function — no plan dependency. Status-code extraction via an `httpStatusCode(err)` interface helper so wrapped errors and custom error types that implement `HTTPStatusCode() int` are classified consistently.
- `provider/route_plan.go` — `RoutePlan.feedback *RoutingFeedback` field + `SetFeedback` setter; `makeAttempt` / `makeUnknownAttempt` / `clampMs` helpers; `handleResult` split into `buildOutcome` + `recordResult`; always returns non-nil outcome; `ActualModel` derived from `attempts[last].Status == Succeeded`; streaming variants use a `pendingAttempts`/`pendingOutcome`/`pendingFallbacksUsed` pattern so the Done handler stays idempotent on user-callback errors; user-callback aborts attribute as `AttemptStatusUnknown` (no-op in RoutingFeedback). `recordOutcomeFeedback` uses `context.WithTimeout(1s)` so a stuck store can't block the routing path.
- `provider/router.go` — `routingFeedback` field + `WithRoutingFeedback` option + one-line `buildPlan` wiring that covers normal, degraded, and chain plans.

## Notable mid-stream fixes

- `333f852` — `ExecuteChatStream` fallback success without Done chunk silently bypassed `handleResult`. Replaced `return nil` with `break` so the bottom-of-function finalization runs. Locked in by `TestExecuteChatStreamFallbackSuccessWithoutDoneRecordsAttempt`.
- `6fd7f38` — Stream Done finalization is now idempotent on user-callback errors. The Done branch builds pending state, calls `fn(chunk)` with the outcome, and only commits side-effects if the callback didn't error.
- `9410cbe` — Addressed routing-feedback review comments: `httpStatusCode(err)` interface helper for status-code extraction across wrapped and custom error types; `recordResult` extracted from `handleResult` so stream Done handlers can pass a prebuilt outcome.
- `c7e6db1` — Criticize-review pass addressed 9 issues:
  - **#1** Streaming `fallbacksUsed` no longer eagerly set at iteration top; Done handler sets it via `pendingFallbacksUsed`, no-Done-success path sets it inline with `break`. All-failed streaming runs now correctly report `fallbacksUsed=0` / `ActualModel=primary`, matching the non-streaming methods.
  - **#2** `recordOutcomeFeedback` uses `context.WithTimeout(1s)` — guards against stuck stores blocking the routing path.
  - **#3** TODO markers in `recordOutcomeFeedback` and `newRouteID` for PR3 to add error counters / once-logged warnings (silent fail-open is fail-silent without telemetry).
  - **#4** Removed dead `else if fallbacksUsed > 0` bridge in `recordResult`; `buildOutcome` derives `ActualModel` from `attempts[last].Status == Succeeded` for stream/non-stream consistency.
  - **#5+#6** Streaming docstrings document the serial-callback contract and multi-provider fn invocation during fallback.
  - **#7** `makeUnknownAttempt` helper extracts the four-way duplication and shares `clampMs` with `makeAttempt` (no more negative-LatencyMs path on Unknown).
  - **#10** Added wrapped-`*HTTPStatusError`, wrapped-`net.OpError`, wrapped-`context.Canceled`, and out-of-range (200, 301) cases to `TestClassifyError`.
  - **#11** Slice copy under lock in `TestExecuteChatEndToEndRecordsPerAttemptFeedback` to match production `MemoryStore.Get` pattern.
  - **#13** Renamed `TestExecuteChatStreamCallbackErrorAttributedAsUnknown` to `TestExecuteChatStreamPropagatesCallbackError` — name now matches what the assertion actually verifies.
  - Added `TestBuildOutcomeActualModelOnAllFail` + `TestBuildOutcomeActualModelOnFallbackSuccess` to lock in #1+#4 contracts.
  - Opportunistic `gofmt -w provider/route_plan_test.go` cleared inherited drift.

## Known follow-ups (deferred)

- `recordResult` and `buildOutcome` were unified once already; if PR3 adds more signal types, revisit a single attempt-driven derivation that replaces both `fallbacksUsed` parameters.
- Telemetry on dropped feedback writes / empty RouteIDs — TODO in code, blocked on PR3's SQLite store landing.
- Five-way duplication across `Execute*` methods is acknowledged maintenance debt; helper extraction was deferred because stream variants don't share shape with non-stream.

## Test plan

- [x] `go test ./provider/ -race -count=1` — all per-attempt tests + integration test + new buildOutcome direct tests green
- [x] `go test ./... -race -count=1` — full module green
- [x] `go build ./... && go vet ./...` — clean
- [x] `gofmt -l provider/route_plan.go provider/route_plan_test.go provider/route_errors.go provider/route_errors_test.go provider/router.go provider/router_test.go` — empty
- [x] `TestExecuteChatEndToEndRecordsPerAttemptFeedback` — locks in the full ExecuteChat → recordResult → recordOutcomeFeedback → MemoryStore wiring with a real `net.OpError`
- [x] `TestExecuteChatStreamDonePartialDefersToPostStream` — locks in the Partial-Done gate
- [x] `TestExecuteChatStreamPropagatesCallbackError` — verifies error propagation
- [x] `TestExecuteChatStreamCallbackErrorDoesNotRecordProviderFailure` — locks in the Unknown-attribution invariant end-to-end via feedback store
- [x] `TestBuildOutcomeActualModelOnAllFail` / `TestBuildOutcomeActualModelOnFallbackSuccess` — locks in the streaming consistency fix
- [x] `TestExecuteChatStreamFallbackSuccessWithoutDoneRecordsAttempt` + Generate mirror — regression guards for the `break`-not-`return-nil` fix

## Sequencing

```
PR1 (merged: #122) ── Seam types + in-memory store + RouteAttempt model
PR2 (this)         ── Wire Execute* methods, classifyError, RecordOutcome plumbing
PR3                ── SQLite store + scoreCandidate ctx + opt-in score read + telemetry
PR4                ── Harness #56 before/after comparison
PR5+               ── Exploration, latency prediction, KV-cache, /v1/completions/feedback
```

Generated with [Claude Code](https://claude.com/claude-code)