### PR TITLE
feat: opt-in MCP conversation persistence (transcript package)

### DIFF
--- a/cmd/go-llm-mcp/main.go
+++ b/cmd/go-llm-mcp/main.go
@@ -21,7 +21,7 @@ func main() {
 	ollamaURL := flag.String("ollama-url", "", "Ollama server URL (default: from config or http://localhost:11434)")
 	configPath := flag.String("config", "", "Path to models.json (default: auto-discover)")
 	ragDB := flag.String("rag-db", "", "RAG database path (default: ~/.local/share/go-llm/rag.db)")
-	conversationDB := flag.String("conversation-db", "", "Transcript database path for opt-in conversation persistence (default: disabled)")
+	conversationDB := flag.String("conversation-db", "", "Transcript database path for opt-in conversation persistence (default: disabled). Stores UNREDACTED prompts and responses locally; do not commit or share the database.")
 	noRAG := flag.Bool("no-rag", false, "Disable RAG tools")
 	tlsCert := flag.String("tls-cert", "", "TLS certificate file (enables HTTPS)")
 	tlsKey := flag.String("tls-key", "", "TLS private key file")

--- a/cmd/go-llm-mcp/main.go
+++ b/cmd/go-llm-mcp/main.go
@@ -21,6 +21,7 @@ func main() {
 	ollamaURL := flag.String("ollama-url", "", "Ollama server URL (default: from config or http://localhost:11434)")
 	configPath := flag.String("config", "", "Path to models.json (default: auto-discover)")
 	ragDB := flag.String("rag-db", "", "RAG database path (default: ~/.local/share/go-llm/rag.db)")
+	conversationDB := flag.String("conversation-db", "", "Transcript database path for opt-in conversation persistence (default: disabled)")
 	noRAG := flag.Bool("no-rag", false, "Disable RAG tools")
 	tlsCert := flag.String("tls-cert", "", "TLS certificate file (enables HTTPS)")
 	tlsKey := flag.String("tls-key", "", "TLS private key file")
@@ -35,6 +36,9 @@ func main() {
 	}
 	if *ragDB != "" {
 		opts = append(opts, mcp.WithRAGPath(*ragDB))
+	}
+	if *conversationDB != "" {
+		opts = append(opts, mcp.WithTranscriptStore(*conversationDB))
 	}
 	if *noRAG {
 		opts = append(opts, mcp.WithRAGDisabled())

--- a/cmd/llm-bench/capture_transcript_roundtrip_test.go
+++ b/cmd/llm-bench/capture_transcript_roundtrip_test.go
@@ -1,0 +1,47 @@
+// cmd/llm-bench/capture_transcript_roundtrip_test.go
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/conversation"
+	"github.com/kstruzzieri/go-llm/transcript"
+)
+
+func TestCaptureReadsTranscriptStoreOutput(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "conv.db")
+	ts, err := transcript.Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("open transcript: %v", err)
+	}
+	// One full session WITH a system message so capture's system-prompt
+	// validator passes without -capture-system.
+	if err := ts.Record(context.Background(), transcript.RecordInput{
+		Request: []conversation.Message{
+			{Role: "system", Content: "You are a helpful assistant."},
+			{Role: "user", Content: "What is 2+2?"},
+		},
+		Response: conversation.Message{Role: "assistant", Content: "4"},
+		Model:    "qwen3:8b",
+		Provider: "ollama",
+	}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	if err := ts.Close(); err != nil { // flush WAL into the main DB file
+		t.Fatalf("Close: %v", err)
+	}
+
+	res, err := runCapture(context.Background(), captureOptions{
+		DBPath:    path,
+		OutputDir: t.TempDir(),
+		Source:    "transcript-roundtrip",
+	})
+	if err != nil {
+		t.Fatalf("runCapture: %v", err)
+	}
+	if len(res.Written) != 1 || len(res.Skipped) != 0 {
+		t.Fatalf("written=%d skipped=%d, want 1 written / 0 skipped", len(res.Written), len(res.Skipped))
+	}
+}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -242,7 +242,7 @@ func NewServer(ctx context.Context, opts ...Option) (*Server, error) {
 			}
 		}
 		if dir := filepath.Dir(s.transcriptDBPath); dir != "" && dir != "." {
-			if err := os.MkdirAll(dir, 0o755); err != nil {
+			if err := os.MkdirAll(dir, 0o700); err != nil {
 				cleanupTranscriptStartupFailure()
 				return nil, fmt.Errorf("mcp: create transcript directory %q: %w", dir, err)
 			}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kstruzzieri/go-llm/provider"
 	"github.com/kstruzzieri/go-llm/provider/openaicompat"
 	"github.com/kstruzzieri/go-llm/rag"
+	"github.com/kstruzzieri/go-llm/transcript"
 )
 
 const (
@@ -48,6 +49,8 @@ type Server struct {
 	configPath        string
 	ragPath           string
 	ragDisabled       bool
+	transcriptDBPath  string
+	transcriptStore   *transcript.Store
 	tlsCert           string
 	tlsKey            string
 
@@ -108,6 +111,17 @@ func WithRAGPath(path string) Option {
 func WithRAGDisabled() Option {
 	return func(s *Server) {
 		s.ragDisabled = true
+	}
+}
+
+// WithTranscriptStore enables opt-in conversation persistence at the given
+// SQLite path. Empty (the default) disables persistence. Every successful chat
+// call is then recorded as a replayable benchmark trace. The DB is local and
+// unredacted; it must not be committed or shared (redaction happens at capture
+// export, not at persistence).
+func WithTranscriptStore(path string) Option {
+	return func(s *Server) {
+		s.transcriptDBPath = path
 	}
 }
 
@@ -218,7 +232,30 @@ func NewServer(ctx context.Context, opts ...Option) (*Server, error) {
 		s.store = store
 	}
 
-	// Step 4b: build warmth source and Router after fallible store setup.
+	// Step 4b: open the optional transcript store (off unless WithTranscriptStore
+	// is set). Failure is fatal: the caller explicitly asked to persist here.
+	if s.transcriptDBPath != "" {
+		cleanupTranscriptStartupFailure := func() {
+			if s.store != nil {
+				_ = s.store.Close()
+				s.store = nil
+			}
+		}
+		if dir := filepath.Dir(s.transcriptDBPath); dir != "" && dir != "." {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				cleanupTranscriptStartupFailure()
+				return nil, fmt.Errorf("mcp: create transcript directory %q: %w", dir, err)
+			}
+		}
+		ts, err := transcript.Open(ctx, s.transcriptDBPath)
+		if err != nil {
+			cleanupTranscriptStartupFailure()
+			return nil, fmt.Errorf("mcp: open transcript store: %w", err)
+		}
+		s.transcriptStore = ts
+	}
+
+	// Step 4c: build warmth source and Router after fallible store setup.
 	// NewRouter does not perform network I/O, so this is safe even when
 	// local providers are unreachable. The warmth source's polling goroutine
 	// starts immediately and is fail-open when the default Ollama instance
@@ -662,6 +699,12 @@ func (s *Server) routerSnapshot() routeEngine {
 	return s.router
 }
 
+func (s *Server) transcriptStoreSnapshot() *transcript.Store {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.transcriptStore
+}
+
 // fimPriority returns the configured FIM routing priority, defaulting to
 // provider.PriorityHigh when WithFIMPriority was not invoked.
 //
@@ -748,12 +791,14 @@ func (s *Server) Close() error {
 	s.stateVersion++
 	store := s.store
 	router := s.router
+	tstore := s.transcriptStore
 	s.store = nil
 	s.indexer = nil
 	s.retriever = nil
 	s.completer = nil
 	s.router = nil
 	s.warmthSource = nil
+	s.transcriptStore = nil
 	s.mu.Unlock()
 
 	var routerErr, storeErr error
@@ -763,5 +808,9 @@ func (s *Server) Close() error {
 	if store != nil {
 		storeErr = store.Close()
 	}
-	return errors.Join(routerErr, storeErr)
+	var transcriptErr error
+	if tstore != nil {
+		transcriptErr = tstore.Close()
+	}
+	return errors.Join(routerErr, storeErr, transcriptErr)
 }

--- a/mcp/server_transcript_test.go
+++ b/mcp/server_transcript_test.go
@@ -1,0 +1,56 @@
+// mcp/server_transcript_test.go
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+)
+
+// newMockedServer builds a server with a permissive routing-fallback mock so
+// NewServer succeeds without a live Ollama, plus the given extra options.
+func newMockedServer(t *testing.T, extra ...Option) (*Server, func()) {
+	t.Helper()
+	mock := httptest.NewServer(routingFallbackHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})))
+	opts := append([]Option{WithOllamaURL(mock.URL), WithRAGDisabled()}, extra...)
+	s, err := NewServer(context.Background(), opts...)
+	if err != nil {
+		mock.Close()
+		t.Fatalf("NewServer: %v", err)
+	}
+	return s, func() { _ = s.Close(); mock.Close() }
+}
+
+func TestWithTranscriptStore_OpensAndClears(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "conv.db")
+	s, cleanup := newMockedServer(t, WithTranscriptStore(path))
+	defer cleanup()
+
+	if s.transcriptStoreSnapshot() == nil {
+		t.Fatal("transcript store was not opened")
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if s.transcriptStoreSnapshot() != nil {
+		t.Error("transcript store not cleared after Close")
+	}
+}
+
+func TestWithTranscriptStore_OpenFailureIsFatal(t *testing.T) {
+	mock := httptest.NewServer(routingFallbackHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})))
+	defer mock.Close()
+	// A path that is an existing directory cannot be opened as a SQLite file.
+	dir := t.TempDir()
+	s, err := NewServer(context.Background(), WithOllamaURL(mock.URL), WithRAGDisabled(), WithTranscriptStore(dir))
+	if err == nil {
+		_ = s.Close()
+		t.Fatal("NewServer should fail when the transcript DB path cannot be opened")
+	}
+}

--- a/mcp/tools_chat.go
+++ b/mcp/tools_chat.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
+	"strings"
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/kstruzzieri/go-llm/conversation"
 	"github.com/kstruzzieri/go-llm/ollama"
 	"github.com/kstruzzieri/go-llm/provider"
+	"github.com/kstruzzieri/go-llm/transcript"
 )
 
 // chatArgs are the parameters for the chat tool.
@@ -148,6 +152,7 @@ func (s *Server) handleChat(ctx context.Context, req *gomcp.CallToolRequest) (*g
 	if err != nil {
 		return toolError("ollama", "%v", err), nil
 	}
+	s.persistTranscript(ctx, req, args, resp)
 	return toolResult(resp.Content), nil
 }
 
@@ -197,4 +202,75 @@ func toProviderToolCalls(in []ollama.ToolCall) []provider.ToolCall {
 		}
 	}
 	return out
