### PR TITLE
docs: publish Round-1 human baseline + finalize benchmark acceptance contract

### DIFF
--- a/docs/llm/benchmarks/2026-06-06-round-1-human-baseline.md
+++ b/docs/llm/benchmarks/2026-06-06-round-1-human-baseline.md
@@ -1,0 +1,70 @@
+<!--
+Round-1 human baseline — NOT an accepted run. Pipeline evidence + rough signal,
+not a decision-grade ranking. Per spec §5.2: aggregates only — no raw prompts,
+transcripts, judge justifications, or error messages.
+-->
+
+# round-1-human-baseline — 2026-06-06
+
+> **This is not an accepted run.** Even on the gate's manual-label path it falls
+> short: the human labels are **not fully paired** across the lineup (only 5/24
+> traces have all 4 models labeled), and the corpus is **plain-chat with no
+> tool-use evidence**. It is a human-judged baseline — evidence the
+> capture→label→replay pipeline works, plus a *rough* quality/latency signal —
+> not a decision-grade model ranking. Do not promote to `harness-results.md` or
+> cite in `recommendation.md`.
+
+## Provenance
+- **Harness commit**: `8b97696` (develop; judge transports + manual scorer, PR #135)
+- **Machine**: MacBook Pro M3 Max, 128 GB unified memory
+- **Trace set**: `first-accepted-run`, count: 24, manifest hash: `sha256:a94b74bd7cd631ba2290ba9e8a0d4238878bd9dceac873424ef8579438319d81`
+- **Models**: `ollama/qwen3-coder-next:latest, ollama/gemma4:31b, ollama/qwen3.6:35b-a3b, ollama/qwen3:8b` (all Q4_K_M)
+- **Quality scorer**: `manual` (human labels); 60 labels, 15 per model
+- **Latency**: separate fresh timed replay (`-scorer exact-match`, `-timeout 10m`, thinking on); frozen artifacts carry no timing
+- **Latency command**:
+  ```
+  llm-bench -traces 'docs/llm/traces/first-accepted-run/conversation-*.json' \
+    -models 'ollama/qwen3-coder-next:latest,ollama/gemma4:31b,ollama/qwen3.6:35b-a3b,ollama/qwen3:8b' \
+    -scorer exact-match -timeout 10m -report <path>
+  ```
+
+## Calibration
+N/A — quality is human-judged (`manual` scorer), so there is no LLM judge to
+calibrate. The automated-judge calibration (frontier judge via `claude-cli`)
+passed the gate once but is **not citable** (single-draw nondeterminism); it is
+Round-2 work and is not used here.
+
+## Results
+Quality n = 15 per model; latency n = 24 per model (23 where a replay was
+excluded). **These are different trace subsets** — see paired-labeling caveat.
+
+| Model | AnswerQuality (human, mean) | LatencyMs p50 / p90 (successful-only) | tokens (sum) | quality n | latency n |
+| --- | --- | --- | --- | --- | --- |
+| ollama/qwen3-coder-next:latest | 0.93 | 21,668 / 94,372 | 25,841 | 15 | 24 |
+| ollama/gemma4:31b | 1.00 | 123,436 / 275,212 | 30,391 | 15 | 23 |
+| ollama/qwen3.6:35b-a3b | 0.93 | 75,565 / 180,653 | 78,385 | 15 | 24 |
+| ollama/qwen3:8b | 0.73 | 54,576 / 145,142 | 59,193 | 15 | 23 |
+
+Tool metrics omitted: plain-chat corpus (zero tool-call traces), so they are
+trivially satisfied and are **not** evidence of tool-calling correctness.
+
+## Errors and exclusions
+- **Error/timeout rate: 2 / 96 replays (2.1%)** — `conversation-fa-m01` (timeout, exceeded the 10 m cap) and `conversation-fa-c07` (other). Raw messages live in the gitignored run log.
+- **Latency p50/p90 are successful-only** → p90 is *optimistic*: the timed-out worst case is excluded, not capped-in. A run with more/harder traces should report timeout rate alongside latency and either cap-in timeouts or label "successful-only" explicitly.
+
+## Findings (signal strength varies)
+- **Strong: `qwen3-coder-next`** — near-top human quality at the **best p50 latency** (21.7 s), despite being the largest model. Worth taking seriously for coding/dev-chat.
+- **Meaningful: `qwen3:8b`** — on this chat/code corpus it is **worse *and* slower** than `coder-next`, so keep it to lightweight/low-stakes use unless a separate FIM/classification benchmark proves a niche.
+- **Weak: the quality ordering among `gemma4:31b`, `qwen3-coder-next`, `qwen3.6:35b-a3b`.** With 15 labels/model on a saturated, largely-unpaired set, `1.00` vs `0.93` is one or two borderline labels. **Do not read Gemma as "best quality"** — it is "top observed score, but indistinguishable under this corpus."
+- **Latency driver**: reported token volume / output verbosity appears to drive latency (the harness records total tokens = prompt-eval + gen-eval, **not** isolated thinking tokens). `coder-next` emitted the fewest tokens and was fastest; `qwen3.6:35b-a3b` the most.
+
+## Conclusion
+- **Verdict**: not decision-grade. Round-1 human baseline; pipeline validated; one strong model signal (`coder-next`).
+- **Lineup**: keep the current lineup. Tactical reads only (not a `recommendation.md` change): prefer `qwen3-coder-next` for coding/dev-chat when memory allows; keep `gemma4:31b` for judge/agent/general until a hard tool-use corpus justifies otherwise; re-test `qwen3.6:35b-a3b` and `qwen3:8b` with thinking off / tighter generation before assigning them "fast" roles.
+
+## Caveats
+- **Corpus saturation/skew**: labels are 49×1.0 / 10×0.5 / 1×0.0 — limited discrimination (ceiling effect). The quality numbers sit near the corpus's resolution limit.
+- **Labels are largely unpaired**: only 5/24 traces have all 4 models labeled (17/24 have 2). Per-model means therefore reflect different trace-difficulty mixes and can be biased — Round 2 must label paired outputs (all candidates on every retained trace).
+- **Two-pass methodology**: quality is on the exact frozen outputs the human judged; latency is a fresh replay (new outputs). Acceptable (latency ≈ model+prompt property) but not the identical generations.
+- **Thinking-on, chat/analysis traces**: high latency variance (p90 ≫ p50); says nothing about inline-completion (FIM) latency, which is a separate measurement.
+- **Model config**: 4/5 models run with a raw `{{ .Prompt }}` Ollama template (confirmed functional for chat) and `presence_penalty 1.5` baked on two — flagged for awareness, not a defect in this run.

--- a/docs/llm/benchmarks/TEMPLATE.md
+++ b/docs/llm/benchmarks/TEMPLATE.md
@@ -25,7 +25,9 @@ output.
   - If `manual`:
     - Label manifest hash: `sha256:...`
     - Artifact manifest hash: `sha256:...`
-    - Paired label coverage: X/Y retained traces complete
+    - Valid labeled artifacts: X (≥50 required → SUFFICIENT)
+    - Paired label coverage: X/Y retained traces complete (≥20 complete
+      traces required → SUFFICIENT)
     - Stale/missing labels: N stale, N missing
     - Labeler / reviewer: `<name> / <name>`
 - **Exact command** (match the declared scorer path):
@@ -34,8 +36,11 @@ output.
   llm-bench -traces '<glob>' -models '...' -scorer llm-judge -judge-model ... \
     -judge-transport <ollama|openai-compat|claude-cli> -judge-cache <path> -report <path>
 
-  # manual-label path (quality from human labels over frozen artifacts):
+  # manual-label path, quality from human labels over frozen artifacts:
   llm-bench -manual-report -labels <labels.jsonl> -artifacts <artifacts.jsonl> -report <path>
+
+  # manual-label path, separate replay metrics over the same trace set:
+  llm-bench -traces '<glob>' -models '...' -scorer exact-match -report <path>
   ```
 
 ## Calibration / Labeling (embedded — not linked to a gitignored file)
@@ -46,7 +51,8 @@ output.
   known subtle-bug fixtures pass → **PASS**
 - Stability runs (M=3, diagnostic): max spread observed: 0.NN
 - Manual-label path: paired labels complete for X/Y retained traces; stale and
-  missing labels excluded and reported.
+  missing labels excluded and reported; ≥50 valid labeled artifacts and ≥20
+  complete retained traces.
 
 ## Results
 | Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | ToolSequenceMatch | ToolArgsValid (computed=N) | LatencyMs (p50 / p90) | TotalTokens | n |

--- a/docs/llm/benchmarks/TEMPLATE.md
+++ b/docs/llm/benchmarks/TEMPLATE.md
@@ -22,6 +22,8 @@ output.
     - Judge model digest (when available via /api/show): `<digest>`
     - Judge cache hit rate: X%
     - Judge cache key version: V
+    - Judge stability policy: `<temperature-pinned/deterministic | multi-vote/stability policy>`
+    - Judge stability verdict: `<PASS | FAIL>` with evidence summary
   - If `manual`:
     - Label manifest hash: `sha256:...`
     - Artifact manifest hash: `sha256:...`
@@ -49,7 +51,11 @@ output.
 - Valid labeled artifacts: X (≥50 required → SUFFICIENT)
 - Agreement: X / Y (Z%) — overall ≥85%, borderline/fail ≥80% when present,
   known subtle-bug fixtures pass → **PASS**
-- Stability runs (M=3, diagnostic): max spread observed: 0.NN
+- Automated-judge stability: `<PASS | FAIL>` — transport is
+  `<temperature-pinned/deterministic | unpinned>`, policy is
+  `<single deterministic draw | median-of-N votes | repeated stability run>`,
+  evidence `<max spread, repeated-pass reports, or deterministic transport proof>`.
+  Single-draw unpinned runs are diagnostic only.
 - Manual-label path: paired labels complete for X/Y retained traces; stale and
   missing labels excluded and reported; ≥50 valid labeled artifacts and ≥20
   complete retained traces.

--- a/docs/llm/benchmarks/TEMPLATE.md
+++ b/docs/llm/benchmarks/TEMPLATE.md
@@ -15,33 +15,62 @@ output.
 - **Machine**: <hardware profile, e.g. M3 Max 128GB>
 - **Trace set**: `<label>`, count: N, manifest hash: `sha256:...`
 - **Models under test**: `<comma list, provider/name>`
-- **Scorer**: `llm-judge`
-  - Judge provider: `<ollama | openai-compat:<endpoint-id> | claude-cli>`
-  - Judge model: `<name>`
-  - Judge model digest (when available via /api/show): `<digest>`
-  - Judge cache hit rate: X%
-  - Judge cache key version: V
-- **Exact command**:
+- **Scorer**: `<llm-judge | manual>`
+  - If `llm-judge`:
+    - Judge provider: `<ollama | openai-compat:<endpoint-id> | claude-cli>`
+    - Judge model: `<name>`
+    - Judge model digest (when available via /api/show): `<digest>`
+    - Judge cache hit rate: X%
+    - Judge cache key version: V
+  - If `manual`:
+    - Label manifest hash: `sha256:...`
+    - Artifact manifest hash: `sha256:...`
+    - Paired label coverage: X/Y retained traces complete
+    - Stale/missing labels: N stale, N missing
+    - Labeler / reviewer: `<name> / <name>`
+- **Exact command** (match the declared scorer path):
   ```
+  # llm-judge path:
   llm-bench -traces '<glob>' -models '...' -scorer llm-judge -judge-model ... \
-    -judge-cache <path> -report <path>
+    -judge-transport <ollama|openai-compat|claude-cli> -judge-cache <path> -report <path>
+
+  # manual-label path (quality from human labels over frozen artifacts):
+  llm-bench -manual-report -labels <labels.jsonl> -artifacts <artifacts.jsonl> -report <path>
   ```
 
-## Calibration (embedded — not linked to a gitignored file)
+## Calibration / Labeling (embedded — not linked to a gitignored file)
 - Judge model: `<name>`
 - Labels manifest hash: `sha256:...`
 - Valid labeled artifacts: X (≥50 required → SUFFICIENT)
 - Agreement: X / Y (Z%) — overall ≥85%, borderline/fail ≥80% when present,
   known subtle-bug fixtures pass → **PASS**
 - Stability runs (M=3, diagnostic): max spread observed: 0.NN
+- Manual-label path: paired labels complete for X/Y retained traces; stale and
+  missing labels excluded and reported.
 
 ## Results
 | Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | ToolSequenceMatch | ToolArgsValid (computed=N) | LatencyMs (p50 / p90) | TotalTokens | n |
 | --- | --- | --- | --- | --- | --- | --- |
 
+Partitioned results:
+- Natural set: reported separately.
+- Challenge/discrimination set: reported separately.
+- Do not average natural and challenge results into one headline.
+
+Paired statistics:
+- Per-trace win/loss/tie table included or linked.
+- Confidence / resolution diagnostic: `<bootstrap/permutation CI, or one-label-flip sensitivity>`.
+
+Tool-call subset:
+- Expected-tool-call traces: N
+- `ToolArgsValid` coverage on expected-tool-call pairs: X/Y
+- Overall `ToolArgsValid` computed coverage: X/Y
+
 ## Errors and exclusions
 - N traces failed (categorized by sanitized reason; raw messages live in the gitignored run log)
 - N traces excluded from `ToolArgsValid` (computed=false)
+- Timeout/error rate by model: `<table or bullets>`
+- Latency policy: `<capped-in timeouts | successful-only; if successful-only, state that p90 is optimistic>`
 
 ## Conclusion
 - **Verdict**: accept / propose change to <X> / inconclusive

--- a/docs/llm/harness-results.md
+++ b/docs/llm/harness-results.md
@@ -19,9 +19,10 @@ A benchmark run is "accepted" iff **all** of:
      or a documented multi-vote/stability policy passes. Single-draw unpinned
      judge runs are diagnostic only.
    - **Manual-label path:** human labels are fully paired across the retained
-     candidate lineup, label/artifact manifest hashes are recorded, stale or
-     missing labels are excluded and reported, and the labeler/reviewer is
-     named in provenance.
+     candidate lineup, with at least 50 valid labeled artifacts and at least
+     20 fully paired retained traces. Label/artifact manifest hashes are
+     recorded, stale or missing labels are excluded and reported, and the
+     labeler/reviewer is named in provenance.
 3. **Tool-call evidence is non-vacuous when tool-use is claimed.**
    `ToolArgsValid` coverage is reported both overall and on the expected
    tool-call subset. For accepted tool-use benchmarks, `ToolArgsValid` is `computed=true`

--- a/docs/llm/harness-results.md
+++ b/docs/llm/harness-results.md
@@ -9,12 +9,28 @@
 A benchmark run is "accepted" iff **all** of:
 
 1. **Commit is clean** (`dirty: no` in provenance).
-2. **Calibration PASS** — exact categorical agreement ≥85% on ≥50 valid
-   labeled artifacts, borderline/fail agreement ≥80% when present, no known
-   subtle-bug fixture judged as `1.0`, and the old tolerance diagnostic
-   reported for context.
-3. **Judge cache hit-rate is reported** (any value; reproducibility signal).
-4. **`ToolArgsValid` is `computed=true` for ≥80% of (model, trace) pairs.**
+2. **Quality scorer provenance is complete**, using exactly one of:
+   - **Automated judge path:** Calibration PASS — exact categorical agreement
+     ≥85% on ≥50 valid labeled artifacts, borderline/fail agreement ≥80%
+     when present, no known subtle-bug fixture judged as `1.0`, the old
+     tolerance diagnostic reported for context, and Judge cache hit-rate
+     reported (any value; reproducibility signal). Judge stability is reported
+     and passed: either the judge transport is temperature-pinned/deterministic,
+     or a documented multi-vote/stability policy passes. Single-draw unpinned
+     judge runs are diagnostic only.
+   - **Manual-label path:** human labels are fully paired across the retained
+     candidate lineup, label/artifact manifest hashes are recorded, stale or
+     missing labels are excluded and reported, and the labeler/reviewer is
+     named in provenance.
+3. **Tool-call evidence is non-vacuous when tool-use is claimed.**
+   `ToolArgsValid` coverage is reported both overall and on the expected
+   tool-call subset. For accepted tool-use benchmarks, `ToolArgsValid` is `computed=true`
+   for ≥80% of expected-tool-call (model, trace) pairs. Rows
+   where no tool calls were expected or made may still report `computed=true`,
+   but they do not count as evidence of tool-calling correctness.
+4. **Failure-aware latency is reported** — timeout/error rate per model is
+   shown, and the latency table states whether timeouts are capped-in or
+   successful-only.
 5. **Trace set manifest hash is recorded.**
 6. **Conclusion has been written and reviewed by the repo owner.**
 


### PR DESCRIPTION
## Summary
Publishes the Round-1 **human-judged baseline** and finalizes the benchmark **acceptance contract**. Round-1 is pipeline evidence + a rough quality/latency signal — **not an accepted run** and **not** a `recommendation.md` change.

## Changes
- **`benchmarks/2026-06-06-round-1-human-baseline.md`** (new): per-model human quality (manual scorer) + a separate fresh latency replay, full provenance, failure-aware exclusions, and honest caveats. Explicitly not accepted: even on the manual-label path, labels aren't fully paired (5/24 traces) and the corpus has no tool-use evidence.
- **`harness-results.md`** acceptance gate: two scoring paths (**automated-judge** / **manual-label**); tool-call evidence must be non-vacuous (expected-tool-call subset); failure-aware latency required; and the automated-judge path requires **reported + passed judge stability** (temp-pinned/deterministic or a documented multi-vote policy) — single-draw unpinned runs are diagnostic only.
- **`TEMPLATE.md`**: supports both `llm-judge` and `manual` scorer provenance, with command examples for each path.

## Not in this PR
- Does **not** promote Round-1 to the accepted index (it isn't accepted).
- DESIGN.md refresh is a separate branch.

## Related
Round-2 harness work is tracked in #137–#142 (failure-aware latency, paired-label tooling, corpus builder/manifest, tool-use subset reporting, FIM-latency mode, token isolation); #136 (candidate openai-compat transport) is deferred unless benchmarking alternate serving stacks.

Generated with [Claude Code](https://claude.com/claude-code)