### PR TITLE
feat(llm-bench): -capture-sample stratification (PR B2)

### DIFF
--- a/cmd/llm-bench/capture.go
+++ b/cmd/llm-bench/capture.go
@@ -35,7 +35,10 @@ type captureOptions struct {
 	Limit            int
 	Source           string
 	FallbackSystem   string
-	ToolSchemaSource toolSchemaSource // nil = no snapshot; configured empty snapshot is authoritative
+	ToolSchemaSource toolSchemaSource   // nil = no snapshot; configured empty snapshot is authoritative
+	SampleSpec       *captureSampleSpec // nil = no sampling
+	SampleSeed       int64
+	Now              func() time.Time // injectable for deterministic recency tests
 }
 
 type captureResult struct {
@@ -168,9 +171,6 @@ func captureConversations(ctx context.Context, store conversationStore, opts cap
 		}
 		return summaries[i].ID < summaries[j].ID
 	})
-	if err := os.MkdirAll(outDir, 0o700); err != nil {
-		return captureResult{}, fmt.Errorf("create trace dir %q: %w", outDir, err)
-	}
 
 	redactor := defaultRedactor()
 	snapshotConfigured := opts.ToolSchemaSource != nil
@@ -186,18 +186,26 @@ func captureConversations(ctx context.Context, store conversationStore, opts cap
 		}
 	}
 