+}
+
+// persistTranscript records a successful chat call to the transcript store when
+// one is configured. Best-effort: any failure is logged and never surfaces to
+// the caller. The original args.Messages (pre-RAG) are recorded; the ephemeral
+// RAG-injected system message is intentionally excluded.
+func (s *Server) persistTranscript(ctx context.Context, req *gomcp.CallToolRequest, args chatArgs, resp *provider.ChatResponse) {
+	store := s.transcriptStoreSnapshot()
+	if store == nil {
+		return
+	}
+
+	reqMsgs, err := conversation.FromChatMessages(args.Messages)
+	if err != nil {
+		log.Printf("mcp: transcript skip (convert request): %v", err)
+		return
+	}
+
+	var toolCalls json.RawMessage
+	if len(resp.ToolCalls) > 0 {
+		if raw, merr := json.Marshal(resp.ToolCalls); merr == nil {
+			toolCalls = raw
+		} else {
+			log.Printf("mcp: transcript marshal tool calls: %v", merr)
+		}
+	}
+	var routeOutcome json.RawMessage
+	if resp.RouteOutcome != nil {
+		if raw, merr := json.Marshal(resp.RouteOutcome); merr == nil {
+			routeOutcome = raw
+		} else {
+			log.Printf("mcp: transcript marshal route outcome: %v", merr)
+		}
+	}
+
+	in := transcript.RecordInput{
+		ConversationID: strings.TrimSpace(args.ConversationID),
+		Request:        reqMsgs,
+		Response: conversation.Message{
+			Role:      "assistant",
+			Content:   resp.Content,
+			ToolCalls: toolCalls,
+		},
+		Model:        resp.Model,
+		Provider:     resp.Provider,
+		RouteOutcome: routeOutcome,
+		SessionHint:  sessionHintFromRequest(req),
+	}
+	if rerr := store.Record(ctx, in); rerr != nil {
+		log.Printf("mcp: transcript record: %v", rerr)
+	}
+}
+
+// sessionHintFromRequest returns a stable MCP session identifier when the
+// transport provides one (streamable HTTP), or "" otherwise (stdio/in-memory).
+// "" is a safe fallback: conversationKey then derives identity from message
+// content (transcript §5).
+//
+// GetSession returns the concrete *ServerSession boxed in the Session
+// interface, so a request created without a session (stdio/in-memory, tests) is
+// a typed nil: the interface is non-nil but the pointer is nil. Comparing the
+// interface to nil would spuriously pass and ID() would then panic on the nil
+// receiver. Assert to the concrete type and nil-check the pointer instead.
+func sessionHintFromRequest(req *gomcp.CallToolRequest) string {
+	if req == nil {
+		return ""
+	}
+	if sess, ok := req.GetSession().(*gomcp.ServerSession); ok && sess != nil {
+		return sess.ID()
+	}
+	return ""
 }

--- a/mcp/tools_chat.go
+++ b/mcp/tools_chat.go
@@ -13,11 +13,12 @@ import (
 
 // chatArgs are the parameters for the chat tool.
 type chatArgs struct {
-	Messages    []ollama.ChatMessage `json:"messages"`
-	Model       string               `json:"model,omitempty"`
-	UseRAG      bool                 `json:"use_rag,omitempty"`
-	RAGTopK     int                  `json:"rag_top_k,omitempty"`
-	Temperature *float64             `json:"temperature,omitempty"`
+	Messages       []ollama.ChatMessage `json:"messages"`
+	Model          string               `json:"model,omitempty"`
+	UseRAG         bool                 `json:"use_rag,omitempty"`
+	RAGTopK        int                  `json:"rag_top_k,omitempty"`
+	Temperature    *float64             `json:"temperature,omitempty"`
+	ConversationID string               `json:"conversation_id,omitempty"`
 }
 
 func (s *Server) registerChatTools() {
@@ -42,10 +43,11 @@ func (s *Server) registerChatTools() {
 						"required": []string{"role", "content"},
 					},
 				},
-				"model":       map[string]any{"type": "string", "description": "Model name (uses configured default if omitted)"},
-				"use_rag":     map[string]any{"type": "boolean", "description": "Prepend RAG context from the vector store"},
-				"rag_top_k":   map[string]any{"type": "integer", "description": "Number of RAG results (default: 5)"},
-				"temperature": map[string]any{"type": "number", "description": "Sampling temperature"},
+				"model":           map[string]any{"type": "string", "description": "Model name (uses configured default if omitted)"},
+				"use_rag":         map[string]any{"type": "boolean", "description": "Prepend RAG context from the vector store"},
+				"rag_top_k":       map[string]any{"type": "integer", "description": "Number of RAG results (default: 5)"},
+				"temperature":     map[string]any{"type": "number", "description": "Sampling temperature"},
+				"conversation_id": map[string]any{"type": "string", "description": "Optional stable id to group calls of one conversation; omit to derive identity from message content"},
 			},
 			"required": []string{"messages"},
 		},

--- a/mcp/tools_chat.go
+++ b/mcp/tools_chat.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -250,7 +251,13 @@ func (s *Server) persistTranscript(ctx context.Context, req *gomcp.CallToolReque
 		RouteOutcome: routeOutcome,
 		SessionHint:  sessionHintFromRequest(req),
 	}
-	if rerr := store.Record(ctx, in); rerr != nil {
+	// Persistence is best-effort work that runs after the response is produced.
+	// Detach from the request context so a client that cancels immediately after
+	// receiving the answer (IDE clients cancel constantly) doesn't drop the
+	// trace. Bound it so a stuck write can't block the handler return.
+	recordCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancel()
+	if rerr := store.Record(recordCtx, in); rerr != nil {
 		log.Printf("mcp: transcript record: %v", rerr)
 	}
 }

--- a/mcp/tools_chat_transcript_test.go
+++ b/mcp/tools_chat_transcript_test.go
@@ -110,3 +110,53 @@ func TestHandleChat_NilTranscriptStoreStillSucceeds(t *testing.T) {
 		t.Fatalf("handleChat with nil store should succeed: err=%v isError=%v", err, res.IsError)
 	}
 }
+
+// TestHandleChat_PersistsDespiteCanceledContext guards the best-effort
+// persistence against request-context cancellation: an IDE client that cancels
+// right after receiving the answer must not cause the trace to be dropped. The
+// handler detaches the persistence write from the request context.
+func TestHandleChat_PersistsDespiteCanceledContext(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "conv.db")
+	ts, err := transcript.Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("open transcript: %v", err)
+	}
+	router := newRecordingRouteEngine("routed-answer")
+	s := &Server{router: router, transcriptStore: ts}
+
+	args, _ := json.Marshal(chatArgs{
+		ConversationID: "conv-cancel",
+		Model:          "ollama/qwen3:8b",
+		Messages:       []ollama.ChatMessage{{Role: "user", Content: "hi"}},
+	})
+
+	// Cancel the request context before the call. The fake router ignores ctx,
+	// so ExecuteChat still succeeds; persistence must survive the cancellation.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	res, err := s.handleChat(ctx, &gomcp.CallToolRequest{
+		Params: &gomcp.CallToolParamsRaw{Arguments: args},
+	})
+	if err != nil {
+		t.Fatalf("handleChat: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("handleChat returned tool error: %s", extractText(res))
+	}
+	_ = ts.Close() // flush WAL so a separate read handle sees the row
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open read handle: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	defer func() { _ = db.Close() }()
+
+	var convCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM conversations WHERE id = ?`, "conv-cancel").Scan(&convCount); err != nil {
+		t.Fatalf("count conversations: %v", err)
+	}
+	if convCount != 1 {
+		t.Errorf("conversations with id=conv-cancel = %d, want 1 (persistence must survive a canceled request context)", convCount)
+	}
+}

--- a/mcp/tools_chat_transcript_test.go
+++ b/mcp/tools_chat_transcript_test.go
@@ -2,8 +2,19 @@
 package mcp
 
 import (
+	"context"
+	"database/sql"
 	"encoding/json"
+	"path/filepath"
 	"testing"
+
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/kstruzzieri/go-llm/conversation"
+	"github.com/kstruzzieri/go-llm/ollama"
+	"github.com/kstruzzieri/go-llm/transcript"
+
+	_ "modernc.org/sqlite"
 )
 
 func TestChatArgs_ParsesConversationID(t *testing.T) {
@@ -14,5 +25,88 @@ func TestChatArgs_ParsesConversationID(t *testing.T) {
 	}
 	if args.ConversationID != "conv-1" {
 		t.Errorf("ConversationID = %q, want conv-1", args.ConversationID)
+	}
+}
+
+func TestHandleChat_PersistsTranscript(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "conv.db")
+	ts, err := transcript.Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("open transcript: %v", err)
+	}
+	router := newRecordingRouteEngine("routed-answer")
+	s := &Server{router: router, transcriptStore: ts}
+
+	args, _ := json.Marshal(chatArgs{
+		ConversationID: "conv-1",
+		Model:          "ollama/qwen3:8b",
+		Messages:       []ollama.ChatMessage{{Role: "user", Content: "hi"}},
+	})
+	res, err := s.handleChat(context.Background(), &gomcp.CallToolRequest{
+		Params: &gomcp.CallToolParamsRaw{Arguments: args},
+	})
+	if err != nil {
+		t.Fatalf("handleChat: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("handleChat returned tool error: %s", extractText(res))
+	}
+	_ = ts.Close() // flush WAL so a separate read handle sees the row
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open read handle: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	defer func() { _ = db.Close() }()
+
+	var convCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM conversations WHERE id = ?`, "conv-1").Scan(&convCount); err != nil {
+		t.Fatalf("count conversations: %v", err)
+	}
+	if convCount != 1 {
+		t.Errorf("conversations with id=conv-1 = %d, want 1", convCount)
+	}
+
+	var messagesJSON string
+	if err := db.QueryRow(`SELECT messages FROM conversations WHERE id = ?`, "conv-1").Scan(&messagesJSON); err != nil {
+		t.Fatalf("read canonical messages: %v", err)
+	}
+	var stored []conversation.Message
+	if err := json.Unmarshal([]byte(messagesJSON), &stored); err != nil {
+		t.Fatalf("unmarshal canonical messages: %v", err)
+	}
+	if len(stored) != 2 ||
+		stored[0].Role != "user" || stored[0].Content != "hi" ||
+		stored[1].Role != "assistant" || stored[1].Content != "routed-answer" {
+		t.Errorf("stored messages = %+v, want original request + assistant response", stored)
+	}
+
+	var provider string
+	var routeOutcome sql.NullString
+	if err := db.QueryRow(`SELECT provider, route_outcome_json FROM raw_chat_calls`).Scan(&provider, &routeOutcome); err != nil {
+		t.Fatalf("read raw provider: %v", err)
+	}
+	if provider != "fake" {
+		t.Errorf("raw provider = %q, want fake (from the served ChatResponse)", provider)
+	}
+	if !routeOutcome.Valid || !json.Valid([]byte(routeOutcome.String)) {
+		t.Errorf("route_outcome_json = %v, want valid JSON", routeOutcome)
+	}
+}
+
+func TestHandleChat_NilTranscriptStoreStillSucceeds(t *testing.T) {
+	router := newRecordingRouteEngine("ok")
+	s := &Server{router: router} // transcriptStore nil
+
+	args, _ := json.Marshal(chatArgs{
+		Model:    "ollama/m",
+		Messages: []ollama.ChatMessage{{Role: "user", Content: "hi"}},
+	})
+	res, err := s.handleChat(context.Background(), &gomcp.CallToolRequest{
+		Params: &gomcp.CallToolParamsRaw{Arguments: args},
+	})
+	if err != nil || res.IsError {
+		t.Fatalf("handleChat with nil store should succeed: err=%v isError=%v", err, res.IsError)
 	}
 }

