### PR TITLE
feat(provider): Feedback store + read-side scoring (Epic #48 Phase 5 PR3)

### DIFF
--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -51,6 +51,18 @@ type RoutePlan struct {
 	wasSticky bool             // internal: propagated to RouteOutcome
 	recorder  RouteRecorder    // internal: set by Router
 	feedback  *RoutingFeedback // internal: set by Router via SetFeedback; nil = no recording
+
+	// scoreBreakdown carries the winning candidate's unexported
+	// scoreBreakdown; buildOutcome translates it into the public
+	// ScoreBreakdown on the RouteOutcome. nil = no public breakdown.
+	scoreBreakdown *scoreBreakdown
+	// builtUnderMode records the FeedbackScoringMode that produced this
+	// plan so buildOutcome can render the matching operator-facing label.
+	builtUnderMode FeedbackScoringMode
+	// feedbackStatus records the route-level feedback snapshot status so
+	// operators can distinguish "off by design" from "off because the
+	// store failed" without parsing logs.
+	feedbackStatus feedbackSnapshotStatus
 }
 
 // String returns a human-readable summary of the route plan.
@@ -76,6 +88,29 @@ func (rp *RoutePlan) SetFeedback(rf *RoutingFeedback) {
 // SetWasSticky marks the plan as having been selected via sticky routing.
 func (rp *RoutePlan) SetWasSticky(v bool) {
 	rp.wasSticky = v
+}
+
+// SetScoreBreakdown stamps the winning candidate's score breakdown onto
+// the plan. The Router calls this from buildPlan; subsequent buildOutcome
+// translates the unexported breakdown into the public ScoreBreakdown.
+// nil disables the public ScoreBreakdown on this plan's outcomes.
+func (rp *RoutePlan) SetScoreBreakdown(bd *scoreBreakdown) {
+	rp.scoreBreakdown = bd
+}
+
+// SetBuiltUnderMode records the FeedbackScoringMode in effect when the
+// Router built this plan so buildOutcome can render the public
+// ScoreBreakdown with the matching operator-facing label.
+func (rp *RoutePlan) SetBuiltUnderMode(mode FeedbackScoringMode) {
+	rp.builtUnderMode = mode
+}
+
+// SetFeedbackStatus records the feedback snapshot status from the route's
+// feedback snapshot so buildOutcome can render it on the public
+// ScoreBreakdown for operator visibility into why feedback was active
+// or inactive.
+func (rp *RoutePlan) SetFeedbackStatus(status feedbackSnapshotStatus) {
+	rp.feedbackStatus = status
 }
 
 // WasSticky reports whether the plan was selected via sticky routing. This
@@ -644,7 +679,7 @@ func (rp *RoutePlan) buildOutcome(fallbacksUsed int, attempts []RouteAttempt) *R
 	if n := len(attempts); n > 0 && attempts[n-1].Status == AttemptStatusSucceeded {
 		actualKey = attempts[n-1].Key
 	}
-	return &RouteOutcome{
+	out := &RouteOutcome{
 		PlannedModel:  rp.Profile.Key,
 		ActualModel:   actualKey,
 		FallbacksUsed: fallbacksUsed,
@@ -653,6 +688,35 @@ func (rp *RoutePlan) buildOutcome(fallbacksUsed int, attempts []RouteAttempt) *R
 		Reason:        rp.Reason,
 		RouteID:       newRouteID(),
 		Attempts:      attempts,
+	}
+	if rp.scoreBreakdown != nil {
+		out.ScoreBreakdown = publicScoreBreakdown(rp.scoreBreakdown, rp.builtUnderMode, rp.feedbackStatus)
+	}
+	return out
+}
+
+// publicScoreBreakdown translates the unexported per-candidate
+// scoreBreakdown into the public ScoreBreakdown for RouteOutcome. The
+// mode argument is the FeedbackScoringMode under which the plan was
+// built (Off mode skips the stamp at the Router call site, so this
+// function is unreachable under Off in production); the status argument
+// is the snapshot's feedbackSnapshotStatus, stamped by the Router from
+// feedbackSnapshot.status at plan-build.
+func publicScoreBreakdown(bd *scoreBreakdown, mode FeedbackScoringMode, status feedbackSnapshotStatus) *ScoreBreakdown {
+	if bd == nil {
+		return nil
+	}
+	return &ScoreBreakdown{
+		FeedbackMode:           mode.String(),
+		FeedbackSnapshotStatus: string(status),
+		FeedbackApplied:        bd.feedbackActive && mode == FeedbackScoringEnforce,
+		FeedbackScore:          bd.feedbackRaw,
+		FeedbackAdjustedScore:  bd.feedbackAdjusted,
+		FeedbackSampleCount:    bd.feedbackSampleCount,
+		FeedbackScoredCount:    bd.feedbackScoredCount,
+		FeedbackUpdatedAt:      bd.feedbackUpdatedAt,
+		ScoreWithoutFeedback:   bd.scoreWithoutFeedback,
+		ScoreWithFeedback:      bd.scoreWithFeedback,
 	}
 }
 

--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"slices"
 	"time"
 )
@@ -747,7 +748,7 @@ func publicScoreBreakdown(bd *scoreBreakdown, mode FeedbackScoringMode, status f
 		FeedbackMode:           mode.String(),
 		FeedbackSnapshotStatus: string(status),
 		FeedbackApplied:        bd.feedbackActive && mode == FeedbackScoringEnforce,
-		FeedbackScore:          bd.feedbackRaw,
+		FeedbackScore:          sanitizeScoreForJSON(bd.feedbackRaw),
 		FeedbackAdjustedScore:  bd.feedbackAdjusted,
 		FeedbackSampleCount:    bd.feedbackSampleCount,
 		FeedbackScoredCount:    bd.feedbackScoredCount,
@@ -755,6 +756,13 @@ func publicScoreBreakdown(bd *scoreBreakdown, mode FeedbackScoringMode, status f
 		ScoreWithoutFeedback:   bd.scoreWithoutFeedback,
 		ScoreWithFeedback:      bd.scoreWithFeedback,
 	}
+}
+
+func sanitizeScoreForJSON(score float64) float64 {
+	if math.IsNaN(score) || math.IsInf(score, 0) {
+		return DefaultNeutralScore
+	}
+	return clip(score, 0, 1)
 }
 
 // ---------------------------------------------------------------------------

--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -63,6 +63,19 @@ type RoutePlan struct {
 	// operators can distinguish "off by design" from "off because the
 	// store failed" without parsing logs.
 	feedbackStatus feedbackSnapshotStatus
+
+	// feedbackLogger is the optional once-logged-warning sink used by
+	// newRouteIDWithWarn (RNG failures) and recordOutcomeFeedback (store
+	// write failures). nil disables emission and the bare PR2 fallback
+	// behavior (empty RouteID / silent swallow) applies. Set by buildPlan
+	// via setFeedbackTelemetry.
+	feedbackLogger feedbackLogger
+
+	// feedbackWarn holds the sync.Once guards backing the above logger so
+	// a persistently broken store cannot flood operator logs. Per-Router
+	// instance; shared with every plan the Router constructs. nil
+	// disables emission. Set by buildPlan via setFeedbackTelemetry.
+	feedbackWarn *feedbackWarningState
 }
 
 // String returns a human-readable summary of the route plan.
@@ -115,6 +128,18 @@ func (rp *RoutePlan) setBuiltUnderMode(mode FeedbackScoringMode) {
 // or inactive. Unexported because it takes an unexported type.
 func (rp *RoutePlan) setFeedbackStatus(status feedbackSnapshotStatus) {
 	rp.feedbackStatus = status
+}
+
+// setFeedbackTelemetry records the once-logged-warning state and logger
+// the plan will use when newRouteIDWithWarn hits a crypto/rand failure or
+// when recordOutcomeFeedback observes a store error. nil values disable
+// warnings (silent fallback to PR2 behavior: empty RouteID, silent-swallow
+// on write). Unexported because it takes an unexported *feedbackWarningState
+// and feedbackLogger; the convention matches the other unexported setters
+// (setScoreBreakdown / setBuiltUnderMode / setFeedbackStatus).
+func (rp *RoutePlan) setFeedbackTelemetry(state *feedbackWarningState, logger feedbackLogger) {
+	rp.feedbackWarn = state
+	rp.feedbackLogger = logger
 }
 
 // WasSticky reports whether the plan was selected via sticky routing. This
@@ -690,7 +715,7 @@ func (rp *RoutePlan) buildOutcome(fallbacksUsed int, attempts []RouteAttempt) *R
 		WasSticky:     rp.wasSticky,
 		Score:         rp.Score,
 		Reason:        rp.Reason,
-		RouteID:       newRouteID(),
+		RouteID:       newRouteIDWithWarn(rp.feedbackWarn, rp.feedbackLogger),
 		Attempts:      attempts,
 	}
 	if rp.scoreBreakdown != nil {
@@ -805,19 +830,35 @@ func hasVisibleContent(content, thinking string, toolCalls []ToolCall) bool {
 // empty-string-on-error branch.
 var routeIDRand io.Reader = rand.Reader
 
+// newRouteIDWithWarn is the warning-emitting variant of newRouteID.
+// state and logger may both be nil; nil disables the once-logged warning
+// emission but preserves the empty-string-on-error fallback (so callers
+// that don't carry a Router-owned warn state — tests, helpers — keep
+// PR2's silent-empty-string behavior).
+//
+// Reuses the package-level routeIDRand io.Reader so tests can inject
+// failure modes without going through a constructor seam.
+func newRouteIDWithWarn(state *feedbackWarningState, logger feedbackLogger) string {
+	var b [16]byte
+	if _, err := io.ReadFull(routeIDRand, b[:]); err != nil {
+		if state != nil {
+			state.warnRouteIDRandOnce(logger, err)
+		}
+		return ""
+	}
+	return hex.EncodeToString(b[:])
+}
+
 // newRouteID returns a 16-byte random hex string (32 chars) suitable as an
 // opaque correlation ID on RouteOutcome.RouteID. crypto/rand failures are
 // silently coerced to an empty string — RouteID is informational; we do
 // not want routing paths to fail because the OS RNG returned an error.
 //
-// TODO: once-logged warning on first RNG failure so operators discover the
-// cause when correlation IDs disappear.
+// Equivalent to newRouteIDWithWarn(nil, nil). Preserved as a bare entry
+// point for callers (tests, helpers) that don't carry a Router-owned
+// warn state.
 func newRouteID() string {
-	var b [16]byte
-	if _, err := io.ReadFull(routeIDRand, b[:]); err != nil {
-		return ""
-	}
-	return hex.EncodeToString(b[:])
+	return newRouteIDWithWarn(nil, nil)
 }
 
 // makeAttempt builds a RouteAttempt for one provider call.
@@ -873,21 +914,25 @@ var feedbackWriteTimeout = 1 * time.Second
 
 // recordOutcomeFeedback delegates to RoutingFeedback.RecordOutcome when a
 // feedback wrapper is configured AND the routing request has a non-empty
-// UseCase. Errors are swallowed — the seam is observational, never
-// load-bearing for routing. Uses a fresh context with a bounded timeout
-// (not the request ctx) so cancellation of the caller's ctx does not cut
-// short the feedback write, and so a slow/stuck store does not block the
-// routing path indefinitely.
+// UseCase. The seam is observational, never load-bearing for routing;
+// errors do not bubble up to the caller. Uses a fresh context with a
+// bounded timeout (not the request ctx) so cancellation of the caller's
+// ctx does not cut short the feedback write, and so a slow/stuck store
+// does not block the routing path indefinitely.
 //
-// TODO: expose a counter or once-logged warning when the store returns a
-// non-nil error. Today's silent-swallow makes a broken store look identical
-// to a working empty store from the operator's view. Track in the PR that
-// adds the SQLite-backed store.
+// On non-nil store error: emits a once-logged warning via feedbackWarn /
+// feedbackLogger (set by buildPlan through setFeedbackTelemetry). Replaces
+// PR2's silent-swallow; nil warn state preserves the silent fallback for
+// plans constructed without telemetry wiring.
 func (rp *RoutePlan) recordOutcomeFeedback(outcome *RouteOutcome) {
 	if rp.feedback == nil || outcome == nil || rp.Request.UseCase == "" {
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), feedbackWriteTimeout)
 	defer cancel()
-	_ = rp.feedback.RecordOutcome(ctx, rp.Request.UseCase, *outcome)
+	if err := rp.feedback.RecordOutcome(ctx, rp.Request.UseCase, *outcome); err != nil {
+		if rp.feedbackWarn != nil {
+			rp.feedbackWarn.warnFeedbackWriteOnce(rp.feedbackLogger, err)
+		}
+	}
 }

--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -854,9 +854,13 @@ func newRouteIDWithWarn(state *feedbackWarningState, logger feedbackLogger) stri
 // silently coerced to an empty string — RouteID is informational; we do
 // not want routing paths to fail because the OS RNG returned an error.
 //
-// Equivalent to newRouteIDWithWarn(nil, nil). Preserved as a bare entry
-// point for callers (tests, helpers) that don't carry a Router-owned
-// warn state.
+// **Test-only entry point.** The production path in `buildOutcome` calls
+// `newRouteIDWithWarn(rp.feedbackWarn, rp.feedbackLogger)` so RNG failures
+// fire the once-logged warning via the Router-owned `feedbackWarn`. This
+// bare variant is equivalent to `newRouteIDWithWarn(nil, nil)` and exists
+// only for tests and helpers that don't carry a Router-owned warn state;
+// it does NOT emit warnings. Do NOT call from production code paths or
+// you will lose visibility on the first RNG failure.
 func newRouteID() string {
 	return newRouteIDWithWarn(nil, nil)
 }

--- a/provider/route_plan.go
+++ b/provider/route_plan.go
@@ -90,26 +90,30 @@ func (rp *RoutePlan) SetWasSticky(v bool) {
 	rp.wasSticky = v
 }
 
-// SetScoreBreakdown stamps the winning candidate's score breakdown onto
+// setScoreBreakdown stamps the winning candidate's score breakdown onto
 // the plan. The Router calls this from buildPlan; subsequent buildOutcome
 // translates the unexported breakdown into the public ScoreBreakdown.
 // nil disables the public ScoreBreakdown on this plan's outcomes.
-func (rp *RoutePlan) SetScoreBreakdown(bd *scoreBreakdown) {
+// Unexported because it takes an unexported type; external callers
+// cannot legally pass a *scoreBreakdown anyway.
+func (rp *RoutePlan) setScoreBreakdown(bd *scoreBreakdown) {
 	rp.scoreBreakdown = bd
 }
 
-// SetBuiltUnderMode records the FeedbackScoringMode in effect when the
+// setBuiltUnderMode records the FeedbackScoringMode in effect when the
 // Router built this plan so buildOutcome can render the public
-// ScoreBreakdown with the matching operator-facing label.
-func (rp *RoutePlan) SetBuiltUnderMode(mode FeedbackScoringMode) {
+// ScoreBreakdown with the matching operator-facing label. Unexported
+// to keep the RoutePlan public surface narrow; this is plumbing,
+// not API.
+func (rp *RoutePlan) setBuiltUnderMode(mode FeedbackScoringMode) {
 	rp.builtUnderMode = mode
 }
 
-// SetFeedbackStatus records the feedback snapshot status from the route's
+// setFeedbackStatus records the feedback snapshot status from the route's
 // feedback snapshot so buildOutcome can render it on the public
 // ScoreBreakdown for operator visibility into why feedback was active
-// or inactive.
-func (rp *RoutePlan) SetFeedbackStatus(status feedbackSnapshotStatus) {
+// or inactive. Unexported because it takes an unexported type.
+func (rp *RoutePlan) setFeedbackStatus(status feedbackSnapshotStatus) {
 	rp.feedbackStatus = status
 }
 
@@ -706,6 +710,14 @@ func publicScoreBreakdown(bd *scoreBreakdown, mode FeedbackScoringMode, status f
 	if bd == nil {
 		return nil
 	}
+	// Convert the zero-value time.Time to a nil *time.Time so the JSON
+	// boundary omits the field entirely (rather than emitting "0001-01-01T..."
+	// which an operator might confuse with a real timestamp).
+	var updatedAt *time.Time
+	if !bd.feedbackUpdatedAt.IsZero() {
+		t := bd.feedbackUpdatedAt
+		updatedAt = &t
+	}
 	return &ScoreBreakdown{
 		FeedbackMode:           mode.String(),
 		FeedbackSnapshotStatus: string(status),
@@ -714,7 +726,7 @@ func publicScoreBreakdown(bd *scoreBreakdown, mode FeedbackScoringMode, status f
 		FeedbackAdjustedScore:  bd.feedbackAdjusted,
 		FeedbackSampleCount:    bd.feedbackSampleCount,
 		FeedbackScoredCount:    bd.feedbackScoredCount,
-		FeedbackUpdatedAt:      bd.feedbackUpdatedAt,
+		FeedbackUpdatedAt:      updatedAt,
 		ScoreWithoutFeedback:   bd.scoreWithoutFeedback,
 		ScoreWithFeedback:      bd.scoreWithFeedback,
 	}

--- a/provider/route_plan_test.go
+++ b/provider/route_plan_test.go
@@ -2,10 +2,13 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 // ---------------------------------------------------------------------------
@@ -1899,5 +1902,108 @@ func TestExecuteGenerateStreamFallbackDuplicateDoneRecordsAttemptOnce(t *testing
 	}
 	if successes := rec.getSuccesses(); len(successes) != 1 {
 		t.Fatalf("successes = %d, want 1", len(successes))
+	}
+}
+
+func TestRouteOutcomeScoreBreakdownNilInOffMode(t *testing.T) {
+	router, _ := setupTestRouter(t) // default Off mode
+	plan, err := router.Route(context.Background(), RoutingRequest{Model: "test/qwen3:8b", UseCase: "chat"})
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	resp, err := plan.ExecuteChat(context.Background())
+	if err != nil {
+		t.Fatalf("ExecuteChat: %v", err)
+	}
+	if resp.RouteOutcome == nil {
+		t.Fatalf("RouteOutcome nil")
+	}
+	if resp.RouteOutcome.ScoreBreakdown != nil {
+		t.Errorf("Off mode: ScoreBreakdown = %+v, want nil", resp.RouteOutcome.ScoreBreakdown)
+	}
+}
+
+func TestRouteOutcomeScoreBreakdownPopulatedInEnforceMode(t *testing.T) {
+	rf := mustNewRoutingFeedback(t, MemoryStoreConfig{})
+	k := FeedbackKey{Provider: "test", Model: "qwen3:8b", UseCase: "chat"}
+	for i := 0; i < feedbackMinScoredCount+2; i++ {
+		if err := rf.Record(context.Background(), k, FeedbackSignal{Kind: RoutingSignalSuccess, At: time.Now()}); err != nil {
+			t.Fatalf("Record: %v", err)
+		}
+	}
+	router, _ := setupTestRouter(t, WithRoutingFeedback(rf), WithFeedbackScoringMode(FeedbackScoringEnforce))
+
+	plan, err := router.Route(context.Background(), RoutingRequest{Model: "test/qwen3:8b", UseCase: "chat"})
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	resp, err := plan.ExecuteChat(context.Background())
+	if err != nil {
+		t.Fatalf("ExecuteChat: %v", err)
+	}
+	bd := resp.RouteOutcome.ScoreBreakdown
+	if bd == nil {
+		t.Fatalf("Enforce mode: ScoreBreakdown = nil, want non-nil")
+	}
+	if !bd.FeedbackApplied {
+		t.Errorf("FeedbackApplied = false, want true (Enforce + valid snapshot)")
+	}
+	if bd.FeedbackMode != FeedbackScoringEnforce.String() {
+		t.Errorf("FeedbackMode = %q, want %q", bd.FeedbackMode, FeedbackScoringEnforce.String())
+	}
+	if bd.FeedbackSnapshotStatus != string(feedbackSnapshotStatusActive) {
+		t.Errorf("FeedbackSnapshotStatus = %q, want %q",
+			bd.FeedbackSnapshotStatus, feedbackSnapshotStatusActive)
+	}
+	if bd.FeedbackScore <= 0.5 {
+		t.Errorf("FeedbackScore = %v, want > 0.5 after seeded successes", bd.FeedbackScore)
+	}
+	if bd.ScoreWithoutFeedback == bd.ScoreWithFeedback {
+		t.Errorf("with/without scores identical %v; expected delta because feedback was non-neutral",
+			bd.ScoreWithFeedback)
+	}
+}
+
+func TestRouteOutcomeScoreBreakdownPopulatedInShadowMode(t *testing.T) {
+	rf := mustNewRoutingFeedback(t, MemoryStoreConfig{})
+	k := FeedbackKey{Provider: "test", Model: "qwen3:8b", UseCase: "chat"}
+	for i := 0; i < feedbackMinScoredCount+2; i++ {
+		if err := rf.Record(context.Background(), k, FeedbackSignal{Kind: RoutingSignalSuccess, At: time.Now()}); err != nil {
+			t.Fatalf("Record: %v", err)
+		}
+	}
+	router, _ := setupTestRouter(t, WithRoutingFeedback(rf), WithFeedbackScoringMode(FeedbackScoringShadow))
+
+	plan, err := router.Route(context.Background(), RoutingRequest{Model: "test/qwen3:8b", UseCase: "chat"})
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	resp, err := plan.ExecuteChat(context.Background())
+	if err != nil {
+		t.Fatalf("ExecuteChat: %v", err)
+	}
+	bd := resp.RouteOutcome.ScoreBreakdown
+	if bd == nil {
+		t.Fatalf("Shadow mode: ScoreBreakdown = nil, want non-nil")
+	}
+	if bd.FeedbackApplied {
+		t.Errorf("Shadow mode: FeedbackApplied = true, want false")
+	}
+	if bd.FeedbackMode != FeedbackScoringShadow.String() {
+		t.Errorf("FeedbackMode = %q, want %q", bd.FeedbackMode, FeedbackScoringShadow.String())
+	}
+	if bd.FeedbackScore <= 0.5 {
+		t.Errorf("Shadow mode: FeedbackScore = %v, want > 0.5 (snapshot still active)", bd.FeedbackScore)
+	}
+}
+
+func TestRouteOutcomeScoreBreakdownJSONOmitemptyWhenNil(t *testing.T) {
+	out := RouteOutcome{PlannedModel: ModelKey{Provider: "p", Model: "m"}}
+	data, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(data), "score_breakdown") {
+		t.Errorf("JSON %s contains score_breakdown despite nil pointer", data)
 	}
 }

--- a/provider/route_plan_test.go
+++ b/provider/route_plan_test.go
@@ -2138,3 +2138,71 @@ func TestBuildOutcomeScoreBreakdownSnapshotStatusReflectsRoute(t *testing.T) {
 			pubBd.FeedbackUpdatedAt)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Task 11 — once-logged warnings on RNG failure / feedback store write
+// ---------------------------------------------------------------------------
+
+// TestNewRouteIDLogsOnceOnRandFailure substitutes a failing RNG and a
+// capturing logger, then asserts the once-logged warning fires exactly
+// once across many calls. Reuses routeIDFailingReader (defined in
+// routing_feedback_test.go).
+func TestNewRouteIDLogsOnceOnRandFailure(t *testing.T) {
+	cap := &capturingLogger{}
+	state := newFeedbackWarningState()
+
+	old := routeIDRand
+	t.Cleanup(func() { routeIDRand = old })
+	routeIDRand = routeIDFailingReader{}
+
+	for i := 0; i < 50; i++ {
+		id := newRouteIDWithWarn(state, cap)
+		if id != "" {
+			t.Errorf("expected empty id on RNG failure, got %q", id)
+		}
+	}
+	if got := len(cap.snapshot()); got != 1 {
+		t.Errorf("warnRouteIDRandOnce fired %d times, want 1", got)
+	}
+}
+
+// recordFailingStore implements RoutingFeedbackStore for the Task 11
+// write-error test. Get returns a neutral aggregate (so Route succeeds);
+// Record / RecordBatch always fail so recordOutcomeFeedback hits its
+// once-logged warning path.
+type recordFailingStore struct{ err error }
+
+func (s *recordFailingStore) Get(_ context.Context, _ FeedbackKey) (Aggregate, error) {
+	return Aggregate{Score: DefaultNeutralScore}, nil
+}
+
+func (s *recordFailingStore) Record(_ context.Context, _ FeedbackKey, _ FeedbackSignal) error {
+	return s.err
+}
+
+func (s *recordFailingStore) RecordBatch(_ context.Context, _ []FeedbackItem) error {
+	return s.err
+}
+
+// TestRecordOutcomeFeedbackLogsOnceOnStoreError drives ExecuteChat
+// repeatedly against a store that always fails on Record/RecordBatch and
+// asserts the once-logged warning fires exactly once across the loop.
+func TestRecordOutcomeFeedbackLogsOnceOnStoreError(t *testing.T) {
+	router, _ := setupTestRouter(t)
+	router.routingFeedback = NewRoutingFeedback(&recordFailingStore{err: errors.New("disk full")})
+	cap := &capturingLogger{}
+	router.feedbackLogger = cap
+
+	plan, err := router.Route(context.Background(), RoutingRequest{Model: "test/qwen3:8b", UseCase: "chat"})
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := plan.ExecuteChat(context.Background()); err != nil {
+			t.Fatalf("ExecuteChat: %v", err)
+		}
+	}
+	if got := len(cap.snapshot()); got != 1 {
+		t.Errorf("warnFeedbackWriteOnce fired %d times, want 1", got)
+	}
+}

--- a/provider/route_plan_test.go
+++ b/provider/route_plan_test.go
@@ -2096,6 +2096,18 @@ func TestBuildOutcomeScoreBreakdownStableAcrossFallback(t *testing.T) {
 		t.Errorf("FeedbackUpdatedAt = %v, want pointer to unix 123 (planned primary's, not rewritten)",
 			pubBd.FeedbackUpdatedAt)
 	}
+	// Mode + counts are translator-read fields; pin them so a future
+	// regression that re-stamps from the fallback's snapshot is caught.
+	if pubBd.FeedbackMode != FeedbackScoringEnforce.String() {
+		t.Errorf("FeedbackMode = %q, want %q (planned primary's mode, not rewritten)",
+			pubBd.FeedbackMode, FeedbackScoringEnforce.String())
+	}
+	if pubBd.FeedbackSampleCount != 30 {
+		t.Errorf("FeedbackSampleCount = %d, want 30 (planned primary's, not rewritten)", pubBd.FeedbackSampleCount)
+	}
+	if pubBd.FeedbackScoredCount != 30 {
+		t.Errorf("FeedbackScoredCount = %d, want 30 (planned primary's, not rewritten)", pubBd.FeedbackScoredCount)
+	}
 }
 
 func TestBuildOutcomeScoreBreakdownSnapshotStatusReflectsRoute(t *testing.T) {
@@ -2136,6 +2148,12 @@ func TestBuildOutcomeScoreBreakdownSnapshotStatusReflectsRoute(t *testing.T) {
 	if pubBd.FeedbackUpdatedAt != nil {
 		t.Errorf("FeedbackUpdatedAt = %v, want nil (zero feedbackUpdatedAt should omit)",
 			pubBd.FeedbackUpdatedAt)
+	}
+	// Operator-facing mode label must say "enforce" even on fail-open so
+	// dashboards can distinguish "Enforce + read_error" from "Shadow"
+	// (both produce FeedbackApplied=false but for different reasons).
+	if pubBd.FeedbackMode != FeedbackScoringEnforce.String() {
+		t.Errorf("FeedbackMode = %q, want %q", pubBd.FeedbackMode, FeedbackScoringEnforce.String())
 	}
 }
 

--- a/provider/route_plan_test.go
+++ b/provider/route_plan_test.go
@@ -2020,3 +2020,121 @@ func TestRouteOutcomeScoreBreakdownJSONOmitemptyWhenNil(t *testing.T) {
 		t.Errorf("JSON %s contains score_breakdown despite nil pointer", data)
 	}
 }
+
+func TestBuildOutcomeScoreBreakdownStableAcrossFallback(t *testing.T) {
+	plannedKey := ModelKey{Provider: "primary", Model: "qwen3:8b"}
+	fallbackKey := ModelKey{Provider: "fallback", Model: "qwen3:8b"}
+
+	// Construct a plan by hand with a planted scoreBreakdown that
+	// describes the planned primary.
+	plan := &RoutePlan{
+		Profile: &ModelProfile{Key: plannedKey},
+		Score:   0.85,
+		Reason:  "primary won",
+	}
+	bd := &scoreBreakdown{
+		feedbackActive:       true,
+		feedbackRaw:          0.8,
+		feedbackAdjusted:     0.7,
+		feedbackSampleCount:  30,
+		feedbackScoredCount:  30,
+		feedbackUpdatedAt:    time.Unix(123, 0),
+		scoreWithoutFeedback: 0.6,
+		scoreWithFeedback:    0.85,
+	}
+	plan.setScoreBreakdown(bd)
+	plan.setBuiltUnderMode(FeedbackScoringEnforce)
+	plan.setFeedbackStatus(feedbackSnapshotStatusActive)
+
+	// Simulate execution: primary failed (HTTP 5xx), fallback succeeded.
+	attempts := []RouteAttempt{
+		{Key: plannedKey, Status: AttemptStatusFailed, ErrorClass: string(ErrorClass5xx), LatencyMs: 50},
+		{Key: fallbackKey, Status: AttemptStatusSucceeded, LatencyMs: 100},
+	}
+	out := plan.buildOutcome(1, attempts)
+
+	// Execution trace reflects the fallback.
+	if out.PlannedModel != plannedKey {
+		t.Errorf("PlannedModel = %v, want %v", out.PlannedModel, plannedKey)
+	}
+	if out.ActualModel != fallbackKey {
+		t.Errorf("ActualModel = %v, want %v (after fallback success)", out.ActualModel, fallbackKey)
+	}
+	if out.FallbacksUsed != 1 {
+		t.Errorf("FallbacksUsed = %d, want 1", out.FallbacksUsed)
+	}
+
+	// ScoreBreakdown describes the planned candidate, NOT the fallback.
+	pubBd := out.ScoreBreakdown
+	if pubBd == nil {
+		t.Fatalf("ScoreBreakdown nil")
+	}
+	if pubBd.FeedbackScore != 0.8 {
+		t.Errorf("FeedbackScore = %v, want 0.8 (planned primary's raw score, unchanged by fallback)",
+			pubBd.FeedbackScore)
+	}
+	if pubBd.FeedbackAdjustedScore != 0.7 {
+		t.Errorf("FeedbackAdjustedScore = %v, want 0.7 (planned primary's adjusted, unchanged by fallback)",
+			pubBd.FeedbackAdjustedScore)
+	}
+	if pubBd.ScoreWithoutFeedback != 0.6 {
+		t.Errorf("ScoreWithoutFeedback = %v, want 0.6", pubBd.ScoreWithoutFeedback)
+	}
+	if pubBd.ScoreWithFeedback != 0.85 {
+		t.Errorf("ScoreWithFeedback = %v, want 0.85", pubBd.ScoreWithFeedback)
+	}
+	if !pubBd.FeedbackApplied {
+		t.Errorf("FeedbackApplied = false, want true (Enforce + active snapshot at plan-build)")
+	}
+	if pubBd.FeedbackSnapshotStatus != FeedbackSnapshotStatusActive {
+		t.Errorf("FeedbackSnapshotStatus = %q, want %q",
+			pubBd.FeedbackSnapshotStatus, FeedbackSnapshotStatusActive)
+	}
+	// FeedbackUpdatedAt is *time.Time post-Task-9-fix; assert it carries
+	// the planted timestamp (not the fallback's execution time).
+	if pubBd.FeedbackUpdatedAt == nil || !pubBd.FeedbackUpdatedAt.Equal(time.Unix(123, 0)) {
+		t.Errorf("FeedbackUpdatedAt = %v, want pointer to unix 123 (planned primary's, not rewritten)",
+			pubBd.FeedbackUpdatedAt)
+	}
+}
+
+func TestBuildOutcomeScoreBreakdownSnapshotStatusReflectsRoute(t *testing.T) {
+	// When the snapshot fail-opens (status=read_error), the breakdown
+	// is still stamped (the plan exists, the breakdown was built) but
+	// FeedbackApplied is false and the status is preserved.
+	plan := &RoutePlan{
+		Profile: &ModelProfile{Key: ModelKey{Provider: "p", Model: "m"}},
+		Score:   0.5,
+		Reason:  "fail-open",
+	}
+	bd := &scoreBreakdown{
+		feedbackActive:       false, // snapshot was inactive
+		feedbackRaw:          0,
+		feedbackAdjusted:     0.5,
+		scoreWithoutFeedback: 0.5,
+		scoreWithFeedback:    0.5,
+	}
+	plan.setScoreBreakdown(bd)
+	plan.setBuiltUnderMode(FeedbackScoringEnforce)
+	plan.setFeedbackStatus(feedbackSnapshotStatusReadError)
+
+	attempts := []RouteAttempt{{Key: ModelKey{Provider: "p", Model: "m"}, Status: AttemptStatusSucceeded}}
+	out := plan.buildOutcome(0, attempts)
+
+	pubBd := out.ScoreBreakdown
+	if pubBd == nil {
+		t.Fatalf("ScoreBreakdown nil")
+	}
+	if pubBd.FeedbackApplied {
+		t.Errorf("read_error: FeedbackApplied = true, want false")
+	}
+	if pubBd.FeedbackSnapshotStatus != FeedbackSnapshotStatusReadError {
+		t.Errorf("FeedbackSnapshotStatus = %q, want %q",
+			pubBd.FeedbackSnapshotStatus, FeedbackSnapshotStatusReadError)
+	}
+	// Zero feedbackUpdatedAt should produce nil pointer (Task 9 fix).
+	if pubBd.FeedbackUpdatedAt != nil {
+		t.Errorf("FeedbackUpdatedAt = %v, want nil (zero feedbackUpdatedAt should omit)",
+			pubBd.FeedbackUpdatedAt)
+	}
+}

--- a/provider/route_plan_test.go
+++ b/provider/route_plan_test.go
@@ -1995,6 +1995,19 @@ func TestRouteOutcomeScoreBreakdownPopulatedInShadowMode(t *testing.T) {
 	if bd.FeedbackScore <= 0.5 {
 		t.Errorf("Shadow mode: FeedbackScore = %v, want > 0.5 (snapshot still active)", bd.FeedbackScore)
 	}
+	// Spec § Behavior contracts 1: Shadow mode must expose the
+	// would-be-applied delta in the breakdown — otherwise the mode
+	// has no operator value during ramp-up. Locks the deltaActiveSignals
+	// vs selectionActiveSignals split.
+	if bd.ScoreWithFeedback == bd.ScoreWithoutFeedback {
+		t.Errorf("Shadow mode: with/without scores identical (%v); breakdown must expose the delta",
+			bd.ScoreWithFeedback)
+	}
+	// Stable enum check against the public string constants.
+	if bd.FeedbackSnapshotStatus != FeedbackSnapshotStatusActive {
+		t.Errorf("Shadow mode: FeedbackSnapshotStatus = %q, want %q",
+			bd.FeedbackSnapshotStatus, FeedbackSnapshotStatusActive)
+	}
 }
 
 func TestRouteOutcomeScoreBreakdownJSONOmitemptyWhenNil(t *testing.T) {

--- a/provider/route_plan_test.go
+++ b/provider/route_plan_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math"
 	"net"
 	"strings"
 	"sync"
@@ -2107,6 +2108,42 @@ func TestBuildOutcomeScoreBreakdownStableAcrossFallback(t *testing.T) {
 	}
 	if pubBd.FeedbackScoredCount != 30 {
 		t.Errorf("FeedbackScoredCount = %d, want 30 (planned primary's, not rewritten)", pubBd.FeedbackScoredCount)
+	}
+}
+
+func TestBuildOutcomeScoreBreakdownSanitizesNonFiniteRawFeedbackScore(t *testing.T) {
+	cases := []float64{math.NaN(), math.Inf(1), math.Inf(-1)}
+	for _, raw := range cases {
+		t.Run("", func(t *testing.T) {
+			plan := &RoutePlan{
+				Profile: &ModelProfile{Key: ModelKey{Provider: "p", Model: "m"}},
+				Score:   0.5,
+				Reason:  "custom store score",
+			}
+			bd := &scoreBreakdown{
+				feedbackActive:       true,
+				feedbackRaw:          raw,
+				feedbackAdjusted:     0.5,
+				feedbackSampleCount:  5,
+				feedbackScoredCount:  5,
+				scoreWithoutFeedback: 0.5,
+				scoreWithFeedback:    0.5,
+			}
+			plan.setScoreBreakdown(bd)
+			plan.setBuiltUnderMode(FeedbackScoringShadow)
+			plan.setFeedbackStatus(feedbackSnapshotStatusActive)
+
+			out := plan.buildOutcome(0, []RouteAttempt{{Key: ModelKey{Provider: "p", Model: "m"}, Status: AttemptStatusSucceeded}})
+			if out.ScoreBreakdown == nil {
+				t.Fatalf("ScoreBreakdown nil")
+			}
+			if out.ScoreBreakdown.FeedbackScore != DefaultNeutralScore {
+				t.Fatalf("FeedbackScore = %v, want neutral %v", out.ScoreBreakdown.FeedbackScore, DefaultNeutralScore)
+			}
+			if _, err := json.Marshal(out); err != nil {
+				t.Fatalf("json.Marshal(RouteOutcome) = %v", err)
+			}
+		})
 	}
 }
 

--- a/provider/router.go
+++ b/provider/router.go
@@ -385,7 +385,7 @@ func (r *Router) Route(ctx context.Context, req RoutingRequest) (*RoutePlan, err
 			// Return best truncatable with adaptation error.
 			sortScoredCandidates(truncatable, r.warmth)
 			winner := truncatable[0]
-			plan, buildErr := r.buildPlan(winner, nil, req, false)
+			plan, buildErr := r.buildPlan(winner, nil, req, false, snap)
 			if buildErr != nil {
 				return nil, ErrNoViableCandidate
 			}
@@ -444,7 +444,7 @@ func (r *Router) Route(ctx context.Context, req RoutingRequest) (*RoutePlan, err
 		fallbacks = executable[1 : 1+maxFb]
 	}
 
-	plan, buildErr := r.buildPlan(executable[0], fallbacks, req, wasSticky)
+	plan, buildErr := r.buildPlan(executable[0], fallbacks, req, wasSticky, snap)
 	if buildErr != nil {
 		return nil, fmt.Errorf("router: %w", buildErr)
 	}
@@ -992,8 +992,12 @@ func (r *Router) findIncumbentScore(key ModelKey, scored []scoredCandidate) int 
 }
 
 // buildPlan constructs a RoutePlan from the winning candidate, fallback
-// candidates, the original request, and the sticky state.
-func (r *Router) buildPlan(winner scoredCandidate, fallbacks []scoredCandidate, req RoutingRequest, wasSticky bool) (*RoutePlan, error) {
+// candidates, the original request, the sticky state, and the route-level
+// feedback snapshot. The snapshot is read for its mode and status fields
+// only — store I/O is the caller's responsibility (Route() / routeChain()
+// build the snapshot exactly once and thread it through). A nil snap is
+// tolerated defensively but should never happen in production.
+func (r *Router) buildPlan(winner scoredCandidate, fallbacks []scoredCandidate, req RoutingRequest, wasSticky bool, snap *feedbackSnapshot) (*RoutePlan, error) {
 	prov, err := r.providers.Resolve(winner.profile.Key)
 	if err != nil {
 		return nil, fmt.Errorf("router: provider resolution failed for %s: %w", winner.profile.Key, err)
@@ -1012,6 +1016,18 @@ func (r *Router) buildPlan(winner scoredCandidate, fallbacks []scoredCandidate, 
 	plan.SetWasSticky(wasSticky)
 	plan.SetRecorder(r)
 	plan.SetFeedback(r.routingFeedback) // ← PR2 addition; nil is fine, SetFeedback handles it
+
+	// Stamp the winner's breakdown and the mode used for selection so
+	// buildOutcome can render the public ScoreBreakdown. Off mode skips
+	// the stamp entirely so RouteOutcome.ScoreBreakdown stays nil. A nil
+	// snap (defensive — Route() and routeChain() always pass one) also
+	// skips the stamp.
+	if r.feedbackScoringMode != FeedbackScoringOff && snap != nil {
+		bd := winner.bd
+		plan.SetScoreBreakdown(&bd)
+		plan.SetBuiltUnderMode(r.feedbackScoringMode)
+		plan.SetFeedbackStatus(snap.status)
+	}
 
 	// Build fallback chain.
 	for _, fb := range fallbacks {

--- a/provider/router.go
+++ b/provider/router.go
@@ -68,6 +68,17 @@ type Router struct {
 	// by this field. See routing_feedback.go and the FeedbackScoringMode
 	// docs for the full truth table.
 	feedbackScoringMode FeedbackScoringMode
+	// feedbackLogger receives once-logged warnings about feedback store
+	// failures and newRouteID RNG failures. Defaults to defaultFeedbackLogger
+	// (wraps log.Default()). Tests in the same package can assign a
+	// capturing implementation directly (router.feedbackLogger = cap)
+	// after setupTestRouter returns — no exported option (would expose
+	// the unexported feedbackLogger interface).
+	feedbackLogger feedbackLogger
+
+	// feedbackWarn holds the sync.Once guards for the three warning types
+	// emitted by the feedback surface.
+	feedbackWarn *feedbackWarningState
 }
 
 // Compile-time assertion that Router implements RouteRecorder.
@@ -246,6 +257,8 @@ func NewRouter(registry *ModelRegistry, providers *Registry, opts ...RouterOptio
 		},
 		done: make(chan struct{}),
 	}
+	r.feedbackLogger = defaultFeedbackLogger
+	r.feedbackWarn = newFeedbackWarningState()
 
 	for _, opt := range opts {
 		opt(r)

--- a/provider/router.go
+++ b/provider/router.go
@@ -757,6 +757,158 @@ func (r *Router) activeSignals() map[string]bool {
 	return active
 }
 
+// ---------------------------------------------------------------------------
+// Feedback snapshot
+// ---------------------------------------------------------------------------
+
+// feedbackSnapshotStatus is the operator-facing reason why a route's
+// feedback snapshot was (or was not) active. Unexported per the spec's
+// PR3-public-surface restriction; the public ScoreBreakdown surfaces
+// the same value as a plain string field so operators can distinguish
+// "feedback off by design" from "feedback off because the store failed"
+// without parsing logs.
+type feedbackSnapshotStatus string
+
+const (
+	// feedbackSnapshotStatusOff indicates the FeedbackScoringMode was Off.
+	feedbackSnapshotStatusOff feedbackSnapshotStatus = "off"
+	// feedbackSnapshotStatusNoStore indicates Shadow/Enforce mode but no
+	// RoutingFeedback was configured (WithRoutingFeedback never called,
+	// or called with nil).
+	feedbackSnapshotStatusNoStore feedbackSnapshotStatus = "no_store"
+	// feedbackSnapshotStatusEmptyUseCase indicates the route had an
+	// empty req.UseCase, which cannot form a FeedbackKey.
+	feedbackSnapshotStatusEmptyUseCase feedbackSnapshotStatus = "empty_use_case"
+	// feedbackSnapshotStatusReadError indicates the store returned a
+	// non-nil error during snapshot construction; fail-open disabled
+	// feedback for the route.
+	feedbackSnapshotStatusReadError feedbackSnapshotStatus = "read_error"
+	// feedbackSnapshotStatusActive indicates the snapshot read every
+	// candidate key successfully and feedback is in effect for the route.
+	feedbackSnapshotStatusActive feedbackSnapshotStatus = "active"
+)
+
+// feedbackSnapshot is the per-Route()-call view of routing-feedback
+// aggregates for all candidate keys touched by the route. All store I/O
+// happens through the snapshot — initially in buildFeedbackSnapshot for
+// the first candidate set, then incrementally via readCandidates for
+// chain routing's later steps. Consumers (scoreCandidate) read via
+// lookup() and never touch the store directly. The snapshot lives only
+// for the duration of one Route() (or routeChain() walk); a future TTL
+// cache would slot in here without changing scoreCandidate.
+//
+// Fail-open is route-level and latching: the first store read error
+// flips failed=true, sets status=read_error, clears byKey, and prevents
+// any further reads for the rest of the route. This preserves the spec
+// contract that one read failure disables feedback for the whole route
+// — including any later chain steps or the recommend tail. The
+// non-Off / non-no_store / non-empty_use_case states (active, read_error)
+// are terminal once set; only the initial unconfigured states can
+// transition to active.
+type feedbackSnapshot struct {
+	active bool
+	failed bool // latches true on first read error; bars further reads
+	mode   FeedbackScoringMode
+	status feedbackSnapshotStatus
+	byKey  map[FeedbackKey]*candidateFeedback
+}
+
+// lookup returns the per-key feedback for a candidate, or nil if the
+// key was not in the snapshot (or the snapshot is inactive).
+func (s *feedbackSnapshot) lookup(key FeedbackKey) *candidateFeedback {
+	if s == nil || !s.active {
+		return nil
+	}
+	return s.byKey[key]
+}
+
+// readCandidates extends the snapshot with reads for any profile whose
+// FeedbackKey is not yet known. Called by routeChain before each
+// scoreChainStep / appendRecommendTail so that lazily-resolved chain
+// step profiles get read into the same route-level snapshot. Fail-open
+// latches inactive for the whole route on the first read error: once
+// snap.failed == true, the snapshot stays inactive and subsequent calls
+// are no-ops, so an early read_error disables feedback for every later
+// chain step AND the recommend tail.
+//
+// No-op when the snapshot is already inactive (off / no_store /
+// empty_use_case / read_error) — nothing to add and nothing to lose.
+func (s *feedbackSnapshot) readCandidates(ctx context.Context, r *Router, profiles []*ModelProfile, useCase string) {
+	if s == nil || s.failed || !s.active || r.routingFeedback == nil || useCase == "" {
+		return
+	}
+	seen := make(map[FeedbackKey]struct{}, len(profiles))
+	for _, p := range profiles {
+		key := FeedbackKey{Provider: p.Key.Provider, Model: p.Key.Model, UseCase: useCase}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		if _, already := s.byKey[key]; already {
+			continue
+		}
+		agg, err := r.routingFeedback.Score(ctx, key)
+		if err != nil {
+			if r.feedbackWarn != nil {
+				r.feedbackWarn.warnFeedbackReadOnce(r.feedbackLogger, key, err)
+			}
+			s.active = false
+			s.failed = true
+			s.status = feedbackSnapshotStatusReadError
+			s.byKey = nil
+			return
+		}
+		s.byKey[key] = &candidateFeedback{
+			raw:      agg,
+			adjusted: adjustFeedbackScore(agg),
+		}
+	}
+}
+
+// buildFeedbackSnapshot constructs the per-route feedback snapshot. The
+// initial candidate set is optional: pass `nil` for chain routing (where
+// chain step profiles are resolved lazily and added incrementally via
+// snap.readCandidates), or pass the full candidate slice for the
+// single-pass scoreAll path.
+//
+// Returns an inactive (active=false) snapshot when:
+//   - mode is FeedbackScoringOff           -> status = "off"
+//   - routingFeedback is nil               -> status = "no_store"
+//   - useCase is empty                     -> status = "empty_use_case"
+//   - any store read returns an error      -> status = "read_error", failed=true
+//
+// Fail-open writes a once-logged warning via feedbackLogger so a
+// persistently broken store is visible without flooding logs.
+//
+// IMPORTANT: this is called exactly ONCE per Route() — the same snapshot
+// is then threaded into every scoreAll / scoreChainStep / appendRecommendTail
+// call for the same route. That guarantees an early read error disables
+// feedback for the whole route, including any later chain steps.
+func (r *Router) buildFeedbackSnapshot(ctx context.Context, candidates []*ModelProfile, useCase string) *feedbackSnapshot {
+	snap := &feedbackSnapshot{mode: r.feedbackScoringMode}
+	switch {
+	case r.feedbackScoringMode == FeedbackScoringOff:
+		snap.status = feedbackSnapshotStatusOff
+		return snap
+	case r.routingFeedback == nil:
+		snap.status = feedbackSnapshotStatusNoStore
+		return snap
+	case useCase == "":
+		snap.status = feedbackSnapshotStatusEmptyUseCase
+		return snap
+	}
+	// Begin in the "active with empty byKey" state so readCandidates can
+	// extend it. The initial readCandidates call below either populates
+	// byKey with the supplied candidates or latches read_error.
+	snap.active = true
+	snap.status = feedbackSnapshotStatusActive
+	snap.byKey = make(map[FeedbackKey]*candidateFeedback, len(candidates))
+	if len(candidates) > 0 {
+		snap.readCandidates(ctx, r, candidates, useCase)
+	}
+	return snap
+}
+
 // getOrCreateBreaker returns the circuit breaker for the named provider,
 // creating one if it doesn't exist. Uses double-check locking.
 func (r *Router) getOrCreateBreaker(provider string) *CircuitBreaker {

--- a/provider/router.go
+++ b/provider/router.go
@@ -178,7 +178,8 @@ type FeedbackScoringMode int
 
 const (
 	// FeedbackScoringOff disables both feedback reads and feedback
-	// breakdown emission. activeSignals does not include "feedback".
+	// breakdown emission. selectionActiveSignals / deltaActiveSignals
+	// both exclude "feedback".
 	FeedbackScoringOff FeedbackScoringMode = iota
 	// FeedbackScoringShadow reads feedback per route, emits ScoreBreakdown
 	// with raw/adjusted values, but route selection uses the
@@ -344,7 +345,13 @@ func (r *Router) Route(ctx context.Context, req RoutingRequest) (*RoutePlan, err
 	}
 
 	// 3. Hard gates + budget + score all candidates.
-	scored := r.scoreAll(ctx, candidates, req)
+	//    PR3: build the per-route feedback snapshot exactly ONCE here and
+	//    thread it through scoreAll. scoreCandidate stays I/O-free. For
+	//    the single-pass branch the snapshot lives only across scoreAll;
+	//    the chain-routing branch (routeChain) builds its own and extends
+	//    it incrementally per step.
+	snap := r.buildFeedbackSnapshot(ctx, candidates, req.UseCase)
+	scored := r.scoreAll(ctx, candidates, req, snap)
 
 	// 4. Partition into executable, truncatable, breakered, budgeted.
 	var executable, truncatable []scoredCandidate
@@ -697,9 +704,22 @@ func (r *Router) resolveCandidates(ctx context.Context, req RoutingRequest) ([]*
 }
 
 // scoreAll evaluates all candidates against the routing request, applying
-// hard gates (capability, breaker, RAM, budget) and computing weighted scores.
-func (r *Router) scoreAll(_ context.Context, candidates []*ModelProfile, req RoutingRequest) []scoredCandidate {
-	active := r.activeSignals()
+// hard gates (capability, breaker, RAM, budget) and computing weighted
+// scores. The caller (Route()) builds the per-route feedback snapshot
+// exactly once and threads it in; scoreCandidate stays I/O-free.
+//
+// Each candidate gets THREE weighted-score computations:
+//   - selection score (chosen via selectionActiveSignals: feedback in
+//     activeSignals iff Enforce + snap.active)
+//   - scoreWithFeedback (deltaActiveSignals: feedback in activeSignals
+//     iff snap.active, regardless of mode — so Shadow exposes a real
+//     delta in the breakdown)
+//   - scoreWithoutFeedback (baseActiveSignals: feedback never in
+//     activeSignals — the PR2 baseline)
+func (r *Router) scoreAll(_ context.Context, candidates []*ModelProfile, req RoutingRequest, snap *feedbackSnapshot) []scoredCandidate {
+	selectActive := r.selectionActiveSignals(snap)
+	deltaActive := r.deltaActiveSignals(snap)
+	baseActive := r.baseActiveSignals()
 	var customWeights *WeightProfile
 	if wp, ok := r.defaultOpts.weightOverrides[req.UseCase]; ok {
 		customWeights = wp
@@ -718,10 +738,13 @@ func (r *Router) scoreAll(_ context.Context, candidates []*ModelProfile, req Rou
 
 		// Score the candidate.
 		breaker := r.getOrCreateBreaker(profile.Key.Provider)
-		bd := scoreCandidate(profile, req, budget, r.warmth, nil, breaker)
+		cf := snap.lookup(FeedbackKey{Provider: profile.Key.Provider, Model: profile.Key.Model, UseCase: req.UseCase})
+		bd := scoreCandidate(profile, req, budget, r.warmth, cf, breaker)
 
-		// Compute weighted score.
-		score := computeWeightedScore(bd, req.UseCase, active, customWeights)
+		// Compute the three weighted score flavors.
+		bd.scoreWithoutFeedback = computeWeightedScore(bd, req.UseCase, baseActive, customWeights)
+		bd.scoreWithFeedback = computeWeightedScore(bd, req.UseCase, deltaActive, customWeights)
+		score := computeWeightedScore(bd, req.UseCase, selectActive, customWeights)
 
 		// Apply breaker penalty (overrides score if -Inf).
 		if math.IsInf(bd.breakerPenalty, -1) {
@@ -739,13 +762,13 @@ func (r *Router) scoreAll(_ context.Context, candidates []*ModelProfile, req Rou
 	return scored
 }
 
-// activeSignals returns the set of scoring signals that are active based
-// on the router's configuration. Signals backed by absent subsystems
-// (e.g. no warmth tracker) are excluded so they don't penalize candidates.
-func (r *Router) activeSignals() map[string]bool {
+// baseActiveSignals returns the always-on scoring signals (everything
+// except "feedback", which is conditional on snapshot/mode). Signals
+// backed by absent subsystems (e.g. no warmth tracker) are excluded so
+// they don't penalize candidates.
+func (r *Router) baseActiveSignals() map[string]bool {
 	active := map[string]bool{
 		"headroom": true,
-		"feedback": true,
 		"quality":  true,
 		"speed":    true,
 		"kvcache":  true,
@@ -753,6 +776,31 @@ func (r *Router) activeSignals() map[string]bool {
 	}
 	if r.warmth != nil {
 		active["warmth"] = true
+	}
+	return active
+}
+
+// selectionActiveSignals is the set used for the score that actually
+// drives candidate selection. Feedback participates only in Enforce
+// mode with a live (non-fail-open) snapshot; Off/Shadow/fail-open all
+// exclude it so pre-PR3 selection math is preserved.
+func (r *Router) selectionActiveSignals(snap *feedbackSnapshot) map[string]bool {
+	active := r.baseActiveSignals()
+	if r.routingFeedback != nil && snap != nil && snap.active && snap.mode == FeedbackScoringEnforce {
+		active["feedback"] = true
+	}
+	return active
+}
+
+// deltaActiveSignals is the set used to compute ScoreWithFeedback for
+// the breakdown. Feedback participates whenever the snapshot is active
+// (Shadow OR Enforce) so the breakdown can expose the would-be-applied
+// delta even in Shadow. Fail-open (snap.active == false) still excludes
+// feedback so the delta reports the same scores as PR2 in that case.
+func (r *Router) deltaActiveSignals(snap *feedbackSnapshot) map[string]bool {
+	active := r.baseActiveSignals()
+	if r.routingFeedback != nil && snap != nil && snap.active {
+		active["feedback"] = true
 	}
 	return active
 }

--- a/provider/router.go
+++ b/provider/router.go
@@ -1024,9 +1024,9 @@ func (r *Router) buildPlan(winner scoredCandidate, fallbacks []scoredCandidate, 
 	// skips the stamp.
 	if r.feedbackScoringMode != FeedbackScoringOff && snap != nil {
 		bd := winner.bd
-		plan.SetScoreBreakdown(&bd)
-		plan.SetBuiltUnderMode(r.feedbackScoringMode)
-		plan.SetFeedbackStatus(snap.status)
+		plan.setScoreBreakdown(&bd)
+		plan.setBuiltUnderMode(r.feedbackScoringMode)
+		plan.setFeedbackStatus(snap.status)
 	}
 
 	// Build fallback chain.

--- a/provider/router.go
+++ b/provider/router.go
@@ -61,6 +61,13 @@ type Router struct {
 	done            chan struct{}
 	closeOnce       sync.Once
 	routingFeedback *RoutingFeedback
+	// feedbackScoringMode controls whether RoutingFeedback influences route
+	// selection. PR3 default is FeedbackScoringOff (pre-PR3 behavior).
+	// Independent of routingFeedback: recording (writes) is governed by
+	// WithRoutingFeedback; reading + selection impact (reads) is governed
+	// by this field. See routing_feedback.go and the FeedbackScoringMode
+	// docs for the full truth table.
+	feedbackScoringMode FeedbackScoringMode
 }
 
 // Compile-time assertion that Router implements RouteRecorder.
@@ -146,6 +153,67 @@ func WithAvailableRAM(gb float64) RouterOption {
 func WithTokenBudgetValidator(v *TokenBudgetValidator) RouterOption {
 	return func(r *Router) {
 		r.tokenBudget = v
+	}
+}
+
+// FeedbackScoringMode controls how the Router uses RoutingFeedback reads
+// during candidate scoring and route selection. Independent of whether
+// recording is enabled (WithRoutingFeedback); a deployment can write
+// signals without ever letting them influence routing.
+//
+// Defaults to FeedbackScoringOff so the post-PR3 routing path is the
+// pre-PR3 routing path until an operator opts in.
+type FeedbackScoringMode int
+
+const (
+	// FeedbackScoringOff disables both feedback reads and feedback
+	// breakdown emission. activeSignals does not include "feedback".
+	FeedbackScoringOff FeedbackScoringMode = iota
+	// FeedbackScoringShadow reads feedback per route, emits ScoreBreakdown
+	// with raw/adjusted values, but route selection uses the
+	// score-without-feedback path. Used to evaluate the impact of feedback
+	// before enforcing it.
+	FeedbackScoringShadow
+	// FeedbackScoringEnforce reads feedback per route, emits the same
+	// breakdown, AND lets the feedback signal participate in weighted
+	// scoring for the route. Snapshot fail-open still disables feedback
+	// for the whole route on any read error.
+	FeedbackScoringEnforce
+)
+
+// String returns the operator-facing label for the mode. Unknown values
+// return a labeled fallback so log lines never contain a bare integer.
+func (m FeedbackScoringMode) String() string {
+	switch m {
+	case FeedbackScoringOff:
+		return "off"
+	case FeedbackScoringShadow:
+		return "shadow"
+	case FeedbackScoringEnforce:
+		return "enforce"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(m))
+	}
+}
+
+// WithFeedbackScoringMode sets the FeedbackScoringMode at construction.
+// Default is FeedbackScoringOff. Recording (writes) is configured
+// separately via WithRoutingFeedback; this option controls only reads
+// and selection impact.
+func WithFeedbackScoringMode(mode FeedbackScoringMode) RouterOption {
+	return func(r *Router) { r.feedbackScoringMode = mode }
+}
+
+// WithFeedbackScoring is compatibility sugar: true maps to
+// FeedbackScoringEnforce, false maps to FeedbackScoringOff. Prefer
+// WithFeedbackScoringMode when ramp-up via shadow mode is wanted.
+func WithFeedbackScoring(enabled bool) RouterOption {
+	return func(r *Router) {
+		if enabled {
+			r.feedbackScoringMode = FeedbackScoringEnforce
+		} else {
+			r.feedbackScoringMode = FeedbackScoringOff
+		}
 	}
 }
 

--- a/provider/router.go
+++ b/provider/router.go
@@ -1016,6 +1016,13 @@ func (r *Router) buildPlan(winner scoredCandidate, fallbacks []scoredCandidate, 
 	plan.SetWasSticky(wasSticky)
 	plan.SetRecorder(r)
 	plan.SetFeedback(r.routingFeedback) // ← PR2 addition; nil is fine, SetFeedback handles it
+	// Stamp the per-Router warn state and logger onto the plan so
+	// newRouteIDWithWarn (called from buildOutcome) and
+	// recordOutcomeFeedback can fire once-logged warnings on RNG /
+	// store failures. Wired unconditionally — the warn state is per-
+	// Router and doesn't track feedback scoring on/off; a nil
+	// routingFeedback still wants RNG-failure warnings.
+	plan.setFeedbackTelemetry(r.feedbackWarn, r.feedbackLogger)
 
 	// Stamp the winner's breakdown and the mode used for selection so
 	// buildOutcome can render the public ScoreBreakdown. Off mode skips

--- a/provider/router.go
+++ b/provider/router.go
@@ -178,12 +178,12 @@ type FeedbackScoringMode int
 
 const (
 	// FeedbackScoringOff disables both feedback reads and feedback
-	// breakdown emission. selectionActiveSignals / deltaActiveSignals
-	// both exclude "feedback".
+	// breakdown emission. Selection still preserves the pre-PR3 neutral
+	// feedback denominator.
 	FeedbackScoringOff FeedbackScoringMode = iota
 	// FeedbackScoringShadow reads feedback per route, emits ScoreBreakdown
 	// with raw/adjusted values, but route selection uses the
-	// score-without-feedback path. Used to evaluate the impact of feedback
+	// neutral-feedback baseline. Used to evaluate the impact of feedback
 	// before enforcing it.
 	FeedbackScoringShadow
 	// FeedbackScoringEnforce reads feedback per route, emits the same
@@ -709,13 +709,12 @@ func (r *Router) resolveCandidates(ctx context.Context, req RoutingRequest) ([]*
 // exactly once and threads it in; scoreCandidate stays I/O-free.
 //
 // Each candidate gets THREE weighted-score computations:
-//   - selection score (chosen via selectionActiveSignals: feedback in
-//     activeSignals iff Enforce + snap.active)
-//   - scoreWithFeedback (deltaActiveSignals: feedback in activeSignals
-//     iff snap.active, regardless of mode — so Shadow exposes a real
-//     delta in the breakdown)
-//   - scoreWithoutFeedback (baseActiveSignals: feedback never in
-//     activeSignals — the PR2 baseline)
+//   - selection score (Enforce + active snapshot uses the snapshot's
+//     adjusted feedback; Off/Shadow/fail-open use neutral feedback)
+//   - scoreWithFeedback (the snapshot-adjusted score when feedback was
+//     read, otherwise the same neutral-feedback baseline)
+//   - scoreWithoutFeedback (neutral feedbackScore=0.5 with the pre-PR3
+//     feedback denominator preserved)
 func (r *Router) scoreAll(_ context.Context, candidates []*ModelProfile, req RoutingRequest, snap *feedbackSnapshot) []scoredCandidate {
 	selectActive := r.selectionActiveSignals(snap)
 	deltaActive := r.deltaActiveSignals(snap)
@@ -742,9 +741,11 @@ func (r *Router) scoreAll(_ context.Context, candidates []*ModelProfile, req Rou
 		bd := scoreCandidate(profile, req, budget, r.warmth, cf, breaker)
 
 		// Compute the three weighted score flavors.
-		bd.scoreWithoutFeedback = computeWeightedScore(bd, req.UseCase, baseActive, customWeights)
+		neutralBD := scoreBreakdownWithNeutralFeedback(bd)
+		bd.scoreWithoutFeedback = computeWeightedScore(neutralBD, req.UseCase, baseActive, customWeights)
 		bd.scoreWithFeedback = computeWeightedScore(bd, req.UseCase, deltaActive, customWeights)
-		score := computeWeightedScore(bd, req.UseCase, selectActive, customWeights)
+		scoreBD := scoreBreakdownForSelection(bd, snap)
+		score := computeWeightedScore(scoreBD, req.UseCase, selectActive, customWeights)
 
 		// Apply breaker penalty (overrides score if -Inf).
 		if math.IsInf(bd.breakerPenalty, -1) {
@@ -762,12 +763,14 @@ func (r *Router) scoreAll(_ context.Context, candidates []*ModelProfile, req Rou
 	return scored
 }
 
-// baseActiveSignals returns the always-on scoring signals (everything
-// except "feedback", which is conditional on snapshot/mode). Signals
+// baseActiveSignals returns the always-on PR2 scoring baseline. Feedback
+// stays active here at the neutral 0.5 value so Off/Shadow/fail-open
+// preserve the pre-PR3 denominator and sticky-routing margins. Signals
 // backed by absent subsystems (e.g. no warmth tracker) are excluded so
 // they don't penalize candidates.
 func (r *Router) baseActiveSignals() map[string]bool {
 	active := map[string]bool{
+		"feedback": true,
 		"headroom": true,
 		"quality":  true,
 		"speed":    true,
@@ -781,28 +784,19 @@ func (r *Router) baseActiveSignals() map[string]bool {
 }
 
 // selectionActiveSignals is the set used for the score that actually
-// drives candidate selection. Feedback participates only in Enforce
-// mode with a live (non-fail-open) snapshot; Off/Shadow/fail-open all
-// exclude it so pre-PR3 selection math is preserved.
+// drives candidate selection. Feedback's denominator is always present;
+// scoreBreakdownForSelection decides whether the value is the live
+// snapshot-adjusted feedback (Enforce + active) or neutral 0.5.
 func (r *Router) selectionActiveSignals(snap *feedbackSnapshot) map[string]bool {
-	active := r.baseActiveSignals()
-	if r.routingFeedback != nil && snap != nil && snap.active && snap.mode == FeedbackScoringEnforce {
-		active["feedback"] = true
-	}
-	return active
+	return r.baseActiveSignals()
 }
 
-// deltaActiveSignals is the set used to compute ScoreWithFeedback for
-// the breakdown. Feedback participates whenever the snapshot is active
-// (Shadow OR Enforce) so the breakdown can expose the would-be-applied
-// delta even in Shadow. Fail-open (snap.active == false) still excludes
-// feedback so the delta reports the same scores as PR2 in that case.
+// deltaActiveSignals is the set used to compute ScoreWithFeedback for the
+// breakdown. The denominator always includes feedback; the scoreBreakdown
+// value is live when a snapshot read supplied candidate feedback and
+// neutral otherwise.
 func (r *Router) deltaActiveSignals(snap *feedbackSnapshot) map[string]bool {
-	active := r.baseActiveSignals()
-	if r.routingFeedback != nil && snap != nil && snap.active {
-		active["feedback"] = true
-	}
-	return active
+	return r.baseActiveSignals()
 }
 
 // ---------------------------------------------------------------------------

--- a/provider/router_chain.go
+++ b/provider/router_chain.go
@@ -30,19 +30,19 @@ func (r *Router) routeChain(ctx context.Context, req RoutingRequest) (*RoutePlan
 
 	working := make([]scoredCandidate, 0, len(req.PreferredChain))
 	truncatable := make([]scoredCandidate, 0)
-	seen := make(map[ModelKey]bool)
 
 	// PR3: build the route-level feedback snapshot ONCE here. It starts
 	// active with empty byKey (or terminally inactive if Off / no_store /
 	// empty_use_case); each per-step snap.readCandidates either extends
 	// it OR latches fail-open. Either way scoreChainStep + the recommend
 	// tail see the same *feedbackSnapshot for every step, so an early
-	// step's read_error disables feedback for every later step too.
+	// step's read_error disables feedback for every candidate in the
+	// route, including candidates resolved before the failed read.
 	snap := r.buildFeedbackSnapshot(ctx, nil, req.UseCase)
 
 	var lookupErrs []error
-	breakerCount, budgetCount := 0, 0
-	resolvedAny := false
+	chainSteps := make([][]*ModelProfile, 0, len(req.PreferredChain))
+	chainSeenForTail := make(map[ModelKey]bool)
 
 	for _, selector := range req.PreferredChain {
 		profiles, err := r.resolveChainEntry(ctx, selector)
@@ -52,13 +52,29 @@ func (r *Router) routeChain(ctx context.Context, req RoutingRequest) (*RoutePlan
 			continue
 		}
 
-		// Extend the route-level snapshot with this step's profiles BEFORE
-		// scoring. If an earlier step already latched read_error,
-		// readCandidates is a no-op; if this step is the one that fails,
-		// the snapshot latches and every later step plus the recommend
-		// tail sees an inactive snapshot via the same pointer.
-		snap.readCandidates(ctx, r, profiles, req.UseCase)
+		chainSteps = append(chainSteps, profiles)
+		r.markChainSeenForTail(chainSeenForTail, profiles, req)
 
+		// Extend the route-level snapshot with this step's profiles. All
+		// chain scoring is deferred until after every chain/tail read has
+		// had a chance to latch fail-open, so a later read_error cannot
+		// leave earlier candidates scored with feedback.
+		snap.readCandidates(ctx, r, profiles, req.UseCase)
+	}
+
+	var tailProfiles []*ModelProfile
+	if !req.StrictChain {
+		var terr error
+		tailProfiles, terr = r.recommendTailProfiles(ctx, req, chainSeenForTail)
+		if terr == nil {
+			snap.readCandidates(ctx, r, tailProfiles, req.UseCase)
+		}
+	}
+
+	seen := make(map[ModelKey]bool)
+	breakerCount, budgetCount := 0, 0
+	resolvedAny := false
+	for _, profiles := range chainSteps {
 		stepSurvivors := r.scoreChainStep(ctx, profiles, req, snap)
 		for _, sc := range stepSurvivors {
 			if seen[sc.profile.Key] {
@@ -85,11 +101,9 @@ func (r *Router) routeChain(ctx context.Context, req RoutingRequest) (*RoutePlan
 		}
 	}
 
-	if !req.StrictChain {
-		tail, terr := r.appendRecommendTail(ctx, req, seen, snap)
-		if terr == nil {
-			working = append(working, tail...)
-		}
+	if !req.StrictChain && len(tailProfiles) > 0 {
+		tail := r.scoreRecommendTail(ctx, tailProfiles, req, seen, snap)
+		working = append(working, tail...)
 	}
 
 	if len(working) == 0 {
@@ -139,17 +153,32 @@ func (r *Router) resolveChainEntry(ctx context.Context, selector string) ([]*Mod
 	return r.registry.LookupAny(ctx, selector)
 }
 
+func (r *Router) markChainSeenForTail(seen map[ModelKey]bool, profiles []*ModelProfile, req RoutingRequest) {
+	for _, profile := range profiles {
+		if seen[profile.Key] {
+			continue
+		}
+		if r.availableRAM > 0 && profile.Resources.RAMRequired > r.availableRAM {
+			continue
+		}
+		if !profileSatisfiesRequiredCaps(profile, req.RequiredCaps) {
+			continue
+		}
+		seen[profile.Key] = true
+	}
+}
+
 // scoreChainStep applies the same hard-gate + scoring pipeline that scoreAll
 // uses for the global-scoring branch, but per chain step. The route-level
-// feedback snapshot is built ONCE by routeChain at entry; callers extend
-// it with this step's profiles via snap.readCandidates() before invoking
-// scoreChainStep, which then stays I/O-free. The selection vs. delta
-// active-signal split mirrors scoreAll.
+// feedback snapshot is built ONCE by routeChain at entry; routeChain extends
+// it with every chain/tail profile before invoking scoreChainStep, which
+// then stays I/O-free. The selection vs. delta active-signal split mirrors
+// scoreAll.
 //
 // Because snap.readCandidates latches snap.failed=true on the first read
-// error, an early step's fail-open carries forward to every later step
-// AND the recommend tail in the same route — the spec's "any read error
-// disables feedback for the whole route" invariant.
+// error, any step's fail-open applies to every chain step and the recommend
+// tail in the same route — the spec's "any read error disables feedback for
+// the whole route" invariant.
 //
 // Returns survivors in score-descending order so the caller can append
 // them to the working list.
@@ -179,9 +208,11 @@ func (r *Router) scoreChainStep(ctx context.Context, profiles []*ModelProfile, r
 		cf := snap.lookup(FeedbackKey{Provider: profile.Key.Provider, Model: profile.Key.Model, UseCase: req.UseCase})
 		bd := scoreCandidate(profile, req, budget, r.warmth, cf, breaker)
 
-		bd.scoreWithoutFeedback = computeWeightedScore(bd, req.UseCase, baseActive, customWeights)
+		neutralBD := scoreBreakdownWithNeutralFeedback(bd)
+		bd.scoreWithoutFeedback = computeWeightedScore(neutralBD, req.UseCase, baseActive, customWeights)
 		bd.scoreWithFeedback = computeWeightedScore(bd, req.UseCase, deltaActive, customWeights)
-		score := computeWeightedScore(bd, req.UseCase, selectActive, customWeights)
+		scoreBD := scoreBreakdownForSelection(bd, snap)
+		score := computeWeightedScore(scoreBD, req.UseCase, selectActive, customWeights)
 
 		if math.IsInf(bd.breakerPenalty, -1) {
 			score = math.Inf(-1)
@@ -224,18 +255,16 @@ func (r *Router) recordChainLookupFailure(selector string, err error) {
 	cb.RecordFailure(err)
 }
 
-// appendRecommendTail runs ModelRegistry.Recommend with the request's
-// constraints and returns scored candidates not already present in seen.
+// recommendTailProfiles runs ModelRegistry.Recommend with the request's
+// constraints and returns candidate profiles not already present in seen.
 // Failures (e.g. registry index empty) return an error so the caller can
-// decide whether to ignore (chain has survivors) or surface (chain empty).
+// keep the chain-only result.
 //
 // PR3: the route-level feedback snapshot is threaded in by routeChain. The
-// tail's profiles are extended into the same snapshot via snap.readCandidates
-// BEFORE scoreChainStep — keeping the snapshot's fail-open latch consistent
-// across the whole route. If an earlier chain step already latched
-// read_error, this extension is a no-op (and the tail sees inactive
-// feedback identically to the latched chain steps).
-func (r *Router) appendRecommendTail(ctx context.Context, req RoutingRequest, seen map[ModelKey]bool, snap *feedbackSnapshot) ([]scoredCandidate, error) {
+// tail's profiles are extended into the same snapshot before any chain/tail
+// scoring happens, keeping the snapshot's fail-open latch consistent across
+// the whole route.
+func (r *Router) recommendTailProfiles(ctx context.Context, req RoutingRequest, seen map[ModelKey]bool) ([]*ModelProfile, error) {
 	all, err := r.registry.Recommend(ctx, RecommendOpts{
 		RequiredCaps: req.RequiredCaps,
 		AvailableRAM: r.availableRAM,
@@ -258,8 +287,17 @@ func (r *Router) appendRecommendTail(ctx context.Context, req RoutingRequest, se
 		}
 		fresh = append(fresh, p)
 	}
-	snap.readCandidates(ctx, r, fresh, req.UseCase)
-	scored := r.scoreChainStep(ctx, fresh, req, snap)
+	return fresh, nil
+}
+
+func (r *Router) scoreRecommendTail(
+	ctx context.Context,
+	profiles []*ModelProfile,
+	req RoutingRequest,
+	seen map[ModelKey]bool,
+	snap *feedbackSnapshot,
+) []scoredCandidate {
+	scored := r.scoreChainStep(ctx, profiles, req, snap)
 
 	tail := make([]scoredCandidate, 0, len(scored))
 	for _, sc := range scored {
@@ -278,7 +316,7 @@ func (r *Router) appendRecommendTail(ctx context.Context, req RoutingRequest, se
 		seen[sc.profile.Key] = true
 		tail = append(tail, sc)
 	}
-	return tail, nil
+	return tail
 }
 
 // classifyChainExhaustion picks the most informative error when chain routing

--- a/provider/router_chain.go
+++ b/provider/router_chain.go
@@ -32,6 +32,14 @@ func (r *Router) routeChain(ctx context.Context, req RoutingRequest) (*RoutePlan
 	truncatable := make([]scoredCandidate, 0)
 	seen := make(map[ModelKey]bool)
 
+	// PR3: build the route-level feedback snapshot ONCE here. It starts
+	// active with empty byKey (or terminally inactive if Off / no_store /
+	// empty_use_case); each per-step snap.readCandidates either extends
+	// it OR latches fail-open. Either way scoreChainStep + the recommend
+	// tail see the same *feedbackSnapshot for every step, so an early
+	// step's read_error disables feedback for every later step too.
+	snap := r.buildFeedbackSnapshot(ctx, nil, req.UseCase)
+
 	var lookupErrs []error
 	breakerCount, budgetCount := 0, 0
 	resolvedAny := false
@@ -44,7 +52,14 @@ func (r *Router) routeChain(ctx context.Context, req RoutingRequest) (*RoutePlan
 			continue
 		}
 
-		stepSurvivors := r.scoreChainStep(profiles, req)
+		// Extend the route-level snapshot with this step's profiles BEFORE
+		// scoring. If an earlier step already latched read_error,
+		// readCandidates is a no-op; if this step is the one that fails,
+		// the snapshot latches and every later step plus the recommend
+		// tail sees an inactive snapshot via the same pointer.
+		snap.readCandidates(ctx, r, profiles, req.UseCase)
+
+		stepSurvivors := r.scoreChainStep(ctx, profiles, req, snap)
 		for _, sc := range stepSurvivors {
 			if seen[sc.profile.Key] {
 				continue
@@ -71,7 +86,7 @@ func (r *Router) routeChain(ctx context.Context, req RoutingRequest) (*RoutePlan
 	}
 
 	if !req.StrictChain {
-		tail, terr := r.appendRecommendTail(ctx, req, seen)
+		tail, terr := r.appendRecommendTail(ctx, req, seen, snap)
 		if terr == nil {
 			working = append(working, tail...)
 		}
@@ -125,10 +140,28 @@ func (r *Router) resolveChainEntry(ctx context.Context, selector string) ([]*Mod
 }
 
 // scoreChainStep applies the same hard-gate + scoring pipeline that scoreAll
-// uses for the global-scoring branch, but per chain step. Returns survivors
-// in score-descending order so the caller can append them to the working list.
-func (r *Router) scoreChainStep(profiles []*ModelProfile, req RoutingRequest) []scoredCandidate {
-	active := r.activeSignals()
+// uses for the global-scoring branch, but per chain step. The route-level
+// feedback snapshot is built ONCE by routeChain at entry; callers extend
+// it with this step's profiles via snap.readCandidates() before invoking
+// scoreChainStep, which then stays I/O-free. The selection vs. delta
+// active-signal split mirrors scoreAll.
+//
+// Because snap.readCandidates latches snap.failed=true on the first read
+// error, an early step's fail-open carries forward to every later step
+// AND the recommend tail in the same route — the spec's "any read error
+// disables feedback for the whole route" invariant.
+//
+// Returns survivors in score-descending order so the caller can append
+// them to the working list.
+//
+// The ctx parameter is currently unused by scoreChainStep itself (all I/O
+// already happened in snap.readCandidates), but is kept on the signature
+// for consistency with scoreAll and so a future cancellation hook
+// inside the per-candidate loop does not require another signature change.
+func (r *Router) scoreChainStep(_ context.Context, profiles []*ModelProfile, req RoutingRequest, snap *feedbackSnapshot) []scoredCandidate {
+	selectActive := r.selectionActiveSignals(snap)
+	deltaActive := r.deltaActiveSignals(snap)
+	baseActive := r.baseActiveSignals()
 	var customWeights *WeightProfile
 	if wp, ok := r.defaultOpts.weightOverrides[req.UseCase]; ok {
 		customWeights = wp
@@ -141,8 +174,13 @@ func (r *Router) scoreChainStep(profiles []*ModelProfile, req RoutingRequest) []
 		}
 		budget := r.tokenBudget.Validate(req, profile)
 		breaker := r.getOrCreateBreaker(profile.Key.Provider)
-		bd := scoreCandidate(profile, req, budget, r.warmth, nil, breaker)
-		score := computeWeightedScore(bd, req.UseCase, active, customWeights)
+		cf := snap.lookup(FeedbackKey{Provider: profile.Key.Provider, Model: profile.Key.Model, UseCase: req.UseCase})
+		bd := scoreCandidate(profile, req, budget, r.warmth, cf, breaker)
+
+		bd.scoreWithoutFeedback = computeWeightedScore(bd, req.UseCase, baseActive, customWeights)
+		bd.scoreWithFeedback = computeWeightedScore(bd, req.UseCase, deltaActive, customWeights)
+		score := computeWeightedScore(bd, req.UseCase, selectActive, customWeights)
+
 		if math.IsInf(bd.breakerPenalty, -1) {
 			score = math.Inf(-1)
 		}
@@ -188,7 +226,14 @@ func (r *Router) recordChainLookupFailure(selector string, err error) {
 // constraints and returns scored candidates not already present in seen.
 // Failures (e.g. registry index empty) return an error so the caller can
 // decide whether to ignore (chain has survivors) or surface (chain empty).
-func (r *Router) appendRecommendTail(ctx context.Context, req RoutingRequest, seen map[ModelKey]bool) ([]scoredCandidate, error) {
+//
+// PR3: the route-level feedback snapshot is threaded in by routeChain. The
+// tail's profiles are extended into the same snapshot via snap.readCandidates
+// BEFORE scoreChainStep — keeping the snapshot's fail-open latch consistent
+// across the whole route. If an earlier chain step already latched
+// read_error, this extension is a no-op (and the tail sees inactive
+// feedback identically to the latched chain steps).
+func (r *Router) appendRecommendTail(ctx context.Context, req RoutingRequest, seen map[ModelKey]bool, snap *feedbackSnapshot) ([]scoredCandidate, error) {
 	all, err := r.registry.Recommend(ctx, RecommendOpts{
 		RequiredCaps: req.RequiredCaps,
 		AvailableRAM: r.availableRAM,
@@ -197,7 +242,8 @@ func (r *Router) appendRecommendTail(ctx context.Context, req RoutingRequest, se
 	if err != nil {
 		return nil, err
 	}
-	scored := r.scoreChainStep(all, req)
+	snap.readCandidates(ctx, r, all, req.UseCase)
+	scored := r.scoreChainStep(ctx, all, req, snap)
 
 	tail := make([]scoredCandidate, 0, len(scored))
 	for _, sc := range scored {

--- a/provider/router_chain.go
+++ b/provider/router_chain.go
@@ -95,7 +95,7 @@ func (r *Router) routeChain(ctx context.Context, req RoutingRequest) (*RoutePlan
 	if len(working) == 0 {
 		if len(truncatable) > 0 {
 			sortScoredCandidates(truncatable, r.warmth)
-			plan, buildErr := r.buildPlan(truncatable[0], nil, req, false /* not sticky */)
+			plan, buildErr := r.buildPlan(truncatable[0], nil, req, false /* not sticky */, snap)
 			if buildErr != nil {
 				return nil, ErrNoViableCandidate
 			}
@@ -118,7 +118,7 @@ func (r *Router) routeChain(ctx context.Context, req RoutingRequest) (*RoutePlan
 		fallbacks = working[1 : 1+maxFb]
 	}
 
-	plan, err := r.buildPlan(winner, fallbacks, req, false /* not sticky */)
+	plan, err := r.buildPlan(winner, fallbacks, req, false /* not sticky */, snap)
 	if err != nil {
 		return nil, fmt.Errorf("router: %w", err)
 	}

--- a/provider/router_chain.go
+++ b/provider/router_chain.go
@@ -154,11 +154,13 @@ func (r *Router) resolveChainEntry(ctx context.Context, selector string) ([]*Mod
 // Returns survivors in score-descending order so the caller can append
 // them to the working list.
 //
-// The ctx parameter is currently unused by scoreChainStep itself (all I/O
-// already happened in snap.readCandidates), but is kept on the signature
-// for consistency with scoreAll and so a future cancellation hook
-// inside the per-candidate loop does not require another signature change.
-func (r *Router) scoreChainStep(_ context.Context, profiles []*ModelProfile, req RoutingRequest, snap *feedbackSnapshot) []scoredCandidate {
+// ctx is checked once up-front so a cancelled route doesn't pay the
+// full per-candidate loop. All store I/O already happened in
+// snap.readCandidates, so per-iteration ctx checks aren't needed.
+func (r *Router) scoreChainStep(ctx context.Context, profiles []*ModelProfile, req RoutingRequest, snap *feedbackSnapshot) []scoredCandidate {
+	if err := ctx.Err(); err != nil {
+		return nil
+	}
 	selectActive := r.selectionActiveSignals(snap)
 	deltaActive := r.deltaActiveSignals(snap)
 	baseActive := r.baseActiveSignals()
@@ -242,8 +244,22 @@ func (r *Router) appendRecommendTail(ctx context.Context, req RoutingRequest, se
 	if err != nil {
 		return nil, err
 	}
-	snap.readCandidates(ctx, r, all, req.UseCase)
-	scored := r.scoreChainStep(ctx, all, req, snap)
+	// Pre-filter Recommend output against the chain's `seen` set before
+	// extending the route-level snapshot. Without this, every candidate
+	// already selected by an earlier chain step would trigger a wasted
+	// store.Score read in readCandidates — costs O(seen ∩ tail) reads
+	// per route once the store is SQLite-backed. Capability/breaker/
+	// budget filtering still happens inside scoreChainStep + the loop
+	// below; we only dedupe what's cheap to dedupe here.
+	fresh := make([]*ModelProfile, 0, len(all))
+	for _, p := range all {
+		if seen[p.Key] {
+			continue
+		}
+		fresh = append(fresh, p)
+	}
+	snap.readCandidates(ctx, r, fresh, req.UseCase)
+	scored := r.scoreChainStep(ctx, fresh, req, snap)
 
 	tail := make([]scoredCandidate, 0, len(scored))
 	for _, sc := range scored {

--- a/provider/router_chain_test.go
+++ b/provider/router_chain_test.go
@@ -43,6 +43,29 @@ func (f *fakeChainProvider) Embed(ctx context.Context, req EmbedRequest) (*Embed
 	return &EmbedResponse{Provider: f.name, Model: req.Model, Embeddings: [][]float64{{1}}}, nil
 }
 
+type keyedChainFeedbackStore struct {
+	aggregates map[FeedbackKey]Aggregate
+	errors     map[FeedbackKey]error
+}
+
+func (s *keyedChainFeedbackStore) Get(_ context.Context, key FeedbackKey) (Aggregate, error) {
+	if err := s.errors[key]; err != nil {
+		return Aggregate{}, err
+	}
+	if agg, ok := s.aggregates[key]; ok {
+		return agg, nil
+	}
+	return Aggregate{Score: DefaultNeutralScore}, nil
+}
+
+func (s *keyedChainFeedbackStore) Record(_ context.Context, _ FeedbackKey, _ FeedbackSignal) error {
+	return nil
+}
+
+func (s *keyedChainFeedbackStore) RecordBatch(_ context.Context, _ []FeedbackItem) error {
+	return nil
+}
+
 // newChainTestRegistry builds a ModelRegistry pre-seeded with profiles
 // matching the given (provider, model) pairs.
 func newChainTestRegistry(t *testing.T, pairs ...ModelKey) (*ModelRegistry, *Registry) {
@@ -197,6 +220,78 @@ func TestRouter_routeChain_WithinStepScoring(t *testing.T) {
 	}
 	if len(plan.Fallbacks) != 1 || plan.Fallbacks[0].Profile.Key.Provider != "slow" {
 		t.Errorf("fallback should be slow/shared:8b, got %v", plan.Fallbacks)
+	}
+}
+
+func TestRouter_routeChain_LaterFeedbackReadErrorRescoresEarlierSteps(t *testing.T) {
+	mr, provReg := newChainTestRegistry(t,
+		ModelKey{Provider: "fast", Model: "shared:8b"},
+		ModelKey{Provider: "slow", Model: "shared:8b"},
+		ModelKey{Provider: "failer", Model: "tail:8b"},
+	)
+	seedChainProfile(t, mr, &ModelProfile{
+		Key: ModelKey{Provider: "fast", Model: "shared:8b"}, Caps: CapChat,
+		Quality: TierGood, Speed: TierBest, ContextWindow: 8192,
+	})
+	seedChainProfile(t, mr, &ModelProfile{
+		Key: ModelKey{Provider: "slow", Model: "shared:8b"}, Caps: CapChat,
+		Quality: TierGood, Speed: TierBasic, ContextWindow: 8192,
+	})
+	seedChainProfile(t, mr, &ModelProfile{
+		Key: ModelKey{Provider: "failer", Model: "tail:8b"}, Caps: CapChat,
+		Quality: TierGood, Speed: TierGood, ContextWindow: 8192,
+	})
+
+	store := &keyedChainFeedbackStore{
+		aggregates: map[FeedbackKey]Aggregate{
+			{Provider: "fast", Model: "shared:8b", UseCase: "chat"}: {
+				Score: 0, SampleCount: 100, ScoredCount: 100,
+			},
+			{Provider: "slow", Model: "shared:8b", UseCase: "chat"}: {
+				Score: 1, SampleCount: 100, ScoredCount: 100,
+			},
+		},
+		errors: map[FeedbackKey]error{
+			{Provider: "failer", Model: "tail:8b", UseCase: "chat"}: errors.New("disk full"),
+		},
+	}
+
+	r := NewRouter(mr, provReg,
+		WithRoutingFeedback(NewRoutingFeedback(store)),
+		WithFeedbackScoringMode(FeedbackScoringEnforce),
+		WithWeightOverrides(map[string]*WeightProfile{
+			"chat": {Feedback: 100, Speed: 1},
+		}),
+	)
+	cleanupRouter(t, r)
+
+	req := RoutingRequest{
+		UseCase:        "chat",
+		RequiredCaps:   CapChat,
+		PreferredChain: []string{"shared:8b", "failer/tail:8b"},
+		StrictChain:    true,
+		Messages:       []ChatMessage{{Role: "user", Content: "hi"}},
+	}
+	plan, err := r.Route(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if plan.Profile.Key.Provider != "fast" {
+		t.Fatalf("primary provider = %q, want fast (later read_error must neutralize earlier feedback)",
+			plan.Profile.Key.Provider)
+	}
+	if plan.feedbackStatus != feedbackSnapshotStatusReadError {
+		t.Fatalf("feedbackStatus = %q, want %q", plan.feedbackStatus, feedbackSnapshotStatusReadError)
+	}
+	if plan.scoreBreakdown == nil {
+		t.Fatalf("scoreBreakdown nil, want read_error-stamped breakdown")
+	}
+	if plan.scoreBreakdown.feedbackActive {
+		t.Errorf("feedbackActive = true after read_error; want false")
+	}
+	if plan.Score != plan.scoreBreakdown.scoreWithoutFeedback {
+		t.Errorf("plan.Score = %v, scoreWithoutFeedback = %v; fail-open selection used stale feedback",
+			plan.Score, plan.scoreBreakdown.scoreWithoutFeedback)
 	}
 }
 

--- a/provider/router_feedback_options_test.go
+++ b/provider/router_feedback_options_test.go
@@ -1,0 +1,62 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFeedbackScoringModeString(t *testing.T) {
+	cases := []struct {
+		mode FeedbackScoringMode
+		want string
+	}{
+		{FeedbackScoringOff, "off"},
+		{FeedbackScoringShadow, "shadow"},
+		{FeedbackScoringEnforce, "enforce"},
+	}
+	for _, tc := range cases {
+		if got := tc.mode.String(); got != tc.want {
+			t.Errorf("FeedbackScoringMode(%d).String() = %q, want %q", tc.mode, got, tc.want)
+		}
+	}
+}
+
+func TestFeedbackScoringModeUnknownString(t *testing.T) {
+	got := FeedbackScoringMode(99).String()
+	// Lock in the godoc contract: unknown values produce a *labeled*
+	// fallback so log lines never contain a bare integer like "99".
+	if !strings.Contains(got, "unknown") {
+		t.Errorf("unknown mode label = %q; want it to contain 'unknown'", got)
+	}
+	if !strings.Contains(got, "99") {
+		t.Errorf("unknown mode label = %q; want it to include the int value 99", got)
+	}
+}
+
+func TestWithFeedbackScoringModeAppliesValue(t *testing.T) {
+	router, _ := setupTestRouter(t, WithFeedbackScoringMode(FeedbackScoringShadow))
+	if router.feedbackScoringMode != FeedbackScoringShadow {
+		t.Errorf("feedbackScoringMode = %v, want FeedbackScoringShadow", router.feedbackScoringMode)
+	}
+}
+
+func TestWithFeedbackScoringSugarMapsToEnforce(t *testing.T) {
+	router, _ := setupTestRouter(t, WithFeedbackScoring(true))
+	if router.feedbackScoringMode != FeedbackScoringEnforce {
+		t.Errorf("WithFeedbackScoring(true) gave mode %v, want FeedbackScoringEnforce", router.feedbackScoringMode)
+	}
+}
+
+func TestWithFeedbackScoringFalseMapsToOff(t *testing.T) {
+	router, _ := setupTestRouter(t, WithFeedbackScoring(false))
+	if router.feedbackScoringMode != FeedbackScoringOff {
+		t.Errorf("WithFeedbackScoring(false) gave mode %v, want FeedbackScoringOff", router.feedbackScoringMode)
+	}
+}
+
+func TestDefaultFeedbackScoringModeIsOff(t *testing.T) {
+	router, _ := setupTestRouter(t)
+	if router.feedbackScoringMode != FeedbackScoringOff {
+		t.Errorf("default feedbackScoringMode = %v, want FeedbackScoringOff", router.feedbackScoringMode)
+	}
+}

--- a/provider/router_integration_test.go
+++ b/provider/router_integration_test.go
@@ -96,10 +96,10 @@ func TestIntegrationRouteAndExecuteChat(t *testing.T) {
 
 	// --- Step 1: Route with AffinityKey and execute chat ---
 	req := RoutingRequest{
-		Model:       "qwen3:8b",
-		UseCase:     "chat",
-		AffinityKey: "session-abc",
-		Messages:    []ChatMessage{{Role: "user", Content: "hello"}},
+		Model:        "qwen3:8b",
+		UseCase:      "chat",
+		AffinityKey:  "session-abc",
+		Messages:     []ChatMessage{{Role: "user", Content: "hello"}},
 		RequiredCaps: CapChat,
 	}
 
@@ -438,11 +438,11 @@ func TestIntegrationDryRun(t *testing.T) {
 	ctx := context.Background()
 
 	req := RoutingRequest{
-		Model:       "dry-model:8b",
-		UseCase:     "chat",
-		AffinityKey: "session-dry-run",
-		DryRun:      true,
-		Messages:    []ChatMessage{{Role: "user", Content: "test dry run"}},
+		Model:        "dry-model:8b",
+		UseCase:      "chat",
+		AffinityKey:  "session-dry-run",
+		DryRun:       true,
+		Messages:     []ChatMessage{{Role: "user", Content: "test dry run"}},
 		RequiredCaps: CapChat,
 	}
 
@@ -1104,7 +1104,8 @@ func TestRouterEnforceModeFeedsBackIntoNextRoute_SQLite(t *testing.T) {
 //
 // No direction assertion: positive adjusted feedback can produce a lower
 // with-feedback weighted average depending on candidate weights. The
-// invariants are (delta != 0) AND (selection score == without-feedback).
+// invariants are (delta != 0) AND (selection score == neutral-feedback
+// baseline).
 // ---------------------------------------------------------------------------
 
 func TestRouterShadowModeExposesDeltaButDoesNotChangeSelection(t *testing.T) {
@@ -1142,7 +1143,7 @@ func TestRouterShadowModeExposesDeltaButDoesNotChangeSelection(t *testing.T) {
 	// Plan-resolved Shadow assertion: breakdown must expose a non-zero
 	// delta even though selection used scoreWithoutFeedback. No direction
 	// assertion — positive adjusted feedback can still produce a lower
-	// with-feedback weighted average than the no-feedback weighted average
+	// with-feedback weighted average than the neutral-feedback baseline
 	// depending on candidate weights. The only spec invariant is that the
 	// breakdown exposes a non-zero delta.
 	if bd.ScoreWithFeedback == bd.ScoreWithoutFeedback {
@@ -1199,7 +1200,7 @@ func TestRouterEnforceModeFailOpenSurfacesReadErrorOnRouteOutcome(t *testing.T) 
 			bd.FeedbackMode, FeedbackScoringEnforce.String())
 	}
 	// Selection score must equal scoreWithoutFeedback on fail-open: the
-	// route used the PR2 baseline weights with no feedback contribution.
+	// route used the PR2 neutral-feedback baseline.
 	if resp.RouteOutcome.Score != bd.ScoreWithoutFeedback {
 		t.Errorf("fail-open: RouteOutcome.Score (%v) != ScoreWithoutFeedback (%v); selection used wrong path",
 			resp.RouteOutcome.Score, bd.ScoreWithoutFeedback)
@@ -1248,18 +1249,10 @@ func TestRouterShadowModeNoSignalsYet(t *testing.T) {
 	if bd.FeedbackSampleCount != 0 || bd.FeedbackScoredCount != 0 {
 		t.Errorf("empty store: counts = (%d,%d), want (0,0)", bd.FeedbackSampleCount, bd.FeedbackScoredCount)
 	}
-	// IMPORTANT — operator-confusing invariant: ScoreWithFeedback !=
-	// ScoreWithoutFeedback even when the store is empty. The two weighted
-	// sums are computed with different active-signal sets:
-	//   - ScoreWithoutFeedback excludes "feedback" entirely; the remaining
-	//     weights renormalize the composite.
-	//   - ScoreWithFeedback includes "feedback" at the neutral 0.5 value;
-	//     other signals' relative weights shrink to make room for it.
-	// So a non-zero delta in Shadow does NOT imply "feedback contributed."
-	// The right signal for "no data yet" is FeedbackSampleCount == 0 +
-	// FeedbackScore == 0.5, not a zero delta. Operators must read the
-	// breakdown holistically; documenting via this assertion so a future
-	// "make delta zero on empty store" change doesn't slip in.
+	if bd.ScoreWithFeedback != bd.ScoreWithoutFeedback {
+		t.Errorf("empty Shadow: ScoreWithFeedback=%v, ScoreWithoutFeedback=%v; want equal neutral-feedback baseline",
+			bd.ScoreWithFeedback, bd.ScoreWithoutFeedback)
+	}
 	if bd.FeedbackUpdatedAt != nil {
 		t.Errorf("empty Shadow: FeedbackUpdatedAt = %v, want nil", bd.FeedbackUpdatedAt)
 	}

--- a/provider/router_integration_test.go
+++ b/provider/router_integration_test.go
@@ -2,10 +2,13 @@ package provider
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"strings"
 	"testing"
 	"time"
+
+	_ "modernc.org/sqlite"
 )
 
 // ---------------------------------------------------------------------------
@@ -944,5 +947,200 @@ func TestIntegrationMultiProviderScoring(t *testing.T) {
 	}
 	if resp.RouteOutcome == nil {
 		t.Error("RouteOutcome is nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestRouterEnforceModeFeedsBackIntoNextRoute_MemoryStore
+//
+// End-to-end Enforce-mode loop with MemoryStore: the first Route observes
+// no signals (adjusted is neutral 0.5 because ScoredCount < feedbackMinScoredCount);
+// successive Route -> Execute cycles accumulate Success signals; the final
+// Route observes FeedbackApplied=true with a non-zero delta between
+// ScoreWithFeedback and ScoreWithoutFeedback.
+// ---------------------------------------------------------------------------
+
+func TestRouterEnforceModeFeedsBackIntoNextRoute_MemoryStore(t *testing.T) {
+	rf := mustNewRoutingFeedback(t, MemoryStoreConfig{})
+	router, _ := setupTestRouter(t, WithRoutingFeedback(rf), WithFeedbackScoringMode(FeedbackScoringEnforce))
+
+	// First Route + Execute records a Success signal.
+	plan, err := router.Route(context.Background(), RoutingRequest{Model: "test/qwen3:8b", UseCase: "chat"})
+	if err != nil {
+		t.Fatalf("first Route: %v", err)
+	}
+	resp1, err := plan.ExecuteChat(context.Background())
+	if err != nil {
+		t.Fatalf("first ExecuteChat: %v", err)
+	}
+	if resp1.RouteOutcome == nil || resp1.RouteOutcome.ScoreBreakdown == nil {
+		t.Fatalf("first route: ScoreBreakdown nil")
+	}
+	// First call sees no prior signals (ScoredCount=0 < feedbackMinScoredCount)
+	// so the confidence-gated adjusted score must still be neutral 0.5.
+	if resp1.RouteOutcome.ScoreBreakdown.FeedbackAdjustedScore != 0.5 {
+		t.Errorf("first route: adjusted = %v, want 0.5 (below scored floor)",
+			resp1.RouteOutcome.ScoreBreakdown.FeedbackAdjustedScore)
+	}
+
+	// Drive enough additional successes to exceed feedbackMinScoredCount.
+	for i := 0; i < feedbackMinScoredCount+1; i++ {
+		plan, err = router.Route(context.Background(), RoutingRequest{Model: "test/qwen3:8b", UseCase: "chat"})
+		if err != nil {
+			t.Fatalf("loop Route %d: %v", i, err)
+		}
+		if _, err := plan.ExecuteChat(context.Background()); err != nil {
+			t.Fatalf("loop ExecuteChat %d: %v", i, err)
+		}
+	}
+
+	// Final route observes accumulated signals.
+	plan, err = router.Route(context.Background(), RoutingRequest{Model: "test/qwen3:8b", UseCase: "chat"})
+	if err != nil {
+		t.Fatalf("final Route: %v", err)
+	}
+	respN, err := plan.ExecuteChat(context.Background())
+	if err != nil {
+		t.Fatalf("final ExecuteChat: %v", err)
+	}
+	bd := respN.RouteOutcome.ScoreBreakdown
+	if bd == nil {
+		t.Fatalf("final route: ScoreBreakdown nil")
+	}
+	if !bd.FeedbackApplied {
+		t.Errorf("FeedbackApplied = false; want true (Enforce + accumulated signals)")
+	}
+	if bd.FeedbackScore <= 0.5 {
+		t.Errorf("FeedbackScore = %v, want > 0.5", bd.FeedbackScore)
+	}
+	if bd.ScoreWithFeedback == bd.ScoreWithoutFeedback {
+		t.Errorf("with == without (%v); expected non-zero delta", bd.ScoreWithFeedback)
+	}
+	if bd.FeedbackSnapshotStatus != FeedbackSnapshotStatusActive {
+		t.Errorf("FeedbackSnapshotStatus = %q, want %q",
+			bd.FeedbackSnapshotStatus, FeedbackSnapshotStatusActive)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestRouterEnforceModeFeedsBackIntoNextRoute_SQLite
+//
+// Persistence-parity counterpart to the MemoryStore test: the same Route ->
+// Execute -> record loop runs against a caller-owned :memory: *sql.DB wrapped
+// by NewSQLiteFeedbackStore. Proves the in-transaction write path lets the
+// next Route observe the previous Execute's signal immediately.
+// ---------------------------------------------------------------------------
+
+func TestRouterEnforceModeFeedsBackIntoNextRoute_SQLite(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+
+	store, err := NewSQLiteFeedbackStore(context.Background(), db, SQLiteFeedbackStoreConfig{MaxRetainedSamples: 100})
+	if err != nil {
+		t.Fatalf("NewSQLiteFeedbackStore: %v", err)
+	}
+	rf := NewRoutingFeedback(store)
+	router, _ := setupTestRouter(t, WithRoutingFeedback(rf), WithFeedbackScoringMode(FeedbackScoringEnforce))
+
+	for i := 0; i < feedbackMinScoredCount+2; i++ {
+		plan, err := router.Route(context.Background(), RoutingRequest{Model: "test/qwen3:8b", UseCase: "chat"})
+		if err != nil {
+			t.Fatalf("loop Route %d: %v", i, err)
+		}
+		if _, err := plan.ExecuteChat(context.Background()); err != nil {
+			t.Fatalf("loop ExecuteChat %d: %v", i, err)
+		}
+		// Give the synchronous write path time to commit. PR3 uses
+		// in-transaction writes so this is effectively unnecessary, but
+		// guards against future SQLite WAL drift.
+		time.Sleep(time.Millisecond)
+	}
+
+	plan, err := router.Route(context.Background(), RoutingRequest{Model: "test/qwen3:8b", UseCase: "chat"})
+	if err != nil {
+		t.Fatalf("final Route: %v", err)
+	}
+	resp, err := plan.ExecuteChat(context.Background())
+	if err != nil {
+		t.Fatalf("final ExecuteChat: %v", err)
+	}
+	bd := resp.RouteOutcome.ScoreBreakdown
+	if bd == nil || !bd.FeedbackApplied {
+		t.Fatalf("ScoreBreakdown=%+v, want non-nil with FeedbackApplied=true", bd)
+	}
+	if bd.FeedbackScore <= 0.5 {
+		t.Errorf("FeedbackScore = %v, want > 0.5", bd.FeedbackScore)
+	}
+	if bd.FeedbackSnapshotStatus != FeedbackSnapshotStatusActive {
+		t.Errorf("FeedbackSnapshotStatus = %q, want %q",
+			bd.FeedbackSnapshotStatus, FeedbackSnapshotStatusActive)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestRouterShadowModeExposesDeltaButDoesNotChangeSelection
+//
+// In Shadow mode, even strong seeded feedback must:
+//   (a) NOT shift FeedbackApplied (stays false because selection uses
+//       scoreWithoutFeedback), and
+//   (b) STILL produce a non-trivial delta in the breakdown so operators
+//       can compare the "would-be-applied" value against the actual
+//       selection. RouteOutcome.Score must equal ScoreWithoutFeedback.
+//
+// No direction assertion: positive adjusted feedback can produce a lower
+// with-feedback weighted average depending on candidate weights. The
+// invariants are (delta != 0) AND (selection score == without-feedback).
+// ---------------------------------------------------------------------------
+
+func TestRouterShadowModeExposesDeltaButDoesNotChangeSelection(t *testing.T) {
+	rf := mustNewRoutingFeedback(t, MemoryStoreConfig{})
+	k := FeedbackKey{Provider: "test", Model: "qwen3:8b", UseCase: "chat"}
+	for i := 0; i < feedbackMinScoredCount+5; i++ {
+		if err := rf.Record(context.Background(), k, FeedbackSignal{Kind: RoutingSignalSuccess, At: time.Now()}); err != nil {
+			t.Fatalf("seed Record: %v", err)
+		}
+	}
+	router, _ := setupTestRouter(t, WithRoutingFeedback(rf), WithFeedbackScoringMode(FeedbackScoringShadow))
+
+	plan, err := router.Route(context.Background(), RoutingRequest{Model: "test/qwen3:8b", UseCase: "chat"})
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	resp, err := plan.ExecuteChat(context.Background())
+	if err != nil {
+		t.Fatalf("ExecuteChat: %v", err)
+	}
+	bd := resp.RouteOutcome.ScoreBreakdown
+	if bd == nil {
+		t.Fatalf("Shadow mode: ScoreBreakdown nil, want non-nil")
+	}
+	if bd.FeedbackApplied {
+		t.Errorf("Shadow mode: FeedbackApplied = true, want false")
+	}
+	if bd.FeedbackSnapshotStatus != FeedbackSnapshotStatusActive {
+		t.Errorf("Shadow mode: FeedbackSnapshotStatus = %q, want %q",
+			bd.FeedbackSnapshotStatus, FeedbackSnapshotStatusActive)
+	}
+	if bd.FeedbackScore <= 0.5 {
+		t.Errorf("Shadow mode: FeedbackScore = %v, want > 0.5 (snapshot active)", bd.FeedbackScore)
+	}
+	// Plan-resolved Shadow assertion: breakdown must expose a non-zero
+	// delta even though selection used scoreWithoutFeedback. No direction
+	// assertion — positive adjusted feedback can still produce a lower
+	// with-feedback weighted average than the no-feedback weighted average
+	// depending on candidate weights. The only spec invariant is that the
+	// breakdown exposes a non-zero delta.
+	if bd.ScoreWithFeedback == bd.ScoreWithoutFeedback {
+		t.Errorf("Shadow mode: with == without (%v); breakdown must expose the would-be-applied delta",
+			bd.ScoreWithFeedback)
+	}
+	// Selection score must equal scoreWithoutFeedback in Shadow.
+	if resp.RouteOutcome.Score != bd.ScoreWithoutFeedback {
+		t.Errorf("Shadow mode: RouteOutcome.Score (%v) != ScoreWithoutFeedback (%v); selection diverged from spec",
+			resp.RouteOutcome.Score, bd.ScoreWithoutFeedback)
 	}
 }

--- a/provider/router_integration_test.go
+++ b/provider/router_integration_test.go
@@ -1054,10 +1054,12 @@ func TestRouterEnforceModeFeedsBackIntoNextRoute_SQLite(t *testing.T) {
 		if _, err := plan.ExecuteChat(context.Background()); err != nil {
 			t.Fatalf("loop ExecuteChat %d: %v", i, err)
 		}
-		// Give the synchronous write path time to commit. PR3 uses
-		// in-transaction writes so this is effectively unnecessary, but
-		// guards against future SQLite WAL drift.
-		time.Sleep(time.Millisecond)
+		// No sleep: PR3 uses in-transaction writes (BEGIN…COMMIT inside
+		// SQLiteFeedbackStore.RecordBatch), and Task 5's benchmark proved
+		// the commit is synchronous + complete by the time RecordBatch
+		// returns. The next Route's snapshot read sees the committed row
+		// immediately. Adding a Sleep here would only mask a future
+		// regression that broke that guarantee.
 	}
 
 	plan, err := router.Route(context.Background(), RoutingRequest{Model: "test/qwen3:8b", UseCase: "chat"})
@@ -1078,6 +1080,15 @@ func TestRouterEnforceModeFeedsBackIntoNextRoute_SQLite(t *testing.T) {
 	if bd.FeedbackSnapshotStatus != FeedbackSnapshotStatusActive {
 		t.Errorf("FeedbackSnapshotStatus = %q, want %q",
 			bd.FeedbackSnapshotStatus, FeedbackSnapshotStatusActive)
+	}
+	// Parity with the MemoryStore twin: the SQLite path must also expose
+	// a non-zero delta in Enforce mode. A regression where in-transaction
+	// write commits but a stale aggregate is read by the next snapshot
+	// (e.g. introduced by a future cache layer) would still surface
+	// FeedbackApplied=true here without this check.
+	if bd.ScoreWithFeedback == bd.ScoreWithoutFeedback {
+		t.Errorf("SQLite Enforce: with == without (%v); expected delta because feedback was non-neutral",
+			bd.ScoreWithFeedback)
 	}
 }
 
@@ -1142,5 +1153,114 @@ func TestRouterShadowModeExposesDeltaButDoesNotChangeSelection(t *testing.T) {
 	if resp.RouteOutcome.Score != bd.ScoreWithoutFeedback {
 		t.Errorf("Shadow mode: RouteOutcome.Score (%v) != ScoreWithoutFeedback (%v); selection diverged from spec",
 			resp.RouteOutcome.Score, bd.ScoreWithoutFeedback)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestRouterEnforceModeFailOpenSurfacesReadErrorOnRouteOutcome
+//
+// End-to-end fail-open: Enforce mode + a RoutingFeedbackStore whose Get
+// always errors. Route + ExecuteChat still succeed; the public
+// ScoreBreakdown is stamped with FeedbackApplied=false and
+// FeedbackSnapshotStatus="read_error", so an operator dashboard can tell
+// "fail-open" apart from "feedback off by design" without parsing logs.
+// This is the hostile-case integration test the readiness review asked
+// for; the internals are already covered by
+// TestSnapshotReadCandidatesAfterLatchIsNoOp (unit) and
+// TestBuildOutcomeScoreBreakdownSnapshotStatusReflectsRoute (translator),
+// but neither exercises the public seam consumers actually read.
+// ---------------------------------------------------------------------------
+
+func TestRouterEnforceModeFailOpenSurfacesReadErrorOnRouteOutcome(t *testing.T) {
+	rf := NewRoutingFeedback(&flakyStore{err: errors.New("disk full")})
+	router, _ := setupTestRouter(t, WithRoutingFeedback(rf), WithFeedbackScoringMode(FeedbackScoringEnforce))
+
+	plan, err := router.Route(context.Background(), RoutingRequest{Model: "test/qwen3:8b", UseCase: "chat"})
+	if err != nil {
+		t.Fatalf("Route: %v (fail-open must NOT propagate to the caller)", err)
+	}
+	resp, err := plan.ExecuteChat(context.Background())
+	if err != nil {
+		t.Fatalf("ExecuteChat: %v", err)
+	}
+	bd := resp.RouteOutcome.ScoreBreakdown
+	if bd == nil {
+		t.Fatalf("Enforce + fail-open: ScoreBreakdown nil; want stamped with read_error status")
+	}
+	if bd.FeedbackApplied {
+		t.Errorf("Enforce + fail-open: FeedbackApplied = true, want false (selection used scoreWithoutFeedback)")
+	}
+	if bd.FeedbackSnapshotStatus != FeedbackSnapshotStatusReadError {
+		t.Errorf("FeedbackSnapshotStatus = %q, want %q",
+			bd.FeedbackSnapshotStatus, FeedbackSnapshotStatusReadError)
+	}
+	if bd.FeedbackMode != FeedbackScoringEnforce.String() {
+		t.Errorf("FeedbackMode = %q, want %q (operator distinguishes Enforce-fail-open from Shadow-active)",
+			bd.FeedbackMode, FeedbackScoringEnforce.String())
+	}
+	// Selection score must equal scoreWithoutFeedback on fail-open: the
+	// route used the PR2 baseline weights with no feedback contribution.
+	if resp.RouteOutcome.Score != bd.ScoreWithoutFeedback {
+		t.Errorf("fail-open: RouteOutcome.Score (%v) != ScoreWithoutFeedback (%v); selection used wrong path",
+			resp.RouteOutcome.Score, bd.ScoreWithoutFeedback)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestRouterShadowModeNoSignalsYet
+//
+// Shadow mode + a configured but empty store: the snapshot status is
+// "active" (the reads succeeded), but no signals have been recorded.
+// FeedbackScore stays neutral 0.5 and the with/without delta is zero.
+// An operator looking at a fresh deployment sees mode=shadow,
+// status=active, score=0.5, delta=0 — distinguishable from a fail-open
+// (which would have status=read_error) and from a never-configured store
+// (status=no_store). Avoids the "everything looks neutral, must be
+// broken" misdiagnosis.
+// ---------------------------------------------------------------------------
+
+func TestRouterShadowModeNoSignalsYet(t *testing.T) {
+	rf := mustNewRoutingFeedback(t, MemoryStoreConfig{})
+	router, _ := setupTestRouter(t, WithRoutingFeedback(rf), WithFeedbackScoringMode(FeedbackScoringShadow))
+
+	plan, err := router.Route(context.Background(), RoutingRequest{Model: "test/qwen3:8b", UseCase: "chat"})
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	resp, err := plan.ExecuteChat(context.Background())
+	if err != nil {
+		t.Fatalf("ExecuteChat: %v", err)
+	}
+	bd := resp.RouteOutcome.ScoreBreakdown
+	if bd == nil {
+		t.Fatalf("Shadow + empty store: ScoreBreakdown nil; want stamped with active status")
+	}
+	if bd.FeedbackApplied {
+		t.Errorf("Shadow: FeedbackApplied = true, want false")
+	}
+	if bd.FeedbackSnapshotStatus != FeedbackSnapshotStatusActive {
+		t.Errorf("FeedbackSnapshotStatus = %q, want %q (reads succeeded, just empty)",
+			bd.FeedbackSnapshotStatus, FeedbackSnapshotStatusActive)
+	}
+	if bd.FeedbackScore != 0.5 {
+		t.Errorf("empty store: FeedbackScore = %v, want neutral 0.5", bd.FeedbackScore)
+	}
+	if bd.FeedbackSampleCount != 0 || bd.FeedbackScoredCount != 0 {
+		t.Errorf("empty store: counts = (%d,%d), want (0,0)", bd.FeedbackSampleCount, bd.FeedbackScoredCount)
+	}
+	// IMPORTANT — operator-confusing invariant: ScoreWithFeedback !=
+	// ScoreWithoutFeedback even when the store is empty. The two weighted
+	// sums are computed with different active-signal sets:
+	//   - ScoreWithoutFeedback excludes "feedback" entirely; the remaining
+	//     weights renormalize the composite.
+	//   - ScoreWithFeedback includes "feedback" at the neutral 0.5 value;
+	//     other signals' relative weights shrink to make room for it.
+	// So a non-zero delta in Shadow does NOT imply "feedback contributed."
+	// The right signal for "no data yet" is FeedbackSampleCount == 0 +
+	// FeedbackScore == 0.5, not a zero delta. Operators must read the
+	// breakdown holistically; documenting via this assertion so a future
+	// "make delta zero on empty store" change doesn't slip in.
+	if bd.FeedbackUpdatedAt != nil {
+		t.Errorf("empty Shadow: FeedbackUpdatedAt = %v, want nil", bd.FeedbackUpdatedAt)
 	}
 }

--- a/provider/router_score.go
+++ b/provider/router_score.go
@@ -130,9 +130,9 @@ type scoreBreakdown struct {
 	// PR3 feedback-source fields. Populated by scoreCandidate when a
 	// route-level feedback snapshot is active; otherwise zero (and the
 	// "feedback" signal is excluded from activeSignals).
-	feedbackActive      bool      // true iff snapshot active and key found
-	feedbackRaw         float64   // raw Aggregate.Score
-	feedbackAdjusted    float64   // confidence-gated/shrunk value
+	feedbackActive      bool    // true iff snapshot active and key found
+	feedbackRaw         float64 // raw Aggregate.Score
+	feedbackAdjusted    float64 // confidence-gated/shrunk value
 	feedbackSampleCount int
 	feedbackScoredCount int
 	feedbackUpdatedAt   time.Time

--- a/provider/router_score.go
+++ b/provider/router_score.go
@@ -185,21 +185,25 @@ func tierToFloat(t Tier) float64 {
 
 // scoreCandidate evaluates a single candidate model against a routing request
 // and returns a scoreBreakdown. This is a standalone function, not a Router
-// method, so it can be tested and used independently.
+// method, so it can be tested and used independently. It performs NO store
+// I/O — the per-route feedback snapshot is built once by the Router and the
+// appropriate *candidateFeedback is passed in (nil when feedback is
+// off/inactive).
 //
 // Parameters:
 //   - profile: the candidate model's metadata
 //   - req: the routing request with capability requirements and use case
 //   - budget: the token budget validation result (headroom feeds scoring)
 //   - warmth: optional warmth source; nil means warmth signal is inactive
-//   - _ : feedback placeholder (reserved for Phase 3)
+//   - feedback: optional per-candidate snapshot view; nil means feedback is
+//     inactive for this candidate (neutral default)
 //   - breaker: circuit breaker for the candidate; never nil (lazily created)
 func scoreCandidate(
 	profile *ModelProfile,
 	req RoutingRequest,
 	budget BudgetResult,
 	warmth WarmthSource,
-	_ interface{},
+	feedback *candidateFeedback,
 	breaker *CircuitBreaker,
 ) scoreBreakdown {
 	var bd scoreBreakdown
@@ -211,8 +215,21 @@ func scoreCandidate(
 	// 2. Headroom from budget validation.
 	bd.headroomScore = budget.HeadroomScore
 
-	// 3. Neutral feedback default (Phase 3 will replace this).
-	bd.feedbackScore = 0.5
+	// 3. Feedback: when a snapshot view is supplied, copy the raw and
+	//    confidence-adjusted values onto the breakdown. When nil, the
+	//    feedback signal stays neutral exactly as in PR2 (the "feedback"
+	//    signal is excluded from activeSignals by the Router).
+	if feedback != nil {
+		bd.feedbackActive = true
+		bd.feedbackRaw = feedback.raw.Score
+		bd.feedbackAdjusted = feedback.adjusted
+		bd.feedbackScore = feedback.adjusted
+		bd.feedbackSampleCount = feedback.raw.SampleCount
+		bd.feedbackScoredCount = feedback.raw.ScoredCount
+		bd.feedbackUpdatedAt = feedback.raw.UpdatedAt
+	} else {
+		bd.feedbackScore = 0.5
+	}
 
 	// 4. Capability gate: if the request requires capabilities the model
 	//    doesn't have, eliminate the candidate immediately. CapInsert is

--- a/provider/router_score.go
+++ b/provider/router_score.go
@@ -9,6 +9,7 @@ package provider
 import (
 	"math"
 	"sort"
+	"time"
 )
 
 // warmthBonusMax is the maximum bonus applied to candidates whose model is
@@ -61,6 +62,45 @@ func defaultWeightProfile(useCase string) *WeightProfile {
 }
 
 // ---------------------------------------------------------------------------
+// Feedback confidence gating
+// ---------------------------------------------------------------------------
+
+// Feedback confidence-gating defaults. PR3's package-level constants
+// (intentionally not knobs): the SampleCount floor below which adjusted
+// feedback is forced neutral, and the prior-samples weight used in the
+// shrinkage formula. PR4 will evaluate whether these defaults are too
+// conservative before any public tuning surface is added.
+const (
+	feedbackMinScoredCount = 3
+	feedbackPriorSamples   = 10
+)
+
+// candidateFeedback is the per-key view extracted from a route-level
+// feedback snapshot. It is a value type (no pointer-aliasing into the
+// snapshot's internal map) so the consumer can mutate freely; all I/O
+// already happened during snapshot construction.
+type candidateFeedback struct {
+	raw      Aggregate // as returned by the store
+	adjusted float64   // confidence-gated/shrunk value used for weighted scoring
+}
+
+// adjustFeedbackScore returns 0.5 when ScoredCount is below the floor,
+// otherwise shrinks the raw score toward 0.5 using a Bayesian-style
+// confidence weight: confidence := ScoredCount / (ScoredCount + prior).
+//
+// At ScoredCount == prior the shrinkage is exactly halfway; large
+// ScoredCounts approach the raw value asymptotically. Conservative by
+// design — single successes don't dominate routing decisions until
+// enough samples accumulate.
+func adjustFeedbackScore(agg Aggregate) float64 {
+	if agg.ScoredCount < feedbackMinScoredCount {
+		return 0.5
+	}
+	confidence := float64(agg.ScoredCount) / float64(agg.ScoredCount+feedbackPriorSamples)
+	return 0.5 + (agg.Score-0.5)*confidence
+}
+
+// ---------------------------------------------------------------------------
 // scoreBreakdown
 // ---------------------------------------------------------------------------
 
@@ -76,6 +116,22 @@ type scoreBreakdown struct {
 	costPenalty    float64 // default 0
 	breakerPenalty float64 // 0 or -Inf
 	capabilityGate bool    // false = eliminated
+
+	// PR3 feedback-source fields. Populated by scoreCandidate when a
+	// route-level feedback snapshot is active; otherwise zero (and the
+	// "feedback" signal is excluded from activeSignals).
+	feedbackActive      bool      // true iff snapshot active and key found
+	feedbackRaw         float64   // raw Aggregate.Score
+	feedbackAdjusted    float64   // confidence-gated/shrunk value
+	feedbackSampleCount int
+	feedbackScoredCount int
+	feedbackUpdatedAt   time.Time
+
+	// PR3 score-with/without-feedback deltas. Computed once per
+	// candidate in scoreAll/scoreChainStep after computeWeightedScore so
+	// the breakdown can report both numbers without re-running scoring.
+	scoreWithoutFeedback float64
+	scoreWithFeedback    float64
 }
 
 // ---------------------------------------------------------------------------

--- a/provider/router_score.go
+++ b/provider/router_score.go
@@ -128,8 +128,8 @@ type scoreBreakdown struct {
 	capabilityGate bool    // false = eliminated
 
 	// PR3 feedback-source fields. Populated by scoreCandidate when a
-	// route-level feedback snapshot is active; otherwise zero (and the
-	// "feedback" signal is excluded from activeSignals).
+	// route-level feedback snapshot is active for this key; otherwise
+	// zero while feedbackScore remains the neutral PR2 baseline.
 	feedbackActive      bool    // true iff snapshot active and key found
 	feedbackRaw         float64 // raw Aggregate.Score
 	feedbackAdjusted    float64 // confidence-gated/shrunk value
@@ -187,8 +187,8 @@ func tierToFloat(t Tier) float64 {
 // and returns a scoreBreakdown. This is a standalone function, not a Router
 // method, so it can be tested and used independently. It performs NO store
 // I/O — the per-route feedback snapshot is built once by the Router and the
-// appropriate *candidateFeedback is passed in (nil when feedback is
-// off/inactive).
+// appropriate *candidateFeedback is passed in (nil when no route-level
+// feedback data is active for this candidate).
 //
 // Parameters:
 //   - profile: the candidate model's metadata
@@ -217,8 +217,7 @@ func scoreCandidate(
 
 	// 3. Feedback: when a snapshot view is supplied, copy the raw and
 	//    confidence-adjusted values onto the breakdown. When nil, the
-	//    feedback signal stays neutral exactly as in PR2 (the "feedback"
-	//    signal is excluded from activeSignals by the Router).
+	//    feedback signal stays neutral exactly as in PR2.
 	if feedback != nil {
 		bd.feedbackActive = true
 		bd.feedbackRaw = feedback.raw.Score
@@ -260,6 +259,18 @@ func scoreCandidate(
 	}
 
 	return bd
+}
+
+func scoreBreakdownWithNeutralFeedback(bd scoreBreakdown) scoreBreakdown {
+	bd.feedbackScore = 0.5
+	return bd
+}
+
+func scoreBreakdownForSelection(bd scoreBreakdown, snap *feedbackSnapshot) scoreBreakdown {
+	if snap != nil && snap.active && snap.mode == FeedbackScoringEnforce {
+		return bd
+	}
+	return scoreBreakdownWithNeutralFeedback(bd)
 }
 
 func profileSatisfiesRequiredCaps(profile *ModelProfile, required Capability) bool {

--- a/provider/router_score.go
+++ b/provider/router_score.go
@@ -92,8 +92,18 @@ type candidateFeedback struct {
 // ScoredCounts approach the raw value asymptotically. Conservative by
 // design — single successes don't dominate routing decisions until
 // enough samples accumulate.
+//
+// Defends against pathological Aggregates from third-party
+// RoutingFeedbackStore implementations: a NaN/Inf raw Score would
+// otherwise propagate as NaN through computeWeightedScore and poison
+// every candidate's composite (sort with NaN scores is order-dependent
+// garbage). NaN/Inf and out-of-range raw scores both fall back to
+// neutral 0.5 — the same outcome as "no signal yet".
 func adjustFeedbackScore(agg Aggregate) float64 {
 	if agg.ScoredCount < feedbackMinScoredCount {
+		return 0.5
+	}
+	if math.IsNaN(agg.Score) || math.IsInf(agg.Score, 0) || agg.Score < 0 || agg.Score > 1 {
 		return 0.5
 	}
 	confidence := float64(agg.ScoredCount) / float64(agg.ScoredCount+feedbackPriorSamples)

--- a/provider/router_score_snapshot_test.go
+++ b/provider/router_score_snapshot_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 	"time"
 )
@@ -30,6 +31,56 @@ func TestAdjustFeedbackScoreLargeScoredCountApproachesRaw(t *testing.T) {
 	got := adjustFeedbackScore(agg)
 	if got < 0.85 {
 		t.Errorf("ScoredCount=%d should approach raw 0.9, got %v", agg.ScoredCount, got)
+	}
+}
+
+// TestAdjustFeedbackScoreAtFloor documents the intentional discontinuity
+// at ScoredCount == feedbackMinScoredCount: count=2 returns neutral 0.5
+// regardless of raw, count=3 jumps to the confidence-shrunk value. For
+// raw < 0.5 this means the third sample DROPS adjusted below 0.5 — a
+// known design trade-off (one new sample is enough to express signal
+// direction, but not enough to express magnitude).
+func TestAdjustFeedbackScoreAtFloor(t *testing.T) {
+	rawLow := 0.1
+	belowFloor := adjustFeedbackScore(Aggregate{Score: rawLow, ScoredCount: feedbackMinScoredCount - 1})
+	if belowFloor != 0.5 {
+		t.Errorf("below floor: adjusted = %v, want 0.5", belowFloor)
+	}
+	atFloor := adjustFeedbackScore(Aggregate{Score: rawLow, ScoredCount: feedbackMinScoredCount})
+	confidence := float64(feedbackMinScoredCount) / float64(feedbackMinScoredCount+feedbackPriorSamples)
+	want := 0.5 + (rawLow-0.5)*confidence
+	if abs(atFloor-want) > 1e-9 {
+		t.Errorf("at floor: adjusted = %v, want %v", atFloor, want)
+	}
+	if atFloor >= 0.5 {
+		t.Errorf("at floor with raw=%v should be < 0.5, got %v (signal-direction property lost)", rawLow, atFloor)
+	}
+}
+
+// TestAdjustFeedbackScoreRejectsPathologicalAggregates guards against
+// third-party RoutingFeedbackStore implementations returning NaN, Inf,
+// or out-of-range scores. Without the guard, NaN propagates through
+// computeWeightedScore (weightedSum += NaN * w) and poisons every
+// candidate's composite, making sort.SliceStable order-dependent
+// garbage. All pathological inputs fall back to neutral 0.5.
+func TestAdjustFeedbackScoreRejectsPathologicalAggregates(t *testing.T) {
+	cases := []struct {
+		name  string
+		score float64
+	}{
+		{"NaN", math.NaN()},
+		{"+Inf", math.Inf(1)},
+		{"-Inf", math.Inf(-1)},
+		{"below_range", -0.5},
+		{"above_range", 1.5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := adjustFeedbackScore(Aggregate{Score: tc.score, ScoredCount: 50})
+			if got != 0.5 {
+				t.Errorf("score=%v: adjusted = %v, want neutral 0.5", tc.score, got)
+			}
+		})
 	}
 }
 
@@ -90,8 +141,63 @@ func TestBuildFeedbackSnapshotFailOpenOnStoreError(t *testing.T) {
 	if snap.active {
 		t.Errorf("snapshot.active = true after fail-open; want false")
 	}
+	// Tighten the latch invariant: every fail-open state mutation must be present
+	// so a later chain step's readCandidates / lookup short-circuits correctly.
+	if !snap.failed {
+		t.Errorf("snapshot.failed = false after fail-open; want true (so further readCandidates is a no-op)")
+	}
+	if snap.status != feedbackSnapshotStatusReadError {
+		t.Errorf("snapshot.status = %q after fail-open; want %q", snap.status, feedbackSnapshotStatusReadError)
+	}
+	if snap.byKey != nil {
+		t.Errorf("snapshot.byKey = %+v after fail-open; want nil (cleared so stale entries cannot leak)", snap.byKey)
+	}
 	if len(cap.snapshot()) != 1 {
 		t.Errorf("warnFeedbackReadOnce fired %d times, want 1", len(cap.snapshot()))
+	}
+}
+
+// TestSnapshotReadCandidatesAfterLatchIsNoOp covers the second
+// fail-open reachable path: buildFeedbackSnapshot succeeded with an
+// empty initial set, then a follow-up readCandidates extension fails.
+// The latch must hold for subsequent extensions, no second warning, no
+// stale entries. This is the chain-routing invariant Task 8 will
+// depend on — landing the assertion now prevents a regression during
+// the wiring change.
+func TestSnapshotReadCandidatesAfterLatchIsNoOp(t *testing.T) {
+	router, _ := setupTestRouter(t)
+	router.routingFeedback = NewRoutingFeedback(&flakyStore{err: errors.New("disk full")})
+	router.feedbackScoringMode = FeedbackScoringEnforce
+	cap := &capturingLogger{}
+	router.feedbackLogger = cap
+
+	snap := router.buildFeedbackSnapshot(context.Background(), nil, "chat")
+	if !snap.active {
+		t.Fatalf("nil-initial-set snapshot inactive after construction; want active with empty byKey")
+	}
+
+	// First extension triggers fail-open + warning.
+	first := []*ModelProfile{{Key: ModelKey{Provider: "test", Model: "qwen3:8b"}}}
+	snap.readCandidates(context.Background(), router, first, "chat")
+	if snap.active || !snap.failed || snap.status != feedbackSnapshotStatusReadError {
+		t.Fatalf("first readCandidates did not latch: active=%v failed=%v status=%q",
+			snap.active, snap.failed, snap.status)
+	}
+	if got := len(cap.snapshot()); got != 1 {
+		t.Errorf("first extension: warning count = %d, want 1", got)
+	}
+
+	// Second extension with a DIFFERENT key must be a no-op.
+	second := []*ModelProfile{{Key: ModelKey{Provider: "fallback", Model: "qwen3:8b"}}}
+	snap.readCandidates(context.Background(), router, second, "chat")
+	if snap.active {
+		t.Errorf("second extension re-activated snapshot; want stays inactive")
+	}
+	if got := len(cap.snapshot()); got != 1 {
+		t.Errorf("second extension fired %d warnings, want still 1 (latch must silence)", got)
+	}
+	if snap.lookup(FeedbackKey{Provider: "fallback", Model: "qwen3:8b", UseCase: "chat"}) != nil {
+		t.Errorf("inactive snapshot returned non-nil lookup; want nil")
 	}
 }
 

--- a/provider/router_score_snapshot_test.go
+++ b/provider/router_score_snapshot_test.go
@@ -1,0 +1,127 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestAdjustFeedbackScoreLowScoredCountReturnsNeutral(t *testing.T) {
+	agg := Aggregate{Score: 0.9, ScoredCount: 2}
+	got := adjustFeedbackScore(agg)
+	if got != 0.5 {
+		t.Errorf("ScoredCount=%d: adjusted = %v, want neutral 0.5", agg.ScoredCount, got)
+	}
+}
+
+func TestAdjustFeedbackScoreShrinksTowardNeutral(t *testing.T) {
+	// ScoredCount = priorSamples should shrink halfway (confidence == 0.5).
+	agg := Aggregate{Score: 1.0, ScoredCount: feedbackPriorSamples}
+	got := adjustFeedbackScore(agg)
+	want := 0.5 + (1.0-0.5)*0.5
+	if abs(got-want) > 1e-9 {
+		t.Errorf("adjusted = %v, want %v", got, want)
+	}
+}
+
+func TestAdjustFeedbackScoreLargeScoredCountApproachesRaw(t *testing.T) {
+	agg := Aggregate{Score: 0.9, ScoredCount: 1000}
+	got := adjustFeedbackScore(agg)
+	if got < 0.85 {
+		t.Errorf("ScoredCount=%d should approach raw 0.9, got %v", agg.ScoredCount, got)
+	}
+}
+
+func TestBuildFeedbackSnapshotOffModeInactive(t *testing.T) {
+	router, _ := setupTestRouter(t)
+	router.routingFeedback = mustNewRoutingFeedback(t, MemoryStoreConfig{})
+	router.feedbackScoringMode = FeedbackScoringOff
+
+	snap := router.buildFeedbackSnapshot(context.Background(), []*ModelProfile{{Key: ModelKey{Provider: "test", Model: "qwen3:8b"}}}, "chat")
+	if snap == nil {
+		t.Fatalf("buildFeedbackSnapshot returned nil; expected non-nil inactive snapshot")
+	}
+	if snap.active {
+		t.Errorf("Off mode snapshot.active = true, want false")
+	}
+}
+
+func TestBuildFeedbackSnapshotShadowReadsStore(t *testing.T) {
+	router, _ := setupTestRouter(t)
+	rf := mustNewRoutingFeedback(t, MemoryStoreConfig{})
+	router.routingFeedback = rf
+	router.feedbackScoringMode = FeedbackScoringShadow
+
+	k := FeedbackKey{Provider: "test", Model: "qwen3:8b", UseCase: "chat"}
+	// Seed enough Success signals to exceed feedbackMinScoredCount.
+	for i := 0; i < feedbackMinScoredCount+1; i++ {
+		if err := rf.Record(context.Background(), k, FeedbackSignal{Kind: RoutingSignalSuccess, At: time.Now()}); err != nil {
+			t.Fatalf("Record: %v", err)
+		}
+	}
+	snap := router.buildFeedbackSnapshot(context.Background(),
+		[]*ModelProfile{{Key: ModelKey{Provider: "test", Model: "qwen3:8b"}}}, "chat")
+	if snap == nil || !snap.active {
+		t.Fatalf("Shadow mode snapshot inactive or nil: %+v", snap)
+	}
+	cf := snap.lookup(FeedbackKey{Provider: "test", Model: "qwen3:8b", UseCase: "chat"})
+	if cf == nil {
+		t.Fatalf("snapshot has no entry for seeded key")
+	}
+	if cf.raw.Score <= 0.5 {
+		t.Errorf("raw score for seeded successes = %v, want > 0.5", cf.raw.Score)
+	}
+}
+
+func TestBuildFeedbackSnapshotFailOpenOnStoreError(t *testing.T) {
+	router, _ := setupTestRouter(t)
+	router.routingFeedback = NewRoutingFeedback(&flakyStore{err: errors.New("disk full")})
+	router.feedbackScoringMode = FeedbackScoringEnforce
+
+	cap := &capturingLogger{}
+	router.feedbackLogger = cap
+
+	snap := router.buildFeedbackSnapshot(context.Background(),
+		[]*ModelProfile{{Key: ModelKey{Provider: "test", Model: "qwen3:8b"}}}, "chat")
+	if snap == nil {
+		t.Fatalf("nil snapshot on read error; want non-nil inactive snapshot")
+	}
+	if snap.active {
+		t.Errorf("snapshot.active = true after fail-open; want false")
+	}
+	if len(cap.snapshot()) != 1 {
+		t.Errorf("warnFeedbackReadOnce fired %d times, want 1", len(cap.snapshot()))
+	}
+}
+
+// mustNewRoutingFeedback returns a RoutingFeedback wrapping a fresh
+// MemoryStore. Test helper to keep the setup terse.
+func mustNewRoutingFeedback(t *testing.T, cfg MemoryStoreConfig) *RoutingFeedback {
+	t.Helper()
+	store, err := NewMemoryStore(cfg)
+	if err != nil {
+		t.Fatalf("NewMemoryStore: %v", err)
+	}
+	return NewRoutingFeedback(store)
+}
+
+// flakyStore is a RoutingFeedbackStore whose Get always returns the
+// configured error. Record/RecordBatch succeed so test setup can still
+// seed signals through other channels.
+type flakyStore struct{ err error }
+
+func (f *flakyStore) Get(_ context.Context, _ FeedbackKey) (Aggregate, error) {
+	return Aggregate{}, f.err
+}
+func (f *flakyStore) Record(_ context.Context, _ FeedbackKey, _ FeedbackSignal) error {
+	return nil
+}
+func (f *flakyStore) RecordBatch(_ context.Context, _ []FeedbackItem) error { return nil }
+
+func abs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/provider/router_score_test.go
+++ b/provider/router_score_test.go
@@ -486,6 +486,21 @@ func TestScoreCandidateNilFeedbackMatchesPR2(t *testing.T) {
 	if bd.feedbackActive {
 		t.Errorf("nil feedback: feedbackActive = true, want false")
 	}
+	// Lock in zero-value on every PR3 feedback field so a future regression
+	// that leaks values into the nil branch gets caught here rather than
+	// surfacing as a confusing public ScoreBreakdown.
+	if bd.feedbackRaw != 0 {
+		t.Errorf("nil feedback: feedbackRaw = %v, want 0", bd.feedbackRaw)
+	}
+	if bd.feedbackAdjusted != 0 {
+		t.Errorf("nil feedback: feedbackAdjusted = %v, want 0", bd.feedbackAdjusted)
+	}
+	if bd.feedbackSampleCount != 0 || bd.feedbackScoredCount != 0 {
+		t.Errorf("nil feedback: counts = (%d,%d), want (0,0)", bd.feedbackSampleCount, bd.feedbackScoredCount)
+	}
+	if !bd.feedbackUpdatedAt.IsZero() {
+		t.Errorf("nil feedback: feedbackUpdatedAt = %v, want zero", bd.feedbackUpdatedAt)
+	}
 }
 
 // TestScoreCandidateActiveFeedbackPopulatesBreakdown asserts that when

--- a/provider/router_score_test.go
+++ b/provider/router_score_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"testing"
+	"time"
 )
 
 // ---------------------------------------------------------------------------
@@ -463,5 +464,64 @@ func TestDefaultWeightProfile_Analysis(t *testing.T) {
 	if wp.Quality != 5 || wp.Speed != 1 || wp.Headroom != 3 {
 		t.Errorf("analysis weights: got Quality=%d Speed=%d Headroom=%d, want 5/1/3",
 			wp.Quality, wp.Speed, wp.Headroom)
+	}
+}
+
+// TestScoreCandidateNilFeedbackMatchesPR2 asserts that when scoreCandidate
+// is called with a nil *candidateFeedback (the path taken by every PR2 call
+// site), the resulting breakdown stays neutral: feedbackScore = 0.5 and
+// feedbackActive = false. This is the no-regression guarantee for Task 7.
+func TestScoreCandidateNilFeedbackMatchesPR2(t *testing.T) {
+	profile := &ModelProfile{
+		Key:     ModelKey{Provider: "test", Model: "qwen3:8b"},
+		Quality: TierGood,
+		Speed:   TierGood,
+		Caps:    CapChat,
+	}
+	req := RoutingRequest{UseCase: "chat", RequiredCaps: CapChat}
+	bd := scoreCandidate(profile, req, BudgetResult{Decision: BudgetOK, HeadroomScore: 0.8}, nil, nil, NewCircuitBreaker())
+	if bd.feedbackScore != 0.5 {
+		t.Errorf("nil feedback: feedbackScore = %v, want 0.5", bd.feedbackScore)
+	}
+	if bd.feedbackActive {
+		t.Errorf("nil feedback: feedbackActive = true, want false")
+	}
+}
+
+// TestScoreCandidateActiveFeedbackPopulatesBreakdown asserts that when
+// scoreCandidate receives a non-nil *candidateFeedback, the breakdown
+// reflects all source fields: feedbackActive flips true, feedbackScore
+// takes the adjusted value (not the raw), and raw/adjusted/sample/scored/
+// UpdatedAt are copied through verbatim.
+func TestScoreCandidateActiveFeedbackPopulatesBreakdown(t *testing.T) {
+	profile := &ModelProfile{
+		Key:     ModelKey{Provider: "test", Model: "qwen3:8b"},
+		Quality: TierGood,
+		Speed:   TierGood,
+		Caps:    CapChat,
+	}
+	req := RoutingRequest{UseCase: "chat", RequiredCaps: CapChat}
+	cf := &candidateFeedback{
+		raw:      Aggregate{Score: 0.8, SampleCount: 30, ScoredCount: 30, UpdatedAt: time.Unix(123, 0)},
+		adjusted: 0.7,
+	}
+	bd := scoreCandidate(profile, req, BudgetResult{Decision: BudgetOK, HeadroomScore: 0.8}, nil, cf, NewCircuitBreaker())
+	if !bd.feedbackActive {
+		t.Errorf("active feedback: feedbackActive = false")
+	}
+	if bd.feedbackScore != 0.7 {
+		t.Errorf("feedbackScore = %v, want 0.7 (adjusted)", bd.feedbackScore)
+	}
+	if bd.feedbackRaw != 0.8 {
+		t.Errorf("feedbackRaw = %v, want 0.8", bd.feedbackRaw)
+	}
+	if bd.feedbackAdjusted != 0.7 {
+		t.Errorf("feedbackAdjusted = %v, want 0.7", bd.feedbackAdjusted)
+	}
+	if bd.feedbackSampleCount != 30 || bd.feedbackScoredCount != 30 {
+		t.Errorf("counts = (%d,%d), want (30,30)", bd.feedbackSampleCount, bd.feedbackScoredCount)
+	}
+	if !bd.feedbackUpdatedAt.Equal(time.Unix(123, 0)) {
+		t.Errorf("feedbackUpdatedAt = %v, want unix 123", bd.feedbackUpdatedAt)
 	}
 }

--- a/provider/router_test.go
+++ b/provider/router_test.go
@@ -876,3 +876,156 @@ func TestRouterWithoutRoutingFeedbackProducesNilPlanFeedback(t *testing.T) {
 		t.Errorf("plan.feedback = %v, want nil (no option configured)", plan.feedback)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// PR3 Task 8: activeSignals split — selection vs. delta
+// ---------------------------------------------------------------------------
+//
+// Three helpers replaced the pre-PR3 activeSignals():
+//
+//   - baseActiveSignals       — feedback NEVER active (PR2 baseline)
+//   - selectionActiveSignals  — feedback active iff Enforce + snap.active
+//   - deltaActiveSignals      — feedback active iff snap.active (any mode)
+//
+// The truth-table tests below pin every interesting (mode, active) cell
+// so future refactors cannot silently regress fail-open or Shadow-mode
+// delta exposure.
+
+func TestRouterScoringSelectionActiveExcludesFeedbackWhenOff(t *testing.T) {
+	rf := mustNewRoutingFeedback(t, MemoryStoreConfig{})
+	router, _ := setupTestRouter(t, WithRoutingFeedback(rf), WithFeedbackScoringMode(FeedbackScoringOff))
+
+	active := router.selectionActiveSignals(&feedbackSnapshot{mode: FeedbackScoringOff})
+	if active["feedback"] {
+		t.Errorf("Off mode: selectionActiveSignals[\"feedback\"] = true, want false")
+	}
+}
+
+func TestRouterScoringSelectionActiveExcludesFeedbackWhenShadow(t *testing.T) {
+	rf := mustNewRoutingFeedback(t, MemoryStoreConfig{})
+	router, _ := setupTestRouter(t, WithRoutingFeedback(rf), WithFeedbackScoringMode(FeedbackScoringShadow))
+
+	snap := &feedbackSnapshot{mode: FeedbackScoringShadow, active: true, byKey: map[FeedbackKey]*candidateFeedback{}}
+	active := router.selectionActiveSignals(snap)
+	if active["feedback"] {
+		t.Errorf("Shadow mode: selectionActiveSignals[\"feedback\"] = true, want false (selection uses without-feedback)")
+	}
+}
+
+func TestRouterScoringSelectionActiveIncludesFeedbackWhenEnforce(t *testing.T) {
+	rf := mustNewRoutingFeedback(t, MemoryStoreConfig{})
+	router, _ := setupTestRouter(t, WithRoutingFeedback(rf), WithFeedbackScoringMode(FeedbackScoringEnforce))
+
+	snap := &feedbackSnapshot{mode: FeedbackScoringEnforce, active: true, byKey: map[FeedbackKey]*candidateFeedback{}}
+	active := router.selectionActiveSignals(snap)
+	if !active["feedback"] {
+		t.Errorf("Enforce mode + active snapshot: selectionActiveSignals[\"feedback\"] = false, want true")
+	}
+}
+
+func TestRouterScoringSelectionActiveExcludesFeedbackOnFailOpen(t *testing.T) {
+	rf := mustNewRoutingFeedback(t, MemoryStoreConfig{})
+	router, _ := setupTestRouter(t, WithRoutingFeedback(rf), WithFeedbackScoringMode(FeedbackScoringEnforce))
+
+	snap := &feedbackSnapshot{mode: FeedbackScoringEnforce, active: false}
+	active := router.selectionActiveSignals(snap)
+	if active["feedback"] {
+		t.Errorf("Enforce mode + inactive snapshot (fail-open): selectionActiveSignals[\"feedback\"] = true, want false")
+	}
+}
+
+func TestRouterScoringDeltaActiveIncludesFeedbackInShadow(t *testing.T) {
+	// In Shadow mode, the delta computation MUST include feedback even
+	// though selection doesn't — otherwise ScoreWithFeedback ==
+	// ScoreWithoutFeedback in Shadow and the breakdown is useless.
+	rf := mustNewRoutingFeedback(t, MemoryStoreConfig{})
+	router, _ := setupTestRouter(t, WithRoutingFeedback(rf), WithFeedbackScoringMode(FeedbackScoringShadow))
+
+	snap := &feedbackSnapshot{mode: FeedbackScoringShadow, active: true, byKey: map[FeedbackKey]*candidateFeedback{}}
+	active := router.deltaActiveSignals(snap)
+	if !active["feedback"] {
+		t.Errorf("Shadow mode + active snapshot: deltaActiveSignals[\"feedback\"] = false, want true (delta needs feedback)")
+	}
+}
+
+func TestRouterScoringDeltaActiveExcludesFeedbackOnFailOpen(t *testing.T) {
+	rf := mustNewRoutingFeedback(t, MemoryStoreConfig{})
+	router, _ := setupTestRouter(t, WithRoutingFeedback(rf), WithFeedbackScoringMode(FeedbackScoringEnforce))
+
+	snap := &feedbackSnapshot{mode: FeedbackScoringEnforce, active: false}
+	active := router.deltaActiveSignals(snap)
+	if active["feedback"] {
+		t.Errorf("inactive snapshot (fail-open): deltaActiveSignals[\"feedback\"] = true, want false")
+	}
+}
+
+func TestRouterScoreAllPopulatesScoreWithAndWithoutFeedback(t *testing.T) {
+	rf := mustNewRoutingFeedback(t, MemoryStoreConfig{})
+	k := FeedbackKey{Provider: "test", Model: "qwen3:8b", UseCase: "chat"}
+	for i := 0; i < feedbackMinScoredCount+2; i++ {
+		if err := rf.Record(context.Background(), k, FeedbackSignal{Kind: RoutingSignalSuccess, At: time.Now()}); err != nil {
+			t.Fatalf("Record: %v", err)
+		}
+	}
+	router, _ := setupTestRouter(t, WithRoutingFeedback(rf), WithFeedbackScoringMode(FeedbackScoringEnforce))
+
+	plan, err := router.Route(context.Background(), RoutingRequest{Model: "test/qwen3:8b", UseCase: "chat"})
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if plan == nil {
+		t.Fatalf("Route returned nil plan")
+	}
+	// The plan's internal scoreBreakdown should expose both scores via
+	// the public ScoreBreakdown after Task 9; here we assert the route
+	// completed without error with feedback active.
+	_ = plan
+}
+
+// TestSnapshotReadCandidatesLatchesOnError proves that once an early
+// readCandidates call fails, subsequent calls are no-ops: the route-level
+// snapshot remains inactive for any chain step / recommend tail that
+// runs later in the same route. This is the central invariant the
+// readiness review called out — a chain route must NOT re-activate
+// feedback for a later step after an earlier step's read_error.
+func TestSnapshotReadCandidatesLatchesOnError(t *testing.T) {
+	rf := NewRoutingFeedback(&flakyStore{err: errors.New("disk full")})
+	router, _ := setupTestRouter(t, WithRoutingFeedback(rf), WithFeedbackScoringMode(FeedbackScoringEnforce))
+	cap := &capturingLogger{}
+	router.feedbackLogger = cap
+
+	// Start the snapshot in an "active with empty byKey" state by passing
+	// nil — mimics how routeChain initialises it.
+	snap := router.buildFeedbackSnapshot(context.Background(), nil, "chat")
+	if !snap.active {
+		t.Fatalf("snapshot inactive immediately after construction; want active(empty byKey)")
+	}
+
+	// First chain step's profiles trigger a read failure; snapshot latches.
+	first := []*ModelProfile{{Key: ModelKey{Provider: "test", Model: "qwen3:8b"}}}
+	snap.readCandidates(context.Background(), router, first, "chat")
+	if snap.active || !snap.failed {
+		t.Fatalf("after first read error: active=%v failed=%v; want active=false failed=true", snap.active, snap.failed)
+	}
+	if snap.status != feedbackSnapshotStatusReadError {
+		t.Errorf("status = %q, want %q", snap.status, feedbackSnapshotStatusReadError)
+	}
+	if got := len(cap.snapshot()); got != 1 {
+		t.Errorf("warnFeedbackReadOnce fired %d times, want 1", got)
+	}
+
+	// Second chain step tries to add fresh candidates — must be a no-op,
+	// no second warning, snapshot stays inactive.
+	second := []*ModelProfile{{Key: ModelKey{Provider: "fallback", Model: "qwen3:8b"}}}
+	snap.readCandidates(context.Background(), router, second, "chat")
+	if snap.active {
+		t.Errorf("snapshot re-activated after latching read_error; want stays inactive")
+	}
+	if got := len(cap.snapshot()); got != 1 {
+		t.Errorf("warning fired again after latch: %d, want still 1", got)
+	}
+	// And the new key must not be present (no read happened).
+	if snap.lookup(FeedbackKey{Provider: "fallback", Model: "qwen3:8b", UseCase: "chat"}) != nil {
+		t.Errorf("inactive snapshot returned non-nil lookup; want nil")
+	}
+}

--- a/provider/router_test.go
+++ b/provider/router_test.go
@@ -883,32 +883,32 @@ func TestRouterWithoutRoutingFeedbackProducesNilPlanFeedback(t *testing.T) {
 //
 // Three helpers replaced the pre-PR3 activeSignals():
 //
-//   - baseActiveSignals       — feedback NEVER active (PR2 baseline)
-//   - selectionActiveSignals  — feedback active iff Enforce + snap.active
-//   - deltaActiveSignals      — feedback active iff snap.active (any mode)
+//   - baseActiveSignals       — feedback denominator active at neutral 0.5
+//   - selectionActiveSignals  — same denominator; value chosen by mode/status
+//   - deltaActiveSignals      — same denominator; live value when available
 //
 // The truth-table tests below pin every interesting (mode, active) cell
 // so future refactors cannot silently regress fail-open or Shadow-mode
 // delta exposure.
 
-func TestRouterScoringSelectionActiveExcludesFeedbackWhenOff(t *testing.T) {
+func TestRouterScoringSelectionActiveIncludesNeutralFeedbackWhenOff(t *testing.T) {
 	rf := mustNewRoutingFeedback(t, MemoryStoreConfig{})
 	router, _ := setupTestRouter(t, WithRoutingFeedback(rf), WithFeedbackScoringMode(FeedbackScoringOff))
 
 	active := router.selectionActiveSignals(&feedbackSnapshot{mode: FeedbackScoringOff})
-	if active["feedback"] {
-		t.Errorf("Off mode: selectionActiveSignals[\"feedback\"] = true, want false")
+	if !active["feedback"] {
+		t.Errorf("Off mode: selectionActiveSignals[\"feedback\"] = false, want true for neutral PR2 denominator")
 	}
 }
 
-func TestRouterScoringSelectionActiveExcludesFeedbackWhenShadow(t *testing.T) {
+func TestRouterScoringSelectionActiveIncludesNeutralFeedbackWhenShadow(t *testing.T) {
 	rf := mustNewRoutingFeedback(t, MemoryStoreConfig{})
 	router, _ := setupTestRouter(t, WithRoutingFeedback(rf), WithFeedbackScoringMode(FeedbackScoringShadow))
 
 	snap := &feedbackSnapshot{mode: FeedbackScoringShadow, active: true, byKey: map[FeedbackKey]*candidateFeedback{}}
 	active := router.selectionActiveSignals(snap)
-	if active["feedback"] {
-		t.Errorf("Shadow mode: selectionActiveSignals[\"feedback\"] = true, want false (selection uses without-feedback)")
+	if !active["feedback"] {
+		t.Errorf("Shadow mode: selectionActiveSignals[\"feedback\"] = false, want true for neutral PR2 denominator")
 	}
 }
 
@@ -923,14 +923,14 @@ func TestRouterScoringSelectionActiveIncludesFeedbackWhenEnforce(t *testing.T) {
 	}
 }
 
-func TestRouterScoringSelectionActiveExcludesFeedbackOnFailOpen(t *testing.T) {
+func TestRouterScoringSelectionActiveIncludesNeutralFeedbackOnFailOpen(t *testing.T) {
 	rf := mustNewRoutingFeedback(t, MemoryStoreConfig{})
 	router, _ := setupTestRouter(t, WithRoutingFeedback(rf), WithFeedbackScoringMode(FeedbackScoringEnforce))
 
 	snap := &feedbackSnapshot{mode: FeedbackScoringEnforce, active: false}
 	active := router.selectionActiveSignals(snap)
-	if active["feedback"] {
-		t.Errorf("Enforce mode + inactive snapshot (fail-open): selectionActiveSignals[\"feedback\"] = true, want false")
+	if !active["feedback"] {
+		t.Errorf("Enforce mode + inactive snapshot: selectionActiveSignals[\"feedback\"] = false, want true for neutral PR2 denominator")
 	}
 }
 
@@ -948,14 +948,50 @@ func TestRouterScoringDeltaActiveIncludesFeedbackInShadow(t *testing.T) {
 	}
 }
 
-func TestRouterScoringDeltaActiveExcludesFeedbackOnFailOpen(t *testing.T) {
+func TestRouterScoringDeltaActiveIncludesNeutralFeedbackOnFailOpen(t *testing.T) {
 	rf := mustNewRoutingFeedback(t, MemoryStoreConfig{})
 	router, _ := setupTestRouter(t, WithRoutingFeedback(rf), WithFeedbackScoringMode(FeedbackScoringEnforce))
 
 	snap := &feedbackSnapshot{mode: FeedbackScoringEnforce, active: false}
 	active := router.deltaActiveSignals(snap)
-	if active["feedback"] {
-		t.Errorf("inactive snapshot (fail-open): deltaActiveSignals[\"feedback\"] = true, want false")
+	if !active["feedback"] {
+		t.Errorf("inactive snapshot: deltaActiveSignals[\"feedback\"] = false, want true for neutral PR2 denominator")
+	}
+}
+
+func TestRouterScoringShadowSelectionUsesNeutralFeedbackValue(t *testing.T) {
+	bd := scoreBreakdown{
+		feedbackActive: true,
+		feedbackScore:  1.0,
+	}
+	snap := &feedbackSnapshot{mode: FeedbackScoringShadow, active: true}
+	got := scoreBreakdownForSelection(bd, snap)
+	if got.feedbackScore != 0.5 {
+		t.Errorf("Shadow selection feedbackScore = %v, want neutral 0.5", got.feedbackScore)
+	}
+}
+
+func TestRouterOffModeNeutralFeedbackPreservesStickyMarginScale(t *testing.T) {
+	router, _ := setupTestRouter(t, WithFeedbackScoringMode(FeedbackScoringOff))
+	active := router.selectionActiveSignals(&feedbackSnapshot{mode: FeedbackScoringOff})
+	wp := &WeightProfile{Headroom: 1, Feedback: 1}
+	incumbent := scoreBreakdown{headroomScore: 0, feedbackScore: 0.5}
+	challenger := scoreBreakdown{headroomScore: 0.29, feedbackScore: 0.5}
+
+	incumbentScore := computeWeightedScore(incumbent, "chat", active, wp)
+	challengerScore := computeWeightedScore(challenger, "chat", active, wp)
+	if challengerScore-incumbentScore > router.defaultOpts.hysteresisMargin {
+		t.Fatalf("neutral-feedback gap = %v, want <= sticky margin %v",
+			challengerScore-incumbentScore, router.defaultOpts.hysteresisMargin)
+	}
+
+	withoutFeedback := router.baseActiveSignals()
+	delete(withoutFeedback, "feedback")
+	incumbentNoFeedback := computeWeightedScore(incumbent, "chat", withoutFeedback, wp)
+	challengerNoFeedback := computeWeightedScore(challenger, "chat", withoutFeedback, wp)
+	if challengerNoFeedback-incumbentNoFeedback <= router.defaultOpts.hysteresisMargin {
+		t.Fatalf("test setup failed: no-feedback gap = %v, want > sticky margin %v",
+			challengerNoFeedback-incumbentNoFeedback, router.defaultOpts.hysteresisMargin)
 	}
 }
 

--- a/provider/routing_feedback.go
+++ b/provider/routing_feedback.go
@@ -291,6 +291,13 @@ func validateKey(k FeedbackKey) error {
 	return nil
 }
 
+func validateNeutralScore(score float64) error {
+	if math.IsNaN(score) || math.IsInf(score, 0) || score < 0 || score > 1 {
+		return fmt.Errorf("provider: NeutralScore %v out of range [0,1]", score)
+	}
+	return nil
+}
+
 // validateSignal enforces shape/payload invariants:
 //   - Kind is one of the known constants.
 //   - Strength, if non-nil, is finite (no NaN/Inf).

--- a/provider/routing_feedback_logger.go
+++ b/provider/routing_feedback_logger.go
@@ -1,0 +1,94 @@
+// routing_feedback_logger.go provides the once-logged warning seam used by
+// the routing-feedback read/write paths and by newRouteID. PR3 wires three
+// independent sync.Once-guarded emitters: feedback read failures, feedback
+// write failures, and crypto/rand failures in route-ID generation. Each
+// fires at most once per Router instance, so a persistently broken store cannot
+// flood logs while still surfacing the first occurrence to operators.
+package provider
+
+import (
+	"log"
+	"sync"
+)
+
+// feedbackLogger is the minimal logger seam used by the routing-feedback
+// surface. Implementations must be safe for concurrent calls. PR3 ships
+// a default implementation backed by log.Default(). The interface is
+// intentionally unexported — the spec restricts PR3's public surface to
+// the SQLite store, FeedbackScoringMode, and ScoreBreakdown. Tests in
+// the same package inject capturing implementations by assigning
+// router.feedbackLogger directly after setupTestRouter returns.
+type feedbackLogger interface {
+	Warnf(format string, args ...any)
+}
+
+// defaultFeedbackLoggerImpl forwards to log.Default(). Used when no
+// override is assigned to router.feedbackLogger.
+type defaultFeedbackLoggerImpl struct{}
+
+func (defaultFeedbackLoggerImpl) Warnf(format string, args ...any) {
+	log.Printf("WARN provider/routing_feedback: "+format, args...)
+}
+
+// defaultFeedbackLogger is the package-level default.
+var defaultFeedbackLogger feedbackLogger = defaultFeedbackLoggerImpl{}
+
+// feedbackWarningState holds the three sync.Once guards used to keep
+// noisy operator warnings to one emission per Router instance. A Router
+// owns exactly one feedbackWarningState; tests construct ad-hoc states to
+// assert the once semantics in isolation.
+type feedbackWarningState struct {
+	readOnce       sync.Once
+	writeOnce      sync.Once
+	routeIDRndOnce sync.Once
+}
+
+// newFeedbackWarningState returns a zero-initialized state.
+func newFeedbackWarningState() *feedbackWarningState {
+	return &feedbackWarningState{}
+}
+
+// warnFeedbackReadOnce emits one warning the first time a feedback store
+// Get/Score call returns an error during snapshot building. Subsequent
+// calls are silent. Nil logger is a no-op for tests that don't care.
+func (s *feedbackWarningState) warnFeedbackReadOnce(l feedbackLogger, key FeedbackKey, err error) {
+	if s == nil {
+		return
+	}
+	s.readOnce.Do(func() {
+		if l == nil {
+			return
+		}
+		l.Warnf("feedback store read failed for key %+v (further read failures silenced): %v", key, err)
+	})
+}
+
+// warnFeedbackWriteOnce emits one warning the first time
+// RoutingFeedback.RecordOutcome returns a non-nil error. Replaces the
+// silent-swallow that recordOutcomeFeedback shipped in PR2.
+func (s *feedbackWarningState) warnFeedbackWriteOnce(l feedbackLogger, err error) {
+	if s == nil {
+		return
+	}
+	s.writeOnce.Do(func() {
+		if l == nil {
+			return
+		}
+		l.Warnf("feedback store RecordOutcome failed (further write failures silenced): %v", err)
+	})
+}
+
+// warnRouteIDRandOnce emits one warning the first time crypto/rand
+// produces an error inside newRouteID. Replaces the silent swallow that
+// route_plan.go shipped in PR2.
+func (s *feedbackWarningState) warnRouteIDRandOnce(l feedbackLogger, err error) {
+	if s == nil {
+		return
+	}
+	s.routeIDRndOnce.Do(func() {
+		if l == nil {
+			return
+		}
+		l.Warnf("newRouteID crypto/rand failure (further failures silenced): %v", err)
+	})
+}

--- a/provider/routing_feedback_logger.go
+++ b/provider/routing_feedback_logger.go
@@ -50,45 +50,43 @@ func newFeedbackWarningState() *feedbackWarningState {
 
 // warnFeedbackReadOnce emits one warning the first time a feedback store
 // Get/Score call returns an error during snapshot building. Subsequent
-// calls are silent. Nil logger is a no-op for tests that don't care.
+// calls are silent.
+//
+// The nil-logger guard runs BEFORE sync.Once.Do so a nil logger does not
+// silently consume the once. If a caller wires the emitter before a real
+// logger is attached (init order, test scaffolding), the once stays
+// armed and the first real-logger call still emits.
 func (s *feedbackWarningState) warnFeedbackReadOnce(l feedbackLogger, key FeedbackKey, err error) {
-	if s == nil {
+	if s == nil || l == nil {
 		return
 	}
 	s.readOnce.Do(func() {
-		if l == nil {
-			return
-		}
 		l.Warnf("feedback store read failed for key %+v (further read failures silenced): %v", key, err)
 	})
 }
 
 // warnFeedbackWriteOnce emits one warning the first time
 // RoutingFeedback.RecordOutcome returns a non-nil error. Replaces the
-// silent-swallow that recordOutcomeFeedback shipped in PR2.
+// silent-swallow that recordOutcomeFeedback shipped in PR2. Same
+// nil-logger-before-Do guard as warnFeedbackReadOnce.
 func (s *feedbackWarningState) warnFeedbackWriteOnce(l feedbackLogger, err error) {
-	if s == nil {
+	if s == nil || l == nil {
 		return
 	}
 	s.writeOnce.Do(func() {
-		if l == nil {
-			return
-		}
 		l.Warnf("feedback store RecordOutcome failed (further write failures silenced): %v", err)
 	})
 }
 
 // warnRouteIDRandOnce emits one warning the first time crypto/rand
 // produces an error inside newRouteID. Replaces the silent swallow that
-// route_plan.go shipped in PR2.
+// route_plan.go shipped in PR2. Same nil-logger-before-Do guard as
+// warnFeedbackReadOnce.
 func (s *feedbackWarningState) warnRouteIDRandOnce(l feedbackLogger, err error) {
-	if s == nil {
+	if s == nil || l == nil {
 		return
 	}
 	s.routeIDRndOnce.Do(func() {
-		if l == nil {
-			return
-		}
 		l.Warnf("newRouteID crypto/rand failure (further failures silenced): %v", err)
 	})
 }

--- a/provider/routing_feedback_logger_test.go
+++ b/provider/routing_feedback_logger_test.go
@@ -1,0 +1,98 @@
+package provider
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+// capturingLogger implements feedbackLogger and records all messages.
+type capturingLogger struct {
+	mu       sync.Mutex
+	messages []string
+}
+
+func (c *capturingLogger) Warnf(format string, args ...any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.messages = append(c.messages, format) // store format; tests assert substrings
+	_ = args
+}
+
+func (c *capturingLogger) snapshot() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, len(c.messages))
+	copy(out, c.messages)
+	return out
+}
+
+func TestFeedbackReadOnceFiresOnce(t *testing.T) {
+	cap := &capturingLogger{}
+	state := newFeedbackWarningState()
+
+	const iterations = 1000
+	var wg sync.WaitGroup
+	for i := 0; i < iterations; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			state.warnFeedbackReadOnce(cap, FeedbackKey{Provider: "p", Model: "m", UseCase: "chat"}, nil)
+		}()
+	}
+	wg.Wait()
+
+	msgs := cap.snapshot()
+	if len(msgs) != 1 {
+		t.Fatalf("warnFeedbackReadOnce fired %d times, want 1", len(msgs))
+	}
+	if !strings.Contains(msgs[0], "feedback") {
+		t.Errorf("warning message %q does not mention feedback", msgs[0])
+	}
+}
+
+func TestFeedbackWriteOnceFiresOnce(t *testing.T) {
+	cap := &capturingLogger{}
+	state := newFeedbackWarningState()
+	for i := 0; i < 50; i++ {
+		state.warnFeedbackWriteOnce(cap, nil)
+	}
+	if got := len(cap.snapshot()); got != 1 {
+		t.Fatalf("warnFeedbackWriteOnce fired %d times, want 1", got)
+	}
+}
+
+func TestRouteIDRandOnceFiresOnce(t *testing.T) {
+	cap := &capturingLogger{}
+	state := newFeedbackWarningState()
+	for i := 0; i < 50; i++ {
+		state.warnRouteIDRandOnce(cap, nil)
+	}
+	if got := len(cap.snapshot()); got != 1 {
+		t.Fatalf("warnRouteIDRandOnce fired %d times, want 1", got)
+	}
+}
+
+func TestFeedbackLoggerNilSafe(t *testing.T) {
+	// A nil logger must not panic.
+	state := newFeedbackWarningState()
+	state.warnFeedbackReadOnce(nil, FeedbackKey{}, nil)
+	state.warnFeedbackWriteOnce(nil, nil)
+	state.warnRouteIDRandOnce(nil, nil)
+}
+
+func TestFeedbackLoggerDirectInjection(t *testing.T) {
+	cap := &capturingLogger{}
+	router, _ := setupTestRouter(t)
+	router.feedbackLogger = cap // direct field set; no exported option
+	if router.feedbackLogger != cap {
+		t.Errorf("feedbackLogger direct injection failed")
+	}
+}
+
+func TestDefaultFeedbackLoggerIsNonNil(t *testing.T) {
+	router, _ := setupTestRouter(t)
+	if router.feedbackLogger == nil {
+		t.Errorf("feedbackLogger default is nil; expected defaultFeedbackLogger")
+	}
+}

--- a/provider/routing_feedback_logger_test.go
+++ b/provider/routing_feedback_logger_test.go
@@ -1,12 +1,16 @@
 package provider
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
 )
 
-// capturingLogger implements feedbackLogger and records all messages.
+// capturingLogger implements feedbackLogger and records the *rendered*
+// message (format applied to args) so tests can assert that args actually
+// flow through the format and aren't silently dropped by a future refactor.
 type capturingLogger struct {
 	mu       sync.Mutex
 	messages []string
@@ -15,8 +19,7 @@ type capturingLogger struct {
 func (c *capturingLogger) Warnf(format string, args ...any) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.messages = append(c.messages, format) // store format; tests assert substrings
-	_ = args
+	c.messages = append(c.messages, fmt.Sprintf(format, args...))
 }
 
 func (c *capturingLogger) snapshot() []string {
@@ -31,13 +34,19 @@ func TestFeedbackReadOnceFiresOnce(t *testing.T) {
 	cap := &capturingLogger{}
 	state := newFeedbackWarningState()
 
+	// First call uses a sentinel error so we can prove later calls' args
+	// are NOT recorded — locks the once-contract against a future refactor
+	// that accidentally records every attempt.
+	firstErr := errors.New("first-call-sentinel")
+	state.warnFeedbackReadOnce(cap, FeedbackKey{Provider: "p", Model: "m", UseCase: "chat"}, firstErr)
+
 	const iterations = 1000
 	var wg sync.WaitGroup
 	for i := 0; i < iterations; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			state.warnFeedbackReadOnce(cap, FeedbackKey{Provider: "p", Model: "m", UseCase: "chat"}, nil)
+			state.warnFeedbackReadOnce(cap, FeedbackKey{Provider: "p", Model: "m", UseCase: "chat"}, errors.New("later-call-should-be-dropped"))
 		}()
 	}
 	wg.Wait()
@@ -48,6 +57,12 @@ func TestFeedbackReadOnceFiresOnce(t *testing.T) {
 	}
 	if !strings.Contains(msgs[0], "feedback") {
 		t.Errorf("warning message %q does not mention feedback", msgs[0])
+	}
+	if !strings.Contains(msgs[0], "first-call-sentinel") {
+		t.Errorf("warning message %q does not include first call's error; format/args may not flow", msgs[0])
+	}
+	if strings.Contains(msgs[0], "later-call-should-be-dropped") {
+		t.Errorf("warning message %q includes a later call's error; once-contract violated", msgs[0])
 	}
 }
 
@@ -79,6 +94,37 @@ func TestFeedbackLoggerNilSafe(t *testing.T) {
 	state.warnFeedbackReadOnce(nil, FeedbackKey{}, nil)
 	state.warnFeedbackWriteOnce(nil, nil)
 	state.warnRouteIDRandOnce(nil, nil)
+}
+
+// TestFeedbackLoggerNilDoesNotConsumeOnce locks in the contract that
+// invoking a warn-once emitter with a nil logger leaves the sync.Once
+// armed, so a subsequent call with a real logger still emits. Caught a
+// real footgun: the previous shape ran the nil check INSIDE Once.Do,
+// which silently burned the Once whenever a caller raced ahead of
+// logger attachment.
+func TestFeedbackLoggerNilDoesNotConsumeOnce(t *testing.T) {
+	state := newFeedbackWarningState()
+	// Burn each emitter with nil logger first.
+	state.warnFeedbackReadOnce(nil, FeedbackKey{Provider: "p", Model: "m", UseCase: "chat"}, errors.New("dropped"))
+	state.warnFeedbackWriteOnce(nil, errors.New("dropped"))
+	state.warnRouteIDRandOnce(nil, errors.New("dropped"))
+
+	// Now attach a real logger and invoke each emitter. All three must emit.
+	cap := &capturingLogger{}
+	state.warnFeedbackReadOnce(cap, FeedbackKey{Provider: "p", Model: "m", UseCase: "chat"}, errors.New("read-emitted"))
+	state.warnFeedbackWriteOnce(cap, errors.New("write-emitted"))
+	state.warnRouteIDRandOnce(cap, errors.New("rng-emitted"))
+
+	msgs := cap.snapshot()
+	if len(msgs) != 3 {
+		t.Fatalf("after nil-then-real, got %d messages, want 3", len(msgs))
+	}
+	joined := strings.Join(msgs, "|")
+	for _, want := range []string{"read-emitted", "write-emitted", "rng-emitted"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("rendered messages %q missing %q; once was consumed during nil-logger call", joined, want)
+		}
+	}
 }
 
 func TestFeedbackLoggerDirectInjection(t *testing.T) {

--- a/provider/routing_feedback_memory.go
+++ b/provider/routing_feedback_memory.go
@@ -79,8 +79,8 @@ func NewMemoryStore(cfg MemoryStoreConfig) (*MemoryStore, error) {
 	if resolved.maxMetaValueBytes == 0 {
 		resolved.maxMetaValueBytes = DefaultMaxMetaValueBytes
 	}
-	if resolved.neutralScore < 0 || resolved.neutralScore > 1 {
-		return nil, fmt.Errorf("provider: NeutralScore %v out of range [0,1]", resolved.neutralScore)
+	if err := validateNeutralScore(resolved.neutralScore); err != nil {
+		return nil, err
 	}
 	if resolved.maxRetainedSamples < -1 {
 		return nil, fmt.Errorf("provider: MaxRetainedSamples %d out of range; use -1 for unbounded", resolved.maxRetainedSamples)

--- a/provider/routing_feedback_sqlite.go
+++ b/provider/routing_feedback_sqlite.go
@@ -62,6 +62,19 @@ type SQLiteFeedbackStore struct {
 
 // NewSQLiteFeedbackStore wraps a caller-owned *sql.DB. Runs the schema
 // migrations; the caller retains responsibility for closing the DB.
+//
+// PRAGMA expectations for the caller-owned path: the routing-feedback
+// workload assumes WAL journal mode (better concurrent-read latency)
+// and a positive busy_timeout (bounded wait on contended write locks).
+// Because PRAGMAs in modernc.org/sqlite apply per-connection, callers
+// who want both to take effect across the whole pool must either
+//   - clamp `db.SetMaxOpenConns(1)` (simplest; serializes writes), or
+//   - apply the PRAGMAs via a `sql.Connector` / DSN `_pragma=` form
+//     before passing the *sql.DB in.
+//
+// OpenSQLiteFeedbackStore does the former internally. Caller-owned
+// users sharing a workspace DB with rag/ inherit whatever that
+// package configured.
 func NewSQLiteFeedbackStore(ctx context.Context, db *sql.DB, cfg SQLiteFeedbackStoreConfig) (*SQLiteFeedbackStore, error) {
 	if db == nil {
 		return nil, errors.New("provider: SQLiteFeedbackStore requires non-nil *sql.DB")
@@ -88,9 +101,20 @@ func OpenSQLiteFeedbackStore(ctx context.Context, path string, cfg SQLiteFeedbac
 	if err != nil {
 		return nil, fmt.Errorf("provider: open sqlite %q: %w", path, err)
 	}
-	if path == ":memory:" {
-		db.SetMaxOpenConns(1)
-	} else {
+	// Clamp the connection pool to one connection regardless of path.
+	// modernc.org/sqlite applies PRAGMAs per-connection; without this,
+	// the WAL + busy_timeout PRAGMAs below would only apply to the
+	// connection that received them, and other connections in the pool
+	// would silently revert to journal_mode=DELETE / busy_timeout=0 —
+	// exactly the contention behavior the PRAGMAs exist to prevent.
+	// Routing-feedback writes are low-rate; serializing through one
+	// connection is acceptable until benchmarks show otherwise.
+	// (:memory: also requires MaxOpenConns(1) because each connection
+	// opens its own private database otherwise — same outcome via a
+	// different mechanism.)
+	db.SetMaxOpenConns(1)
+
+	if path != ":memory:" {
 		if _, err := db.ExecContext(ctx, "PRAGMA journal_mode=WAL"); err != nil {
 			_ = db.Close()
 			return nil, fmt.Errorf("provider: set WAL mode: %w", err)
@@ -98,8 +122,7 @@ func OpenSQLiteFeedbackStore(ctx context.Context, path string, cfg SQLiteFeedbac
 		// busy_timeout = 5000ms: bounded wait on a contended write lock
 		// before giving up with SQLITE_BUSY. Avoids tight retry loops in
 		// the calling code while still respecting the feedbackWriteTimeout
-		// the caller passes on the outer ctx. Caller-owned *sql.DB users
-		// can set their own PRAGMA before passing the handle in.
+		// the caller passes on the outer ctx.
 		if _, err := db.ExecContext(ctx, "PRAGMA busy_timeout=5000"); err != nil {
 			_ = db.Close()
 			return nil, fmt.Errorf("provider: set busy_timeout: %w", err)
@@ -297,8 +320,11 @@ func (s *SQLiteFeedbackStore) runInTx(ctx context.Context, fn func(*sql.Tx) erro
 	if err != nil {
 		return fmt.Errorf("provider: SQLiteFeedbackStore begin: %w", err)
 	}
+	// Defensive rollback covers the panic path (return early on success
+	// commit). database/sql treats Rollback after Commit as a no-op, so
+	// this is safe.
+	defer func() { _ = tx.Rollback() }()
 	if err := fn(tx); err != nil {
-		_ = tx.Rollback()
 		return err
 	}
 	if err := tx.Commit(); err != nil {

--- a/provider/routing_feedback_sqlite.go
+++ b/provider/routing_feedback_sqlite.go
@@ -170,8 +170,8 @@ func resolveSQLiteConfig(cfg SQLiteFeedbackStoreConfig) (resolvedConfig, error) 
 	if r.maxMetaValueBytes == 0 {
 		r.maxMetaValueBytes = DefaultMaxMetaValueBytes
 	}
-	if r.neutralScore < 0 || r.neutralScore > 1 {
-		return r, fmt.Errorf("provider: NeutralScore %v out of range [0,1]", r.neutralScore)
+	if err := validateNeutralScore(r.neutralScore); err != nil {
+		return r, err
 	}
 	if r.maxRetainedSamples < -1 {
 		return r, fmt.Errorf("provider: MaxRetainedSamples %d out of range; use -1 for unbounded", r.maxRetainedSamples)

--- a/provider/routing_feedback_sqlite.go
+++ b/provider/routing_feedback_sqlite.go
@@ -1,0 +1,365 @@
+// routing_feedback_sqlite.go provides the SQLite-backed RoutingFeedbackStore.
+// Identical semantics to MemoryStore (validation, retention, atomic batch)
+// but persistent and shareable across processes (e.g., the same workspace
+// *sql.DB used by rag/, conversation/, fingerprint/).
+//
+// Constructor shape: caller-owned *sql.DB is the primary path
+// (NewSQLiteFeedbackStore); OpenSQLiteFeedbackStore is a convenience for
+// quick setup and tests that requires an explicit path argument
+// (":memory:" is the only zero-arg-equivalent that must be spelled out).
+package provider
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// Compile-time interface check.
+var _ RoutingFeedbackStore = (*SQLiteFeedbackStore)(nil)
+
+// SQLiteFeedbackStoreConfig configures a SQLiteFeedbackStore. Per-key
+// retention knobs mirror MemoryStoreConfig so an operator switching
+// stores does not change observable Get/Record/RecordBatch behavior.
+type SQLiteFeedbackStoreConfig struct {
+	// NeutralScore is returned by Get() when ScoredCount == 0. Zero value
+	// selects DefaultNeutralScore (0.5). Out-of-range fails construction.
+	NeutralScore float64
+
+	// MaxRetainedSamples bounds per-key retention. 0 -> default 1000;
+	// -1 -> unbounded; >0 -> explicit cap with FIFO eviction on overflow.
+	MaxRetainedSamples int
+
+	// MaxMetaKeys / MaxMetaValueBytes bound Meta. 0 -> defaults.
+	MaxMetaKeys       int
+	MaxMetaValueBytes int
+
+	// ownDB is set internally by OpenSQLiteFeedbackStore; users of the
+	// caller-owned constructor leave it false. Controls whether Close
+	// closes the underlying *sql.DB.
+	ownDB bool
+}
+
+// SQLiteFeedbackStore is the persistent RoutingFeedbackStore. Safe for
+// concurrent use; SQLite serializes writes via the connection pool, and
+// reads use a single SELECT per call.
+type SQLiteFeedbackStore struct {
+	db    *sql.DB
+	cfg   resolvedConfig
+	ownDB bool
+
+	// closeOnce guards the conditional Close-the-DB path so that calling
+	// Close twice on a store opened via OpenSQLiteFeedbackStore does not
+	// double-close.
+	closeOnce sync.Once
+}
+
+// NewSQLiteFeedbackStore wraps a caller-owned *sql.DB. Runs the schema
+// migrations; the caller retains responsibility for closing the DB.
+func NewSQLiteFeedbackStore(ctx context.Context, db *sql.DB, cfg SQLiteFeedbackStoreConfig) (*SQLiteFeedbackStore, error) {
+	if db == nil {
+		return nil, errors.New("provider: SQLiteFeedbackStore requires non-nil *sql.DB")
+	}
+	resolved, err := resolveSQLiteConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if err := runFeedbackMigrations(db); err != nil {
+		return nil, err
+	}
+	return &SQLiteFeedbackStore{db: db, cfg: resolved, ownDB: cfg.ownDB}, nil
+}
+
+// OpenSQLiteFeedbackStore opens a SQLite database at path (use ":memory:"
+// for in-process tests; explicit empty string is rejected to avoid the
+// default-string footgun) and returns a store that owns the *sql.DB.
+// Close on this store closes the DB.
+func OpenSQLiteFeedbackStore(ctx context.Context, path string, cfg SQLiteFeedbackStoreConfig) (*SQLiteFeedbackStore, error) {
+	if path == "" {
+		return nil, errors.New("provider: OpenSQLiteFeedbackStore requires non-empty path; pass \":memory:\" explicitly")
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("provider: open sqlite %q: %w", path, err)
+	}
+	if path == ":memory:" {
+		db.SetMaxOpenConns(1)
+	} else {
+		if _, err := db.ExecContext(ctx, "PRAGMA journal_mode=WAL"); err != nil {
+			_ = db.Close()
+			return nil, fmt.Errorf("provider: set WAL mode: %w", err)
+		}
+		// busy_timeout = 5000ms: bounded wait on a contended write lock
+		// before giving up with SQLITE_BUSY. Avoids tight retry loops in
+		// the calling code while still respecting the feedbackWriteTimeout
+		// the caller passes on the outer ctx. Caller-owned *sql.DB users
+		// can set their own PRAGMA before passing the handle in.
+		if _, err := db.ExecContext(ctx, "PRAGMA busy_timeout=5000"); err != nil {
+			_ = db.Close()
+			return nil, fmt.Errorf("provider: set busy_timeout: %w", err)
+		}
+	}
+	cfg.ownDB = true
+	store, err := NewSQLiteFeedbackStore(ctx, db, cfg)
+	if err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return store, nil
+}
+
+// Close releases the underlying *sql.DB if and only if the store opened
+// it (via OpenSQLiteFeedbackStore). Stores constructed against a
+// caller-owned *sql.DB leave Close as a no-op so the caller can manage
+// its own lifecycle.
+func (s *SQLiteFeedbackStore) Close() error {
+	var err error
+	s.closeOnce.Do(func() {
+		if s.ownDB {
+			err = s.db.Close()
+		}
+	})
+	return err
+}
+
+func resolveSQLiteConfig(cfg SQLiteFeedbackStoreConfig) (resolvedConfig, error) {
+	r := resolvedConfig{
+		neutralScore:       cfg.NeutralScore,
+		maxRetainedSamples: cfg.MaxRetainedSamples,
+		maxMetaKeys:        cfg.MaxMetaKeys,
+		maxMetaValueBytes:  cfg.MaxMetaValueBytes,
+	}
+	if r.neutralScore == 0 {
+		r.neutralScore = DefaultNeutralScore
+	}
+	if r.maxRetainedSamples == 0 {
+		r.maxRetainedSamples = DefaultMaxRetainedSamples
+	}
+	if r.maxMetaKeys == 0 {
+		r.maxMetaKeys = DefaultMaxMetaKeys
+	}
+	if r.maxMetaValueBytes == 0 {
+		r.maxMetaValueBytes = DefaultMaxMetaValueBytes
+	}
+	if r.neutralScore < 0 || r.neutralScore > 1 {
+		return r, fmt.Errorf("provider: NeutralScore %v out of range [0,1]", r.neutralScore)
+	}
+	if r.maxRetainedSamples < -1 {
+		return r, fmt.Errorf("provider: MaxRetainedSamples %d out of range; use -1 for unbounded", r.maxRetainedSamples)
+	}
+	if r.maxMetaKeys < 0 {
+		return r, fmt.Errorf("provider: MaxMetaKeys %d out of range", r.maxMetaKeys)
+	}
+	if r.maxMetaValueBytes < 0 {
+		return r, fmt.Errorf("provider: MaxMetaValueBytes %d out of range", r.maxMetaValueBytes)
+	}
+	return r, nil
+}
+
+// Get aggregates signals for key via a single SELECT. Returns a neutral
+// aggregate when no rows exist.
+func (s *SQLiteFeedbackStore) Get(ctx context.Context, key FeedbackKey) (Aggregate, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT kind, strength, at_ns FROM routing_feedback_signals
+		   WHERE provider = ? AND model = ? AND use_case = ?
+		   ORDER BY at_ns ASC, id ASC`,
+		key.Provider, key.Model, key.UseCase,
+	)
+	if err != nil {
+		return Aggregate{}, fmt.Errorf("provider: SQLiteFeedbackStore.Get: %w", err)
+	}
+	defer rows.Close()
+
+	var (
+		sum         float64
+		scored      int
+		sampleCount int
+		latestAtNs  int64
+	)
+	for rows.Next() {
+		var (
+			kind     string
+			strength sql.NullFloat64
+			atNs     int64
+		)
+		if err := rows.Scan(&kind, &strength, &atNs); err != nil {
+			return Aggregate{}, fmt.Errorf("provider: SQLiteFeedbackStore.Get scan: %w", err)
+		}
+		sampleCount++
+		if atNs > latestAtNs {
+			latestAtNs = atNs
+		}
+		var eff float64
+		if strength.Valid {
+			eff = strength.Float64
+		} else {
+			eff = defaultStrength[RoutingSignalKind(kind)]
+		}
+		if eff == 0 {
+			continue
+		}
+		if eff < -1 {
+			eff = -1
+		} else if eff > 1 {
+			eff = 1
+		}
+		sum += eff
+		scored++
+	}
+	if err := rows.Err(); err != nil {
+		return Aggregate{}, fmt.Errorf("provider: SQLiteFeedbackStore.Get rows: %w", err)
+	}
+	if sampleCount == 0 {
+		return Aggregate{Score: s.cfg.neutralScore}, nil
+	}
+	updatedAt := time.Unix(0, latestAtNs)
+	if scored == 0 {
+		return Aggregate{Score: s.cfg.neutralScore, SampleCount: sampleCount, UpdatedAt: updatedAt}, nil
+	}
+	return Aggregate{
+		Score:       0.5 + 0.5*(sum/float64(scored)),
+		SampleCount: sampleCount,
+		ScoredCount: scored,
+		UpdatedAt:   updatedAt,
+	}, nil
+}
+
+// Record persists a single signal. Validates the key/signal, defaults At
+// to time.Now() when zero, and applies retention inside a transaction so
+// reads cannot observe an over-cap state.
+func (s *SQLiteFeedbackStore) Record(ctx context.Context, key FeedbackKey, sig FeedbackSignal) error {
+	if err := validateKey(key); err != nil {
+		return err
+	}
+	if err := validateSignal(sig, s.cfg.maxMetaKeys, s.cfg.maxMetaValueBytes); err != nil {
+		return err
+	}
+	stored := cloneSignal(sig)
+	if stored.At.IsZero() {
+		stored.At = time.Now()
+	}
+	return s.runInTx(ctx, func(tx *sql.Tx) error {
+		if err := insertSignalTx(ctx, tx, key, stored); err != nil {
+			return err
+		}
+		return applyRetentionTx(ctx, tx, key, s.cfg.maxRetainedSamples)
+	})
+}
+
+// RecordBatch persists multiple signals as one atomic transition.
+// Per-key FIFO retention is applied once per touched key after all
+// inserts complete, still inside the same transaction.
+func (s *SQLiteFeedbackStore) RecordBatch(ctx context.Context, items []FeedbackItem) error {
+	if len(items) == 0 {
+		return nil
+	}
+	cloned := make([]FeedbackItem, len(items))
+	for i, item := range items {
+		if err := validateKey(item.Key); err != nil {
+			return err
+		}
+		if err := validateSignal(item.Signal, s.cfg.maxMetaKeys, s.cfg.maxMetaValueBytes); err != nil {
+			return err
+		}
+		cloned[i] = FeedbackItem{Key: item.Key, Signal: cloneSignal(item.Signal)}
+	}
+	now := time.Now()
+	for i := range cloned {
+		if cloned[i].Signal.At.IsZero() {
+			cloned[i].Signal.At = now
+		}
+	}
+	return s.runInTx(ctx, func(tx *sql.Tx) error {
+		touched := make(map[FeedbackKey]struct{}, len(cloned))
+		for i := range cloned {
+			if err := insertSignalTx(ctx, tx, cloned[i].Key, cloned[i].Signal); err != nil {
+				return err
+			}
+			touched[cloned[i].Key] = struct{}{}
+		}
+		for k := range touched {
+			if err := applyRetentionTx(ctx, tx, k, s.cfg.maxRetainedSamples); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func (s *SQLiteFeedbackStore) runInTx(ctx context.Context, fn func(*sql.Tx) error) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("provider: SQLiteFeedbackStore begin: %w", err)
+	}
+	if err := fn(tx); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("provider: SQLiteFeedbackStore commit: %w", err)
+	}
+	return nil
+}
+
+// insertSignalTx writes one signal row. Meta is marshalled to JSON; the
+// caller has already enforced the key-count / value-byte limits via
+// validateSignal so json.Marshal cannot exceed the column expectations.
+func insertSignalTx(ctx context.Context, tx *sql.Tx, key FeedbackKey, sig FeedbackSignal) error {
+	var strength sql.NullFloat64
+	if sig.Strength != nil {
+		strength = sql.NullFloat64{Float64: *sig.Strength, Valid: true}
+	}
+	meta := []byte("{}")
+	if len(sig.Meta) > 0 {
+		m, err := json.Marshal(sig.Meta)
+		if err != nil {
+			return fmt.Errorf("provider: marshal meta: %w", err)
+		}
+		meta = m
+	}
+	_, err := tx.ExecContext(ctx,
+		`INSERT INTO routing_feedback_signals
+		   (provider, model, use_case, kind, strength, at_ns,
+		    latency_ms, error_class, route_id, completion_id, meta)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		key.Provider, key.Model, key.UseCase,
+		string(sig.Kind), strength, sig.At.UnixNano(),
+		sig.LatencyMs, sig.ErrorClass, sig.RouteID, sig.CompletionID, string(meta),
+	)
+	if err != nil {
+		return fmt.Errorf("provider: insert signal: %w", err)
+	}
+	return nil
+}
+
+// applyRetentionTx deletes all but the newest maxRetained rows for key,
+// ordered by (at_ns DESC, id DESC) so same-timestamp batch rows have a
+// deterministic FIFO tiebreaker. No-op when maxRetained <= 0 (the
+// "unbounded" semantics from MemoryStoreConfig).
+func applyRetentionTx(ctx context.Context, tx *sql.Tx, key FeedbackKey, maxRetained int) error {
+	if maxRetained <= 0 {
+		return nil
+	}
+	_, err := tx.ExecContext(ctx,
+		`DELETE FROM routing_feedback_signals
+		   WHERE provider = ? AND model = ? AND use_case = ?
+		     AND id NOT IN (
+		       SELECT id FROM routing_feedback_signals
+		         WHERE provider = ? AND model = ? AND use_case = ?
+		         ORDER BY at_ns DESC, id DESC
+		         LIMIT ?
+		     )`,
+		key.Provider, key.Model, key.UseCase,
+		key.Provider, key.Model, key.UseCase, maxRetained,
+	)
+	if err != nil {
+		return fmt.Errorf("provider: retention DELETE: %w", err)
+	}
+	return nil
+}

--- a/provider/routing_feedback_sqlite.go
+++ b/provider/routing_feedback_sqlite.go
@@ -187,7 +187,7 @@ func resolveSQLiteConfig(cfg SQLiteFeedbackStoreConfig) (resolvedConfig, error) 
 
 // Get aggregates signals for key via a single SELECT. Returns a neutral
 // aggregate when no rows exist.
-func (s *SQLiteFeedbackStore) Get(ctx context.Context, key FeedbackKey) (Aggregate, error) {
+func (s *SQLiteFeedbackStore) Get(ctx context.Context, key FeedbackKey) (agg Aggregate, err error) {
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT kind, strength, at_ns FROM routing_feedback_signals
 		   WHERE provider = ? AND model = ? AND use_case = ?
@@ -197,7 +197,11 @@ func (s *SQLiteFeedbackStore) Get(ctx context.Context, key FeedbackKey) (Aggrega
 	if err != nil {
 		return Aggregate{}, fmt.Errorf("provider: SQLiteFeedbackStore.Get: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if closeErr := rows.Close(); err == nil && closeErr != nil {
+			err = fmt.Errorf("provider: SQLiteFeedbackStore.Get close rows: %w", closeErr)
+		}
+	}()
 
 	var (
 		sum         float64
@@ -364,10 +368,10 @@ func insertSignalTx(ctx context.Context, tx *sql.Tx, key FeedbackKey, sig Feedba
 	return nil
 }
 
-// applyRetentionTx deletes all but the newest maxRetained rows for key,
-// ordered by (at_ns DESC, id DESC) so same-timestamp batch rows have a
-// deterministic FIFO tiebreaker. No-op when maxRetained <= 0 (the
-// "unbounded" semantics from MemoryStoreConfig).
+// applyRetentionTx deletes all but the newest maxRetained inserted rows for
+// key, ordered by id DESC to match MemoryStore's FIFO retention even when a
+// caller records backdated or delayed signals. No-op when maxRetained <= 0
+// (the "unbounded" semantics from MemoryStoreConfig).
 func applyRetentionTx(ctx context.Context, tx *sql.Tx, key FeedbackKey, maxRetained int) error {
 	if maxRetained <= 0 {
 		return nil
@@ -378,7 +382,7 @@ func applyRetentionTx(ctx context.Context, tx *sql.Tx, key FeedbackKey, maxRetai
 		     AND id NOT IN (
 		       SELECT id FROM routing_feedback_signals
 		         WHERE provider = ? AND model = ? AND use_case = ?
-		         ORDER BY at_ns DESC, id DESC
+		         ORDER BY id DESC
 		         LIMIT ?
 		     )`,
 		key.Provider, key.Model, key.UseCase,

--- a/provider/routing_feedback_sqlite_bench_test.go
+++ b/provider/routing_feedback_sqlite_bench_test.go
@@ -42,10 +42,10 @@ func BenchmarkSQLiteFeedbackStoreRecordBatch(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		// Stamp At freshly per iteration so retention's
-		// ORDER BY at_ns DESC, id DESC actually orders rows by time and
-		// the trim hits a real ordering — not the degenerate
-		// "every row shares one at_ns" case.
+		// Stamp At freshly per iteration so read-side aggregation walks a
+		// realistic time-ordered range rather than the degenerate
+		// "every row shares one at_ns" case. Retention itself is FIFO by
+		// insertion id to match MemoryStore.
 		now := time.Now()
 		for j := range items {
 			items[j] = FeedbackItem{Key: k, Signal: FeedbackSignal{Kind: RoutingSignalSuccess, At: now.Add(time.Duration(j) * time.Microsecond)}}

--- a/provider/routing_feedback_sqlite_bench_test.go
+++ b/provider/routing_feedback_sqlite_bench_test.go
@@ -6,6 +6,28 @@ import (
 	"time"
 )
 
+// BenchmarkSQLiteFeedbackStoreRecordBatch measures the synchronous
+// write-path latency the PR2 carry-in feedbackWriteTimeout (currently
+// 1s) needs to bound.
+//
+// LIMITATIONS — read these before treating the numbers as a ceiling:
+//   - Uses ":memory:" SQLite. File-backed deployments incur fsync,
+//     journal-mode transitions, and busy-timeout effects that this
+//     baseline does NOT measure. PR5+ may re-run against a file-backed
+//     fixture if a deployment surfaces contention.
+//   - Single-key fixture. Production has many distinct
+//     (provider, model, use_case) keys; per-key indexes don't see the
+//     same hot row. Retention pressure on a single key over-exercises
+//     the DELETE path relative to a balanced workload.
+//   - 8-item batch size mirrors PR2's per-attempt decomposition
+//     (success + up-to-N fallback failures); production batches are
+//     typically smaller (1-3 items).
+//
+// Per-iteration At timestamps and per-iteration unique keys would help
+// retention realism but add overhead that biases the latency number.
+// We trade realism for a stable upper bound here; the realism gap is
+// called out explicitly so the timeout decision can be revisited
+// against representative production traces.
 func BenchmarkSQLiteFeedbackStoreRecordBatch(b *testing.B) {
 	store, err := OpenSQLiteFeedbackStore(context.Background(), ":memory:", SQLiteFeedbackStoreConfig{
 		MaxRetainedSamples: 1000,
@@ -13,22 +35,31 @@ func BenchmarkSQLiteFeedbackStoreRecordBatch(b *testing.B) {
 	if err != nil {
 		b.Fatalf("OpenSQLiteFeedbackStore: %v", err)
 	}
-	defer store.Close()
+	b.Cleanup(func() { _ = store.Close() })
 
 	k := FeedbackKey{Provider: "p", Model: "m", UseCase: "chat"}
 	items := make([]FeedbackItem, 8)
-	for i := range items {
-		items[i] = FeedbackItem{Key: k, Signal: FeedbackSignal{Kind: RoutingSignalSuccess, At: time.Now()}}
-	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		// Stamp At freshly per iteration so retention's
+		// ORDER BY at_ns DESC, id DESC actually orders rows by time and
+		// the trim hits a real ordering — not the degenerate
+		// "every row shares one at_ns" case.
+		now := time.Now()
+		for j := range items {
+			items[j] = FeedbackItem{Key: k, Signal: FeedbackSignal{Kind: RoutingSignalSuccess, At: now.Add(time.Duration(j) * time.Microsecond)}}
+		}
 		if err := store.RecordBatch(context.Background(), items); err != nil {
 			b.Fatalf("RecordBatch: %v", err)
 		}
 	}
 }
 
+// BenchmarkSQLiteFeedbackStoreGet measures the read-path latency that
+// the routing-hot-path pays per scoring decision when feedback is on.
+// Same ":memory:" caveat as RecordBatch above. Seeds the cap with
+// distinct timestamps so the aggregation loop walks an ordered range.
 func BenchmarkSQLiteFeedbackStoreGet(b *testing.B) {
 	store, err := OpenSQLiteFeedbackStore(context.Background(), ":memory:", SQLiteFeedbackStoreConfig{
 		MaxRetainedSamples: 1000,
@@ -36,14 +67,18 @@ func BenchmarkSQLiteFeedbackStoreGet(b *testing.B) {
 	if err != nil {
 		b.Fatalf("OpenSQLiteFeedbackStore: %v", err)
 	}
-	defer store.Close()
+	b.Cleanup(func() { _ = store.Close() })
 
 	k := FeedbackKey{Provider: "p", Model: "m", UseCase: "chat"}
-	items := make([]FeedbackItem, 50)
-	for i := range items {
-		items[i] = FeedbackItem{Key: k, Signal: FeedbackSignal{Kind: RoutingSignalSuccess, At: time.Now()}}
+	seed := make([]FeedbackItem, 50)
+	base := time.Now()
+	for i := range seed {
+		seed[i] = FeedbackItem{
+			Key:    k,
+			Signal: FeedbackSignal{Kind: RoutingSignalSuccess, At: base.Add(time.Duration(i) * time.Millisecond)},
+		}
 	}
-	if err := store.RecordBatch(context.Background(), items); err != nil {
+	if err := store.RecordBatch(context.Background(), seed); err != nil {
 		b.Fatalf("seed RecordBatch: %v", err)
 	}
 

--- a/provider/routing_feedback_sqlite_bench_test.go
+++ b/provider/routing_feedback_sqlite_bench_test.go
@@ -1,0 +1,56 @@
+package provider
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func BenchmarkSQLiteFeedbackStoreRecordBatch(b *testing.B) {
+	store, err := OpenSQLiteFeedbackStore(context.Background(), ":memory:", SQLiteFeedbackStoreConfig{
+		MaxRetainedSamples: 1000,
+	})
+	if err != nil {
+		b.Fatalf("OpenSQLiteFeedbackStore: %v", err)
+	}
+	defer store.Close()
+
+	k := FeedbackKey{Provider: "p", Model: "m", UseCase: "chat"}
+	items := make([]FeedbackItem, 8)
+	for i := range items {
+		items[i] = FeedbackItem{Key: k, Signal: FeedbackSignal{Kind: RoutingSignalSuccess, At: time.Now()}}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := store.RecordBatch(context.Background(), items); err != nil {
+			b.Fatalf("RecordBatch: %v", err)
+		}
+	}
+}
+
+func BenchmarkSQLiteFeedbackStoreGet(b *testing.B) {
+	store, err := OpenSQLiteFeedbackStore(context.Background(), ":memory:", SQLiteFeedbackStoreConfig{
+		MaxRetainedSamples: 1000,
+	})
+	if err != nil {
+		b.Fatalf("OpenSQLiteFeedbackStore: %v", err)
+	}
+	defer store.Close()
+
+	k := FeedbackKey{Provider: "p", Model: "m", UseCase: "chat"}
+	items := make([]FeedbackItem, 50)
+	for i := range items {
+		items[i] = FeedbackItem{Key: k, Signal: FeedbackSignal{Kind: RoutingSignalSuccess, At: time.Now()}}
+	}
+	if err := store.RecordBatch(context.Background(), items); err != nil {
+		b.Fatalf("seed RecordBatch: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := store.Get(context.Background(), k); err != nil {
+			b.Fatalf("Get: %v", err)
+		}
+	}
+}

--- a/provider/routing_feedback_sqlite_migration.go
+++ b/provider/routing_feedback_sqlite_migration.go
@@ -1,0 +1,197 @@
+// routing_feedback_sqlite_migration.go owns the schema migrations for the
+// SQLite-backed routing-feedback store. Schema lives in a version-tracking
+// table (routing_feedback_schema_version) that the migration runner
+// inserts into atomically inside each migration's own transaction, so a
+// crash between DDL and version-record cannot leave a half-applied state.
+//
+// Pattern mirrors rag/migration.go so future migrations follow the same
+// shape; intentional duplication beats coupling provider/ to rag/ types.
+package provider
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// migration is one ordered schema step.
+type migration struct {
+	version     int
+	description string
+	fn          func(tx *sql.Tx) error
+}
+
+// feedbackMigrations is the ordered list of routing-feedback-store schema
+// migrations. v1 is the baseline single-table schema with indexes and
+// CHECK constraints matching the in-memory store's validation rules.
+var feedbackMigrations = []migration{
+	{
+		version:     1,
+		description: "baseline routing_feedback_signals table + indexes",
+		fn:          migrateFeedbackV1,
+	},
+}
+
+func migrateFeedbackV1(tx *sql.Tx) error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS routing_feedback_signals (
+			id            INTEGER PRIMARY KEY AUTOINCREMENT,
+			provider      TEXT NOT NULL,
+			model         TEXT NOT NULL,
+			use_case      TEXT NOT NULL,
+			kind          TEXT NOT NULL CHECK (kind IN ('success', 'failure', 'latency')),
+			strength      REAL,
+			at_ns         INTEGER NOT NULL,
+			latency_ms    INTEGER NOT NULL DEFAULT 0 CHECK (latency_ms >= 0),
+			error_class   TEXT NOT NULL DEFAULT '',
+			route_id      TEXT NOT NULL DEFAULT '',
+			completion_id TEXT NOT NULL DEFAULT '',
+			meta          TEXT NOT NULL DEFAULT '{}',
+			CHECK (
+				(kind = 'success' AND latency_ms = 0 AND error_class = '') OR
+				(kind = 'failure' AND latency_ms = 0 AND error_class <> '') OR
+				(kind = 'latency' AND latency_ms > 0 AND error_class = '')
+			)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_rfs_key_at
+			ON routing_feedback_signals(provider, model, use_case, at_ns, id)`,
+		`CREATE INDEX IF NOT EXISTS idx_rfs_key_kind
+			ON routing_feedback_signals(provider, model, use_case, kind)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := tx.Exec(stmt); err != nil {
+			return fmt.Errorf("provider: feedback migrate v1: %w", err)
+		}
+	}
+	return nil
+}
+
+// runFeedbackMigrations applies all pending migrations. Handles three
+// scenarios identical to rag/runMigrations:
+//  1. Fresh DB: creates routing_feedback_schema_version, runs all migrations.
+//  2. Existing DB at version N: runs only versions > N.
+//  3. Pre-migration DB (routing_feedback_signals table exists, no version
+//     row): records v1 as already-applied, then runs v2+.
+func runFeedbackMigrations(db *sql.DB) error {
+	const createVersionTable = `CREATE TABLE IF NOT EXISTS routing_feedback_schema_version (
+		version     INTEGER PRIMARY KEY,
+		description TEXT NOT NULL,
+		applied_at  INTEGER NOT NULL
+	)`
+	if _, err := db.Exec(createVersionTable); err != nil {
+		return fmt.Errorf("provider: create feedback version table: %w", err)
+	}
+
+	currentVersion, err := currentFeedbackSchemaVersion(db)
+	if err != nil {
+		return err
+	}
+
+	if currentVersion == 0 && tableExists(db, "routing_feedback_signals") {
+		// Database predates the migration runner. Validate the existing
+		// schema matches v1 before marking it as applied; blessing an
+		// incompatible table would surface as a confusing "no such
+		// column" error far from the actual cause.
+		if err := validateExistingSignalsSchema(db); err != nil {
+			return fmt.Errorf("provider: pre-existing routing_feedback_signals table is incompatible with v1 schema: %w", err)
+		}
+		if err := recordFeedbackVersionsUpTo(db, 1); err != nil {
+			return err
+		}
+		currentVersion = 1
+	}
+
+	for _, m := range feedbackMigrations {
+		if m.version <= currentVersion {
+			continue
+		}
+		tx, err := db.Begin()
+		if err != nil {
+			return fmt.Errorf("provider: begin feedback migration v%d: %w", m.version, err)
+		}
+		if err := m.fn(tx); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("provider: feedback migration v%d (%s): %w", m.version, m.description, err)
+		}
+		if _, err := tx.Exec(
+			`INSERT INTO routing_feedback_schema_version (version, description, applied_at) VALUES (?, ?, ?)`,
+			m.version, m.description, time.Now().Unix(),
+		); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("provider: record feedback version %d: %w", m.version, err)
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("provider: commit feedback migration v%d: %w", m.version, err)
+		}
+	}
+	return nil
+}
+
+// currentFeedbackSchemaVersion returns the highest applied version, or 0
+// when no version rows exist.
+func currentFeedbackSchemaVersion(db *sql.DB) (int, error) {
+	var version int
+	err := db.QueryRow(`SELECT COALESCE(MAX(version), 0) FROM routing_feedback_schema_version`).Scan(&version)
+	if err != nil {
+		return 0, fmt.Errorf("provider: query feedback schema version: %w", err)
+	}
+	return version, nil
+}
+
+// tableExists checks whether a table by the given name exists. Mirrors
+// the rag helper of the same name; provider-local copy to avoid an
+// upward dependency on rag/.
+func tableExists(db *sql.DB, name string) bool {
+	var count int
+	err := db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?`, name,
+	).Scan(&count)
+	return err == nil && count > 0
+}
+
+// validateExistingSignalsSchema runs a no-op SELECT against every column
+// the v1 schema declares. SQLite reports "no such column" if any column
+// is missing or named differently. Used by runFeedbackMigrations when a
+// pre-existing routing_feedback_signals table is detected without a
+// schema_version row.
+//
+// The SELECT 0 LIMIT 0 form scans no rows; we only care about the column
+// resolution at prepare time.
+func validateExistingSignalsSchema(db *sql.DB) error {
+	_, err := db.Exec(`SELECT
+		id, provider, model, use_case, kind, strength, at_ns,
+		latency_ms, error_class, route_id, completion_id, meta
+		FROM routing_feedback_signals
+		WHERE 0 LIMIT 0`)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// recordFeedbackVersionsUpTo inserts version records for every migration
+// up to and including upTo. Used for pre-migration DB detection so a
+// crash cannot leave a partial version state.
+func recordFeedbackVersionsUpTo(db *sql.DB, upTo int) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("provider: begin feedback version recording: %w", err)
+	}
+	now := time.Now().Unix()
+	for _, m := range feedbackMigrations {
+		if m.version > upTo {
+			break
+		}
+		if _, err := tx.Exec(
+			`INSERT OR IGNORE INTO routing_feedback_schema_version (version, description, applied_at) VALUES (?, ?, ?)`,
+			m.version, m.description+" (pre-existing)", now,
+		); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("provider: record feedback version %d: %w", m.version, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("provider: commit feedback version recording: %w", err)
+	}
+	return nil
+}

--- a/provider/routing_feedback_sqlite_migration.go
+++ b/provider/routing_feedback_sqlite_migration.go
@@ -1,8 +1,16 @@
 // routing_feedback_sqlite_migration.go owns the schema migrations for the
 // SQLite-backed routing-feedback store. Schema lives in a version-tracking
-// table (routing_feedback_schema_version) that the migration runner
-// inserts into atomically inside each migration's own transaction, so a
-// crash between DDL and version-record cannot leave a half-applied state.
+// table (routing_feedback_schema_version).
+//
+// Atomicity guarantee, per migration: each entry in feedbackMigrations
+// runs its DDL and version-record INSERT inside one transaction, so a
+// crash between those two cannot leave a half-applied state for that
+// migration. Across migrations the guarantee is only "no partial
+// individual step" — a crash between v1 and v2 commits leaves v1 applied
+// and the next startup picks up at v2. The pre-migration-detection path
+// (recording v1 for a DB that already has routing_feedback_signals)
+// uses its own transaction; a crash between that and v2's commit also
+// safely resumes at v2.
 //
 // Pattern mirrors rag/migration.go so future migrations follow the same
 // shape; intentional duplication beats coupling provider/ to rag/ types.
@@ -11,6 +19,7 @@ package provider
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -87,11 +96,16 @@ func runFeedbackMigrations(db *sql.DB) error {
 		return err
 	}
 
-	if currentVersion == 0 && tableExists(db, "routing_feedback_signals") {
+	exists, err := tableExists(db, "routing_feedback_signals")
+	if err != nil {
+		return fmt.Errorf("provider: probe routing_feedback_signals existence: %w", err)
+	}
+	if currentVersion == 0 && exists {
 		// Database predates the migration runner. Validate the existing
 		// schema matches v1 before marking it as applied; blessing an
 		// incompatible table would surface as a confusing "no such
-		// column" error far from the actual cause.
+		// column" error far from the actual cause — or worse, silently
+		// accept rows that v1's CHECK constraints would have rejected.
 		if err := validateExistingSignalsSchema(db); err != nil {
 			return fmt.Errorf("provider: pre-existing routing_feedback_signals table is incompatible with v1 schema: %w", err)
 		}
@@ -138,33 +152,62 @@ func currentFeedbackSchemaVersion(db *sql.DB) (int, error) {
 	return version, nil
 }
 
-// tableExists checks whether a table by the given name exists. Mirrors
-// the rag helper of the same name; provider-local copy to avoid an
-// upward dependency on rag/.
-func tableExists(db *sql.DB, name string) bool {
+// tableExists checks whether a table by the given name exists. Returns
+// (false, nil) when the table is absent; (false, err) when the
+// underlying probe fails so callers can distinguish "not present" from
+// "could not determine" — a closed or corrupt DB would otherwise be
+// silently treated as "table missing" and cascade into a worse error
+// later in the migration loop. Mirrors the rag helper of the same name;
+// provider-local copy to avoid an upward dependency on rag/.
+func tableExists(db *sql.DB, name string) (bool, error) {
 	var count int
-	err := db.QueryRow(
+	if err := db.QueryRow(
 		`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?`, name,
-	).Scan(&count)
-	return err == nil && count > 0
+	).Scan(&count); err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }
 
-// validateExistingSignalsSchema runs a no-op SELECT against every column
-// the v1 schema declares. SQLite reports "no such column" if any column
-// is missing or named differently. Used by runFeedbackMigrations when a
-// pre-existing routing_feedback_signals table is detected without a
-// schema_version row.
+// validateExistingSignalsSchema checks that a pre-existing
+// routing_feedback_signals table both has every v1 column AND carries
+// the kind-specific composite CHECK constraint that enforces v1's
+// payload invariants. Used by runFeedbackMigrations when the table is
+// detected without a schema_version row.
 //
-// The SELECT 0 LIMIT 0 form scans no rows; we only care about the column
-// resolution at prepare time.
+// Two checks:
+//  1. A SELECT 0 LIMIT 0 against every v1 column — SQLite reports "no
+//     such column" if any column is missing or renamed.
+//  2. A sqlite_master.sql lookup to verify the composite kind/latency/
+//     error_class CHECK is present. Without this, a pre-existing table
+//     that had the right columns but lacked the CHECK would be blessed
+//     as v1 and silently accept rows v1 would have rejected.
 func validateExistingSignalsSchema(db *sql.DB) error {
-	_, err := db.Exec(`SELECT
+	if _, err := db.Exec(`SELECT
 		id, provider, model, use_case, kind, strength, at_ns,
 		latency_ms, error_class, route_id, completion_id, meta
 		FROM routing_feedback_signals
-		WHERE 0 LIMIT 0`)
-	if err != nil {
-		return err
+		WHERE 0 LIMIT 0`); err != nil {
+		return fmt.Errorf("column check: %w", err)
+	}
+	var ddl string
+	if err := db.QueryRow(
+		`SELECT sql FROM sqlite_master WHERE type='table' AND name='routing_feedback_signals'`,
+	).Scan(&ddl); err != nil {
+		return fmt.Errorf("sqlite_master lookup: %w", err)
+	}
+	// The composite CHECK fingerprint — case-insensitive, whitespace-
+	// tolerant. We only require the disjunction's distinguishing tokens
+	// be present, not byte-for-byte identical, so a DBA-normalised DDL
+	// (different newlines, different quoting) still passes.
+	lower := strings.ToLower(ddl)
+	for _, want := range []string{
+		"kind = 'success'", "kind = 'failure'", "kind = 'latency'",
+		"latency_ms = 0", "latency_ms > 0", "error_class",
+	} {
+		if !strings.Contains(lower, want) {
+			return fmt.Errorf("missing v1 CHECK fingerprint %q in pre-existing DDL", want)
+		}
 	}
 	return nil
 }

--- a/provider/routing_feedback_sqlite_migration_test.go
+++ b/provider/routing_feedback_sqlite_migration_test.go
@@ -33,7 +33,11 @@ func TestRunFeedbackMigrationsFreshDB(t *testing.T) {
 	if v != len(feedbackMigrations) {
 		t.Errorf("schema version = %d, want %d", v, len(feedbackMigrations))
 	}
-	if !tableExists(db, "routing_feedback_signals") {
+	exists, err := tableExists(db, "routing_feedback_signals")
+	if err != nil {
+		t.Fatalf("tableExists: %v", err)
+	}
+	if !exists {
 		t.Errorf("routing_feedback_signals table missing after migration")
 	}
 }
@@ -56,9 +60,46 @@ func TestRunFeedbackMigrationsIdempotent(t *testing.T) {
 func TestRunFeedbackMigrationsPreMigrationCompatibleDB(t *testing.T) {
 	db := newMigrationTestDB(t)
 	// Simulate a DB that has the full v1 routing_feedback_signals schema
-	// but no schema_version row (e.g., created by a future tool before
-	// the migration runner existed). Must mark v1 as applied so the
-	// runner doesn't try to re-CREATE the table.
+	// including the composite CHECK but no schema_version row (e.g.,
+	// created by a future tool before the migration runner existed).
+	// Must mark v1 as applied so the runner doesn't try to re-CREATE.
+	if _, err := db.Exec(`CREATE TABLE routing_feedback_signals (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		provider TEXT NOT NULL,
+		model TEXT NOT NULL,
+		use_case TEXT NOT NULL,
+		kind TEXT NOT NULL CHECK (kind IN ('success', 'failure', 'latency')),
+		strength REAL,
+		at_ns INTEGER NOT NULL,
+		latency_ms INTEGER NOT NULL DEFAULT 0 CHECK (latency_ms >= 0),
+		error_class TEXT NOT NULL DEFAULT '',
+		route_id TEXT NOT NULL DEFAULT '',
+		completion_id TEXT NOT NULL DEFAULT '',
+		meta TEXT NOT NULL DEFAULT '{}',
+		CHECK (
+			(kind = 'success' AND latency_ms = 0 AND error_class = '') OR
+			(kind = 'failure' AND latency_ms = 0 AND error_class <> '') OR
+			(kind = 'latency' AND latency_ms > 0 AND error_class = '')
+		)
+	)`); err != nil {
+		t.Fatalf("seed signals table: %v", err)
+	}
+	if err := runFeedbackMigrations(db); err != nil {
+		t.Fatalf("runFeedbackMigrations: %v", err)
+	}
+	v, _ := currentFeedbackSchemaVersion(db)
+	if v < 1 {
+		t.Errorf("compatible pre-migration DB should be recorded at >=v1, got %d", v)
+	}
+}
+
+// TestRunFeedbackMigrationsRejectsPreExistingTableMissingChecks proves
+// validateExistingSignalsSchema is not satisfied by columns alone — a
+// pre-existing table with the right columns but lacking v1's composite
+// CHECK is rejected. Otherwise the migration runner would bless a
+// schema that silently accepts rows the in-memory store would reject.
+func TestRunFeedbackMigrationsRejectsPreExistingTableMissingChecks(t *testing.T) {
+	db := newMigrationTestDB(t)
 	if _, err := db.Exec(`CREATE TABLE routing_feedback_signals (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
 		provider TEXT NOT NULL,
@@ -75,12 +116,9 @@ func TestRunFeedbackMigrationsPreMigrationCompatibleDB(t *testing.T) {
 	)`); err != nil {
 		t.Fatalf("seed signals table: %v", err)
 	}
-	if err := runFeedbackMigrations(db); err != nil {
-		t.Fatalf("runFeedbackMigrations: %v", err)
-	}
-	v, _ := currentFeedbackSchemaVersion(db)
-	if v < 1 {
-		t.Errorf("compatible pre-migration DB should be recorded at >=v1, got %d", v)
+	err := runFeedbackMigrations(db)
+	if err == nil {
+		t.Fatalf("accepted pre-existing table missing v1 CHECK fingerprint; want error")
 	}
 }
 
@@ -114,10 +152,12 @@ func TestRunFeedbackMigrationsCorruptVersionTable(t *testing.T) {
 	}
 }
 
-func TestCurrentFeedbackSchemaVersionEmpty(t *testing.T) {
+// TestCurrentFeedbackSchemaVersionEmptyVersionTable confirms that an
+// existing but empty routing_feedback_schema_version table returns 0
+// cleanly (no rows means "version 0"). The "no version table at all"
+// case is covered transitively by TestRunFeedbackMigrationsFreshDB.
+func TestCurrentFeedbackSchemaVersionEmptyVersionTable(t *testing.T) {
 	db := newMigrationTestDB(t)
-	// Without the version table, currentFeedbackSchemaVersion should
-	// return 0 cleanly (no rows means "version 0").
 	if _, err := db.Exec(`CREATE TABLE routing_feedback_schema_version (
 		version INTEGER PRIMARY KEY, description TEXT NOT NULL, applied_at INTEGER NOT NULL)`); err != nil {
 		t.Fatalf("seed version table: %v", err)

--- a/provider/routing_feedback_sqlite_migration_test.go
+++ b/provider/routing_feedback_sqlite_migration_test.go
@@ -1,0 +1,160 @@
+package provider
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// newMigrationTestDB opens an isolated in-memory database that survives
+// across multiple connections (file::memory: with cache=shared) and is
+// scoped to the test via t.Cleanup.
+func newMigrationTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestRunFeedbackMigrationsFreshDB(t *testing.T) {
+	db := newMigrationTestDB(t)
+	if err := runFeedbackMigrations(db); err != nil {
+		t.Fatalf("runFeedbackMigrations: %v", err)
+	}
+	v, err := currentFeedbackSchemaVersion(db)
+	if err != nil {
+		t.Fatalf("currentFeedbackSchemaVersion: %v", err)
+	}
+	if v != len(feedbackMigrations) {
+		t.Errorf("schema version = %d, want %d", v, len(feedbackMigrations))
+	}
+	if !tableExists(db, "routing_feedback_signals") {
+		t.Errorf("routing_feedback_signals table missing after migration")
+	}
+}
+
+func TestRunFeedbackMigrationsIdempotent(t *testing.T) {
+	db := newMigrationTestDB(t)
+	if err := runFeedbackMigrations(db); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	v1, _ := currentFeedbackSchemaVersion(db)
+	if err := runFeedbackMigrations(db); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	v2, _ := currentFeedbackSchemaVersion(db)
+	if v1 != v2 {
+		t.Errorf("version drifted on second run: %d -> %d", v1, v2)
+	}
+}
+
+func TestRunFeedbackMigrationsPreMigrationCompatibleDB(t *testing.T) {
+	db := newMigrationTestDB(t)
+	// Simulate a DB that has the full v1 routing_feedback_signals schema
+	// but no schema_version row (e.g., created by a future tool before
+	// the migration runner existed). Must mark v1 as applied so the
+	// runner doesn't try to re-CREATE the table.
+	if _, err := db.Exec(`CREATE TABLE routing_feedback_signals (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		provider TEXT NOT NULL,
+		model TEXT NOT NULL,
+		use_case TEXT NOT NULL,
+		kind TEXT NOT NULL,
+		strength REAL,
+		at_ns INTEGER NOT NULL,
+		latency_ms INTEGER NOT NULL DEFAULT 0,
+		error_class TEXT NOT NULL DEFAULT '',
+		route_id TEXT NOT NULL DEFAULT '',
+		completion_id TEXT NOT NULL DEFAULT '',
+		meta TEXT NOT NULL DEFAULT '{}'
+	)`); err != nil {
+		t.Fatalf("seed signals table: %v", err)
+	}
+	if err := runFeedbackMigrations(db); err != nil {
+		t.Fatalf("runFeedbackMigrations: %v", err)
+	}
+	v, _ := currentFeedbackSchemaVersion(db)
+	if v < 1 {
+		t.Errorf("compatible pre-migration DB should be recorded at >=v1, got %d", v)
+	}
+}
+
+func TestRunFeedbackMigrationsRejectsIncompatiblePreExistingTable(t *testing.T) {
+	db := newMigrationTestDB(t)
+	// Pre-existing table is missing required columns/checks. The
+	// runner must refuse to mark v1 as applied; otherwise a future
+	// Record() would fail with a confusing "no such column" error
+	// far from the actual cause.
+	if _, err := db.Exec(`CREATE TABLE routing_feedback_signals (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatalf("seed signals table: %v", err)
+	}
+	err := runFeedbackMigrations(db)
+	if err == nil {
+		t.Fatalf("runFeedbackMigrations accepted incompatible pre-existing table; want error")
+	}
+}
+
+func TestRunFeedbackMigrationsCorruptVersionTable(t *testing.T) {
+	db := newMigrationTestDB(t)
+	// Create the version table with a wrong column name. The runner
+	// will not detect this at CREATE TABLE IF NOT EXISTS time (no-op
+	// when the table exists) but will fail on the version SELECT.
+	// Surface as a clean error, not a panic.
+	if _, err := db.Exec(`CREATE TABLE routing_feedback_schema_version (foo TEXT)`); err != nil {
+		t.Fatalf("seed bad version table: %v", err)
+	}
+	err := runFeedbackMigrations(db)
+	if err == nil {
+		t.Fatalf("runFeedbackMigrations accepted corrupt schema_version table; want error")
+	}
+}
+
+func TestCurrentFeedbackSchemaVersionEmpty(t *testing.T) {
+	db := newMigrationTestDB(t)
+	// Without the version table, currentFeedbackSchemaVersion should
+	// return 0 cleanly (no rows means "version 0").
+	if _, err := db.Exec(`CREATE TABLE routing_feedback_schema_version (
+		version INTEGER PRIMARY KEY, description TEXT NOT NULL, applied_at INTEGER NOT NULL)`); err != nil {
+		t.Fatalf("seed version table: %v", err)
+	}
+	v, err := currentFeedbackSchemaVersion(db)
+	if err != nil {
+		t.Fatalf("currentFeedbackSchemaVersion: %v", err)
+	}
+	if v != 0 {
+		t.Errorf("empty version table = %d, want 0", v)
+	}
+}
+
+func TestFeedbackSignalsTableCheckConstraints(t *testing.T) {
+	db := newMigrationTestDB(t)
+	if err := runFeedbackMigrations(db); err != nil {
+		t.Fatalf("runFeedbackMigrations: %v", err)
+	}
+	// Success with non-zero latency must be rejected by the CHECK constraint.
+	_, err := db.Exec(`INSERT INTO routing_feedback_signals
+		(provider, model, use_case, kind, at_ns, latency_ms, error_class, route_id, completion_id, meta)
+		VALUES ('p','m','chat','success',1,500,'','','','{}')`)
+	if err == nil {
+		t.Errorf("expected CHECK violation for success+latency_ms>0, got nil")
+	}
+	// Failure with empty error_class must be rejected.
+	_, err = db.Exec(`INSERT INTO routing_feedback_signals
+		(provider, model, use_case, kind, at_ns, latency_ms, error_class, route_id, completion_id, meta)
+		VALUES ('p','m','chat','failure',1,0,'','','','{}')`)
+	if err == nil {
+		t.Errorf("expected CHECK violation for failure with empty error_class, got nil")
+	}
+	// Latency with zero latency_ms must be rejected.
+	_, err = db.Exec(`INSERT INTO routing_feedback_signals
+		(provider, model, use_case, kind, at_ns, latency_ms, error_class, route_id, completion_id, meta)
+		VALUES ('p','m','chat','latency',1,0,'','','','{}')`)
+	if err == nil {
+		t.Errorf("expected CHECK violation for latency with latency_ms=0, got nil")
+	}
+}

--- a/provider/routing_feedback_sqlite_test.go
+++ b/provider/routing_feedback_sqlite_test.go
@@ -1,0 +1,181 @@
+package provider
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// newSQLiteFeedbackStoreForTest opens an isolated in-memory DB pinned
+// to one connection so the pool doesn't observe an empty DB on a second
+// connection, then constructs the store via the caller-owned-*sql.DB path.
+func newSQLiteFeedbackStoreForTest(t *testing.T, cfg SQLiteFeedbackStoreConfig) *SQLiteFeedbackStore {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := NewSQLiteFeedbackStore(context.Background(), db, cfg)
+	if err != nil {
+		t.Fatalf("NewSQLiteFeedbackStore: %v", err)
+	}
+	return store
+}
+
+// runRoutingFeedbackStoreContract is the parity test runner: PR3 keeps
+// MemoryStore and SQLiteFeedbackStore behavior in lockstep by running
+// every contract case against both implementations.
+func runRoutingFeedbackStoreContract(t *testing.T, name string, factory func(t *testing.T) RoutingFeedbackStore) {
+	t.Helper()
+	t.Run(name+"/GetEmptyIsNeutral", func(t *testing.T) {
+		store := factory(t)
+		got, err := store.Get(context.Background(), FeedbackKey{Provider: "p", Model: "m", UseCase: "chat"})
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if got.SampleCount != 0 || got.ScoredCount != 0 {
+			t.Errorf("empty store returned %+v, want zero counts", got)
+		}
+		if got.Score != DefaultNeutralScore {
+			t.Errorf("empty store score = %v, want %v", got.Score, DefaultNeutralScore)
+		}
+	})
+	t.Run(name+"/RecordRejectsInvalidKey", func(t *testing.T) {
+		store := factory(t)
+		err := store.Record(context.Background(), FeedbackKey{Model: "m"}, FeedbackSignal{Kind: RoutingSignalSuccess})
+		if !errors.Is(err, ErrInvalidFeedbackKey) {
+			t.Errorf("Record err = %v, want ErrInvalidFeedbackKey", err)
+		}
+	})
+	t.Run(name+"/RecordSuccessIncrementsScore", func(t *testing.T) {
+		store := factory(t)
+		k := FeedbackKey{Provider: "p", Model: "m", UseCase: "chat"}
+		if err := store.Record(context.Background(), k, FeedbackSignal{Kind: RoutingSignalSuccess, At: time.Now()}); err != nil {
+			t.Fatalf("Record: %v", err)
+		}
+		agg, err := store.Get(context.Background(), k)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if agg.SampleCount != 1 || agg.ScoredCount != 1 {
+			t.Errorf("counts = (%d,%d), want (1,1)", agg.SampleCount, agg.ScoredCount)
+		}
+		if agg.Score <= DefaultNeutralScore {
+			t.Errorf("Score = %v, want > %v", agg.Score, DefaultNeutralScore)
+		}
+	})
+	t.Run(name+"/RecordBatchAtomicValidationFailureRollsBack", func(t *testing.T) {
+		store := factory(t)
+		k := FeedbackKey{Provider: "p", Model: "m", UseCase: "chat"}
+		items := []FeedbackItem{
+			{Key: k, Signal: FeedbackSignal{Kind: RoutingSignalSuccess, At: time.Now()}},
+			{Key: FeedbackKey{}, Signal: FeedbackSignal{Kind: RoutingSignalSuccess}}, // invalid
+		}
+		err := store.RecordBatch(context.Background(), items)
+		if !errors.Is(err, ErrInvalidFeedbackKey) {
+			t.Fatalf("RecordBatch err = %v, want ErrInvalidFeedbackKey", err)
+		}
+		agg, _ := store.Get(context.Background(), k)
+		if agg.SampleCount != 0 {
+			t.Errorf("partial application: SampleCount = %d, want 0 (full rollback)", agg.SampleCount)
+		}
+	})
+	t.Run(name+"/RetentionFIFOSameTimestamp", func(t *testing.T) {
+		store := factory(t)
+		k := FeedbackKey{Provider: "p", Model: "m", UseCase: "chat"}
+		now := time.Now()
+		items := make([]FeedbackItem, 5)
+		for i := range items {
+			items[i] = FeedbackItem{Key: k, Signal: FeedbackSignal{Kind: RoutingSignalSuccess, At: now}}
+		}
+		if err := store.RecordBatch(context.Background(), items); err != nil {
+			t.Fatalf("RecordBatch: %v", err)
+		}
+		agg, err := store.Get(context.Background(), k)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if agg.SampleCount != 3 {
+			t.Errorf("retention SampleCount = %d, want 3 (cap honored even on same timestamp)", agg.SampleCount)
+		}
+	})
+}
+
+func TestMemoryStoreContract(t *testing.T) {
+	runRoutingFeedbackStoreContract(t, "MemoryStore", func(t *testing.T) RoutingFeedbackStore {
+		store, err := NewMemoryStore(MemoryStoreConfig{MaxRetainedSamples: 3})
+		if err != nil {
+			t.Fatalf("NewMemoryStore: %v", err)
+		}
+		return store
+	})
+}
+
+func TestSQLiteFeedbackStoreContract(t *testing.T) {
+	runRoutingFeedbackStoreContract(t, "SQLiteFeedbackStore", func(t *testing.T) RoutingFeedbackStore {
+		return newSQLiteFeedbackStoreForTest(t, SQLiteFeedbackStoreConfig{MaxRetainedSamples: 3})
+	})
+}
+
+func TestSQLiteFeedbackStoreConcurrentRecord(t *testing.T) {
+	store := newSQLiteFeedbackStoreForTest(t, SQLiteFeedbackStoreConfig{MaxRetainedSamples: 0 /* default 1000 */})
+	k := FeedbackKey{Provider: "p", Model: "m", UseCase: "chat"}
+
+	const goroutines = 16
+	const perGoroutine = 32
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				if err := store.Record(context.Background(), k, FeedbackSignal{Kind: RoutingSignalSuccess, At: time.Now()}); err != nil {
+					t.Errorf("Record: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	agg, err := store.Get(context.Background(), k)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if agg.SampleCount != goroutines*perGoroutine {
+		t.Errorf("SampleCount = %d, want %d (concurrent Record lost writes)", agg.SampleCount, goroutines*perGoroutine)
+	}
+}
+
+func TestNewSQLiteFeedbackStoreNilDB(t *testing.T) {
+	_, err := NewSQLiteFeedbackStore(context.Background(), nil, SQLiteFeedbackStoreConfig{})
+	if err == nil {
+		t.Errorf("NewSQLiteFeedbackStore(nil) should error, got nil")
+	}
+}
+
+func TestOpenSQLiteFeedbackStoreEmptyPath(t *testing.T) {
+	_, err := OpenSQLiteFeedbackStore(context.Background(), "", SQLiteFeedbackStoreConfig{})
+	if err == nil {
+		t.Errorf("OpenSQLiteFeedbackStore(\"\") should error, got nil")
+	}
+}
+
+func TestOpenSQLiteFeedbackStoreInMemory(t *testing.T) {
+	store, err := OpenSQLiteFeedbackStore(context.Background(), ":memory:", SQLiteFeedbackStoreConfig{})
+	if err != nil {
+		t.Fatalf("OpenSQLiteFeedbackStore(:memory:): %v", err)
+	}
+	defer store.Close()
+	if err := store.Record(context.Background(), FeedbackKey{Provider: "p", Model: "m", UseCase: "chat"},
+		FeedbackSignal{Kind: RoutingSignalSuccess, At: time.Now()}); err != nil {
+		t.Errorf("Record after Open: %v", err)
+	}
+}

--- a/provider/routing_feedback_sqlite_test.go
+++ b/provider/routing_feedback_sqlite_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -199,6 +200,23 @@ func TestOpenSQLiteFeedbackStoreEmptyPath(t *testing.T) {
 	_, err := OpenSQLiteFeedbackStore(context.Background(), "", SQLiteFeedbackStoreConfig{})
 	if err == nil {
 		t.Errorf("OpenSQLiteFeedbackStore(\"\") should error, got nil")
+	}
+}
+
+func TestNewSQLiteFeedbackStoreRejectsInvalidNeutralScore(t *testing.T) {
+	cases := []float64{-0.01, 1.01, -1.0, 2.0, math.NaN(), math.Inf(1), math.Inf(-1)}
+	for _, n := range cases {
+		t.Run("", func(t *testing.T) {
+			db, err := sql.Open("sqlite", ":memory:")
+			if err != nil {
+				t.Fatalf("sql.Open: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+			_, err = NewSQLiteFeedbackStore(context.Background(), db, SQLiteFeedbackStoreConfig{NeutralScore: n})
+			if err == nil {
+				t.Fatalf("NewSQLiteFeedbackStore(NeutralScore=%v) returned nil error", n)
+			}
+		})
 	}
 }
 

--- a/provider/routing_feedback_sqlite_test.go
+++ b/provider/routing_feedback_sqlite_test.go
@@ -106,6 +106,40 @@ func runRoutingFeedbackStoreContract(t *testing.T, name string, factory func(t *
 			t.Errorf("retention SampleCount = %d, want 3 (cap honored even on same timestamp)", agg.SampleCount)
 		}
 	})
+	t.Run(name+"/RetentionFIFOBackdatedInsert", func(t *testing.T) {
+		store := factory(t)
+		k := FeedbackKey{Provider: "p", Model: "m", UseCase: "chat"}
+		positive := 1.0
+		negative := -1.0
+		base := time.Unix(100, 0)
+		for i := 0; i < 3; i++ {
+			if err := store.Record(context.Background(), k, FeedbackSignal{
+				Kind:     RoutingSignalSuccess,
+				Strength: &positive,
+				At:       base.Add(time.Duration(i) * time.Second),
+			}); err != nil {
+				t.Fatalf("Record positive %d: %v", i, err)
+			}
+		}
+		if err := store.Record(context.Background(), k, FeedbackSignal{
+			Kind:     RoutingSignalSuccess,
+			Strength: &negative,
+			At:       base.Add(-time.Hour),
+		}); err != nil {
+			t.Fatalf("Record backdated: %v", err)
+		}
+		agg, err := store.Get(context.Background(), k)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if agg.SampleCount != 3 {
+			t.Errorf("SampleCount = %d, want 3 after retention", agg.SampleCount)
+		}
+		want := 0.5 + 0.5*(1.0/3.0)
+		if abs(agg.Score-want) > 1e-9 {
+			t.Errorf("Score = %v, want %v (newest inserted backdated signal retained)", agg.Score, want)
+		}
+	})
 }
 
 func TestMemoryStoreContract(t *testing.T) {
@@ -173,7 +207,7 @@ func TestOpenSQLiteFeedbackStoreInMemory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenSQLiteFeedbackStore(:memory:): %v", err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 	if err := store.Record(context.Background(), FeedbackKey{Provider: "p", Model: "m", UseCase: "chat"},
 		FeedbackSignal{Kind: RoutingSignalSuccess, At: time.Now()}); err != nil {
 		t.Errorf("Record after Open: %v", err)

--- a/provider/routing_feedback_test.go
+++ b/provider/routing_feedback_test.go
@@ -194,7 +194,7 @@ func TestNewMemoryStoreAppliesDefaults(t *testing.T) {
 }
 
 func TestNewMemoryStoreRejectsOutOfRangeNeutralScore(t *testing.T) {
-	cases := []float64{-0.01, 1.01, -1.0, 2.0}
+	cases := []float64{-0.01, 1.01, -1.0, 2.0, math.NaN(), math.Inf(1), math.Inf(-1)}
 	for _, n := range cases {
 		t.Run("", func(t *testing.T) {
 			_, err := NewMemoryStore(MemoryStoreConfig{NeutralScore: n})

--- a/provider/types.go
+++ b/provider/types.go
@@ -488,23 +488,29 @@ type RouteAttempt struct {
 // whether the breakdown appears in JSON at all.
 type ScoreBreakdown struct {
 	// FeedbackMode is the operator-facing label for the FeedbackScoringMode
-	// in effect when the plan was built: "off", "shadow", or "enforce".
+	// in effect when the plan was built. Equals FeedbackScoringMode.String()
+	// for one of the three mode constants ("off", "shadow", "enforce").
 	FeedbackMode string `json:"feedback_mode"`
 
 	// FeedbackSnapshotStatus reports why the snapshot was active or
-	// inactive: "off", "no_store", "empty_use_case", "read_error",
-	// or "active". Lets operators distinguish a configuration issue
-	// from a transient store failure without parsing logs.
+	// inactive. Stable closed set — compare against the
+	// FeedbackSnapshotStatus* string constants below. Lets operators
+	// distinguish a configuration issue from a transient store failure
+	// without parsing logs.
 	FeedbackSnapshotStatus string `json:"feedback_snapshot_status"`
 
 	// FeedbackApplied reports whether feedback participated in route
-	// selection. True iff mode == "enforce" and a valid snapshot was
-	// available (no fail-open).
+	// selection for the *winning planned candidate*. True iff mode ==
+	// "enforce" AND the snapshot was active AND the candidate's key was
+	// in the snapshot. False with mode == "enforce" + snapshot active
+	// means the winning candidate's key was absent from the snapshot
+	// (cross-check via FeedbackSampleCount == 0).
 	FeedbackApplied bool `json:"feedback_applied"`
 
 	// FeedbackScore is the raw Aggregate.Score as returned by
 	// RoutingFeedback.Score at plan-build. Zero when feedback was
 	// inactive for this candidate (or when the raw score really is 0.0).
+	// Disambiguate via FeedbackSnapshotStatus and FeedbackSampleCount.
 	FeedbackScore float64 `json:"feedback_score"`
 
 	// FeedbackAdjustedScore is the value actually fed into weighted
@@ -519,8 +525,11 @@ type ScoreBreakdown struct {
 	FeedbackScoredCount int `json:"feedback_scored_count"`
 
 	// FeedbackUpdatedAt is the most recent signal timestamp in the
-	// aggregate. Zero when feedback was inactive for this candidate.
-	FeedbackUpdatedAt time.Time `json:"feedback_updated_at"`
+	// aggregate, or nil when feedback was inactive for this candidate.
+	// Pointer + omitempty so JSON omits the field entirely rather than
+	// emitting Go's zero time ("0001-01-01T00:00:00Z"), which an
+	// operator dashboard might confuse with a real timestamp.
+	FeedbackUpdatedAt *time.Time `json:"feedback_updated_at,omitempty"`
 
 	// ScoreWithoutFeedback and ScoreWithFeedback are the two weighted
 	// scores computed once per candidate. Off mode selects using
@@ -528,10 +537,42 @@ type ScoreBreakdown struct {
 	// ScoreWithoutFeedback but still computes ScoreWithFeedback for
 	// the delta; Enforce mode selects using ScoreWithFeedback when
 	// feedback is active. Both are always populated so operators can
-	// inspect the delta without re-running scoring.
+	// inspect the delta without re-running scoring. When the snapshot
+	// fail-opens (FeedbackSnapshotStatus == "read_error"), the two
+	// scores are equal because deltaActiveSignals also excludes
+	// feedback in that case.
 	ScoreWithoutFeedback float64 `json:"score_without_feedback"`
 	ScoreWithFeedback    float64 `json:"score_with_feedback"`
 }
+
+// FeedbackSnapshotStatus* are the stable string values that
+// ScoreBreakdown.FeedbackSnapshotStatus can hold. Exported as plain
+// string constants (no new public type) so JSON consumers and
+// downstream parsers can compare against a named contract instead of
+// hardcoding literals.
+const (
+	// FeedbackSnapshotStatusOff indicates the FeedbackScoringMode was
+	// FeedbackScoringOff at plan-build — no feedback reads, no breakdown.
+	// (Note: in Off mode the public ScoreBreakdown is nil entirely;
+	// this value is supplied only to operators reading the unexported
+	// snapshot status, e.g., via test fixtures.)
+	FeedbackSnapshotStatusOff = "off"
+	// FeedbackSnapshotStatusNoStore indicates Shadow/Enforce mode but
+	// no RoutingFeedback was configured (WithRoutingFeedback never
+	// called, or called with nil).
+	FeedbackSnapshotStatusNoStore = "no_store"
+	// FeedbackSnapshotStatusEmptyUseCase indicates the route had an
+	// empty RoutingRequest.UseCase, which cannot form a FeedbackKey.
+	FeedbackSnapshotStatusEmptyUseCase = "empty_use_case"
+	// FeedbackSnapshotStatusReadError indicates the store returned a
+	// non-nil error during snapshot construction (or extension during
+	// chain routing); fail-open disabled feedback for the entire route.
+	FeedbackSnapshotStatusReadError = "read_error"
+	// FeedbackSnapshotStatusActive indicates the snapshot read every
+	// requested candidate key successfully and feedback was in effect
+	// for the route.
+	FeedbackSnapshotStatusActive = "active"
+)
 
 // RouteOutcome captures the Router's decision metadata for a request.
 // Provider responses copy a pointer to a RouteOutcome onto Chat/Generate/

--- a/provider/types.go
+++ b/provider/types.go
@@ -470,6 +470,69 @@ type RouteAttempt struct {
 	ErrorClass string        `json:"error_class,omitempty"`
 }
 
+// ScoreBreakdown exposes the routing-feedback scoring inputs that fed into
+// the Router's candidate selection decision. Populated on RouteOutcome
+// only when feedback scoring is in Shadow or Enforce mode at the time
+// the plan was built; nil on Off mode.
+//
+// The breakdown describes the *planned/root* winning candidate. It is
+// NOT rewritten when execution falls back to a sibling — use Attempts
+// and ActualModel for the execution trace. Read-time snapshot only: the
+// FeedbackScore, FeedbackAdjustedScore, sample counts, and UpdatedAt
+// reflect the store state at plan-build, not at attempt completion.
+//
+// Note on JSON tags: numeric and time fields do NOT use omitempty —
+// a zero score, count, or updated_at is meaningful (e.g., FeedbackScore
+// = 0.0 means "perfectly bad"; FeedbackSampleCount = 0 means "no
+// samples yet"). The pointer field on RouteOutcome already controls
+// whether the breakdown appears in JSON at all.
+type ScoreBreakdown struct {
+	// FeedbackMode is the operator-facing label for the FeedbackScoringMode
+	// in effect when the plan was built: "off", "shadow", or "enforce".
+	FeedbackMode string `json:"feedback_mode"`
+
+	// FeedbackSnapshotStatus reports why the snapshot was active or
+	// inactive: "off", "no_store", "empty_use_case", "read_error",
+	// or "active". Lets operators distinguish a configuration issue
+	// from a transient store failure without parsing logs.
+	FeedbackSnapshotStatus string `json:"feedback_snapshot_status"`
+
+	// FeedbackApplied reports whether feedback participated in route
+	// selection. True iff mode == "enforce" and a valid snapshot was
+	// available (no fail-open).
+	FeedbackApplied bool `json:"feedback_applied"`
+
+	// FeedbackScore is the raw Aggregate.Score as returned by
+	// RoutingFeedback.Score at plan-build. Zero when feedback was
+	// inactive for this candidate (or when the raw score really is 0.0).
+	FeedbackScore float64 `json:"feedback_score"`
+
+	// FeedbackAdjustedScore is the value actually fed into weighted
+	// scoring after confidence gating: 0.5 when below the sample floor,
+	// otherwise shrunk toward 0.5 by the package's prior weight.
+	FeedbackAdjustedScore float64 `json:"feedback_adjusted_score"`
+
+	// FeedbackSampleCount is the total sample count from the snapshot.
+	FeedbackSampleCount int `json:"feedback_sample_count"`
+
+	// FeedbackScoredCount is the score-bearing subset of SampleCount.
+	FeedbackScoredCount int `json:"feedback_scored_count"`
+
+	// FeedbackUpdatedAt is the most recent signal timestamp in the
+	// aggregate. Zero when feedback was inactive for this candidate.
+	FeedbackUpdatedAt time.Time `json:"feedback_updated_at"`
+
+	// ScoreWithoutFeedback and ScoreWithFeedback are the two weighted
+	// scores computed once per candidate. Off mode selects using
+	// ScoreWithoutFeedback; Shadow mode selects using
+	// ScoreWithoutFeedback but still computes ScoreWithFeedback for
+	// the delta; Enforce mode selects using ScoreWithFeedback when
+	// feedback is active. Both are always populated so operators can
+	// inspect the delta without re-running scoring.
+	ScoreWithoutFeedback float64 `json:"score_without_feedback"`
+	ScoreWithFeedback    float64 `json:"score_with_feedback"`
+}
+
 // RouteOutcome captures the Router's decision metadata for a request.
 // Provider responses copy a pointer to a RouteOutcome onto Chat/Generate/
 // Embed responses so callers can observe planned vs actual model, sticky
@@ -512,6 +575,12 @@ type RouteOutcome struct {
 	// future /v1/completions/feedback endpoint may attach a distinct
 	// client-visible CompletionID without conflating the two.
 	RouteID string `json:"route_id,omitempty"`
+
+	// ScoreBreakdown carries the routing-feedback scoring inputs that
+	// fed into plan-build's candidate selection. Non-nil only in
+	// Shadow / Enforce modes. See ScoreBreakdown's docs for read-time
+	// semantics.
+	ScoreBreakdown *ScoreBreakdown `json:"score_breakdown,omitempty"`
 }
 
 // ---------------------------------------------------------------------------

--- a/provider/types.go
+++ b/provider/types.go
@@ -532,15 +532,16 @@ type ScoreBreakdown struct {
 	FeedbackUpdatedAt *time.Time `json:"feedback_updated_at,omitempty"`
 
 	// ScoreWithoutFeedback and ScoreWithFeedback are the two weighted
-	// scores computed once per candidate. Off mode selects using
-	// ScoreWithoutFeedback; Shadow mode selects using
-	// ScoreWithoutFeedback but still computes ScoreWithFeedback for
-	// the delta; Enforce mode selects using ScoreWithFeedback when
-	// feedback is active. Both are always populated so operators can
-	// inspect the delta without re-running scoring. When the snapshot
-	// fail-opens (FeedbackSnapshotStatus == "read_error"), the two
-	// scores are equal because deltaActiveSignals also excludes
-	// feedback in that case.
+	// scores computed once per candidate. ScoreWithoutFeedback preserves
+	// the pre-PR3 neutral feedbackScore=0.5 denominator; it does not remove
+	// the feedback weight from normalization. Off mode selects using
+	// ScoreWithoutFeedback; Shadow mode selects using ScoreWithoutFeedback
+	// but still computes ScoreWithFeedback for the delta; Enforce mode
+	// selects using ScoreWithFeedback when feedback is active. Both are
+	// always populated so operators can inspect the delta without re-running
+	// scoring. When the snapshot fail-opens
+	// (FeedbackSnapshotStatus == "read_error"), the two scores are equal
+	// because ScoreWithFeedback also uses the neutral baseline.
 	ScoreWithoutFeedback float64 `json:"score_without_feedback"`
 	ScoreWithFeedback    float64 `json:"score_with_feedback"`
 }

--- a/provider/types.go
+++ b/provider/types.go
@@ -507,10 +507,11 @@ type ScoreBreakdown struct {
 	// (cross-check via FeedbackSampleCount == 0).
 	FeedbackApplied bool `json:"feedback_applied"`
 
-	// FeedbackScore is the raw Aggregate.Score as returned by
-	// RoutingFeedback.Score at plan-build. Zero when feedback was
-	// inactive for this candidate (or when the raw score really is 0.0).
-	// Disambiguate via FeedbackSnapshotStatus and FeedbackSampleCount.
+	// FeedbackScore is the Aggregate.Score observed at plan-build,
+	// sanitized to a finite [0,1] value before crossing the JSON boundary.
+	// Zero when feedback was inactive for this candidate (or when the
+	// sanitized raw score really is 0.0). Disambiguate via
+	// FeedbackSnapshotStatus and FeedbackSampleCount.
 	FeedbackScore float64 `json:"feedback_score"`
 
 	// FeedbackAdjustedScore is the value actually fed into weighted


### PR DESCRIPTION
## Summary

Lands the SQLite-backed `RoutingFeedbackStore` and wires its read side into routing decisions via a tri-mode `FeedbackScoringMode` (Off/Shadow/Enforce) gated by a route-level feedback snapshot, with fail-open semantics, once-logged warnings, and a per-plan `ScoreBreakdown` exposed on `RouteOutcome`.

Closes the PR3 slice of Epic #48 Phase 5.

## What changed

**Public API (per spec § Out of scope — only these are new):**
- `SQLiteFeedbackStore` + `SQLiteFeedbackStoreConfig` + `NewSQLiteFeedbackStore(ctx, db, cfg)` / `OpenSQLiteFeedbackStore(ctx, path, cfg)` / `Close()`
- `FeedbackScoringMode` enum + `WithFeedbackScoringMode(mode)` + `WithFeedbackScoring(bool)` sugar
- `ScoreBreakdown` struct + `RouteOutcome.ScoreBreakdown *ScoreBreakdown` field
- Stable string constants `FeedbackSnapshotStatusOff` / `NoStore` / `EmptyUseCase` / `ReadError` / `Active`

**Internal:**
- `feedbackLogger` interface (unexported) + `feedbackWarningState` with three `sync.Once` guards; once-per-Router emission so a broken store doesn't flood logs
- Route-level `feedbackSnapshot` built once per `Route()` invocation; chain routing extends it incrementally via `readCandidates` which latches `failed=true` on the first read error — disables feedback for every later chain step + the recommend tail
- `scoreCandidate` consumes a pure `*candidateFeedback` (no I/O); confidence gating via `adjustFeedbackScore` (floor=3, prior=10, NaN/Inf/out-of-range guard)
- `recordOutcomeFeedback` no longer silently swallows store errors; `newRouteID` no longer silently returns `""` on RNG failure

## Architecture invariants verified

1. **One snapshot per Route()** — `routeChain` builds it once at function entry, threads the same pointer through every `scoreChainStep` + `appendRecommendTail`.
2. **Latch propagates** — `TestSnapshotReadCandidatesAfterLatchIsNoOp` + `TestSnapshotReadCandidatesLatchesOnError` prove that an early `read_error` disables feedback for later chain steps.
3. **PR2 selection math preserved** — Off / Shadow / fail-open all fall back to `baseActiveSignals` (= old `activeSignals` minus the feedback key). Existing chain tests pass unchanged.
4. **Shadow delta is real** — `deltaActiveSignals` includes feedback whenever `snap.active`, independent of mode. `TestRouterShadowModeExposesDeltaButDoesNotChangeSelection` asserts `ScoreWithFeedback != ScoreWithoutFeedback`.
5. **Breakdown stable across fallback** — `TestBuildOutcomeScoreBreakdownStableAcrossFallback` proves `ScoreBreakdown` describes the planned/root candidate even after execution falls back.

## Microbenchmarks (Apple M3 Max, n=5)

```
BenchmarkSQLiteFeedbackStoreRecordBatch    ~610 µs/op  (8 items)
BenchmarkSQLiteFeedbackStoreGet            ~27  µs/op  (50 rows aggregated)
```

RecordBatch p99 well under the 1s `feedbackWriteTimeout`, so PR3 keeps the synchronous write path. PR5+ can revisit async batching only if a real deployment surfaces contention.

## Deferred

- **VACUUM hook** — spec § A.7 marks it deferred to PR5+; no observable consumer in PR3.
- **PR4 harness comparison** — before/after PR3 with a fixed workload.
- **Optimizing PRAGMA-per-connection** — current implementation clamps `SetMaxOpenConns(1)` for consistent WAL + busy_timeout. PR5+ can switch to a `sql.Connector` / `_pragma=` DSN form if benchmarks show the single-conn bound becoming a bottleneck.

## Test Plan

- [x] `go test ./... -count=1 -race` passes across all 20 packages
- [x] `go build ./... && go vet ./...` clean
- [x] `gofmt -l` clean on PR3-touched files (`router_integration_test.go` has pre-existing drift on develop; left alone)
- [x] Microbenchmarks within spec
- [x] Two-stage review (code-review + criticize-review) run after each substantive task; all High/Medium findings either resolved or documented as PR5+ scope

Generated with [Claude Code](https://claude.com/claude-code)