-	var result captureResult
-	for _, summary := range summaries {
-		if opts.Limit > 0 && len(result.Written) >= opts.Limit {
-			break
-		}
+	if err := os.MkdirAll(outDir, 0o700); err != nil {
+		return captureResult{}, fmt.Errorf("create trace dir %q: %w", outDir, err)
+	}
 
+	var result captureResult
+
+	// Phase A: list → convert → enrich.
+	// Skipped conversations are removed here, before sampling, so they
+	// are never sampling candidates (spec §4.4 ordering).
+	type pendingTrace struct {
+		Trace Trace
+		Path  string
+	}
+	var enriched []pendingTrace
+	for _, summary := range summaries {
 		conv, err := store.Load(ctx, summary.ID)
 		if err != nil {
 			result.Skipped = append(result.Skipped, fmt.Sprintf("%s: %v", summary.ID, err))
 			continue
 		}
-
 		trace, err := conversationToTrace(*conv, source, opts.FallbackSystem, redactor, snapshotTools, snapshotConfigured)
 		if err != nil {
 			if errors.Is(err, errToolNameNotDeclared) {
@@ -208,17 +216,76 @@ func captureConversations(ctx context.Context, store conversationStore, opts cap
 			}
 			continue
 		}
+		enriched = append(enriched, pendingTrace{
+			Trace: trace,
+			Path:  filepath.Join(outDir, safeTraceFilename(trace.ID)+".json"),
+		})
+	}
 
-		path := filepath.Join(outDir, safeTraceFilename(trace.ID)+".json")
-		data, err := json.MarshalIndent(trace, "", "  ")
+	// Phase B: sample (if requested) or apply -capture-limit.
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	var written []pendingTrace
+	var manifest *sampleManifest
+	switch {
+	case opts.SampleSpec != nil:
+		traces := make([]Trace, 0, len(enriched))
+		for _, p := range enriched {
+			traces = append(traces, p.Trace)
+		}
+		seed := opts.SampleSeed
+		if seed == 0 {
+			seed = now().UnixNano()
+		}
+		sampled, m, err := stratifiedSample(traces, *opts.SampleSpec, seed, now())
 		if err != nil {
-			return result, fmt.Errorf("marshal trace %q: %w", trace.ID, err)
+			return result, fmt.Errorf("capture: sample: %w", err)
+		}
+		manifest = &m
+		idx := make(map[string]pendingTrace, len(enriched))
+		for _, p := range enriched {
+			idx[p.Trace.ID] = p
+		}
+		for _, t := range sampled {
+			if p, ok := idx[t.ID]; ok {
+				written = append(written, p)
+			}
+		}
+	case opts.Limit > 0:
+		if opts.Limit > len(enriched) {
+			written = enriched
+		} else {
+			written = enriched[:opts.Limit]
+		}
+	default:
+		written = enriched
+	}
+
+	// Phase C: write traces.
+	for _, p := range written {
+		data, err := json.MarshalIndent(p.Trace, "", "  ")
+		if err != nil {
+			return result, fmt.Errorf("marshal trace %q: %w", p.Trace.ID, err)
 		}
 		data = append(data, '\n')
-		if err := os.WriteFile(path, data, 0o600); err != nil {
-			return result, fmt.Errorf("write trace %q: %w", path, err)
+		if err := os.WriteFile(p.Path, data, 0o600); err != nil {
+			return result, fmt.Errorf("write trace %q: %w", p.Path, err)
 		}
-		result.Written = append(result.Written, path)
+		result.Written = append(result.Written, p.Path)
+	}
+
+	// Write the sample manifest when sampling was requested.
+	if manifest != nil {
+		data, err := json.MarshalIndent(manifest, "", "  ")
+		if err != nil {
+			return result, fmt.Errorf("marshal sample manifest: %w", err)
+		}
+		manifestPath := filepath.Join(outDir, "_sample-manifest.json")
+		if err := os.WriteFile(manifestPath, append(data, '\n'), 0o600); err != nil {
+			return result, fmt.Errorf("write sample manifest: %w", err)
+		}
 	}
 
 	return result, nil

--- a/cmd/llm-bench/capture.go
+++ b/cmd/llm-bench/capture.go
@@ -220,6 +220,9 @@ func captureConversations(ctx context.Context, store conversationStore, opts cap
 			Trace: trace,
 			Path:  filepath.Join(outDir, safeTraceFilename(trace.ID)+".json"),
 		})
+		if opts.SampleSpec == nil && opts.Limit > 0 && len(enriched) >= opts.Limit {
+			break
+		}
 	}
 
 	// Phase B: sample (if requested) or apply -capture-limit.

--- a/cmd/llm-bench/capture_test.go
+++ b/cmd/llm-bench/capture_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -638,4 +639,71 @@ func TestCaptureConversationsNilSourceLeavesEmptyTools(t *testing.T) {
 	if len(trace.Tools) != 0 {
 		t.Fatalf("trace.Tools=%v; want empty when no source configured", trace.Tools)
 	}
+}
+
+func TestCaptureConversationsAppliesSampleAfterEnrichment(t *testing.T) {
+	// 4 conversations, one of them with an undeclared tool that will be
+	// dropped during enrichment. Spec asks for n=2 — the manifest must
+	// list exactly the 2 written traces (not 2 of the 4 original
+	// candidates).
+	tools := []json.RawMessage{json.RawMessage(`{"name":"read_file","inputSchema":{"type":"object"}}`)}
+	store := makeStoreWithOneUndeclared("undeclared_tool", 4)
+	outDir := t.TempDir()
+	spec, _ := parseCaptureSample("n=2,stratify=turn-count")
+	res, err := captureConversations(context.Background(), store, captureOptions{
+		OutputDir:        outDir,
+		ToolSchemaSource: staticToolSchemaSource{tools: tools},
+		SampleSpec:       &spec,
+		SampleSeed:       42,
+		Now:              time.Now,
+	})
+	if err != nil {
+		t.Fatalf("captureConversations: %v", err)
+	}
+	if len(res.Written) != 2 {
+		t.Fatalf("Written=%d; want 2 (post-sample)", len(res.Written))
+	}
+	manifestPath := filepath.Join(outDir, "_sample-manifest.json")
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var manifest sampleManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	if len(manifest.SampledIDs) != 2 {
+		t.Fatalf("manifest.SampledIDs=%v; want 2", manifest.SampledIDs)
+	}
+	for _, id := range manifest.SampledIDs {
+		if strings.Contains(id, "undeclared") {
+			t.Fatalf("manifest lists dropped trace %q", id)
+		}
+	}
+}
+
+// makeStoreWithOneUndeclared returns a fakeConversationStore with N
+// conversations. Each is a valid 5-message tool-call convo using
+// "read_file"; the last conversation instead uses the supplied
+// undeclared tool name (so it will fail validateTrace under any
+// snapshot that doesn't declare it).
+func makeStoreWithOneUndeclared(undeclared string, n int) fakeConversationStore {
+	now := time.Now()
+	summaries := make([]conversation.Summary, n)
+	conversations := make(map[string]conversation.Conversation, n)
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("c-%03d", i)
+		toolName := "read_file"
+		if i == n-1 {
+			toolName = undeclared
+		}
+		conv := conversation.Conversation{
+			ID:        id,
+			Messages:  buildToolCallConvo(toolName),
+			UpdatedAt: now.Add(-time.Duration(i) * time.Minute),
+		}
+		summaries[i] = conversation.Summary{ID: id, UpdatedAt: conv.UpdatedAt}
+		conversations[id] = conv
+	}
+	return fakeConversationStore{summaries: summaries, conversations: conversations}
 }