--- a/mcp/tools_chat_transcript_test.go
+++ b/mcp/tools_chat_transcript_test.go
@@ -1,0 +1,18 @@
+// mcp/tools_chat_transcript_test.go
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestChatArgs_ParsesConversationID(t *testing.T) {
+	var args chatArgs
+	raw := `{"messages":[{"role":"user","content":"hi"}],"conversation_id":"conv-1"}`
+	if err := json.Unmarshal([]byte(raw), &args); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if args.ConversationID != "conv-1" {
+		t.Errorf("ConversationID = %q, want conv-1", args.ConversationID)
+	}
+}

--- a/transcript/canonical.go
+++ b/transcript/canonical.go
@@ -1,0 +1,68 @@
+// Package transcript persists MCP chat calls as replayable benchmark traces.
+// It appends an immutable raw call record first (the durable source of truth)
+// and then projects a best-effort canonical conversation. The canonical
+// conversations table is a strict superset of the columns cmd/llm-bench's
+// capture reader consumes, so captured traces need no schema changes.
+package transcript
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+
+	"github.com/kstruzzieri/go-llm/conversation"
+)
+
+// canonicalMsg is the comparison/hashing form of a conversation.Message. Every
+// field is a string so the struct is comparable with ==; ToolCalls holds the
+// canonical JSON of the message's tool_calls ("" when absent).
+type canonicalMsg struct {
+	Role       string `json:"role"`
+	Content    string `json:"content"`
+	ToolCalls  string `json:"tool_calls"`
+	ToolName   string `json:"tool_name"`
+	ToolCallID string `json:"tool_call_id"`
+}
+
+// canonicalToolCallsJSON re-marshals a tool_calls payload with stable key
+// ordering so whitespace/key-order differences never produce false divergences
+// or fork ids. Empty, omitted, null, and empty-array payloads all canonicalize
+// to "" (absence). A payload that is not valid JSON is returned verbatim so a
+// malformed value never silently collides with a different one.
+func canonicalToolCallsJSON(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return string(raw)
+	}
+	if v == nil {
+		return ""
+	}
+	if arr, ok := v.([]any); ok && len(arr) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(v) // encoding/json emits map keys in sorted order
+	if err != nil {
+		return string(raw)
+	}
+	return string(b)
+}
+
+// canonicalMessage converts a conversation.Message into its comparison form.
+func canonicalMessage(m conversation.Message) canonicalMsg {
+	return canonicalMsg{
+		Role:       m.Role,
+		Content:    m.Content,
+		ToolCalls:  canonicalToolCallsJSON(m.ToolCalls),
+		ToolName:   m.ToolName,
+		ToolCallID: m.ToolCallID,
+	}
+}
+
+// sha256Hex returns the lowercase hex SHA-256 of s.
+func sha256Hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}

--- a/transcript/canonical.go
+++ b/transcript/canonical.go
@@ -66,3 +66,41 @@ func sha256Hex(s string) string {
 	sum := sha256.Sum256([]byte(s))
 	return hex.EncodeToString(sum[:])
 }
+
+// canonicalMessagesJSON returns a stable JSON encoding of a message slice for
+// hashing (derived keys §5.3 and fork ids §7).
+func canonicalMessagesJSON(msgs []conversation.Message) string {
+	cs := make([]canonicalMsg, len(msgs))
+	for i, m := range msgs {
+		cs[i] = canonicalMessage(m)
+	}
+	b, _ := json.Marshal(cs) // canonicalMsg has only string fields; cannot fail
+	return string(b)
+}
+
+// messagesEqual reports whether two histories are element-wise canonically equal.
+func messagesEqual(a, b []conversation.Message) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if canonicalMessage(a[i]) != canonicalMessage(b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// isStrictPrefix reports whether prefix is an element-wise canonical prefix of
+// full and strictly shorter (a genuine extension, never equality).
+func isStrictPrefix(prefix, full []conversation.Message) bool {
+	if len(prefix) >= len(full) {
+		return false
+	}
+	for i := range prefix {
+		if canonicalMessage(prefix[i]) != canonicalMessage(full[i]) {
+			return false
+		}
+	}
+	return true
+}

--- a/transcript/canonical_test.go
+++ b/transcript/canonical_test.go
@@ -48,3 +48,40 @@ func TestSHA256Hex_Deterministic(t *testing.T) {
 		t.Errorf("sha256Hex length = %d, want 64", len(got))
 	}
 }
+
+func TestMessagesEqual(t *testing.T) {
+	a := []conversation.Message{{Role: "user", Content: "hi"}}
+	b := []conversation.Message{{Role: "user", Content: "hi"}}
+	c := []conversation.Message{{Role: "user", Content: "bye"}}
+	if !messagesEqual(a, b) {
+		t.Error("equal slices reported unequal")
+	}
+	if messagesEqual(a, c) {
+		t.Error("different content reported equal")
+	}
+	if messagesEqual(a, append(a, b...)) {
+		t.Error("different lengths reported equal")
+	}
+}
+
+func TestIsStrictPrefix(t *testing.T) {
+	short := []conversation.Message{{Role: "user", Content: "hi"}}
+	long := []conversation.Message{{Role: "user", Content: "hi"}, {Role: "assistant", Content: "hello"}}
+	if !isStrictPrefix(short, long) {
+		t.Error("short should be a strict prefix of long")
+	}
+	if isStrictPrefix(long, short) {
+		t.Error("long is not a prefix of short")
+	}
+	if isStrictPrefix(short, short) {
+		t.Error("equal slices are not a STRICT prefix")
+	}
+}
+
+func TestCanonicalMessagesJSON_StableAcrossToolCallFormatting(t *testing.T) {
+	a := []conversation.Message{{Role: "assistant", ToolCalls: json.RawMessage(`{"b":2,"a":1}`)}}
+	b := []conversation.Message{{Role: "assistant", ToolCalls: json.RawMessage(`{"a":1,"b":2}`)}}
+	if canonicalMessagesJSON(a) != canonicalMessagesJSON(b) {
+		t.Error("canonicalMessagesJSON should be stable across tool-call key order")
+	}
+}

--- a/transcript/canonical_test.go
+++ b/transcript/canonical_test.go
@@ -1,0 +1,50 @@
+package transcript
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/conversation"
+)
+
+func TestCanonicalToolCallsJSON_NormalizesAbsence(t *testing.T) {
+	for _, tc := range []struct{ name, raw string }{
+		{"empty", ``},
+		{"null", `null`},
+		{"empty array", `[]`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := canonicalToolCallsJSON(json.RawMessage(tc.raw)); got != "" {
+				t.Errorf("canonicalToolCallsJSON(%q) = %q, want \"\"", tc.raw, got)
+			}
+		})
+	}
+}
+
+func TestCanonicalToolCallsJSON_StableKeyOrder(t *testing.T) {
+	a := json.RawMessage(`[{"id":"c1","type":"function","function":{"name":"x","index":0,"arguments":{"b":2,"a":1}}}]`)
+	b := json.RawMessage(`[{"type":"function","id":"c1","function":{"arguments":{"a":1,"b":2},"index":0,"name":"x"}}]`)
+	if canonicalToolCallsJSON(a) != canonicalToolCallsJSON(b) {
+		t.Errorf("key-order/whitespace differences produced different canonical forms:\n a=%s\n b=%s",
+			canonicalToolCallsJSON(a), canonicalToolCallsJSON(b))
+	}
+}
+
+func TestCanonicalMessage_TreatsAbsenceUniformly(t *testing.T) {
+	withNull := conversation.Message{Role: "assistant", Content: "hi", ToolCalls: json.RawMessage(`null`)}
+	without := conversation.Message{Role: "assistant", Content: "hi"}
+	if canonicalMessage(withNull) != canonicalMessage(without) {
+		t.Error("null tool_calls should canonicalize identically to absent tool_calls")
+	}
+}
+
+func TestSHA256Hex_Deterministic(t *testing.T) {
+	const want = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad" // SHA-256("abc"), NIST vector
+	got := sha256Hex("abc")
+	if got != want {
+		t.Errorf("sha256Hex(%q) = %q, want %q", "abc", got, want)
+	}
+	if len(got) != 64 {
+		t.Errorf("sha256Hex length = %d, want 64", len(got))
+	}
+}

--- a/transcript/identity.go
+++ b/transcript/identity.go
@@ -1,0 +1,71 @@
+package transcript
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/kstruzzieri/go-llm/conversation"
+)
+
+// identity_source values recorded for a conversation. "forked" is assigned at
+// projection time (see stitch.go), never at key derivation.
+const (
+	identityExplicit = "explicit"
+	identityDerived  = "derived"
+	identityForked   = "forked"
+)
+
+// RecordInput is one chat call to persist. Request is the original user-facing
+// history (any RAG-injected system message already excluded by the caller);
+// Response is the assistant turn that answered it.
+type RecordInput struct {
+	ConversationID string                 // explicit id from the chat tool arg; "" if absent
+	Request        []conversation.Message // original user-facing history
+	Response       conversation.Message   // assistant turn: content + tool_calls when present
+	Model          string                 // model that served the call; "" if unknown
+	Provider       string                 // provider instance that served the call; "" if unknown
+	RouteOutcome   json.RawMessage        // optional serialized RouteOutcome; nil ok
+	SessionHint    string                 // stable MCP session/client id; "" when unavailable
+}
+
+// conversationKey derives the base conversation key and its identity source
+// (§5). An explicit id always wins; otherwise the key is derived from the
+// stable parts of the request so the growing history of one session resolves
+// to the same key on every turn.
+func conversationKey(in RecordInput) (key, source string) {
+	if in.ConversationID != "" {
+		return in.ConversationID, identityExplicit
+	}
+	if first, ok := firstUserContent(in.Request); ok {
+		seed := systemContent(in.Request) + "\x00" + first + "\x00" + in.SessionHint
+		return sha256Hex(seed), identityDerived
+	}
+	// No user turn: hash the full canonical request so distinct user-less calls
+	// (system-only, tool-only) each become their own conversation.
+	return sha256Hex(canonicalMessagesJSON(in.Request)), identityDerived
+}
+
+// firstUserContent returns the content of the first user-role message and
+// whether one exists.
+func firstUserContent(msgs []conversation.Message) (string, bool) {
+	for _, m := range msgs {
+		if m.Role == "user" {
+			return m.Content, true
+		}
+	}
+	return "", false
+}
+
+// systemContent concatenates the content of every system-role message in the
+// request, preserving order. Messages are NUL-separated (matching the seed's
+// field separators) so a multi-message block can never collide with a single
+// message that happens to contain the separator. Empty when none were sent.
+func systemContent(msgs []conversation.Message) string {
+	var parts []string
+	for _, m := range msgs {
+		if m.Role == "system" {
+			parts = append(parts, m.Content)
+		}
+	}
+	return strings.Join(parts, "\x00")
+}

