### PR TITLE
feat(llm-bench): citable recommendation scaffolding (PR C)

### DIFF
--- a/cmd/llm-bench/doc_lint_test.go
+++ b/cmd/llm-bench/doc_lint_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// docPath returns the absolute path of a docs/llm/<name> file relative
+// to this test's package directory (cmd/llm-bench/). Tests run with cwd
+// = package dir, so docs/llm lives two levels up.
+func docPath(name string) string {
+	return filepath.Join("..", "..", "docs", "llm", name)
+}
+
+func readDoc(t *testing.T, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(docPath(name))
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(data)
+}
+
+func TestAnalysisMDHasHistoricalBanner(t *testing.T) {
+	body := readDoc(t, "analysis.md")
+	if !strings.HasPrefix(body, "> **Status — 2026-05-25**:") {
+		first := body
+		if len(first) > 80 {
+			first = first[:80]
+		}
+		t.Fatalf("analysis.md must start with the historical banner; first 80 chars: %q", first)
+	}
+	if !strings.Contains(body, "[harness-results.md](harness-results.md)") {
+		t.Errorf("analysis.md banner must link to harness-results.md")
+	}
+	if !strings.Contains(body, "[benchmarks/](benchmarks/)") {
+		t.Errorf("analysis.md banner must link to benchmarks/")
+	}
+}
+
+func TestHarnessResultsHasAcceptanceGate(t *testing.T) {
+	body := readDoc(t, "harness-results.md")
+	for _, must := range []string{
+		"## Acceptance gate",
+		"`dirty: no`",
+		"Calibration PASS",
+		"Judge cache hit-rate",
+		"`ToolArgsValid` is `computed=true`",
+		"manifest hash",
+		"reviewed by the repo owner",
+	} {
+		if !strings.Contains(body, must) {
+			t.Errorf("harness-results.md missing required acceptance criterion fragment %q", must)
+		}
+	}
+}
+
+func TestRecommendationCitationOnceFirstRunAccepted(t *testing.T) {
+	// Conditional check — runs only after the first accepted-run PR
+	// replaces the "No accepted runs yet" placeholder in
+	// harness-results.md. While scaffolding-only, this is a no-op.
+	results := readDoc(t, "harness-results.md")
+	if strings.Contains(results, "No accepted runs yet") {
+		t.Skip("scaffolding state: no accepted run yet — recommendation lint deferred")
+	}
+	rec := readDoc(t, "recommendation.md")
+	if !strings.Contains(rec, "[harness-results.md](harness-results.md)") {
+		t.Errorf("recommendation.md must cite harness-results.md once a run is accepted")
+	}
+	// Once an accepted run exists, the "April 2026 analysis" framing
+	// must only appear inside historical contexts, not as a current
+	// citation.
+	if strings.Count(rec, "April 2026 analysis") > 0 {
+		// Tolerate inside a quote/blockquote, but reject as a top-level claim.
+		// The cheapest reliable check: every occurrence must be on a line
+		// that also contains "historical" or starts with ">".
+		lines := strings.Split(rec, "\n")
+		for _, line := range lines {
+			if strings.Contains(line, "April 2026 analysis") &&
+				!strings.Contains(line, "historical") &&
+				!strings.HasPrefix(strings.TrimSpace(line), ">") {
+				t.Errorf("recommendation.md still cites April 2026 analysis as current evidence: %q", line)
+			}
+		}
+	}
+}
+
+func TestBenchmarksTemplateExists(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join("..", "..", "docs", "llm", "benchmarks", "TEMPLATE.md"))
+	if err != nil {
+		t.Fatalf("read TEMPLATE.md: %v", err)
+	}
+	for _, must := range []string{
+		"## Provenance",
+		"## Calibration",
+		"## Results",
+		"## Conclusion",
+		"## Caveats",
+		"AnswerQuality (mean / p25 / p50 / p75 / p90)",
+		"ToolArgsValid (computed=N)",
+	} {
+		if !strings.Contains(string(body), must) {
+			t.Errorf("TEMPLATE.md missing required section/column fragment %q", must)
+		}
+	}
+}

--- a/cmd/llm-bench/doc_lint_test.go
+++ b/cmd/llm-bench/doc_lint_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -23,14 +24,16 @@ func readDoc(t *testing.T, name string) string {
 	return string(data)
 }
 
+var analysisBannerPrefixRegexp = regexp.MustCompile(`^> \*\*Status — \d{4}-\d{2}-\d{2}\*\*:`)
+
 func TestAnalysisMDHasHistoricalBanner(t *testing.T) {
 	body := readDoc(t, "analysis.md")
-	if !strings.HasPrefix(body, "> **Status — 2026-05-25**:") {
+	if !analysisBannerPrefixRegexp.MatchString(body) {
 		first := body
 		if len(first) > 80 {
 			first = first[:80]
 		}
-		t.Fatalf("analysis.md must start with the historical banner; first 80 chars: %q", first)
+		t.Fatalf("analysis.md must start with `> **Status — YYYY-MM-DD**:` historical banner; first 80 chars: %q", first)
 	}
 	if !strings.Contains(body, "[harness-results.md](harness-results.md)") {
 		t.Errorf("analysis.md banner must link to harness-results.md")

--- a/cmd/llm-bench/judge_cache.go
+++ b/cmd/llm-bench/judge_cache.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	_ "modernc.org/sqlite"
@@ -70,6 +71,7 @@ type judgeCacheEntry struct {
 type judgeCacheStore interface {
 	Get(ctx context.Context, key string) (judgeCacheEntry, bool, error)
 	Put(ctx context.Context, e judgeCacheEntry) error
+	Stats() (hits, misses int64)
 	Close() error
 }
 
@@ -87,7 +89,9 @@ var (
 // to construct one (it handles migrations); callers MUST treat all returned
 // errors as non-fatal and degrade to an uncached judge call.
 type sqliteJudgeCache struct {
-	db *sql.DB
+	db     *sql.DB
+	hits   atomic.Int64
+	misses atomic.Int64
 }
 
 // openJudgeCache opens (and migrates) the judge cache DB at path. Empty
@@ -111,6 +115,7 @@ func openJudgeCache(path string) (*sqliteJudgeCache, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("%w %q: %v", errJudgeCacheOpen, path, err)
 	}
+	db.SetMaxOpenConns(1) // SQLite does not support concurrent writers; serialize all ops.
 	if err := migrateJudgeCache(db); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("%w: %v", errJudgeCacheMigrate, err)
@@ -190,6 +195,13 @@ func migrateJudgeCache(db *sql.DB) error {
 	return nil
 }
 
+// Stats returns the running hit/miss counters since this cache was
+// opened. Counters are atomic and safe under concurrent Get callers.
+// Per spec §5.2 these participate in the benchmark provenance block.
+func (c *sqliteJudgeCache) Stats() (int64, int64) {
+	return c.hits.Load(), c.misses.Load()
+}
+
 // Get returns the entry for key plus ok=true on hit, ok=false on miss.
 // On a hit, hit_count is bumped and last_used_at is set to now; the
 // returned entry reflects the post-bump values so caller telemetry sees
@@ -208,6 +220,7 @@ func (c *sqliteJudgeCache) Get(ctx context.Context, key string) (judgeCacheEntry
 		&createdNs, &lastUsedNs, &e.HitCount,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
+		c.misses.Add(1)
 		return judgeCacheEntry{}, false, nil
 	}
 	if err != nil {
@@ -225,6 +238,7 @@ func (c *sqliteJudgeCache) Get(ctx context.Context, key string) (judgeCacheEntry
 	}
 	e.HitCount++
 	e.LastUsedAt = time.Unix(0, nowNs).UTC()
+	c.hits.Add(1)
 	return e, true, nil
 }
 

--- a/cmd/llm-bench/judge_cache.go
+++ b/cmd/llm-bench/judge_cache.go
@@ -41,7 +41,14 @@ type judgeCacheRequest struct {
 // encoding/json's stable struct-tag ordering (Go's encoding/json marshals
 // struct fields in declaration order), then SHA-256s the bytes.
 func canonicalCacheKey(r judgeCacheRequest) string {
-	raw, _ := json.Marshal(r) // marshaling a fixed-shape struct cannot fail
+	raw, err := json.Marshal(r)
+	if err != nil {
+		// judgeCacheRequest is a fixed-shape struct of primitive types
+		// (string/int/float/bool); marshaling cannot fail without a future
+		// breaking change. Panic so the cache never silently produces
+		// sha256("") and collides every key.
+		panic(fmt.Sprintf("canonicalCacheKey: json.Marshal failed on fixed-shape struct: %v", err))
+	}
 	sum := sha256.Sum256(raw)
 	return hex.EncodeToString(sum[:])
 }
@@ -111,11 +118,11 @@ func openJudgeCache(path string) (*sqliteJudgeCache, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%w %q: %v", errJudgeCacheOpen, path, err)
 	}
+	db.SetMaxOpenConns(1) // SQLite does not support concurrent writers; serialize all ops.
 	if err := db.Ping(); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("%w %q: %v", errJudgeCacheOpen, path, err)
 	}
-	db.SetMaxOpenConns(1) // SQLite does not support concurrent writers; serialize all ops.
 	if err := migrateJudgeCache(db); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("%w: %v", errJudgeCacheMigrate, err)
@@ -234,10 +241,13 @@ func (c *sqliteJudgeCache) Get(ctx context.Context, key string) (judgeCacheEntry
 		`UPDATE judge_cache SET hit_count = hit_count + 1, last_used_at = ? WHERE cache_key = ?`,
 		nowNs, key,
 	); err != nil {
-		return judgeCacheEntry{}, false, fmt.Errorf("%w hit-count for key %s: %v", errJudgeCacheGet, key, err)
+		// Hit-count is observational; surface to stderr but keep the verdict
+		// so the caller is not forced to re-invoke the judge.
+		fmt.Fprintf(os.Stderr, "llm-bench: judge cache hit-count update failed (key=%s): %v\n", key, err)
+	} else {
+		e.HitCount++
+		e.LastUsedAt = time.Unix(0, nowNs).UTC()
 	}
-	e.HitCount++
-	e.LastUsedAt = time.Unix(0, nowNs).UTC()
 	c.hits.Add(1)
 	return e, true, nil
 }

--- a/cmd/llm-bench/judge_cache.go
+++ b/cmd/llm-bench/judge_cache.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"database/sql"
@@ -49,7 +50,11 @@ func canonicalCacheKey(r judgeCacheRequest) string {
 		// sha256("") and collides every key.
 		panic(fmt.Sprintf("canonicalCacheKey: json.Marshal failed on fixed-shape struct: %v", err))
 	}
-	sum := sha256.Sum256(raw)
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, raw); err != nil {
+		panic(fmt.Sprintf("canonicalCacheKey: json.Compact failed: %v", err))
+	}
+	sum := sha256.Sum256(compact.Bytes())
 	return hex.EncodeToString(sum[:])
 }
 

--- a/cmd/llm-bench/judge_cache_test.go
+++ b/cmd/llm-bench/judge_cache_test.go
@@ -200,3 +200,94 @@ func TestSQLiteJudgeCache_ConcurrentGetPut_NoRace(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+func TestJudgeCacheStatsStartAtZero(t *testing.T) {
+	dir := t.TempDir()
+	c, err := openJudgeCache(filepath.Join(dir, "cache.db"))
+	if err != nil {
+		t.Fatalf("openJudgeCache: %v", err)
+	}
+	defer c.Close()
+	hits, misses := c.Stats()
+	if hits != 0 || misses != 0 {
+		t.Fatalf("initial Stats() = (%d,%d); want (0,0)", hits, misses)
+	}
+}
+
+func TestJudgeCacheStatsIncrement(t *testing.T) {
+	dir := t.TempDir()
+	c, err := openJudgeCache(filepath.Join(dir, "cache.db"))
+	if err != nil {
+		t.Fatalf("openJudgeCache: %v", err)
+	}
+	defer c.Close()
+	ctx := context.Background()
+
+	if _, ok, err := c.Get(ctx, "key-A"); err != nil || ok {
+		t.Fatalf("first Get: ok=%v err=%v; want ok=false err=nil", ok, err)
+	}
+	hits, misses := c.Stats()
+	if hits != 0 || misses != 1 {
+		t.Fatalf("after one miss Stats() = (%d,%d); want (0,1)", hits, misses)
+	}
+
+	// Use a Put with realistic fields so the migrated table accepts the row.
+	if err := c.Put(ctx, judgeCacheEntry{
+		CacheKey:        "key-A",
+		JudgeModel:      "test-judge",
+		TraceID:         "t",
+		CandidateModel:  "test-cand",
+		PromptHash:      "ph",
+		RequestJSON:     "{}",
+		ResponseContent: "{}",
+	}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if _, ok, err := c.Get(ctx, "key-A"); err != nil || !ok {
+		t.Fatalf("second Get: ok=%v err=%v; want ok=true err=nil", ok, err)
+	}
+	hits, misses = c.Stats()
+	if hits != 1 || misses != 1 {
+		t.Fatalf("after hit Stats() = (%d,%d); want (1,1)", hits, misses)
+	}
+}
+
+func TestJudgeCacheStatsAreConcurrentSafe(t *testing.T) {
+	dir := t.TempDir()
+	c, err := openJudgeCache(filepath.Join(dir, "cache.db"))
+	if err != nil {
+		t.Fatalf("openJudgeCache: %v", err)
+	}
+	defer c.Close()
+	ctx := context.Background()
+
+	if err := c.Put(ctx, judgeCacheEntry{
+		CacheKey:        "k",
+		JudgeModel:      "test-judge",
+		TraceID:         "t",
+		CandidateModel:  "test-cand",
+		PromptHash:      "ph",
+		RequestJSON:     "{}",
+		ResponseContent: "{}",
+	}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	const goroutines = 8
+	const ops = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < ops; j++ {
+				_, _, _ = c.Get(ctx, "k")
+			}
+		}()
+	}
+	wg.Wait()
+	hits, misses := c.Stats()
+	if hits != goroutines*ops || misses != 0 {
+		t.Fatalf("hits=%d misses=%d; want hits=%d misses=0", hits, misses, goroutines*ops)
+	}
+}

--- a/cmd/llm-bench/judge_cache_test.go
+++ b/cmd/llm-bench/judge_cache_test.go
@@ -291,3 +291,31 @@ func TestJudgeCacheStatsAreConcurrentSafe(t *testing.T) {
 		t.Fatalf("hits=%d misses=%d; want hits=%d misses=0", hits, misses, goroutines*ops)
 	}
 }
+
+func TestJudgeCacheGetPreservesVerdictOnHit(t *testing.T) {
+	dir := t.TempDir()
+	c, err := openJudgeCache(filepath.Join(dir, "cache.db"))
+	if err != nil {
+		t.Fatalf("openJudgeCache: %v", err)
+	}
+	defer c.Close()
+	ctx := context.Background()
+	want := judgeCacheEntry{
+		CacheKey: "k", JudgeModel: "j", TraceID: "t", CandidateModel: "cm",
+		PromptHash: "p", RequestJSON: "{}", ResponseContent: `{"answer_quality":0.7}`,
+		AnswerQuality: 0.7, Justification: "good",
+	}
+	if err := c.Put(ctx, want); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, ok, err := c.Get(ctx, "k")
+	if err != nil || !ok {
+		t.Fatalf("Get: ok=%v err=%v", ok, err)
+	}
+	if got.AnswerQuality != want.AnswerQuality {
+		t.Fatalf("Get returned AnswerQuality=%v; want %v", got.AnswerQuality, want.AnswerQuality)
+	}
+	if got.Justification != want.Justification {
+		t.Fatalf("Get returned Justification=%q; want %q", got.Justification, want.Justification)
+	}
+}

--- a/cmd/llm-bench/judge_cache_test.go
+++ b/cmd/llm-bench/judge_cache_test.go
@@ -75,8 +75,17 @@ func newTestCache(t *testing.T) (*sqliteJudgeCache, string) {
 	if err != nil {
 		t.Fatalf("openJudgeCache: %v", err)
 	}
-	t.Cleanup(func() { _ = c.Close() })
+	cleanupJudgeCache(t, c)
 	return c, path
+}
+
+func cleanupJudgeCache(t *testing.T, c *sqliteJudgeCache) {
+	t.Helper()
+	t.Cleanup(func() {
+		if err := c.Close(); err != nil {
+			t.Errorf("close judge cache: %v", err)
+		}
+	})
 }
 
 func TestSQLiteJudgeCache_PutThenGetReturnsEntry(t *testing.T) {
@@ -129,7 +138,7 @@ func TestSQLiteJudgeCache_MigrationIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("re-open: %v", err)
 	}
-	defer func() { _ = c2.Close() }()
+	cleanupJudgeCache(t, c2)
 }
 
 func TestOpenJudgeCache_CreatesParentDirectory(t *testing.T) {
@@ -138,7 +147,7 @@ func TestOpenJudgeCache_CreatesParentDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openJudgeCache: %v", err)
 	}
-	defer func() { _ = c.Close() }()
+	cleanupJudgeCache(t, c)
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("cache file stat: %v", err)
 	}
