### PR TITLE
[codex] use categorical judge calibration

### DIFF
--- a/cmd/llm-bench/calibration.go
+++ b/cmd/llm-bench/calibration.go
@@ -260,9 +260,10 @@ func validExpectedAnswerQuality(v float64) bool {
 }
 
 const (
-	calibrationAgreementDelta   = 0.25
-	calibrationPassThreshold    = 0.85
-	calibrationDefaultMinLabels = 50
+	calibrationAgreementDelta          = 0.25
+	calibrationPassThreshold           = 0.85
+	calibrationBorderlinePassThreshold = 0.80
+	calibrationDefaultMinLabels        = 50
 )
 
 type calibrationAgreementMode string
@@ -338,6 +339,7 @@ type CalibrationResult struct {
 	HarshDisagreementCount   int
 	LenientDisagreementCount int
 	KnownFixtures            map[string]knownFixtureOutcome
+	StratifiedGateFailures   []string
 	MinLabels                int
 	StabilityRuns            int
 	Verdict                  string // PASS / FAIL / INSUFFICIENT_LABELS
@@ -363,8 +365,8 @@ type perLabelOutcome struct {
 // runCalibrate loads (labels, artifacts), invokes the scorer once per
 // matched (label, artifact) pair, and computes the agreement rate against
 // human ExpectedAnswerQuality values. The verdict is INSUFFICIENT_LABELS
-// when MatchedCount < MinLabels, otherwise PASS when AgreementRate is at
-// least calibrationPassThreshold (0.85), else FAIL.
+// when MatchedCount < MinLabels, otherwise PASS only when overall agreement
+// reaches calibrationPassThreshold (0.85) and all stratified gates pass.
 //
 // The synthesized Trace inside the loop uses a placeholder System and a
 // single empty user turn so Scorer.Score's signature is satisfied. The
@@ -495,13 +497,16 @@ func runCalibrate(ctx context.Context, opts calibrateOptions) (CalibrationResult
 	finalizeSubset(&res.R1Anchor)
 	finalizeSubset(&res.Borderline)
 	finalizeSubset(&res.ClearOne)
+	res.StratifiedGateFailures = calibrationStratifiedGateFailures(res)
 	switch {
 	case res.MatchedCount < opts.MinLabels:
 		res.Verdict = "INSUFFICIENT_LABELS"
-	case res.AgreementRate >= calibrationPassThreshold:
-		res.Verdict = "PASS"
-	default:
+	case res.AgreementRate < calibrationPassThreshold:
 		res.Verdict = "FAIL"
+	case len(res.StratifiedGateFailures) > 0:
+		res.Verdict = "FAIL"
+	default:
+		res.Verdict = "PASS"
 	}
 	if opts.ReportDir != "" {
 		path, writeErr := writeCalibrationReport(opts.ReportDir, opts.JudgeModel, res, opts.Clock)
@@ -535,6 +540,21 @@ func finalizeSubset(s *calibrationSubsetSummary) {
 	if s.Count > 0 {
 		s.AgreementRate = float64(s.AgreeCount) / float64(s.Count)
 	}
+}
+
+func calibrationStratifiedGateFailures(res CalibrationResult) []string {
+	var failures []string
+	if res.Borderline.Count > 0 && res.Borderline.AgreementRate < calibrationBorderlinePassThreshold {
+		failures = append(failures, fmt.Sprintf("borderline/fail agreement %.0f%% below %.0f%% threshold (%d/%d)",
+			res.Borderline.AgreementRate*100, calibrationBorderlinePassThreshold*100, res.Borderline.AgreeCount, res.Borderline.Count))
+	}
+	for _, id := range knownSubtleBugFixtureIDs {
+		fixture := res.KnownFixtures[id]
+		if fixture.Present && !fixture.Pass {
+			failures = append(failures, fmt.Sprintf("known subtle-bug fixture %s judged 1.0", id))
+		}
+	}
+	return failures
 }
 
 func calibrationScorer(s Scorer, stabilityRuns int) Scorer {
@@ -606,6 +626,16 @@ func writeCalibrationReport(dir, judgeModel string, res CalibrationResult, clock
 	fmt.Fprintf(&b, "| clear-1.0 | %s |\n", formatSubsetAgreement(res.ClearOne))
 	fmt.Fprintf(&b, "\nHarsh disagreements: %d\n", res.HarshDisagreementCount)
 	fmt.Fprintf(&b, "Lenient disagreements: %d\n\n", res.LenientDisagreementCount)
+	if len(res.StratifiedGateFailures) == 0 {
+		fmt.Fprintln(&b, "Stratified gate failures: none")
+		fmt.Fprintln(&b)
+	} else {
+		fmt.Fprintln(&b, "Stratified gate failures:")
+		for _, failure := range res.StratifiedGateFailures {
+			fmt.Fprintf(&b, "- %s\n", failure)
+		}
+		fmt.Fprintln(&b)
+	}
 	fmt.Fprintln(&b, "## Known subtle-bug fixtures")
 	fmt.Fprintln(&b, "| trace_id | expected | judge | roll-call |")
 	fmt.Fprintln(&b, "|---|---|---|---|")

--- a/cmd/llm-bench/calibration.go
+++ b/cmd/llm-bench/calibration.go
@@ -265,6 +265,41 @@ const (
 	calibrationDefaultMinLabels = 50
 )
 
+type calibrationAgreementMode string
+
+const (
+	calibrationAgreementExact     calibrationAgreementMode = "exact"
+	calibrationAgreementTolerance calibrationAgreementMode = "tolerance"
+)
+
+func normalizeCalibrationAgreementMode(mode calibrationAgreementMode) (calibrationAgreementMode, error) {
+	if mode == "" {
+		return calibrationAgreementExact, nil
+	}
+	switch mode {
+	case calibrationAgreementExact, calibrationAgreementTolerance:
+		return mode, nil
+	default:
+		return "", fmt.Errorf("invalid calibrate agreement mode %q (want exact or tolerance)", mode)
+	}
+}
+
+type calibrationSubsetSummary struct {
+	Count         int
+	AgreeCount    int
+	AgreementRate float64
+}
+
+type knownFixtureOutcome struct {
+	TraceID  string
+	Expected float64
+	Judge    float64
+	Present  bool
+	Pass     bool
+}
+
+var knownSubtleBugFixtureIDs = []string{"fa-f03", "fa-c05", "fa-g04"}
+
 // calibrateOptions configures runCalibrate.
 //
 // MinLabels defaults to calibrationDefaultMinLabels (50) when zero so a
@@ -280,23 +315,34 @@ type calibrateOptions struct {
 	ReportDir     string
 	MinLabels     int // defaults to calibrationDefaultMinLabels when zero
 	StabilityRuns int // when >1, runs the judge exactly N times per artifact and reports max-min spread as a diagnostic (does NOT gate the PASS/FAIL verdict); uses bypass-cache (Task 23)
+	AgreementMode calibrationAgreementMode
 	Clock         func() time.Time
 }
 
 // CalibrationResult is the in-memory summary returned by runCalibrate. The
 // markdown report contains the same data plus per-label rows.
 type CalibrationResult struct {
-	JudgeModel          string
-	MatchedCount        int
-	StaleCount          int
-	SelfJudgedSkipCount int
-	AgreeCount          int
-	AgreementRate       float64
-	MinLabels           int
-	StabilityRuns       int
-	Verdict             string // PASS / FAIL / INSUFFICIENT_LABELS
-	ReportPath          string
-	PerLabel            []perLabelOutcome
+	JudgeModel               string
+	MatchedCount             int
+	StaleCount               int
+	SelfJudgedSkipCount      int
+	AgreeCount               int
+	AgreementRate            float64
+	AgreementMode            calibrationAgreementMode
+	ToleranceAgreeCount      int
+	ToleranceAgreementRate   float64
+	Overall                  calibrationSubsetSummary
+	R1Anchor                 calibrationSubsetSummary
+	Borderline               calibrationSubsetSummary
+	ClearOne                 calibrationSubsetSummary
+	HarshDisagreementCount   int
+	LenientDisagreementCount int
+	KnownFixtures            map[string]knownFixtureOutcome
+	MinLabels                int
+	StabilityRuns            int
+	Verdict                  string // PASS / FAIL / INSUFFICIENT_LABELS
+	ReportPath               string
+	PerLabel                 []perLabelOutcome
 }
 
 // perLabelOutcome is one row of the calibration report: a label paired with
@@ -309,6 +355,8 @@ type perLabelOutcome struct {
 	Judge           float64
 	Delta           float64
 	Agree           bool
+	ToleranceAgree  bool
+	LabelNotes      string
 	StabilitySpread float64
 }
 
@@ -330,6 +378,10 @@ func runCalibrate(ctx context.Context, opts calibrateOptions) (CalibrationResult
 	if opts.Scorer == nil {
 		return CalibrationResult{}, errors.New("calibrate: nil scorer")
 	}
+	agreementMode, err := normalizeCalibrationAgreementMode(opts.AgreementMode)
+	if err != nil {
+		return CalibrationResult{}, err
+	}
 	if opts.MinLabels == 0 {
 		opts.MinLabels = calibrationDefaultMinLabels
 	}
@@ -342,6 +394,11 @@ func runCalibrate(ctx context.Context, opts calibrateOptions) (CalibrationResult
 		StaleCount:    len(stale),
 		MinLabels:     opts.MinLabels,
 		StabilityRuns: opts.StabilityRuns,
+		AgreementMode: agreementMode,
+		KnownFixtures: make(map[string]knownFixtureOutcome, len(knownSubtleBugFixtureIDs)),
+	}
+	for _, id := range knownSubtleBugFixtureIDs {
+		res.KnownFixtures[id] = knownFixtureOutcome{TraceID: id}
 	}
 	for _, m := range matched {
 		if sameModelSelector(opts.JudgeModel, m.Artifact.CandidateModel) {
@@ -367,13 +424,21 @@ func runCalibrate(ctx context.Context, opts calibrateOptions) (CalibrationResult
 		if delta < 0 {
 			delta = -delta
 		}
+		exactAgree := score.AnswerQuality == m.Label.ExpectedAnswerQuality
+		toleranceAgree := delta <= calibrationAgreementDelta
+		agree := exactAgree
+		if agreementMode == calibrationAgreementTolerance {
+			agree = toleranceAgree
+		}
 		outcome := perLabelOutcome{
 			TraceID:        m.Artifact.TraceID,
 			CandidateModel: m.Artifact.CandidateModel,
 			Expected:       m.Label.ExpectedAnswerQuality,
 			Judge:          score.AnswerQuality,
 			Delta:          delta,
-			Agree:          delta <= calibrationAgreementDelta,
+			Agree:          agree,
+			ToleranceAgree: toleranceAgree,
+			LabelNotes:     m.Label.LabelNotes,
 		}
 		if opts.StabilityRuns > 1 {
 			scores := []float64{score.AnswerQuality}
@@ -391,11 +456,45 @@ func runCalibrate(ctx context.Context, opts calibrateOptions) (CalibrationResult
 		if outcome.Agree {
 			res.AgreeCount++
 		}
+		if outcome.ToleranceAgree {
+			res.ToleranceAgreeCount++
+		}
+		addSubsetOutcome(&res.Overall, outcome.Agree)
+		if labelHasToken(outcome.LabelNotes, "r1-anchor") {
+			addSubsetOutcome(&res.R1Anchor, outcome.Agree)
+		}
+		if outcome.Expected == 0 || outcome.Expected == 0.5 {
+			addSubsetOutcome(&res.Borderline, outcome.Agree)
+		}
+		if outcome.Expected == 1 {
+			addSubsetOutcome(&res.ClearOne, outcome.Agree)
+		}
+		if !outcome.Agree {
+			if outcome.Judge < outcome.Expected {
+				res.HarshDisagreementCount++
+			} else if outcome.Judge > outcome.Expected {
+				res.LenientDisagreementCount++
+			}
+		}
+		if _, ok := res.KnownFixtures[outcome.TraceID]; ok {
+			res.KnownFixtures[outcome.TraceID] = knownFixtureOutcome{
+				TraceID:  outcome.TraceID,
+				Expected: outcome.Expected,
+				Judge:    outcome.Judge,
+				Present:  true,
+				Pass:     outcome.Judge != 1,
+			}
+		}
 		res.MatchedCount++
 	}
 	if res.MatchedCount > 0 {
 		res.AgreementRate = float64(res.AgreeCount) / float64(res.MatchedCount)
+		res.ToleranceAgreementRate = float64(res.ToleranceAgreeCount) / float64(res.MatchedCount)
 	}
+	finalizeSubset(&res.Overall)
+	finalizeSubset(&res.R1Anchor)
+	finalizeSubset(&res.Borderline)
+	finalizeSubset(&res.ClearOne)
 	switch {
 	case res.MatchedCount < opts.MinLabels:
 		res.Verdict = "INSUFFICIENT_LABELS"
@@ -412,6 +511,30 @@ func runCalibrate(ctx context.Context, opts calibrateOptions) (CalibrationResult
 		res.ReportPath = path
 	}
 	return res, nil
+}
+
+func labelHasToken(notes, token string) bool {
+	for _, field := range strings.FieldsFunc(strings.ToLower(notes), func(r rune) bool {
+		return r == ',' || r == ';' || r == ' ' || r == '\t' || r == '\n'
+	}) {
+		if field == token {
+			return true
+		}
+	}
+	return false
+}
+
+func addSubsetOutcome(s *calibrationSubsetSummary, agree bool) {
+	s.Count++
+	if agree {
+		s.AgreeCount++
+	}
+}
+
+func finalizeSubset(s *calibrationSubsetSummary) {
+	if s.Count > 0 {
+		s.AgreementRate = float64(s.AgreeCount) / float64(s.Count)
+	}
 }
 
 func calibrationScorer(s Scorer, stabilityRuns int) Scorer {
@@ -472,6 +595,31 @@ func writeCalibrationReport(dir, judgeModel string, res CalibrationResult, clock
 	fmt.Fprintf(&b, "Self-judged labels skipped: %d\n", res.SelfJudgedSkipCount)
 	fmt.Fprintf(&b, "Agreement: %d / %d (%.0f%%) → **%s**\n\n",
 		res.AgreeCount, res.MatchedCount, res.AgreementRate*100, res.Verdict)
+	fmt.Fprintf(&b, "Agreement mode: %s\n", res.AgreementMode)
+	fmt.Fprintf(&b, "Old tolerance diagnostic: %d / %d (%.0f%%) would have agreed under |judge - expected| <= %.2f\n\n",
+		res.ToleranceAgreeCount, res.MatchedCount, res.ToleranceAgreementRate*100, calibrationAgreementDelta)
+	fmt.Fprintln(&b, "| subset | agreement |")
+	fmt.Fprintln(&b, "|---|---|")
+	fmt.Fprintf(&b, "| overall | %s |\n", formatSubsetAgreement(res.Overall))
+	fmt.Fprintf(&b, "| R1-60 anchor | %s |\n", formatSubsetAgreement(res.R1Anchor))
+	fmt.Fprintf(&b, "| Borderline/fail subset | %s |\n", formatSubsetAgreement(res.Borderline))
+	fmt.Fprintf(&b, "| clear-1.0 | %s |\n", formatSubsetAgreement(res.ClearOne))
+	fmt.Fprintf(&b, "\nHarsh disagreements: %d\n", res.HarshDisagreementCount)
+	fmt.Fprintf(&b, "Lenient disagreements: %d\n\n", res.LenientDisagreementCount)
+	fmt.Fprintln(&b, "## Known subtle-bug fixtures")
+	fmt.Fprintln(&b, "| trace_id | expected | judge | roll-call |")
+	fmt.Fprintln(&b, "|---|---|---|---|")
+	for _, id := range knownSubtleBugFixtureIDs {
+		f := res.KnownFixtures[id]
+		status := "MISSING"
+		if f.Present && f.Pass {
+			status = "PASS"
+		} else if f.Present {
+			status = "FAIL"
+		}
+		fmt.Fprintf(&b, "| %s | %.2f | %.2f | %s |\n", id, f.Expected, f.Judge, status)
+	}
+	fmt.Fprintln(&b)
 	fmt.Fprintln(&b, "| trace_id | candidate | expected | judge | Δ | agree | stability |")
 	fmt.Fprintln(&b, "|---|---|---|---|---|---|---|")
 	for _, p := range res.PerLabel {
@@ -498,6 +646,13 @@ func writeCalibrationReport(dir, judgeModel string, res CalibrationResult, clock
 		return "", fmt.Errorf("close %q: %w", path, err)
 	}
 	return path, nil
+}
+
+func formatSubsetAgreement(s calibrationSubsetSummary) string {
+	if s.Count == 0 {
+		return "0 / 0 (n/a)"
+	}
+	return fmt.Sprintf("%d / %d (%.0f%%)", s.AgreeCount, s.Count, s.AgreementRate*100)
 }
 
 func createCalibrationReportFile(dir, judgeModel string, now time.Time) (*os.File, string, error) {

--- a/cmd/llm-bench/calibration_test.go
+++ b/cmd/llm-bench/calibration_test.go
@@ -338,22 +338,16 @@ func TestRunCalibrate_UsesArtifactTraceRubric(t *testing.T) {
 	}
 }
 
-func TestRunCalibrate_AgreementMatchesByHand(t *testing.T) {
+func TestRunCalibrate_ExactAgreementIsDefault(t *testing.T) {
 	dir := t.TempDir()
 	arts := filepath.Join(dir, "artifacts.jsonl")
 	labels := filepath.Join(dir, "labels.jsonl")
-	reportDir := filepath.Join(dir, "reports")
 
-	// 4 artifacts, 4 labels:
-	// - label 0: expected 1.0, judge 1.0 → agree (Δ=0)
-	// - label 1: expected 1.0, judge 0.6 → disagree (Δ=0.4 > 0.25)
-	// - label 2: expected 0.5, judge 0.7 → agree (Δ=0.2 ≤ 0.25)
-	// - label 3: expected 0.0, judge 0.25 → agree (Δ=0.25 == 0.25)
 	var artifacts []any
 	var labelRecs []any
 	judge := map[string]float64{}
 	expected := []float64{1.0, 1.0, 0.5, 0.0}
-	judged := []float64{1.0, 0.6, 0.7, 0.25}
+	judged := []float64{1.0, 0.6, 0.5, 0.25}
 	for i := 0; i < 4; i++ {
 		traceID := fmt.Sprintf("t%d", i)
 		a := testCalibrationArtifact(traceID, traceID)
@@ -377,19 +371,130 @@ func TestRunCalibrate_AgreementMatchesByHand(t *testing.T) {
 		ArtifactsPath: arts,
 		Scorer:        fs,
 		JudgeModel:    "ollama/judge",
-		ReportDir:     reportDir,
 		MinLabels:     2, // lower threshold for the test
-		Clock:         func() time.Time { return time.Date(2026, 5, 25, 0, 0, 0, 0, time.UTC) },
 	})
 	if err != nil {
 		t.Fatalf("runCalibrate: %v", err)
 	}
-	if res.MatchedCount != 4 || res.AgreeCount != 3 {
-		t.Fatalf("MatchedCount=%d AgreeCount=%d; want 4 / 3", res.MatchedCount, res.AgreeCount)
+	if res.AgreementMode != calibrationAgreementExact {
+		t.Fatalf("AgreementMode=%q; want exact", res.AgreementMode)
 	}
-	// 3 of 4 agreed = 75% < 85% threshold → FAIL.
+	if res.MatchedCount != 4 || res.AgreeCount != 2 {
+		t.Fatalf("MatchedCount=%d AgreeCount=%d; want 4 / 2 exact matches", res.MatchedCount, res.AgreeCount)
+	}
+	if res.ToleranceAgreeCount != 3 {
+		t.Fatalf("ToleranceAgreeCount=%d; want old tolerance diagnostic: 3", res.ToleranceAgreeCount)
+	}
 	if res.Verdict != "FAIL" {
-		t.Fatalf("Verdict=%q; want FAIL (3/4 = 75%% below 85%% threshold)", res.Verdict)
+		t.Fatalf("Verdict=%q; want FAIL (2/4 exact below 85%% threshold)", res.Verdict)
+	}
+}
+
+func TestRunCalibrate_ToleranceAgreementModeStillAvailable(t *testing.T) {
+	dir := t.TempDir()
+	arts := filepath.Join(dir, "artifacts.jsonl")
+	labels := filepath.Join(dir, "labels.jsonl")
+	a := testCalibrationArtifact("t", "answer")
+	if err := writeJSONL(arts, []any{a}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONL(labels, []any{Label{
+		TraceID: "t", CandidateModel: "ollama/c", ArtifactHash: a.ArtifactHash,
+		ExpectedAnswerQuality: 0.5, Labeler: "manual",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := runCalibrate(context.Background(), calibrateOptions{
+		LabelsPath: labels, ArtifactsPath: arts,
+		Scorer:        &fakeScorer{judgeByTrace: map[string]float64{"t": 0.75}},
+		JudgeModel:    "ollama/judge",
+		MinLabels:     1,
+		AgreementMode: calibrationAgreementTolerance,
+	})
+	if err != nil {
+		t.Fatalf("runCalibrate: %v", err)
+	}
+	if res.AgreeCount != 1 || res.ToleranceAgreeCount != 1 {
+		t.Fatalf("AgreeCount=%d ToleranceAgreeCount=%d; want 1/1 in tolerance mode", res.AgreeCount, res.ToleranceAgreeCount)
+	}
+}
+
+func TestRunCalibrate_StrataHarshLenientAndKnownFixtures(t *testing.T) {
+	dir := t.TempDir()
+	arts := filepath.Join(dir, "artifacts.jsonl")
+	labels := filepath.Join(dir, "labels.jsonl")
+	reportDir := filepath.Join(dir, "reports")
+
+	rows := []struct {
+		id    string
+		exp   float64
+		judge float64
+		notes string
+	}{
+		{id: "fa-f03", exp: 0.5, judge: 1.0, notes: "r1-anchor"},
+		{id: "fa-c05", exp: 0.0, judge: 0.0, notes: "r1-anchor"},
+		{id: "fa-g04", exp: 0.5, judge: 0.5, notes: "r1-anchor"},
+		{id: "clear-good", exp: 1.0, judge: 0.5, notes: "judge-validation-fixture"},
+	}
+	var artifacts []any
+	var labelsOut []any
+	judged := map[string]float64{}
+	for _, row := range rows {
+		a := testCalibrationArtifact(row.id, "answer "+row.id)
+		artifacts = append(artifacts, a)
+		labelsOut = append(labelsOut, Label{
+			TraceID: row.id, CandidateModel: "ollama/c", ArtifactHash: a.ArtifactHash,
+			ExpectedAnswerQuality: row.exp, LabelNotes: row.notes, Labeler: "manual",
+		})
+		judged[row.id] = row.judge
+	}
+	if err := writeJSONL(arts, artifacts); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONL(labels, labelsOut); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := runCalibrate(context.Background(), calibrateOptions{
+		LabelsPath: labels, ArtifactsPath: arts,
+		Scorer:     &fakeScorer{judgeByTrace: judged},
+		JudgeModel: "ollama/judge", MinLabels: 1, ReportDir: reportDir,
+		Clock: func() time.Time { return time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatalf("runCalibrate: %v", err)
+	}
+	if res.Borderline.Count != 3 || res.Borderline.AgreeCount != 2 {
+		t.Fatalf("Borderline=%+v; want 3 count / 2 agree", res.Borderline)
+	}
+	if res.ClearOne.Count != 1 || res.ClearOne.AgreeCount != 0 {
+		t.Fatalf("ClearOne=%+v; want 1 count / 0 agree", res.ClearOne)
+	}
+	if res.R1Anchor.Count != 3 {
+		t.Fatalf("R1Anchor.Count=%d; want 3", res.R1Anchor.Count)
+	}
+	if res.LenientDisagreementCount != 1 || res.HarshDisagreementCount != 1 {
+		t.Fatalf("lenient=%d harsh=%d; want 1/1", res.LenientDisagreementCount, res.HarshDisagreementCount)
+	}
+	got := res.KnownFixtures["fa-f03"]
+	if got.Pass || got.Judge != 1.0 {
+		t.Fatalf("fa-f03 roll-call=%+v; want FAIL because judge emitted 1.0", got)
+	}
+	report, err := os.ReadFile(res.ReportPath)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	for _, want := range []string{
+		"Agreement mode: exact",
+		"Old tolerance diagnostic:",
+		"Borderline/fail subset",
+		"Known subtle-bug fixtures",
+		"| fa-f03 | 0.50 | 1.00 | FAIL |",
+	} {
+		if !strings.Contains(string(report), want) {
+			t.Fatalf("report missing %q:\n%s", want, report)
+		}
 	}
 }
 
@@ -619,7 +724,7 @@ func TestRunCalibrate_StabilityRunsReportSpread(t *testing.T) {
 	}}); err != nil {
 		t.Fatal(err)
 	}
-	fs := &fakeStabilityScorer{sequence: []float64{0.8, 1.0, 0.6}} // primary=0.8, spread across 3 runs = 0.4
+	fs := &fakeStabilityScorer{sequence: []float64{1.0, 0.5, 1.0}} // primary=1.0, spread across 3 runs = 0.5
 	res, err := runCalibrate(context.Background(), calibrateOptions{
 		LabelsPath: labels, ArtifactsPath: arts, Scorer: fs,
 		JudgeModel: "ollama/judge", MinLabels: 1, StabilityRuns: 3,
@@ -630,8 +735,8 @@ func TestRunCalibrate_StabilityRunsReportSpread(t *testing.T) {
 	if len(res.PerLabel) != 1 {
 		t.Fatalf("PerLabel=%d; want 1", len(res.PerLabel))
 	}
-	if res.PerLabel[0].StabilitySpread != 0.4 {
-		t.Fatalf("StabilitySpread=%v; want 0.4", res.PerLabel[0].StabilitySpread)
+	if res.PerLabel[0].StabilitySpread != 0.5 {
+		t.Fatalf("StabilitySpread=%v; want 0.5", res.PerLabel[0].StabilitySpread)
 	}
 	if fs.callCount != 3 {
 		t.Fatalf("Score calls=%d; want 3 total stability samples", fs.callCount)

--- a/cmd/llm-bench/calibration_test.go
+++ b/cmd/llm-bench/calibration_test.go
@@ -498,6 +498,71 @@ func TestRunCalibrate_StrataHarshLenientAndKnownFixtures(t *testing.T) {
 	}
 }
 
+func TestRunCalibrate_StrataGateFailuresAffectVerdict(t *testing.T) {
+	dir := t.TempDir()
+	arts := filepath.Join(dir, "artifacts.jsonl")
+	labels := filepath.Join(dir, "labels.jsonl")
+
+	var artifacts []any
+	var labelsOut []any
+	judged := map[string]float64{}
+	for i := 0; i < 17; i++ {
+		traceID := fmt.Sprintf("clear-%02d", i)
+		a := testCalibrationArtifact(traceID, "answer "+traceID)
+		artifacts = append(artifacts, a)
+		labelsOut = append(labelsOut, Label{
+			TraceID: traceID, CandidateModel: "ollama/c", ArtifactHash: a.ArtifactHash,
+			ExpectedAnswerQuality: 1.0, Labeler: "manual",
+		})
+		judged[traceID] = 1.0
+	}
+	borderlineRows := []struct {
+		id    string
+		exp   float64
+		judge float64
+	}{
+		{id: "fa-f03", exp: 0.5, judge: 1.0},
+		{id: "borderline-miss", exp: 0.5, judge: 1.0},
+		{id: "borderline-hit", exp: 0.5, judge: 0.5},
+	}
+	for _, row := range borderlineRows {
+		a := testCalibrationArtifact(row.id, "answer "+row.id)
+		artifacts = append(artifacts, a)
+		labelsOut = append(labelsOut, Label{
+			TraceID: row.id, CandidateModel: "ollama/c", ArtifactHash: a.ArtifactHash,
+			ExpectedAnswerQuality: row.exp, Labeler: "manual",
+		})
+		judged[row.id] = row.judge
+	}
+	if err := writeJSONL(arts, artifacts); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONL(labels, labelsOut); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := runCalibrate(context.Background(), calibrateOptions{
+		LabelsPath: labels, ArtifactsPath: arts,
+		Scorer:     &fakeScorer{judgeByTrace: judged},
+		JudgeModel: "ollama/judge", MinLabels: 1,
+	})
+	if err != nil {
+		t.Fatalf("runCalibrate: %v", err)
+	}
+	if res.AgreementRate < calibrationPassThreshold {
+		t.Fatalf("test setup invalid: overall agreement=%v, want >= %v", res.AgreementRate, calibrationPassThreshold)
+	}
+	if res.Verdict != "FAIL" {
+		t.Fatalf("Verdict=%q; want FAIL when overall passes but stratified gates fail", res.Verdict)
+	}
+	failures := strings.Join(res.StratifiedGateFailures, "\n")
+	for _, want := range []string{"borderline/fail", "fa-f03"} {
+		if !strings.Contains(failures, want) {
+			t.Fatalf("StratifiedGateFailures=%q; want mention %q", failures, want)
+		}
+	}
+}
+
 func TestRunCalibrate_SkipsSelfJudgedArtifacts(t *testing.T) {
 	dir := t.TempDir()
 	arts := filepath.Join(dir, "artifacts.jsonl")

--- a/cmd/llm-bench/judge_cache.go
+++ b/cmd/llm-bench/judge_cache.go
@@ -87,6 +87,13 @@ type judgeCacheStore interface {
 	Close() error
 }
 
+// judgeCachePresenceStore is implemented by stores that can perform a
+// speculative lookup without counting an absent key as a miss. Hits still
+// behave like Get hits: hit counters and last_used_at are updated.
+type judgeCachePresenceStore interface {
+	GetIfPresent(ctx context.Context, key string) (judgeCacheEntry, bool, error)
+}
+
 // Sentinel errors so callers can distinguish the four failure modes per
 // feedback_error_granularity. All four are non-fatal: callers log + bypass
 // to a direct judge call.
@@ -219,6 +226,17 @@ func (c *sqliteJudgeCache) Stats() (int64, int64) {
 // returned entry reflects the post-bump values so caller telemetry sees
 // the same state the DB now holds.
 func (c *sqliteJudgeCache) Get(ctx context.Context, key string) (judgeCacheEntry, bool, error) {
+	return c.get(ctx, key, true)
+}
+
+// GetIfPresent returns the entry for key when present, but an absent key does
+// not increment the miss counter. Use this only for speculative alternate-key
+// probes where a miss should not affect benchmark cache-hit provenance.
+func (c *sqliteJudgeCache) GetIfPresent(ctx context.Context, key string) (judgeCacheEntry, bool, error) {
+	return c.get(ctx, key, false)
+}
+
+func (c *sqliteJudgeCache) get(ctx context.Context, key string, countMiss bool) (judgeCacheEntry, bool, error) {
 	var e judgeCacheEntry
 	var createdNs, lastUsedNs int64
 	err := c.db.QueryRowContext(ctx, `
@@ -232,7 +250,9 @@ func (c *sqliteJudgeCache) Get(ctx context.Context, key string) (judgeCacheEntry
 		&createdNs, &lastUsedNs, &e.HitCount,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
-		c.misses.Add(1)
+		if countMiss {
+			c.misses.Add(1)
+		}
 		return judgeCacheEntry{}, false, nil
 	}
 	if err != nil {

--- a/cmd/llm-bench/judge_cache_test.go
+++ b/cmd/llm-bench/judge_cache_test.go
@@ -311,8 +311,8 @@ func TestJudgeCacheGetPreservesVerdictOnHit(t *testing.T) {
 	ctx := context.Background()
 	want := judgeCacheEntry{
 		CacheKey: "k", JudgeModel: "j", TraceID: "t", CandidateModel: "cm",
-		PromptHash: "p", RequestJSON: "{}", ResponseContent: `{"answer_quality":0.7}`,
-		AnswerQuality: 0.7, Justification: "good",
+		PromptHash: "p", RequestJSON: "{}", ResponseContent: `{"answer_quality":0.5}`,
+		AnswerQuality: 0.5, Justification: "good",
 	}
 	if err := c.Put(ctx, want); err != nil {
 		t.Fatalf("Put: %v", err)

--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -45,6 +45,7 @@ func main() {
 	labelsOut := flag.String("labels-out", filepath.Join("docs", "llm", "calibration", "artifacts.jsonl"), "Output path for -calibrate-capture artifacts.jsonl")
 	artifactsPath := flag.String("artifacts", filepath.Join("docs", "llm", "calibration", "artifacts.jsonl"), "Path to artifacts.jsonl (Phase 2)")
 	calibrateReportDir := flag.String("calibrate-report-dir", filepath.Join("docs", "llm", "calibration", "reports"), "Directory for calibration reports")
+	calibrateAgreement := flag.String("calibrate-agreement", string(calibrationAgreementExact), "Calibration agreement mode: exact or tolerance")
 	judgeStabilityRuns := flag.Int("judge-stability-runs", 0, "When >1, run the judge that many times per artifact (cache bypassed) and report spread as a diagnostic")
 
 	tracesGlob := flag.String("traces", "", "Glob pattern for trace JSON files (required for normal runs and -calibrate-capture)")
@@ -187,6 +188,7 @@ func main() {
 			JudgeModel:    judgeName,
 			ReportDir:     *calibrateReportDir,
 			StabilityRuns: *judgeStabilityRuns,
+			AgreementMode: calibrationAgreementMode(*calibrateAgreement),
 		})
 		if err != nil {
 			log.Fatalf("llm-bench: calibrate: %v", err)

--- a/cmd/llm-bench/runner.go
+++ b/cmd/llm-bench/runner.go
@@ -34,6 +34,7 @@ var (
 	errMissingJudgeCriteria     = errors.New("judge scorer requires golden.final_answer_criteria or golden.final_answer_substring")
 	errJudgeSelfPreference      = errors.New("judge model must differ from candidate model")
 	errMalformedJudgeResponse   = errors.New("malformed judge response")
+	errOffGridJudgeScore        = errors.New("off-grid judge answer_quality")
 	errNoAssistantFinalAnswer   = errors.New("judge scorer requires an assistant final answer")
 )
 

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -347,18 +347,12 @@ func (s *LLMJudgeScorer) Score(ctx context.Context, trace Trace, actual Result) 
 	if err != nil {
 		return Score{}, err
 	}
-	if s.Cache != nil && !s.BypassCache {
-		cacheKey := s.cacheKeyForJudgeRequest(req)
-		if hit, ok, getErr := s.Cache.Get(ctx, cacheKey); getErr != nil {
-			fmt.Fprintf(os.Stderr, "llm-bench: judge cache get bypassed: %v\n", getErr)
-		} else if ok {
-			matHit, _, hitErr := materializeJudgement(base, s.JudgeModel, hit.ResponseContent)
-			if hitErr != nil {
-				fmt.Fprintf(os.Stderr, "llm-bench: judge cache hit bypassed: %v\n", hitErr)
-			} else {
-				return matHit, nil
-			}
-		}
+	if hit, ok := s.scoreFromCache(ctx, base, req); ok {
+		return hit, nil
+	}
+	repairReq := repairOffGridJudgeRequest(req)
+	if hit, ok := s.scoreFromCache(ctx, base, repairReq); ok {
+		return hit, nil
 	}
 	content, err := s.callJudge(ctx, req)
 	if err != nil {
@@ -367,7 +361,9 @@ func (s *LLMJudgeScorer) Score(ctx context.Context, trace Trace, actual Result) 
 	requestForCache := req
 	materialized, judgement, err := materializeJudgement(base, s.JudgeModel, content)
 	if errors.Is(err, errOffGridJudgeScore) {
-		repairReq := repairOffGridJudgeRequest(req)
+		if hit, ok := s.scoreFromCache(ctx, base, repairReq); ok {
+			return hit, nil
+		}
 		content, err = s.callJudge(ctx, repairReq)
 		if err != nil {
 			return Score{}, err
@@ -400,6 +396,25 @@ func (s *LLMJudgeScorer) Score(ctx context.Context, trace Trace, actual Result) 
 		}
 	}
 	return materialized, nil
+}
+
+func (s *LLMJudgeScorer) scoreFromCache(ctx context.Context, base Score, req ollama.ChatRequest) (Score, bool) {
+	if s.Cache == nil || s.BypassCache {
+		return Score{}, false
+	}
+	cacheKey := s.cacheKeyForJudgeRequest(req)
+	if hit, ok, getErr := s.Cache.Get(ctx, cacheKey); getErr != nil {
+		fmt.Fprintf(os.Stderr, "llm-bench: judge cache get bypassed: %v\n", getErr)
+		return Score{}, false
+	} else if ok {
+		matHit, _, hitErr := materializeJudgement(base, s.JudgeModel, hit.ResponseContent)
+		if hitErr != nil {
+			fmt.Fprintf(os.Stderr, "llm-bench: judge cache hit bypassed: %v\n", hitErr)
+			return Score{}, false
+		}
+		return matHit, true
+	}
+	return Score{}, false
 }
 
 func (s *LLMJudgeScorer) cacheKeyForJudgeRequest(req ollama.ChatRequest) string {
@@ -574,20 +589,16 @@ func parseJudgeResponse(content string) (judgeResponse, error) {
 
 	var parsed struct {
 		AnswerQuality *float64 `json:"answer_quality"`
-		Score         *float64 `json:"score"`
 		Justification string   `json:"justification"`
 		Notes         string   `json:"notes"`
 	}
 	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
 		return judgeResponse{}, fmt.Errorf("%w: %v", errMalformedJudgeResponse, err)
 	}
-	quality := parsed.AnswerQuality
-	if quality == nil {
-		quality = parsed.Score
-	}
-	if quality == nil {
+	if parsed.AnswerQuality == nil {
 		return judgeResponse{}, fmt.Errorf("%w: missing answer_quality", errMalformedJudgeResponse)
 	}
+	quality := parsed.AnswerQuality
 	if *quality < 0 || *quality > 1 {
 		return judgeResponse{}, fmt.Errorf("%w: answer_quality %.3f outside [0,1]", errMalformedJudgeResponse, *quality)
 	}

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -346,19 +347,8 @@ func (s *LLMJudgeScorer) Score(ctx context.Context, trace Trace, actual Result) 
 	if err != nil {
 		return Score{}, err
 	}
-	var cacheKey string
 	if s.Cache != nil && !s.BypassCache {
-		cacheKey = canonicalCacheKey(judgeCacheRequest{
-			Version:          judgeCacheKeyVersion,
-			JudgeModel:       normalizeModelSelector(s.JudgeModel),
-			JudgeModelDigest: s.JudgeModelDigest,
-			SystemPrompt:     judgeSystemPrompt,
-			UserPrompt:       judgeUserPromptOf(req),
-			Format:           req.Format,
-			Think:            req.Think,
-			Temperature:      judgeTemperature,
-			NumPredict:       judgeTokenBudget,
-		})
+		cacheKey := s.cacheKeyForJudgeRequest(req)
 		if hit, ok, getErr := s.Cache.Get(ctx, cacheKey); getErr != nil {
 			fmt.Fprintf(os.Stderr, "llm-bench: judge cache get bypassed: %v\n", getErr)
 		} else if ok {
@@ -374,12 +364,23 @@ func (s *LLMJudgeScorer) Score(ctx context.Context, trace Trace, actual Result) 
 	if err != nil {
 		return Score{}, err
 	}
+	requestForCache := req
 	materialized, judgement, err := materializeJudgement(base, s.JudgeModel, content)
+	if errors.Is(err, errOffGridJudgeScore) {
+		repairReq := repairOffGridJudgeRequest(req)
+		content, err = s.callJudge(ctx, repairReq)
+		if err != nil {
+			return Score{}, err
+		}
+		materialized, judgement, err = materializeJudgement(base, s.JudgeModel, content)
+		requestForCache = repairReq
+	}
 	if err != nil {
 		return Score{}, err
 	}
-	if s.Cache != nil && !s.BypassCache && cacheKey != "" {
-		sum := sha256.Sum256([]byte(judgeUserPromptOf(req)))
+	if s.Cache != nil && !s.BypassCache {
+		cacheKey := s.cacheKeyForJudgeRequest(requestForCache)
+		sum := sha256.Sum256([]byte(judgeUserPromptOf(requestForCache)))
 		now := s.now()
 		if putErr := s.Cache.Put(ctx, judgeCacheEntry{
 			CacheKey:         cacheKey,
@@ -388,7 +389,7 @@ func (s *LLMJudgeScorer) Score(ctx context.Context, trace Trace, actual Result) 
 			TraceID:          trace.ID,
 			CandidateModel:   actual.Model,
 			PromptHash:       hex.EncodeToString(sum[:]),
-			RequestJSON:      prettyRequestJSON(req),
+			RequestJSON:      prettyRequestJSON(requestForCache),
 			ResponseContent:  content,
 			AnswerQuality:    materialized.AnswerQuality,
 			Justification:    judgement.Justification,
@@ -399,6 +400,20 @@ func (s *LLMJudgeScorer) Score(ctx context.Context, trace Trace, actual Result) 
 		}
 	}
 	return materialized, nil
+}
+
+func (s *LLMJudgeScorer) cacheKeyForJudgeRequest(req ollama.ChatRequest) string {
+	return canonicalCacheKey(judgeCacheRequest{
+		Version:          judgeCacheKeyVersion,
+		JudgeModel:       normalizeModelSelector(s.JudgeModel),
+		JudgeModelDigest: s.JudgeModelDigest,
+		SystemPrompt:     judgeSystemPrompt,
+		UserPrompt:       judgeUserPromptOf(req),
+		Format:           req.Format,
+		Think:            req.Think,
+		Temperature:      judgeTemperature,
+		NumPredict:       judgeTokenBudget,
+	})
 }
 
 // judgeUserPromptOf extracts the user prompt that buildJudgeCall composed.
@@ -426,17 +441,31 @@ func prettyRequestJSON(req ollama.ChatRequest) string {
 	return string(raw)
 }
 
-const judgeSystemPrompt = `You are an impartial evaluator for local LLM benchmark replays.
-Score only the candidate assistant's final answer against the golden rubric.
-Return only valid JSON with this schema:
-{"answer_quality":0.5,"justification":"short reason"}
+const judgeSystemPrompt = "You are an impartial evaluator for local LLM benchmark replays.\n" +
+	"Score only the candidate assistant's final answer against the golden rubric.\n" +
+	"Return only valid JSON with this schema:\n" +
+	"{\"answer_quality\":0.5,\"justification\":\"short reason\"}\n\n" +
+	"answer_quality must be exactly one of `0.0`, `0.5`, or `1.0`:\n" +
+	"0.0 means the answer is wrong, fabricated, absent, or materially misleading.\n" +
+	"0.5 means the answer is partially correct but missing important requirements, or contains a contained technical flaw.\n" +
+	"1.0 means the answer fully satisfies the rubric with no material technical error.\n" +
+	"Penalize unsupported claims, missing requested details, contradictions, and material technical errors.\n" +
+	"Do not reward style, verbosity, or model identity."
 
-answer_quality must be a number from 0 to 1:
-0.0 means the answer is wrong or absent.
-0.5 means the answer is partially correct but misses important requirements.
-1.0 means the answer fully satisfies the rubric.
-Penalize unsupported claims, missing requested details, and contradictions.
-Do not reward style, verbosity, or model identity.`
+const offGridJudgeRepairInstruction = "Repair instruction: answer_quality must be exactly one of 0.0, 0.5, or 1.0. Return only valid JSON matching {\"answer_quality\":0.5,\"justification\":\"short reason\"}."
+
+func repairOffGridJudgeRequest(req ollama.ChatRequest) ollama.ChatRequest {
+	repaired := req
+	repaired.Messages = append([]ollama.ChatMessage(nil), req.Messages...)
+	for i := len(repaired.Messages) - 1; i >= 0; i-- {
+		if repaired.Messages[i].Role == "user" {
+			repaired.Messages[i].Content = strings.TrimSpace(repaired.Messages[i].Content) + "\n\n" + offGridJudgeRepairInstruction
+			return repaired
+		}
+	}
+	repaired.Messages = append(repaired.Messages, ollama.ChatMessage{Role: "user", Content: offGridJudgeRepairInstruction})
+	return repaired
+}
 
 type judgePromptPayload struct {
 	TraceID                       string      `json:"trace_id"`
@@ -562,6 +591,9 @@ func parseJudgeResponse(content string) (judgeResponse, error) {
 	if *quality < 0 || *quality > 1 {
 		return judgeResponse{}, fmt.Errorf("%w: answer_quality %.3f outside [0,1]", errMalformedJudgeResponse, *quality)
 	}
+	if !validJudgeAnswerQuality(*quality) {
+		return judgeResponse{}, fmt.Errorf("%w: answer_quality %.3f must be exactly one of 0.0, 0.5, or 1.0", errOffGridJudgeScore, *quality)
+	}
 
 	justification := strings.TrimSpace(parsed.Justification)
 	if justification == "" {
@@ -575,6 +607,10 @@ func parseJudgeResponse(content string) (judgeResponse, error) {
 		AnswerQuality: *quality,
 		Justification: normalizeNote(justification),
 	}, nil
+}
+
+func validJudgeAnswerQuality(v float64) bool {
+	return v == 0 || v == 0.5 || v == 1
 }
 
 func firstJSONObject(s string) string {

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -351,7 +351,7 @@ func (s *LLMJudgeScorer) Score(ctx context.Context, trace Trace, actual Result) 
 		return hit, nil
 	}
 	repairReq := repairOffGridJudgeRequest(req)
-	if hit, ok := s.scoreFromCache(ctx, base, repairReq); ok {
+	if hit, ok := s.scoreFromCacheIfPresent(ctx, base, repairReq); ok {
 		return hit, nil
 	}
 	content, err := s.callJudge(ctx, req)
@@ -403,18 +403,37 @@ func (s *LLMJudgeScorer) scoreFromCache(ctx context.Context, base Score, req oll
 		return Score{}, false
 	}
 	cacheKey := s.cacheKeyForJudgeRequest(req)
-	if hit, ok, getErr := s.Cache.Get(ctx, cacheKey); getErr != nil {
+	hit, ok, getErr := s.Cache.Get(ctx, cacheKey)
+	return s.materializeCacheLookup(base, hit, ok, getErr)
+}
+
+func (s *LLMJudgeScorer) scoreFromCacheIfPresent(ctx context.Context, base Score, req ollama.ChatRequest) (Score, bool) {
+	if s.Cache == nil || s.BypassCache {
+		return Score{}, false
+	}
+	presenceStore, ok := s.Cache.(judgeCachePresenceStore)
+	if !ok {
+		return Score{}, false
+	}
+	cacheKey := s.cacheKeyForJudgeRequest(req)
+	hit, ok, getErr := presenceStore.GetIfPresent(ctx, cacheKey)
+	return s.materializeCacheLookup(base, hit, ok, getErr)
+}
+
+func (s *LLMJudgeScorer) materializeCacheLookup(base Score, hit judgeCacheEntry, ok bool, getErr error) (Score, bool) {
+	if getErr != nil {
 		fmt.Fprintf(os.Stderr, "llm-bench: judge cache get bypassed: %v\n", getErr)
 		return Score{}, false
-	} else if ok {
-		matHit, _, hitErr := materializeJudgement(base, s.JudgeModel, hit.ResponseContent)
-		if hitErr != nil {
-			fmt.Fprintf(os.Stderr, "llm-bench: judge cache hit bypassed: %v\n", hitErr)
-			return Score{}, false
-		}
-		return matHit, true
 	}
-	return Score{}, false
+	if !ok {
+		return Score{}, false
+	}
+	matHit, _, hitErr := materializeJudgement(base, s.JudgeModel, hit.ResponseContent)
+	if hitErr != nil {
+		fmt.Fprintf(os.Stderr, "llm-bench: judge cache hit bypassed: %v\n", hitErr)
+		return Score{}, false
+	}
+	return matHit, true
 }
 
 func (s *LLMJudgeScorer) cacheKeyForJudgeRequest(req ollama.ChatRequest) string {

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -858,6 +858,16 @@ func TestParseJudgeResponseRejectsOffGridScore(t *testing.T) {
 	}
 }
 
+func TestParseJudgeResponseRejectsScoreOnlyAlias(t *testing.T) {
+	_, err := parseJudgeResponse(`{"score":1.0,"justification":"legacy alias"}`)
+	if !errors.Is(err, errMalformedJudgeResponse) {
+		t.Fatalf("err = %v, want errMalformedJudgeResponse", err)
+	}
+	if err != nil && strings.Contains(err.Error(), "off-grid") {
+		t.Fatalf("err = %v, want schema error instead of off-grid repair", err)
+	}
+}
+
 func TestParseJudgeResponseRejectsOutOfRangeScore(t *testing.T) {
 	_, err := parseJudgeResponse(`{"answer_quality":1.2,"justification":"too high"}`)
 	if !errors.Is(err, errMalformedJudgeResponse) {
@@ -1087,6 +1097,12 @@ func TestLLMJudgeScorer_OffGridRepairCachesOnlyRepairRequest(t *testing.T) {
 	}
 	if !strings.Contains(requestJSON, "Repair instruction") {
 		t.Fatalf("cached request_json does not contain repair instruction:\n%s", requestJSON)
+	}
+	if _, err := scorer.Score(context.Background(), trace, actual); err != nil {
+		t.Fatalf("second Score: %v", err)
+	}
+	if judge.called != 2 {
+		t.Fatalf("judge called %d times after repaired cache hit; want still 2", judge.called)
 	}
 }
 

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -1106,6 +1106,28 @@ func TestLLMJudgeScorer_OffGridRepairCachesOnlyRepairRequest(t *testing.T) {
 	}
 }
 
+func TestLLMJudgeScorer_NormalCacheMissDoesNotCountRepairProbeMiss(t *testing.T) {
+	c, _ := newTestCache(t)
+	judge := &fakeJudgeClient{resp: &ollama.ChatResponse{Message: ollama.ChatMessage{
+		Content: `{"answer_quality":1.0,"justification":"valid first response"}`,
+	}}}
+	scorer := &LLMJudgeScorer{
+		Client:     judge,
+		JudgeModel: "ollama/judge",
+		Cache:      c,
+	}
+	trace := Trace{ID: "normal-cache-miss", System: "s", Turns: []Turn{{Role: "user", Content: "u"}}, Golden: Golden{FinalAnswerCriteria: "c"}}
+	actual := Result{Model: "ollama/candidate", Transcript: []Turn{{Role: "assistant", Content: "answer"}}}
+
+	if _, err := scorer.Score(context.Background(), trace, actual); err != nil {
+		t.Fatalf("Score: %v", err)
+	}
+	hits, misses := c.Stats()
+	if hits != 0 || misses != 1 {
+		t.Fatalf("cache stats after normal miss = hits:%d misses:%d; want hits:0 misses:1", hits, misses)
+	}
+}
+
 func TestLLMJudgeScorer_MalformedCacheHitFallsBackToJudge(t *testing.T) {
 	c, _ := newTestCache(t)
 	judge := &fakeJudgeClient{resp: &ollama.ChatResponse{Message: ollama.ChatMessage{

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -15,7 +15,9 @@ import (
 
 type fakeJudgeClient struct {
 	req    ollama.ChatRequest
+	reqs   []ollama.ChatRequest
 	resp   *ollama.ChatResponse
+	resps  []*ollama.ChatResponse
 	err    error
 	called int
 }
@@ -23,8 +25,16 @@ type fakeJudgeClient struct {
 func (f *fakeJudgeClient) Chat(_ context.Context, req ollama.ChatRequest) (*ollama.ChatResponse, error) {
 	f.called++
 	f.req = req
+	f.reqs = append(f.reqs, req)
 	if f.err != nil {
 		return nil, f.err
+	}
+	if len(f.resps) > 0 {
+		idx := f.called - 1
+		if idx >= len(f.resps) {
+			idx = len(f.resps) - 1
+		}
+		return f.resps[idx], nil
 	}
 	return f.resp, nil
 }
@@ -445,6 +455,40 @@ func TestBuildJudgeCall_PopulatesBaseScoreAndRequest(t *testing.T) {
 	}
 }
 
+func TestBuildJudgeCall_UsesCategoricalJudgeContract(t *testing.T) {
+	trace := Trace{
+		ID:     "categorical-prompt",
+		System: "sys",
+		Turns:  []Turn{{Role: "user", Content: "question"}},
+		Golden: Golden{FinalAnswerCriteria: "answer the question correctly"},
+	}
+	actual := Result{
+		Model:      "ollama/candidate",
+		TraceID:    "categorical-prompt",
+		Transcript: []Turn{{Role: "assistant", Content: "answer"}},
+	}
+	scorer := &LLMJudgeScorer{Client: &fakeJudgeClient{}, JudgeModel: "ollama/judge"}
+
+	req, _, err := scorer.buildJudgeCall(trace, actual)
+	if err != nil {
+		t.Fatalf("buildJudgeCall: %v", err)
+	}
+	system := req.Messages[0].Content
+	for _, want := range []string{
+		"answer_quality must be exactly one of `0.0`, `0.5`, or `1.0`",
+		"0.0 means the answer is wrong, fabricated, absent, or materially misleading.",
+		"0.5 means the answer is partially correct but missing important requirements, or contains a contained technical flaw.",
+		"1.0 means the answer fully satisfies the rubric with no material technical error.",
+	} {
+		if !strings.Contains(system, want) {
+			t.Fatalf("judge system prompt missing %q:\n%s", want, system)
+		}
+	}
+	if strings.Contains(system, "must be a number from 0 to 1") {
+		t.Fatalf("judge system prompt still allows continuous scores:\n%s", system)
+	}
+}
+
 func TestBuildJudgeCall_StripsBenchProviderFromJudgeRequestModel(t *testing.T) {
 	trace := Trace{ID: "t", System: "s", Turns: []Turn{{Role: "user", Content: "x"}}, Golden: Golden{FinalAnswerCriteria: "fc"}}
 	actual := Result{Model: "ollama/cand", TraceID: "t", Transcript: []Turn{{Role: "assistant", Content: "y"}}}
@@ -490,7 +534,7 @@ func TestLLMJudgeScorerScoresFromJSON(t *testing.T) {
 		resp: &ollama.ChatResponse{
 			Message: ollama.ChatMessage{
 				Role:    "assistant",
-				Content: `{"answer_quality":0.75,"justification":"Identifies the main issue but misses the fallback detail."}`,
+				Content: `{"answer_quality":0.5,"justification":"Identifies the main issue but misses the fallback detail."}`,
 			},
 		},
 	}
@@ -523,8 +567,8 @@ func TestLLMJudgeScorerScoresFromJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Score() error: %v", err)
 	}
-	if score.AnswerQuality != 0.75 {
-		t.Fatalf("AnswerQuality = %f, want 0.75", score.AnswerQuality)
+	if score.AnswerQuality != 0.5 {
+		t.Fatalf("AnswerQuality = %f, want 0.5", score.AnswerQuality)
 	}
 	if score.ToolSequenceMatch != 1.0 {
 		t.Fatalf("ToolSequenceMatch = %f, want 1.0", score.ToolSequenceMatch)
@@ -797,13 +841,20 @@ func TestParseJudgeResponseExtractsJSON(t *testing.T) {
 	}
 }
 
-func TestParseJudgeResponseIgnoresTrailingText(t *testing.T) {
-	got, err := parseJudgeResponse("{\"answer_quality\":0.25,\"justification\":\"weak\"}\nextra text")
+func TestParseJudgeResponseIgnoresTrailingTextForCategoricalScore(t *testing.T) {
+	got, err := parseJudgeResponse("{\"answer_quality\":0.5,\"justification\":\"partial\"}\nextra text")
 	if err != nil {
 		t.Fatalf("parseJudgeResponse() error: %v", err)
 	}
-	if got.AnswerQuality != 0.25 {
-		t.Fatalf("AnswerQuality = %f, want 0.25", got.AnswerQuality)
+	if got.AnswerQuality != 0.5 {
+		t.Fatalf("AnswerQuality = %f, want 0.5", got.AnswerQuality)
+	}
+}
+
+func TestParseJudgeResponseRejectsOffGridScore(t *testing.T) {
+	_, err := parseJudgeResponse(`{"answer_quality":0.25,"justification":"between labels"}`)
+	if !errors.Is(err, errOffGridJudgeScore) {
+		t.Fatalf("err = %v, want errOffGridJudgeScore", err)
 	}
 }
 
@@ -832,7 +883,7 @@ func TestLLMJudgeScorer_CacheHit_ReusesContentButRecomputesToolSequenceMatch(t *
 	judge := &fakeJudgeClient{
 		resp: &ollama.ChatResponse{
 			Message: ollama.ChatMessage{
-				Content: `{"answer_quality":0.7,"justification":"meh"}`,
+				Content: `{"answer_quality":0.5,"justification":"meh"}`,
 			},
 		},
 	}
@@ -950,10 +1001,99 @@ func TestLLMJudgeScorer_BypassCache_AlwaysCallsJudgeAndDoesNotPersist(t *testing
 	}
 }
 
+func TestLLMJudgeScorer_OffGridRetriesOnceWithRepairPrompt(t *testing.T) {
+	judge := &fakeJudgeClient{resps: []*ollama.ChatResponse{
+		{Message: ollama.ChatMessage{Content: `{"answer_quality":0.7,"justification":"continuous"}`}},
+		{Message: ollama.ChatMessage{Content: `{"answer_quality":0.5,"justification":"categorical repair"}`}},
+	}}
+	scorer := &LLMJudgeScorer{Client: judge, JudgeModel: "ollama/judge"}
+	trace := Trace{ID: "repair", System: "s", Turns: []Turn{{Role: "user", Content: "u"}}, Golden: Golden{FinalAnswerCriteria: "c"}}
+	actual := Result{Model: "ollama/candidate", Transcript: []Turn{{Role: "assistant", Content: "answer"}}}
+
+	score, err := scorer.Score(context.Background(), trace, actual)
+	if err != nil {
+		t.Fatalf("Score: %v", err)
+	}
+	if score.AnswerQuality != 0.5 {
+		t.Fatalf("AnswerQuality=%v; want repaired 0.5", score.AnswerQuality)
+	}
+	if judge.called != 2 {
+		t.Fatalf("judge called %d times; want initial + one repair", judge.called)
+	}
+	if len(judge.reqs) != 2 || !strings.Contains(judgeUserPromptOf(judge.reqs[1]), "Repair instruction") {
+		t.Fatalf("second request missing repair instruction: %+v", judge.reqs)
+	}
+}
+
+func TestLLMJudgeScorer_OffGridRetryFailureSurfacesError(t *testing.T) {
+	judge := &fakeJudgeClient{resps: []*ollama.ChatResponse{
+		{Message: ollama.ChatMessage{Content: `{"answer_quality":0.7,"justification":"continuous"}`}},
+		{Message: ollama.ChatMessage{Content: `{"answer_quality":0.9,"justification":"still continuous"}`}},
+	}}
+	scorer := &LLMJudgeScorer{Client: judge, JudgeModel: "ollama/judge"}
+	trace := Trace{ID: "repair-fail", System: "s", Turns: []Turn{{Role: "user", Content: "u"}}, Golden: Golden{FinalAnswerCriteria: "c"}}
+	actual := Result{Model: "ollama/candidate", Transcript: []Turn{{Role: "assistant", Content: "answer"}}}
+
+	_, err := scorer.Score(context.Background(), trace, actual)
+	if !errors.Is(err, errOffGridJudgeScore) {
+		t.Fatalf("err=%v; want errOffGridJudgeScore", err)
+	}
+	if judge.called != 2 {
+		t.Fatalf("judge called %d times; want exactly 2", judge.called)
+	}
+}
+
+func TestLLMJudgeScorer_OffGridRepairCachesOnlyRepairRequest(t *testing.T) {
+	c, _ := newTestCache(t)
+	judge := &fakeJudgeClient{resps: []*ollama.ChatResponse{
+		{Message: ollama.ChatMessage{Content: `{"answer_quality":0.7,"justification":"continuous"}`}},
+		{Message: ollama.ChatMessage{Content: `{"answer_quality":0.5,"justification":"repair valid"}`}},
+	}}
+	scorer := &LLMJudgeScorer{
+		Client:           judge,
+		JudgeModel:       "ollama/judge",
+		JudgeModelDigest: "sha256:shim",
+		Cache:            c,
+		Clock:            func() time.Time { return time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC) },
+	}
+	trace := Trace{ID: "repair-cache", System: "s", Turns: []Turn{{Role: "user", Content: "u"}}, Golden: Golden{FinalAnswerCriteria: "c"}}
+	actual := Result{Model: "ollama/candidate", Transcript: []Turn{{Role: "assistant", Content: "answer"}}}
+
+	if _, err := scorer.Score(context.Background(), trace, actual); err != nil {
+		t.Fatalf("Score: %v", err)
+	}
+	var requestJSON string
+	var storedQuality float64
+	var rowCount int
+	rows, err := c.db.Query(`SELECT request_json, answer_quality FROM judge_cache WHERE trace_id = ?`, "repair-cache")
+	if err != nil {
+		t.Fatalf("query repair cache row: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		rowCount++
+		if err := rows.Scan(&requestJSON, &storedQuality); err != nil {
+			t.Fatalf("scan repair cache row: %v", err)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate repair cache rows: %v", err)
+	}
+	if rowCount != 1 {
+		t.Fatalf("cache rows=%d; want 1 valid repaired row", rowCount)
+	}
+	if storedQuality != 0.5 {
+		t.Fatalf("stored answer_quality=%v; want 0.5", storedQuality)
+	}
+	if !strings.Contains(requestJSON, "Repair instruction") {
+		t.Fatalf("cached request_json does not contain repair instruction:\n%s", requestJSON)
+	}
+}
+
 func TestLLMJudgeScorer_MalformedCacheHitFallsBackToJudge(t *testing.T) {
 	c, _ := newTestCache(t)
 	judge := &fakeJudgeClient{resp: &ollama.ChatResponse{Message: ollama.ChatMessage{
-		Content: `{"answer_quality":0.9,"justification":"fresh"}`,
+		Content: `{"answer_quality":1.0,"justification":"fresh"}`,
 	}}}
 	scorer := &LLMJudgeScorer{
 		Client:     judge,
@@ -999,8 +1139,8 @@ func TestLLMJudgeScorer_MalformedCacheHitFallsBackToJudge(t *testing.T) {
 	if judge.called != 1 {
 		t.Fatalf("judge called %d times; want 1 fallback call", judge.called)
 	}
-	if score.AnswerQuality != 0.9 {
-		t.Fatalf("AnswerQuality = %v; want fresh judge score 0.9", score.AnswerQuality)
+	if score.AnswerQuality != 1.0 {
+		t.Fatalf("AnswerQuality = %v; want fresh judge score 1.0", score.AnswerQuality)
 	}
 }
 

--- a/docs/llm/CALIBRATION.md
+++ b/docs/llm/CALIBRATION.md
@@ -102,9 +102,10 @@ already exists for the same timestamp and judge model, a numeric suffix is
 added so prior reports are not overwritten. Verdict is one of:
 
 - **PASS** — exact categorical agreement ≥85% on ≥50 matched non-stale
-  labels.
-- **FAIL** — exact categorical agreement <85% on ≥50 matched non-stale
-  labels.
+  labels, borderline/fail agreement ≥80% when that subset is present, and
+  no known subtle-bug fixture judged as `1.0`.
+- **FAIL** — enough labels exist, but overall exact agreement, the
+  borderline/fail gate, or a known subtle-bug fixture gate failed.
 - **INSUFFICIENT_LABELS** — fewer than 50 matched non-stale labels.
   Never claims PASS. Label more artifacts and rerun.
 
@@ -116,8 +117,9 @@ acceptance.
 
 The report includes overall exact agreement, R1-anchor agreement,
 borderline/fail agreement (`expected_answer_quality` of `0.0` or `0.5`),
-clear-1.0 agreement, harsh and lenient disagreement counts, and a roll-call
-for the known subtle-bug fixtures (`fa-f03`, `fa-c05`, `fa-g04`).
+clear-1.0 agreement, harsh and lenient disagreement counts, stratified gate
+failures, and a roll-call for the known subtle-bug fixtures (`fa-f03`,
+`fa-c05`, `fa-g04`).
 
 A label is "stale" iff its `artifact_hash` doesn't match the current
 `artifacts.jsonl`. Stale labels are listed in the report and excluded from
@@ -159,5 +161,5 @@ to non-floating tags or digests.
 `-calibrate-suggest` (an "active learning" subcommand that highlights
 artifacts most worth labeling) is a planned follow-up. For now, label
 incrementally — start with 20 artifacts, run `-calibrate`, then label
-artifacts where the judge disagreed with your label or where the answer
-falls in the borderline 0.4–0.6 band.
+artifacts where the judge disagreed with your label or where exact labels
+are hardest to assign, especially borderline/fail cases (`0.0` or `0.5`).

--- a/docs/llm/CALIBRATION.md
+++ b/docs/llm/CALIBRATION.md
@@ -48,7 +48,7 @@ Writes one JSON object per line to `artifacts.jsonl`:
 ## Phase 2 — Label the artifacts
 
 Open `artifacts.jsonl` and create a parallel `labels.jsonl` where each line
-adds `expected_answer_quality` ∈ {0.0, 0.5, 1.0}:
+adds `expected_answer_quality` exactly equal to one of `{0.0, 0.5, 1.0}`:
 
 ```json
 {
@@ -70,11 +70,18 @@ Labels with `expected_answer_quality` outside `{0.0, 0.5, 1.0}` are rejected.
 
 ### How to label
 
-- **1.0** — fully satisfies the rubric: every required element present, no
-  contradictions, no unsupported claims.
-- **0.5** — partially correct: gets the gist or some required elements
-  right but misses something material.
-- **0.0** — wrong or absent.
+- **1.0** — fully satisfies the rubric with no material technical error.
+- **0.5** — partially correct but missing important requirements, or
+  contains a contained technical flaw.
+- **0.0** — wrong, fabricated, absent, or materially misleading.
+
+Round 2 uses `label_notes` tokens for calibration-report stratification
+without changing the label schema:
+
+- `r1-anchor` marks the 60 labels carried from Round 1.
+- `judge-validation-fixture` marks curated P1 adversarial fixtures that
+  validate the judge and stay out of the P2 accepted-run corpus unless they
+  are real captured artifacts.
 
 ## Phase 3 — Calibrate
 
@@ -85,7 +92,8 @@ changes).
 llm-bench -calibrate \
   -labels docs/llm/calibration/labels.jsonl \
   -artifacts docs/llm/calibration/artifacts.jsonl \
-  -judge-model ollama/gemma4:31b
+  -judge-model ollama/gemma4:31b \
+  -calibrate-agreement exact
 ```
 
 Writes a markdown report to
@@ -93,10 +101,23 @@ Writes a markdown report to
 already exists for the same timestamp and judge model, a numeric suffix is
 added so prior reports are not overwritten. Verdict is one of:
 
-- **PASS** — agreement ≥85% on ≥50 matched non-stale labels.
-- **FAIL** — agreement <85% on ≥50 matched non-stale labels.
+- **PASS** — exact categorical agreement ≥85% on ≥50 matched non-stale
+  labels.
+- **FAIL** — exact categorical agreement <85% on ≥50 matched non-stale
+  labels.
 - **INSUFFICIENT_LABELS** — fewer than 50 matched non-stale labels.
   Never claims PASS. Label more artifacts and rerun.
+
+Primary agreement is `judge == expected`. The report also prints the retired
+tolerance diagnostic, `|judge - expected| <= 0.25`, so historical comparisons
+remain visible without gating the verdict. `-calibrate-agreement tolerance`
+is retained for historical comparison runs and must not be used for Round 2
+acceptance.
+
+The report includes overall exact agreement, R1-anchor agreement,
+borderline/fail agreement (`expected_answer_quality` of `0.0` or `0.5`),
+clear-1.0 agreement, harsh and lenient disagreement counts, and a roll-call
+for the known subtle-bug fixtures (`fa-f03`, `fa-c05`, `fa-g04`).
 
 A label is "stale" iff its `artifact_hash` doesn't match the current
 `artifacts.jsonl`. Stale labels are listed in the report and excluded from

--- a/docs/llm/benchmark-plan.md
+++ b/docs/llm/benchmark-plan.md
@@ -213,8 +213,11 @@ First implementation slice:
 The judge scorer is calibrated against human labels via a two-phase
 workflow documented in [CALIBRATION.md](CALIBRATION.md). Headline numbers:
 
-- Primary agreement criterion: `|judge - expected| ≤ 0.25`.
-- Pass threshold: ≥85% agreement on ≥50 matched non-stale labels.
+- Primary agreement criterion: exact categorical match, `judge == expected`,
+  where both values are one of `{0.0, 0.5, 1.0}`.
+- Diagnostic only: the report also prints the retired tolerance agreement
+  count, `|judge - expected| ≤ 0.25`.
+- Pass threshold: ≥85% exact agreement on ≥50 matched non-stale labels.
 - Below 50 matched non-stale labels: verdict is `INSUFFICIENT_LABELS`
   (never PASS).
 - Stale labels (label `artifact_hash` ≠ frozen `artifacts.jsonl` hash) are

--- a/docs/llm/benchmark-plan.md
+++ b/docs/llm/benchmark-plan.md
@@ -217,7 +217,9 @@ workflow documented in [CALIBRATION.md](CALIBRATION.md). Headline numbers:
   where both values are one of `{0.0, 0.5, 1.0}`.
 - Diagnostic only: the report also prints the retired tolerance agreement
   count, `|judge - expected| ≤ 0.25`.
-- Pass threshold: ≥85% exact agreement on ≥50 matched non-stale labels.
+- Pass threshold: ≥85% exact agreement on ≥50 matched non-stale labels,
+  borderline/fail agreement ≥80% when that subset is present, and no known
+  subtle-bug fixture judged as `1.0`.
 - Below 50 matched non-stale labels: verdict is `INSUFFICIENT_LABELS`
   (never PASS).
 - Stale labels (label `artifact_hash` ≠ frozen `artifacts.jsonl` hash) are

--- a/docs/llm/benchmarks/TEMPLATE.md
+++ b/docs/llm/benchmarks/TEMPLATE.md
@@ -30,7 +30,8 @@ output.
 - Judge model: `<name>`
 - Labels manifest hash: `sha256:...`
 - Valid labeled artifacts: X (≥50 required → SUFFICIENT)
-- Agreement: X / Y (Z%) — threshold ≥85% → **PASS**
+- Agreement: X / Y (Z%) — overall ≥85%, borderline/fail ≥80% when present,
+  known subtle-bug fixtures pass → **PASS**
 - Stability runs (M=3, diagnostic): max spread observed: 0.NN
 
 ## Results

--- a/docs/llm/harness-results.md
+++ b/docs/llm/harness-results.md
@@ -10,7 +10,9 @@ A benchmark run is "accepted" iff **all** of:
 
 1. **Commit is clean** (`dirty: no` in provenance).
 2. **Calibration PASS** — exact categorical agreement ≥85% on ≥50 valid
-   labeled artifacts, with the old tolerance diagnostic reported for context.
+   labeled artifacts, borderline/fail agreement ≥80% when present, no known
+   subtle-bug fixture judged as `1.0`, and the old tolerance diagnostic
+   reported for context.
 3. **Judge cache hit-rate is reported** (any value; reproducibility signal).
 4. **`ToolArgsValid` is `computed=true` for ≥80% of (model, trace) pairs.**
 5. **Trace set manifest hash is recorded.**

--- a/docs/llm/harness-results.md
+++ b/docs/llm/harness-results.md
@@ -9,7 +9,8 @@
 A benchmark run is "accepted" iff **all** of:
 
 1. **Commit is clean** (`dirty: no` in provenance).
-2. **Calibration PASS** — agreement ≥85% on ≥50 valid labeled artifacts.
+2. **Calibration PASS** — exact categorical agreement ≥85% on ≥50 valid
+   labeled artifacts, with the old tolerance diagnostic reported for context.
 3. **Judge cache hit-rate is reported** (any value; reproducibility signal).
 4. **`ToolArgsValid` is `computed=true` for ≥80% of (model, trace) pairs.**
 5. **Trace set manifest hash is recorded.**


### PR DESCRIPTION
## Summary
- Make llm-judge output categorical answer_quality values only: 0.0, 0.5, or 1.0.
- Reject off-grid judge scores, retry once with a stricter repair prompt, and cache only valid categorical responses under the actual request used.
- Switch calibration to exact categorical agreement by default, keep the old tolerance as a diagnostic, and add stratified calibration reporting.
- Update calibration and accepted-run docs for the exact metric.

## Test Plan
- go test ./cmd/llm-bench
- go test ./...
- git diff --check

## Notes
- This is the standalone Round 2 categorical-judge PR. It intentionally excludes the private frontier shim, raw corpus files, calibration reports, and run notes.