### PR TITLE
feat(llm-bench): paired-label tooling + paired report stats (#138)

### DIFF
--- a/cmd/llm-bench/calibration.go
+++ b/cmd/llm-bench/calibration.go
@@ -189,13 +189,23 @@ func loadLabelsMatchedAgainst(labelsPath, artifactsPath string) ([]matchedLabel,
 	if err != nil {
 		return nil, nil, fmt.Errorf("load artifacts: %w", err)
 	}
-	byHash := make(map[string]Artifact, len(arts))
-	for _, a := range arts {
-		byHash[a.ArtifactHash] = a
-	}
 	labels, err := loadLabels(labelsPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("load labels: %w", err)
+	}
+	return matchLabels(labels, arts)
+}
+
+// matchLabels partitions already-loaded labels into (matched, stale) against
+// the artifact set. A label is "matched" when its ArtifactHash is present in
+// arts and "stale" otherwise; stale labels are reported, not errors. Duplicate
+// matched ArtifactHash values are rejected so each artifact contributes at most
+// once. Kept pure (no I/O) so the paired-report path can load artifacts once
+// and retain the full set for lineup/gap detection.
+func matchLabels(labels []Label, arts []Artifact) ([]matchedLabel, []Label, error) {
+	byHash := make(map[string]Artifact, len(arts))
+	for _, a := range arts {
+		byHash[a.ArtifactHash] = a
 	}
 	var matched []matchedLabel
 	var stale []Label

--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -42,6 +42,8 @@ func main() {
 	calibrateCapture := flag.Bool("calibrate-capture", false, "Phase 1: replay candidates and write frozen artifacts.jsonl")
 	calibrate := flag.Bool("calibrate", false, "Phase 2: re-score frozen labeled artifacts with the judge model")
 	manualReport := flag.Bool("manual-report", false, "Score frozen labeled artifacts with human labels (manual scorer) and emit a quality baseline report (uses -labels, -artifacts, -report)")
+	pairedReport := flag.Bool("paired-report", false, "Emit the paired-label report: paired-complete means, completeness worklist, win/loss/tie matrix, bootstrap delta CIs, resolution diagnostic (uses -labels, -artifacts, -baseline, -report)")
+	baseline := flag.String("baseline", "", "Baseline model selector for -paired-report deltas (default: first lineup model, derived from artifacts)")
 	labelsPath := flag.String("labels", filepath.Join("docs", "llm", "calibration", "labels.jsonl"), "Path to labels.jsonl (Phase 2)")
 	labelsOut := flag.String("labels-out", filepath.Join("docs", "llm", "calibration", "artifacts.jsonl"), "Output path for -calibrate-capture artifacts.jsonl")
 	artifactsPath := flag.String("artifacts", filepath.Join("docs", "llm", "calibration", "artifacts.jsonl"), "Path to artifacts.jsonl (Phase 2)")
@@ -77,8 +79,11 @@ func main() {
 	if *manualReport {
 		modes++
 	}
+	if *pairedReport {
+		modes++
+	}
 	if modes > 1 {
-		log.Fatalf("llm-bench: -capture, -calibrate-capture, -calibrate, -manual-report are mutually exclusive")
+		log.Fatalf("llm-bench: -capture, -calibrate-capture, -calibrate, -manual-report, -paired-report are mutually exclusive")
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -230,6 +235,22 @@ func main() {
 			log.Fatalf("llm-bench: write report: %v", err)
 		}
 		fmt.Fprintf(os.Stderr, "llm-bench: manual quality report written to %s\n", *reportPath)
+		return
+	}
+
+	if *pairedReport {
+		report, err := runPairedReport(*labelsPath, *artifactsPath, *baseline)
+		if err != nil {
+			log.Fatalf("llm-bench: paired-report: %v", err)
+		}
+		if *reportPath == "" {
+			fmt.Print(report)
+			return
+		}
+		if err := os.WriteFile(*reportPath, []byte(report), 0o600); err != nil {
+			log.Fatalf("llm-bench: write report: %v", err)
+		}
+		fmt.Fprintf(os.Stderr, "llm-bench: paired-label report written to %s\n", *reportPath)
 		return
 	}
 

--- a/cmd/llm-bench/main_test.go
+++ b/cmd/llm-bench/main_test.go
@@ -69,6 +69,48 @@ func TestMainManualScorerUsesLabelsFlag(t *testing.T) {
 	}
 }
 
+func TestMainPairedReportEndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	artsPath := filepath.Join(dir, "artifacts.jsonl")
+	labelsPath := filepath.Join(dir, "labels.jsonl")
+	reportPath := filepath.Join(dir, "report.md")
+
+	a1A, l1A := labeledArtifact("t1", "ollama/a", "x", 1.0, "keith")
+	a1B, l1B := labeledArtifact("t1", "ollama/b", "x", 0.0, "keith")
+	if err := writeJSONL(artsPath, []any{a1A, a1B}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONL(labelsPath, []any{l1A, l1B}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(os.Args[0],
+		"-paired-report",
+		"-labels", labelsPath,
+		"-artifacts", artsPath,
+		"-baseline", "ollama/a",
+		"-report", reportPath,
+	)
+	cmd.Env = append(os.Environ(), "LLM_BENCH_TEST_MAIN=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("llm-bench -paired-report failed: %v\n%s", err, out)
+	}
+	body, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	for _, want := range []string{
+		"Quality by model (paired-complete)",
+		"Model vs baseline (ollama/a)",
+		"Bootstrap: seed=1, n=10000",
+	} {
+		if !strings.Contains(string(body), want) {
+			t.Fatalf("paired report missing %q:\n%s", want, body)
+		}
+	}
+}
+
 func TestResolveToolSchemaSourceStdio(t *testing.T) {
 	src, err := resolveToolSchemaSource("echo mock-server", "")
 	if err != nil {

--- a/cmd/llm-bench/manual_scorer_test.go
+++ b/cmd/llm-bench/manual_scorer_test.go
@@ -57,7 +57,7 @@ func TestFormatManualQualityReport_AggregatesPerModelAndFlagsLatency(t *testing.
 		{Model: "gemma4:31b", TraceID: "t1", Score: Score{AnswerQuality: 1.0}},
 	}
 	out := formatManualQualityReport([]string{"qwen3:8b", "gemma4:31b"}, results, manualReportCoverage{Scored: 3, Stale: 1, Errored: 0})
-	for _, want := range []string{"qwen3:8b", "gemma4:31b", "human label", "Latency is NOT included", "stale"} {
+	for _, want := range []string{"qwen3:8b", "gemma4:31b", "human label", "Latency is NOT included", "stale", "all matched labels"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("report missing %q:\n%s", want, out)
 		}

--- a/cmd/llm-bench/paired.go
+++ b/cmd/llm-bench/paired.go
@@ -1,0 +1,391 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"sort"
+	"strings"
+)
+
+// lineupFromArtifacts returns the candidate-model lineup as the distinct,
+// normalized, sorted set of CandidateModel values across the artifact set.
+//
+// The lineup is derived from artifacts — NOT from matched labels — so a model
+// that was captured but has zero fresh labels still appears (and shows as
+// all-gap in the completeness worklist) instead of vanishing.
+func lineupFromArtifacts(arts []Artifact) []string {
+	seen := make(map[string]struct{}, len(arts))
+	var out []string
+	for _, a := range arts {
+		m := normalizeModelSelector(a.CandidateModel)
+		if m == "" {
+			continue
+		}
+		if _, ok := seen[m]; ok {
+			continue
+		}
+		seen[m] = struct{}{}
+		out = append(out, m)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// bootstrapDeltaCI returns a percentile (2.5%, 97.5%) confidence interval for
+// the mean of paired deltas via the bootstrap. It is deterministic: a given
+// (deltas, seed, n) always yields the same interval, so callers MUST pass a
+// fixed seed (the harness uses seed=1, n=10000). Each of the n resamples draws
+// len(deltas) deltas with replacement and records the resample mean; the CI is
+// the nearest-rank 2.5/97.5 percentiles of those means. Empty input → NaN,NaN
+// so the report renders "n/a" rather than a fake zero interval.
+func bootstrapDeltaCI(deltas []float64, seed int64, n int) (lo, hi float64) {
+	if len(deltas) == 0 || n <= 0 {
+		return math.NaN(), math.NaN()
+	}
+	rng := rand.New(rand.NewSource(seed))
+	means := make([]float64, n)
+	k := len(deltas)
+	for i := 0; i < n; i++ {
+		var sum float64
+		for j := 0; j < k; j++ {
+			sum += deltas[rng.Intn(k)]
+		}
+		means[i] = sum / float64(k)
+	}
+	ps := percentiles(means, 0.025, 0.975)
+	return ps[0], ps[1]
+}
+
+const (
+	// pairedBootstrapSeed and pairedBootstrapN fix the paired bootstrap so the
+	// CI is reproducible across runs and machines (spec: seed=1, n=10000).
+	pairedBootstrapSeed = 1
+	pairedBootstrapN    = 10000
+)
+
+// runPairedReport loads the (labels, artifacts) pair, computes the paired-label
+// analysis, and renders the paired report. It loads artifacts once and keeps
+// the full set so the lineup and completeness worklist see captured-but-
+// unlabeled models. baseline is the optional baseline model selector (empty →
+// first lineup model).
+func runPairedReport(labelsPath, artifactsPath, baseline string) (string, error) {
+	arts, err := loadArtifacts(artifactsPath)
+	if err != nil {
+		return "", fmt.Errorf("paired report: load artifacts: %w", err)
+	}
+	labels, err := loadLabels(labelsPath)
+	if err != nil {
+		return "", fmt.Errorf("paired report: load labels: %w", err)
+	}
+	matched, stale, err := matchLabels(labels, arts)
+	if err != nil {
+		return "", fmt.Errorf("paired report: %w", err)
+	}
+	pa, err := computePairedAnalysis(matched, stale, arts, baseline, pairedBootstrapSeed, pairedBootstrapN)
+	if err != nil {
+		return "", err
+	}
+	return formatPairedReport(pa), nil
+}
+
+// gapReason classifies why a (trace, lineup-model) cell is not paired-complete.
+type gapReason string
+
+const (
+	// gapMissingArtifact: the lineup model has no captured artifact for the
+	// trace at all (nothing to label yet — re-run calibrate-capture).
+	gapMissingArtifact gapReason = "missing-artifact"
+	// gapMissingLabel: an artifact exists but no label references its hash
+	// (the human still has to score it).
+	gapMissingLabel gapReason = "missing-label"
+	// gapStaleLabel: a label for the cell exists but its hash no longer
+	// matches the current artifact (the artifact was re-captured — re-label).
+	gapStaleLabel gapReason = "stale-label"
+)
+
+// completenessGap is one (trace, model) cell that blocks a trace from counting
+// as paired-complete, with the reason the labeler needs to act on.
+type completenessGap struct {
+	TraceID string
+	Model   string
+	Reason  gapReason
+}
+
+// pairwiseRecord is one cell of the win/loss/tie matrix, stored once per
+// unordered pair with ModelA before ModelB in lineup order. Counts are over the
+// paired-complete trace subset: Wins = traces where A's quality exceeds B's.
+type pairwiseRecord struct {
+	ModelA string
+	ModelB string
+	Wins   int
+	Losses int
+	Ties   int
+}
+
+// baselineDelta is the model-vs-baseline summary over the paired-complete
+// subset: the mean per-trace quality delta, its bootstrap CI, and the
+// win/loss/tie tally (oriented as model-vs-baseline).
+type baselineDelta struct {
+	Model     string
+	MeanDelta float64
+	CILow     float64
+	CIHigh    float64
+	Wins      int
+	Losses    int
+	Ties      int
+}
+
+// pairedAnalysis is the computed paired-label evidence for a corpus.
+type pairedAnalysis struct {
+	Lineup          []string           // normalized, sorted candidate models
+	Baseline        string             // declared (or default) baseline model
+	AllTraces       []string           // every trace ID present in artifacts, sorted
+	CompleteTraces  []string           // paired-complete trace IDs, sorted
+	Gaps            []completenessGap  // worklist, sorted (trace, model)
+	PerModelMean    map[string]float64 // mean AnswerQuality over CompleteTraces
+	PerModelN       int                // == len(CompleteTraces)
+	AllMatchedMean  map[string]float64 // mean over ALL matched labels (confounded; comparison only)
+	AllMatchedN     map[string]int     // matched-label count per model
+	Pairwise        []pairwiseRecord   // full matrix (i<j lineup order)
+	BaselineSummary []baselineDelta    // model vs baseline (excludes baseline)
+	ResolutionFull  float64            // 1/n: a full 0↔1 label flip's mean impact
+	ResolutionStep  float64            // 0.5/n: one rubric-step flip's mean impact
+	Labelers        []string           // distinct labelers on the complete subset
+	BootstrapSeed   int64
+	BootstrapN      int
+}
+
+// cellKey identifies a (trace, candidate-model) cell using the same
+// normalization the manual scorer uses, so prefix/casing variants collapse.
+type cellKey struct {
+	trace string
+	model string
+}
+
+func newCellKey(trace, model string) cellKey {
+	return cellKey{trace: normalizeModelSelector(trace), model: modelKey(model)}
+}
+
+// modelKey canonicalizes a model selector for cell matching: strip the bench
+// provider prefix then lowercase/trim, so a label stored bare ("qwen3:8b")
+// matches a prefixed artifact ("ollama/qwen3:8b"). Mirrors manualScorerKey.
+func modelKey(model string) string {
+	return normalizeModelSelector(modelSelectorWithoutBenchProvider(model))
+}
+
+// computePairedAnalysis turns matched labels (+ stale labels + the full
+// artifact set) into paired-label evidence. The lineup is derived from the
+// artifacts (not the matched labels) so a captured-but-unlabeled model still
+// appears. Quality comes directly from Label.ExpectedAnswerQuality — never from
+// ManualScorer.Score, whose tool-metric computation can error for reasons
+// unrelated to the human quality verdict. seed/bootstrapN drive the
+// deterministic CI (the harness uses seed=1, n=10000).
+func computePairedAnalysis(matched []matchedLabel, stale []Label, arts []Artifact, baseline string, seed int64, bootstrapN int) (pairedAnalysis, error) {
+	if len(arts) == 0 {
+		return pairedAnalysis{}, fmt.Errorf("paired analysis: no artifacts")
+	}
+	lineup := lineupFromArtifacts(arts)
+	if len(lineup) == 0 {
+		return pairedAnalysis{}, fmt.Errorf("paired analysis: no candidate models found in artifacts (all CandidateModel values are blank)")
+	}
+
+	// Resolve baseline against the lineup (matching on the stripped key so both
+	// "ollama/b" and bare "b" resolve to the canonical lineup form). Empty
+	// defaults to the first (sorted) lineup model and is reported.
+	var resolvedBaseline string
+	if strings.TrimSpace(baseline) == "" {
+		resolvedBaseline = lineup[0]
+	} else {
+		want := modelKey(baseline)
+		for _, m := range lineup {
+			if modelKey(m) == want {
+				resolvedBaseline = m
+				break
+			}
+		}
+		if resolvedBaseline == "" {
+			return pairedAnalysis{}, fmt.Errorf("paired analysis: baseline %q is not in the lineup %v", baseline, lineup)
+		}
+	}
+
+	// Index artifacts by cell; reject duplicate (trace, model) cells (mirrors
+	// runManualReport — two artifacts for one cell is an ambiguity).
+	artCell := make(map[cellKey]struct{}, len(arts))
+	traceDisplay := make(map[string]string)
+	for _, a := range arts {
+		k := newCellKey(a.TraceID, a.CandidateModel)
+		if _, ok := artCell[k]; ok {
+			return pairedAnalysis{}, fmt.Errorf("paired analysis: duplicate artifacts for (trace %q, model %q)", a.TraceID, a.CandidateModel)
+		}
+		artCell[k] = struct{}{}
+		tk := normalizeModelSelector(a.TraceID)
+		if _, ok := traceDisplay[tk]; !ok {
+			traceDisplay[tk] = a.TraceID
+		}
+	}
+
+	// Quality per labeled cell (from the human label), and labeler per cell.
+	quality := make(map[cellKey]float64, len(matched))
+	labelerByCell := make(map[cellKey]string, len(matched))
+	for _, m := range matched {
+		k := newCellKey(m.Artifact.TraceID, m.Artifact.CandidateModel)
+		quality[k] = m.Label.ExpectedAnswerQuality
+		if lb := strings.TrimSpace(m.Label.Labeler); lb != "" {
+			labelerByCell[k] = lb
+		}
+	}
+
+	// Cells that have a stale label (artifact present but label hash mismatched).
+	staleCell := make(map[cellKey]struct{}, len(stale))
+	for _, l := range stale {
+		staleCell[newCellKey(l.TraceID, l.CandidateModel)] = struct{}{}
+	}
+
+	// Sorted distinct trace keys.
+	traceKeys := make([]string, 0, len(traceDisplay))
+	for tk := range traceDisplay {
+		traceKeys = append(traceKeys, tk)
+	}
+	sort.Strings(traceKeys)
+
+	pa := pairedAnalysis{
+		Lineup:         lineup,
+		Baseline:       resolvedBaseline,
+		PerModelMean:   make(map[string]float64, len(lineup)),
+		AllMatchedMean: make(map[string]float64, len(lineup)),
+		AllMatchedN:    make(map[string]int, len(lineup)),
+		BootstrapSeed:  seed,
+		BootstrapN:     bootstrapN,
+	}
+
+	// All-matched per-model means (confounded; for the comparison table). Bucket
+	// each matched label under its lineup display form, using the human label
+	// quality directly (never ManualScorer.Score).
+	keyToDisplay := make(map[string]string, len(lineup))
+	for _, m := range lineup {
+		keyToDisplay[modelKey(m)] = m
+	}
+	allMatched := make(map[string][]float64, len(lineup))
+	for _, m := range matched {
+		disp := keyToDisplay[modelKey(m.Artifact.CandidateModel)]
+		allMatched[disp] = append(allMatched[disp], m.Label.ExpectedAnswerQuality)
+	}
+	for _, m := range lineup {
+		pa.AllMatchedMean[m] = mean(allMatched[m])
+		pa.AllMatchedN[m] = len(allMatched[m])
+	}
+
+	// Walk every (trace, model) cell: record gaps, and collect the per-model
+	// quality vectors over the paired-complete traces.
+	var completeKeys []string
+	perModelComplete := make(map[string][]float64, len(lineup))
+	labelerSet := make(map[string]struct{})
+	for _, tk := range traceKeys {
+		display := traceDisplay[tk]
+		pa.AllTraces = append(pa.AllTraces, display)
+		complete := true
+		for _, model := range lineup {
+			k := cellKey{trace: tk, model: modelKey(model)}
+			if _, labeled := quality[k]; labeled {
+				continue
+			}
+			complete = false
+			reason := gapMissingArtifact
+			if _, hasArt := artCell[k]; hasArt {
+				reason = gapMissingLabel
+				if _, isStale := staleCell[k]; isStale {
+					reason = gapStaleLabel
+				}
+			}
+			pa.Gaps = append(pa.Gaps, completenessGap{TraceID: display, Model: model, Reason: reason})
+		}
+		if !complete {
+			continue
+		}
+		completeKeys = append(completeKeys, tk)
+		pa.CompleteTraces = append(pa.CompleteTraces, display)
+		for _, model := range lineup {
+			k := cellKey{trace: tk, model: modelKey(model)}
+			perModelComplete[model] = append(perModelComplete[model], quality[k])
+			if lb, ok := labelerByCell[k]; ok {
+				labelerSet[lb] = struct{}{}
+			}
+		}
+	}
+
+	pa.PerModelN = len(completeKeys)
+	for _, model := range lineup {
+		pa.PerModelMean[model] = mean(perModelComplete[model])
+	}
+	for lb := range labelerSet {
+		pa.Labelers = append(pa.Labelers, lb)
+	}
+	sort.Strings(pa.Labelers)
+
+	// Pairwise matrix (i<j) over the complete subset.
+	for i := 0; i < len(lineup); i++ {
+		for j := i + 1; j < len(lineup); j++ {
+			a, b := lineup[i], lineup[j]
+			rec := pairwiseRecord{ModelA: a, ModelB: b}
+			va, vb := perModelComplete[a], perModelComplete[b]
+			for idx := range completeKeys {
+				switch {
+				case va[idx] > vb[idx]:
+					rec.Wins++
+				case va[idx] < vb[idx]:
+					rec.Losses++
+				default:
+					rec.Ties++
+				}
+			}
+			pa.Pairwise = append(pa.Pairwise, rec)
+		}
+	}
+
+	// Baseline-focused summary: every non-baseline model vs the baseline.
+	base := perModelComplete[resolvedBaseline]
+	for _, model := range lineup {
+		if model == resolvedBaseline {
+			continue
+		}
+		vm := perModelComplete[model]
+		deltas := make([]float64, len(completeKeys))
+		bd := baselineDelta{Model: model}
+		for idx := range completeKeys {
+			d := vm[idx] - base[idx]
+			deltas[idx] = d
+			switch {
+			case d > 0:
+				bd.Wins++
+			case d < 0:
+				bd.Losses++
+			default:
+				bd.Ties++
+			}
+		}
+		bd.MeanDelta = mean(deltas)
+		bd.CILow, bd.CIHigh = bootstrapDeltaCI(deltas, seed, bootstrapN)
+		pa.BaselineSummary = append(pa.BaselineSummary, bd)
+	}
+
+	if pa.PerModelN > 0 {
+		pa.ResolutionFull = 1.0 / float64(pa.PerModelN)
+		pa.ResolutionStep = 0.5 / float64(pa.PerModelN)
+	} else {
+		pa.ResolutionFull = math.NaN()
+		pa.ResolutionStep = math.NaN()
+	}
+	return pa, nil
+}
+
+func mean(xs []float64) float64 {
+	if len(xs) == 0 {
+		return math.NaN()
+	}
+	var sum float64
+	for _, x := range xs {
+		sum += x
+	}
+	return sum / float64(len(xs))
+}

--- a/cmd/llm-bench/paired.go
+++ b/cmd/llm-bench/paired.go
@@ -10,26 +10,39 @@ import (
 
 // lineupFromArtifacts returns the candidate-model lineup as the distinct,
 // normalized, sorted set of CandidateModel values across the artifact set.
+// Distinctness uses modelKey, matching the paired cell logic, so bare model
+// selectors and the default bench-provider-prefixed form collapse to one model.
 //
 // The lineup is derived from artifacts — NOT from matched labels — so a model
 // that was captured but has zero fresh labels still appears (and shows as
 // all-gap in the completeness worklist) instead of vanishing.
 func lineupFromArtifacts(arts []Artifact) []string {
-	seen := make(map[string]struct{}, len(arts))
-	var out []string
+	displayByKey := make(map[string]string, len(arts))
 	for _, a := range arts {
-		m := normalizeModelSelector(a.CandidateModel)
-		if m == "" {
+		display := normalizeModelSelector(a.CandidateModel)
+		key := modelKey(a.CandidateModel)
+		if key == "" {
 			continue
 		}
-		if _, ok := seen[m]; ok {
-			continue
+		if current, ok := displayByKey[key]; !ok || preferLineupDisplay(display, current) {
+			displayByKey[key] = display
 		}
-		seen[m] = struct{}{}
-		out = append(out, m)
+	}
+	out := make([]string, 0, len(displayByKey))
+	for _, display := range displayByKey {
+		out = append(out, display)
 	}
 	sort.Strings(out)
 	return out
+}
+
+func preferLineupDisplay(candidate, current string) bool {
+	candidatePrefixed := strings.HasPrefix(candidate, defaultBenchProvider+"/")
+	currentPrefixed := strings.HasPrefix(current, defaultBenchProvider+"/")
+	if candidatePrefixed != currentPrefixed {
+		return candidatePrefixed
+	}
+	return candidate < current
 }
 
 // bootstrapDeltaCI returns a percentile (2.5%, 97.5%) confidence interval for

--- a/cmd/llm-bench/paired_test.go
+++ b/cmd/llm-bench/paired_test.go
@@ -1,0 +1,520 @@
+package main
+
+import (
+	"math"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// pairedTestArtifact builds a frozen Artifact for an arbitrary (trace, model)
+// with a deterministic hash, so paired tests can construct multi-model corpora
+// (testCalibrationArtifact hardcodes a single candidate model).
+func pairedTestArtifact(traceID, model, answer string) Artifact {
+	a := Artifact{
+		TraceID:        traceID,
+		CandidateModel: model,
+		Trace: Trace{
+			ID:     traceID,
+			System: "system for " + traceID,
+			Turns:  []Turn{{Role: "user", Content: "q for " + traceID}},
+			Golden: Golden{FinalAnswerCriteria: "rubric for " + traceID},
+		},
+		ActualFinalAnswer: answer,
+		ActualTranscript:  []Turn{{Role: "assistant", Content: answer}},
+	}
+	a.ArtifactHash = artifactHash(a)
+	return a
+}
+
+func TestLineupFromArtifacts_SortedDedupedNormalized(t *testing.T) {
+	arts := []Artifact{
+		pairedTestArtifact("t1", "ollama/gemma4:31b", "a"),
+		pairedTestArtifact("t1", "ollama/qwen3:8b", "a"),
+		pairedTestArtifact("t2", "ollama/GEMMA4:31b", "a"), // dup of gemma after normalize
+	}
+	got := lineupFromArtifacts(arts)
+	want := []string{"ollama/gemma4:31b", "ollama/qwen3:8b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("lineupFromArtifacts = %v; want %v", got, want)
+	}
+}
+
+// A model that appears only in artifacts with no fresh labels must still be in
+// the lineup — otherwise matched-label inference would hide it completely.
+func TestLineupFromArtifacts_IncludesModelWithoutLabels(t *testing.T) {
+	arts := []Artifact{
+		pairedTestArtifact("t1", "ollama/labeled", "a"),
+		pairedTestArtifact("t1", "ollama/unlabeled", "a"),
+	}
+	got := lineupFromArtifacts(arts)
+	want := []string{"ollama/labeled", "ollama/unlabeled"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("lineupFromArtifacts = %v; want %v (unlabeled model must appear)", got, want)
+	}
+}
+
+// When every paired delta is identical, every bootstrap resample has the same
+// mean, so the CI collapses to that value regardless of seed.
+func TestBootstrapDeltaCI_DegenerateAllEqual(t *testing.T) {
+	lo, hi := bootstrapDeltaCI([]float64{0.5, 0.5, 0.5, 0.5}, 1, 10000)
+	if lo != 0.5 || hi != 0.5 {
+		t.Fatalf("bootstrapDeltaCI(all 0.5) = [%v, %v]; want [0.5, 0.5]", lo, hi)
+	}
+}
+
+// With balanced extreme deltas {0,1}, the 2.5th-percentile resample mean lands
+// in the all-zero tail and the 97.5th in the all-one tail, pinning the
+// nearest-rank percentile mapping to [0.0, 1.0].
+func TestBootstrapDeltaCI_PercentileMapping(t *testing.T) {
+	lo, hi := bootstrapDeltaCI([]float64{0.0, 1.0}, 1, 10000)
+	if lo != 0.0 || hi != 1.0 {
+		t.Fatalf("bootstrapDeltaCI({0,1}) = [%v, %v]; want [0.0, 1.0]", lo, hi)
+	}
+}
+
+// Determinism is the actual spec requirement: the same seed must reproduce the
+// same CI exactly, and lo<=hi must always hold.
+func TestBootstrapDeltaCI_DeterministicForSeed(t *testing.T) {
+	deltas := []float64{0.0, 0.5, 1.0, 0.5, 0.0, 1.0, 0.5}
+	lo1, hi1 := bootstrapDeltaCI(deltas, 1, 10000)
+	lo2, hi2 := bootstrapDeltaCI(deltas, 1, 10000)
+	if lo1 != lo2 || hi1 != hi2 {
+		t.Fatalf("non-deterministic for seed=1: [%v,%v] vs [%v,%v]", lo1, hi1, lo2, hi2)
+	}
+	if lo1 > hi1 {
+		t.Fatalf("lo>hi: [%v, %v]", lo1, hi1)
+	}
+}
+
+func TestBootstrapDeltaCI_EmptyIsNaN(t *testing.T) {
+	lo, hi := bootstrapDeltaCI(nil, 1, 10000)
+	if !math.IsNaN(lo) || !math.IsNaN(hi) {
+		t.Fatalf("bootstrapDeltaCI(nil) = [%v, %v]; want [NaN, NaN]", lo, hi)
+	}
+}
+
+func TestMatchLabels_PartitionsMatchedAndStale(t *testing.T) {
+	a1 := pairedTestArtifact("t1", "ollama/m", "ans1")
+	labels := []Label{
+		{TraceID: "t1", CandidateModel: "ollama/m", ArtifactHash: a1.ArtifactHash, ExpectedAnswerQuality: 1.0},
+		{TraceID: "t2", CandidateModel: "ollama/m", ArtifactHash: "sha256:gone", ExpectedAnswerQuality: 0.5},
+	}
+	matched, stale, err := matchLabels(labels, []Artifact{a1})
+	if err != nil {
+		t.Fatalf("matchLabels: %v", err)
+	}
+	if len(matched) != 1 || matched[0].Artifact.ArtifactHash != a1.ArtifactHash {
+		t.Fatalf("matched = %+v; want 1 row for a1", matched)
+	}
+	if len(stale) != 1 || stale[0].TraceID != "t2" {
+		t.Fatalf("stale = %+v; want 1 row for t2", stale)
+	}
+}
+
+func TestMatchLabels_RejectsDuplicateMatchedHash(t *testing.T) {
+	a1 := pairedTestArtifact("t1", "ollama/m", "ans1")
+	labels := []Label{
+		{TraceID: "t1", CandidateModel: "ollama/m", ArtifactHash: a1.ArtifactHash, ExpectedAnswerQuality: 1.0},
+		{TraceID: "t1", CandidateModel: "ollama/m", ArtifactHash: a1.ArtifactHash, ExpectedAnswerQuality: 0.5},
+	}
+	if _, _, err := matchLabels(labels, []Artifact{a1}); err == nil {
+		t.Fatalf("matchLabels accepted two labels for the same artifact hash; want error")
+	}
+}
+
+func mustMatch(t *testing.T, labels []Label, arts []Artifact) ([]matchedLabel, []Label) {
+	t.Helper()
+	m, s, err := matchLabels(labels, arts)
+	if err != nil {
+		t.Fatalf("matchLabels: %v", err)
+	}
+	return m, s
+}
+
+func hasGap(gaps []completenessGap, trace, model string, reason gapReason) bool {
+	for _, g := range gaps {
+		if g.TraceID == trace && g.Model == model && g.Reason == reason {
+			return true
+		}
+	}
+	return false
+}
+
+// labeledArtifact builds an artifact and a matching label in one shot.
+func labeledArtifact(traceID, model, answer string, q float64, labeler string) (Artifact, Label) {
+	a := pairedTestArtifact(traceID, model, answer)
+	l := Label{
+		TraceID: traceID, CandidateModel: model, ArtifactHash: a.ArtifactHash,
+		ExpectedAnswerQuality: q, Labeler: labeler,
+	}
+	return a, l
+}
+
+// TestComputePairedAnalysis_GapReasonsAndCompleteness exercises all three gap
+// reasons (missing-artifact, missing-label, stale-label) and confirms a trace
+// counts as paired-complete only when every lineup cell is labeled.
+func TestComputePairedAnalysis_GapReasonsAndCompleteness(t *testing.T) {
+	// t1: both A and B labeled -> complete.
+	a1A, l1A := labeledArtifact("t1", "ollama/a", "x", 1.0, "keith")
+	a1B, l1B := labeledArtifact("t1", "ollama/b", "x", 0.0, "keith")
+	// t2: A labeled, B has an artifact but NO label -> missing-label.
+	a2A, l2A := labeledArtifact("t2", "ollama/a", "x", 0.0, "keith")
+	a2B := pairedTestArtifact("t2", "ollama/b", "x")
+	// t3: A labeled, B has NO artifact at all -> missing-artifact.
+	a3A, l3A := labeledArtifact("t3", "ollama/a", "x", 1.0, "keith")
+	// t4: A labeled, B has an artifact + a STALE label (wrong hash) -> stale-label.
+	a4A, l4A := labeledArtifact("t4", "ollama/a", "x", 1.0, "keith")
+	a4B := pairedTestArtifact("t4", "ollama/b", "x")
+	l4Bstale := Label{TraceID: "t4", CandidateModel: "ollama/b", ArtifactHash: "sha256:stale", ExpectedAnswerQuality: 0.5}
+
+	arts := []Artifact{a1A, a1B, a2A, a2B, a3A, a4A, a4B}
+	labels := []Label{l1A, l1B, l2A, l3A, l4A, l4Bstale}
+	matched, stale := mustMatch(t, labels, arts)
+
+	pa, err := computePairedAnalysis(matched, stale, arts, "", 1, 10000)
+	if err != nil {
+		t.Fatalf("computePairedAnalysis: %v", err)
+	}
+
+	if want := []string{"ollama/a", "ollama/b"}; !reflect.DeepEqual(pa.Lineup, want) {
+		t.Fatalf("Lineup = %v; want %v", pa.Lineup, want)
+	}
+	if want := []string{"t1"}; !reflect.DeepEqual(pa.CompleteTraces, want) {
+		t.Fatalf("CompleteTraces = %v; want %v", pa.CompleteTraces, want)
+	}
+	if !hasGap(pa.Gaps, "t2", "ollama/b", gapMissingLabel) {
+		t.Errorf("missing gap {t2, ollama/b, missing-label}; gaps=%+v", pa.Gaps)
+	}
+	if !hasGap(pa.Gaps, "t3", "ollama/b", gapMissingArtifact) {
+		t.Errorf("missing gap {t3, ollama/b, missing-artifact}; gaps=%+v", pa.Gaps)
+	}
+	if !hasGap(pa.Gaps, "t4", "ollama/b", gapStaleLabel) {
+		t.Errorf("missing gap {t4, ollama/b, stale-label}; gaps=%+v", pa.Gaps)
+	}
+}
+
+// TestComputePairedAnalysis_PairedMeansDifferFromUnpaired pins that the paired-
+// complete mean is computed only over the intersection, so it differs from the
+// confounded all-matched-labels mean.
+func TestComputePairedAnalysis_PairedMeansDifferFromUnpaired(t *testing.T) {
+	a1A, l1A := labeledArtifact("t1", "ollama/a", "x", 1.0, "keith")
+	a1B, l1B := labeledArtifact("t1", "ollama/b", "x", 0.0, "keith")
+	a2A, l2A := labeledArtifact("t2", "ollama/a", "x", 0.0, "keith") // only A labeled on t2
+	arts := []Artifact{a1A, a1B, a2A}
+	labels := []Label{l1A, l1B, l2A}
+	matched, stale := mustMatch(t, labels, arts)
+
+	pa, err := computePairedAnalysis(matched, stale, arts, "", 1, 10000)
+	if err != nil {
+		t.Fatalf("computePairedAnalysis: %v", err)
+	}
+	if pa.PerModelN != 1 {
+		t.Fatalf("PerModelN = %d; want 1 (only t1 is complete)", pa.PerModelN)
+	}
+	// Paired-complete mean for A is 1.0 (t1 only), NOT the confounded 0.5 it
+	// would be averaged over both matched labels.
+	if pa.PerModelMean["ollama/a"] != 1.0 {
+		t.Errorf("paired mean A = %v; want 1.0 (unpaired would be 0.5)", pa.PerModelMean["ollama/a"])
+	}
+	if pa.PerModelMean["ollama/b"] != 0.0 {
+		t.Errorf("paired mean B = %v; want 0.0", pa.PerModelMean["ollama/b"])
+	}
+}
+
+// TestComputePairedAnalysis_PairwiseAndBaseline checks the win/loss/tie matrix
+// (including ties) and that the baseline-focused summary agrees with the matrix.
+func TestComputePairedAnalysis_PairwiseAndBaseline(t *testing.T) {
+	// Two complete traces; A beats B once, ties once.
+	a1A, l1A := labeledArtifact("t1", "ollama/a", "x", 1.0, "keith")
+	a1B, l1B := labeledArtifact("t1", "ollama/b", "x", 0.0, "keith")
+	a2A, l2A := labeledArtifact("t2", "ollama/a", "x", 0.5, "keith")
+	a2B, l2B := labeledArtifact("t2", "ollama/b", "x", 0.5, "keith")
+	arts := []Artifact{a1A, a1B, a2A, a2B}
+	labels := []Label{l1A, l1B, l2A, l2B}
+	matched, stale := mustMatch(t, labels, arts)
+
+	pa, err := computePairedAnalysis(matched, stale, arts, "ollama/b", 1, 10000)
+	if err != nil {
+		t.Fatalf("computePairedAnalysis: %v", err)
+	}
+	if len(pa.Pairwise) != 1 {
+		t.Fatalf("Pairwise = %+v; want 1 record", pa.Pairwise)
+	}
+	rec := pa.Pairwise[0]
+	// Records are stored A<B in lineup order: A=ollama/a, B=ollama/b.
+	if rec.ModelA != "ollama/a" || rec.ModelB != "ollama/b" || rec.Wins != 1 || rec.Losses != 0 || rec.Ties != 1 {
+		t.Fatalf("Pairwise[0] = %+v; want a-vs-b 1/0/1", rec)
+	}
+	// Baseline is B; the summary row for A must show A beating B once, tying once.
+	if pa.Baseline != "ollama/b" {
+		t.Fatalf("Baseline = %q; want ollama/b", pa.Baseline)
+	}
+	if len(pa.BaselineSummary) != 1 {
+		t.Fatalf("BaselineSummary = %+v; want 1 row (A vs baseline B)", pa.BaselineSummary)
+	}
+	bd := pa.BaselineSummary[0]
+	if bd.Model != "ollama/a" || bd.Wins != 1 || bd.Losses != 0 || bd.Ties != 1 {
+		t.Fatalf("BaselineSummary[0] = %+v; want A 1/0/1 vs baseline", bd)
+	}
+	// MeanDelta = mean(A-B) over [1-0, 0.5-0.5] = 0.5.
+	if bd.MeanDelta != 0.5 {
+		t.Errorf("MeanDelta = %v; want 0.5", bd.MeanDelta)
+	}
+}
+
+// TestComputePairedAnalysis_ResolutionTwoScales pins the resolution diagnostic
+// at both the full-flip (1/n) and rubric-step (0.5/n) scales.
+func TestComputePairedAnalysis_ResolutionTwoScales(t *testing.T) {
+	var arts []Artifact
+	var labels []Label
+	for _, id := range []string{"t1", "t2", "t3", "t4"} {
+		aA, lA := labeledArtifact(id, "ollama/a", "x", 1.0, "keith")
+		aB, lB := labeledArtifact(id, "ollama/b", "x", 1.0, "keith")
+		arts = append(arts, aA, aB)
+		labels = append(labels, lA, lB)
+	}
+	matched, stale := mustMatch(t, labels, arts)
+	pa, err := computePairedAnalysis(matched, stale, arts, "", 1, 10000)
+	if err != nil {
+		t.Fatalf("computePairedAnalysis: %v", err)
+	}
+	if pa.PerModelN != 4 {
+		t.Fatalf("PerModelN = %d; want 4", pa.PerModelN)
+	}
+	if pa.ResolutionFull != 0.25 {
+		t.Errorf("ResolutionFull = %v; want 0.25 (1/4)", pa.ResolutionFull)
+	}
+	if pa.ResolutionStep != 0.125 {
+		t.Errorf("ResolutionStep = %v; want 0.125 (0.5/4)", pa.ResolutionStep)
+	}
+}
+
+// TestComputePairedAnalysis_LabelersSortedDeduped pins provenance: distinct
+// labelers from the complete-trace evidence, sorted and deduped.
+func TestComputePairedAnalysis_LabelersSortedDeduped(t *testing.T) {
+	a1A, l1A := labeledArtifact("t1", "ollama/a", "x", 1.0, "zoe")
+	a1B, l1B := labeledArtifact("t1", "ollama/b", "x", 1.0, "amy")
+	a2A, l2A := labeledArtifact("t2", "ollama/a", "x", 1.0, "amy")
+	a2B, l2B := labeledArtifact("t2", "ollama/b", "x", 1.0, "zoe")
+	arts := []Artifact{a1A, a1B, a2A, a2B}
+	labels := []Label{l1A, l1B, l2A, l2B}
+	matched, stale := mustMatch(t, labels, arts)
+	pa, err := computePairedAnalysis(matched, stale, arts, "", 1, 10000)
+	if err != nil {
+		t.Fatalf("computePairedAnalysis: %v", err)
+	}
+	if want := []string{"amy", "zoe"}; !reflect.DeepEqual(pa.Labelers, want) {
+		t.Fatalf("Labelers = %v; want %v (sorted, deduped)", pa.Labelers, want)
+	}
+}
+
+// A model with artifacts but zero labels stays in the lineup and produces a
+// missing-label gap on every trace (never silently dropped).
+func TestComputePairedAnalysis_FullyUnlabeledModelIsAllGap(t *testing.T) {
+	a1A, l1A := labeledArtifact("t1", "ollama/a", "x", 1.0, "keith")
+	a1C := pairedTestArtifact("t1", "ollama/c", "x") // never labeled
+	arts := []Artifact{a1A, a1C}
+	labels := []Label{l1A}
+	matched, stale := mustMatch(t, labels, arts)
+	pa, err := computePairedAnalysis(matched, stale, arts, "", 1, 10000)
+	if err != nil {
+		t.Fatalf("computePairedAnalysis: %v", err)
+	}
+	if !contains(pa.Lineup, "ollama/c") {
+		t.Fatalf("Lineup %v must include the unlabeled model ollama/c", pa.Lineup)
+	}
+	if !hasGap(pa.Gaps, "t1", "ollama/c", gapMissingLabel) {
+		t.Fatalf("expected missing-label gap for the unlabeled model; gaps=%+v", pa.Gaps)
+	}
+	if len(pa.CompleteTraces) != 0 {
+		t.Fatalf("CompleteTraces = %v; want none (c unlabeled)", pa.CompleteTraces)
+	}
+}
+
+func TestComputePairedAnalysis_BaselineNotInLineupErrors(t *testing.T) {
+	a1A, l1A := labeledArtifact("t1", "ollama/a", "x", 1.0, "keith")
+	matched, stale := mustMatch(t, []Label{l1A}, []Artifact{a1A})
+	if _, err := computePairedAnalysis(matched, stale, []Artifact{a1A}, "ollama/nope", 1, 10000); err == nil {
+		t.Fatalf("computePairedAnalysis accepted a baseline not in the lineup; want error")
+	}
+}
+
+// A baseline passed bare ("a") must resolve to the prefixed lineup form
+// ("ollama/a") — labels are stored bare, artifacts carry the bench prefix.
+func TestComputePairedAnalysis_BaselineBareResolvesToLineup(t *testing.T) {
+	a1A, l1A := labeledArtifact("t1", "ollama/a", "x", 1.0, "keith")
+	a1B, l1B := labeledArtifact("t1", "ollama/b", "x", 0.0, "keith")
+	arts := []Artifact{a1A, a1B}
+	matched, stale := mustMatch(t, []Label{l1A, l1B}, arts)
+	pa, err := computePairedAnalysis(matched, stale, arts, "a", 1, 10000)
+	if err != nil {
+		t.Fatalf("computePairedAnalysis: %v", err)
+	}
+	if pa.Baseline != "ollama/a" {
+		t.Fatalf("Baseline = %q; want ollama/a (bare 'a' must resolve to prefixed form)", pa.Baseline)
+	}
+}
+
+// All artifacts having a blank CandidateModel yields an empty lineup; that must
+// be a clean error, not a lineup[0] panic (symmetric with the no-artifacts guard).
+func TestComputePairedAnalysis_EmptyLineupErrors(t *testing.T) {
+	blank := pairedTestArtifact("t1", "", "x")
+	if _, err := computePairedAnalysis(nil, nil, []Artifact{blank}, "", 1, 10000); err == nil {
+		t.Fatalf("computePairedAnalysis accepted artifacts with no candidate models; want error")
+	}
+}
+
+func TestComputePairedAnalysis_DuplicateArtifactCellErrors(t *testing.T) {
+	a1 := pairedTestArtifact("t1", "ollama/a", "ans A")
+	a2 := pairedTestArtifact("t1", "ollama/a", "ans B") // same (trace,model), different content/hash
+	if _, err := computePairedAnalysis(nil, nil, []Artifact{a1, a2}, "", 1, 10000); err == nil {
+		t.Fatalf("computePairedAnalysis accepted duplicate (trace,model) artifacts; want error")
+	}
+}
+
+// Zero paired-complete traces must render cleanly: empty CompleteTraces, NaN
+// resolution, and a still-populated gap worklist.
+func TestComputePairedAnalysis_ZeroCompleteRendersClean(t *testing.T) {
+	a1A, l1A := labeledArtifact("t1", "ollama/a", "x", 1.0, "keith")
+	a1B := pairedTestArtifact("t1", "ollama/b", "x") // unlabeled -> t1 incomplete
+	arts := []Artifact{a1A, a1B}
+	matched, stale := mustMatch(t, []Label{l1A}, arts)
+	pa, err := computePairedAnalysis(matched, stale, arts, "", 1, 10000)
+	if err != nil {
+		t.Fatalf("computePairedAnalysis: %v", err)
+	}
+	if len(pa.CompleteTraces) != 0 {
+		t.Fatalf("CompleteTraces = %v; want empty", pa.CompleteTraces)
+	}
+	if !math.IsNaN(pa.ResolutionFull) || !math.IsNaN(pa.ResolutionStep) {
+		t.Fatalf("resolution = [%v, %v]; want NaN when n=0", pa.ResolutionFull, pa.ResolutionStep)
+	}
+	if len(pa.Gaps) == 0 {
+		t.Fatalf("expected a non-empty gap worklist even with zero complete traces")
+	}
+}
+
+// TestComputePairedAnalysis_AllMatchedMeans pins the confounded all-matched
+// per-model means (used for the "all matched labels" comparison table), which
+// differ from the paired-complete means.
+func TestComputePairedAnalysis_AllMatchedMeans(t *testing.T) {
+	a1A, l1A := labeledArtifact("t1", "ollama/a", "x", 1.0, "keith")
+	a1B, l1B := labeledArtifact("t1", "ollama/b", "x", 0.0, "keith")
+	a2A, l2A := labeledArtifact("t2", "ollama/a", "x", 0.0, "keith")
+	arts := []Artifact{a1A, a1B, a2A}
+	matched, stale := mustMatch(t, []Label{l1A, l1B, l2A}, arts)
+	pa, err := computePairedAnalysis(matched, stale, arts, "", 1, 10000)
+	if err != nil {
+		t.Fatalf("computePairedAnalysis: %v", err)
+	}
+	if pa.AllMatchedMean["ollama/a"] != 0.5 || pa.AllMatchedN["ollama/a"] != 2 {
+		t.Errorf("all-matched A = %v (n=%d); want 0.5 (n=2)", pa.AllMatchedMean["ollama/a"], pa.AllMatchedN["ollama/a"])
+	}
+	if pa.AllMatchedMean["ollama/b"] != 0.0 || pa.AllMatchedN["ollama/b"] != 1 {
+		t.Errorf("all-matched B = %v (n=%d); want 0.0 (n=1)", pa.AllMatchedMean["ollama/b"], pa.AllMatchedN["ollama/b"])
+	}
+}
+
+// TestFormatPairedReport_AllSections renders a partially-complete corpus and
+// pins every required section: paired-complete headline, all-matched table,
+// completeness worklist, pairwise matrix, baseline summary with CI, and the
+// two-scale resolution diagnostic.
+func TestFormatPairedReport_AllSections(t *testing.T) {
+	a1A, l1A := labeledArtifact("t1", "ollama/a", "x", 1.0, "keith")
+	a1B, l1B := labeledArtifact("t1", "ollama/b", "x", 0.0, "keith")
+	a2A, l2A := labeledArtifact("t2", "ollama/a", "x", 0.0, "keith")
+	a2B := pairedTestArtifact("t2", "ollama/b", "x") // unlabeled -> gap
+	arts := []Artifact{a1A, a1B, a2A, a2B}
+	matched, stale := mustMatch(t, []Label{l1A, l1B, l2A}, arts)
+	pa, err := computePairedAnalysis(matched, stale, arts, "", 1, 10000)
+	if err != nil {
+		t.Fatalf("computePairedAnalysis: %v", err)
+	}
+	out := formatPairedReport(pa)
+	for _, want := range []string{
+		"Quality by model (paired-complete)",
+		"Quality by model (all matched labels)",
+		"Completeness worklist",
+		"missing-label",
+		"| t2 | ollama/b | missing-label |",
+		"Pairwise win/loss/tie",
+		"| ollama/a | ollama/b | 1 | 0 | 0 |",
+		"Model vs baseline (ollama/a)",
+		"95% CI",
+		"Resolution diagnostic",
+		"1/1",   // full-flip scale, n=1
+		"0.5/1", // rubric-step scale, n=1
+		"Labelers: keith",
+		"Bootstrap: seed=1, n=10000",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("paired report missing %q:\n%s", want, out)
+		}
+	}
+	// Headline paired-complete mean for A is 1.00; the all-matched mean is 0.50.
+	if !strings.Contains(out, "| ollama/a | 1.00 | 1 |") {
+		t.Errorf("paired report missing paired-complete A row (1.00, n=1):\n%s", out)
+	}
+	if !strings.Contains(out, "| ollama/a | 0.50 | 2 |") {
+		t.Errorf("paired report missing all-matched A row (0.50, n=2):\n%s", out)
+	}
+}
+
+func TestRunPairedReport_EndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	artsPath := filepath.Join(dir, "artifacts.jsonl")
+	labelsPath := filepath.Join(dir, "labels.jsonl")
+
+	a1A, l1A := labeledArtifact("t1", "ollama/a", "x", 1.0, "keith")
+	a1B, l1B := labeledArtifact("t1", "ollama/b", "x", 0.0, "keith")
+	a2A, l2A := labeledArtifact("t2", "ollama/a", "x", 0.0, "keith")
+	a2B := pairedTestArtifact("t2", "ollama/b", "x") // unlabeled -> gap
+	if err := writeJSONL(artsPath, []any{a1A, a1B, a2A, a2B}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONL(labelsPath, []any{l1A, l1B, l2A}); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runPairedReport(labelsPath, artsPath, "")
+	if err != nil {
+		t.Fatalf("runPairedReport: %v", err)
+	}
+	for _, want := range []string{
+		"Quality by model (paired-complete)",
+		"Completeness worklist",
+		"| t2 | ollama/b | missing-label |",
+		"Bootstrap: seed=1, n=10000",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("runPairedReport output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunPairedReport_BaselineNotInLineupErrors(t *testing.T) {
+	dir := t.TempDir()
+	artsPath := filepath.Join(dir, "artifacts.jsonl")
+	labelsPath := filepath.Join(dir, "labels.jsonl")
+	a1A, l1A := labeledArtifact("t1", "ollama/a", "x", 1.0, "keith")
+	if err := writeJSONL(artsPath, []any{a1A}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONL(labelsPath, []any{l1A}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runPairedReport(labelsPath, artsPath, "ollama/ghost"); err == nil {
+		t.Fatalf("runPairedReport accepted a baseline not in the lineup; want error")
+	}
+}
+
+func contains(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/llm-bench/paired_test.go
+++ b/cmd/llm-bench/paired_test.go
@@ -41,6 +41,27 @@ func TestLineupFromArtifacts_SortedDedupedNormalized(t *testing.T) {
 	}
 }
 
+func TestComputePairedAnalysis_DedupesBareAndProviderPrefixedArtifacts(t *testing.T) {
+	a1, l1 := labeledArtifact("t1", "ollama/a", "x", 1.0, "keith")
+	a2, l2 := labeledArtifact("t2", "a", "x", 0.0, "keith")
+	arts := []Artifact{a1, a2}
+	matched, stale := mustMatch(t, []Label{l1, l2}, arts)
+
+	pa, err := computePairedAnalysis(matched, stale, arts, "", 1, 10000)
+	if err != nil {
+		t.Fatalf("computePairedAnalysis: %v", err)
+	}
+	if want := []string{"ollama/a"}; !reflect.DeepEqual(pa.Lineup, want) {
+		t.Fatalf("Lineup = %v; want %v", pa.Lineup, want)
+	}
+	if pa.PerModelN != 2 {
+		t.Fatalf("PerModelN = %d; want both labeled traces counted under one canonical model", pa.PerModelN)
+	}
+	if pa.AllMatchedN["ollama/a"] != 2 {
+		t.Fatalf("AllMatchedN[ollama/a] = %d; want 2", pa.AllMatchedN["ollama/a"])
+	}
+}
+
 // A model that appears only in artifacts with no fresh labels must still be in
 // the lineup — otherwise matched-label inference would hide it completely.
 func TestLineupFromArtifacts_IncludesModelWithoutLabels(t *testing.T) {

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 	"time"
@@ -124,7 +125,7 @@ func formatManualQualityReport(models []string, results []Result, cov manualRepo
 	fmt.Fprintln(&b, "Latency is NOT included here — frozen artifacts carry no timing; measure latency in a separate pass.")
 	fmt.Fprintf(&b, "\nCoverage: %d scored, stale: %d (excluded — label hash no longer matches an artifact), scoring errors: %d.\n\n",
 		cov.Scored, cov.Stale, cov.Errored)
-	fmt.Fprintln(&b, "## Quality by model")
+	fmt.Fprintln(&b, "## Quality by model (all matched labels)")
 	fmt.Fprintln(&b, "| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | n |")
 	fmt.Fprintln(&b, "|---|---|---|")
 	for _, m := range models {
@@ -140,6 +141,136 @@ func formatManualQualityReport(models []string, results []Result, cov manualRepo
 	}
 	fmt.Fprintln(&b)
 	return redactPaths(b.String())
+}
+
+// formatPairedReport renders the paired-label analysis: the paired-complete
+// "Quality by model" headline (accepted-run evidence), the confounded
+// all-matched table for comparison, the completeness worklist, the pairwise
+// win/loss/tie matrix, the model-vs-baseline deltas with bootstrap CIs, and the
+// two-scale resolution diagnostic. Like the manual report it omits latency
+// (frozen artifacts carry no timing).
+func formatPairedReport(pa pairedAnalysis) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# llm-bench — paired-label quality report\n\n")
+	fmt.Fprintf(&b, "Generated: %s\n\n", time.Now().UTC().Format(time.RFC3339))
+	fmt.Fprintln(&b, "AnswerQuality is the human label (`expected_answer_quality`): gold-standard, deterministic, on-box — no LLM judge, no model call.")
+	fmt.Fprintln(&b, "Latency is NOT included here — frozen artifacts carry no timing; measure latency in a separate pass.")
+	fmt.Fprintln(&b)
+
+	fmt.Fprintln(&b, "## Provenance")
+	fmt.Fprintln(&b)
+	fmt.Fprintf(&b, "- Lineup (from artifacts): %s\n", joinMarkdownCells(pa.Lineup))
+	fmt.Fprintf(&b, "- Baseline: %s\n", markdownCell(pa.Baseline))
+	fmt.Fprintf(&b, "- Paired-complete traces: %d of %d\n", pa.PerModelN, len(pa.AllTraces))
+	if len(pa.Labelers) > 0 {
+		fmt.Fprintf(&b, "- Labelers: %s\n", joinMarkdownCells(pa.Labelers))
+	} else {
+		fmt.Fprintln(&b, "- Labelers: (none recorded)")
+	}
+	fmt.Fprintf(&b, "- Bootstrap: seed=%d, n=%d\n", pa.BootstrapSeed, pa.BootstrapN)
+	fmt.Fprintln(&b)
+
+	fmt.Fprintln(&b, "## Quality by model (paired-complete)")
+	fmt.Fprintln(&b)
+	fmt.Fprintf(&b, "> Headline accepted-run evidence: means over the %d trace(s) where every lineup model is labeled.\n\n", pa.PerModelN)
+	fmt.Fprintln(&b, "| Model | AnswerQuality (mean) | n |")
+	fmt.Fprintln(&b, "|---|---|---|")
+	for _, m := range pa.Lineup {
+		fmt.Fprintf(&b, "| %s | %s | %d |\n", markdownCell(m), meanCell(pa.PerModelMean[m]), pa.PerModelN)
+	}
+	fmt.Fprintln(&b)
+
+	fmt.Fprintln(&b, "## Quality by model (all matched labels)")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "> Confounded by trace-difficulty mix (each model averaged over a different trace subset). Shown for comparison, not as accepted-run evidence.")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "| Model | AnswerQuality (mean) | n |")
+	fmt.Fprintln(&b, "|---|---|---|")
+	for _, m := range pa.Lineup {
+		fmt.Fprintf(&b, "| %s | %s | %d |\n", markdownCell(m), meanCell(pa.AllMatchedMean[m]), pa.AllMatchedN[m])
+	}
+	fmt.Fprintln(&b)
+
+	fmt.Fprintln(&b, "## Completeness worklist")
+	fmt.Fprintln(&b)
+	if len(pa.Gaps) == 0 {
+		fmt.Fprintln(&b, "All traces are paired-complete — no gaps.")
+	} else {
+		incomplete := len(pa.AllTraces) - pa.PerModelN
+		fmt.Fprintf(&b, "%d gap(s) block %d trace(s) from counting. Resolve each cell, then re-run.\n\n", len(pa.Gaps), incomplete)
+		fmt.Fprintln(&b, "| Trace | Model | Gap |")
+		fmt.Fprintln(&b, "|---|---|---|")
+		for _, g := range pa.Gaps {
+			fmt.Fprintf(&b, "| %s | %s | %s |\n", markdownCell(g.TraceID), markdownCell(g.Model), markdownCell(string(g.Reason)))
+		}
+	}
+	fmt.Fprintln(&b)
+
+	fmt.Fprintln(&b, "## Pairwise win/loss/tie (paired-complete)")
+	fmt.Fprintln(&b)
+	fmt.Fprintf(&b, "Wins/losses/ties of model A vs model B over the %d paired-complete trace(s).\n\n", pa.PerModelN)
+	fmt.Fprintln(&b, "| Model A | Model B | A wins | A losses | ties |")
+	fmt.Fprintln(&b, "|---|---|---|---|---|")
+	for _, rec := range pa.Pairwise {
+		fmt.Fprintf(&b, "| %s | %s | %d | %d | %d |\n", markdownCell(rec.ModelA), markdownCell(rec.ModelB), rec.Wins, rec.Losses, rec.Ties)
+	}
+	fmt.Fprintln(&b)
+
+	fmt.Fprintf(&b, "## Model vs baseline (%s)\n\n", markdownCell(pa.Baseline))
+	fmt.Fprintf(&b, "Mean per-trace quality delta vs baseline with a deterministic bootstrap 95%% CI (seed=%d, n=%d) and win/loss/tie.\n\n", pa.BootstrapSeed, pa.BootstrapN)
+	fmt.Fprintln(&b, "| Model | mean Δ vs baseline | 95% CI | wins | losses | ties |")
+	fmt.Fprintln(&b, "|---|---|---|---|---|---|")
+	for _, bd := range pa.BaselineSummary {
+		fmt.Fprintf(&b, "| %s | %s | %s | %d | %d | %d |\n",
+			markdownCell(bd.Model), signedMeanCell(bd.MeanDelta), ciCell(bd.CILow, bd.CIHigh), bd.Wins, bd.Losses, bd.Ties)
+	}
+	fmt.Fprintln(&b)
+
+	fmt.Fprintln(&b, "## Resolution diagnostic")
+	fmt.Fprintln(&b)
+	if pa.PerModelN > 0 {
+		fmt.Fprintf(&b, "Over n=%d paired-complete trace(s): one full label flip (0↔1) moves a model's mean by %.2f (1/%d); one rubric step (0.5) moves it by %.2f (0.5/%d). Do not over-read a one-label gap.\n",
+			pa.PerModelN, pa.ResolutionFull, pa.PerModelN, pa.ResolutionStep, pa.PerModelN)
+	} else {
+		fmt.Fprintln(&b, "No paired-complete traces — resolution is undefined. Resolve the completeness worklist first.")
+	}
+	fmt.Fprintln(&b)
+
+	return redactPaths(b.String())
+}
+
+// meanCell renders a mean as 2 decimals, or "n/a" for NaN (no observations).
+func meanCell(v float64) string {
+	if math.IsNaN(v) {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.2f", v)
+}
+
+// signedMeanCell renders a delta with an explicit sign so a positive vs
+// negative direction vs the baseline is unambiguous; "n/a" for NaN.
+func signedMeanCell(v float64) string {
+	if math.IsNaN(v) {
+		return "n/a"
+	}
+	return fmt.Sprintf("%+.2f", v)
+}
+
+// ciCell renders a [lo, hi] confidence interval, or "n/a" when undefined.
+func ciCell(lo, hi float64) string {
+	if math.IsNaN(lo) || math.IsNaN(hi) {
+		return "n/a"
+	}
+	return fmt.Sprintf("[%+.2f, %+.2f]", lo, hi)
+}
+
+// joinMarkdownCells escapes each cell and joins with ", " for inline lists.
+func joinMarkdownCells(xs []string) string {
+	cells := make([]string, len(xs))
+	for i, x := range xs {
+		cells[i] = markdownCell(x)
+	}
+	return strings.Join(cells, ", ")
 }
 
 // reportOptions carries metadata that formatReport embeds in report headers.


### PR DESCRIPTION
Closes #138. Stacked on #144 (#137 failure-aware latency) — base will retarget to `develop` once #144 merges.

## Why
Per-model quality means were computed independently, but manual labels are often unpaired (not every candidate labeled on every retained trace), so the means are confounded by the trace-difficulty mix each model happened to be scored on. The acceptance gate now requires fully-paired labels analyzed as paired data.

## What
- **`lineupFromArtifacts`** — lineup derived from the **artifact set**, not matched labels, so a captured-but-unlabeled model still appears (and shows as all-gap) instead of vanishing.
- **`matchLabels`** — pure matcher extracted from `loadLabelsMatchedAgainst`; the paired path loads artifacts once and keeps the full set for lineup/gap detection. Behavior preserved (dup-hash rejection, stale partitioning); existing calibration suite stays green.
- **`computePairedAnalysis`** — the core paired analysis:
  - Completeness worklist with three distinct gap reasons: `missing-artifact` / `missing-label` / `stale-label`. A trace counts only when **every** lineup cell is labeled (refuses to count partially-labeled traces).
  - **Paired-complete per-model means** (headline accepted-run evidence) + the confounded **all-matched means** (comparison only), both computed directly from `Label.ExpectedAnswerQuality` (never `ManualScorer.Score`).
  - Full **pairwise win/loss/tie** matrix + a **baseline-focused summary** with **deterministic bootstrap delta CIs** (seed=1, n=10000) and a **resolution diagnostic** at both `1/n` (full flip) and `0.5/n` (rubric step) scales.
- **`formatPairedReport`** — renders both quality tables, the worklist, the matrix, the baseline deltas/CIs, and the resolution lines; relabels the existing manual table "all matched labels".
- **CLI** — `-paired-report` mode + `-baseline` flag.

## Acceptance (#138)
- ✅ Tooling refuses to count partially-labeled traces (completeness worklist; partial traces excluded from the headline subset).
- ✅ Report shows paired win/loss/tie + CIs + resolution diagnostic.
- ✅ Supports the manual-label accepted path in `docs/llm/harness-results.md` (paired-complete headline + provenance/labelers).

## Testing
TDD throughout (RED→GREEN per unit). Coverage includes: gap-reason classification, paired≠unpaired means, pairwise ties, baseline↔matrix consistency, bootstrap determinism + percentile mapping, labeler dedup/sort, prefix/normalization, zero-paired-complete render, and error edges (baseline-not-in-lineup, duplicate-artifact cell, empty lineup). Full module `go build ./...` + `go test ./...` green; `gofmt` + `go vet` clean.

Generated with [Claude Code](https://claude.com/claude-code)