@@ -207,7 +216,7 @@ func TestJudgeCacheStatsStartAtZero(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openJudgeCache: %v", err)
 	}
-	defer c.Close()
+	cleanupJudgeCache(t, c)
 	hits, misses := c.Stats()
 	if hits != 0 || misses != 0 {
 		t.Fatalf("initial Stats() = (%d,%d); want (0,0)", hits, misses)
@@ -220,7 +229,7 @@ func TestJudgeCacheStatsIncrement(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openJudgeCache: %v", err)
 	}
-	defer c.Close()
+	cleanupJudgeCache(t, c)
 	ctx := context.Background()
 
 	if _, ok, err := c.Get(ctx, "key-A"); err != nil || ok {
@@ -258,7 +267,7 @@ func TestJudgeCacheStatsAreConcurrentSafe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openJudgeCache: %v", err)
 	}
-	defer c.Close()
+	cleanupJudgeCache(t, c)
 	ctx := context.Background()
 
 	if err := c.Put(ctx, judgeCacheEntry{
@@ -298,7 +307,7 @@ func TestJudgeCacheGetPreservesVerdictOnHit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openJudgeCache: %v", err)
 	}
-	defer c.Close()
+	cleanupJudgeCache(t, c)
 	ctx := context.Background()
 	want := judgeCacheEntry{
 		CacheKey: "k", JudgeModel: "j", TraceID: "t", CandidateModel: "cm",

--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -222,6 +222,9 @@ func main() {
 		log.Fatalf("llm-bench: load traces: %v", err)
 	}
 
+	traceSetHash := traceSetManifestHash(traces)
+	log.Printf("llm-bench: trace set manifest hash %s (n=%d)", traceSetHash, len(traces))
+
 	resolvedJudgeModel := strings.TrimSpace(*judgeModel)
 	if *scorerName == "llm-judge" && resolvedJudgeModel == "" {
 		resolvedJudgeModel = defaultJudgeModelName()
@@ -265,14 +268,22 @@ func main() {
 		log.Fatalf("llm-bench: run: %v", err)
 	}
 
+	var judgeCacheHits, judgeCacheMisses int64
+	if cacheStore != nil {
+		judgeCacheHits, judgeCacheMisses = cacheStore.Stats()
+	}
+
 	modelNames := make([]string, 0, len(targets))
 	for _, target := range targets {
 		modelNames = append(modelNames, target.Display)
 	}
 
 	report := formatReport(modelNames, results, reportOptions{
-		Scorer:     *scorerName,
-		JudgeModel: resolvedJudgeModel,
+		Scorer:               *scorerName,
+		JudgeModel:           resolvedJudgeModel,
+		JudgeCacheHits:       judgeCacheHits,
+		JudgeCacheMisses:     judgeCacheMisses,
+		TraceSetManifestHash: traceSetHash,
 	})
 
 	if *reportPath == "" {

--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -163,7 +163,7 @@ func main() {
 		// pointer is genuinely non-nil.
 		var cacheStore judgeCacheStore
 		if c, err := openJudgeCache(*judgeCachePath); err != nil {
-			fmt.Fprintf(os.Stderr, "llm-bench: judge cache disabled: %v\n", err)
+			fmt.Fprintf(os.Stderr, "llm-bench: judge cache disabled (%s)\n", redactErrorMessage(err.Error()))
 		} else if c != nil {
 			cacheStore = c
 			defer func() { _ = c.Close() }()
@@ -241,7 +241,7 @@ func main() {
 	// non-nil.
 	var cacheStore judgeCacheStore
 	if c, err := openJudgeCache(*judgeCachePath); err != nil {
-		fmt.Fprintf(os.Stderr, "llm-bench: judge cache disabled: %v\n", err)
+		fmt.Fprintf(os.Stderr, "llm-bench: judge cache disabled (%s)\n", redactErrorMessage(err.Error()))
 	} else if c != nil {
 		cacheStore = c
 		defer func() { _ = c.Close() }()

--- a/cmd/llm-bench/percentiles.go
+++ b/cmd/llm-bench/percentiles.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"math"
+	"sort"
+)
+
+// percentiles returns nearest-rank percentiles for the given fractions
+// (each in [0,1]). NaN is returned for every fraction when values is
+// empty so callers can decide whether to render "n/a" or hide the row.
+// Nearest-rank: for ordered sample of size N, p_q is the value at
+// 1-indexed rank ceil(q*N), or the last element when q==0 or N==1.
+func percentiles(values []float64, fractions ...float64) []float64 {
+	out := make([]float64, len(fractions))
+	if len(values) == 0 {
+		for i := range out {
+			out[i] = math.NaN()
+		}
+		return out
+	}
+	sorted := append([]float64(nil), values...)
+	sort.Float64s(sorted)
+	for i, q := range fractions {
+		out[i] = sorted[percentileIndex(len(sorted), q)]
+	}
+	return out
+}
+
+// int64Percentiles mirrors percentiles for integer latency samples.
+// Empty input returns zeros — callers should length-check before
+// interpreting (latency in ms is always non-negative so 0 is a valid
+// observation).
+func int64Percentiles(values []int64, fractions ...float64) []int64 {
+	out := make([]int64, len(fractions))
+	if len(values) == 0 {
+		return out
+	}
+	sorted := append([]int64(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	for i, q := range fractions {
+		out[i] = sorted[percentileIndex(len(sorted), q)]
+	}
+	return out
+}
+
+func percentileIndex(n int, q float64) int {
+	if q <= 0 {
+		return 0
+	}
+	if q >= 1 {
+		return n - 1
+	}
+	rank := int(math.Ceil(q * float64(n)))
+	if rank <= 0 {
+		rank = 1
+	}
+	if rank > n {
+		rank = n
+	}
+	return rank - 1
+}

--- a/cmd/llm-bench/percentiles_test.go
+++ b/cmd/llm-bench/percentiles_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"math"
+	"reflect"
+	"testing"
+)
+
+func TestPercentilesEmpty(t *testing.T) {
+	got := percentiles(nil, 0.25, 0.5, 0.75)
+	if len(got) != 3 {
+		t.Fatalf("len=%d; want 3", len(got))
+	}
+	for i, v := range got {
+		if !math.IsNaN(v) {
+			t.Errorf("got[%d]=%v; want NaN", i, v)
+		}
+	}
+}
+
+func TestPercentilesSingle(t *testing.T) {
+	got := percentiles([]float64{0.42}, 0.25, 0.5, 0.75, 0.9)
+	want := []float64{0.42, 0.42, 0.42, 0.42}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v; want %v", got, want)
+	}
+}
+
+func TestPercentilesEvenSplit(t *testing.T) {
+	// Nearest-rank: for N=4 values [1,2,3,4], p25 → rank ceil(0.25*4)=1 → values[0]=1.
+	got := percentiles([]float64{1, 2, 3, 4}, 0.25, 0.5, 0.75, 1.0)
+	want := []float64{1, 2, 3, 4}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v; want %v", got, want)
+	}
+}
+
+func TestPercentilesRequiresSortedOutputDespiteShuffledInput(t *testing.T) {
+	got := percentiles([]float64{4, 2, 1, 3}, 0.5)
+	if got[0] != 2 {
+		t.Fatalf("p50 of [4,2,1,3] = %v; want 2 (nearest-rank ceil(0.5*4)=2 → sorted[1]=2)", got[0])
+	}
+}
+
+func TestInt64PercentilesEqualValues(t *testing.T) {
+	got := int64Percentiles([]int64{100, 100, 100}, 0.5, 0.9)
+	if got[0] != 100 || got[1] != 100 {
+		t.Fatalf("got %v; want [100 100]", got)
+	}
+}
+
+func TestInt64PercentilesP90KnownFixture(t *testing.T) {
+	// N=10 → p90 → ceil(0.9*10)=9 → sorted[8]
+	xs := []int64{10, 20, 30, 40, 50, 60, 70, 80, 90, 100}
+	got := int64Percentiles(xs, 0.9)
+	if got[0] != 90 {
+		t.Fatalf("p90 = %v; want 90", got[0])
+	}
+}

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -69,7 +69,7 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 		for _, r := range rs {
 			if r.Err != nil {
 				fmt.Fprintf(&b, "| %s | — | — | — | — | — | %s |\n",
-					markdownCell(r.TraceID), redactErrorMessage(r.Err.Error()))
+					markdownCell(r.TraceID), markdownCell(redactErrorMessage(r.Err.Error())))
 				continue
 			}
 			fmt.Fprintf(&b, "| %s | %.2f | %.2f | %s | %d | %d | %s |\n",
@@ -82,7 +82,7 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 	}
 
 	out := b.String()
-	out = pathPattern.ReplaceAllString(out, "<redacted-path>")
+	out = redactPaths(out)
 	return out
 }
 
@@ -154,14 +154,18 @@ func aggregate(rs []Result) modelAggregate {
 	if a.toolArgsComputed > 0 {
 		a.meanToolArgs = taSum / float64(a.toolArgsComputed)
 	}
-	qPs := percentiles(qVals, 0.25, 0.5, 0.75, 0.9)
-	a.qualityP25 = qPs[0]
-	a.qualityP50 = qPs[1]
-	a.qualityP75 = qPs[2]
-	a.qualityP90 = qPs[3]
-	lPs := int64Percentiles(lVals, 0.5, 0.9)
-	a.latencyP50 = lPs[0]
-	a.latencyP90 = lPs[1]
+	if len(qVals) > 0 {
+		qPs := percentiles(qVals, 0.25, 0.5, 0.75, 0.9)
+		a.qualityP25 = qPs[0]
+		a.qualityP50 = qPs[1]
+		a.qualityP75 = qPs[2]
+		a.qualityP90 = qPs[3]
+	}
+	if len(lVals) > 0 {
+		lPs := int64Percentiles(lVals, 0.5, 0.9)
+		a.latencyP50 = lPs[0]
+		a.latencyP90 = lPs[1]
+	}
 	return a
 }
 

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -24,15 +24,21 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 		fmt.Fprintf(&b, "Judge model: `%s`\n\n", markdownCell(opts.JudgeModel))
 	}
 
-	if opts.TraceSetManifestHash != "" || opts.JudgeCacheHits+opts.JudgeCacheMisses > 0 {
+	emitCacheLine := opts.Scorer == "llm-judge"
+	emitProvenance := opts.TraceSetManifestHash != "" || emitCacheLine
+	if emitProvenance {
 		fmt.Fprintf(&b, "## Provenance\n\n")
 		if opts.TraceSetManifestHash != "" {
 			fmt.Fprintf(&b, "- Trace set manifest hash: `%s`\n", markdownCell(opts.TraceSetManifestHash))
 		}
-		if opts.JudgeCacheHits+opts.JudgeCacheMisses > 0 {
+		if emitCacheLine {
 			total := opts.JudgeCacheHits + opts.JudgeCacheMisses
-			rate := 100 * float64(opts.JudgeCacheHits) / float64(total)
-			fmt.Fprintf(&b, "- Judge cache hit rate: %.1f%% (%d/%d)\n", rate, opts.JudgeCacheHits, total)
+			if total > 0 {
+				rate := 100 * float64(opts.JudgeCacheHits) / float64(total)
+				fmt.Fprintf(&b, "- Judge cache hit rate: %.1f%% (%d/%d)\n", rate, opts.JudgeCacheHits, total)
+			} else {
+				fmt.Fprintf(&b, "- Judge cache: no activity recorded (cache may be disabled or no traces ran)\n")
+			}
 		}
 		fmt.Fprintln(&b)
 	}

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -24,57 +24,94 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 		fmt.Fprintf(&b, "Judge model: `%s`\n\n", markdownCell(opts.JudgeModel))
 	}
 
-	fmt.Fprintf(&b, "## Summary\n\n")
-	fmt.Fprintf(&b, "| Model | Traces | Errors | Mean Quality | Mean ToolSeq | Mean ToolArgs | Mean Replay Latency (ms) | Mean Scorer Latency (ms) |\n")
-	fmt.Fprintf(&b, "|---|---|---|---|---|---|---|---|\n")
+	if opts.TraceSetManifestHash != "" || opts.JudgeCacheHits+opts.JudgeCacheMisses > 0 {
+		fmt.Fprintf(&b, "## Provenance\n\n")
+		if opts.TraceSetManifestHash != "" {
+			fmt.Fprintf(&b, "- Trace set manifest hash: `%s`\n", markdownCell(opts.TraceSetManifestHash))
+		}
+		if opts.JudgeCacheHits+opts.JudgeCacheMisses > 0 {
+			total := opts.JudgeCacheHits + opts.JudgeCacheMisses
+			rate := 100 * float64(opts.JudgeCacheHits) / float64(total)
+			fmt.Fprintf(&b, "- Judge cache hit rate: %.1f%% (%d/%d)\n", rate, opts.JudgeCacheHits, total)
+		}
+		fmt.Fprintln(&b)
+	}
+
+	fmt.Fprintf(&b, "## Results\n\n")
+	fmt.Fprintf(&b, "| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | ToolSequenceMatch | ToolArgsValid (computed=N) | LatencyMs (p50 / p90) | TotalTokens | n |\n")
+	fmt.Fprintf(&b, "|---|---|---|---|---|---|---|\n")
 	for _, m := range models {
 		rs := byModel[m]
 		agg := aggregate(rs)
-		fmt.Fprintf(&b, "| %s | %d | %d | %.2f | %.2f | %s | %d | %d |\n",
-			markdownCell(m), len(rs), agg.errors, agg.meanQuality, agg.meanToolSeq,
-			metricCell(agg.meanToolArgs, agg.toolArgsComputed > 0),
-			agg.meanLatencyMs, agg.meanScorerLatencyMs)
+		scored := len(rs) - agg.errors
+
+		qCell := fmt.Sprintf("%.2f / %.2f / %.2f / %.2f / %.2f",
+			agg.meanQuality, agg.qualityP25, agg.qualityP50, agg.qualityP75, agg.qualityP90)
+		toolArgsCell := fmt.Sprintf("%s (computed=%d)",
+			metricCell(agg.meanToolArgs, agg.toolArgsComputed > 0), agg.toolArgsComputed)
+		latencyCell := fmt.Sprintf("%d / %d", agg.latencyP50, agg.latencyP90)
+		tokensCell := "n/a"
+		if agg.totalTokensAvailable > 0 {
+			tokensCell = fmt.Sprintf("%d", agg.totalTokensSum)
+		}
+
+		fmt.Fprintf(&b, "| %s | %s | %.2f | %s | %s | %s | %d |\n",
+			markdownCell(m), qCell, agg.meanToolSeq, toolArgsCell, latencyCell, tokensCell, scored)
 	}
 
 	fmt.Fprintf(&b, "\n## Per-trace detail\n\n")
 	for _, m := range models {
 		fmt.Fprintf(&b, "### %s\n\n", markdownCell(m))
-		fmt.Fprintf(&b, "| Trace | Quality | ToolSeq | ToolArgs | Replay Latency (ms) | Scorer Latency (ms) | Notes | Error |\n")
-		fmt.Fprintf(&b, "|---|---|---|---|---|---|---|---|\n")
+		fmt.Fprintf(&b, "| Trace | Quality | ToolSeq | ToolArgs | Replay Latency (ms) | Scorer Latency (ms) | Status |\n")
+		fmt.Fprintf(&b, "|---|---|---|---|---|---|---|\n")
 		rs := byModel[m]
 		sort.Slice(rs, func(i, j int) bool { return rs[i].TraceID < rs[j].TraceID })
 		for _, r := range rs {
 			if r.Err != nil {
-				// Errored runs: render em-dash in metric cells so a reader
-				// never confuses an error with a genuine zero score.
-				fmt.Fprintf(&b, "| %s | — | — | — | — | — |  | %s |\n",
-					markdownCell(r.TraceID), markdownCell(r.Err.Error()))
+				fmt.Fprintf(&b, "| %s | — | — | — | — | — | %s |\n",
+					markdownCell(r.TraceID), redactErrorMessage(r.Err.Error()))
 				continue
 			}
-			fmt.Fprintf(&b, "| %s | %.2f | %.2f | %s | %d | %d | %s |  |\n",
+			fmt.Fprintf(&b, "| %s | %.2f | %.2f | %s | %d | %d | %s |\n",
 				markdownCell(r.TraceID), r.Score.AnswerQuality, r.Score.ToolSequenceMatch,
 				metricCell(r.Score.ToolArgsValid, r.Score.ToolArgsValidComputed),
-				r.Score.LatencyMs, r.Score.ScorerLatencyMs, markdownCell(r.Score.Notes))
+				r.Score.LatencyMs, r.Score.ScorerLatencyMs,
+				markdownCell(redactString(r.Score.Notes)))
 		}
 		fmt.Fprintln(&b)
 	}
 
-	return b.String()
+	out := b.String()
+	out = pathPattern.ReplaceAllString(out, "<redacted-path>")
+	return out
 }
 
+// reportOptions carries metadata that formatReport embeds in report headers.
 type reportOptions struct {
-	Scorer     string
-	JudgeModel string
+	Scorer               string
+	JudgeModel           string
+	JudgeCacheHits       int64
+	JudgeCacheMisses     int64
+	TraceSetManifestHash string
 }
 
+// modelAggregate holds computed statistics for one model's result set.
 type modelAggregate struct {
-	errors              int
-	meanQuality         float64
-	meanToolSeq         float64
-	meanToolArgs        float64
-	toolArgsComputed    int
-	meanLatencyMs       int64
-	meanScorerLatencyMs int64
+	errors               int
+	meanQuality          float64
+	qualityP25           float64
+	qualityP50           float64
+	qualityP75           float64
+	qualityP90           float64
+	meanToolSeq          float64
+	meanToolArgs         float64
+	toolArgsComputed     int
+	meanLatencyMs        int64
+	latencyP50           int64
+	latencyP90           int64
+	meanScorerLatencyMs  int64
+	totalTokensSum       int
+	totalTokensAvailable int
 }
 
 func aggregate(rs []Result) modelAggregate {
@@ -82,6 +119,8 @@ func aggregate(rs []Result) modelAggregate {
 		return modelAggregate{}
 	}
 	var a modelAggregate
+	var qVals []float64
+	var lVals []int64
 	var qSum, tsSum, taSum float64
 	var latSum, scorerLatSum int64
 	var scored int
@@ -90,6 +129,8 @@ func aggregate(rs []Result) modelAggregate {
 			a.errors++
 			continue
 		}
+		qVals = append(qVals, r.Score.AnswerQuality)
+		lVals = append(lVals, r.Score.LatencyMs)
 		qSum += r.Score.AnswerQuality
 		tsSum += r.Score.ToolSequenceMatch
 		latSum += r.Score.LatencyMs
@@ -98,6 +139,10 @@ func aggregate(rs []Result) modelAggregate {
 		if r.Score.ToolArgsValidComputed {
 			taSum += r.Score.ToolArgsValid
 			a.toolArgsComputed++
+		}
+		if r.Score.TotalTokens > 0 {
+			a.totalTokensSum += r.Score.TotalTokens
+			a.totalTokensAvailable++
 		}
 	}
 	if scored > 0 {
@@ -109,6 +154,14 @@ func aggregate(rs []Result) modelAggregate {
 	if a.toolArgsComputed > 0 {
 		a.meanToolArgs = taSum / float64(a.toolArgsComputed)
 	}
+	qPs := percentiles(qVals, 0.25, 0.5, 0.75, 0.9)
+	a.qualityP25 = qPs[0]
+	a.qualityP50 = qPs[1]
+	a.qualityP75 = qPs[2]
+	a.qualityP90 = qPs[3]
+	lPs := int64Percentiles(lVals, 0.5, 0.9)
+	a.latencyP50 = lPs[0]
+	a.latencyP90 = lPs[1]
 	return a
 }
 

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -51,18 +51,28 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 		agg := aggregate(rs)
 		scored := len(rs) - agg.errors
 
-		qCell := fmt.Sprintf("%.2f / %.2f / %.2f / %.2f / %.2f",
-			agg.meanQuality, agg.qualityP25, agg.qualityP50, agg.qualityP75, agg.qualityP90)
+		qCell := "n/a"
+		if scored > 0 {
+			qCell = fmt.Sprintf("%.2f / %.2f / %.2f / %.2f / %.2f",
+				agg.meanQuality, agg.qualityP25, agg.qualityP50, agg.qualityP75, agg.qualityP90)
+		}
+		toolSeqCell := "n/a"
+		if scored > 0 {
+			toolSeqCell = fmt.Sprintf("%.2f", agg.meanToolSeq)
+		}
 		toolArgsCell := fmt.Sprintf("%s (computed=%d)",
 			metricCell(agg.meanToolArgs, agg.toolArgsComputed > 0), agg.toolArgsComputed)
-		latencyCell := fmt.Sprintf("%d / %d", agg.latencyP50, agg.latencyP90)
+		latencyCell := "n/a"
+		if scored > 0 {
+			latencyCell = fmt.Sprintf("%d / %d", agg.latencyP50, agg.latencyP90)
+		}
 		tokensCell := "n/a"
 		if agg.totalTokensAvailable > 0 {
 			tokensCell = fmt.Sprintf("%d", agg.totalTokensSum)
 		}
 
-		fmt.Fprintf(&b, "| %s | %s | %.2f | %s | %s | %s | %d |\n",
-			markdownCell(m), qCell, agg.meanToolSeq, toolArgsCell, latencyCell, tokensCell, scored)
+		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s | %s | %d |\n",
+			markdownCell(m), qCell, toolSeqCell, toolArgsCell, latencyCell, tokensCell, scored)
 	}
 
 	fmt.Fprintf(&b, "\n## Per-trace detail\n\n")

--- a/cmd/llm-bench/report_test.go
+++ b/cmd/llm-bench/report_test.go
@@ -160,6 +160,16 @@ func TestFormatReportDoesNotLeakRawErrorOrJustification(t *testing.T) {
 	}
 }
 
+func TestFormatReportAllErrorsRowDoesNotRenderNaN(t *testing.T) {
+	report := formatReport([]string{"m1"}, []Result{
+		{Model: "m1", TraceID: "t1", Err: errors.New("context deadline exceeded")},
+		{Model: "m1", TraceID: "t2", Err: errors.New("connection refused")},
+	}, reportOptions{Scorer: "llm-judge", JudgeModel: "gemma4:31b"})
+	if strings.Contains(report, "NaN") {
+		t.Fatalf("report contains NaN with all errors:\n%s", report)
+	}
+}
+
 func TestFormatReportProvenanceBlock(t *testing.T) {
 	report := formatReport([]string{"m1"}, []Result{
 		{Model: "m1", TraceID: "t1", Score: Score{AnswerQuality: 0.5}},

--- a/cmd/llm-bench/report_test.go
+++ b/cmd/llm-bench/report_test.go
@@ -168,6 +168,12 @@ func TestFormatReportAllErrorsRowDoesNotRenderNaN(t *testing.T) {
 	if strings.Contains(report, "NaN") {
 		t.Fatalf("report contains NaN with all errors:\n%s", report)
 	}
+	// Strengthened: zero-observation rows must render n/a in the
+	// quality, toolseq, and latency cells so a casual reader cannot
+	// mistake them for genuine zero scores.
+	if !strings.Contains(report, "| m1 | n/a | n/a | n/a (computed=0) | n/a | n/a | 0 |") {
+		t.Errorf("expected all-errors row to render n/a across metric cells:\n%s", report)
+	}
 }
 
 func TestFormatReportProvenanceBlock(t *testing.T) {

--- a/cmd/llm-bench/report_test.go
+++ b/cmd/llm-bench/report_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
 
+// TestFormatReportIncludesToolArgsMetric verifies that ToolArgsValid is
+// rendered in both the summary and per-trace sections when it is computed.
 func TestFormatReportIncludesToolArgsMetric(t *testing.T) {
 	report := formatReport([]string{"model-a"}, []Result{
 		{
@@ -19,13 +22,19 @@ func TestFormatReportIncludesToolArgsMetric(t *testing.T) {
 		},
 	}, reportOptions{Scorer: "exact-match"})
 
-	for _, want := range []string{"Mean ToolArgs", "| Trace | Quality | ToolSeq | ToolArgs |", "| trace-1 | 1.00 | 1.00 | 0.50 |"} {
+	for _, want := range []string{
+		"ToolArgsValid (computed=N)",
+		"| Trace | Quality | ToolSeq | ToolArgs | Replay Latency (ms) | Scorer Latency (ms) | Status |",
+		"| trace-1 | 1.00 | 1.00 | 0.50 |",
+	} {
 		if !strings.Contains(report, want) {
 			t.Fatalf("report missing %q:\n%s", want, report)
 		}
 	}
 }
 
+// TestFormatReportRendersToolArgsNAWhenNotComputed verifies that ToolArgsValid
+// renders as "n/a" in both the summary and per-trace sections when not computed.
 func TestFormatReportRendersToolArgsNAWhenNotComputed(t *testing.T) {
 	report := formatReport([]string{"model-a"}, []Result{
 		{
@@ -40,9 +49,11 @@ func TestFormatReportRendersToolArgsNAWhenNotComputed(t *testing.T) {
 		},
 	}, reportOptions{Scorer: "exact-match"})
 
-	if !strings.Contains(report, "| model-a | 1 | 0 | 1.00 | 0.00 | n/a |") {
-		t.Fatalf("summary should render ToolArgs as n/a when not computed:\n%s", report)
+	// Summary: ToolArgsValid column should show "n/a (computed=0)"
+	if !strings.Contains(report, "n/a (computed=0)") {
+		t.Fatalf("summary should render ToolArgs as n/a (computed=0) when not computed:\n%s", report)
 	}
+	// Per-trace: first four cells still follow the same format
 	if !strings.Contains(report, "| trace-1 | 1.00 | 0.00 | n/a |") {
 		t.Fatalf("detail should render ToolArgs as n/a when not computed:\n%s", report)
 	}
@@ -59,5 +70,110 @@ func TestAggregateToolArgsIgnoresNotComputedRows(t *testing.T) {
 	}
 	if agg.meanToolArgs != 0.5 {
 		t.Fatalf("meanToolArgs=%v; want 0.5", agg.meanToolArgs)
+	}
+}
+
+func TestAggregateComputesQualityPercentiles(t *testing.T) {
+	rs := []Result{
+		{Score: Score{AnswerQuality: 0.1}},
+		{Score: Score{AnswerQuality: 0.2}},
+		{Score: Score{AnswerQuality: 0.3}},
+		{Score: Score{AnswerQuality: 0.4}},
+	}
+	agg := aggregate(rs)
+	if got := agg.qualityP25; got != 0.1 {
+		t.Errorf("qualityP25=%v; want 0.1", got)
+	}
+	if got := agg.qualityP50; got != 0.2 {
+		t.Errorf("qualityP50=%v; want 0.2", got)
+	}
+	if got := agg.qualityP90; got != 0.4 {
+		t.Errorf("qualityP90=%v; want 0.4", got)
+	}
+}
+
+func TestAggregateComputesLatencyPercentiles(t *testing.T) {
+	rs := []Result{
+		{Score: Score{LatencyMs: 100}},
+		{Score: Score{LatencyMs: 200}},
+		{Score: Score{LatencyMs: 300}},
+		{Score: Score{LatencyMs: 1000}},
+	}
+	agg := aggregate(rs)
+	if agg.latencyP50 != 200 {
+		t.Errorf("latencyP50=%d; want 200", agg.latencyP50)
+	}
+	if agg.latencyP90 != 1000 {
+		t.Errorf("latencyP90=%d; want 1000", agg.latencyP90)
+	}
+}
+
+func TestAggregateSumsTokens(t *testing.T) {
+	rs := []Result{
+		{Score: Score{TotalTokens: 100}},
+		{Score: Score{TotalTokens: 0}}, // unavailable — does NOT count toward "available"
+		{Score: Score{TotalTokens: 50}},
+	}
+	agg := aggregate(rs)
+	if agg.totalTokensSum != 150 {
+		t.Errorf("totalTokensSum=%d; want 150", agg.totalTokensSum)
+	}
+	if agg.totalTokensAvailable != 2 {
+		t.Errorf("totalTokensAvailable=%d; want 2", agg.totalTokensAvailable)
+	}
+}
+
+func TestFormatReportSummaryMatchesTemplateColumns(t *testing.T) {
+	report := formatReport([]string{"m1"}, []Result{
+		{Model: "m1", TraceID: "t1", Score: Score{AnswerQuality: 0.5, ToolSequenceMatch: 1, ToolArgsValid: 1, ToolArgsValidComputed: true, LatencyMs: 100, TotalTokens: 42}},
+	}, reportOptions{Scorer: "llm-judge", JudgeModel: "gemma4:31b"})
+
+	want := "| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | ToolSequenceMatch | ToolArgsValid (computed=N) | LatencyMs (p50 / p90) | TotalTokens | n |"
+	if !strings.Contains(report, want) {
+		t.Fatalf("rendered report missing TEMPLATE column header.\nWant: %q\nGot:\n%s", want, report)
+	}
+}
+
+func TestFormatReportTotalTokensNAWhenAllUnavailable(t *testing.T) {
+	report := formatReport([]string{"m1"}, []Result{
+		{Model: "m1", TraceID: "t1", Score: Score{AnswerQuality: 0.5, LatencyMs: 100}}, // TotalTokens=0
+	}, reportOptions{Scorer: "exact-match"})
+	if !strings.Contains(report, "| n/a |") {
+		t.Fatalf("TotalTokens=0 should render as n/a; got:\n%s", report)
+	}
+}
+
+func TestFormatReportDoesNotLeakRawErrorOrJustification(t *testing.T) {
+	report := formatReport([]string{"m1"}, []Result{
+		{Model: "m1", TraceID: "t1", Err: errors.New("dial tcp /tmp/foo: connection refused")},
+		{Model: "m1", TraceID: "t2", Score: Score{Notes: `justification: "model picked the wrong tool"`, AnswerQuality: 0.7}},
+	}, reportOptions{Scorer: "llm-judge", JudgeModel: "gemma4:31b"})
+
+	forbidden := []string{"/tmp/", "/Users/", "justification:", "connection refused"}
+	for _, f := range forbidden {
+		if strings.Contains(report, f) {
+			t.Errorf("forbidden substring %q leaked into report:\n%s", f, report)
+		}
+	}
+	if !strings.Contains(report, "<error:") {
+		t.Error("expected categorized error stub in rendered table")
+	}
+}
+
+func TestFormatReportProvenanceBlock(t *testing.T) {
+	report := formatReport([]string{"m1"}, []Result{
+		{Model: "m1", TraceID: "t1", Score: Score{AnswerQuality: 0.5}},
+	}, reportOptions{
+		Scorer:               "llm-judge",
+		JudgeModel:           "gemma4:31b",
+		JudgeCacheHits:       7,
+		JudgeCacheMisses:     3,
+		TraceSetManifestHash: "sha256:abc123",
+	})
+	if !strings.Contains(report, "Judge cache hit rate: 70.0%") {
+		t.Error("missing judge cache hit rate in provenance")
+	}
+	if !strings.Contains(report, "Trace set manifest hash: `sha256:abc123`") {
+		t.Error("missing trace set manifest hash in provenance")
 	}
 }

--- a/cmd/llm-bench/report_test.go
+++ b/cmd/llm-bench/report_test.go
@@ -147,9 +147,10 @@ func TestFormatReportDoesNotLeakRawErrorOrJustification(t *testing.T) {
 	report := formatReport([]string{"m1"}, []Result{
 		{Model: "m1", TraceID: "t1", Err: errors.New("dial tcp /tmp/foo: connection refused")},
 		{Model: "m1", TraceID: "t2", Score: Score{Notes: `justification: "model picked the wrong tool"`, AnswerQuality: 0.7}},
+		{Model: "m1", TraceID: "t3", Score: Score{Notes: `llm-judge=gemma4:31b: exposed judge rationale`, AnswerQuality: 0.8}},
 	}, reportOptions{Scorer: "llm-judge", JudgeModel: "gemma4:31b"})
 
-	forbidden := []string{"/tmp/", "/Users/", "justification:", "connection refused"}
+	forbidden := []string{"/tmp/", "/Users/", "justification:", "connection refused", "exposed judge rationale"}
 	for _, f := range forbidden {
 		if strings.Contains(report, f) {
 			t.Errorf("forbidden substring %q leaked into report:\n%s", f, report)

--- a/cmd/llm-bench/report_test.go
+++ b/cmd/llm-bench/report_test.go
@@ -187,3 +187,17 @@ func TestFormatReportProvenanceBlock(t *testing.T) {
 		t.Error("missing trace set manifest hash in provenance")
 	}
 }
+
+func TestFormatReportProvenanceReportsCacheDisabledForLLMJudge(t *testing.T) {
+	report := formatReport([]string{"m1"}, []Result{
+		{Model: "m1", TraceID: "t1", Score: Score{AnswerQuality: 0.5}},
+	}, reportOptions{
+		Scorer:               "llm-judge",
+		JudgeModel:           "gemma4:31b",
+		TraceSetManifestHash: "sha256:abc123",
+		// JudgeCacheHits/Misses both zero → cache disabled or unused
+	})
+	if !strings.Contains(report, "Judge cache: no activity recorded") {
+		t.Fatalf("expected cache-disabled signal in provenance:\n%s", report)
+	}
+}

--- a/cmd/llm-bench/run_all_test.go
+++ b/cmd/llm-bench/run_all_test.go
@@ -180,6 +180,9 @@ type fakeChatResp struct {
 // absent, matching providers that omit counts entirely.
 func newSequencedFakeChatServer(t *testing.T, replies ...fakeChatResp) *httptest.Server {
 	t.Helper()
+	if len(replies) == 0 {
+		t.Fatalf("newSequencedFakeChatServer: at least one reply required")
+	}
 	var calls atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.HasSuffix(r.URL.Path, "/api/chat") {

--- a/cmd/llm-bench/run_all_test.go
+++ b/cmd/llm-bench/run_all_test.go
@@ -2,12 +2,16 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/kstruzzieri/go-llm/ollama"
 )
 
 // newFakeChatServer responds to /api/chat with a fixed assistant reply.
@@ -155,5 +159,117 @@ func TestRunAllLatencyExcludesScorerWork(t *testing.T) {
 	}
 	if results[0].Score.ScorerLatencyMs <= 0 {
 		t.Fatalf("ScorerLatencyMs = %d, want scorer work to be visible", results[0].Score.ScorerLatencyMs)
+	}
+}
+
+// fakeChatResp is a scripted chat reply for newSequencedFakeChatServer.
+// PromptEvalCount + EvalCount are surfaced into the JSON response so
+// callers can verify token-sum accounting.
+type fakeChatResp struct {
+	Content         string
+	PromptEvalCount int
+	EvalCount       int
+}
+
+// newSequencedFakeChatServer returns a fake /api/chat server that
+// answers consecutive requests with replies[0], replies[1], … When
+// requests outnumber replies, the server returns the LAST reply for
+// every overflow call so the test fails loudly via wrong content rather
+// than via a 5xx response. Token counts are JSON-omitempty: a zero
+// PromptEvalCount / EvalCount produces a response with the field
+// absent, matching providers that omit counts entirely.
+func newSequencedFakeChatServer(t *testing.T, replies ...fakeChatResp) *httptest.Server {
+	t.Helper()
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/api/chat") {
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		idx := int(calls.Add(1) - 1)
+		if idx >= len(replies) {
+			idx = len(replies) - 1
+		}
+		body := struct {
+			Model           string             `json:"model"`
+			Done            bool               `json:"done"`
+			Message         ollama.ChatMessage `json:"message"`
+			PromptEvalCount int                `json:"prompt_eval_count,omitempty"`
+			EvalCount       int                `json:"eval_count,omitempty"`
+		}{
+			Model:           "m",
+			Done:            true,
+			Message:         ollama.ChatMessage{Role: "assistant", Content: replies[idx].Content},
+			PromptEvalCount: replies[idx].PromptEvalCount,
+			EvalCount:       replies[idx].EvalCount,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(body); err != nil {
+			t.Errorf("fake server encode: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestRunnerSumsTokenCountsAcrossTurns(t *testing.T) {
+	srv := newSequencedFakeChatServer(t,
+		fakeChatResp{Content: "hi", PromptEvalCount: 11, EvalCount: 7},
+		fakeChatResp{Content: "bye", PromptEvalCount: 13, EvalCount: 5},
+	)
+
+	trace := Trace{
+		ID:     "t1",
+		System: "sys",
+		Turns: []Turn{
+			{Role: "user", Content: "ping"},
+			{Role: "assistant", Content: "hi"},
+			{Role: "user", Content: "again"},
+			{Role: "assistant", Content: "bye"},
+		},
+		Golden: Golden{FinalAnswerSubstring: "bye"},
+	}
+	r := &Runner{OllamaURL: srv.URL, Timeout: 5 * time.Second, Scorer: &ExactMatchScorer{}}
+	results, err := r.RunAll(context.Background(),
+		[]ModelTarget{{Display: "fake", Provider: "ollama", Model: "fake"}},
+		[]Trace{trace})
+	if err != nil {
+		t.Fatalf("RunAll: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results=%d; want 1", len(results))
+	}
+	if results[0].Err != nil {
+		t.Fatalf("unexpected result error: %v", results[0].Err)
+	}
+	if got, want := results[0].Score.TotalTokens, 36; got != want {
+		t.Fatalf("TotalTokens=%d; want %d", got, want)
+	}
+}
+
+func TestRunnerLeavesTotalTokensZeroWhenUnreported(t *testing.T) {
+	srv := newSequencedFakeChatServer(t, fakeChatResp{Content: "hi"})
+
+	trace := Trace{
+		ID:     "t2",
+		System: "sys",
+		Turns: []Turn{
+			{Role: "user", Content: "ping"},
+			{Role: "assistant", Content: "hi"},
+		},
+		Golden: Golden{FinalAnswerSubstring: "hi"},
+	}
+	r := &Runner{OllamaURL: srv.URL, Timeout: 5 * time.Second, Scorer: &ExactMatchScorer{}}
+	results, err := r.RunAll(context.Background(),
+		[]ModelTarget{{Display: "fake", Provider: "ollama", Model: "fake"}},
+		[]Trace{trace})
+	if err != nil {
+		t.Fatalf("RunAll: %v", err)
+	}
+	if results[0].Err != nil {
+		t.Fatalf("unexpected result error: %v", results[0].Err)
+	}
+	if got := results[0].Score.TotalTokens; got != 0 {
+		t.Fatalf("TotalTokens=%d; want 0 (unavailable)", got)
 	}
 }

--- a/cmd/llm-bench/runner.go
+++ b/cmd/llm-bench/runner.go
@@ -131,6 +131,7 @@ func (r *Runner) runOne(ctx context.Context, client *ollama.Client, target Model
 	// Latency reflects replay only; ScorerLatencyMs keeps judge/scorer work visible
 	// without polluting the target model latency metric.
 	score.ScorerLatencyMs = scorerMs
+	score.TotalTokens = out.TotalTokens
 
 	return Result{
 		Model:      target.Display,
@@ -145,6 +146,7 @@ type replayOutput struct {
 	Transcript      []Turn
 	Notes           []string
 	TurnLatenciesMs []int64
+	TotalTokens     int
 }
 
 // replayOptions are the per-replay knobs threaded down from Runner.
@@ -217,11 +219,12 @@ func replayWith(ctx context.Context, client *ollama.Client, model string, trace 
 				i++
 			}
 
-			msg, actualTurn, latencyMs, err := chatReplayTurn(ctx, client, model, messages, tools, opts)
+			msg, actualTurn, latencyMs, tokens, err := chatReplayTurn(ctx, client, model, messages, tools, opts)
 			out.TurnLatenciesMs = append(out.TurnLatenciesMs, latencyMs)
 			if err != nil {
 				return out, err
 			}
+			out.TotalTokens += tokens
 			messages = append(messages, msg)
 			out.Transcript = append(out.Transcript, actualTurn)
 
@@ -272,7 +275,7 @@ func hasUserTurn(turns []Turn) bool {
 	return false
 }
 
-func chatReplayTurn(ctx context.Context, client *ollama.Client, model string, messages []ollama.ChatMessage, tools []ollama.Tool, opts replayOptions) (ollama.ChatMessage, Turn, int64, error) {
+func chatReplayTurn(ctx context.Context, client *ollama.Client, model string, messages []ollama.ChatMessage, tools []ollama.Tool, opts replayOptions) (ollama.ChatMessage, Turn, int64, int, error) {
 	turnCtx := ctx
 	if opts.PerTurnTimeout > 0 {
 		var cancel context.CancelFunc
@@ -294,15 +297,16 @@ func chatReplayTurn(ctx context.Context, client *ollama.Client, model string, me
 	resp, err := client.Chat(turnCtx, req)
 	latencyMs := time.Since(start).Milliseconds()
 	if err != nil {
-		return ollama.ChatMessage{}, Turn{}, latencyMs, err
+		return ollama.ChatMessage{}, Turn{}, latencyMs, 0, err
 	}
 
 	msg := normalizeAssistantMessage(resp.Message)
 	turn, err := assistantTurnFromMessage(msg)
 	if err != nil {
-		return ollama.ChatMessage{}, Turn{}, latencyMs, err
+		return ollama.ChatMessage{}, Turn{}, latencyMs, 0, err
 	}
-	return msg, turn, latencyMs, nil
+	tokens := resp.PromptEvalCount + resp.EvalCount
+	return msg, turn, latencyMs, tokens, nil
 }
 
 func normalizeAssistantMessage(msg ollama.ChatMessage) ollama.ChatMessage {

--- a/cmd/llm-bench/sanitize.go
+++ b/cmd/llm-bench/sanitize.go
@@ -19,6 +19,12 @@ var (
 	// justificationPrefix strips through the end of the line so that
 	// multi-clause values like "completed.task; foo" are fully removed.
 	justificationPrefix = regexp.MustCompile(`(?i)\bjustification\s*:\s*(?:"[^"]*"|'[^']*'|[^\n]+)`)
+
+	// materializeJudgement appends llm-judge=<model>: <justification> to
+	// Score.Notes. Drop that whole suffix because the model tag is useful
+	// internally but the following free-form judge reasoning is not artifact
+	// safe, and model names themselves can contain colons.
+	judgeNotePrefix = regexp.MustCompile(`(?i)(?:^|;\s*)llm-judge=[^\n]*`)
 )
 
 // redactPaths replaces local-path occurrences with <redacted-path> while
@@ -42,6 +48,7 @@ func redactPaths(s string) string {
 // spec §5.2 sanitization rules.
 func redactString(s string) string {
 	s = redactPaths(s)
+	s = judgeNotePrefix.ReplaceAllString(s, "")
 	s = justificationPrefix.ReplaceAllString(s, "")
 	return strings.TrimSpace(s)
 }

--- a/cmd/llm-bench/sanitize.go
+++ b/cmd/llm-bench/sanitize.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Patterns are intentionally narrow: a path must look like an absolute
+// posix path with one of a few well-known sensitive roots. The point is
+// not to catch every conceivable path — operator hygiene plus this
+// renderer-side check is the defense-in-depth design from spec §5.2.
+var (
+	pathPattern         = regexp.MustCompile(`(?:(?:/tmp|/Users/[^/\s]+)(?:/[^\s]+)?|\$HOME)`)
+	justificationPrefix = regexp.MustCompile(`(?i)\bjustification\s*:\s*(?:"[^"]*"|'[^']*'|[^;.\n]+)[;.]?`)
+)
+
+// redactString returns s with local paths and judge justification
+// fragments replaced by sanitized placeholders. Idempotent — running it
+// twice yields the same result. Used as the renderer's chokepoint per
+// spec §5.2 sanitization rules.
+func redactString(s string) string {
+	s = pathPattern.ReplaceAllString(s, "<redacted-path>")
+	s = justificationPrefix.ReplaceAllString(s, "")
+	return strings.TrimSpace(s)
+}
+
+// redactErrorMessage maps a raw error string to a categorized stub.
+// The category is best-effort; the goal is to record "what kind of
+// failure" without leaking host/path/internal details.
+func redactErrorMessage(s string) string {
+	switch {
+	case strings.Contains(s, "context deadline exceeded") || strings.Contains(s, "timeout"):
+		return "<error: timeout>"
+	case strings.Contains(s, "connection refused") || strings.Contains(s, "no such host") || strings.Contains(s, "dial "):
+		return "<error: network>"
+	case strings.Contains(s, "cannot unmarshal") || strings.Contains(s, "json:") || strings.Contains(s, "parse"):
+		return "<error: parse>"
+	default:
+		return "<error: other>"
+	}
+}

--- a/cmd/llm-bench/sanitize.go
+++ b/cmd/llm-bench/sanitize.go
@@ -14,7 +14,7 @@ var (
 	// containing /tmp-like substrings (e.g. "org/tmp-model:v1") are not
 	// incorrectly redacted. The leading group captures the boundary character
 	// (whitespace, punctuation, or start-of-string); group 1 is the path.
-	pathPattern = regexp.MustCompile(`(?:^|[\s,;:=>}\]'"(\[<])(/tmp(?:/[^\s"'<>\]\[{},;]+)?|/Users/[^/\s"'<>\]\[{},;]+(?:/[^\s"'<>\]\[{},;]+)?|\$HOME)`)
+	pathPattern = regexp.MustCompile("(?:^|[\\s,;:=>}\\]`'\"(\\[<])(/tmp(?:/[^\\s`\"'<>\\]\\[{},;]+)?|/Users/[^/\\s`\"'<>\\]\\[{},;]+(?:/[^\\s`\"'<>\\]\\[{},;]+)?|\\$HOME)")
 
 	// justificationPrefix strips through the end of the line so that
 	// multi-clause values like "completed.task; foo" are fully removed.

--- a/cmd/llm-bench/sanitize.go
+++ b/cmd/llm-bench/sanitize.go
@@ -10,16 +10,38 @@ import (
 // not to catch every conceivable path — operator hygiene plus this
 // renderer-side check is the defense-in-depth design from spec §5.2.
 var (
-	pathPattern         = regexp.MustCompile(`(?:(?:/tmp|/Users/[^/\s]+)(?:/[^\s]+)?|\$HOME)`)
-	justificationPrefix = regexp.MustCompile(`(?i)\bjustification\s*:\s*(?:"[^"]*"|'[^']*'|[^;.\n]+)[;.]?`)
+	// pathPattern requires a path-start boundary so that identifiers
+	// containing /tmp-like substrings (e.g. "org/tmp-model:v1") are not
+	// incorrectly redacted. The leading group captures the boundary character
+	// (whitespace, punctuation, or start-of-string); group 1 is the path.
+	pathPattern = regexp.MustCompile(`(?:^|[\s,;'"(\[<])(/tmp(?:/[^\s]+)?|/Users/[^/\s]+(?:/[^\s]+)?|\$HOME)`)
+
+	// justificationPrefix strips through the end of the line so that
+	// multi-clause values like "completed.task; foo" are fully removed.
+	justificationPrefix = regexp.MustCompile(`(?i)\bjustification\s*:\s*(?:"[^"]*"|'[^']*'|[^\n]+)`)
 )
+
+// redactPaths replaces local-path occurrences with <redacted-path> while
+// preserving the boundary character (whitespace, comma, paren, etc.).
+// Identifiers containing /tmp-like substrings (e.g. "org/tmp-model:v1")
+// are left intact because the regex requires a path-start boundary.
+func redactPaths(s string) string {
+	return pathPattern.ReplaceAllStringFunc(s, func(m string) string {
+		sub := pathPattern.FindStringSubmatch(m)
+		if len(sub) < 2 {
+			return m
+		}
+		boundary := strings.TrimSuffix(m, sub[1])
+		return boundary + "<redacted-path>"
+	})
+}
 
 // redactString returns s with local paths and judge justification
 // fragments replaced by sanitized placeholders. Idempotent — running it
 // twice yields the same result. Used as the renderer's chokepoint per
 // spec §5.2 sanitization rules.
 func redactString(s string) string {
-	s = pathPattern.ReplaceAllString(s, "<redacted-path>")
+	s = redactPaths(s)
 	s = justificationPrefix.ReplaceAllString(s, "")
 	return strings.TrimSpace(s)
 }

--- a/cmd/llm-bench/sanitize.go
+++ b/cmd/llm-bench/sanitize.go
@@ -14,7 +14,7 @@ var (
 	// containing /tmp-like substrings (e.g. "org/tmp-model:v1") are not
 	// incorrectly redacted. The leading group captures the boundary character
 	// (whitespace, punctuation, or start-of-string); group 1 is the path.
-	pathPattern = regexp.MustCompile(`(?:^|[\s,;'"(\[<])(/tmp(?:/[^\s]+)?|/Users/[^/\s]+(?:/[^\s]+)?|\$HOME)`)
+	pathPattern = regexp.MustCompile(`(?:^|[\s,;:=>}\]'"(\[<])(/tmp(?:/[^\s"'<>\]\[{},;]+)?|/Users/[^/\s"'<>\]\[{},;]+(?:/[^\s"'<>\]\[{},;]+)?|\$HOME)`)
 
 	// justificationPrefix strips through the end of the line so that
 	// multi-clause values like "completed.task; foo" are fully removed.

--- a/cmd/llm-bench/sanitize_test.go
+++ b/cmd/llm-bench/sanitize_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedactStringsStripsLocalPaths(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"failed reading /tmp/foo.json", "failed reading <redacted-path>"},
+		{"home is /Users/keith.struzzieri/work", "home is <redacted-path>"},
+		{"$HOME/.cache trashed", "<redacted-path>/.cache trashed"},
+		{"no paths here", "no paths here"},
+	}
+	for _, tc := range cases {
+		if got := redactString(tc.in); got != tc.want {
+			t.Errorf("redactString(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestRedactStringsStripsJudgeJustification(t *testing.T) {
+	// LLMJudgeScorer writes "justification: ..." sentences into Notes
+	// when in debug mode. The redactor drops them so the artifact never
+	// contains free-form judge reasoning.
+	got := redactString(`score: 0.8; justification: "the model called the wrong tool then recovered"`)
+	if strings.Contains(got, "justification") {
+		t.Fatalf("redactString left judge justification in place: %q", got)
+	}
+	if !strings.Contains(got, "score: 0.8") {
+		t.Fatalf("redactString stripped the wrong content; got %q", got)
+	}
+}
+
+func TestRedactErrorMessage(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"context deadline exceeded", "<error: timeout>"},
+		{"dial tcp 127.0.0.1:11434: connection refused", "<error: network>"},
+		{"json: cannot unmarshal number into Go struct field", "<error: parse>"},
+		{"something totally unexpected happened", "<error: other>"},
+	}
+	for _, tc := range cases {
+		if got := redactErrorMessage(tc.in); got != tc.want {
+			t.Errorf("redactErrorMessage(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestRedactStringPreservesAllowedSubstrings(t *testing.T) {
+	const allowed = "qwen3-coder-next:latest trace-001 sha256:abc123"
+	if got := redactString(allowed); got != allowed {
+		t.Fatalf("redactString stripped allowed content: %q", got)
+	}
+}

--- a/cmd/llm-bench/sanitize_test.go
+++ b/cmd/llm-bench/sanitize_test.go
@@ -35,6 +35,18 @@ func TestRedactStringsStripsJudgeJustification(t *testing.T) {
 	}
 }
 
+func TestRedactStringStripsLLMJudgeNoteSuffix(t *testing.T) {
+	got := redactString("tool arg mismatch: missing query; llm-judge=gemma4:31b: model picked the wrong tool; leaked detail")
+	for _, forbidden := range []string{"llm-judge=", "model picked", "leaked detail"} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("redactString left %q in judge note: %q", forbidden, got)
+		}
+	}
+	if got != "tool arg mismatch: missing query" {
+		t.Fatalf("redactString stripped the wrong content; got %q", got)
+	}
+}
+
 func TestRedactErrorMessage(t *testing.T) {
 	cases := []struct {
 		in   string

--- a/cmd/llm-bench/sanitize_test.go
+++ b/cmd/llm-bench/sanitize_test.go
@@ -106,6 +106,8 @@ func TestRedactStringStripsColonPrefixedPaths(t *testing.T) {
 		{"cache=/Users/keith.struzzieri/.cache run", "cache=<redacted-path> run"},
 		{"key:/tmp/secret leaked", "key:<redacted-path> leaked"},
 		{"json={\"path\":\"/tmp/x\"}", "json={\"path\":\"<redacted-path>\"}"},
+		{"read `/tmp/foo.json` failed", "read `<redacted-path>` failed"},
+		{"cache `$HOME/.cache`", "cache `<redacted-path>/.cache`"},
 	}
 	for _, tc := range cases {
 		if got := redactString(tc.in); got != tc.want {

--- a/cmd/llm-bench/sanitize_test.go
+++ b/cmd/llm-bench/sanitize_test.go
@@ -84,3 +84,20 @@ func TestRedactStringStripsJustificationThroughNewline(t *testing.T) {
 		t.Errorf("redactString consumed past newline: %q", got)
 	}
 }
+
+func TestRedactStringStripsColonPrefixedPaths(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"error at module:/tmp/foo missing", "error at module:<redacted-path> missing"},
+		{"cache=/Users/keith.struzzieri/.cache run", "cache=<redacted-path> run"},
+		{"key:/tmp/secret leaked", "key:<redacted-path> leaked"},
+		{"json={\"path\":\"/tmp/x\"}", "json={\"path\":\"<redacted-path>\"}"},
+	}
+	for _, tc := range cases {
+		if got := redactString(tc.in); got != tc.want {
+			t.Errorf("redactString(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/cmd/llm-bench/sanitize_test.go
+++ b/cmd/llm-bench/sanitize_test.go
@@ -58,3 +58,29 @@ func TestRedactStringPreservesAllowedSubstrings(t *testing.T) {
 		t.Fatalf("redactString stripped allowed content: %q", got)
 	}
 }
+
+func TestRedactStringDoesNotMatchPathSubstringInsideIdentifier(t *testing.T) {
+	cases := []string{
+		"model org/tmp-model:v1 ran",
+		"selector pipeline/tmpfile-cache idle",
+		"name a/Users-shared-cache:v3",
+	}
+	for _, in := range cases {
+		if got := redactString(in); got != in {
+			t.Errorf("redactString(%q) = %q; want unchanged", in, got)
+		}
+	}
+}
+
+func TestRedactStringStripsJustificationThroughNewline(t *testing.T) {
+	in := `score: 0.9; justification: completed.task; foo bar` + "\nnext line"
+	got := redactString(in)
+	for _, forbidden := range []string{"task", "foo bar"} {
+		if strings.Contains(got, forbidden) {
+			t.Errorf("redactString left %q in: %q", forbidden, got)
+		}
+	}
+	if !strings.Contains(got, "next line") {
+		t.Errorf("redactString consumed past newline: %q", got)
+	}
+}

--- a/cmd/llm-bench/trace_hash.go
+++ b/cmd/llm-bench/trace_hash.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -27,7 +28,13 @@ func canonicalTraceHash(t Trace) string {
 		// shared hash. Panic loudly.
 		panic(fmt.Sprintf("canonicalTraceHash: json.Marshal failed for trace %q: %v", t.ID, err))
 	}
-	sum := sha256.Sum256(data)
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, data); err != nil {
+		// json.Marshal output is always valid JSON, so json.Compact
+		// cannot fail; panic if encoding/json ever changes.
+		panic(fmt.Sprintf("canonicalTraceHash: json.Compact failed for trace %q: %v", t.ID, err))
+	}
+	sum := sha256.Sum256(compact.Bytes())
 	return hex.EncodeToString(sum[:])
 }
 

--- a/cmd/llm-bench/trace_hash.go
+++ b/cmd/llm-bench/trace_hash.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"sort"
 )
 
@@ -19,11 +20,12 @@ func canonicalTraceHash(t Trace) string {
 	clone.ID = ""
 	data, err := json.Marshal(clone)
 	if err != nil {
-		// Trace fields are all JSON-marshalable today; a non-nil error
-		// here means a future field introduced an un-marshalable type.
-		// Surface as an obviously-wrong sentinel rather than crashing
-		// the benchmark; report-time tests will catch it.
-		return "unhashable"
+		// Trace fields are all JSON-marshalable today. A future field
+		// breaking that invariant must be caught: the manifest hash is
+		// the provenance anchor for benchmark artifacts, so silently
+		// returning a sentinel would collapse all corrupt traces to one
+		// shared hash. Panic loudly.
+		panic(fmt.Sprintf("canonicalTraceHash: json.Marshal failed for trace %q: %v", t.ID, err))
 	}
 	sum := sha256.Sum256(data)
 	return hex.EncodeToString(sum[:])

--- a/cmd/llm-bench/trace_hash.go
+++ b/cmd/llm-bench/trace_hash.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+)
+
+// canonicalTraceHash returns a stable sha256 fingerprint of a trace,
+// excluding its ID. Two traces with identical content but different IDs
+// hash to the same value; two traces with the same ID but different
+// content hash to different values. The hash format is the raw hex
+// digest (no "sha256:" prefix) so callers can re-prefix once when
+// composing manifest entries.
+func canonicalTraceHash(t Trace) string {
+	// Marshal with a copy that zeroes ID so only content participates.
+	clone := t
+	clone.ID = ""
+	data, err := json.Marshal(clone)
+	if err != nil {
+		// Trace fields are all JSON-marshalable today; a non-nil error
+		// here means a future field introduced an un-marshalable type.
+		// Surface as an obviously-wrong sentinel rather than crashing
+		// the benchmark; report-time tests will catch it.
+		return "unhashable"
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// traceSetManifestHash returns a stable sha256 fingerprint of an entire
+// trace set: sorted pairs of (trace_id, canonical_trace_hash) are
+// concatenated and hashed once. Per spec §5.2 this lets a benchmark
+// artifact pin "the set of traces I ran on" without committing the
+// trace contents themselves.
+func traceSetManifestHash(traces []Trace) string {
+	entries := make([]string, 0, len(traces))
+	for _, tr := range traces {
+		entries = append(entries, tr.ID+"|"+canonicalTraceHash(tr))
+	}
+	sort.Strings(entries)
+	h := sha256.New()
+	for _, e := range entries {
+		h.Write([]byte(e))
+		h.Write([]byte{0}) // delimiter; prevents id||hash collisions
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil))
+}

--- a/cmd/llm-bench/trace_hash_test.go
+++ b/cmd/llm-bench/trace_hash_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -51,5 +52,21 @@ func TestTraceSetManifestHashSingleTrace(t *testing.T) {
 	got := traceSetManifestHash([]Trace{t1})
 	if len(got) != len("sha256:")+64 {
 		t.Fatalf("expected sha256:<64 hex>; got len=%d", len(got))
+	}
+}
+
+func TestCanonicalTraceHashNormalizesEmbeddedRawWhitespace(t *testing.T) {
+	// Two traces with identical semantics but different Raw whitespace
+	// must hash identically — provenance invariant per spec §5.2.
+	a := Trace{
+		ID:    "x",
+		Turns: []Turn{{Role: "user", Content: "hi", Raw: json.RawMessage(`{"role":"user","content":"hi"}`)}},
+	}
+	b := Trace{
+		ID:    "x",
+		Turns: []Turn{{Role: "user", Content: "hi", Raw: json.RawMessage(`{"role": "user", "content": "hi"}`)}},
+	}
+	if canonicalTraceHash(a) != canonicalTraceHash(b) {
+		t.Fatalf("canonical hash must ignore Raw whitespace; got %s != %s", canonicalTraceHash(a), canonicalTraceHash(b))
 	}
 }

--- a/cmd/llm-bench/trace_hash_test.go
+++ b/cmd/llm-bench/trace_hash_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCanonicalTraceHashIgnoresIDDifferences(t *testing.T) {
+	a := Trace{ID: "trace-A", Source: "test", Turns: []Turn{{Role: "user", Content: "hi"}}}
+	b := Trace{ID: "trace-B", Source: "test", Turns: []Turn{{Role: "user", Content: "hi"}}}
+	if got, want := canonicalTraceHash(a), canonicalTraceHash(b); got != want {
+		t.Fatalf("canonicalTraceHash should ignore ID; got %s != %s", got, want)
+	}
+}
+
+func TestCanonicalTraceHashReactsToContent(t *testing.T) {
+	a := Trace{ID: "x", Turns: []Turn{{Role: "user", Content: "hi"}}}
+	b := Trace{ID: "x", Turns: []Turn{{Role: "user", Content: "hello"}}}
+	if canonicalTraceHash(a) == canonicalTraceHash(b) {
+		t.Fatalf("canonicalTraceHash must react to Turn content changes")
+	}
+}
+
+func TestTraceSetManifestHashOrderInvariant(t *testing.T) {
+	t1 := Trace{ID: "t1", Turns: []Turn{{Role: "user", Content: "a"}}}
+	t2 := Trace{ID: "t2", Turns: []Turn{{Role: "user", Content: "b"}}}
+	h12 := traceSetManifestHash([]Trace{t1, t2})
+	h21 := traceSetManifestHash([]Trace{t2, t1})
+	if h12 != h21 {
+		t.Fatalf("traceSetManifestHash must be order-invariant; got %s != %s", h12, h21)
+	}
+}
+
+func TestTraceSetManifestHashContentSensitive(t *testing.T) {
+	t1a := Trace{ID: "t1", Turns: []Turn{{Role: "user", Content: "a"}}}
+	t1b := Trace{ID: "t1", Turns: []Turn{{Role: "user", Content: "DIFFERENT"}}}
+	if traceSetManifestHash([]Trace{t1a}) == traceSetManifestHash([]Trace{t1b}) {
+		t.Fatalf("same ID, different content must produce different manifest hash")
+	}
+}
+
+func TestTraceSetManifestHashEmpty(t *testing.T) {
+	got := traceSetManifestHash(nil)
+	if !strings.HasPrefix(got, "sha256:") {
+		t.Fatalf("manifest hash should be prefixed with sha256:; got %q", got)
+	}
+}
+
+func TestTraceSetManifestHashSingleTrace(t *testing.T) {
+	t1 := Trace{ID: "t1", Turns: []Turn{{Role: "user", Content: "a"}}}
+	got := traceSetManifestHash([]Trace{t1})
+	if len(got) != len("sha256:")+64 {
+		t.Fatalf("expected sha256:<64 hex>; got len=%d", len(got))
+	}
+}

--- a/docs/llm/analysis.md
+++ b/docs/llm/analysis.md
@@ -1,3 +1,8 @@
+> **Status — 2026-05-25**: This document is historical. It captured the
+> April 2026 model landscape before the harness existed. For the current
+> validated lineup decision, see [harness-results.md](harness-results.md)
+> and the linked per-run artifacts under [benchmarks/](benchmarks/).
+
 # LLM Landscape Analysis — April 2026
 
 ## Context

--- a/docs/llm/benchmarks/TEMPLATE.md
+++ b/docs/llm/benchmarks/TEMPLATE.md
@@ -1,0 +1,51 @@
+<!--
+Per spec docs/superpowers/specs/2026-05-25-harness-followups-design.md §5.2:
+Do NOT paste raw prompts, transcripts, judge justifications, or error
+messages into this file. The harness report renderer sanitizes its own
+output; manual fills must obey the same rules. Sensitive content
+sources: per-trace Notes, per-trace Errors, local paths, judge debug
+output.
+-->
+
+# <slug> — YYYY-MM-DD
+
+## Provenance
+- **Commit**: `<sha>` (dirty: no)
+- **go-llm version**: <module version or commit>
+- **Machine**: <hardware profile, e.g. M3 Max 128GB>
+- **Trace set**: `<label>`, count: N, manifest hash: `sha256:...`
+- **Models under test**: `<comma list, provider/name>`
+- **Scorer**: `llm-judge`
+  - Judge model: `<name>`
+  - Judge model digest (when available via /api/show): `<digest>`
+  - Judge cache hit rate: X%
+  - Judge cache key version: V
+- **Exact command**:
+  ```
+  llm-bench -traces '<glob>' -models '...' -scorer llm-judge -judge-model ... \
+    -judge-cache <path> -report <path>
+  ```
+
+## Calibration (embedded — not linked to a gitignored file)
+- Judge model: `<name>`
+- Labels manifest hash: `sha256:...`
+- Valid labeled artifacts: X (≥50 required → SUFFICIENT)
+- Agreement: X / Y (Z%) — threshold ≥85% → **PASS**
+- Stability runs (M=3, diagnostic): max spread observed: 0.NN
+
+## Results
+| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | ToolSequenceMatch | ToolArgsValid (computed=N) | LatencyMs (p50 / p90) | TotalTokens | n |
+| --- | --- | --- | --- | --- | --- | --- |
+
+## Errors and exclusions
+- N traces failed (categorized by sanitized reason; raw messages live in the gitignored run log)
+- N traces excluded from `ToolArgsValid` (computed=false)
+
+## Conclusion
+- **Verdict**: accept / propose change to <X> / inconclusive
+- **Quality delta vs prior accepted run**: ±N on AnswerQuality.p50
+- **Latency delta vs prior accepted run**: ±N ms on LatencyMs.p90
+- **Justification**: 1–3 sentences (no PII, no raw trace content)
+
+## Caveats
+- Flags or trace-set anomalies that limit generalization

--- a/docs/llm/harness-results.md
+++ b/docs/llm/harness-results.md
@@ -1,0 +1,24 @@
+# Harness Results — Latest Accepted
+
+> Index of accepted benchmark runs. Every entry links to a dated, immutable
+> artifact under `docs/llm/benchmarks/`. Once an accepted run exists, the top
+> entry is what `recommendation.md` currently cites.
+
+## Acceptance gate
+
+A benchmark run is "accepted" iff **all** of:
+
+1. **Commit is clean** (`dirty: no` in provenance).
+2. **Calibration PASS** — agreement ≥85% on ≥50 valid labeled artifacts.
+3. **Judge cache hit-rate is reported** (any value; reproducibility signal).
+4. **`ToolArgsValid` is `computed=true` for ≥80% of (model, trace) pairs.**
+5. **Trace set manifest hash is recorded.**
+6. **Conclusion has been written and reviewed by the repo owner.**
+
+`harness-results.md` only indexes runs meeting all six. Failed/inconclusive
+runs stay as artifacts in `benchmarks/` but aren't promoted.
+
+## Accepted runs (newest first)
+
+No accepted runs yet. The first accepted-run PR replaces this paragraph with
+the newest run entry.


### PR DESCRIPTION
## Summary
- Adds `docs/llm/benchmarks/TEMPLATE.md` (per-run artifact template with embedded calibration block + sanitization reminder), `docs/llm/harness-results.md` (index + 6-criterion acceptance gate + "no accepted runs yet" placeholder), and a historical banner at the top of `docs/llm/analysis.md`.
- Extends `cmd/llm-bench/report.go` to emit the TEMPLATE-compatible Results table (`AnswerQuality (mean / p25 / p50 / p75 / p90)`, `ToolArgsValid (computed=N)`, `LatencyMs (p50 / p90)`, `TotalTokens`, `n`), a `## Provenance` block with `TraceSetManifestHash` and judge-cache hit rate, and renderer-side sanitization that strips local paths, judge justification fragments, and raw error text.
- Adds `traceSetManifestHash` over sorted `(trace_id, canonical_trace_hash)` pairs, judge-cache hit/miss accounting via `Stats()`, nearest-rank percentile helpers, and `Score.TotalTokens` population from `PromptEvalCount + EvalCount`.
- New Go doc-lint test `cmd/llm-bench/doc_lint_test.go` asserts the analysis banner + acceptance-gate fragments and conditionally checks the `recommendation.md` citation once an accepted run exists (skipped while the placeholder is in place).

## Out of scope (per spec §5.4 / §5.8 #2)
- No edits to `docs/llm/recommendation.md` — those land in the first accepted-run PR.
- No first benchmark artifact under `docs/llm/benchmarks/` — also deferred.

## Spec
- Implements §5.1–§5.5, §5.6, §5.7, §5.8 #1 of `docs/superpowers/specs/2026-05-25-harness-followups-design.md` (gitignored).
- PR A (#123 + #124), PR B1 (#126), PR B2 (#128) already on develop; this is the scaffolding half of PR C.

## Test plan
- [x] `go test -race ./cmd/llm-bench/...` — passes
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] Manual smoke: `llm-bench -traces '<existing glob>' -models '<single model>' -scorer exact-match -report /tmp/r.md` renders without paths, without justifications, and includes a `## Provenance` block with the trace-set manifest hash. `cat /tmp/r.md | grep -E '/Users/|/tmp/|justification:'` returns nothing.
- [x] Visual diff: column header on the rendered table is byte-identical to `docs/llm/benchmarks/TEMPLATE.md`'s Results-section header.

Generated with [Claude Code](https://claude.com/claude-code)