--- a/transcript/identity_test.go
+++ b/transcript/identity_test.go
@@ -1,0 +1,79 @@
+package transcript
+
+import (
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/conversation"
+)
+
+func mustKey(t *testing.T, in RecordInput) string {
+	t.Helper()
+	k, _ := conversationKey(in)
+	return k
+}
+
+func TestConversationKey_ExplicitWins(t *testing.T) {
+	in := RecordInput{
+		ConversationID: "conv-123",
+		Request:        []conversation.Message{{Role: "user", Content: "hi"}},
+	}
+	key, src := conversationKey(in)
+	if key != "conv-123" || src != identityExplicit {
+		t.Errorf("got (%q,%q), want (conv-123, explicit)", key, src)
+	}
+}
+
+func TestConversationKey_DerivedStableAcrossTurns(t *testing.T) {
+	turn1 := RecordInput{Request: []conversation.Message{
+		{Role: "system", Content: "be helpful"},
+		{Role: "user", Content: "hi"},
+	}}
+	turn2 := RecordInput{Request: []conversation.Message{
+		{Role: "system", Content: "be helpful"},
+		{Role: "user", Content: "hi"},
+		{Role: "assistant", Content: "hello"},
+		{Role: "user", Content: "more"},
+	}}
+	k1, s1 := conversationKey(turn1)
+	k2, s2 := conversationKey(turn2)
+	if k1 != k2 {
+		t.Errorf("derived key not stable across turns: %q vs %q", k1, k2)
+	}
+	if s1 != identityDerived || s2 != identityDerived {
+		t.Errorf("identity source = (%q,%q), want derived", s1, s2)
+	}
+}
+
+func TestConversationKey_SessionHintChangesKey(t *testing.T) {
+	base := RecordInput{Request: []conversation.Message{{Role: "user", Content: "hi"}}}
+	withHint := base
+	withHint.SessionHint = "sess-A"
+	if mustKey(t, base) == mustKey(t, withHint) {
+		t.Error("session hint should change the derived key")
+	}
+}
+
+func TestConversationKey_NoUserMessageHashesFullRequest(t *testing.T) {
+	a := RecordInput{Request: []conversation.Message{{Role: "system", Content: "A"}}}
+	b := RecordInput{Request: []conversation.Message{{Role: "system", Content: "B"}}}
+	ka, sa := conversationKey(a)
+	kb, _ := conversationKey(b)
+	if ka == kb {
+		t.Error("distinct user-less requests must not collapse to one key")
+	}
+	if sa != identityDerived {
+		t.Errorf("identity source = %q, want derived", sa)
+	}
+}
+
+func TestConversationKey_NilRequestProducesStableKey(t *testing.T) {
+	in := RecordInput{} // nil Request, no ConversationID
+	k1, s1 := conversationKey(in)
+	k2, _ := conversationKey(in)
+	if k1 != k2 {
+		t.Errorf("nil-request key not stable: %q vs %q", k1, k2)
+	}
+	if s1 != identityDerived {
+		t.Errorf("identity source = %q, want derived", s1)
+	}
+}

