### PR TITLE
fix(llm-bench): enforce subtle-bug fixture gate on prefixed trace IDs

### DIFF
--- a/cmd/llm-bench/calibration.go
+++ b/cmd/llm-bench/calibration.go
@@ -301,6 +301,13 @@ type knownFixtureOutcome struct {
 
 var knownSubtleBugFixtureIDs = []string{"fa-f03", "fa-c05", "fa-g04"}
 
+// normalizeFixtureTraceID maps a captured trace ID to its bare conversation
+// id so known-bug fixtures match regardless of the conversationTraceIDPrefix
+// that capture prepends (see conversationToTrace).
+func normalizeFixtureTraceID(traceID string) string {
+	return strings.TrimPrefix(traceID, conversationTraceIDPrefix)
+}
+
 // calibrateOptions configures runCalibrate.
 //
 // MinLabels defaults to calibrationDefaultMinLabels (50) when zero so a
@@ -400,7 +407,7 @@ func runCalibrate(ctx context.Context, opts calibrateOptions) (CalibrationResult
 		KnownFixtures: make(map[string]knownFixtureOutcome, len(knownSubtleBugFixtureIDs)),
 	}
 	for _, id := range knownSubtleBugFixtureIDs {
-		res.KnownFixtures[id] = knownFixtureOutcome{TraceID: id}
+		res.KnownFixtures[id] = knownFixtureOutcome{TraceID: id, Pass: true}
 	}
 	for _, m := range matched {
 		if sameModelSelector(opts.JudgeModel, m.Artifact.CandidateModel) {
@@ -478,13 +485,22 @@ func runCalibrate(ctx context.Context, opts calibrateOptions) (CalibrationResult
 				res.LenientDisagreementCount++
 			}
 		}
-		if _, ok := res.KnownFixtures[outcome.TraceID]; ok {
-			res.KnownFixtures[outcome.TraceID] = knownFixtureOutcome{
-				TraceID:  outcome.TraceID,
-				Expected: outcome.Expected,
-				Judge:    outcome.Judge,
-				Present:  true,
-				Pass:     outcome.Judge != 1,
+		// Known subtle-bug fixtures gate only the bug instances (expected < 1.0)
+		// and match on the normalized (prefix-stripped) trace id. A fixture fails
+		// if ANY of its bug artifacts is judged a perfect 1.0; record the most
+		// concerning (highest-judge) one for the report.
+		if outcome.Expected < 1 {
+			normID := normalizeFixtureTraceID(outcome.TraceID)
+			if fixture, ok := res.KnownFixtures[normID]; ok {
+				if !fixture.Present || outcome.Judge > fixture.Judge {
+					fixture.Expected = outcome.Expected
+					fixture.Judge = outcome.Judge
+				}
+				fixture.Present = true
+				if outcome.Judge == 1 {
+					fixture.Pass = false
+				}
+				res.KnownFixtures[normID] = fixture
 			}
 		}
 		res.MatchedCount++

--- a/cmd/llm-bench/calibration_test.go
+++ b/cmd/llm-bench/calibration_test.go
@@ -498,6 +498,71 @@ func TestRunCalibrate_StrataHarshLenientAndKnownFixtures(t *testing.T) {
 	}
 }
 
+func TestRunCalibrate_KnownFixturesMatchPrefixedTraceIDs(t *testing.T) {
+	// Captured traces are keyed "conversation-<id>" while the fixture list
+	// is bare ("fa-f03"). The gate must normalize the prefix AND only gate
+	// the known-bug instances (expected < 1.0) — a legitimately-1.0 sibling
+	// artifact on the same trace must not count.
+	dir := t.TempDir()
+	arts := filepath.Join(dir, "artifacts.jsonl")
+	labels := filepath.Join(dir, "labels.jsonl")
+
+	rows := []struct {
+		id    string
+		exp   float64
+		judge float64
+	}{
+		{id: "conversation-fa-f03", exp: 0.5, judge: 1.0}, // known bug judged perfect -> FAIL
+		{id: "conversation-fa-c05", exp: 0.5, judge: 0.5}, // known bug caught -> PASS
+		{id: "conversation-fa-g04", exp: 1.0, judge: 1.0}, // only a legit 1.0 artifact -> NOT gated
+	}
+	var artifacts []any
+	var labelsOut []any
+	judged := map[string]float64{}
+	for _, row := range rows {
+		a := testCalibrationArtifact(row.id, "answer "+row.id)
+		artifacts = append(artifacts, a)
+		labelsOut = append(labelsOut, Label{
+			TraceID: row.id, CandidateModel: "ollama/c", ArtifactHash: a.ArtifactHash,
+			ExpectedAnswerQuality: row.exp, Labeler: "manual",
+		})
+		judged[row.id] = row.judge
+	}
+	if err := writeJSONL(arts, artifacts); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONL(labels, labelsOut); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := runCalibrate(context.Background(), calibrateOptions{
+		LabelsPath: labels, ArtifactsPath: arts,
+		Scorer:     &fakeScorer{judgeByTrace: judged},
+		JudgeModel: "ollama/judge", MinLabels: 1,
+	})
+	if err != nil {
+		t.Fatalf("runCalibrate: %v", err)
+	}
+	if f := res.KnownFixtures["fa-f03"]; !f.Present || f.Pass || f.Judge != 1.0 {
+		t.Fatalf("fa-f03=%+v; want Present + FAIL (prefixed id must match, judge=1.0)", f)
+	}
+	if f := res.KnownFixtures["fa-c05"]; !f.Present || !f.Pass {
+		t.Fatalf("fa-c05=%+v; want Present + PASS (judge caught the bug at 0.5)", f)
+	}
+	if f := res.KnownFixtures["fa-g04"]; f.Present {
+		t.Fatalf("fa-g04=%+v; want NOT Present (no expected<1.0 instance to gate)", f)
+	}
+	gateFound := false
+	for _, gf := range res.StratifiedGateFailures {
+		if strings.Contains(gf, "fa-f03") {
+			gateFound = true
+		}
+	}
+	if !gateFound {
+		t.Fatalf("StratifiedGateFailures=%v; want a fa-f03 known-bug failure", res.StratifiedGateFailures)
+	}
+}
+
 func TestRunCalibrate_StrataGateFailuresAffectVerdict(t *testing.T) {
 	dir := t.TempDir()
 	arts := filepath.Join(dir, "artifacts.jsonl")

--- a/cmd/llm-bench/capture.go
+++ b/cmd/llm-bench/capture.go
@@ -21,6 +21,12 @@ import (
 
 const defaultCaptureSource = "conversation-store"
 
+// conversationTraceIDPrefix is prepended to a conversation's id when it
+// becomes a trace (see conversationToTrace). Calibration strips it to match
+// known-bug fixtures; keep the writer and reader on this single constant so
+// the prefix can never drift between them.
+const conversationTraceIDPrefix = "conversation-"
+
 var (
 	errConversationMissingID        = errors.New("conversation has empty id")
 	errConversationMissingSystem    = errors.New("conversation has no system message")
@@ -309,7 +315,7 @@ func conversationToTrace(conv conversation.Conversation, source, fallbackSystem 
 	}
 
 	trace := Trace{
-		ID:         "conversation-" + conv.ID,
+		ID:         conversationTraceIDPrefix + conv.ID,
 		Source:     source,
 		CapturedAt: captureTime(conv),
 		System:     system,


### PR DESCRIPTION
## Problem
The categorical-judge calibration gate from #133 checks that the judge never rates a known subtle-bug answer a perfect `1.0` (`knownSubtleBugFixtureIDs` = `fa-f03`/`fa-c05`/`fa-g04`). But it matched those fixture IDs against raw trace IDs, while captured traces are keyed `conversation-<id>`. The IDs never matched, so every fixture reported `MISSING` and the gate was a silent **no-op** — the regression protection #133 intended did not actually run.

## Fix
- Normalize the `conversation-` prefix when matching fixtures.
- Gate only the known-bug instances (`expected < 1.0`); a legitimately-`1.0` sibling artifact on the same trace can no longer mask the bug.
- A fixture fails if **any** of its bug artifacts is judged `1.0`; record the most concerning one for the report.
- Extract a shared `conversationTraceIDPrefix` const so the capture writer and calibration reader can't drift apart again (the root-cause class).

## Tests
- New test exercises `conversation-`-prefixed IDs plus a legitimately-`1.0` sibling — fails without the fix, passes with it.
- Existing calibration tests stay green; `go test ./cmd/llm-bench/` and `go vet` clean.

## Follow-up (separate)
The fixtures are specific captured trace IDs, so the gate only protects corpora that contain them. Making it durable across corpora (e.g. injected synthetic known-bad fixtures) is tracked separately.

Generated with [Claude Code](https://claude.com/claude-code)