--- a/cmd/llm-bench/capture_test.go
+++ b/cmd/llm-bench/capture_test.go
@@ -18,6 +18,7 @@ import (
 type fakeConversationStore struct {
 	summaries     []conversation.Summary
 	conversations map[string]conversation.Conversation
+	loaded        *[]string
 }
 
 func (s fakeConversationStore) List(context.Context) ([]conversation.Summary, error) {
@@ -27,6 +28,9 @@ func (s fakeConversationStore) List(context.Context) ([]conversation.Summary, er
 }
 
 func (s fakeConversationStore) Load(_ context.Context, id string) (*conversation.Conversation, error) {
+	if s.loaded != nil {
+		*s.loaded = append(*s.loaded, id)
+	}
 	conv, ok := s.conversations[id]
 	if !ok {
 		return nil, errors.New("missing conversation")
@@ -254,6 +258,7 @@ func TestCaptureConversationsSkipsMalformedAndWritesDeterministicOutput(t *testi
 
 func TestCaptureLimitCountsWrittenTraces(t *testing.T) {
 	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	var loaded []string
 	store := fakeConversationStore{
 		summaries: []conversation.Summary{
 			{ID: "bad", UpdatedAt: now.Add(3 * time.Minute)},
@@ -268,6 +273,7 @@ func TestCaptureLimitCountsWrittenTraces(t *testing.T) {
 			"good-1": validTestConversation("good-1", "first", now),
 			"good-2": validTestConversation("good-2", "second", now),
 		},
+		loaded: &loaded,
 	}
 
 	dir := t.TempDir()
@@ -287,6 +293,9 @@ func TestCaptureLimitCountsWrittenTraces(t *testing.T) {
 	}
 	if filepath.Base(result.Written[0]) != "conversation-good-1.json" {
 		t.Fatalf("written file = %q", result.Written[0])
+	}
+	if got, want := strings.Join(loaded, ","), "bad,good-1"; got != want {
+		t.Fatalf("loaded conversations = %s, want %s", got, want)
 	}
 	if _, err := os.Stat(filepath.Join(dir, "conversation-good-2.json")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("good-2 should not be written after limit, stat err=%v", err)

--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -80,10 +80,10 @@ func main() {
 		if err := validateCaptureSampleAndLimit(*captureLimit, *captureSample); err != nil {
 			log.Fatalf("llm-bench: %v", err)
 		}
-		if err := resolveCaptureSample(*captureSample); err != nil {
+		sampleSpec, err := resolveCaptureSample(*captureSample)
+		if err != nil {
 			log.Fatalf("llm-bench: %v", err)
 		}
-		_ = captureSampleSeed // wired up in track B2
 		src, err := resolveToolSchemaSource(*mcpStdioCommand, *mcpURL)
 		if err != nil {
 			log.Fatalf("llm-bench: %v", err)
@@ -98,6 +98,8 @@ func main() {
 			Source:           *captureSource,
 			FallbackSystem:   *captureSystem,
 			ToolSchemaSource: src,
+			SampleSpec:       sampleSpec,
+			SampleSeed:       *captureSampleSeed,
 		})
 		if err != nil {
 			log.Fatalf("llm-bench: capture: %v", err)
@@ -322,15 +324,18 @@ func validateCaptureSampleAndLimit(limit int, sample string) error {
 	return nil
 }
 
-// resolveCaptureSample is a B1 placeholder. B2 (sampling.go) replaces
-// the body with real parsing + allocator. Until then, supplying a
-// non-empty spec is a hard error rather than a silent no-op so users
-// can't think sampling is happening.
-func resolveCaptureSample(spec string) error {
+// resolveCaptureSample parses the -capture-sample flag into a
+// *captureSampleSpec. Returns (nil, nil) when spec is empty (no
+// sampling requested). Any parse error is returned as a non-nil error.
+func resolveCaptureSample(spec string) (*captureSampleSpec, error) {
 	if strings.TrimSpace(spec) == "" {
-		return nil
+		return nil, nil
 	}
-	return fmt.Errorf("-capture-sample: sampling not yet implemented (track B2)")
+	parsed, err := parseCaptureSample(spec)
+	if err != nil {
+		return nil, err
+	}
+	return &parsed, nil
 }
 
 // resolveToolSchemaSource picks a tool-schema source from CLI flags.

--- a/cmd/llm-bench/main_test.go
+++ b/cmd/llm-bench/main_test.go
@@ -48,14 +48,22 @@ func TestCaptureSampleAndLimitMutuallyExclusive(t *testing.T) {
 	}
 }
 
-func TestCaptureSampleNotYetImplementedReturnsError(t *testing.T) {
-	if err := resolveCaptureSample("n=20"); err == nil || !strings.Contains(err.Error(), "sampling not yet implemented") {
-		t.Fatalf("want not-yet-implemented error; got %v", err)
+func TestResolveCaptureSampleParsesValidSpec(t *testing.T) {
+	spec, err := resolveCaptureSample("n=10,stratify=token-length")
+	if err != nil {
+		t.Fatalf("resolveCaptureSample: %v", err)
+	}
+	if spec == nil || spec.N != 10 {
+		t.Fatalf("spec=%+v; want N=10", spec)
 	}
 }
 
-func TestCaptureSampleEmptyOK(t *testing.T) {
-	if err := resolveCaptureSample(""); err != nil {
-		t.Fatalf("empty spec: %v", err)
+func TestResolveCaptureSampleEmptyReturnsNil(t *testing.T) {
+	spec, err := resolveCaptureSample("")
+	if err != nil {
+		t.Fatalf("resolveCaptureSample(empty): %v", err)
+	}
+	if spec != nil {
+		t.Fatalf("want nil spec for empty input; got %+v", spec)
 	}
 }

--- a/cmd/llm-bench/sampling.go
+++ b/cmd/llm-bench/sampling.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -167,4 +169,181 @@ func traceHasToolCalls(t Trace) bool {
 		}
 	}
 	return false
+}
+
+// sampleManifest records what stratifiedSample selected and why.
+// It is emitted as _sample-manifest.json alongside the sampled trace set.
+type sampleManifest struct {
+	Seed       int64          `json:"seed"`
+	Spec       string         `json:"spec"`
+	CellCounts map[string]int `json:"cell_counts"`
+	SampledIDs []string       `json:"sampled_ids"`
+}
+
+// stratifiedSample applies hard filters, groups into cells by the spec's
+// stratify dimensions, allocates slots with floor+remainder logic, then
+// redistributes any slack from short cells to non-empty cells.
+func stratifiedSample(traces []Trace, spec captureSampleSpec, seed int64, now time.Time) ([]Trace, sampleManifest, error) {
+	filtered := applyCaptureFilters(traces, spec, now)
+	if len(filtered) == 0 {
+		return nil, sampleManifest{Seed: seed, CellCounts: map[string]int{}, SampledIDs: []string{}}, nil
+	}
+
+	rng := rand.New(rand.NewSource(seed))
+	cells := groupByStratum(filtered, spec.Stratify, now)
+	keys := sortedKeys(cells)
+
+	// First pass: balanced floor+remainder allocation capped by cell size.
+	// When target < len(keys), only target cells receive one slot; the
+	// first pass must never oversample beyond target.
+	target := spec.N
+	if target > len(filtered) {
+		target = len(filtered)
+	}
+	if len(keys) == 0 {
+		// No stratify dims: degenerate one-cell case.
+		// NOTE: this branch is dead when spec.Stratify is empty because
+		// groupByStratum with empty dims always produces {"": traces},
+		// giving len(keys)==1. The guard is kept for safety.
+		return uniformPick(filtered, target, rng, spec, seed, now)
+	}
+
+	baseAlloc := target / len(keys)
+	remainder := target % len(keys)
+
+	picked := make([]Trace, 0, target)
+	remaining := make(map[string][]Trace, len(cells))
+	cellCounts := make(map[string]int, len(cells))
+	for i, k := range keys {
+		c := cells[k]
+		shuffle(c, rng)
+		n := baseAlloc
+		if i < remainder {
+			n++
+		}
+		if n > len(c) {
+			n = len(c)
+		}
+		picked = append(picked, c[:n]...)
+		remaining[k] = c[n:]
+		cellCounts[k] = n
+	}
+
+	// Slack redistribution: fill until we hit target or run out of candidates.
+	for len(picked) < target {
+		progressed := false
+		for _, k := range keys {
+			if len(picked) >= target {
+				break
+			}
+			if len(remaining[k]) == 0 {
+				continue
+			}
+			picked = append(picked, remaining[k][0])
+			remaining[k] = remaining[k][1:]
+			cellCounts[k]++
+			progressed = true
+		}
+		if !progressed {
+			break
+		}
+	}
+
+	ids := make([]string, 0, len(picked))
+	for _, p := range picked {
+		ids = append(ids, p.ID)
+	}
+	return picked, sampleManifest{
+		Seed:       seed,
+		Spec:       captureSpecString(spec),
+		CellCounts: cellCounts,
+		SampledIDs: ids,
+	}, nil
+}
+
+// uniformPick is the degenerate path when no stratify dimensions are set
+// (or len(keys)==0 in some future caller). It shuffles and picks the
+// first n traces.
+func uniformPick(traces []Trace, n int, rng *rand.Rand, spec captureSampleSpec, seed int64, _ time.Time) ([]Trace, sampleManifest, error) {
+	tmp := append([]Trace(nil), traces...)
+	shuffle(tmp, rng)
+	if n > len(tmp) {
+		n = len(tmp)
+	}
+	out := tmp[:n]
+	ids := make([]string, 0, n)
+	for _, t := range out {
+		ids = append(ids, t.ID)
+	}
+	return out, sampleManifest{
+		Seed:       seed,
+		Spec:       captureSpecString(spec),
+		CellCounts: map[string]int{"all": n},
+		SampledIDs: ids,
+	}, nil
+}
+
+func shuffle(traces []Trace, rng *rand.Rand) {
+	rng.Shuffle(len(traces), func(i, j int) { traces[i], traces[j] = traces[j], traces[i] })
+}
+
+func sortedKeys(m map[string][]Trace) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func groupByStratum(traces []Trace, dims []string, now time.Time) map[string][]Trace {
+	cells := make(map[string][]Trace)
+	for _, t := range traces {
+		key := stratumKey(t, dims, now)
+		cells[key] = append(cells[key], t)
+	}
+	return cells
+}
+
+func applyCaptureFilters(traces []Trace, spec captureSampleSpec, now time.Time) []Trace {
+	var out []Trace
+	for _, t := range traces {
+		if spec.Recency != "" && recencyBucket(t.CapturedAt, now) != spec.Recency {
+			continue
+		}
+		if spec.HasToolCalls != nil && traceHasToolCalls(t) != *spec.HasToolCalls {
+			continue
+		}
+		if spec.HasFinalAnswerCriteria != nil {
+			has := strings.TrimSpace(t.Golden.FinalAnswerCriteria) != ""
+			if has != *spec.HasFinalAnswerCriteria {
+				continue
+			}
+		}
+		if spec.Source != "" && t.Source != spec.Source {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
+func captureSpecString(spec captureSampleSpec) string {
+	parts := []string{fmt.Sprintf("n=%d", spec.N)}
+	if len(spec.Stratify) > 0 {
+		parts = append(parts, "stratify="+strings.Join(spec.Stratify, ":"))
+	}
+	if spec.Recency != "" {
+		parts = append(parts, "recency="+spec.Recency)
+	}
+	if spec.HasToolCalls != nil {
+		parts = append(parts, fmt.Sprintf("has-tool-calls=%v", *spec.HasToolCalls))
+	}
+	if spec.HasFinalAnswerCriteria != nil {
+		parts = append(parts, fmt.Sprintf("has-final-answer-criteria=%v", *spec.HasFinalAnswerCriteria))
+	}
+	if spec.Source != "" {
+		parts = append(parts, "source="+spec.Source)
+	}
+	return strings.Join(parts, ",")
 }

--- a/cmd/llm-bench/sampling.go
+++ b/cmd/llm-bench/sampling.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// captureSampleSpec is the parsed -capture-sample flag. Reserved
+// dimensions (token-length, turn-count, has-tool-calls,
+// has-final-answer-criteria, source, recency) match spec §4.4.
+type captureSampleSpec struct {
+	N                      int
+	Stratify               []string
+	Recency                string
+	HasToolCalls           *bool
+	HasFinalAnswerCriteria *bool
+	Source                 string
+}
+
+var allowedStratifyDimensions = map[string]struct{}{
+	"token-length":              {},
+	"turn-count":                {},
+	"has-tool-calls":            {},
+	"has-final-answer-criteria": {},
+	"source":                    {},
+	"recency":                   {},
+}
+
+func parseCaptureSample(spec string) (captureSampleSpec, error) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return captureSampleSpec{}, fmt.Errorf("empty -capture-sample spec")
+	}
+	var out captureSampleSpec
+	for _, part := range strings.Split(spec, ",") {
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) != 2 {
+			return captureSampleSpec{}, fmt.Errorf("malformed token %q (expected key=value)", part)
+		}
+		key, val := strings.TrimSpace(kv[0]), strings.TrimSpace(kv[1])
+		switch key {
+		case "n":
+			n, err := strconv.Atoi(val)
+			if err != nil || n <= 0 {
+				return captureSampleSpec{}, fmt.Errorf("n=%q (want positive integer)", val)
+			}
+			out.N = n
+		case "stratify":
+			dims := strings.Split(val, ":")
+			for _, d := range dims {
+				d = strings.TrimSpace(d)
+				if _, ok := allowedStratifyDimensions[d]; !ok {
+					return captureSampleSpec{}, fmt.Errorf("unknown stratify dimension %s", d)
+				}
+				out.Stratify = append(out.Stratify, d)
+			}
+		case "recency":
+			switch val {
+			case "last-7d", "last-30d", "older":
+				out.Recency = val
+			default:
+				return captureSampleSpec{}, fmt.Errorf("recency=%q (want last-7d|last-30d|older)", val)
+			}
+		case "has-tool-calls":
+			b, err := strconv.ParseBool(val)
+			if err != nil {
+				return captureSampleSpec{}, fmt.Errorf("has-tool-calls=%q (want true|false)", val)
+			}
+			out.HasToolCalls = &b
+		case "has-final-answer-criteria":
+			b, err := strconv.ParseBool(val)
+			if err != nil {
+				return captureSampleSpec{}, fmt.Errorf("has-final-answer-criteria=%q (want true|false)", val)
+			}
+			out.HasFinalAnswerCriteria = &b
+		case "source":
+			out.Source = val
+		default:
+			return captureSampleSpec{}, fmt.Errorf("unknown key %s", key)
+		}
+	}
+	if out.N == 0 {
+		return captureSampleSpec{}, fmt.Errorf("missing required key n=")
+	}
+	return out, nil
+}

--- a/cmd/llm-bench/sampling.go
+++ b/cmd/llm-bench/sampling.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // captureSampleSpec is the parsed -capture-sample flag. Reserved
@@ -84,4 +85,86 @@ func parseCaptureSample(spec string) (captureSampleSpec, error) {
 		return captureSampleSpec{}, fmt.Errorf("missing required key n=")
 	}
 	return out, nil
+}
+
+// tokenLengthBucket maps total content rune-count to size buckets.
+// The conversion factor (~4 runes/token) mirrors the rough estimate
+// used elsewhere in the harness; it overestimates for code-heavy
+// content, which is fine for stratification.
+// Boundaries: small ≤ 4 000 runes (~1 k tokens), medium ≤ 32 000 (~8 k tokens).
+func tokenLengthBucket(runes int) string {
+	switch {
+	case runes <= 4000:
+		return "small"
+	case runes <= 32000:
+		return "medium"
+	default:
+		return "large"
+	}
+}
+
+func turnCountBucket(n int) string {
+	switch {
+	case n <= 2:
+		return "short"
+	case n <= 10:
+		return "medium"
+	default:
+		return "long"
+	}
+}
+
+func recencyBucket(capturedAt, now time.Time) string {
+	delta := now.Sub(capturedAt)
+	switch {
+	case delta <= 7*24*time.Hour:
+		return "last-7d"
+	case delta <= 30*24*time.Hour:
+		return "last-30d"
+	default:
+		return "older"
+	}
+}
+
+func stratumKey(t Trace, dims []string, now time.Time) string {
+	if len(dims) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(dims))
+	for _, dim := range dims {
+		parts = append(parts, dim+"="+stratumValue(t, dim, now))
+	}
+	return strings.Join(parts, "|")
+}
+
+func stratumValue(t Trace, dim string, now time.Time) string {
+	switch dim {
+	case "token-length":
+		var n int
+		for _, turn := range t.Turns {
+			n += len([]rune(turn.Content))
+		}
+		return tokenLengthBucket(n)
+	case "turn-count":
+		return turnCountBucket(len(t.Turns))
+	case "has-tool-calls":
+		return strconv.FormatBool(traceHasToolCalls(t))
+	case "has-final-answer-criteria":
+		return strconv.FormatBool(strings.TrimSpace(t.Golden.FinalAnswerCriteria) != "")
+	case "source":
+		return t.Source
+	case "recency":
+		return recencyBucket(t.CapturedAt, now)
+	default:
+		return "unknown"
+	}
+}
+
+func traceHasToolCalls(t Trace) bool {
+	for _, turn := range t.Turns {
+		if turn.Role == "assistant" && len(turn.ToolCalls) > 0 {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/llm-bench/sampling_test.go
+++ b/cmd/llm-bench/sampling_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestParseCaptureSample(t *testing.T) {
@@ -71,4 +72,52 @@ func TestParseCaptureSample(t *testing.T) {
 func trueBool() *bool {
 	b := true
 	return &b
+}
+
+func TestTokenLengthBucket(t *testing.T) {
+	cases := []struct {
+		runes int
+		want  string
+	}{
+		{0, "small"},
+		{3500, "small"},
+		{4000, "small"}, // ~1k tokens at 4 bytes/token
+		{4001, "medium"},
+		{32000, "medium"},
+		{32001, "large"},
+	}
+	for _, tc := range cases {
+		if got := tokenLengthBucket(tc.runes); got != tc.want {
+			t.Errorf("tokenLengthBucket(%d)=%q; want %q", tc.runes, got, tc.want)
+		}
+	}
+}
+
+func TestTurnCountBucket(t *testing.T) {
+	if got := turnCountBucket(2); got != "short" {
+		t.Errorf("turnCountBucket(2)=%q; want short", got)
+	}
+	if got := turnCountBucket(5); got != "medium" {
+		t.Errorf("turnCountBucket(5)=%q; want medium", got)
+	}
+	if got := turnCountBucket(20); got != "long" {
+		t.Errorf("turnCountBucket(20)=%q; want long", got)
+	}
+}
+
+func TestRecencyBucket(t *testing.T) {
+	now := time.Date(2026, 5, 26, 0, 0, 0, 0, time.UTC)
+	cases := []struct {
+		captured time.Time
+		want     string
+	}{
+		{now.Add(-3 * 24 * time.Hour), "last-7d"},
+		{now.Add(-15 * 24 * time.Hour), "last-30d"},
+		{now.Add(-60 * 24 * time.Hour), "older"},
+	}
+	for _, tc := range cases {
+		if got := recencyBucket(tc.captured, now); got != tc.want {
+			t.Errorf("recencyBucket=%q; want %q", got, tc.want)
+		}
+	}
 }

--- a/cmd/llm-bench/sampling_test.go
+++ b/cmd/llm-bench/sampling_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -120,4 +121,120 @@ func TestRecencyBucket(t *testing.T) {
 			t.Errorf("recencyBucket=%q; want %q", got, tc.want)
 		}
 	}
+}
+
+func TestStratifiedSampleDeterministicWithSeed(t *testing.T) {
+	traces := makeStratificationFixture(60)
+	spec, _ := parseCaptureSample("n=20,stratify=turn-count")
+	now := time.Date(2026, 5, 26, 0, 0, 0, 0, time.UTC)
+
+	got1, manifest1, _ := stratifiedSample(traces, spec, 42, now)
+	got2, manifest2, _ := stratifiedSample(traces, spec, 42, now)
+	if !reflect.DeepEqual(got1, got2) {
+		t.Fatalf("seed=42 produced different selections")
+	}
+	if !reflect.DeepEqual(manifest1.SampledIDs, manifest2.SampledIDs) {
+		t.Fatalf("manifest IDs differ across runs with same seed")
+	}
+	if manifest1.Seed != 42 {
+		t.Fatalf("manifest.Seed=%d; want 42", manifest1.Seed)
+	}
+}
+
+func TestStratifiedSampleRedistributesSlack(t *testing.T) {
+	// Cells: short=2, medium=50. n=20, 2 cells → 10 each, short cell
+	// only has 2 → slack of 8 must go to medium, yielding 2+18=20 total.
+	traces := makeTwoCellFixture(2, 50)
+	spec, _ := parseCaptureSample("n=20,stratify=turn-count")
+	now := time.Now()
+	got, manifest, _ := stratifiedSample(traces, spec, 1, now)
+	if len(got) != 20 {
+		t.Fatalf("got %d sampled; want 20 (slack redistribution)", len(got))
+	}
+	if manifest.CellCounts["turn-count=short"] != 2 {
+		t.Fatalf("short cell sampled %d; want 2 (all)", manifest.CellCounts["turn-count=short"])
+	}
+	if manifest.CellCounts["turn-count=medium"] != 18 {
+		t.Fatalf("medium cell sampled %d; want 18 (10 + 8 slack)", manifest.CellCounts["turn-count=medium"])
+	}
+}
+
+func TestStratifiedSampleRespectsHardFilters(t *testing.T) {
+	// Half the traces have a final-answer-criteria; spec filters for them.
+	traces := makeHalfWithCriteria(40)
+	spec, _ := parseCaptureSample("n=10,stratify=turn-count,has-final-answer-criteria=true")
+	got, _, _ := stratifiedSample(traces, spec, 7, time.Now())
+	for _, tr := range got {
+		if strings.TrimSpace(tr.Golden.FinalAnswerCriteria) == "" {
+			t.Fatalf("sampled trace %q has no final-answer-criteria but filter required it", tr.ID)
+		}
+	}
+}
+
+func TestStratifiedSampleDoesNotOversampleWhenMoreCellsThanN(t *testing.T) {
+	traces := makeStratificationFixture(3) // short, medium, long cells
+	spec, _ := parseCaptureSample("n=2,stratify=turn-count")
+	got, manifest, _ := stratifiedSample(traces, spec, 9, time.Now())
+	if len(got) != 2 {
+		t.Fatalf("got %d sampled; want exactly 2 when cells > n", len(got))
+	}
+	var counted int
+	for _, n := range manifest.CellCounts {
+		counted += n
+	}
+	if counted != 2 {
+		t.Fatalf("manifest counted %d sampled traces; want exactly 2", counted)
+	}
+}
+
+// makeStratificationFixture returns N traces with rotating turn-counts
+// (1, 5, 12) so the turn-count bucket cycles through short/medium/long.
+func makeStratificationFixture(n int) []Trace {
+	out := make([]Trace, n)
+	for i := range out {
+		turns := []int{1, 5, 12}[i%3]
+		out[i] = Trace{
+			ID:    fmt.Sprintf("trace-%03d", i),
+			Turns: makeTurns(turns),
+		}
+	}
+	return out
+}
+
+// makeTwoCellFixture returns short turn-count traces followed by
+// medium turn-count traces, in that order.
+func makeTwoCellFixture(short, medium int) []Trace {
+	out := make([]Trace, 0, short+medium)
+	for i := 0; i < short; i++ {
+		out = append(out, Trace{ID: fmt.Sprintf("s-%03d", i), Turns: makeTurns(1)})
+	}
+	for i := 0; i < medium; i++ {
+		out = append(out, Trace{ID: fmt.Sprintf("m-%03d", i), Turns: makeTurns(5)})
+	}
+	return out
+}
+
+// makeHalfWithCriteria returns N traces, the first half with a
+// non-empty FinalAnswerCriteria, the second half empty.
+func makeHalfWithCriteria(n int) []Trace {
+	out := make([]Trace, n)
+	for i := range out {
+		out[i] = Trace{ID: fmt.Sprintf("c-%03d", i), Turns: makeTurns(5)}
+		if i < n/2 {
+			out[i].Golden = Golden{FinalAnswerCriteria: "non-empty"}
+		}
+	}
+	return out
+}
+
+func makeTurns(n int) []Turn {
+	out := make([]Turn, n)
+	for i := range out {
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		out[i] = Turn{Role: role, Content: "hi"}
+	}
+	return out
 }

--- a/cmd/llm-bench/sampling_test.go
+++ b/cmd/llm-bench/sampling_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseCaptureSample(t *testing.T) {
+	cases := []struct {
+		name    string
+		spec    string
+		want    captureSampleSpec
+		wantErr string
+	}{
+		{
+			name: "n-only",
+			spec: "n=20",
+			want: captureSampleSpec{N: 20},
+		},
+		{
+			name: "stratify-and-filters",
+			spec: "n=50,stratify=token-length:turn-count,recency=last-30d,has-tool-calls=true",
+			want: captureSampleSpec{
+				N:            50,
+				Stratify:     []string{"token-length", "turn-count"},
+				Recency:      "last-30d",
+				HasToolCalls: trueBool(),
+			},
+		},
+		{
+			name:    "empty-rejected",
+			spec:    "",
+			wantErr: "empty",
+		},
+		{
+			name:    "unknown-key",
+			spec:    "n=10,wat=1",
+			wantErr: "unknown key wat",
+		},
+		{
+			name:    "bad-n",
+			spec:    "n=zero",
+			wantErr: "n=",
+		},
+		{
+			name:    "bad-stratify-dimension",
+			spec:    "n=10,stratify=wat",
+			wantErr: "unknown stratify dimension wat",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseCaptureSample(tc.spec)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err=%v; want %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("got %+v; want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func trueBool() *bool {
+	b := true
+	return &b
+}

--- a/docs/llm/benchmark-plan.md
+++ b/docs/llm/benchmark-plan.md
@@ -174,9 +174,22 @@ First implementation slice:
   semantics). When no transport is configured, capture writes
   `trace.Tools = []` and replay reports `ToolArgsValid` as
   not-computed.
-- Feedback-driven sampling is deferred until feedback rows can be tied
-  to conversations; today `feedback_retrievals` and `feedback_signals`
-  do not carry a conversation id.
+- Capture-derivable stratification: `llm-bench -capture -capture-sample
+  <spec>` partitions the enriched trace pool by any cross-product of
+  `token-length`, `turn-count`, `has-tool-calls`,
+  `has-final-answer-criteria`, `source`, and `recency`, then samples
+  uniformly within each cell. The seed (`-capture-sample-seed`) makes
+  the selection reproducible across machines; a `_sample-manifest.json`
+  in the output directory records the seed, parsed spec, cell counts,
+  and the IDs of every trace written.
+- The sampling pipeline runs `list → convert → enrich → sample → write`,
+  so conversations skipped during enrichment (e.g. undeclared tool
+  references) are not eligible for sampling and never appear in the
+  manifest.
+- Feedback-driven sampling is still deferred: today
+  `feedback_retrievals` and `feedback_signals` do not carry a
+  conversation id. Once retrieval/session provenance lands, a future
+  capture flag can join sampling against that source.
 
 ### Phase 3 — LLM-as-judge scorer
 


### PR DESCRIPTION
## Summary
- Registers `-capture-sample <spec>` with deterministic stratified sampling: comma-separated grammar (`n=`, `stratify=`, `recency=`, `has-tool-calls=`, `has-final-answer-criteria=`, `source=`), six allowed stratify dimensions, hard filters applied before grouping.
- Wires a three-phase capture pipeline (`list → convert → enrich → sample → write`) so conversations skipped during enrichment (e.g. undeclared tool references) are never sampling candidates, and `_sample-manifest.json` describes exactly the written set.
- Implements floor+remainder allocation with slack redistribution: short cells donate unused slots to non-empty cells, and the allocator never emits more than `n` traces when cells outnumber the target. Determinism comes from sorted cell-key iteration plus a seeded RNG (`-capture-sample-seed`, default `time.Now().UnixNano()`).
- Replaces the B1 placeholder `-capture-sample: sampling not yet implemented (track B2)` hard error in `resolveCaptureSample`.
- Documents sampling in Phase 2 of `docs/llm/benchmark-plan.md`; feedback-driven sampling remains deferred (no conversation-id seam on feedback rows yet).

## Spec
- Implements §4.4 of `docs/superpowers/specs/2026-05-25-harness-followups-design.md` (gitignored).
- PR A (#123 + #124) and PR B1 (#126) already on develop; this is the next PR in the harness-followups track.

## Test plan
- [x] `go test -race ./cmd/llm-bench/...`
- [x] `go vet ./...`
- [x] Manual smoke: `llm-bench -capture -capture-db <local> -capture-sample 'n=10,stratify=turn-count' -capture-sample-seed 42 -capture-out <dir>` writes ≤10 traces plus `_sample-manifest.json` containing the seed, parsed spec, cell counts, and sampled IDs.
- [x] Second smoke run with the same seed produces identical `SampledIDs` (reproducibility check).

Generated with [Claude Code](https://claude.com/claude-code)