--- a/transcript/migration.go
+++ b/transcript/migration.go
@@ -1,0 +1,120 @@
+// transcript/migration.go
+package transcript
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+const createRawTable = `CREATE TABLE IF NOT EXISTS raw_chat_calls (
+	call_id            TEXT PRIMARY KEY,
+	conversation_key   TEXT NOT NULL,
+	conversation_id    TEXT NOT NULL,
+	identity_source    TEXT NOT NULL,
+	request_messages   TEXT NOT NULL,
+	response_message   TEXT NOT NULL,
+	model              TEXT NOT NULL DEFAULT '',
+	provider           TEXT NOT NULL DEFAULT '',
+	route_outcome_json TEXT,
+	created_at         INTEGER NOT NULL,
+	projection_status  TEXT NOT NULL,
+	projection_error   TEXT
+)`
+
+const createRawIndex = `CREATE INDEX IF NOT EXISTS idx_raw_calls_conv
+	ON raw_chat_calls(conversation_id, created_at)`
+
+// createConversationsTable is a strict superset of the five columns capture.go
+// reads. Audit columns carry NOT NULL DEFAULT so the ALTER path (legacy DBs)
+// can add them; fresh rows always supply explicit values.
+const createConversationsTable = `CREATE TABLE IF NOT EXISTS conversations (
+	id               TEXT PRIMARY KEY,
+	title            TEXT NOT NULL DEFAULT '',
+	messages         TEXT NOT NULL,
+	created_at       INTEGER NOT NULL,
+	updated_at       INTEGER NOT NULL,
+	conversation_key TEXT NOT NULL DEFAULT '',
+	identity_source  TEXT NOT NULL DEFAULT '',
+	latest_call_id   TEXT NOT NULL DEFAULT '',
+	message_count    INTEGER NOT NULL DEFAULT 0,
+	stitch_status    TEXT NOT NULL DEFAULT ''
+)`
+
+const createConvKeyIndex = `CREATE INDEX IF NOT EXISTS idx_conversations_key
+	ON conversations(conversation_key)`
+
+const createConvUpdatedIndex = `CREATE INDEX IF NOT EXISTS idx_conversations_updated
+	ON conversations(updated_at DESC, id ASC)`
+
+// auditColumns are the conversations columns beyond the five-column
+// conversation/ baseline, added via ALTER TABLE ADD COLUMN on legacy DBs.
+var auditColumns = []struct{ name, ddl string }{
+	{"conversation_key", "TEXT NOT NULL DEFAULT ''"},
+	{"identity_source", "TEXT NOT NULL DEFAULT ''"},
+	{"latest_call_id", "TEXT NOT NULL DEFAULT ''"},
+	{"message_count", "INTEGER NOT NULL DEFAULT 0"},
+	{"stitch_status", "TEXT NOT NULL DEFAULT ''"},
+}
+
+// migrate ensures both tables, their indexes, and the conversations audit
+// columns exist. Idempotent and safe against a pre-existing five-column
+// conversations table written by the conversation/ store.
+func migrate(ctx context.Context, db *sql.DB) error {
+	for _, stmt := range []string{createRawTable, createRawIndex, createConversationsTable} {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("transcript: migrate: %w", err)
+		}
+	}
+	if err := addMissingAuditColumns(ctx, db); err != nil {
+		return err
+	}
+	for _, stmt := range []string{createConvKeyIndex, createConvUpdatedIndex} {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("transcript: migrate index: %w", err)
+		}
+	}
+	return nil
+}
+
+func addMissingAuditColumns(ctx context.Context, db *sql.DB) error {
+	existing, err := conversationColumns(ctx, db)
+	if err != nil {
+		return err
+	}
+	for _, col := range auditColumns {
+		if existing[col.name] {
+			continue
+		}
+		stmt := fmt.Sprintf("ALTER TABLE conversations ADD COLUMN %s %s", col.name, col.ddl)
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("transcript: add column %s: %w", col.name, err)
+		}
+	}
+	return nil
+}
+
+func conversationColumns(ctx context.Context, db *sql.DB) (map[string]bool, error) {
+	rows, err := db.QueryContext(ctx, "PRAGMA table_info(conversations)")
+	if err != nil {
+		return nil, fmt.Errorf("transcript: table_info: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	cols := map[string]bool{}
+	for rows.Next() {
+		var (
+			cid, notNull, pk int
+			name, ctype      string
+			dfltValue        sql.NullString
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notNull, &dfltValue, &pk); err != nil {
+			return nil, fmt.Errorf("transcript: scan table_info: %w", err)
+		}
+		cols[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("transcript: iterate table_info: %w", err)
+	}
+	return cols, nil
+}

--- a/transcript/migration_test.go
+++ b/transcript/migration_test.go
@@ -77,3 +77,60 @@ func TestMigrate_Idempotent(t *testing.T) {
 		t.Fatalf("second migrate: %v", err)
 	}
 }
+
+func TestMigrate_LegacyFiveColumnTableGetsAuditColumns(t *testing.T) {
+	db := openMem(t)
+	// Simulate a conversation/ store DB: exact five-column baseline + one row.
+	if _, err := db.Exec(`CREATE TABLE conversations (
+		id         TEXT PRIMARY KEY,
+		title      TEXT NOT NULL DEFAULT '',
+		messages   TEXT NOT NULL,
+		created_at INTEGER NOT NULL,
+		updated_at INTEGER NOT NULL
+	)`); err != nil {
+		t.Fatalf("create legacy table: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO conversations (id, title, messages, created_at, updated_at) VALUES (?,?,?,?,?)`,
+		"legacy-1", "old", `[{"role":"user","content":"hi"}]`, int64(1), int64(2),
+	); err != nil {
+		t.Fatalf("insert legacy row: %v", err)
+	}
+
+	if err := migrate(context.Background(), db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	conv := columns(t, db, "conversations")
+	for _, c := range []string{"conversation_key", "identity_source", "latest_call_id", "message_count", "stitch_status"} {
+		if !conv[c] {
+			t.Errorf("legacy conversations missing audit column %q after migrate", c)
+		}
+	}
+
+	// Pre-existing row survives and stays capture-readable (five base columns).
+	var (
+		id, title, messages string
+		created, updated    int64
+	)
+	if err := db.QueryRow(
+		`SELECT id, title, messages, created_at, updated_at FROM conversations WHERE id = ?`, "legacy-1",
+	).Scan(&id, &title, &messages, &created, &updated); err != nil {
+		t.Fatalf("read legacy row: %v", err)
+	}
+	if id != "legacy-1" || title != "old" || messages != `[{"role":"user","content":"hi"}]` {
+		t.Errorf("legacy row mutated: id=%q title=%q messages=%q", id, title, messages)
+	}
+
+	// Backfilled audit defaults are usable.
+	var convKey string
+	var msgCount int
+	if err := db.QueryRow(
+		`SELECT conversation_key, message_count FROM conversations WHERE id = ?`, "legacy-1",
+	).Scan(&convKey, &msgCount); err != nil {
+		t.Fatalf("read audit cols: %v", err)
+	}
+	if convKey != "" || msgCount != 0 {
+		t.Errorf("legacy audit defaults = (%q,%d), want (\"\",0)", convKey, msgCount)
+	}
+}

--- a/transcript/migration_test.go
+++ b/transcript/migration_test.go
@@ -1,0 +1,79 @@
+// transcript/migration_test.go
+package transcript
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func openMem(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	db.SetMaxOpenConns(1) // :memory: opens a private DB per connection otherwise
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func columns(t *testing.T, db *sql.DB, table string) map[string]bool {
+	t.Helper()
+	rows, err := db.Query("PRAGMA table_info(" + table + ")")
+	if err != nil {
+		t.Fatalf("table_info(%s): %v", table, err)
+	}
+	defer func() { _ = rows.Close() }()
+	out := map[string]bool{}
+	for rows.Next() {
+		var (
+			cid, notnull, pk int
+			name, ctype      string
+			dflt             sql.NullString
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			t.Fatalf("scan table_info: %v", err)
+		}
+		out[name] = true
+	}
+	return out
+}
+
+func TestMigrate_FreshCreatesBothTables(t *testing.T) {
+	db := openMem(t)
+	if err := migrate(context.Background(), db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	raw := columns(t, db, "raw_chat_calls")
+	for _, c := range []string{
+		"call_id", "conversation_key", "conversation_id", "identity_source",
+		"request_messages", "response_message", "model", "provider", "route_outcome_json",
+		"created_at", "projection_status", "projection_error",
+	} {
+		if !raw[c] {
+			t.Errorf("raw_chat_calls missing column %q", c)
+		}
+	}
+	conv := columns(t, db, "conversations")
+	for _, c := range []string{
+		"id", "title", "messages", "created_at", "updated_at",
+		"conversation_key", "identity_source", "latest_call_id", "message_count", "stitch_status",
+	} {
+		if !conv[c] {
+			t.Errorf("conversations missing column %q", c)
+		}
+	}
+}
+
+func TestMigrate_Idempotent(t *testing.T) {
+	db := openMem(t)
+	if err := migrate(context.Background(), db); err != nil {
+		t.Fatalf("first migrate: %v", err)
+	}
+	if err := migrate(context.Background(), db); err != nil {
+		t.Fatalf("second migrate: %v", err)
+	}
+}

--- a/transcript/stitch.go
+++ b/transcript/stitch.go
@@ -1,0 +1,95 @@
+package transcript
+
+import (
+	"time"
+
+	"github.com/kstruzzieri/go-llm/conversation"
+)
+
+// stitch_status values recorded on a canonical conversation row.
+const (
+	statusCreated    = "created"
+	statusExtended   = "extended"
+	statusForked     = "forked"
+	statusIdempotent = "idempotent"
+)
+
+// Lease-guard defaults (§7): a prefix candidate that is both stale and short is
+// treated as a coincidental common opener and forked rather than extended.
+const (
+	defaultLeaseWindow    = 12 * time.Hour
+	defaultShortThreshold = 2
+)
+
+// candidate is one canonical row participating in a stitch decision.
+type candidate struct {
+	id           string
+	messages     []conversation.Message
+	messageCount int   // len(messages); recomputed at load, never trusted from the column
+	updatedAt    int64 // unix millis
+}
+
+// stitchDecision is the outcome of decideStitch.
+type stitchDecision struct {
+	targetID string
+	status   string
+}
+
+// forkID returns the content-addressed id of a forked sibling of key. Because
+// it is content-addressed, re-sending the same forked history resolves back to
+// the same sibling (no unbounded fork growth).
+func forkID(key string, incoming []conversation.Message) string {
+	return key + ":" + sha256Hex(canonicalMessagesJSON(incoming))[:12]
+}
+
+// decideStitch resolves how an incoming full history relates to the candidate
+// rows that share its base key (§7). candidates must already be the full set of
+// rows sharing the key (base + every forked sibling).
+func decideStitch(key string, incoming []conversation.Message, candidates []candidate, now time.Time, leaseWindow time.Duration, shortThreshold int) stitchDecision {
+	if len(candidates) == 0 {
+		return stitchDecision{targetID: key, status: statusCreated}
+	}
+
+	// 2. Exact re-record.
+	for _, c := range candidates {
+		if messagesEqual(c.messages, incoming) {
+			return stitchDecision{targetID: c.id, status: statusIdempotent}
+		}
+	}
+
+	// 3. Genuine extension: a candidate is a strict prefix of incoming. Pick the
+	// longest (most specific continuation).
+	var ext *candidate
+	for i := range candidates {
+		if isStrictPrefix(candidates[i].messages, incoming) {
+			if ext == nil || candidates[i].messageCount > ext.messageCount {
+				ext = &candidates[i]
+			}
+		}
+	}
+	if ext != nil {
+		stale := now.Sub(time.UnixMilli(ext.updatedAt)) > leaseWindow
+		short := ext.messageCount <= shortThreshold
+		if stale && short {
+			return stitchDecision{targetID: forkID(key, incoming), status: statusForked}
+		}
+		return stitchDecision{targetID: ext.id, status: statusExtended}
+	}
+
+	// 4. Re-send of an earlier state: incoming is a strict prefix of a candidate.
+	// Keep the longer stored history (no shrink).
+	var longer *candidate
+	for i := range candidates {
+		if isStrictPrefix(incoming, candidates[i].messages) {
+			if longer == nil || candidates[i].messageCount > longer.messageCount {
+				longer = &candidates[i]
+			}
+		}
+	}
+	if longer != nil {
+		return stitchDecision{targetID: longer.id, status: statusIdempotent}
+	}
+
+	// 5. All diverge.
+	return stitchDecision{targetID: forkID(key, incoming), status: statusForked}
+}

--- a/transcript/stitch_test.go
+++ b/transcript/stitch_test.go
@@ -1,0 +1,88 @@
+package transcript
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/conversation"
+)
+
+// msgs builds a message slice with alternating user/assistant roles. The roles
+// are irrelevant to decideStitch (it compares canonical content) but keep the
+// fixtures realistic.
+func msgs(contents ...string) []conversation.Message {
+	out := make([]conversation.Message, len(contents))
+	for i, c := range contents {
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		out[i] = conversation.Message{Role: role, Content: c}
+	}
+	return out
+}
+
+func TestDecideStitch_Created(t *testing.T) {
+	dec := decideStitch("k", msgs("a", "b"), nil, time.UnixMilli(1000), defaultLeaseWindow, defaultShortThreshold)
+	if dec.status != statusCreated || dec.targetID != "k" {
+		t.Errorf("got %+v, want {k created}", dec)
+	}
+}
+
+func TestDecideStitch_Idempotent(t *testing.T) {
+	c := candidate{id: "k", messages: msgs("a", "b"), messageCount: 2, updatedAt: 900}
+	dec := decideStitch("k", msgs("a", "b"), []candidate{c}, time.UnixMilli(1000), defaultLeaseWindow, defaultShortThreshold)
+	if dec.status != statusIdempotent || dec.targetID != "k" {
+		t.Errorf("got %+v, want {k idempotent}", dec)
+	}
+}
+
+func TestDecideStitch_Extended(t *testing.T) {
+	c := candidate{id: "k", messages: msgs("a", "b"), messageCount: 2, updatedAt: 900}
+	dec := decideStitch("k", msgs("a", "b", "c", "d"), []candidate{c}, time.UnixMilli(1000), defaultLeaseWindow, defaultShortThreshold)
+	if dec.status != statusExtended || dec.targetID != "k" {
+		t.Errorf("got %+v, want {k extended}", dec)
+	}
+}
+
+func TestDecideStitch_ShorterIncomingNoShrink(t *testing.T) {
+	c := candidate{id: "k", messages: msgs("a", "b", "c", "d"), messageCount: 4, updatedAt: 900}
+	dec := decideStitch("k", msgs("a", "b"), []candidate{c}, time.UnixMilli(1000), defaultLeaseWindow, defaultShortThreshold)
+	if dec.status != statusIdempotent || dec.targetID != "k" {
+		t.Errorf("got %+v, want {k idempotent} (no shrink)", dec)
+	}
+}
+
+func TestDecideStitch_DivergentForks(t *testing.T) {
+	c := candidate{id: "k", messages: msgs("a", "b"), messageCount: 2, updatedAt: 900}
+	incoming := msgs("x", "y")
+	dec := decideStitch("k", incoming, []candidate{c}, time.UnixMilli(1000), defaultLeaseWindow, defaultShortThreshold)
+	if dec.status != statusForked {
+		t.Fatalf("got %+v, want forked", dec)
+	}
+	if dec.targetID != forkID("k", incoming) {
+		t.Errorf("fork target = %q, want %q", dec.targetID, forkID("k", incoming))
+	}
+}
+
+func TestDecideStitch_ExtendsSiblingNotBase(t *testing.T) {
+	// Once a session has forked, its later turns still derive the base key, so
+	// the decision must extend the matching sibling rather than mint a new fork.
+	base := candidate{id: "k", messages: msgs("a", "b"), messageCount: 2, updatedAt: 950}
+	sibling := candidate{id: "k:abc123def456", messages: msgs("p", "q"), messageCount: 2, updatedAt: 950}
+	incoming := msgs("p", "q", "r", "s")
+	dec := decideStitch("k", incoming, []candidate{base, sibling}, time.UnixMilli(1000), defaultLeaseWindow, defaultShortThreshold)
+	if dec.status != statusExtended || dec.targetID != "k:abc123def456" {
+		t.Errorf("got %+v, want {k:abc123def456 extended}", dec)
+	}
+}
+
+func TestForkID_ContentAddressed(t *testing.T) {
+	incoming := msgs("a", "b")
+	if forkID("k", incoming) != forkID("k", incoming) {
+		t.Fatal("forkID not deterministic for identical history")
+	}
+	if forkID("k", incoming) == forkID("k", msgs("a", "c")) {
+		t.Error("forkID should differ for different histories")
+	}
+}

--- a/transcript/stitch_test.go
+++ b/transcript/stitch_test.go
@@ -79,7 +79,8 @@ func TestDecideStitch_ExtendsSiblingNotBase(t *testing.T) {
 
 func TestForkID_ContentAddressed(t *testing.T) {
 	incoming := msgs("a", "b")
-	if forkID("k", incoming) != forkID("k", incoming) {
+	sameHistory := msgs("a", "b")
+	if forkID("k", incoming) != forkID("k", sameHistory) {
 		t.Fatal("forkID not deterministic for identical history")
 	}
 	if forkID("k", incoming) == forkID("k", msgs("a", "c")) {

--- a/transcript/stitch_test.go
+++ b/transcript/stitch_test.go
@@ -86,3 +86,37 @@ func TestForkID_ContentAddressed(t *testing.T) {
 		t.Error("forkID should differ for different histories")
 	}
 }
+
+func TestDecideStitch_LeaseGuard(t *testing.T) {
+	const leaseWindow = 12 * time.Hour
+	const short = 2
+	base := time.UnixMilli(0)
+	now := base.Add(13 * time.Hour) // 1h past the lease window vs updatedAt=0
+
+	incoming := msgs("a", "b", "c", "d")
+
+	t.Run("stale and short forks", func(t *testing.T) {
+		stub := candidate{id: "k", messages: msgs("a", "b"), messageCount: 2, updatedAt: 0}
+		dec := decideStitch("k", incoming, []candidate{stub}, now, leaseWindow, short)
+		if dec.status != statusForked {
+			t.Errorf("stale+short prefix should fork, got %+v", dec)
+		}
+	})
+
+	t.Run("fresh extends", func(t *testing.T) {
+		fresh := candidate{id: "k", messages: msgs("a", "b"), messageCount: 2, updatedAt: now.Add(-time.Minute).UnixMilli()}
+		dec := decideStitch("k", incoming, []candidate{fresh}, now, leaseWindow, short)
+		if dec.status != statusExtended {
+			t.Errorf("fresh prefix should extend, got %+v", dec)
+		}
+	})
+
+	t.Run("long extends even when stale", func(t *testing.T) {
+		long := candidate{id: "k", messages: msgs("a", "b", "c"), messageCount: 3, updatedAt: 0}
+		incomingLong := msgs("a", "b", "c", "d", "e")
+		dec := decideStitch("k", incomingLong, []candidate{long}, now, leaseWindow, short)
+		if dec.status != statusExtended {
+			t.Errorf("stale but long prefix should extend, got %+v", dec)
+		}
+	})
+}

--- a/transcript/store.go
+++ b/transcript/store.go
@@ -367,7 +367,7 @@ func (s *Store) upsertCanonical(ctx context.Context, dec stitchDecision, key, so
 }
 
 func (s *Store) finalizeRawOK(ctx context.Context, callID string, dec stitchDecision, key string) error {
-	if dec.status == statusForked && dec.targetID != key {
+	if dec.targetID != key {
 		_, err := s.db.ExecContext(ctx,
 			`UPDATE raw_chat_calls SET projection_status = 'ok',
 			    conversation_id = ?, identity_source = ? WHERE call_id = ?`,

--- a/transcript/store.go
+++ b/transcript/store.go
@@ -3,12 +3,18 @@ package transcript
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"log"
 	"sync"
 	"time"
 
 	_ "modernc.org/sqlite"
+
+	"github.com/kstruzzieri/go-llm/conversation"
 )
 
 // Store persists MCP chat calls: an immutable raw_chat_calls row (source of
@@ -75,8 +81,257 @@ func (s *Store) Close() error {
 	return err
 }
 
-// Record is implemented in Task 9. Stub keeps the package compiling.
+// Record persists one chat call. It appends the immutable raw row first
+// (returning an error only when that append fails — meaning nothing was
+// persisted) then projects the canonical conversation best-effort; a projection
+// failure is logged, recorded on the raw row, and swallowed so a non-nil return
+// always means "nothing was persisted."
 func (s *Store) Record(ctx context.Context, in RecordInput) error {
-	_ = in
+	callID, err := newCallID()
+	if err != nil {
+		return fmt.Errorf("transcript: generate call id: %w", err)
+	}
+	key, source := conversationKey(in)
+
+	reqJSON, err := json.Marshal(nonNilMessages(in.Request))
+	if err != nil {
+		return fmt.Errorf("transcript: marshal request: %w", err)
+	}
+	respJSON, err := json.Marshal(in.Response)
+	if err != nil {
+		return fmt.Errorf("transcript: marshal response: %w", err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.now().UnixMilli()
+
+	if err := s.insertRaw(ctx, rawRow{
+		callID:         callID,
+		key:            key,
+		conversationID: key,
+		identitySource: source,
+		requestJSON:    string(reqJSON),
+		responseJSON:   string(respJSON),
+		model:          in.Model,
+		provider:       in.Provider,
+		routeOutcome:   in.RouteOutcome,
+		createdAt:      now,
+	}); err != nil {
+		return fmt.Errorf("transcript: append raw call: %w", err)
+	}
+
+	if perr := s.project(ctx, callID, key, source, in, now); perr != nil {
+		log.Printf("transcript: canonical projection failed for call %s: %v", callID, perr)
+		s.finalizeRawError(ctx, callID, perr)
+	}
 	return nil
+}
+
+type rawRow struct {
+	callID         string
+	key            string
+	conversationID string
+	identitySource string
+	requestJSON    string
+	responseJSON   string
+	model          string
+	provider       string
+	routeOutcome   json.RawMessage
+	createdAt      int64
+}
+
+func (s *Store) insertRaw(ctx context.Context, r rawRow) error {
+	var routeOutcome any // nil → SQL NULL
+	if len(r.routeOutcome) > 0 {
+		routeOutcome = string(r.routeOutcome)
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO raw_chat_calls
+		   (call_id, conversation_key, conversation_id, identity_source,
+		    request_messages, response_message, model, provider, route_outcome_json,
+		    created_at, projection_status, projection_error)
+		 VALUES (?,?,?,?,?,?,?,?,?,?,?,NULL)`,
+		r.callID, r.key, r.conversationID, r.identitySource,
+		r.requestJSON, r.responseJSON, r.model, r.provider, routeOutcome,
+		r.createdAt, "pending",
+	)
+	return err
+}
+
+// project loads the candidate set, decides the stitch, upserts the canonical
+// row, and finalizes the raw row's projection columns. Any returned error is
+// swallowed by Record (the raw row remains the durable source of truth).
+func (s *Store) project(ctx context.Context, callID, key, source string, in RecordInput, now int64) error {
+	incoming := append(append([]conversation.Message{}, in.Request...), in.Response)
+
+	candidates, err := s.loadCandidates(ctx, key)
+	if err != nil {
+		return err
+	}
+	dec := decideStitch(key, incoming, candidates, time.UnixMilli(now), s.leaseWindow, s.shortThreshold)
+	if err := s.upsertCanonical(ctx, dec, key, source, callID, incoming, now); err != nil {
+		return err
+	}
+	return s.finalizeRawOK(ctx, callID, dec, key)
+}
+
+// loadCandidates returns every canonical row sharing the base key (base + forked
+// siblings) plus any row whose id == key (the legacy-migrated explicit-id row,
+// whose conversation_key is still ”). message_count is recomputed from the
+// stored messages so a stale audit column never skews the stitch decision.
+func (s *Store) loadCandidates(ctx context.Context, key string) ([]candidate, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, messages, updated_at FROM conversations
+		   WHERE conversation_key = ? OR id = ?`,
+		key, key,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("transcript: load candidates: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []candidate
+	for rows.Next() {
+		var (
+			id        string
+			msgsJSON  string
+			updatedMs int64
+		)
+		if err := rows.Scan(&id, &msgsJSON, &updatedMs); err != nil {
+			return nil, fmt.Errorf("transcript: scan candidate: %w", err)
+		}
+		var msgs []conversation.Message
+		if err := json.Unmarshal([]byte(msgsJSON), &msgs); err != nil {
+			return nil, fmt.Errorf("transcript: unmarshal candidate %q: %w", id, err)
+		}
+		out = append(out, candidate{id: id, messages: msgs, messageCount: len(msgs), updatedAt: updatedMs})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("transcript: iterate candidates: %w", err)
+	}
+	return out, nil
+}
+
+// upsertCanonical writes the canonical row for the decision. created/forked
+// INSERT a new row; extended overwrites messages (longer history); idempotent
+// refreshes recency/provenance only (never shrinks). Legacy rows (audit columns
+// defaulted to ”) are backfilled when touched.
+func (s *Store) upsertCanonical(ctx context.Context, dec stitchDecision, key, source, callID string, incoming []conversation.Message, now int64) error {
+	switch dec.status {
+	case statusCreated, statusForked:
+		msgsJSON, err := json.Marshal(incoming)
+		if err != nil {
+			return fmt.Errorf("transcript: marshal canonical messages: %w", err)
+		}
+		identity := source
+		if dec.status == statusForked {
+			identity = identityForked
+		}
+		if _, err := s.db.ExecContext(ctx,
+			`INSERT INTO conversations
+			   (id, title, messages, created_at, updated_at,
+			    conversation_key, identity_source, latest_call_id, message_count, stitch_status)
+			 VALUES (?,?,?,?,?,?,?,?,?,?)`,
+			dec.targetID, conversationTitle(incoming), string(msgsJSON), now, now,
+			key, identity, callID, len(incoming), dec.status,
+		); err != nil {
+			return fmt.Errorf("transcript: insert canonical: %w", err)
+		}
+		return nil
+
+	case statusExtended:
+		msgsJSON, err := json.Marshal(incoming)
+		if err != nil {
+			return fmt.Errorf("transcript: marshal canonical messages: %w", err)
+		}
+		if _, err := s.db.ExecContext(ctx,
+			`UPDATE conversations SET
+			    messages = ?, updated_at = ?, latest_call_id = ?,
+			    message_count = ?, stitch_status = ?,
+			    conversation_key = ?,
+			    identity_source = CASE WHEN identity_source = '' THEN ? ELSE identity_source END,
+			    title = CASE WHEN title = '' THEN ? ELSE title END
+			  WHERE id = ?`,
+			string(msgsJSON), now, callID, len(incoming), statusExtended,
+			key, source, conversationTitle(incoming), dec.targetID,
+		); err != nil {
+			return fmt.Errorf("transcript: extend canonical: %w", err)
+		}
+		return nil
+
+	case statusIdempotent:
+		// No shrink: refresh recency + provenance, keep the stored messages.
+		if _, err := s.db.ExecContext(ctx,
+			`UPDATE conversations SET
+			    updated_at = ?, latest_call_id = ?, stitch_status = ?,
+			    conversation_key = CASE WHEN conversation_key = '' THEN ? ELSE conversation_key END,
+			    identity_source = CASE WHEN identity_source = '' THEN ? ELSE identity_source END
+			  WHERE id = ?`,
+			now, callID, statusIdempotent, key, source, dec.targetID,
+		); err != nil {
+			return fmt.Errorf("transcript: idempotent update: %w", err)
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("transcript: unknown stitch status %q", dec.status)
+	}
+}
+
+func (s *Store) finalizeRawOK(ctx context.Context, callID string, dec stitchDecision, key string) error {
+	if dec.status == statusForked && dec.targetID != key {
+		_, err := s.db.ExecContext(ctx,
+			`UPDATE raw_chat_calls SET projection_status = 'ok',
+			    conversation_id = ?, identity_source = ? WHERE call_id = ?`,
+			dec.targetID, identityForked, callID,
+		)
+		return err
+	}
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE raw_chat_calls SET projection_status = 'ok' WHERE call_id = ?`, callID,
+	)
+	return err
+}
+
+func (s *Store) finalizeRawError(ctx context.Context, callID string, cause error) {
+	if _, err := s.db.ExecContext(ctx,
+		`UPDATE raw_chat_calls SET projection_status = 'error', projection_error = ? WHERE call_id = ?`,
+		cause.Error(), callID,
+	); err != nil {
+		log.Printf("transcript: failed to mark projection error for call %s: %v", callID, err)
+	}
+}
+
+func newCallID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+func nonNilMessages(msgs []conversation.Message) []conversation.Message {
+	if msgs == nil {
+		return []conversation.Message{}
+	}
+	return msgs
+}
+
+// conversationTitle returns the first user message content trimmed to 80 runes.
+func conversationTitle(msgs []conversation.Message) string {
+	for _, m := range msgs {
+		if m.Role == "user" {
+			return trimRunes(m.Content, 80)
+		}
+	}
+	return ""
+}
+
+func trimRunes(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max])
 }

--- a/transcript/store.go
+++ b/transcript/store.go
@@ -1,0 +1,82 @@
+// transcript/store.go
+package transcript
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// Store persists MCP chat calls: an immutable raw_chat_calls row (source of
+// truth) followed by a best-effort canonical conversations projection. Safe for
+// concurrent use — a store-level mutex serializes Record so concurrent same-key
+// calls cannot interleave their stitch decisions.
+type Store struct {
+	db    *sql.DB
+	ownDB bool
+
+	mu             sync.Mutex // serializes Record (preserves the stitch invariant)
+	now            func() time.Time
+	leaseWindow    time.Duration
+	shortThreshold int
+
+	closeOnce sync.Once
+}
+
+// Open opens (or creates) a transcript database at path and runs migrations.
+// Pass ":memory:" explicitly for in-process tests (empty string is rejected to
+// avoid the default-string footgun). The returned store owns the *sql.DB and
+// closes it on Close.
+func Open(ctx context.Context, path string) (*Store, error) {
+	if path == "" {
+		return nil, fmt.Errorf("transcript: Open requires non-empty path; pass \":memory:\" explicitly")
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("transcript: open sqlite %q: %w", path, err)
+	}
+	// modernc.org/sqlite applies PRAGMAs per-connection; clamp the pool to one
+	// connection so the WAL + busy_timeout settings hold for every write, and so
+	// :memory: does not open a fresh private DB per connection.
+	db.SetMaxOpenConns(1)
+	if path != ":memory:" {
+		for _, pragma := range []string{"PRAGMA journal_mode=WAL", "PRAGMA busy_timeout=5000"} {
+			if _, err := db.ExecContext(ctx, pragma); err != nil {
+				_ = db.Close()
+				return nil, fmt.Errorf("transcript: %s: %w", pragma, err)
+			}
+		}
+	}
+	if err := migrate(ctx, db); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return &Store{
+		db:             db,
+		ownDB:          true,
+		now:            time.Now,
+		leaseWindow:    defaultLeaseWindow,
+		shortThreshold: defaultShortThreshold,
+	}, nil
+}
+
+// Close releases the underlying *sql.DB. Safe to call multiple times.
+func (s *Store) Close() error {
+	var err error
+	s.closeOnce.Do(func() {
+		if s.ownDB {
+			err = s.db.Close()
+		}
+	})
+	return err
+}
+
+// Record is implemented in Task 9. Stub keeps the package compiling.
+func (s *Store) Record(ctx context.Context, in RecordInput) error {
+	_ = in
+	return nil
+}

--- a/transcript/store.go
+++ b/transcript/store.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -24,6 +26,7 @@ import (
 type Store struct {
 	db    *sql.DB
 	ownDB bool
+	path  string
 
 	mu             sync.Mutex // serializes Record (preserves the stitch invariant)
 	now            func() time.Time
@@ -41,6 +44,11 @@ func Open(ctx context.Context, path string) (*Store, error) {
 	if path == "" {
 		return nil, fmt.Errorf("transcript: Open requires non-empty path; pass \":memory:\" explicitly")
 	}
+	if path != ":memory:" {
+		if err := prepareTranscriptDBFile(path); err != nil {
+			return nil, err
+		}
+	}
 	db, err := sql.Open("sqlite", path)
 	if err != nil {
 		return nil, fmt.Errorf("transcript: open sqlite %q: %w", path, err)
@@ -56,18 +64,87 @@ func Open(ctx context.Context, path string) (*Store, error) {
 				return nil, fmt.Errorf("transcript: %s: %w", pragma, err)
 			}
 		}
+		if err := chmodTranscriptDBFiles(path); err != nil {
+			_ = db.Close()
+			return nil, err
+		}
 	}
 	if err := migrate(ctx, db); err != nil {
 		_ = db.Close()
 		return nil, err
 	}
+	if path != ":memory:" {
+		if err := chmodTranscriptDBFiles(path); err != nil {
+			_ = db.Close()
+			return nil, err
+		}
+	}
 	return &Store{
 		db:             db,
 		ownDB:          true,
+		path:           dbPath(path),
 		now:            time.Now,
 		leaseWindow:    defaultLeaseWindow,
 		shortThreshold: defaultShortThreshold,
 	}, nil
+}
+
+const (
+	transcriptDirMode  os.FileMode = 0o700
+	transcriptFileMode os.FileMode = 0o600
+)
+
+func prepareTranscriptDBFile(path string) error {
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, transcriptDirMode); err != nil {
+			return fmt.Errorf("transcript: create directory %q: %w", dir, err)
+		}
+	}
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, transcriptFileMode)
+	if err != nil {
+		return fmt.Errorf("transcript: create sqlite %q: %w", path, err)
+	}
+	if err := f.Chmod(transcriptFileMode); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("transcript: chmod sqlite %q: %w", path, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("transcript: close sqlite %q: %w", path, err)
+	}
+	return nil
+}
+
+func dbPath(path string) string {
+	if path == ":memory:" {
+		return ""
+	}
+	return path
+}
+
+func chmodTranscriptDBFiles(path string) error {
+	for _, file := range []string{path, path + "-wal", path + "-shm"} {
+		if err := chmodTranscriptFileIfExists(file); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func chmodTranscriptFileIfExists(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("transcript: stat %q: %w", path, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("transcript: %q is a directory", path)
+	}
+	if err := os.Chmod(path, transcriptFileMode); err != nil {
+		return fmt.Errorf("transcript: chmod %q: %w", path, err)
+	}
+	return nil
 }
 
 // Close releases the underlying *sql.DB. Safe to call multiple times.
@@ -87,6 +164,16 @@ func (s *Store) Close() error {
 // failure is logged, recorded on the raw row, and swallowed so a non-nil return
 // always means "nothing was persisted."
 func (s *Store) Record(ctx context.Context, in RecordInput) error {
+	if s.path != "" {
+		if err := chmodTranscriptDBFiles(s.path); err != nil {
+			return err
+		}
+		defer func() {
+			if err := chmodTranscriptDBFiles(s.path); err != nil {
+				log.Printf("transcript: failed to secure sqlite files: %v", err)
+			}
+		}()
+	}
 	callID, err := newCallID()
 	if err != nil {
 		return fmt.Errorf("transcript: generate call id: %w", err)

--- a/transcript/store_test.go
+++ b/transcript/store_test.go
@@ -201,3 +201,53 @@ func TestRecord_PersistsRouteOutcomeJSON(t *testing.T) {
 		t.Errorf("route_outcome_json = %v, want %s", got, ro)
 	}
 }
+
+func TestRecord_ProjectionErrorStillPersistsRaw(t *testing.T) {
+	s, _ := Open(context.Background(), ":memory:")
+	defer func() { _ = s.Close() }()
+	// Force projection failure: remove the canonical table after open. The raw
+	// append still succeeds (raw_chat_calls intact).
+	if _, err := s.db.Exec(`DROP TABLE conversations`); err != nil {
+		t.Fatalf("drop conversations: %v", err)
+	}
+
+	if err := s.Record(context.Background(), RecordInput{
+		Request:  []conversation.Message{{Role: "user", Content: "hi"}},
+		Response: conversation.Message{Role: "assistant", Content: "yo"},
+	}); err != nil {
+		t.Fatalf("Record should swallow projection error and return nil, got %v", err)
+	}
+
+	var status string
+	var perr sql.NullString
+	if err := s.db.QueryRow(`SELECT projection_status, projection_error FROM raw_chat_calls`).Scan(&status, &perr); err != nil {
+		t.Fatalf("read raw row: %v", err)
+	}
+	if status != "error" || !perr.Valid || perr.String == "" {
+		t.Errorf("raw row status=%q err=%v, want error + non-empty reason", status, perr)
+	}
+}
+
+func TestRecord_RawAppendErrorPersistsNothing(t *testing.T) {
+	s, _ := Open(context.Background(), ":memory:")
+	defer func() { _ = s.Close() }()
+	// Force raw-append failure: remove the raw table.
+	if _, err := s.db.Exec(`DROP TABLE raw_chat_calls`); err != nil {
+		t.Fatalf("drop raw_chat_calls: %v", err)
+	}
+
+	if err := s.Record(context.Background(), RecordInput{
+		Request:  []conversation.Message{{Role: "user", Content: "hi"}},
+		Response: conversation.Message{Role: "assistant", Content: "yo"},
+	}); err == nil {
+		t.Fatal("Record should return an error when the raw append fails")
+	}
+
+	var convRows int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM conversations`).Scan(&convRows); err != nil {
+		t.Fatal(err)
+	}
+	if convRows != 0 {
+		t.Errorf("conversations rows = %d, want 0 (nothing persisted)", convRows)
+	}
+}

--- a/transcript/store_test.go
+++ b/transcript/store_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/kstruzzieri/go-llm/conversation"
@@ -249,5 +250,55 @@ func TestRecord_RawAppendErrorPersistsNothing(t *testing.T) {
 	}
 	if convRows != 0 {
 		t.Errorf("conversations rows = %d, want 0 (nothing persisted)", convRows)
+	}
+}
+
+func TestRecord_ConcurrentSameKeyNoRaceSingleRow(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "t.db")
+	s, err := Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	const n = 16
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Identical history under a fixed explicit id → first creates, the
+			// rest are idempotent; serialization must prevent a double-fork.
+			_ = s.Record(context.Background(), RecordInput{
+				ConversationID: "conv-fixed",
+				Request:        []conversation.Message{{Role: "user", Content: "hi"}},
+				Response:       conversation.Message{Role: "assistant", Content: "yo"},
+			})
+		}()
+	}
+	wg.Wait()
+
+	var rows int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM conversations`).Scan(&rows); err != nil {
+		t.Fatal(err)
+	}
+	if rows != 1 {
+		t.Errorf("conversation rows = %d, want 1 (no interleaved double-fork/insert)", rows)
+	}
+
+	var rawRows int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM raw_chat_calls`).Scan(&rawRows); err != nil {
+		t.Fatal(err)
+	}
+	if rawRows != n {
+		t.Errorf("raw rows = %d, want %d (one durable row per call)", rawRows, n)
+	}
+
+	var projectionErrors int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM raw_chat_calls WHERE projection_status != 'ok'`).Scan(&projectionErrors); err != nil {
+		t.Fatal(err)
+	}
+	if projectionErrors != 0 {
+		t.Errorf("raw rows with non-ok projection_status = %d, want 0", projectionErrors)
 	}
 }

--- a/transcript/store_test.go
+++ b/transcript/store_test.go
@@ -1,0 +1,43 @@
+// transcript/store_test.go
+package transcript
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpen_RejectsEmptyPath(t *testing.T) {
+	if _, err := Open(context.Background(), ""); err == nil {
+		t.Fatal("Open(\"\") should error")
+	}
+}
+
+func TestOpen_MemoryAndCloseIdempotent(t *testing.T) {
+	s, err := Open(context.Background(), ":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}
+
+func TestOpen_FileUsesWAL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "t.db")
+	s, err := Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+	var mode string
+	if err := s.db.QueryRow("PRAGMA journal_mode").Scan(&mode); err != nil {
+		t.Fatalf("query journal_mode: %v", err)
+	}
+	if mode != "wal" {
+		t.Errorf("journal_mode = %q, want wal", mode)
+	}
+}

--- a/transcript/store_test.go
+++ b/transcript/store_test.go
@@ -3,6 +3,7 @@ package transcript
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"path/filepath"
 	"testing"
@@ -90,5 +91,113 @@ func TestRecord_CreatesCanonicalAndRawRow(t *testing.T) {
 	}
 	if model != "qwen3:8b" || provider != "ollama" || pstatus != "ok" {
 		t.Errorf("raw row model=%q provider=%q status=%q, want qwen3:8b/ollama/ok", model, provider, pstatus)
+	}
+}
+
+func recordTurn(t *testing.T, s *Store, req []conversation.Message, resp string) {
+	t.Helper()
+	if err := s.Record(context.Background(), RecordInput{
+		Request:  req,
+		Response: conversation.Message{Role: "assistant", Content: resp},
+	}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+}
+
+func countConversations(t *testing.T, s *Store) int {
+	t.Helper()
+	var n int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM conversations`).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	return n
+}
+
+func TestRecord_ExtendsAcrossTurns(t *testing.T) {
+	s, _ := Open(context.Background(), ":memory:")
+	defer func() { _ = s.Close() }()
+
+	recordTurn(t, s, []conversation.Message{{Role: "user", Content: "hi"}}, "hello")
+	recordTurn(t, s, []conversation.Message{
+		{Role: "user", Content: "hi"},
+		{Role: "assistant", Content: "hello"},
+		{Role: "user", Content: "more"},
+	}, "sure")
+
+	if n := countConversations(t, s); n != 1 {
+		t.Fatalf("conversation rows = %d, want 1 (extended, not forked)", n)
+	}
+	var msgCount int
+	var status string
+	if err := s.db.QueryRow(`SELECT message_count, stitch_status FROM conversations`).Scan(&msgCount, &status); err != nil {
+		t.Fatal(err)
+	}
+	if msgCount != 4 || status != statusExtended {
+		t.Errorf("got count=%d status=%q, want 4/extended", msgCount, status)
+	}
+}
+
+func TestRecord_DivergentSessionsForkUnderSameKey(t *testing.T) {
+	s, _ := Open(context.Background(), ":memory:")
+	defer func() { _ = s.Close() }()
+
+	recordTurn(t, s, []conversation.Message{
+		{Role: "user", Content: "hi"}, {Role: "assistant", Content: "A"}, {Role: "user", Content: "x"},
+	}, "ansA")
+	recordTurn(t, s, []conversation.Message{
+		{Role: "user", Content: "hi"}, {Role: "assistant", Content: "B"}, {Role: "user", Content: "y"},
+	}, "ansB")
+
+	if n := countConversations(t, s); n != 2 {
+		t.Fatalf("conversation rows = %d, want 2 siblings", n)
+	}
+	var distinctKeys int
+	if err := s.db.QueryRow(`SELECT COUNT(DISTINCT conversation_key) FROM conversations`).Scan(&distinctKeys); err != nil {
+		t.Fatal(err)
+	}
+	if distinctKeys != 1 {
+		t.Errorf("distinct conversation_key = %d, want 1 (siblings share the key)", distinctKeys)
+	}
+}
+
+func TestRecord_ExtendsForkedSibling(t *testing.T) {
+	s, _ := Open(context.Background(), ":memory:")
+	defer func() { _ = s.Close() }()
+
+	recordTurn(t, s, []conversation.Message{
+		{Role: "user", Content: "hi"}, {Role: "assistant", Content: "A"}, {Role: "user", Content: "x"},
+	}, "ansA")
+	recordTurn(t, s, []conversation.Message{
+		{Role: "user", Content: "hi"}, {Role: "assistant", Content: "B"}, {Role: "user", Content: "y"},
+	}, "ansB") // diverges → fork
+	// Next turn of the forked session: it resends its own full history + a turn.
+	recordTurn(t, s, []conversation.Message{
+		{Role: "user", Content: "hi"}, {Role: "assistant", Content: "B"}, {Role: "user", Content: "y"},
+		{Role: "assistant", Content: "ansB"}, {Role: "user", Content: "z"},
+	}, "ansB2")
+
+	if n := countConversations(t, s); n != 2 {
+		t.Fatalf("conversation rows = %d, want 2 (sibling extended, not a 3rd fork)", n)
+	}
+}
+
+func TestRecord_PersistsRouteOutcomeJSON(t *testing.T) {
+	s, _ := Open(context.Background(), ":memory:")
+	defer func() { _ = s.Close() }()
+
+	ro := json.RawMessage(`{"planned_model":{"provider":"ollama","model":"qwen3:8b"}}`)
+	if err := s.Record(context.Background(), RecordInput{
+		Request:      []conversation.Message{{Role: "user", Content: "hi"}},
+		Response:     conversation.Message{Role: "assistant", Content: "yo"},
+		RouteOutcome: ro,
+	}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	var got sql.NullString
+	if err := s.db.QueryRow(`SELECT route_outcome_json FROM raw_chat_calls`).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.Valid || got.String != string(ro) {
+		t.Errorf("route_outcome_json = %v, want %s", got, ro)
 	}
 }

--- a/transcript/store_test.go
+++ b/transcript/store_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -44,6 +46,49 @@ func TestOpen_FileUsesWAL(t *testing.T) {
 	}
 	if mode != "wal" {
 		t.Errorf("journal_mode = %q, want wal", mode)
+	}
+}
+
+func TestOpen_FileUsesPrivatePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file mode bits are not portable on Windows")
+	}
+	dir := filepath.Join(t.TempDir(), "private", "nested")
+	path := filepath.Join(dir, "t.db")
+	s, err := Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	assertPerm(t, dir, transcriptDirMode)
+	assertPerm(t, path, transcriptFileMode)
+
+	if err := s.Record(context.Background(), RecordInput{
+		Request:  []conversation.Message{{Role: "user", Content: "hello"}},
+		Response: conversation.Message{Role: "assistant", Content: "hi"},
+	}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	for _, sidecar := range []string{path + "-wal", path + "-shm"} {
+		if _, err := os.Stat(sidecar); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			t.Fatalf("stat sidecar %q: %v", sidecar, err)
+		}
+		assertPerm(t, sidecar, transcriptFileMode)
+	}
+}
+
+func assertPerm(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %q: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("%s mode = %o, want %o", path, got, want)
 	}
 }
 

--- a/transcript/store_test.go
+++ b/transcript/store_test.go
@@ -225,6 +225,21 @@ func TestRecord_ExtendsForkedSibling(t *testing.T) {
 	if n := countConversations(t, s); n != 2 {
 		t.Fatalf("conversation rows = %d, want 2 (sibling extended, not a 3rd fork)", n)
 	}
+
+	var forkID string
+	if err := s.db.QueryRow(`SELECT id FROM conversations WHERE identity_source = ?`, identityForked).Scan(&forkID); err != nil {
+		t.Fatalf("read forked conversation id: %v", err)
+	}
+	var forkRawRows int
+	if err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM raw_chat_calls WHERE conversation_id = ? AND identity_source = ?`,
+		forkID, identityForked,
+	).Scan(&forkRawRows); err != nil {
+		t.Fatalf("count fork raw rows: %v", err)
+	}
+	if forkRawRows != 2 {
+		t.Errorf("raw rows under fork id = %d, want 2 (fork creation + later extension)", forkRawRows)
+	}
 }
 
 func TestRecord_PersistsRouteOutcomeJSON(t *testing.T) {

--- a/transcript/store_test.go
+++ b/transcript/store_test.go
@@ -3,8 +3,11 @@ package transcript
 
 import (
 	"context"
+	"encoding/json"
 	"path/filepath"
 	"testing"
+
+	"github.com/kstruzzieri/go-llm/conversation"
 )
 
 func TestOpen_RejectsEmptyPath(t *testing.T) {
@@ -39,5 +42,53 @@ func TestOpen_FileUsesWAL(t *testing.T) {
 	}
 	if mode != "wal" {
 		t.Errorf("journal_mode = %q, want wal", mode)
+	}
+}
+
+func TestRecord_CreatesCanonicalAndRawRow(t *testing.T) {
+	s, err := Open(context.Background(), ":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	in := RecordInput{
+		Request:  []conversation.Message{{Role: "user", Content: "hello"}},
+		Response: conversation.Message{Role: "assistant", Content: "hi there"},
+		Model:    "qwen3:8b",
+		Provider: "ollama",
+	}
+	if err := s.Record(context.Background(), in); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	var (
+		msgsJSON, status string
+		msgCount         int
+	)
+	if err := s.db.QueryRow(
+		`SELECT messages, message_count, stitch_status FROM conversations`,
+	).Scan(&msgsJSON, &msgCount, &status); err != nil {
+		t.Fatalf("read canonical: %v", err)
+	}
+	if status != statusCreated || msgCount != 2 {
+		t.Errorf("canonical status=%q count=%d, want created/2", status, msgCount)
+	}
+	var stored []conversation.Message
+	if err := json.Unmarshal([]byte(msgsJSON), &stored); err != nil {
+		t.Fatalf("unmarshal stored messages: %v", err)
+	}
+	if len(stored) != 2 || stored[1].Role != "assistant" || stored[1].Content != "hi there" {
+		t.Errorf("stored messages = %+v", stored)
+	}
+
+	var model, provider, pstatus string
+	if err := s.db.QueryRow(
+		`SELECT model, provider, projection_status FROM raw_chat_calls`,
+	).Scan(&model, &provider, &pstatus); err != nil {
+		t.Fatalf("read raw: %v", err)
+	}
+	if model != "qwen3:8b" || provider != "ollama" || pstatus != "ok" {
+		t.Errorf("raw row model=%q provider=%q status=%q, want qwen3:8b/ollama/ok", model, provider, pstatus)
 	}
 }


### PR DESCRIPTION
## Summary
- Adds **opt-in** conversation persistence to the MCP server via a new `transcript/` package, so real go-llm usage accumulates capturable benchmark traces.
- **Off by default** — enabled only via the new `-conversation-db <path>` flag (or `mcp.WithTranscriptStore`). When unset, nothing is written.
- **Raw-first storage:** an immutable append-only log of chat calls (the durable source of truth) plus a best-effort canonical `conversations` projection that is a strict superset of the columns the `llm-bench` capture reader already consumes — captured traces need no schema changes, and a pre-existing `conversation/` DB is migrated additively.
- **Best-effort:** persistence never fails the chat tool, and it survives request-context cancellation (the common IDE-client pattern).
- **Privacy:** the local DB stores unredacted prompts/responses; the flag help and option docs warn not to commit or share it.

## Test plan
- [x] `go test ./...` green
- [x] `go test -race ./transcript/ ./mcp/ ./cmd/llm-bench/` clean (single-writer concurrency verified)
- [x] `go vet ./...` clean; `gofmt` clean on all changed files
- [x] End-to-end: a session written by the store is read cleanly by the real capture reader (1 written / 0 skipped)
- [x] Unit coverage for durability under forced failure, conversation stitching/identity, and legacy-DB migration

Generated with [Claude Code](https://claude.com/claude-code)