### PR TITLE
feat(llm-bench): failure-aware latency reporting (#137)

### DIFF
--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -47,8 +47,8 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 	}
 
 	fmt.Fprintf(&b, "## Results\n\n")
-	fmt.Fprintf(&b, "| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | ToolSequenceMatch | ToolArgsValid (computed=N) | LatencyMs (p50 / p90) | TotalTokens | n |\n")
-	fmt.Fprintf(&b, "|---|---|---|---|---|---|---|\n")
+	fmt.Fprintf(&b, "| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | ToolSequenceMatch | ToolArgsValid (computed=N) | LatencyMs (p50 / p90, successful-only) | TotalTokens | n | Failures/total (timeout) |\n")
+	fmt.Fprintf(&b, "|---|---|---|---|---|---|---|---|\n")
 	for _, m := range models {
 		rs := byModel[m]
 		agg := aggregate(rs)
@@ -74,8 +74,9 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 			tokensCell = fmt.Sprintf("%d", agg.totalTokensSum)
 		}
 
-		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s | %s | %d |\n",
-			markdownCell(m), qCell, toolSeqCell, toolArgsCell, latencyCell, tokensCell, scored)
+		failuresCell := fmt.Sprintf("%d/%d (%d timeout)", agg.errors, agg.errors+scored, agg.timeouts)
+		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s | %s | %d | %s |\n",
+			markdownCell(m), qCell, toolSeqCell, toolArgsCell, latencyCell, tokensCell, scored, failuresCell)
 	}
 
 	fmt.Fprintf(&b, "\n## Per-trace detail\n\n")
@@ -154,6 +155,7 @@ type reportOptions struct {
 // modelAggregate holds computed statistics for one model's result set.
 type modelAggregate struct {
 	errors               int
+	timeouts             int
 	meanQuality          float64
 	qualityP25           float64
 	qualityP50           float64
@@ -183,6 +185,9 @@ func aggregate(rs []Result) modelAggregate {
 	for _, r := range rs {
 		if r.Err != nil {
 			a.errors++
+			if redactErrorMessage(r.Err.Error()) == "<error: timeout>" {
+				a.timeouts++
+			}
 			continue
 		}
 		qVals = append(qVals, r.Score.AnswerQuality)

--- a/cmd/llm-bench/report_test.go
+++ b/cmd/llm-bench/report_test.go
@@ -6,6 +6,24 @@ import (
 	"testing"
 )
 
+// TestFormatReport_FailureAwareLatency pins that latency is reported
+// failure-aware: a per-model failures/total (timeout) count is shown, and the
+// latency column is labeled successful-only (since errored/timed-out replays
+// are excluded from the latency aggregate, making p90 otherwise optimistic).
+func TestFormatReport_FailureAwareLatency(t *testing.T) {
+	results := []Result{
+		{Model: "m", TraceID: "t1", Score: Score{AnswerQuality: 1.0, LatencyMs: 100}},
+		{Model: "m", TraceID: "t2", Err: errors.New("context deadline exceeded")}, // timeout
+		{Model: "m", TraceID: "t3", Err: errors.New("connection refused")},        // non-timeout
+	}
+	out := formatReport([]string{"m"}, results, reportOptions{Scorer: "exact-match"})
+	for _, want := range []string{"successful-only", "Failures/total (timeout)", "2/3 (1 timeout)"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("report missing %q:\n%s", want, out)
+		}
+	}
+}
+
 // TestFormatReportIncludesToolArgsMetric verifies that ToolArgsValid is
 // rendered in both the summary and per-trace sections when it is computed.
 func TestFormatReportIncludesToolArgsMetric(t *testing.T) {
@@ -128,7 +146,7 @@ func TestFormatReportSummaryMatchesTemplateColumns(t *testing.T) {
 		{Model: "m1", TraceID: "t1", Score: Score{AnswerQuality: 0.5, ToolSequenceMatch: 1, ToolArgsValid: 1, ToolArgsValidComputed: true, LatencyMs: 100, TotalTokens: 42}},
 	}, reportOptions{Scorer: "llm-judge", JudgeModel: "gemma4:31b"})
 
-	want := "| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | ToolSequenceMatch | ToolArgsValid (computed=N) | LatencyMs (p50 / p90) | TotalTokens | n |"
+	want := "| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | ToolSequenceMatch | ToolArgsValid (computed=N) | LatencyMs (p50 / p90, successful-only) | TotalTokens | n | Failures/total (timeout) |"
 	if !strings.Contains(report, want) {
 		t.Fatalf("rendered report missing TEMPLATE column header.\nWant: %q\nGot:\n%s", want, report)
 	}

--- a/docs/llm/benchmarks/TEMPLATE.md
+++ b/docs/llm/benchmarks/TEMPLATE.md
@@ -61,8 +61,8 @@ output.
   complete retained traces.
 
 ## Results
-| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | ToolSequenceMatch | ToolArgsValid (computed=N) | LatencyMs (p50 / p90) | TotalTokens | n |
-| --- | --- | --- | --- | --- | --- | --- |
+| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | ToolSequenceMatch | ToolArgsValid (computed=N) | LatencyMs (p50 / p90, successful-only) | TotalTokens | n | Failures/total (timeout) |
+| --- | --- | --- | --- | --- | --- | --- | --- |
 
 Partitioned results:
 - Natural set: reported separately.


### PR DESCRIPTION
## Summary

Makes replay failures first-class in the benchmark report. Previously the latency aggregate silently excluded errored/timed-out replays, so `p50`/`p90` were successful-only and `p90` was optimistic — a model that timed out on its slowest 20% of traces looked *faster* than one that completed them.

This satisfies the **failure-aware-latency** requirement in the Round-2 acceptance gate (`docs/llm/harness-results.md`), the first harness item in the Round-2 sequence.

## Changes

- `modelAggregate` now tracks `timeouts`, classified via the existing `redactErrorMessage` sanitizer (`<error: timeout>`), counted alongside total `errors`.
- `formatReport` labels the latency column **`LatencyMs (p50 / p90, successful-only)`** so the exclusion is explicit, and adds a **`Failures/total (timeout)`** column = per-model failure count / total + timeout split.
- `TEMPLATE.md`'s Results header is synced to match — the report↔TEMPLATE column-guard test (`TestFormatReportSummaryMatchesTemplateColumns`) requires the documented columns to equal the rendered ones.

## Testing

- New `TestFormatReport_FailureAwareLatency` pins the `successful-only` label, the new column, and the `2/3 (1 timeout)` rate rendering.
- `go build ./...`, `go vet ./cmd/llm-bench/`, and `go test ./...` all green.

## Context

Rebased onto develop after #143 (Round-1 human baseline + two-path acceptance gate) merged. Per the Round-2 corpus spec, this is harness item 1 of 6; #138–#142 follow.

Generated with [Claude Code](https://claude.com/claude-code)