### PR TITLE
feat(llm-bench): judge transports (openai-compat, claude-cli) + provenance + manual scorer

### DIFF
--- a/cmd/llm-bench/calibration.go
+++ b/cmd/llm-bench/calibration.go
@@ -320,7 +320,7 @@ type calibrateOptions struct {
 	ArtifactsPath string
 	Scorer        Scorer
 	JudgeModel    string
-	JudgeProvider string // provider instance identity for report provenance (e.g. "ollama", "openai-compat")
+	JudgeProvider string // provider instance identity for report provenance (e.g. "ollama", "openai-compat:<endpoint-id>")
 	ReportDir     string
 	MinLabels     int // defaults to calibrationDefaultMinLabels when zero
 	StabilityRuns int // when >1, runs the judge exactly N times per artifact and reports max-min spread as a diagnostic (does NOT gate the PASS/FAIL verdict); uses bypass-cache (Task 23)

--- a/cmd/llm-bench/calibration.go
+++ b/cmd/llm-bench/calibration.go
@@ -320,6 +320,7 @@ type calibrateOptions struct {
 	ArtifactsPath string
 	Scorer        Scorer
 	JudgeModel    string
+	JudgeProvider string // provider instance identity for report provenance (e.g. "ollama", "openai-compat")
 	ReportDir     string
 	MinLabels     int // defaults to calibrationDefaultMinLabels when zero
 	StabilityRuns int // when >1, runs the judge exactly N times per artifact and reports max-min spread as a diagnostic (does NOT gate the PASS/FAIL verdict); uses bypass-cache (Task 23)
@@ -331,6 +332,7 @@ type calibrateOptions struct {
 // markdown report contains the same data plus per-label rows.
 type CalibrationResult struct {
 	JudgeModel               string
+	JudgeProvider            string
 	MatchedCount             int
 	StaleCount               int
 	SelfJudgedSkipCount      int
@@ -400,6 +402,7 @@ func runCalibrate(ctx context.Context, opts calibrateOptions) (CalibrationResult
 	}
 	res := CalibrationResult{
 		JudgeModel:    opts.JudgeModel,
+		JudgeProvider: opts.JudgeProvider,
 		StaleCount:    len(stale),
 		MinLabels:     opts.MinLabels,
 		StabilityRuns: opts.StabilityRuns,
@@ -626,6 +629,9 @@ func writeCalibrationReport(dir, judgeModel string, res CalibrationResult, clock
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "# Judge calibration — %s — %s\n\n", judgeModel, now.Format("2006-01-02"))
+	if provider := strings.TrimSpace(res.JudgeProvider); provider != "" {
+		fmt.Fprintf(&b, "Judge provider: %s\n", provider)
+	}
 	fmt.Fprintf(&b, "Matched labels: %d / %d required → %s\n", res.MatchedCount, res.MinLabels, sufficiencyLabel(res))
 	fmt.Fprintf(&b, "Stale labels: %d\n", res.StaleCount)
 	fmt.Fprintf(&b, "Self-judged labels skipped: %d\n", res.SelfJudgedSkipCount)

--- a/cmd/llm-bench/calibration_test.go
+++ b/cmd/llm-bench/calibration_test.go
@@ -498,6 +498,43 @@ func TestRunCalibrate_StrataHarshLenientAndKnownFixtures(t *testing.T) {
 	}
 }
 
+func TestRunCalibrate_ReportRecordsJudgeProvider(t *testing.T) {
+	dir := t.TempDir()
+	arts := filepath.Join(dir, "artifacts.jsonl")
+	labels := filepath.Join(dir, "labels.jsonl")
+	reportDir := filepath.Join(dir, "reports")
+
+	a := testCalibrationArtifact("t1", "answer t1")
+	if err := writeJSONL(arts, []any{a}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONL(labels, []any{Label{
+		TraceID: "t1", CandidateModel: "ollama/c", ArtifactHash: a.ArtifactHash,
+		ExpectedAnswerQuality: 1.0, Labeler: "manual",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := runCalibrate(context.Background(), calibrateOptions{
+		LabelsPath: labels, ArtifactsPath: arts,
+		Scorer:        &fakeScorer{judgeByTrace: map[string]float64{"t1": 1.0}},
+		JudgeModel:    "claude-x",
+		JudgeProvider: "openai-compat",
+		MinLabels:     1, ReportDir: reportDir,
+		Clock: func() time.Time { return time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatalf("runCalibrate: %v", err)
+	}
+	report, err := os.ReadFile(res.ReportPath)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	if !strings.Contains(string(report), "Judge provider: openai-compat") {
+		t.Fatalf("report missing judge provider provenance line:\n%s", report)
+	}
+}
+
 func TestRunCalibrate_KnownFixturesMatchPrefixedTraceIDs(t *testing.T) {
 	// Captured traces are keyed "conversation-<id>" while the fixture list
 	// is bare ("fa-f03"). The gate must normalize the prefix AND only gate

--- a/cmd/llm-bench/judge_cache.go
+++ b/cmd/llm-bench/judge_cache.go
@@ -20,14 +20,23 @@ import (
 
 // judgeCacheKeyVersion is bumped to force-invalidate every entry. Increment
 // when changing the canonical request shape (new field, semantic shift).
-const judgeCacheKeyVersion = 2
+// v3 adds JudgeProvider so frontier (openai-compat) and local (ollama)
+// verdicts for an identically-named, digest-less judge model cannot alias.
+const judgeCacheKeyVersion = 3
 
 // judgeCacheRequest is the canonical envelope hashed to produce the cache
 // key. Fields here MUST be limited to inputs that affect judgment semantics.
 // KeepAlive, JudgeTimeout, OllamaURL are deliberately excluded — they
 // affect execution, not the judge's verdict.
+//
+// JudgeProvider is the judge provider *instance* identity (e.g. "ollama" or
+// the openai-compat instance name), not the API kind. Two providers serving
+// the same model name produce different keys so a frontier-judge verdict
+// never reuses a local one's cached score (see feedback: provider instance
+// vs kind).
 type judgeCacheRequest struct {
 	Version          int     `json:"version"`
+	JudgeProvider    string  `json:"judge_provider"`
 	JudgeModel       string  `json:"judge_model"`
 	JudgeModelDigest string  `json:"judge_model_digest"`
 	SystemPrompt     string  `json:"system_prompt"`
@@ -63,6 +72,7 @@ func canonicalCacheKey(r judgeCacheRequest) string {
 // parsed verdict (denormalized so cache audits don't need to re-parse).
 type judgeCacheEntry struct {
 	CacheKey         string
+	JudgeProvider    string // provider instance identity (e.g. "ollama", "openai-compat")
 	JudgeModel       string
 	JudgeModelDigest string
 	TraceID          string
@@ -187,6 +197,13 @@ func migrateJudgeCache(db *sql.DB) error {
             CREATE INDEX idx_judge_cache_model_trace ON judge_cache(judge_model, trace_id);
             `,
 		},
+		{
+			version:     2,
+			description: "add judge_provider column for provider-instance provenance",
+			ddl: `
+            ALTER TABLE judge_cache ADD COLUMN judge_provider TEXT NOT NULL DEFAULT '';
+            `,
+		},
 	}
 	for _, m := range migrations {
 		if m.version <= current {
@@ -240,12 +257,12 @@ func (c *sqliteJudgeCache) get(ctx context.Context, key string, countMiss bool) 
 	var e judgeCacheEntry
 	var createdNs, lastUsedNs int64
 	err := c.db.QueryRowContext(ctx, `
-        SELECT cache_key, judge_model, judge_model_digest, trace_id, candidate_model,
+        SELECT cache_key, judge_provider, judge_model, judge_model_digest, trace_id, candidate_model,
                prompt_hash, request_json, response_content, answer_quality, justification,
                created_at, last_used_at, hit_count
         FROM judge_cache WHERE cache_key = ?`, key,
 	).Scan(
-		&e.CacheKey, &e.JudgeModel, &e.JudgeModelDigest, &e.TraceID, &e.CandidateModel,
+		&e.CacheKey, &e.JudgeProvider, &e.JudgeModel, &e.JudgeModelDigest, &e.TraceID, &e.CandidateModel,
 		&e.PromptHash, &e.RequestJSON, &e.ResponseContent, &e.AnswerQuality, &e.Justification,
 		&createdNs, &lastUsedNs, &e.HitCount,
 	)
@@ -283,14 +300,14 @@ func (c *sqliteJudgeCache) get(ctx context.Context, key string, countMiss bool) 
 // a Get-hit.
 func (c *sqliteJudgeCache) Put(ctx context.Context, e judgeCacheEntry) error {
 	_, err := c.db.ExecContext(ctx, `
-        INSERT INTO judge_cache (cache_key, judge_model, judge_model_digest, trace_id, candidate_model,
+        INSERT INTO judge_cache (cache_key, judge_provider, judge_model, judge_model_digest, trace_id, candidate_model,
             prompt_hash, request_json, response_content, answer_quality, justification,
             created_at, last_used_at, hit_count)
-        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
         ON CONFLICT(cache_key) DO UPDATE SET
             last_used_at = excluded.last_used_at,
             hit_count    = judge_cache.hit_count + 1`,
-		e.CacheKey, e.JudgeModel, e.JudgeModelDigest, e.TraceID, e.CandidateModel,
+		e.CacheKey, e.JudgeProvider, e.JudgeModel, e.JudgeModelDigest, e.TraceID, e.CandidateModel,
 		e.PromptHash, e.RequestJSON, e.ResponseContent, e.AnswerQuality, e.Justification,
 		e.CreatedAt.UnixNano(), e.LastUsedAt.UnixNano(), e.HitCount,
 	)

--- a/cmd/llm-bench/judge_cache.go
+++ b/cmd/llm-bench/judge_cache.go
@@ -20,8 +20,9 @@ import (
 
 // judgeCacheKeyVersion is bumped to force-invalidate every entry. Increment
 // when changing the canonical request shape (new field, semantic shift).
-// v3 adds JudgeProvider so frontier (openai-compat) and local (ollama)
-// verdicts for an identically-named, digest-less judge model cannot alias.
+// v3 adds JudgeProvider so frontier (openai-compat:<endpoint-id>) and local
+// (ollama) verdicts for an identically-named, digest-less judge model cannot
+// alias.
 const judgeCacheKeyVersion = 3
 
 // judgeCacheRequest is the canonical envelope hashed to produce the cache
@@ -30,10 +31,9 @@ const judgeCacheKeyVersion = 3
 // affect execution, not the judge's verdict.
 //
 // JudgeProvider is the judge provider *instance* identity (e.g. "ollama" or
-// the openai-compat instance name), not the API kind. Two providers serving
-// the same model name produce different keys so a frontier-judge verdict
-// never reuses a local one's cached score (see feedback: provider instance
-// vs kind).
+// "openai-compat:<endpoint-id>"), not the API kind. Two providers serving the
+// same model name produce different keys so a frontier-judge verdict never
+// reuses another provider's cached score.
 type judgeCacheRequest struct {
 	Version          int     `json:"version"`
 	JudgeProvider    string  `json:"judge_provider"`
@@ -72,7 +72,7 @@ func canonicalCacheKey(r judgeCacheRequest) string {
 // parsed verdict (denormalized so cache audits don't need to re-parse).
 type judgeCacheEntry struct {
 	CacheKey         string
-	JudgeProvider    string // provider instance identity (e.g. "ollama", "openai-compat")
+	JudgeProvider    string // provider instance identity (e.g. "ollama", "openai-compat:<endpoint-id>")
 	JudgeModel       string
 	JudgeModelDigest string
 	TraceID          string

--- a/cmd/llm-bench/judge_cache_test.go
+++ b/cmd/llm-bench/judge_cache_test.go
@@ -47,6 +47,18 @@ func TestCanonicalCacheKey_DigestSensitive(t *testing.T) {
 	}
 }
 
+func TestCanonicalCacheKey_ProviderSensitive(t *testing.T) {
+	// A frontier judge served via openai-compat and a local Ollama judge can
+	// share a model name (e.g. neither carries a digest). The provider must
+	// participate in the key so their verdicts never alias each other.
+	base := judgeCacheRequest{Version: judgeCacheKeyVersion, JudgeProvider: "ollama", JudgeModel: "m", SystemPrompt: "s", UserPrompt: "u", Format: "json", Temperature: 0.1, NumPredict: 100}
+	diff := base
+	diff.JudgeProvider = "openai-compat"
+	if canonicalCacheKey(base) == canonicalCacheKey(diff) {
+		t.Fatalf("judge provider change did not invalidate key")
+	}
+}
+
 func TestCanonicalCacheKey_ThinkSensitive(t *testing.T) {
 	base := judgeCacheRequest{Version: judgeCacheKeyVersion, JudgeModel: "m", SystemPrompt: "s", UserPrompt: "u", Format: "json", Temperature: 0.1, NumPredict: 100}
 	thinkFalse := false
@@ -117,6 +129,29 @@ func TestSQLiteJudgeCache_PutThenGetReturnsEntry(t *testing.T) {
 	}
 	if got.HitCount != 1 {
 		t.Fatalf("HitCount not bumped: %d", got.HitCount)
+	}
+}
+
+func TestSQLiteJudgeCache_PersistsJudgeProvider(t *testing.T) {
+	c, _ := newTestCache(t)
+	ctx := context.Background()
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	entry := judgeCacheEntry{
+		CacheKey: "pk", JudgeProvider: "openai-compat", JudgeModel: "claude-x",
+		TraceID: "t", CandidateModel: "ollama/cand", PromptHash: "ph",
+		RequestJSON: "{}", ResponseContent: `{"answer_quality":1.0}`,
+		AnswerQuality: 1.0, Justification: "j",
+		CreatedAt: now, LastUsedAt: now,
+	}
+	if err := c.Put(ctx, entry); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, ok, err := c.Get(ctx, "pk")
+	if err != nil || !ok {
+		t.Fatalf("Get: ok=%v err=%v", ok, err)
+	}
+	if got.JudgeProvider != "openai-compat" {
+		t.Fatalf("JudgeProvider = %q; want openai-compat", got.JudgeProvider)
 	}
 }
 

--- a/cmd/llm-bench/judge_claude_cli.go
+++ b/cmd/llm-bench/judge_claude_cli.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+// claudeCLIProviderName is the judge provider instance identity for the
+// claude-cli transport — folded into the cache key and provenance.
+const claudeCLIProviderName = "claude-cli"
+
+// claudeCLIModelAliases is the set of Claude Code model selectors the
+// claude-cli transport validates against. Claude Code's aliases are stable;
+// pass one of these via -judge-model (e.g. "opus"). This is an allowlist for
+// fail-fast typo detection, not a placeholder — the CLI is the source of truth
+// and would also reject an unknown --model at first call.
+var claudeCLIModelAliases = []string{"opus", "sonnet", "haiku"}
+
+// claudeCLIJudgeClient adapts the `claude` CLI (headless `-p` mode) to the
+// Ollama-typed judge seams. It runs on the user's Claude subscription (no API
+// billing) and is locked down for judging: the judge system prompt REPLACES
+// Claude Code's default system prompt (--system-prompt), tools are disabled
+// (--allowedTools ""), and each call runs in an empty working directory so no
+// CLAUDE.md leaks into the judge context.
+//
+// Determinism caveat: the CLI exposes no temperature flag, so the judge's
+// configured temperature is NOT honored — the model runs at Claude Code's
+// default. The categorical {0,0.5,1.0} rubric + off-grid repair re-prompt make
+// this acceptable, but it is recorded here so provenance readers know the
+// transport cannot pin temperature.
+type claudeCLIJudgeClient struct {
+	model string
+	// run executes the claude CLI with args and stdin, returning stdout.
+	// Injectable so unit tests drive the adapter without the real binary.
+	run func(ctx context.Context, args []string, stdin string) ([]byte, error)
+}
+
+// newClaudeCLIJudge wraps the claude CLI as a judge transport for the given
+// Claude Code model selector (e.g. "opus").
+func newClaudeCLIJudge(model string) *claudeCLIJudgeClient {
+	return &claudeCLIJudgeClient{model: strings.TrimSpace(model), run: runClaudeCLI}
+}
+
+// Chat implements judgeChatClient. The judge system prompt is passed as
+// --system-prompt (replacing the default), the user prompt is fed on stdin,
+// and the model's text (envelope .result) is returned as ChatResponse content
+// for the unchanged judge parser to consume.
+func (j *claudeCLIJudgeClient) Chat(ctx context.Context, req ollama.ChatRequest) (*ollama.ChatResponse, error) {
+	system, user := splitJudgeMessages(req.Messages)
+	args := []string{
+		"-p",
+		"--system-prompt", system,
+		"--allowedTools", "",
+		"--output-format", "json",
+		"--model", j.model,
+	}
+	out, err := j.run(ctx, args, user)
+	if err != nil {
+		return nil, fmt.Errorf("claude-cli judge: %w", err)
+	}
+	result, err := claudeResultFromEnvelope(out)
+	if err != nil {
+		return nil, err
+	}
+	return &ollama.ChatResponse{
+		Message: ollama.ChatMessage{Role: "assistant", Content: result},
+		Done:    true,
+	}, nil
+}
+
+// AvailableModels implements judgeModelChecker against the stable Claude Code
+// alias allowlist so judge-model validation fails fast on a typo before any
+// subscription call.
+func (j *claudeCLIJudgeClient) AvailableModels(_ context.Context) ([]string, error) {
+	out := make([]string, len(claudeCLIModelAliases))
+	copy(out, claudeCLIModelAliases)
+	return out, nil
+}
+
+// ShowModel implements judgeModelChecker by reporting the claude CLI version
+// as the model "digest", so the CLI version pins the cached judge verdict (a
+// CLI upgrade can change judge behavior). Errors degrade to (nil, nil) like
+// the Ollama path, so a missing version never fails calibration.
+func (j *claudeCLIJudgeClient) ShowModel(ctx context.Context, _ string) (*ollama.ModelInfo, error) {
+	out, err := j.run(ctx, []string{"--version"}, "")
+	if err != nil {
+		return nil, nil
+	}
+	version := strings.TrimSpace(string(out))
+	if version == "" {
+		return nil, nil
+	}
+	return &ollama.ModelInfo{Digest: "claude-cli/" + version}, nil
+}
+
+// splitJudgeMessages returns the system and user content from the judge's
+// [system, user] message pair, tolerating either being absent.
+func splitJudgeMessages(msgs []ollama.ChatMessage) (system, user string) {
+	for _, m := range msgs {
+		switch m.Role {
+		case "system":
+			if system == "" {
+				system = m.Content
+			}
+		case "user":
+			if user == "" {
+				user = m.Content
+			}
+		}
+	}
+	return system, user
+}
+
+// claudeResultFromEnvelope extracts the model's text from a `claude -p
+// --output-format json` envelope. is_error envelopes are surfaced as errors.
+func claudeResultFromEnvelope(out []byte) (string, error) {
+	var env struct {
+		Result  string `json:"result"`
+		IsError bool   `json:"is_error"`
+		Subtype string `json:"subtype"`
+	}
+	if err := json.Unmarshal(out, &env); err != nil {
+		return "", fmt.Errorf("claude-cli judge: decode envelope: %w", err)
+	}
+	if env.IsError {
+		return "", fmt.Errorf("claude-cli judge: claude reported is_error (subtype=%s)", env.Subtype)
+	}
+	return env.Result, nil
+}
+
+// runClaudeCLI is the production runner: it execs `claude` with args, feeds
+// stdin, and runs in a fresh empty directory so no project CLAUDE.md leaks into
+// the judge context. On non-zero exit it includes captured stderr.
+func runClaudeCLI(ctx context.Context, args []string, stdin string) ([]byte, error) {
+	dir, err := os.MkdirTemp("", "judge-cli-")
+	if err != nil {
+		return nil, fmt.Errorf("mkdir empty judge cwd: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	cmd := exec.CommandContext(ctx, "claude", args...)
+	cmd.Dir = dir
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		stderr := ""
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			stderr = strings.TrimSpace(string(ee.Stderr))
+		}
+		return nil, fmt.Errorf("exec claude: %w; stderr=%s", err, stderr)
+	}
+	return out, nil
+}

--- a/cmd/llm-bench/judge_claude_cli.go
+++ b/cmd/llm-bench/judge_claude_cli.go
@@ -30,6 +30,14 @@ var claudeCLIModelAliases = []string{"opus", "sonnet", "haiku"}
 // (--allowedTools ""), and each call runs in an empty working directory so no
 // CLAUDE.md leaks into the judge context.
 //
+// Cleanliness caveat: this is the Claude Code *agent* in headless mode, not a
+// bare chat completion. Even with the system-prompt override and tools
+// disabled, the harness still injects its own scaffolding context (~tens of
+// thousands of tokens of tool schemas / environment / reminders). Empirically
+// the judge produces clean single-turn verdicts, but a citable calibration
+// should treat this transport as "Claude Code judging", not "raw model
+// judging", and ideally verify the lockdown rather than assume it.
+//
 // Determinism caveat: the CLI exposes no temperature flag, so the judge's
 // configured temperature is NOT honored — the model runs at Claude Code's
 // default. The categorical {0,0.5,1.0} rubric + off-grid repair re-prompt make

--- a/cmd/llm-bench/judge_claude_cli.go
+++ b/cmd/llm-bench/judge_claude_cli.go
@@ -26,9 +26,9 @@ var claudeCLIModelAliases = []string{"opus", "sonnet", "haiku"}
 // claudeCLIJudgeClient adapts the `claude` CLI (headless `-p` mode) to the
 // Ollama-typed judge seams. It runs on the user's Claude subscription (no API
 // billing) and is locked down for judging: the judge system prompt REPLACES
-// Claude Code's default system prompt (--system-prompt), tools are disabled
-// (--allowedTools ""), and each call runs in an empty working directory so no
-// CLAUDE.md leaks into the judge context.
+// Claude Code's default system prompt (--system-prompt), tools are removed
+// (--tools "") and not auto-allowed (--allowedTools ""), and each call runs in
+// an empty working directory so no CLAUDE.md leaks into the judge context.
 //
 // Cleanliness caveat: this is the Claude Code *agent* in headless mode, not a
 // bare chat completion. Even with the system-prompt override and tools
@@ -66,6 +66,7 @@ func (j *claudeCLIJudgeClient) Chat(ctx context.Context, req ollama.ChatRequest)
 		"-p",
 		"--system-prompt", system,
 		"--allowedTools", "",
+		"--tools", "",
 		"--output-format", "json",
 		"--model", j.model,
 	}

--- a/cmd/llm-bench/judge_claude_cli_test.go
+++ b/cmd/llm-bench/judge_claude_cli_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+func argHasValue(args []string, flag, value string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+func argsContain(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func judgeCLIReqFixture() ollama.ChatRequest {
+	return ollama.ChatRequest{
+		Model: "opus",
+		Messages: []ollama.ChatMessage{
+			{Role: "system", Content: judgeSystemPrompt},
+			{Role: "user", Content: "USER-PROMPT-MARKER"},
+		},
+		Format:  "json",
+		Options: &ollama.ModelOptions{Temperature: 0.1, NumPredict: 512},
+	}
+}
+
+func TestClaudeCLIJudge_ChatExecsLockedDownAndReturnsResult(t *testing.T) {
+	var gotArgs []string
+	var gotStdin string
+	j := &claudeCLIJudgeClient{model: "opus", run: func(_ context.Context, args []string, stdin string) ([]byte, error) {
+		gotArgs, gotStdin = args, stdin
+		return []byte(`{"type":"result","is_error":false,"result":"{\"answer_quality\":1.0,\"justification\":\"good\"}"}`), nil
+	}}
+
+	resp, err := j.Chat(context.Background(), judgeCLIReqFixture())
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp == nil || resp.Message.Content != `{"answer_quality":1.0,"justification":"good"}` {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+	if gotStdin != "USER-PROMPT-MARKER" {
+		t.Fatalf("stdin = %q; want the judge user prompt", gotStdin)
+	}
+	if !argsContain(gotArgs, "-p") {
+		t.Fatalf("missing -p (headless): %v", gotArgs)
+	}
+	if !argHasValue(gotArgs, "--system-prompt", judgeSystemPrompt) {
+		t.Fatalf("--system-prompt not set to judge rubric: %v", gotArgs)
+	}
+	if !argHasValue(gotArgs, "--allowedTools", "") {
+		t.Fatalf("--allowedTools not disabled: %v", gotArgs)
+	}
+	if !argHasValue(gotArgs, "--output-format", "json") {
+		t.Fatalf("--output-format not json: %v", gotArgs)
+	}
+	if !argHasValue(gotArgs, "--model", "opus") {
+		t.Fatalf("--model not opus: %v", gotArgs)
+	}
+}
+
+func TestClaudeCLIJudge_ChatSurfacesEnvelopeError(t *testing.T) {
+	j := &claudeCLIJudgeClient{model: "opus", run: func(_ context.Context, _ []string, _ string) ([]byte, error) {
+		return []byte(`{"type":"result","is_error":true,"subtype":"error_max_turns","result":""}`), nil
+	}}
+	if _, err := j.Chat(context.Background(), judgeCLIReqFixture()); err == nil {
+		t.Fatalf("Chat error = nil; want is_error envelope surfaced")
+	}
+}
+
+func TestClaudeCLIJudge_ChatSurfacesRunnerError(t *testing.T) {
+	j := &claudeCLIJudgeClient{model: "opus", run: func(_ context.Context, _ []string, _ string) ([]byte, error) {
+		return nil, errors.New("claude not found")
+	}}
+	if _, err := j.Chat(context.Background(), judgeCLIReqFixture()); err == nil {
+		t.Fatalf("Chat error = nil; want runner error surfaced")
+	}
+}
+
+func TestClaudeCLIJudge_AvailableModelsIncludesAliases(t *testing.T) {
+	j := &claudeCLIJudgeClient{model: "opus"}
+	models, err := j.AvailableModels(context.Background())
+	if err != nil {
+		t.Fatalf("AvailableModels: %v", err)
+	}
+	if !argsContain(models, "opus") {
+		t.Fatalf("models = %v; want to include opus", models)
+	}
+}
+
+func TestClaudeCLIJudge_ShowModelReportsCLIVersionAsDigest(t *testing.T) {
+	j := &claudeCLIJudgeClient{model: "opus", run: func(_ context.Context, args []string, _ string) ([]byte, error) {
+		if !argsContain(args, "--version") {
+			t.Errorf("ShowModel did not invoke --version: %v", args)
+		}
+		return []byte("2.1.159 (Claude Code)\n"), nil
+	}}
+	info, err := j.ShowModel(context.Background(), "opus")
+	if err != nil {
+		t.Fatalf("ShowModel: %v", err)
+	}
+	if info == nil || !strings.Contains(info.Digest, "2.1.159") {
+		t.Fatalf("info = %+v; want digest carrying the CLI version", info)
+	}
+}
+
+func TestClaudeCLIJudge_ShowModelDegradesOnRunnerError(t *testing.T) {
+	j := &claudeCLIJudgeClient{model: "opus", run: func(_ context.Context, _ []string, _ string) ([]byte, error) {
+		return nil, errors.New("no claude binary")
+	}}
+	info, err := j.ShowModel(context.Background(), "opus")
+	if err != nil || info != nil {
+		t.Fatalf("ShowModel on runner error = (%+v, %v); want (nil, nil) degrade", info, err)
+	}
+}
+
+func TestNewJudgeTransport_ClaudeCLI(t *testing.T) {
+	tr, err := newJudgeTransport(scorerOptions{judgeTransport: "claude-cli", judgeModel: "opus"})
+	if err != nil {
+		t.Fatalf("newJudgeTransport: %v", err)
+	}
+	if tr.providerName != claudeCLIProviderName {
+		t.Fatalf("providerName = %q; want %q", tr.providerName, claudeCLIProviderName)
+	}
+	if _, ok := tr.chat.(*claudeCLIJudgeClient); !ok {
+		t.Fatalf("chat is %T; want *claudeCLIJudgeClient", tr.chat)
+	}
+	if _, ok := tr.checker.(*claudeCLIJudgeClient); !ok {
+		t.Fatalf("checker is %T; want *claudeCLIJudgeClient", tr.checker)
+	}
+}

--- a/cmd/llm-bench/judge_claude_cli_test.go
+++ b/cmd/llm-bench/judge_claude_cli_test.go
@@ -66,6 +66,9 @@ func TestClaudeCLIJudge_ChatExecsLockedDownAndReturnsResult(t *testing.T) {
 	if !argHasValue(gotArgs, "--allowedTools", "") {
 		t.Fatalf("--allowedTools not disabled: %v", gotArgs)
 	}
+	if !argHasValue(gotArgs, "--tools", "") {
+		t.Fatalf("--tools not disabled: %v", gotArgs)
+	}
 	if !argHasValue(gotArgs, "--output-format", "json") {
 		t.Fatalf("--output-format not json: %v", gotArgs)
 	}

--- a/cmd/llm-bench/judge_openaicompat.go
+++ b/cmd/llm-bench/judge_openaicompat.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+	"github.com/kstruzzieri/go-llm/provider"
+	"github.com/kstruzzieri/go-llm/provider/openaicompat"
+)
+
+// openAICompatJudgeClient adapts an *openaicompat.Provider to the Ollama-typed
+// judgeChatClient + judgeModelChecker seams the LLMJudgeScorer is built on. It
+// is a judge-only transport: it translates the narrow judge ChatRequest
+// (system + user messages, temperature, num_predict) to an OpenAI
+// /v1/chat/completions call and maps the response content back, leaving the
+// judge prompt contract and parser untouched.
+//
+// JSON-mode note: the Ollama path sets ChatRequest.Format="json", but the
+// openaicompat provider exposes no response_format field. The judge system
+// prompt already mandates strict JSON and parseJudgeResponse extracts the
+// first balanced JSON object, so a frontier judge stays robust on the prompt
+// alone; Format is intentionally dropped here rather than widening the
+// provider package for one caller.
+type openAICompatJudgeClient struct {
+	provider *openaicompat.Provider
+}
+
+// newOpenAICompatJudge wraps an openaicompat provider as a judge transport.
+func newOpenAICompatJudge(p *openaicompat.Provider) *openAICompatJudgeClient {
+	return &openAICompatJudgeClient{provider: p}
+}
+
+// Chat implements judgeChatClient by translating the Ollama judge request to a
+// provider.ChatRequest, issuing it through the openaicompat provider, and
+// mapping provider.ChatResponse.Content back onto ollama.ChatResponse so the
+// scorer's parser sees an unchanged shape.
+func (j *openAICompatJudgeClient) Chat(ctx context.Context, req ollama.ChatRequest) (*ollama.ChatResponse, error) {
+	presp, err := j.provider.Chat(ctx, provider.ChatRequest{
+		Model:    req.Model,
+		Messages: toProviderJudgeMessages(req.Messages),
+		Options:  toProviderJudgeOptions(req.Options),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if presp == nil {
+		return nil, fmt.Errorf("openai-compat judge: nil response")
+	}
+	return &ollama.ChatResponse{
+		Model: presp.Model,
+		Message: ollama.ChatMessage{
+			Role:    "assistant",
+			Content: presp.Content,
+		},
+		Done: true,
+	}, nil
+}
+
+// toProviderJudgeMessages copies the role/content of each judge message. The
+// judge only ever sends system + user turns, so tool fields are not carried.
+func toProviderJudgeMessages(in []ollama.ChatMessage) []provider.ChatMessage {
+	out := make([]provider.ChatMessage, len(in))
+	for i, m := range in {
+		out[i] = provider.ChatMessage{Role: m.Role, Content: m.Content}
+	}
+	return out
+}
+
+// toProviderJudgeOptions maps the judge's temperature + token budget. The
+// temperature pointer is always set when options are present: the judge wants
+// a specific low temperature, and a frontier endpoint accepts an explicit
+// value (including 0) the same way Ollama does.
+func toProviderJudgeOptions(opts *ollama.ModelOptions) provider.ModelOptions {
+	if opts == nil {
+		return provider.ModelOptions{}
+	}
+	temp := opts.Temperature
+	return provider.ModelOptions{
+		Temperature: &temp,
+		NumPredict:  opts.NumPredict,
+	}
+}
+
+// AvailableModels implements judgeModelChecker via /v1/models so judge-model
+// validation works on this transport.
+func (j *openAICompatJudgeClient) AvailableModels(ctx context.Context) ([]string, error) {
+	models, err := j.provider.Models(ctx)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(models))
+	for _, m := range models {
+		names = append(names, m.Name)
+	}
+	return names, nil
+}
+
+// ShowModel implements judgeModelChecker. OpenAI-compatible servers expose no
+// /api/show digest equivalent, so this returns (nil, nil); resolveJudgeDigest
+// degrades to an empty digest. No network call is made.
+func (j *openAICompatJudgeClient) ShowModel(_ context.Context, _ string) (*ollama.ModelInfo, error) {
+	return nil, nil
+}

--- a/cmd/llm-bench/judge_openaicompat_test.go
+++ b/cmd/llm-bench/judge_openaicompat_test.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+	"github.com/kstruzzieri/go-llm/provider/openaicompat"
+)
+
+// TestOpenAICompatJudgeClient_ChatTranslatesRequestAndResponse drives the
+// adapter through a real *openaicompat.Provider over httptest: the ollama
+// judge request must translate to an OpenAI /v1/chat/completions call
+// (messages, temperature, max_tokens preserved) and the OpenAI response
+// content must map back onto ollama.ChatResponse.Message.Content so the
+// existing judge parser sees an unchanged contract.
+func TestOpenAICompatJudgeClient_ChatTranslatesRequestAndResponse(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("path = %q; want /v1/chat/completions", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"x","model":"claude-x","choices":[{"index":0,"message":{"role":"assistant","content":"{\"answer_quality\":1.0,\"justification\":\"good\"}"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`))
+	}))
+	defer srv.Close()
+
+	judge := newOpenAICompatJudge(openaicompat.NewProvider(openaicompat.NewClient(srv.URL)))
+
+	resp, err := judge.Chat(context.Background(), ollama.ChatRequest{
+		Model: "claude-x",
+		Messages: []ollama.ChatMessage{
+			{Role: "system", Content: "you are a judge"},
+			{Role: "user", Content: "evaluate this"},
+		},
+		Format:  "json",
+		Options: &ollama.ModelOptions{Temperature: 0.1, NumPredict: 512},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp == nil || resp.Message.Content != `{"answer_quality":1.0,"justification":"good"}` {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+
+	if gotBody["model"] != "claude-x" {
+		t.Fatalf("model = %v; want claude-x", gotBody["model"])
+	}
+	msgs, _ := gotBody["messages"].([]any)
+	if len(msgs) != 2 {
+		t.Fatalf("messages len = %d; want 2 (system+user)", len(msgs))
+	}
+	if gotBody["temperature"] != 0.1 {
+		t.Fatalf("temperature = %v; want 0.1", gotBody["temperature"])
+	}
+	if gotBody["max_tokens"] != float64(512) {
+		t.Fatalf("max_tokens = %v; want 512", gotBody["max_tokens"])
+	}
+}
+
+// TestOpenAICompatJudgeClient_AvailableModels confirms the model-checker seam
+// lists models via /v1/models so newScorer's judge-model validation works on
+// the openai-compat transport.
+func TestOpenAICompatJudgeClient_AvailableModels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Errorf("path = %q; want /v1/models", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"data":[{"id":"claude-x"},{"id":"gpt-4o"}]}`))
+	}))
+	defer srv.Close()
+
+	judge := newOpenAICompatJudge(openaicompat.NewProvider(openaicompat.NewClient(srv.URL)))
+	models, err := judge.AvailableModels(context.Background())
+	if err != nil {
+		t.Fatalf("AvailableModels: %v", err)
+	}
+	if len(models) != 2 || models[0] != "claude-x" || models[1] != "gpt-4o" {
+		t.Fatalf("models = %v; want [claude-x gpt-4o]", models)
+	}
+}
+
+// TestLLMJudgeScorer_OpenAICompatTransport_ProducesVerdictPreservingContract
+// drives the whole judge path through the openai-compat adapter: Score must
+// produce a parsed verdict, AND the judge system prompt must reach the wire
+// unchanged. This is the integration the unit tests skip — the adapter is
+// tested alone and Score is tested with a fake client, but their seam (and the
+// preserved prompt contract) is only exercised here.
+func TestLLMJudgeScorer_OpenAICompatTransport_ProducesVerdictPreservingContract(t *testing.T) {
+	var sawSystemPrompt bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Messages []struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			} `json:"messages"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		for _, m := range body.Messages {
+			if m.Role == "system" && m.Content == judgeSystemPrompt {
+				sawSystemPrompt = true
+			}
+		}
+		_, _ = w.Write([]byte(`{"id":"x","model":"claude-x","choices":[{"index":0,"message":{"role":"assistant","content":"{\"answer_quality\":1.0,\"justification\":\"matches rubric\"}"},"finish_reason":"stop"}],"usage":{}}`))
+	}))
+	defer srv.Close()
+
+	adapter := newOpenAICompatJudge(openaicompat.NewProvider(openaicompat.NewClient(srv.URL)))
+	scorer := &LLMJudgeScorer{Client: adapter, JudgeModel: "claude-x", JudgeProvider: "openai-compat"}
+	trace := Trace{ID: "t1", System: "s", Turns: []Turn{{Role: "user", Content: "q"}}, Golden: Golden{FinalAnswerCriteria: "answer must be correct"}}
+	actual := Result{Model: "ollama/cand", Transcript: []Turn{{Role: "assistant", Content: "the answer"}}}
+
+	score, err := scorer.Score(context.Background(), trace, actual)
+	if err != nil {
+		t.Fatalf("Score: %v", err)
+	}
+	if score.AnswerQuality != 1.0 {
+		t.Fatalf("AnswerQuality = %v; want 1.0", score.AnswerQuality)
+	}
+	if !sawSystemPrompt {
+		t.Fatalf("judge system prompt not delivered through openai-compat transport (prompt contract not preserved)")
+	}
+}
+
+// TestNewJudgeTransport_OllamaDefault pins that an empty or "ollama" transport
+// resolves to the existing Ollama client and a provider identity of "ollama".
+func TestNewJudgeTransport_OllamaDefault(t *testing.T) {
+	for _, name := range []string{"", "ollama", "OLLAMA"} {
+		tr, err := newJudgeTransport(scorerOptions{judgeTransport: name, ollamaURL: "http://localhost:11434"})
+		if err != nil {
+			t.Fatalf("newJudgeTransport(%q): %v", name, err)
+		}
+		if tr.providerName != defaultBenchProvider {
+			t.Fatalf("newJudgeTransport(%q) providerName = %q; want %q", name, tr.providerName, defaultBenchProvider)
+		}
+		if _, ok := tr.chat.(*ollama.Client); !ok {
+			t.Fatalf("newJudgeTransport(%q) chat is %T; want *ollama.Client", name, tr.chat)
+		}
+	}
+}
+
+// TestNewJudgeTransport_OpenAICompat pins that the openai-compat transport
+// resolves to the adapter and the provider instance name.
+func TestNewJudgeTransport_OpenAICompat(t *testing.T) {
+	tr, err := newJudgeTransport(scorerOptions{judgeTransport: "openai-compat", judgeBaseURL: "https://api.example.com"})
+	if err != nil {
+		t.Fatalf("newJudgeTransport: %v", err)
+	}
+	if tr.providerName != "openai-compat" {
+		t.Fatalf("providerName = %q; want openai-compat", tr.providerName)
+	}
+	if _, ok := tr.chat.(*openAICompatJudgeClient); !ok {
+		t.Fatalf("chat is %T; want *openAICompatJudgeClient", tr.chat)
+	}
+	if _, ok := tr.checker.(*openAICompatJudgeClient); !ok {
+		t.Fatalf("checker is %T; want *openAICompatJudgeClient", tr.checker)
+	}
+}
+
+// TestNewJudgeTransport_OpenAICompatRequiresBaseURL pins that the compat
+// transport refuses to run without an endpoint rather than defaulting to one.
+func TestNewJudgeTransport_OpenAICompatRequiresBaseURL(t *testing.T) {
+	if _, err := newJudgeTransport(scorerOptions{judgeTransport: "openai-compat"}); err == nil {
+		t.Fatalf("newJudgeTransport(openai-compat, no base url) error = nil; want error")
+	}
+}
+
+// TestNewJudgeTransport_UnknownRejected pins that an unrecognized transport is
+// a hard error, not a silent fallback.
+func TestNewJudgeTransport_UnknownRejected(t *testing.T) {
+	if _, err := newJudgeTransport(scorerOptions{judgeTransport: "bogus"}); err == nil {
+		t.Fatalf("newJudgeTransport(bogus) error = nil; want error")
+	}
+}
+
+// TestNewScorer_OpenAICompatSetsJudgeProvider drives newScorer end-to-end on
+// the openai-compat path: /v1/models validation passes and the returned scorer
+// records JudgeProvider="openai-compat".
+func TestNewScorer_OpenAICompatSetsJudgeProvider(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/models" {
+			_, _ = w.Write([]byte(`{"data":[{"id":"claude-x"}]}`))
+			return
+		}
+		t.Errorf("unexpected path %s", r.URL.Path)
+	}))
+	defer srv.Close()
+
+	sc, err := newScorer(context.Background(), "llm-judge", scorerOptions{
+		judgeTransport: "openai-compat",
+		judgeBaseURL:   srv.URL,
+		judgeModel:     "claude-x",
+		judgeTimeout:   5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("newScorer: %v", err)
+	}
+	js, ok := sc.(*LLMJudgeScorer)
+	if !ok {
+		t.Fatalf("scorer type %T; want *LLMJudgeScorer", sc)
+	}
+	if js.JudgeProvider != "openai-compat" {
+		t.Fatalf("JudgeProvider = %q; want openai-compat", js.JudgeProvider)
+	}
+}
+
+// TestOpenAICompatJudgeClient_ShowModelReturnsNil pins that the openai-compat
+// transport reports no model digest (there is no /api/show equivalent), so
+// resolveJudgeDigest degrades to an empty digest rather than erroring. It must
+// not touch the network.
+func TestOpenAICompatJudgeClient_ShowModelReturnsNil(t *testing.T) {
+	judge := newOpenAICompatJudge(openaicompat.NewProvider(openaicompat.NewClient("http://example.invalid")))
+	info, err := judge.ShowModel(context.Background(), "claude-x")
+	if err != nil {
+		t.Fatalf("ShowModel err = %v; want nil", err)
+	}
+	if info != nil {
+		t.Fatalf("ShowModel info = %+v; want nil (no digest concept on openai-compat)", info)
+	}
+}

--- a/cmd/llm-bench/judge_openaicompat_test.go
+++ b/cmd/llm-bench/judge_openaicompat_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -155,14 +156,31 @@ func TestNewJudgeTransport_OpenAICompat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newJudgeTransport: %v", err)
 	}
-	if tr.providerName != "openai-compat" {
-		t.Fatalf("providerName = %q; want openai-compat", tr.providerName)
+	if want := openAICompatJudgeProviderName("https://api.example.com"); tr.providerName != want {
+		t.Fatalf("providerName = %q; want %q", tr.providerName, want)
 	}
 	if _, ok := tr.chat.(*openAICompatJudgeClient); !ok {
 		t.Fatalf("chat is %T; want *openAICompatJudgeClient", tr.chat)
 	}
 	if _, ok := tr.checker.(*openAICompatJudgeClient); !ok {
 		t.Fatalf("checker is %T; want *openAICompatJudgeClient", tr.checker)
+	}
+}
+
+func TestNewJudgeTransport_OpenAICompatProviderNameDistinguishesBaseURL(t *testing.T) {
+	first, err := newJudgeTransport(scorerOptions{judgeTransport: "openai-compat", judgeBaseURL: "https://judge-a.example.com"})
+	if err != nil {
+		t.Fatalf("newJudgeTransport first: %v", err)
+	}
+	second, err := newJudgeTransport(scorerOptions{judgeTransport: "openai-compat", judgeBaseURL: "https://judge-b.example.com"})
+	if err != nil {
+		t.Fatalf("newJudgeTransport second: %v", err)
+	}
+	if first.providerName == second.providerName {
+		t.Fatalf("providerName reused across distinct base URLs: %q", first.providerName)
+	}
+	if !strings.HasPrefix(first.providerName, openAICompatTransport+":") {
+		t.Fatalf("providerName = %q; want %s:<endpoint-id>", first.providerName, openAICompatTransport)
 	}
 }
 
@@ -184,7 +202,7 @@ func TestNewJudgeTransport_UnknownRejected(t *testing.T) {
 
 // TestNewScorer_OpenAICompatSetsJudgeProvider drives newScorer end-to-end on
 // the openai-compat path: /v1/models validation passes and the returned scorer
-// records JudgeProvider="openai-compat".
+// records an endpoint-scoped JudgeProvider.
 func TestNewScorer_OpenAICompatSetsJudgeProvider(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1/models" {
@@ -208,8 +226,8 @@ func TestNewScorer_OpenAICompatSetsJudgeProvider(t *testing.T) {
 	if !ok {
 		t.Fatalf("scorer type %T; want *LLMJudgeScorer", sc)
 	}
-	if js.JudgeProvider != "openai-compat" {
-		t.Fatalf("JudgeProvider = %q; want openai-compat", js.JudgeProvider)
+	if !strings.HasPrefix(js.JudgeProvider, openAICompatTransport+":") {
+		t.Fatalf("JudgeProvider = %q; want %s:<endpoint-id>", js.JudgeProvider, openAICompatTransport)
 	}
 }
 

--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -51,8 +51,8 @@ func main() {
 	tracesGlob := flag.String("traces", "", "Glob pattern for trace JSON files (required for normal runs and -calibrate-capture)")
 	modelsArg := flag.String("models", "", "Comma-separated model selectors (provider/model or bare model name; required)")
 	scorerName := flag.String("scorer", "exact-match", "Scoring strategy: exact-match, llm-judge, manual")
-	judgeModel := flag.String("judge-model", "", "Ollama model used by -scorer llm-judge; default uses models.json role judge or gemma4:31b")
-	judgeOllamaURL := flag.String("judge-ollama-url", "", "Ollama base URL for -scorer llm-judge (default: -ollama-url)")
+	judgeModel := flag.String("judge-model", "", "Judge model/selector used by -scorer llm-judge; default uses models.json role judge or gemma4:31b")
+	judgeOllamaURL := flag.String("judge-ollama-url", "", "Ollama base URL for the Ollama judge transport (default: -ollama-url)")
 	judgeTimeout := flag.Duration("judge-timeout", 5*time.Minute, "Timeout for each llm-judge scoring request")
 	judgeCachePath := flag.String("judge-cache", defaultJudgeCachePath(), "SQLite path for judge response cache; empty disables")
 	judgeTransport := flag.String("judge-transport", "", "Judge backend for -scorer llm-judge: ollama (default), openai-compat, or claude-cli (headless `claude -p`, subscription)")
@@ -274,6 +274,10 @@ func main() {
 	if err != nil {
 		log.Fatalf("llm-bench: scorer: %v", err)
 	}
+	judgeProviderName := defaultBenchProvider
+	if js, ok := scorer.(*LLMJudgeScorer); ok {
+		judgeProviderName = js.JudgeProvider
+	}
 
 	runner := &Runner{
 		OllamaURL: *ollamaURL,
@@ -299,6 +303,7 @@ func main() {
 	report := formatReport(modelNames, results, reportOptions{
 		Scorer:               *scorerName,
 		JudgeModel:           resolvedJudgeModel,
+		JudgeProvider:        judgeProviderName,
 		JudgeCacheHits:       judgeCacheHits,
 		JudgeCacheMisses:     judgeCacheMisses,
 		TraceSetManifestHash: traceSetHash,

--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -55,7 +55,7 @@ func main() {
 	judgeOllamaURL := flag.String("judge-ollama-url", "", "Ollama base URL for -scorer llm-judge (default: -ollama-url)")
 	judgeTimeout := flag.Duration("judge-timeout", 5*time.Minute, "Timeout for each llm-judge scoring request")
 	judgeCachePath := flag.String("judge-cache", defaultJudgeCachePath(), "SQLite path for judge response cache; empty disables")
-	judgeTransport := flag.String("judge-transport", "", "Judge backend for -scorer llm-judge: ollama (default) or openai-compat")
+	judgeTransport := flag.String("judge-transport", "", "Judge backend for -scorer llm-judge: ollama (default), openai-compat, or claude-cli (headless `claude -p`, subscription)")
 	judgeBaseURL := flag.String("judge-base-url", "", "Base URL for -judge-transport openai-compat (server root, no /v1 suffix)")
 	judgeAPIKey := flag.String("judge-api-key", "", "Bearer token for -judge-transport openai-compat; falls back to $"+judgeAPIKeyEnvVar)
 	reportPath := flag.String("report", "", "Output report path (default: stdout)")

--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -41,6 +41,7 @@ func main() {
 
 	calibrateCapture := flag.Bool("calibrate-capture", false, "Phase 1: replay candidates and write frozen artifacts.jsonl")
 	calibrate := flag.Bool("calibrate", false, "Phase 2: re-score frozen labeled artifacts with the judge model")
+	manualReport := flag.Bool("manual-report", false, "Score frozen labeled artifacts with human labels (manual scorer) and emit a quality baseline report (uses -labels, -artifacts, -report)")
 	labelsPath := flag.String("labels", filepath.Join("docs", "llm", "calibration", "labels.jsonl"), "Path to labels.jsonl (Phase 2)")
 	labelsOut := flag.String("labels-out", filepath.Join("docs", "llm", "calibration", "artifacts.jsonl"), "Output path for -calibrate-capture artifacts.jsonl")
 	artifactsPath := flag.String("artifacts", filepath.Join("docs", "llm", "calibration", "artifacts.jsonl"), "Path to artifacts.jsonl (Phase 2)")
@@ -73,8 +74,11 @@ func main() {
 	if *calibrate {
 		modes++
 	}
+	if *manualReport {
+		modes++
+	}
 	if modes > 1 {
-		log.Fatalf("llm-bench: -capture, -calibrate-capture, -calibrate are mutually exclusive")
+		log.Fatalf("llm-bench: -capture, -calibrate-capture, -calibrate, -manual-report are mutually exclusive")
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -210,6 +214,22 @@ func main() {
 		if code := calibrationExitCode(res.Verdict); code != 0 {
 			os.Exit(code)
 		}
+		return
+	}
+
+	if *manualReport {
+		report, err := runManualReport(ctx, *labelsPath, *artifactsPath)
+		if err != nil {
+			log.Fatalf("llm-bench: manual-report: %v", err)
+		}
+		if *reportPath == "" {
+			fmt.Print(report)
+			return
+		}
+		if err := os.WriteFile(*reportPath, []byte(report), 0o600); err != nil {
+			log.Fatalf("llm-bench: write report: %v", err)
+		}
+		fmt.Fprintf(os.Stderr, "llm-bench: manual quality report written to %s\n", *reportPath)
 		return
 	}
 

--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -55,6 +55,9 @@ func main() {
 	judgeOllamaURL := flag.String("judge-ollama-url", "", "Ollama base URL for -scorer llm-judge (default: -ollama-url)")
 	judgeTimeout := flag.Duration("judge-timeout", 5*time.Minute, "Timeout for each llm-judge scoring request")
 	judgeCachePath := flag.String("judge-cache", defaultJudgeCachePath(), "SQLite path for judge response cache; empty disables")
+	judgeTransport := flag.String("judge-transport", "", "Judge backend for -scorer llm-judge: ollama (default) or openai-compat")
+	judgeBaseURL := flag.String("judge-base-url", "", "Base URL for -judge-transport openai-compat (server root, no /v1 suffix)")
+	judgeAPIKey := flag.String("judge-api-key", "", "Bearer token for -judge-transport openai-compat; falls back to $"+judgeAPIKeyEnvVar)
 	reportPath := flag.String("report", "", "Output report path (default: stdout)")
 	ollamaURL := flag.String("ollama-url", "http://localhost:11434", "Ollama base URL")
 	timeout := flag.Duration("timeout", 5*time.Minute, "Per-replay timeout for candidate model calls")
@@ -169,11 +172,15 @@ func main() {
 			cacheStore = c
 			defer func() { _ = c.Close() }()
 		}
+		jt := resolveJudgeTransportConfig(*judgeTransport, *judgeBaseURL, *judgeAPIKey, os.Getenv)
 		scorer, err := newScorer(ctx, "llm-judge", scorerOptions{
-			ollamaURL:    judgeURL,
-			judgeModel:   judgeName,
-			judgeTimeout: *judgeTimeout,
-			judgeCache:   cacheStore,
+			ollamaURL:      judgeURL,
+			judgeModel:     judgeName,
+			judgeTimeout:   *judgeTimeout,
+			judgeCache:     cacheStore,
+			judgeTransport: jt.transport,
+			judgeBaseURL:   jt.baseURL,
+			judgeAPIKey:    jt.apiKey,
 			// Primary calibration run is cached; stability runs flip
 			// the flag internally (Task 23).
 			bypassCache: false,
@@ -181,11 +188,16 @@ func main() {
 		if err != nil {
 			log.Fatalf("llm-bench: calibrate: %v", err)
 		}
+		judgeProviderName := defaultBenchProvider
+		if js, ok := scorer.(*LLMJudgeScorer); ok {
+			judgeProviderName = js.JudgeProvider
+		}
 		res, err := runCalibrate(ctx, calibrateOptions{
 			LabelsPath:    *labelsPath,
 			ArtifactsPath: *artifactsPath,
 			Scorer:        scorer,
 			JudgeModel:    judgeName,
+			JudgeProvider: judgeProviderName,
 			ReportDir:     *calibrateReportDir,
 			StabilityRuns: *judgeStabilityRuns,
 			AgreementMode: calibrationAgreementMode(*calibrateAgreement),
@@ -249,11 +261,15 @@ func main() {
 		defer func() { _ = c.Close() }()
 	}
 
+	jt := resolveJudgeTransportConfig(*judgeTransport, *judgeBaseURL, *judgeAPIKey, os.Getenv)
 	scorer, err := newScorer(ctx, *scorerName, scorerOptions{
-		ollamaURL:    resolvedJudgeURL,
-		judgeModel:   resolvedJudgeModel,
-		judgeTimeout: *judgeTimeout,
-		judgeCache:   cacheStore,
+		ollamaURL:      resolvedJudgeURL,
+		judgeModel:     resolvedJudgeModel,
+		judgeTimeout:   *judgeTimeout,
+		judgeCache:     cacheStore,
+		judgeTransport: jt.transport,
+		judgeBaseURL:   jt.baseURL,
+		judgeAPIKey:    jt.apiKey,
 	})
 	if err != nil {
 		log.Fatalf("llm-bench: scorer: %v", err)
@@ -349,6 +365,36 @@ func resolveCaptureSample(spec string) (*captureSampleSpec, error) {
 		return nil, err
 	}
 	return &parsed, nil
+}
+
+// judgeAPIKeyEnvVar is the environment variable consulted for the openai-compat
+// judge Bearer token when -judge-api-key is empty. Preferring the env var keeps
+// the secret out of shell history and process listings.
+const judgeAPIKeyEnvVar = "LLM_BENCH_JUDGE_API_KEY"
+
+// judgeTransportConfig is the resolved judge transport selection fed into
+// scorerOptions.
+type judgeTransportConfig struct {
+	transport string
+	baseURL   string
+	apiKey    string
+}
+
+// resolveJudgeTransportConfig applies flag/env precedence for the judge
+// transport. The API key flag takes precedence; when empty it falls back to
+// LLM_BENCH_JUDGE_API_KEY via lookupEnv (injected for tests). transport and
+// baseURL are trimmed and passed through unchanged — newJudgeTransport
+// validates them per backend.
+func resolveJudgeTransportConfig(transport, baseURL, apiKey string, lookupEnv func(string) string) judgeTransportConfig {
+	cfg := judgeTransportConfig{
+		transport: strings.TrimSpace(transport),
+		baseURL:   strings.TrimSpace(baseURL),
+		apiKey:    strings.TrimSpace(apiKey),
+	}
+	if cfg.apiKey == "" {
+		cfg.apiKey = strings.TrimSpace(lookupEnv(judgeAPIKeyEnvVar))
+	}
+	return cfg
 }
 
 // resolveToolSchemaSource picks a tool-schema source from CLI flags.

--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -283,13 +283,14 @@ func main() {
 
 	jt := resolveJudgeTransportConfig(*judgeTransport, *judgeBaseURL, *judgeAPIKey, os.Getenv)
 	scorer, err := newScorer(ctx, *scorerName, scorerOptions{
-		ollamaURL:      resolvedJudgeURL,
-		judgeModel:     resolvedJudgeModel,
-		judgeTimeout:   *judgeTimeout,
-		judgeCache:     cacheStore,
-		judgeTransport: jt.transport,
-		judgeBaseURL:   jt.baseURL,
-		judgeAPIKey:    jt.apiKey,
+		ollamaURL:        resolvedJudgeURL,
+		judgeModel:       resolvedJudgeModel,
+		judgeTimeout:     *judgeTimeout,
+		judgeCache:       cacheStore,
+		judgeTransport:   jt.transport,
+		judgeBaseURL:     jt.baseURL,
+		judgeAPIKey:      jt.apiKey,
+		manualLabelsPath: *labelsPath,
 	})
 	if err != nil {
 		log.Fatalf("llm-bench: scorer: %v", err)

--- a/cmd/llm-bench/main_test.go
+++ b/cmd/llm-bench/main_test.go
@@ -1,9 +1,73 @@
 package main
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestMain(m *testing.M) {
+	if os.Getenv("LLM_BENCH_TEST_MAIN") == "1" {
+		main()
+		return
+	}
+	os.Exit(m.Run())
+}
+
+func TestMainManualScorerUsesLabelsFlag(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"message": map[string]string{
+				"role":    "assistant",
+				"content": "smoke-ok",
+			},
+			"done":              true,
+			"prompt_eval_count": 1,
+			"eval_count":        1,
+		})
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	labels := filepath.Join(dir, "labels.jsonl")
+	if err := writeJSONL(labels, []any{
+		Label{TraceID: "smoke-minimal-001", CandidateModel: "fake", ExpectedAnswerQuality: 1.0},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	report := filepath.Join(dir, "report.md")
+
+	cmd := exec.Command(os.Args[0],
+		"-traces", "testdata/smoke/minimal.json",
+		"-models", "fake",
+		"-scorer", "manual",
+		"-labels", labels,
+		"-ollama-url", server.URL,
+		"-judge-cache", "",
+		"-report", report,
+	)
+	cmd.Env = append(os.Environ(), "LLM_BENCH_TEST_MAIN=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("llm-bench -scorer manual failed: %v\n%s", err, out)
+	}
+	reportBytes, err := os.ReadFile(report)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	if !strings.Contains(string(reportBytes), "manual-label") {
+		t.Fatalf("report did not include manual scorer notes:\n%s", reportBytes)
+	}
+}
 
 func TestResolveToolSchemaSourceStdio(t *testing.T) {
 	src, err := resolveToolSchemaSource("echo mock-server", "")

--- a/cmd/llm-bench/main_test.go
+++ b/cmd/llm-bench/main_test.go
@@ -42,6 +42,36 @@ func TestResolveToolSchemaSourceBothEmptyIsNil(t *testing.T) {
 	}
 }
 
+func TestResolveJudgeTransportConfig_APIKeyFlagWins(t *testing.T) {
+	cfg := resolveJudgeTransportConfig("openai-compat", " https://api.example.com ", "flag-key", func(string) string { return "env-key" })
+	if cfg.apiKey != "flag-key" {
+		t.Fatalf("apiKey = %q; want flag-key (flag overrides env)", cfg.apiKey)
+	}
+	if cfg.baseURL != "https://api.example.com" {
+		t.Fatalf("baseURL = %q; want trimmed value", cfg.baseURL)
+	}
+	if cfg.transport != "openai-compat" {
+		t.Fatalf("transport = %q; want openai-compat", cfg.transport)
+	}
+}
+
+func TestResolveJudgeTransportConfig_APIKeyEnvFallback(t *testing.T) {
+	calls := 0
+	cfg := resolveJudgeTransportConfig("openai-compat", "https://x", "", func(name string) string {
+		calls++
+		if name != judgeAPIKeyEnvVar {
+			t.Errorf("looked up %q; want %q", name, judgeAPIKeyEnvVar)
+		}
+		return "env-key"
+	})
+	if cfg.apiKey != "env-key" {
+		t.Fatalf("apiKey = %q; want env-key fallback", cfg.apiKey)
+	}
+	if calls != 1 {
+		t.Fatalf("env lookups = %d; want exactly 1", calls)
+	}
+}
+
 func TestCaptureSampleAndLimitMutuallyExclusive(t *testing.T) {
 	if err := validateCaptureSampleAndLimit(10, "n=20"); err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
 		t.Fatalf("want mutex error; got %v", err)

--- a/cmd/llm-bench/manual_scorer.go
+++ b/cmd/llm-bench/manual_scorer.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+)
+
+// ManualScorer scores AnswerQuality from human labels rather than an LLM judge
+// or substring match. The quality is the expected_answer_quality the labeler
+// recorded for the (trace, candidate-model) pair — the gold-standard,
+// deterministic, on-box quality signal: no judge, no model call, nothing leaves
+// the box. Tool metrics are computed from the actual transcript exactly as the
+// other scorers do.
+//
+// It is the trustworthy basis for a first accepted run: the labels ARE the
+// human judgment the LLM judge was only ever trying to approximate.
+type ManualScorer struct {
+	labels map[manualLabelKey]manualLabel
+}
+
+type manualLabelKey struct {
+	traceID string
+	model   string
+}
+
+type manualLabel struct {
+	quality float64
+	notes   string
+}
+
+// manualScorerKey canonicalizes a (traceID, model) pair so labels stored bare
+// (e.g. "qwen3:8b") match a run's actual.Model regardless of bench-provider
+// prefix or casing.
+func manualScorerKey(traceID, model string) manualLabelKey {
+	return manualLabelKey{
+		traceID: normalizeModelSelector(traceID),
+		model:   normalizeModelSelector(modelSelectorWithoutBenchProvider(model)),
+	}
+}
+
+// newManualScorer indexes the labels by canonical (trace, model) key. A later
+// label for the same key wins, matching last-write-wins JSONL semantics.
+func newManualScorer(labels []Label) *ManualScorer {
+	m := make(map[manualLabelKey]manualLabel, len(labels))
+	for _, l := range labels {
+		m[manualScorerKey(l.TraceID, l.CandidateModel)] = manualLabel{quality: l.ExpectedAnswerQuality, notes: l.LabelNotes}
+	}
+	return &ManualScorer{labels: m}
+}
+
+// Score implements Scorer. AnswerQuality is the human label; a missing label is
+// a loud error (never a silent 0) so coverage gaps in a human-judged run are
+// visible rather than scored as failures.
+func (s *ManualScorer) Score(_ context.Context, trace Trace, actual Result) (Score, error) {
+	label, ok := s.labels[manualScorerKey(trace.ID, actual.Model)]
+	if !ok {
+		return Score{}, fmt.Errorf("manual scorer: no human label for trace %q model %q", trace.ID, actual.Model)
+	}
+
+	toolArgsScore, toolArgsComputed, toolArgsNotes, schemaErr := scoreToolArguments(trace, actual.Transcript)
+	if schemaErr != nil {
+		return Score{}, fmt.Errorf("trace %q: compile tool schemas: %w", trace.ID, schemaErr)
+	}
+
+	return Score{
+		ToolSequenceMatch:     toolSequenceScore(trace.Golden.ToolCalls, extractToolNames(actual.Transcript)),
+		ToolArgsValid:         toolArgsScore,
+		ToolArgsValidComputed: toolArgsComputed,
+		AnswerQuality:         label.quality,
+		Notes:                 joinScoreNotes(toolArgsNotes, fmt.Sprintf("manual-label: %s", label.notes)),
+	}, nil
+}
+
+// runManualReport scores every frozen labeled artifact with the human labels
+// and returns a per-model quality baseline report. It reads the same
+// (labels, artifacts) pair the calibration flow uses, so the scored outputs
+// are exactly the ones the human judged — no fresh replay, no judge.
+func runManualReport(ctx context.Context, labelsPath, artifactsPath string) (string, error) {
+	matched, _, err := loadLabelsMatchedAgainst(labelsPath, artifactsPath)
+	if err != nil {
+		return "", err
+	}
+	if len(matched) == 0 {
+		return "", fmt.Errorf("no labels matched artifacts in %q / %q", labelsPath, artifactsPath)
+	}
+	labels, err := loadLabels(labelsPath)
+	if err != nil {
+		return "", err
+	}
+	scorer := newManualScorer(labels)
+
+	results := make([]Result, 0, len(matched))
+	modelSeen := map[string]bool{}
+	models := make([]string, 0)
+	for _, m := range matched {
+		trace, traceErr := calibrationTraceFromArtifact(m.Artifact)
+		if traceErr != nil {
+			return "", traceErr
+		}
+		actual := Result{Model: m.Artifact.CandidateModel, TraceID: m.Artifact.TraceID, Transcript: m.Artifact.ActualTranscript}
+		score, scoreErr := scorer.Score(ctx, trace, actual)
+		results = append(results, Result{Model: m.Artifact.CandidateModel, TraceID: m.Artifact.TraceID, Score: score, Err: scoreErr})
+		if !modelSeen[m.Artifact.CandidateModel] {
+			modelSeen[m.Artifact.CandidateModel] = true
+			models = append(models, m.Artifact.CandidateModel)
+		}
+	}
+	sort.Strings(models)
+	return formatManualQualityReport(models, results), nil
+}

--- a/cmd/llm-bench/manual_scorer.go
+++ b/cmd/llm-bench/manual_scorer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 )
 
 // ManualScorer scores AnswerQuality from human labels rather than an LLM judge
@@ -39,14 +40,30 @@ func manualScorerKey(traceID, model string) manualLabelKey {
 	}
 }
 
-// newManualScorer indexes the labels by canonical (trace, model) key. A later
-// label for the same key wins, matching last-write-wins JSONL semantics.
-func newManualScorer(labels []Label) *ManualScorer {
+// newManualScorer indexes the labels by canonical (trace, model) key. Duplicate
+// labels for a key are rejected because the live replay path has no artifact
+// hash to bind the score to a specific labeled output.
+func newManualScorer(labels []Label) (*ManualScorer, error) {
 	m := make(map[manualLabelKey]manualLabel, len(labels))
+	seen := make(map[manualLabelKey]string, len(labels))
 	for _, l := range labels {
-		m[manualScorerKey(l.TraceID, l.CandidateModel)] = manualLabel{quality: l.ExpectedAnswerQuality, notes: l.LabelNotes}
+		key := manualScorerKey(l.TraceID, l.CandidateModel)
+		source := manualLabelSource(l)
+		if prev, ok := seen[key]; ok {
+			return nil, fmt.Errorf("manual scorer: ambiguous labels for (trace, model) key %q/%q: %s and %s", key.traceID, key.model, prev, source)
+		}
+		seen[key] = source
+		m[key] = manualLabel{quality: l.ExpectedAnswerQuality, notes: l.LabelNotes}
 	}
-	return &ManualScorer{labels: m}
+	return &ManualScorer{labels: m}, nil
+}
+
+func manualLabelSource(l Label) string {
+	source := fmt.Sprintf("trace %q model %q", l.TraceID, l.CandidateModel)
+	if hash := strings.TrimSpace(l.ArtifactHash); hash != "" {
+		source += fmt.Sprintf(" artifact_hash %q", hash)
+	}
+	return source
 }
 
 // Score implements Scorer. AnswerQuality is the human label; a missing label is
@@ -109,7 +126,10 @@ func runManualReport(ctx context.Context, labelsPath, artifactsPath string) (str
 		seen[key] = id
 		labels = append(labels, m.Label)
 	}
-	scorer := newManualScorer(labels)
+	scorer, err := newManualScorer(labels)
+	if err != nil {
+		return "", err
+	}
 
 	results := make([]Result, 0, len(matched))
 	modelSeen := map[string]bool{}

--- a/cmd/llm-bench/manual_scorer.go
+++ b/cmd/llm-bench/manual_scorer.go
@@ -72,27 +72,49 @@ func (s *ManualScorer) Score(_ context.Context, trace Trace, actual Result) (Sco
 	}, nil
 }
 
+// manualReportCoverage records how completely the report covers the labels, so
+// a citable artifact never silently under-counts: Stale labels (hash no longer
+// matches an artifact) and Errored scorings are surfaced rather than dropped.
+type manualReportCoverage struct {
+	Scored  int
+	Stale   int
+	Errored int
+}
+
 // runManualReport scores every frozen labeled artifact with the human labels
 // and returns a per-model quality baseline report. It reads the same
 // (labels, artifacts) pair the calibration flow uses, so the scored outputs
-// are exactly the ones the human judged — no fresh replay, no judge.
+// are exactly the ones the human judged — no fresh replay, no judge. Stale
+// labels and scoring errors are surfaced in the coverage line; a duplicate
+// (trace, model) is a hard error because the manual scorer keys on it.
 func runManualReport(ctx context.Context, labelsPath, artifactsPath string) (string, error) {
-	matched, _, err := loadLabelsMatchedAgainst(labelsPath, artifactsPath)
+	matched, stale, err := loadLabelsMatchedAgainst(labelsPath, artifactsPath)
 	if err != nil {
 		return "", err
 	}
 	if len(matched) == 0 {
 		return "", fmt.Errorf("no labels matched artifacts in %q / %q", labelsPath, artifactsPath)
 	}
-	labels, err := loadLabels(labelsPath)
-	if err != nil {
-		return "", err
+
+	// Build the scorer from the matched (non-stale) labels, guarding against
+	// two artifacts colliding on the (trace, model) key the scorer uses.
+	seen := make(map[manualLabelKey]string, len(matched))
+	labels := make([]Label, 0, len(matched))
+	for _, m := range matched {
+		key := manualScorerKey(m.Label.TraceID, m.Label.CandidateModel)
+		id := m.Label.TraceID + "/" + m.Label.CandidateModel
+		if prev, ok := seen[key]; ok {
+			return "", fmt.Errorf("manual report: %s and %s map to the same (trace, model); one artifact per (trace, model) is required", prev, id)
+		}
+		seen[key] = id
+		labels = append(labels, m.Label)
 	}
 	scorer := newManualScorer(labels)
 
 	results := make([]Result, 0, len(matched))
 	modelSeen := map[string]bool{}
 	models := make([]string, 0)
+	errored := 0
 	for _, m := range matched {
 		trace, traceErr := calibrationTraceFromArtifact(m.Artifact)
 		if traceErr != nil {
@@ -100,6 +122,9 @@ func runManualReport(ctx context.Context, labelsPath, artifactsPath string) (str
 		}
 		actual := Result{Model: m.Artifact.CandidateModel, TraceID: m.Artifact.TraceID, Transcript: m.Artifact.ActualTranscript}
 		score, scoreErr := scorer.Score(ctx, trace, actual)
+		if scoreErr != nil {
+			errored++
+		}
 		results = append(results, Result{Model: m.Artifact.CandidateModel, TraceID: m.Artifact.TraceID, Score: score, Err: scoreErr})
 		if !modelSeen[m.Artifact.CandidateModel] {
 			modelSeen[m.Artifact.CandidateModel] = true
@@ -107,5 +132,6 @@ func runManualReport(ctx context.Context, labelsPath, artifactsPath string) (str
 		}
 	}
 	sort.Strings(models)
-	return formatManualQualityReport(models, results), nil
+	cov := manualReportCoverage{Scored: len(matched) - errored, Stale: len(stale), Errored: errored}
+	return formatManualQualityReport(models, results, cov), nil
 }

--- a/cmd/llm-bench/manual_scorer_test.go
+++ b/cmd/llm-bench/manual_scorer_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewScorer_ManualBuildsFromLabelsFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "labels.jsonl")
+	if err := writeJSONL(path, []any{
+		Label{TraceID: "t1", CandidateModel: "qwen3:8b", ExpectedAnswerQuality: 0.5},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	sc, err := newScorer(context.Background(), "manual", scorerOptions{manualLabelsPath: path})
+	if err != nil {
+		t.Fatalf("newScorer(manual): %v", err)
+	}
+	if _, ok := sc.(*ManualScorer); !ok {
+		t.Fatalf("scorer type %T; want *ManualScorer", sc)
+	}
+}
+
+func TestNewScorer_ManualRequiresLabels(t *testing.T) {
+	if _, err := newScorer(context.Background(), "manual", scorerOptions{manualLabelsPath: ""}); err == nil {
+		t.Fatalf("newScorer(manual) with no labels path returned nil error; want error")
+	}
+}
+
+func TestFormatManualQualityReport_AggregatesPerModelAndFlagsLatency(t *testing.T) {
+	results := []Result{
+		{Model: "qwen3:8b", TraceID: "t1", Score: Score{AnswerQuality: 1.0}},
+		{Model: "qwen3:8b", TraceID: "t2", Score: Score{AnswerQuality: 0.5}},
+		{Model: "gemma4:31b", TraceID: "t1", Score: Score{AnswerQuality: 1.0}},
+	}
+	out := formatManualQualityReport([]string{"qwen3:8b", "gemma4:31b"}, results)
+	for _, want := range []string{"qwen3:8b", "gemma4:31b", "human label", "Latency is NOT included"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("report missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestManualScorer_ReturnsHumanLabelAsAnswerQuality(t *testing.T) {
+	s := newManualScorer([]Label{
+		{TraceID: "conversation-fa-l02", CandidateModel: "qwen3:8b", ExpectedAnswerQuality: 0.5, LabelNotes: "partial"},
+	})
+	trace := Trace{ID: "conversation-fa-l02"}
+	actual := Result{Model: "qwen3:8b", Transcript: []Turn{{Role: "assistant", Content: "ans"}}}
+	score, err := s.Score(context.Background(), trace, actual)
+	if err != nil {
+		t.Fatalf("Score: %v", err)
+	}
+	if score.AnswerQuality != 0.5 {
+		t.Fatalf("AnswerQuality = %v; want 0.5 (the human label)", score.AnswerQuality)
+	}
+}
+
+func TestManualScorer_MatchesProviderPrefixedAndCasedModel(t *testing.T) {
+	// Labels are stored bare ("qwen3:8b"); a run's actual.Model may carry the
+	// bench provider prefix ("ollama/qwen3:8b") or different casing.
+	s := newManualScorer([]Label{
+		{TraceID: "t1", CandidateModel: "qwen3:8b", ExpectedAnswerQuality: 1.0},
+	})
+	score, err := s.Score(context.Background(), Trace{ID: "t1"}, Result{Model: "ollama/QWEN3:8b"})
+	if err != nil {
+		t.Fatalf("Score: %v", err)
+	}
+	if score.AnswerQuality != 1.0 {
+		t.Fatalf("AnswerQuality = %v; want 1.0 (prefix/case-insensitive match)", score.AnswerQuality)
+	}
+}
+
+func TestManualScorer_MissingLabelFailsLoud(t *testing.T) {
+	s := newManualScorer([]Label{
+		{TraceID: "t1", CandidateModel: "qwen3:8b", ExpectedAnswerQuality: 1.0},
+	})
+	if _, err := s.Score(context.Background(), Trace{ID: "t1"}, Result{Model: "gemma4:31b"}); err == nil {
+		t.Fatalf("Score for an unlabeled (trace, model) returned nil error; want a loud miss")
+	}
+}

--- a/cmd/llm-bench/manual_scorer_test.go
+++ b/cmd/llm-bench/manual_scorer_test.go
@@ -36,11 +36,58 @@ func TestFormatManualQualityReport_AggregatesPerModelAndFlagsLatency(t *testing.
 		{Model: "qwen3:8b", TraceID: "t2", Score: Score{AnswerQuality: 0.5}},
 		{Model: "gemma4:31b", TraceID: "t1", Score: Score{AnswerQuality: 1.0}},
 	}
-	out := formatManualQualityReport([]string{"qwen3:8b", "gemma4:31b"}, results)
-	for _, want := range []string{"qwen3:8b", "gemma4:31b", "human label", "Latency is NOT included"} {
+	out := formatManualQualityReport([]string{"qwen3:8b", "gemma4:31b"}, results, manualReportCoverage{Scored: 3, Stale: 1, Errored: 0})
+	for _, want := range []string{"qwen3:8b", "gemma4:31b", "human label", "Latency is NOT included", "stale"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("report missing %q:\n%s", want, out)
 		}
+	}
+}
+
+func TestRunManualReport_SurfacesStaleAndScoredCounts(t *testing.T) {
+	dir := t.TempDir()
+	arts := filepath.Join(dir, "artifacts.jsonl")
+	labels := filepath.Join(dir, "labels.jsonl")
+	a1 := testCalibrationArtifact("t1", "answer one")
+	a2 := testCalibrationArtifact("t2", "answer two")
+	if err := writeJSONL(arts, []any{a1, a2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONL(labels, []any{
+		Label{TraceID: "t1", CandidateModel: "ollama/c", ArtifactHash: a1.ArtifactHash, ExpectedAnswerQuality: 1.0},
+		Label{TraceID: "t2", CandidateModel: "ollama/c", ArtifactHash: a2.ArtifactHash, ExpectedAnswerQuality: 0.5},
+		Label{TraceID: "t3", CandidateModel: "ollama/c", ArtifactHash: "stale-no-match", ExpectedAnswerQuality: 1.0},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	report, err := runManualReport(context.Background(), labels, arts)
+	if err != nil {
+		t.Fatalf("runManualReport: %v", err)
+	}
+	if !strings.Contains(report, "stale: 1") {
+		t.Fatalf("report does not surface the 1 stale label:\n%s", report)
+	}
+}
+
+func TestRunManualReport_RejectsAmbiguousTraceModel(t *testing.T) {
+	dir := t.TempDir()
+	arts := filepath.Join(dir, "artifacts.jsonl")
+	labels := filepath.Join(dir, "labels.jsonl")
+	// Two artifacts share (trace, model) but differ in content -> distinct
+	// hashes -> both match their labels -> ambiguous for a (trace, model) key.
+	a1 := testCalibrationArtifact("t1", "answer A")
+	a2 := testCalibrationArtifact("t1", "answer B")
+	if err := writeJSONL(arts, []any{a1, a2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONL(labels, []any{
+		Label{TraceID: "t1", CandidateModel: "ollama/c", ArtifactHash: a1.ArtifactHash, ExpectedAnswerQuality: 1.0},
+		Label{TraceID: "t1", CandidateModel: "ollama/c", ArtifactHash: a2.ArtifactHash, ExpectedAnswerQuality: 0.5},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runManualReport(context.Background(), labels, arts); err == nil {
+		t.Fatalf("runManualReport accepted two artifacts sharing (trace, model); want a loud ambiguity error")
 	}
 }
 

--- a/cmd/llm-bench/manual_scorer_test.go
+++ b/cmd/llm-bench/manual_scorer_test.go
@@ -30,6 +30,26 @@ func TestNewScorer_ManualRequiresLabels(t *testing.T) {
 	}
 }
 
+func TestNewScorer_ManualRejectsAmbiguousTraceModelLabels(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "labels.jsonl")
+	if err := writeJSONL(path, []any{
+		Label{TraceID: "t1", CandidateModel: "ollama/c", ArtifactHash: "sha256:first", ExpectedAnswerQuality: 1.0},
+		Label{TraceID: "t1", CandidateModel: "ollama/c", ArtifactHash: "sha256:second", ExpectedAnswerQuality: 0.5},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := newScorer(context.Background(), "manual", scorerOptions{manualLabelsPath: path})
+	if err == nil {
+		t.Fatalf("newScorer(manual) accepted ambiguous labels for the same trace/model; want error")
+	}
+	for _, want := range []string{"ambiguous", "(trace, model)", "sha256:first", "sha256:second"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err, want)
+		}
+	}
+}
+
 func TestFormatManualQualityReport_AggregatesPerModelAndFlagsLatency(t *testing.T) {
 	results := []Result{
 		{Model: "qwen3:8b", TraceID: "t1", Score: Score{AnswerQuality: 1.0}},
@@ -92,9 +112,12 @@ func TestRunManualReport_RejectsAmbiguousTraceModel(t *testing.T) {
 }
 
 func TestManualScorer_ReturnsHumanLabelAsAnswerQuality(t *testing.T) {
-	s := newManualScorer([]Label{
+	s, err := newManualScorer([]Label{
 		{TraceID: "conversation-fa-l02", CandidateModel: "qwen3:8b", ExpectedAnswerQuality: 0.5, LabelNotes: "partial"},
 	})
+	if err != nil {
+		t.Fatalf("newManualScorer: %v", err)
+	}
 	trace := Trace{ID: "conversation-fa-l02"}
 	actual := Result{Model: "qwen3:8b", Transcript: []Turn{{Role: "assistant", Content: "ans"}}}
 	score, err := s.Score(context.Background(), trace, actual)
@@ -109,9 +132,12 @@ func TestManualScorer_ReturnsHumanLabelAsAnswerQuality(t *testing.T) {
 func TestManualScorer_MatchesProviderPrefixedAndCasedModel(t *testing.T) {
 	// Labels are stored bare ("qwen3:8b"); a run's actual.Model may carry the
 	// bench provider prefix ("ollama/qwen3:8b") or different casing.
-	s := newManualScorer([]Label{
+	s, err := newManualScorer([]Label{
 		{TraceID: "t1", CandidateModel: "qwen3:8b", ExpectedAnswerQuality: 1.0},
 	})
+	if err != nil {
+		t.Fatalf("newManualScorer: %v", err)
+	}
 	score, err := s.Score(context.Background(), Trace{ID: "t1"}, Result{Model: "ollama/QWEN3:8b"})
 	if err != nil {
 		t.Fatalf("Score: %v", err)
@@ -122,9 +148,12 @@ func TestManualScorer_MatchesProviderPrefixedAndCasedModel(t *testing.T) {
 }
 
 func TestManualScorer_MissingLabelFailsLoud(t *testing.T) {
-	s := newManualScorer([]Label{
+	s, err := newManualScorer([]Label{
 		{TraceID: "t1", CandidateModel: "qwen3:8b", ExpectedAnswerQuality: 1.0},
 	})
+	if err != nil {
+		t.Fatalf("newManualScorer: %v", err)
+	}
 	if _, err := s.Score(context.Background(), Trace{ID: "t1"}, Result{Model: "gemma4:31b"}); err == nil {
 		t.Fatalf("Score for an unlabeled (trace, model) returned nil error; want a loud miss")
 	}

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -31,6 +31,9 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 		if opts.TraceSetManifestHash != "" {
 			fmt.Fprintf(&b, "- Trace set manifest hash: `%s`\n", markdownCell(opts.TraceSetManifestHash))
 		}
+		if opts.Scorer == "llm-judge" && opts.JudgeProvider != "" {
+			fmt.Fprintf(&b, "- Judge provider: `%s`\n", markdownCell(opts.JudgeProvider))
+		}
 		if emitCacheLine {
 			total := opts.JudgeCacheHits + opts.JudgeCacheMisses
 			if total > 0 {
@@ -106,6 +109,7 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 type reportOptions struct {
 	Scorer               string
 	JudgeModel           string
+	JudgeProvider        string
 	JudgeCacheHits       int64
 	JudgeCacheMisses     int64
 	TraceSetManifestHash string

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -110,7 +110,7 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 // labeled artifacts carry no timing, so latency is a separate measurement
 // pass. Showing a zero latency column would be misleading, so it is dropped
 // and the omission is stated.
-func formatManualQualityReport(models []string, results []Result) string {
+func formatManualQualityReport(models []string, results []Result, cov manualReportCoverage) string {
 	byModel := make(map[string][]Result, len(models))
 	for _, r := range results {
 		byModel[r.Model] = append(byModel[r.Model], r)
@@ -121,7 +121,8 @@ func formatManualQualityReport(models []string, results []Result) string {
 	fmt.Fprintf(&b, "Generated: %s\n\n", time.Now().UTC().Format(time.RFC3339))
 	fmt.Fprintln(&b, "AnswerQuality is the human label (`expected_answer_quality`): gold-standard, deterministic, on-box — no LLM judge, no model call, nothing leaves the box.")
 	fmt.Fprintln(&b, "Latency is NOT included here — frozen artifacts carry no timing; measure latency in a separate pass.")
-	fmt.Fprintln(&b)
+	fmt.Fprintf(&b, "\nCoverage: %d scored, stale: %d (excluded — label hash no longer matches an artifact), scoring errors: %d.\n\n",
+		cov.Scored, cov.Stale, cov.Errored)
 	fmt.Fprintln(&b, "## Quality by model")
 	fmt.Fprintln(&b, "| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | n |")
 	fmt.Fprintln(&b, "|---|---|---|")

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -105,6 +105,41 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 	return out
 }
 
+// formatManualQualityReport renders a per-model AnswerQuality comparison from
+// human labels (the manual scorer). It deliberately omits latency: frozen
+// labeled artifacts carry no timing, so latency is a separate measurement
+// pass. Showing a zero latency column would be misleading, so it is dropped
+// and the omission is stated.
+func formatManualQualityReport(models []string, results []Result) string {
+	byModel := make(map[string][]Result, len(models))
+	for _, r := range results {
+		byModel[r.Model] = append(byModel[r.Model], r)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "# llm-bench — human-judged quality baseline (manual scorer)\n\n")
+	fmt.Fprintf(&b, "Generated: %s\n\n", time.Now().UTC().Format(time.RFC3339))
+	fmt.Fprintln(&b, "AnswerQuality is the human label (`expected_answer_quality`): gold-standard, deterministic, on-box — no LLM judge, no model call, nothing leaves the box.")
+	fmt.Fprintln(&b, "Latency is NOT included here — frozen artifacts carry no timing; measure latency in a separate pass.")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "## Quality by model")
+	fmt.Fprintln(&b, "| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | n |")
+	fmt.Fprintln(&b, "|---|---|---|")
+	for _, m := range models {
+		rs := byModel[m]
+		agg := aggregate(rs)
+		scored := len(rs) - agg.errors
+		qCell := "n/a"
+		if scored > 0 {
+			qCell = fmt.Sprintf("%.2f / %.2f / %.2f / %.2f / %.2f",
+				agg.meanQuality, agg.qualityP25, agg.qualityP50, agg.qualityP75, agg.qualityP90)
+		}
+		fmt.Fprintf(&b, "| %s | %s | %d |\n", markdownCell(m), qCell, scored)
+	}
+	fmt.Fprintln(&b)
+	return redactPaths(b.String())
+}
+
 // reportOptions carries metadata that formatReport embeds in report headers.
 type reportOptions struct {
 	Scorer               string

--- a/cmd/llm-bench/report_test.go
+++ b/cmd/llm-bench/report_test.go
@@ -183,10 +183,14 @@ func TestFormatReportProvenanceBlock(t *testing.T) {
 	}, reportOptions{
 		Scorer:               "llm-judge",
 		JudgeModel:           "gemma4:31b",
+		JudgeProvider:        "ollama",
 		JudgeCacheHits:       7,
 		JudgeCacheMisses:     3,
 		TraceSetManifestHash: "sha256:abc123",
 	})
+	if !strings.Contains(report, "Judge provider: `ollama`") {
+		t.Error("missing judge provider in provenance")
+	}
 	if !strings.Contains(report, "Judge cache hit rate: 70.0%") {
 		t.Error("missing judge cache hit rate in provenance")
 	}

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -291,7 +291,7 @@ func validateJudgeModel(ctx context.Context, checker judgeModelChecker, judgeMod
 			return nil
 		}
 	}
-	return fmt.Errorf("judge model %q is not available from the configured Ollama server; pull it or pass -judge-model/-judge-ollama-url", judgeModel)
+	return fmt.Errorf("judge model %q is not available from the configured judge transport; pass a -judge-model the active -judge-transport exposes (or fix -judge-transport)", judgeModel)
 }
 
 // buildJudgeCall produces the judge ChatRequest and the partial Score that

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -682,8 +682,9 @@ type judgeResponse struct {
 // echoed struct literal, `{}`, a quoted example — so the FIRST object is not
 // reliably the verdict (observed live as "missing answer_quality"). We scan
 // each candidate object and select the one that actually carries
-// answer_quality; objects that don't parse or lack the field are skipped.
-// Comment stripping is handled by firstJSONObject.
+// answer_quality; when multiple verdict-shaped objects are present, the last
+// one wins so quoted candidate text cannot self-score before the judge's final
+// verdict. Comment stripping is handled by firstJSONObject.
 func parseJudgeResponse(content string) (judgeResponse, error) {
 	raw := strings.TrimSpace(content)
 	if raw == "" {
@@ -691,18 +692,26 @@ func parseJudgeResponse(content string) (judgeResponse, error) {
 	}
 
 	sawObject := false
+	sawVerdictObject := false
+	var lastVerdict judgeResponse
+	haveLastVerdict := false
+	var lastVerdictErr error
 	for pos := 0; pos < len(raw); {
 		idx := strings.IndexByte(raw[pos:], '{')
 		if idx < 0 {
 			break
 		}
 		abs := pos + idx
-		obj := firstJSONObject(raw[abs:])
+		obj, consumed := firstJSONObjectWithEnd(raw[abs:])
 		if obj == "" {
 			pos = abs + 1
 			continue
 		}
 		sawObject = true
+		nextPos := abs + consumed
+		if nextPos <= pos {
+			nextPos = abs + 1
+		}
 		var parsed struct {
 			AnswerQuality *float64 `json:"answer_quality"`
 			Justification string   `json:"justification"`
@@ -710,16 +719,23 @@ func parseJudgeResponse(content string) (judgeResponse, error) {
 		}
 		if err := json.Unmarshal([]byte(obj), &parsed); err != nil || parsed.AnswerQuality == nil {
 			// Not the verdict object (malformed, or a non-verdict blob like an
-			// echoed struct literal). Resume scanning after this object's start.
-			pos = abs + 1
+			// echoed struct literal). Resume scanning after this object.
+			pos = nextPos
 			continue
 		}
+		sawVerdictObject = true
 		quality := *parsed.AnswerQuality
 		if quality < 0 || quality > 1 {
-			return judgeResponse{}, fmt.Errorf("%w: answer_quality %.3f outside [0,1]", errMalformedJudgeResponse, quality)
+			lastVerdictErr = fmt.Errorf("%w: answer_quality %.3f outside [0,1]", errMalformedJudgeResponse, quality)
+			haveLastVerdict = false
+			pos = nextPos
+			continue
 		}
 		if !validJudgeAnswerQuality(quality) {
-			return judgeResponse{}, fmt.Errorf("%w: answer_quality %.3f must be exactly one of 0.0, 0.5, or 1.0", errOffGridJudgeScore, quality)
+			lastVerdictErr = fmt.Errorf("%w: answer_quality %.3f must be exactly one of 0.0, 0.5, or 1.0", errOffGridJudgeScore, quality)
+			haveLastVerdict = false
+			pos = nextPos
+			continue
 		}
 		justification := strings.TrimSpace(parsed.Justification)
 		if justification == "" {
@@ -728,14 +744,23 @@ func parseJudgeResponse(content string) (judgeResponse, error) {
 		if justification == "" {
 			justification = "no justification returned"
 		}
-		return judgeResponse{
+		lastVerdict = judgeResponse{
 			AnswerQuality: quality,
 			Justification: normalizeNote(justification),
-		}, nil
+		}
+		haveLastVerdict = true
+		lastVerdictErr = nil
+		pos = nextPos
 	}
 
+	if haveLastVerdict {
+		return lastVerdict, nil
+	}
 	if !sawObject {
 		return judgeResponse{}, fmt.Errorf("%w: missing JSON object", errMalformedJudgeResponse)
+	}
+	if sawVerdictObject && lastVerdictErr != nil {
+		return judgeResponse{}, lastVerdictErr
 	}
 	return judgeResponse{}, fmt.Errorf("%w: missing answer_quality", errMalformedJudgeResponse)
 }
@@ -753,9 +778,14 @@ func validJudgeAnswerQuality(v float64) bool {
 // inside the justification string is preserved verbatim. Comment-aware scanning
 // also prevents a brace inside a comment from corrupting the depth count.
 func firstJSONObject(s string) string {
+	obj, _ := firstJSONObjectWithEnd(s)
+	return obj
+}
+
+func firstJSONObjectWithEnd(s string) (string, int) {
 	start := strings.IndexByte(s, '{')
 	if start < 0 {
-		return ""
+		return "", 0
 	}
 
 	var b strings.Builder
@@ -791,7 +821,7 @@ func firstJSONObject(s string) string {
 		}
 		if ch == '/' && i+1 < len(s) && s[i+1] == '*' {
 			i += 2
-			for i+1 < len(s) && !(s[i] == '*' && s[i+1] == '/') {
+			for i+1 < len(s) && (s[i] != '*' || s[i+1] != '/') {
 				i++
 			}
 			i++      // position on the closing '/'
@@ -808,10 +838,10 @@ func firstJSONObject(s string) string {
 		}
 		b.WriteByte(ch)
 		if ch == '}' && depth == 0 {
-			return b.String()
+			return b.String(), i + 1
 		}
 	}
-	return ""
+	return "", 0
 }
 
 func sameModelSelector(a, b string) bool {

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -118,7 +118,7 @@ func newScorer(ctx context.Context, name string, opts scorerOptions) (Scorer, er
 		if len(labels) == 0 {
 			return nil, fmt.Errorf("manual scorer: no labels in %q", opts.manualLabelsPath)
 		}
-		return newManualScorer(labels), nil
+		return newManualScorer(labels)
 	default:
 		return nil, fmt.Errorf("unknown scorer %q", name)
 	}

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -29,6 +29,10 @@ const (
 // through provider/openaicompat instead of the default Ollama client.
 const openAICompatTransport = "openai-compat"
 
+// claudeCLITransport is the -judge-transport value that routes the judge
+// through the local `claude` CLI headless mode (subscription, no API billing).
+const claudeCLITransport = "claude-cli"
+
 // Score captures the evaluation dimensions for a single (model, trace) run.
 // See docs/llm/benchmark-plan.md for the scoring rationale.
 type Score struct {
@@ -145,8 +149,11 @@ func newJudgeTransport(opts scorerOptions) (judgeTransport, error) {
 		prov := openaicompat.NewProvider(openaicompat.NewClient(baseURL, clientOpts...))
 		adapter := newOpenAICompatJudge(prov)
 		return judgeTransport{chat: adapter, checker: adapter, providerName: prov.Name()}, nil
+	case claudeCLITransport:
+		adapter := newClaudeCLIJudge(opts.judgeModel)
+		return judgeTransport{chat: adapter, checker: adapter, providerName: claudeCLIProviderName}, nil
 	default:
-		return judgeTransport{}, fmt.Errorf("unknown judge transport %q (want %q or %q)", opts.judgeTransport, defaultBenchProvider, openAICompatTransport)
+		return judgeTransport{}, fmt.Errorf("unknown judge transport %q (want %q, %q, or %q)", opts.judgeTransport, defaultBenchProvider, openAICompatTransport, claudeCLITransport)
 	}
 }
 
@@ -657,65 +664,95 @@ type judgeResponse struct {
 	Justification string
 }
 
+// parseJudgeResponse extracts the verdict from a judge response. A frontier
+// judge sometimes precedes the verdict with other balanced {...} blobs — an
+// echoed struct literal, `{}`, a quoted example — so the FIRST object is not
+// reliably the verdict (observed live as "missing answer_quality"). We scan
+// each candidate object and select the one that actually carries
+// answer_quality; objects that don't parse or lack the field are skipped.
+// Comment stripping is handled by firstJSONObject.
 func parseJudgeResponse(content string) (judgeResponse, error) {
 	raw := strings.TrimSpace(content)
 	if raw == "" {
 		return judgeResponse{}, fmt.Errorf("%w: empty response", errMalformedJudgeResponse)
 	}
-	raw = firstJSONObject(raw)
-	if raw == "" {
+
+	sawObject := false
+	for pos := 0; pos < len(raw); {
+		idx := strings.IndexByte(raw[pos:], '{')
+		if idx < 0 {
+			break
+		}
+		abs := pos + idx
+		obj := firstJSONObject(raw[abs:])
+		if obj == "" {
+			pos = abs + 1
+			continue
+		}
+		sawObject = true
+		var parsed struct {
+			AnswerQuality *float64 `json:"answer_quality"`
+			Justification string   `json:"justification"`
+			Notes         string   `json:"notes"`
+		}
+		if err := json.Unmarshal([]byte(obj), &parsed); err != nil || parsed.AnswerQuality == nil {
+			// Not the verdict object (malformed, or a non-verdict blob like an
+			// echoed struct literal). Resume scanning after this object's start.
+			pos = abs + 1
+			continue
+		}
+		quality := *parsed.AnswerQuality
+		if quality < 0 || quality > 1 {
+			return judgeResponse{}, fmt.Errorf("%w: answer_quality %.3f outside [0,1]", errMalformedJudgeResponse, quality)
+		}
+		if !validJudgeAnswerQuality(quality) {
+			return judgeResponse{}, fmt.Errorf("%w: answer_quality %.3f must be exactly one of 0.0, 0.5, or 1.0", errOffGridJudgeScore, quality)
+		}
+		justification := strings.TrimSpace(parsed.Justification)
+		if justification == "" {
+			justification = strings.TrimSpace(parsed.Notes)
+		}
+		if justification == "" {
+			justification = "no justification returned"
+		}
+		return judgeResponse{
+			AnswerQuality: quality,
+			Justification: normalizeNote(justification),
+		}, nil
+	}
+
+	if !sawObject {
 		return judgeResponse{}, fmt.Errorf("%w: missing JSON object", errMalformedJudgeResponse)
 	}
-
-	var parsed struct {
-		AnswerQuality *float64 `json:"answer_quality"`
-		Justification string   `json:"justification"`
-		Notes         string   `json:"notes"`
-	}
-	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
-		return judgeResponse{}, fmt.Errorf("%w: %v", errMalformedJudgeResponse, err)
-	}
-	if parsed.AnswerQuality == nil {
-		return judgeResponse{}, fmt.Errorf("%w: missing answer_quality", errMalformedJudgeResponse)
-	}
-	quality := parsed.AnswerQuality
-	if *quality < 0 || *quality > 1 {
-		return judgeResponse{}, fmt.Errorf("%w: answer_quality %.3f outside [0,1]", errMalformedJudgeResponse, *quality)
-	}
-	if !validJudgeAnswerQuality(*quality) {
-		return judgeResponse{}, fmt.Errorf("%w: answer_quality %.3f must be exactly one of 0.0, 0.5, or 1.0", errOffGridJudgeScore, *quality)
-	}
-
-	justification := strings.TrimSpace(parsed.Justification)
-	if justification == "" {
-		justification = strings.TrimSpace(parsed.Notes)
-	}
-	if justification == "" {
-		justification = "no justification returned"
-	}
-
-	return judgeResponse{
-		AnswerQuality: *quality,
-		Justification: normalizeNote(justification),
-	}, nil
+	return judgeResponse{}, fmt.Errorf("%w: missing answer_quality", errMalformedJudgeResponse)
 }
 
 func validJudgeAnswerQuality(v float64) bool {
 	return v == 0 || v == 0.5 || v == 1
 }
 
+// firstJSONObject extracts the first balanced {...} object from s and returns
+// it with JSON-illegal // line comments and /* */ block comments stripped.
+// LLM judges (especially when the judged content itself contains code) sometimes
+// emit comments — observed live with a frontier judge producing
+// `{"answer_quality":1.0, // matches\n ...}`, which json.Unmarshal rejects.
+// Comments are stripped only OUTSIDE string literals, so a // or /* that lives
+// inside the justification string is preserved verbatim. Comment-aware scanning
+// also prevents a brace inside a comment from corrupting the depth count.
 func firstJSONObject(s string) string {
 	start := strings.IndexByte(s, '{')
 	if start < 0 {
 		return ""
 	}
 
+	var b strings.Builder
 	depth := 0
 	inString := false
 	escaped := false
 	for i := start; i < len(s); i++ {
 		ch := s[i]
 		if inString {
+			b.WriteByte(ch)
 			if escaped {
 				escaped = false
 				continue
@@ -729,6 +766,25 @@ func firstJSONObject(s string) string {
 			continue
 		}
 
+		// Outside a string: skip // line and /* */ block comments so the
+		// extracted object is valid JSON and braces inside comments do not
+		// affect depth.
+		if ch == '/' && i+1 < len(s) && s[i+1] == '/' {
+			i += 2
+			for i < len(s) && s[i] != '\n' {
+				i++
+			}
+			continue // loop i++ steps past the newline (or EOF)
+		}
+		if ch == '/' && i+1 < len(s) && s[i+1] == '*' {
+			i += 2
+			for i+1 < len(s) && !(s[i] == '*' && s[i+1] == '/') {
+				i++
+			}
+			i++      // position on the closing '/'
+			continue // loop i++ steps past it
+		}
+
 		switch ch {
 		case '"':
 			inString = true
@@ -736,9 +792,10 @@ func firstJSONObject(s string) string {
 			depth++
 		case '}':
 			depth--
-			if depth == 0 {
-				return s[start : i+1]
-			}
+		}
+		b.WriteByte(ch)
+		if ch == '}' && depth == 0 {
+			return b.String()
 		}
 	}
 	return ""

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -7,12 +7,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"time"
 	"unicode/utf8"
 
 	"github.com/kstruzzieri/go-llm/ollama"
+	"github.com/kstruzzieri/go-llm/provider/openaicompat"
 )
 
 const (
@@ -22,6 +24,10 @@ const (
 	maxJudgeTurnContentBytes = 8192
 	maxJudgeAnswerBytes      = 32768
 )
+
+// openAICompatTransport is the -judge-transport value that routes the judge
+// through provider/openaicompat instead of the default Ollama client.
+const openAICompatTransport = "openai-compat"
 
 // Score captures the evaluation dimensions for a single (model, trace) run.
 // See docs/llm/benchmark-plan.md for the scoring rationale.
@@ -51,6 +57,13 @@ type scorerOptions struct {
 	ollamaURL    string
 	judgeModel   string
 	judgeTimeout time.Duration
+	// judgeTransport selects the judge backend: "" or "ollama" (default) uses
+	// the local Ollama client; "openai-compat" routes through
+	// provider/openaicompat for a frontier judge. judgeBaseURL is required for
+	// the openai-compat transport; judgeAPIKey is the optional Bearer token.
+	judgeTransport string
+	judgeBaseURL   string
+	judgeAPIKey    string
 	// judgeCache is the optional judge response cache. Callers MUST avoid
 	// the typed-nil interface trap: assign only a non-nil concrete
 	// implementation (e.g. *sqliteJudgeCache) or leave this field unset.
@@ -69,18 +82,19 @@ func newScorer(ctx context.Context, name string, opts scorerOptions) (Scorer, er
 		if opts.judgeTimeout < 0 {
 			return nil, fmt.Errorf("negative judge timeout %s", opts.judgeTimeout)
 		}
-		client, err := newOllamaClient(opts.ollamaURL, ollama.WithTimeout(opts.judgeTimeout))
-		if err != nil {
-			return nil, fmt.Errorf("llm-judge client: %w", err)
-		}
-		scorer, err := newLLMJudgeScorer(client, opts.judgeModel, opts.judgeTimeout)
+		transport, err := newJudgeTransport(opts)
 		if err != nil {
 			return nil, err
 		}
-		if err := validateJudgeModel(ctx, client, scorer.JudgeModel); err != nil {
+		scorer, err := newLLMJudgeScorer(transport.chat, opts.judgeModel, opts.judgeTimeout)
+		if err != nil {
 			return nil, err
 		}
-		digest, _ := resolveJudgeDigest(ctx, client, scorer.JudgeModel)
+		scorer.JudgeProvider = transport.providerName
+		if err := validateJudgeModel(ctx, transport.checker, scorer.JudgeModel); err != nil {
+			return nil, err
+		}
+		digest, _ := resolveJudgeDigest(ctx, transport.checker, scorer.JudgeModel)
 		scorer.JudgeModelDigest = digest
 		scorer.Cache = opts.judgeCache
 		scorer.BypassCache = opts.bypassCache
@@ -89,6 +103,50 @@ func newScorer(ctx context.Context, name string, opts scorerOptions) (Scorer, er
 		return nil, fmt.Errorf("manual scorer not yet implemented")
 	default:
 		return nil, fmt.Errorf("unknown scorer %q", name)
+	}
+}
+
+// judgeTransport bundles the judge's chat client, model checker, and provider
+// instance identity so newScorer builds the scorer uniformly regardless of
+// backend. The same concrete value satisfies both the chat and checker seams
+// for each transport (*ollama.Client; *openAICompatJudgeClient).
+type judgeTransport struct {
+	chat         judgeChatClient
+	checker      judgeModelChecker
+	providerName string
+}
+
+// newJudgeTransport resolves opts.judgeTransport to a judge backend. Empty or
+// "ollama" (case-insensitive) is the default local path; "openai-compat"
+// routes a frontier judge through provider/openaicompat. The returned
+// providerName is the provider *instance* identity that gets folded into the
+// cache key and provenance — for openai-compat it is the provider's Name(),
+// not the API kind, so a renamed instance keys distinctly.
+func newJudgeTransport(opts scorerOptions) (judgeTransport, error) {
+	switch normalizeModelSelector(opts.judgeTransport) {
+	case "", defaultBenchProvider:
+		client, err := newOllamaClient(opts.ollamaURL, ollama.WithTimeout(opts.judgeTimeout))
+		if err != nil {
+			return judgeTransport{}, fmt.Errorf("llm-judge client: %w", err)
+		}
+		return judgeTransport{chat: client, checker: client, providerName: defaultBenchProvider}, nil
+	case openAICompatTransport:
+		baseURL := strings.TrimSpace(opts.judgeBaseURL)
+		if baseURL == "" {
+			return judgeTransport{}, fmt.Errorf("llm-judge %s transport requires -judge-base-url", openAICompatTransport)
+		}
+		clientOpts := []openaicompat.ClientOption{}
+		if opts.judgeTimeout > 0 {
+			clientOpts = append(clientOpts, openaicompat.WithHTTPClient(&http.Client{Timeout: opts.judgeTimeout}))
+		}
+		if key := strings.TrimSpace(opts.judgeAPIKey); key != "" {
+			clientOpts = append(clientOpts, openaicompat.WithAPIKey(key))
+		}
+		prov := openaicompat.NewProvider(openaicompat.NewClient(baseURL, clientOpts...))
+		adapter := newOpenAICompatJudge(prov)
+		return judgeTransport{chat: adapter, checker: adapter, providerName: prov.Name()}, nil
+	default:
+		return judgeTransport{}, fmt.Errorf("unknown judge transport %q (want %q or %q)", opts.judgeTransport, defaultBenchProvider, openAICompatTransport)
 	}
 }
 
@@ -177,6 +235,7 @@ func resolveJudgeDigest(ctx context.Context, checker judgeModelChecker, judgeMod
 // typed-nil interface trap before assignment.
 type LLMJudgeScorer struct {
 	Client           judgeChatClient
+	JudgeProvider    string // provider instance identity (e.g. "ollama", "openai-compat"); folded into the cache key and persisted for provenance
 	JudgeModel       string
 	JudgeModelDigest string // optional; empty when /api/show was unavailable
 	JudgeTimeout     time.Duration
@@ -380,6 +439,7 @@ func (s *LLMJudgeScorer) Score(ctx context.Context, trace Trace, actual Result) 
 		now := s.now()
 		if putErr := s.Cache.Put(ctx, judgeCacheEntry{
 			CacheKey:         cacheKey,
+			JudgeProvider:    s.JudgeProvider,
 			JudgeModel:       s.JudgeModel,
 			JudgeModelDigest: s.JudgeModelDigest,
 			TraceID:          trace.ID,
@@ -439,6 +499,7 @@ func (s *LLMJudgeScorer) materializeCacheLookup(base Score, hit judgeCacheEntry,
 func (s *LLMJudgeScorer) cacheKeyForJudgeRequest(req ollama.ChatRequest) string {
 	return canonicalCacheKey(judgeCacheRequest{
 		Version:          judgeCacheKeyVersion,
+		JudgeProvider:    normalizeModelSelector(s.JudgeProvider),
 		JudgeModel:       normalizeModelSelector(s.JudgeModel),
 		JudgeModelDigest: s.JudgeModelDigest,
 		SystemPrompt:     judgeSystemPrompt,

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -137,8 +138,9 @@ type judgeTransport struct {
 // "ollama" (case-insensitive) is the default local path; "openai-compat"
 // routes a frontier judge through provider/openaicompat. The returned
 // providerName is the provider *instance* identity that gets folded into the
-// cache key and provenance — for openai-compat it is the provider's Name(),
-// not the API kind, so a renamed instance keys distinctly.
+// cache key and provenance. For openai-compat it is endpoint-scoped so two
+// base URLs that expose the same model id cannot reuse each other's digest-less
+// cached verdicts.
 func newJudgeTransport(opts scorerOptions) (judgeTransport, error) {
 	switch normalizeModelSelector(opts.judgeTransport) {
 	case "", defaultBenchProvider:
@@ -159,7 +161,11 @@ func newJudgeTransport(opts scorerOptions) (judgeTransport, error) {
 		if key := strings.TrimSpace(opts.judgeAPIKey); key != "" {
 			clientOpts = append(clientOpts, openaicompat.WithAPIKey(key))
 		}
-		prov := openaicompat.NewProvider(openaicompat.NewClient(baseURL, clientOpts...))
+		providerName := openAICompatJudgeProviderName(baseURL)
+		prov := openaicompat.NewProvider(
+			openaicompat.NewClient(baseURL, clientOpts...),
+			openaicompat.WithProviderName(providerName),
+		)
 		adapter := newOpenAICompatJudge(prov)
 		return judgeTransport{chat: adapter, checker: adapter, providerName: prov.Name()}, nil
 	case claudeCLITransport:
@@ -168,6 +174,28 @@ func newJudgeTransport(opts scorerOptions) (judgeTransport, error) {
 	default:
 		return judgeTransport{}, fmt.Errorf("unknown judge transport %q (want %q, %q, or %q)", opts.judgeTransport, defaultBenchProvider, openAICompatTransport, claudeCLITransport)
 	}
+}
+
+func openAICompatJudgeProviderName(baseURL string) string {
+	canonical := canonicalJudgeBaseURL(baseURL)
+	sum := sha256.Sum256([]byte(canonical))
+	return fmt.Sprintf("%s:%s", openAICompatTransport, hex.EncodeToString(sum[:])[:12])
+}
+
+func canonicalJudgeBaseURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return raw
+	}
+	u.Scheme = strings.ToLower(u.Scheme)
+	u.Host = strings.ToLower(u.Host)
+	u.User = nil
+	u.RawQuery = ""
+	u.Fragment = ""
+	u.RawPath = ""
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String()
 }
 
 // ExactMatchScorer is a dependency-free baseline. Answer quality is scored
@@ -255,7 +283,7 @@ func resolveJudgeDigest(ctx context.Context, checker judgeModelChecker, judgeMod
 // typed-nil interface trap before assignment.
 type LLMJudgeScorer struct {
 	Client           judgeChatClient
-	JudgeProvider    string // provider instance identity (e.g. "ollama", "openai-compat"); folded into the cache key and persisted for provenance
+	JudgeProvider    string // provider instance identity (e.g. "ollama", "openai-compat:<endpoint-id>"); folded into the cache key and persisted for provenance
 	JudgeModel       string
 	JudgeModelDigest string // optional; empty when /api/show was unavailable
 	JudgeTimeout     time.Duration

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -68,6 +68,9 @@ type scorerOptions struct {
 	judgeTransport string
 	judgeBaseURL   string
 	judgeAPIKey    string
+	// manualLabelsPath is the human labels JSONL consumed by the "manual"
+	// scorer (AnswerQuality = expected_answer_quality).
+	manualLabelsPath string
 	// judgeCache is the optional judge response cache. Callers MUST avoid
 	// the typed-nil interface trap: assign only a non-nil concrete
 	// implementation (e.g. *sqliteJudgeCache) or leave this field unset.
@@ -104,7 +107,17 @@ func newScorer(ctx context.Context, name string, opts scorerOptions) (Scorer, er
 		scorer.BypassCache = opts.bypassCache
 		return scorer, nil
 	case "manual":
-		return nil, fmt.Errorf("manual scorer not yet implemented")
+		if strings.TrimSpace(opts.manualLabelsPath) == "" {
+			return nil, fmt.Errorf("manual scorer requires -labels (human labels JSONL)")
+		}
+		labels, err := loadLabels(opts.manualLabelsPath)
+		if err != nil {
+			return nil, fmt.Errorf("manual scorer: load labels: %w", err)
+		}
+		if len(labels) == 0 {
+			return nil, fmt.Errorf("manual scorer: no labels in %q", opts.manualLabelsPath)
+		}
+		return newManualScorer(labels), nil
 	default:
 		return nil, fmt.Errorf("unknown scorer %q", name)
 	}

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -940,6 +940,48 @@ func TestLLMJudgeScorer_CacheHit_ReusesContentButRecomputesToolSequenceMatch(t *
 	}
 }
 
+// TestLLMJudgeScorer_CacheKeyIncludesProvider pins that two scorers differing
+// only in JudgeProvider produce different cache keys, so a frontier judge's
+// verdict can never reuse a same-named local Ollama judge's cached score.
+func TestLLMJudgeScorer_CacheKeyIncludesProvider(t *testing.T) {
+	req := ollama.ChatRequest{Messages: []ollama.ChatMessage{
+		{Role: "system", Content: "s"},
+		{Role: "user", Content: "u"},
+	}}
+	ollamaJudge := &LLMJudgeScorer{JudgeModel: "m", JudgeProvider: "ollama"}
+	compatJudge := &LLMJudgeScorer{JudgeModel: "m", JudgeProvider: "openai-compat"}
+	if ollamaJudge.cacheKeyForJudgeRequest(req) == compatJudge.cacheKeyForJudgeRequest(req) {
+		t.Fatalf("cache key did not vary with JudgeProvider")
+	}
+}
+
+// TestLLMJudgeScorer_CachePutRecordsProvider pins that Score persists the
+// scorer's JudgeProvider into the cache row for per-verdict provenance.
+func TestLLMJudgeScorer_CachePutRecordsProvider(t *testing.T) {
+	c, _ := newTestCache(t)
+	judge := &fakeJudgeClient{resp: &ollama.ChatResponse{Message: ollama.ChatMessage{
+		Content: `{"answer_quality":1.0,"justification":"good"}`,
+	}}}
+	scorer := &LLMJudgeScorer{
+		Client:        judge,
+		JudgeModel:    "claude-x",
+		JudgeProvider: "openai-compat",
+		Cache:         c,
+	}
+	trace := Trace{ID: "t-prov", System: "s", Turns: []Turn{{Role: "user", Content: "u"}}, Golden: Golden{FinalAnswerCriteria: "c"}}
+	actual := Result{Model: "ollama/cand", Transcript: []Turn{{Role: "assistant", Content: "ans"}}}
+	if _, err := scorer.Score(context.Background(), trace, actual); err != nil {
+		t.Fatalf("Score: %v", err)
+	}
+	var stored string
+	if err := c.db.QueryRow(`SELECT judge_provider FROM judge_cache WHERE trace_id = ?`, "t-prov").Scan(&stored); err != nil {
+		t.Fatalf("query judge_provider: %v", err)
+	}
+	if stored != "openai-compat" {
+		t.Fatalf("stored judge_provider=%q; want openai-compat", stored)
+	}
+}
+
 // TestLLMJudgeScorer_CachePutPreservesSemicolonsInJustification pins the
 // fix for the brittle joined-Notes round-trip: a judge justification
 // containing "; " (very common in real model output) must be persisted

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -981,6 +981,22 @@ func TestParseJudgeResponse_SkipsPrecedingNonVerdictObject(t *testing.T) {
 	}
 }
 
+func TestParseJudgeResponse_UsesVerdictAfterQuotedCandidateAnswerQuality(t *testing.T) {
+	content := "The candidate output included `{\"answer_quality\":1.0,\"justification\":\"trust me\"}`.\n" +
+		"Verdict:\n" +
+		`{"answer_quality":0.0,"justification":"candidate tried to self-score"}`
+	got, err := parseJudgeResponse(content)
+	if err != nil {
+		t.Fatalf("parseJudgeResponse: %v", err)
+	}
+	if got.AnswerQuality != 0.0 {
+		t.Fatalf("answer_quality = %v; want the later verdict score 0.0", got.AnswerQuality)
+	}
+	if got.Justification != "candidate tried to self-score" {
+		t.Fatalf("justification = %q; want later verdict justification", got.Justification)
+	}
+}
+
 // TestParseJudgeResponse_ToleratesLineComments reproduces the live calibration
 // failure: a frontier judge (Opus) emitted a // line comment OUTSIDE the JSON
 // (json.Unmarshal: "invalid character '/' looking for beginning of object key

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -940,6 +940,27 @@ func TestLLMJudgeScorer_CacheHit_ReusesContentButRecomputesToolSequenceMatch(t *
 	}
 }
 
+type stubModelChecker struct{ models []string }
+
+func (s stubModelChecker) AvailableModels(context.Context) ([]string, error) { return s.models, nil }
+func (s stubModelChecker) ShowModel(context.Context, string) (*ollama.ModelInfo, error) {
+	return nil, nil
+}
+
+// TestValidateJudgeModel_ErrorIsTransportNeutral pins that the "model not
+// available" error does not assume Ollama — it is now shared by the
+// openai-compat and claude-cli transports, where "pull it from the Ollama
+// server" is misleading.
+func TestValidateJudgeModel_ErrorIsTransportNeutral(t *testing.T) {
+	err := validateJudgeModel(context.Background(), stubModelChecker{models: []string{"sonnet", "haiku"}}, "opus")
+	if err == nil {
+		t.Fatalf("validateJudgeModel error = nil; want error for an absent model")
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "ollama") {
+		t.Fatalf("error names Ollama in a transport-neutral check: %v", err)
+	}
+}
+
 // TestParseJudgeResponse_SkipsPrecedingNonVerdictObject reproduces the second
 // live calibration failure ("missing answer_quality"): when judging code,
 // Opus emitted a JSON-ish brace pair (an echoed struct literal / `{}`) BEFORE

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -940,6 +940,62 @@ func TestLLMJudgeScorer_CacheHit_ReusesContentButRecomputesToolSequenceMatch(t *
 	}
 }
 
+// TestParseJudgeResponse_SkipsPrecedingNonVerdictObject reproduces the second
+// live calibration failure ("missing answer_quality"): when judging code,
+// Opus emitted a JSON-ish brace pair (an echoed struct literal / `{}`) BEFORE
+// the verdict. The first balanced object must NOT win — the parser must select
+// the object that actually carries answer_quality.
+func TestParseJudgeResponse_SkipsPrecedingNonVerdictObject(t *testing.T) {
+	content := "The candidate wrote `type T struct{}` and returned `{}`. Verdict:\n" +
+		`{"answer_quality":0.0,"justification":"materially wrong"}`
+	got, err := parseJudgeResponse(content)
+	if err != nil {
+		t.Fatalf("parseJudgeResponse: %v", err)
+	}
+	if got.AnswerQuality != 0.0 {
+		t.Fatalf("answer_quality = %v; want 0.0", got.AnswerQuality)
+	}
+	if got.Justification != "materially wrong" {
+		t.Fatalf("justification = %q; want \"materially wrong\"", got.Justification)
+	}
+}
+
+// TestParseJudgeResponse_ToleratesLineComments reproduces the live calibration
+// failure: a frontier judge (Opus) emitted a // line comment OUTSIDE the JSON
+// (json.Unmarshal: "invalid character '/' looking for beginning of object key
+// string"). Comments outside strings must be stripped, but a // that lives
+// INSIDE the justification string (common when judging code) must survive.
+func TestParseJudgeResponse_ToleratesLineComments(t *testing.T) {
+	content := "{\n  \"answer_quality\": 1.0, // perfect, matches golden\n  \"justification\": \"candidate produced `// Open opens the store` verbatim\"\n}"
+	got, err := parseJudgeResponse(content)
+	if err != nil {
+		t.Fatalf("parseJudgeResponse: %v", err)
+	}
+	if got.AnswerQuality != 1.0 {
+		t.Fatalf("answer_quality = %v; want 1.0", got.AnswerQuality)
+	}
+	if !strings.Contains(got.Justification, "// Open opens the store") {
+		t.Fatalf("justification lost the in-string // content: %q", got.Justification)
+	}
+}
+
+// TestParseJudgeResponse_ToleratesBlockCommentsWithBraces pins that block
+// comments are stripped AND that a brace inside a comment does not throw off
+// the balanced-object scan (the comment-aware extractor must not count it).
+func TestParseJudgeResponse_ToleratesBlockCommentsWithBraces(t *testing.T) {
+	content := "```json\n{\n  /* note: a } here is not a real brace */\n  \"answer_quality\": 0.5,\n  \"justification\": \"partial\"\n}\n```"
+	got, err := parseJudgeResponse(content)
+	if err != nil {
+		t.Fatalf("parseJudgeResponse: %v", err)
+	}
+	if got.AnswerQuality != 0.5 {
+		t.Fatalf("answer_quality = %v; want 0.5", got.AnswerQuality)
+	}
+	if got.Justification != "partial" {
+		t.Fatalf("justification = %q; want \"partial\"", got.Justification)
+	}
+}
+
 // TestLLMJudgeScorer_CacheKeyIncludesProvider pins that two scorers differing
 // only in JudgeProvider produce different cache keys, so a frontier judge's
 // verdict can never reuse a same-named local Ollama judge's cached score.

--- a/docs/llm/CALIBRATION.md
+++ b/docs/llm/CALIBRATION.md
@@ -96,6 +96,34 @@ llm-bench -calibrate \
   -calibrate-agreement exact
 ```
 
+For a frontier judge, keep the same labels/artifacts and switch only the judge
+transport:
+
+```
+LLM_BENCH_JUDGE_API_KEY=... llm-bench -calibrate \
+  -labels docs/llm/calibration/labels.jsonl \
+  -artifacts docs/llm/calibration/artifacts.jsonl \
+  -judge-transport openai-compat \
+  -judge-base-url https://api.openai.com \
+  -judge-model <model-listed-by-/v1/models> \
+  -calibrate-agreement exact
+```
+
+For subscription-backed Claude Code diagnostics:
+
+```
+llm-bench -calibrate \
+  -labels docs/llm/calibration/labels.jsonl \
+  -artifacts docs/llm/calibration/artifacts.jsonl \
+  -judge-transport claude-cli \
+  -judge-model opus \
+  -calibrate-agreement exact
+```
+
+`claude-cli` reports provider provenance as `claude-cli` and caches against
+the Claude CLI version when available. It is not a raw API transport and cannot
+pin temperature, so run stability diagnostics before citing a pass.
+
 Writes a markdown report to
 `docs/llm/calibration/reports/YYYY-MM-DDTHHMMSSZ-<slug>.md`. If a report
 already exists for the same timestamp and judge model, a numeric suffix is

--- a/docs/llm/CALIBRATION.md
+++ b/docs/llm/CALIBRATION.md
@@ -109,6 +109,10 @@ LLM_BENCH_JUDGE_API_KEY=... llm-bench -calibrate \
   -calibrate-agreement exact
 ```
 
+`openai-compat` reports provider provenance as `openai-compat:<endpoint-id>`;
+the endpoint id is derived from the base URL so two compatible endpoints with
+the same model id do not share cached digest-less verdicts.
+
 For subscription-backed Claude Code diagnostics:
 
 ```

--- a/docs/llm/README.md
+++ b/docs/llm/README.md
@@ -92,6 +92,41 @@ in the report and shown separately as scorer latency. Use
 `-judge-ollama-url` when the judge should run on a different Ollama
 instance than the candidate models.
 
+`llm-judge` can also use a frontier judge without replaying candidate models
+through a non-Ollama backend:
+
+```bash
+go run ./cmd/llm-bench \
+  -traces 'cmd/llm-bench/testdata/smoke/*.json' \
+  -models 'ollama/qwen3.6:35b-a3b' \
+  -scorer llm-judge \
+  -judge-transport openai-compat \
+  -judge-base-url https://api.openai.com \
+  -judge-model '<model-listed-by-/v1/models>' \
+  -report /tmp/llm-bench-frontier-judge.md
+```
+
+For `openai-compat`, set the Bearer token with
+`LLM_BENCH_JUDGE_API_KEY`; `-judge-api-key` exists for local experiments but
+can leak through shell history or process listings.
+
+For local subscription-backed diagnostics, `-judge-transport claude-cli`
+adapts `claude -p` headless mode:
+
+```bash
+go run ./cmd/llm-bench \
+  -traces 'cmd/llm-bench/testdata/smoke/*.json' \
+  -models 'ollama/qwen3.6:35b-a3b' \
+  -scorer llm-judge \
+  -judge-transport claude-cli \
+  -judge-model opus \
+  -report /tmp/llm-bench-claude-cli-judge.md
+```
+
+Treat `claude-cli` provenance as "Claude Code CLI judge", not a raw model API:
+the CLI does not expose a temperature pin, and its headless runtime is still an
+agent surface. Use `-judge-stability-runs 3` before citing a borderline pass.
+
 ## Local trace capture
 
 Captured traces are written under `docs/llm/traces/`, which is gitignored

--- a/docs/llm/README.md
+++ b/docs/llm/README.md
@@ -108,7 +108,9 @@ go run ./cmd/llm-bench \
 
 For `openai-compat`, set the Bearer token with
 `LLM_BENCH_JUDGE_API_KEY`; `-judge-api-key` exists for local experiments but
-can leak through shell history or process listings.
+can leak through shell history or process listings. Report provenance records
+the judge provider as `openai-compat:<endpoint-id>` so two endpoints with the
+same model id do not share cached digest-less verdicts.
 
 For local subscription-backed diagnostics, `-judge-transport claude-cli`
 adapts `claude -p` headless mode:

--- a/docs/llm/benchmarks/TEMPLATE.md
+++ b/docs/llm/benchmarks/TEMPLATE.md
@@ -16,7 +16,7 @@ output.
 - **Trace set**: `<label>`, count: N, manifest hash: `sha256:...`
 - **Models under test**: `<comma list, provider/name>`
 - **Scorer**: `llm-judge`
-  - Judge provider: `<ollama | openai-compat | claude-cli>`
+  - Judge provider: `<ollama | openai-compat:<endpoint-id> | claude-cli>`
   - Judge model: `<name>`
   - Judge model digest (when available via /api/show): `<digest>`
   - Judge cache hit rate: X%

--- a/docs/llm/benchmarks/TEMPLATE.md
+++ b/docs/llm/benchmarks/TEMPLATE.md
@@ -16,6 +16,7 @@ output.
 - **Trace set**: `<label>`, count: N, manifest hash: `sha256:...`
 - **Models under test**: `<comma list, provider/name>`
 - **Scorer**: `llm-judge`
+  - Judge provider: `<ollama | openai-compat | claude-cli>`
   - Judge model: `<name>`
   - Judge model digest (when available via /api/show): `<digest>`
   - Judge cache hit rate: X%


### PR DESCRIPTION
## Summary

Adds judge-transport infrastructure and a human-label scorer to `llm-bench`, and produces an honest, on-box quality baseline for the first accepted run.

**What this includes**
- **openai-compat judge transport** (`-judge-transport openai-compat -judge-base-url -judge-api-key`, env fallback `LLM_BENCH_JUDGE_API_KEY`) — temperature-pinnable frontier judge via any OpenAI-compatible endpoint. Ollama stays the default.
- **claude-cli judge transport** (`-judge-transport claude-cli`) — runs the judge through headless `claude -p` on a Claude subscription (no API billing), locked down for judging (system-prompt override, tools disabled, empty cwd).
- **Provenance + cache isolation** — judge provider folded into the cache key (`judgeCacheKeyVersion` v2→v3) + a `judge_provider` column + report/calibration-report lines, so a frontier verdict never reuses a same-named local one.
- **Robust judge-response parsing** (general, all transports) — strips `//`/`/* */` comments outside strings and selects the verdict object that actually carries `answer_quality`, fixing two real malformations a frontier judge emitted during a live run.
- **Manual (human-label) scorer** (`-scorer manual`, `-manual-report`) — scores `AnswerQuality` from human labels over the frozen, labeled artifacts (the exact outputs judged): deterministic, on-box, no model call. The report surfaces coverage (scored/stale/errors) and omits latency honestly (frozen artifacts carry no timing).

**Honest status**
- The **manual scorer** unblocks the first accepted run's *quality* dimension with a gold-standard, on-box, human-judged baseline.
- The **automated frontier judge** is *capability-demonstrated* (it clears the calibration gate where the local judge could not, never lenient) but is **NOT a citable calibrated benchmark yet**: the `claude-cli` path can't pin temperature, so borderline/subtle-bug verdicts are non-deterministic. Determinism mitigation (multi-vote / temperature-pinned transport / strong local judge) and a cloud-judge data-governance guardrail are tracked as follow-up.

**Testing**
- TDD throughout; full module suite + `-race` green; `go vet` / `gofmt` clean.
- Two adversarial review passes applied (transports, manual scorer); their fixes are in this branch.

Generated with [Claude Code](https://claude.com/claude-code)