### PR TITLE
feat(llm-bench): corpus builder + manifest with partition reporting (#139)

### DIFF
--- a/cmd/llm-bench/corpus.go
+++ b/cmd/llm-bench/corpus.go
@@ -1,0 +1,288 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// CorpusPartition is the closed set of Round-2 corpus partitions. Natural and
+// challenge are accepted-run model evidence and answer different questions (so
+// they are reported separately, never averaged); judge-validation items are
+// scorer-calibration evidence only and never count as model-workload evidence.
+type CorpusPartition string
+
+const (
+	PartitionNatural         CorpusPartition = "natural"
+	PartitionChallenge       CorpusPartition = "challenge"
+	PartitionJudgeValidation CorpusPartition = "judge-validation"
+)
+
+// corpusPartitionOrder is the canonical display order for partition tables.
+var corpusPartitionOrder = []CorpusPartition{PartitionNatural, PartitionChallenge, PartitionJudgeValidation}
+
+func validCorpusPartition(p CorpusPartition) bool {
+	switch p {
+	case PartitionNatural, PartitionChallenge, PartitionJudgeValidation:
+		return true
+	default:
+		return false
+	}
+}
+
+// ManifestEntry classifies one trace: its partition, category, provenance
+// source, and whether it may be cited as accepted-run model evidence (curated
+// judge-validation fixtures set this false so they never inflate model scores).
+type ManifestEntry struct {
+	TraceID                string          `json:"trace_id"`
+	Partition              CorpusPartition `json:"partition"`
+	Category               string          `json:"category"`
+	Source                 string          `json:"source,omitempty"`
+	AllowedAsModelEvidence bool            `json:"allowed_as_model_evidence"`
+}
+
+// Manifest is the corpus descriptor: one ManifestEntry per trace. It is a
+// partition/category descriptor, distinct from traceSetManifestHash (a content
+// fingerprint of the trace bytes).
+type Manifest struct {
+	Entries []ManifestEntry
+}
+
+// writeManifest writes the manifest as JSONL (one entry per line), mirroring
+// the artifacts/labels conventions.
+func writeManifest(path string, m Manifest) (retErr error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("manifest: mkdir: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("manifest: open output: %w", err)
+	}
+	defer func() {
+		if closeErr := f.Close(); retErr == nil && closeErr != nil {
+			retErr = fmt.Errorf("manifest: close output: %w", closeErr)
+		}
+	}()
+	enc := json.NewEncoder(f)
+	for _, e := range m.Entries {
+		if err := enc.Encode(e); err != nil {
+			return fmt.Errorf("manifest: encode entry %q: %w", e.TraceID, err)
+		}
+	}
+	return nil
+}
+
+// loadManifest reads and validates a JSONL manifest: every entry must have a
+// known partition, a non-empty category, and a trace ID unique across the file;
+// an empty manifest is an error.
+func loadManifest(path string) (Manifest, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return Manifest{}, fmt.Errorf("manifest: open %q: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var m Manifest
+	seen := make(map[string]struct{})
+	dec := json.NewDecoder(f)
+	for dec.More() {
+		var e ManifestEntry
+		if err := dec.Decode(&e); err != nil {
+			return Manifest{}, fmt.Errorf("manifest: decode entry: %w", err)
+		}
+		if strings.TrimSpace(e.TraceID) == "" {
+			return Manifest{}, fmt.Errorf("manifest: entry with empty trace_id")
+		}
+		if !validCorpusPartition(e.Partition) {
+			return Manifest{}, fmt.Errorf("manifest: entry %q has unknown partition %q (want natural, challenge, or judge-validation)", e.TraceID, e.Partition)
+		}
+		if strings.TrimSpace(e.Category) == "" {
+			return Manifest{}, fmt.Errorf("manifest: entry %q has empty category", e.TraceID)
+		}
+		if _, dup := seen[e.TraceID]; dup {
+			return Manifest{}, fmt.Errorf("manifest: duplicate trace_id %q", e.TraceID)
+		}
+		seen[e.TraceID] = struct{}{}
+		m.Entries = append(m.Entries, e)
+	}
+	if len(m.Entries) == 0 {
+		return Manifest{}, fmt.Errorf("manifest: %q is empty", path)
+	}
+	return m, nil
+}
+
+// corpusCounts tallies a manifest by partition and category.
+type corpusCounts struct {
+	ByPartition map[CorpusPartition]int
+	ByCategory  map[string]int
+	Total       int
+}
+
+// Counts tallies the manifest entries by partition and category.
+func (m Manifest) Counts() corpusCounts {
+	c := corpusCounts{
+		ByPartition: make(map[CorpusPartition]int),
+		ByCategory:  make(map[string]int),
+		Total:       len(m.Entries),
+	}
+	for _, e := range m.Entries {
+		c.ByPartition[e.Partition]++
+		c.ByCategory[e.Category]++
+	}
+	return c
+}
+
+// corpusSelection filters a manifest into a run. Empty Partitions/Categories
+// mean "all"; OnlyModelEvidence restricts to entries flagged as accepted-run
+// model evidence.
+type corpusSelection struct {
+	Partitions        []CorpusPartition
+	Categories        []string
+	OnlyModelEvidence bool
+}
+
+// Select returns the trace IDs matching the selection — the builder that
+// assembles a run from manifest selections.
+func (m Manifest) Select(sel corpusSelection) []string {
+	partOK := make(map[CorpusPartition]struct{}, len(sel.Partitions))
+	for _, p := range sel.Partitions {
+		partOK[p] = struct{}{}
+	}
+	catOK := make(map[string]struct{}, len(sel.Categories))
+	for _, c := range sel.Categories {
+		catOK[c] = struct{}{}
+	}
+	var out []string
+	for _, e := range m.Entries {
+		if len(partOK) > 0 {
+			if _, ok := partOK[e.Partition]; !ok {
+				continue
+			}
+		}
+		if len(catOK) > 0 {
+			if _, ok := catOK[e.Category]; !ok {
+				continue
+			}
+		}
+		if sel.OnlyModelEvidence && !e.AllowedAsModelEvidence {
+			continue
+		}
+		out = append(out, e.TraceID)
+	}
+	return out
+}
+
+// parseCorpusPartitions parses a comma-separated -corpus-partitions flag into a
+// validated partition list. Empty input returns nil (meaning "all"); an unknown
+// partition is an error.
+func parseCorpusPartitions(s string) ([]CorpusPartition, error) {
+	if strings.TrimSpace(s) == "" {
+		return nil, nil
+	}
+	var out []CorpusPartition
+	for _, raw := range strings.Split(s, ",") {
+		p := CorpusPartition(strings.TrimSpace(raw))
+		if p == "" {
+			continue
+		}
+		if !validCorpusPartition(p) {
+			return nil, fmt.Errorf("unknown corpus partition %q (want natural, challenge, or judge-validation)", p)
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+// splitCommaList splits a comma-separated flag value, trimming each item and
+// dropping empties. Empty input returns nil ("all"). Used for free-form
+// category selection (categories are not a closed enum, so no validation).
+func splitCommaList(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	var out []string
+	for _, raw := range strings.Split(s, ",") {
+		if v := strings.TrimSpace(raw); v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// entriesFor returns the sub-manifest of entries whose trace ID is in keep,
+// preserving manifest order.
+func (m Manifest) entriesFor(keep map[string]struct{}) Manifest {
+	var sub Manifest
+	for _, e := range m.Entries {
+		if _, ok := keep[e.TraceID]; ok {
+			sub.Entries = append(sub.Entries, e)
+		}
+	}
+	return sub
+}
+
+// buildCorpusRun assembles a run from a manifest selection: it returns the
+// loaded traces matching the selection (in manifest order), corpus report data
+// scoped to that run subset, and the trace IDs that were selected but not
+// present in the loaded set (so a missing-trace gap is visible, not silent).
+func buildCorpusRun(m Manifest, sel corpusSelection, loaded []Trace) (run []Trace, data *corpusReportData, missing []string) {
+	loadedByID := make(map[string]Trace, len(loaded))
+	for _, tr := range loaded {
+		loadedByID[tr.ID] = tr
+	}
+	keep := make(map[string]struct{})
+	for _, id := range m.Select(sel) {
+		if tr, ok := loadedByID[id]; ok {
+			run = append(run, tr)
+			keep[id] = struct{}{}
+		} else {
+			missing = append(missing, id)
+		}
+	}
+	sub := m.entriesFor(keep)
+	data = &corpusReportData{
+		Counts:           sub.Counts(),
+		TraceToPartition: sub.partitionByTrace(),
+	}
+	return run, data, missing
+}
+
+// excludeJudgeValidation returns results whose trace is NOT in the
+// judge-validation partition, plus the count excluded. Judge-validation traces
+// are scorer-calibration evidence and must never enter model-quality
+// aggregates, so the combined summary table filters them out.
+func excludeJudgeValidation(results []Result, traceToPartition map[string]CorpusPartition) ([]Result, int) {
+	var kept []Result
+	excluded := 0
+	for _, r := range results {
+		if traceToPartition[r.TraceID] == PartitionJudgeValidation {
+			excluded++
+			continue
+		}
+		kept = append(kept, r)
+	}
+	return kept, excluded
+}
+
+// partitionByTrace maps each trace ID to its partition for report wiring.
+func (m Manifest) partitionByTrace() map[string]CorpusPartition {
+	out := make(map[string]CorpusPartition, len(m.Entries))
+	for _, e := range m.Entries {
+		out[e.TraceID] = e.Partition
+	}
+	return out
+}
+
+// sortedCategories returns the manifest's distinct categories in stable order
+// for deterministic report rendering.
+func (c corpusCounts) sortedCategories() []string {
+	cats := make([]string, 0, len(c.ByCategory))
+	for cat := range c.ByCategory {
+		cats = append(cats, cat)
+	}
+	sort.Strings(cats)
+	return cats
+}

--- a/cmd/llm-bench/corpus_test.go
+++ b/cmd/llm-bench/corpus_test.go
@@ -1,0 +1,308 @@
+package main
+
+import (
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func sampleCorpusManifest() Manifest {
+	return Manifest{Entries: []ManifestEntry{
+		{TraceID: "t1", Partition: PartitionNatural, Category: "chat", Source: "captured", AllowedAsModelEvidence: true},
+		{TraceID: "t2", Partition: PartitionChallenge, Category: "subtle-bug", Source: "authored", AllowedAsModelEvidence: true},
+		{TraceID: "t3", Partition: PartitionJudgeValidation, Category: "adversarial", Source: "curated", AllowedAsModelEvidence: false},
+	}}
+}
+
+func TestManifest_RoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manifest.jsonl")
+	m := sampleCorpusManifest()
+	if err := writeManifest(path, m); err != nil {
+		t.Fatalf("writeManifest: %v", err)
+	}
+	got, err := loadManifest(path)
+	if err != nil {
+		t.Fatalf("loadManifest: %v", err)
+	}
+	if !reflect.DeepEqual(got, m) {
+		t.Fatalf("round-trip mismatch:\n got %+v\nwant %+v", got, m)
+	}
+}
+
+func TestLoadManifest_RejectsUnknownPartition(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manifest.jsonl")
+	if err := writeJSONL(path, []any{
+		ManifestEntry{TraceID: "t1", Partition: CorpusPartition("bogus"), Category: "chat"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadManifest(path); err == nil {
+		t.Fatalf("loadManifest accepted an unknown partition; want error")
+	}
+}
+
+func TestLoadManifest_RejectsEmptyCategory(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manifest.jsonl")
+	if err := writeJSONL(path, []any{
+		ManifestEntry{TraceID: "t1", Partition: PartitionNatural, Category: ""},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadManifest(path); err == nil {
+		t.Fatalf("loadManifest accepted an empty category; want error")
+	}
+}
+
+func TestLoadManifest_RejectsDuplicateTraceID(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manifest.jsonl")
+	if err := writeJSONL(path, []any{
+		ManifestEntry{TraceID: "t1", Partition: PartitionNatural, Category: "chat"},
+		ManifestEntry{TraceID: "t1", Partition: PartitionChallenge, Category: "subtle-bug"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadManifest(path); err == nil {
+		t.Fatalf("loadManifest accepted a duplicate trace ID; want error")
+	}
+}
+
+func TestLoadManifest_RejectsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manifest.jsonl")
+	if err := writeJSONL(path, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadManifest(path); err == nil {
+		t.Fatalf("loadManifest accepted an empty manifest; want error")
+	}
+}
+
+func TestManifest_Counts(t *testing.T) {
+	c := sampleCorpusManifest().Counts()
+	if c.Total != 3 {
+		t.Errorf("Total = %d; want 3", c.Total)
+	}
+	if c.ByPartition[PartitionNatural] != 1 || c.ByPartition[PartitionChallenge] != 1 || c.ByPartition[PartitionJudgeValidation] != 1 {
+		t.Errorf("ByPartition = %v; want one each", c.ByPartition)
+	}
+	if c.ByCategory["chat"] != 1 || c.ByCategory["subtle-bug"] != 1 {
+		t.Errorf("ByCategory = %v; want chat=1 subtle-bug=1", c.ByCategory)
+	}
+}
+
+func TestManifest_Select(t *testing.T) {
+	m := sampleCorpusManifest()
+	cases := []struct {
+		name string
+		sel  corpusSelection
+		want []string
+	}{
+		{"all", corpusSelection{}, []string{"t1", "t2", "t3"}},
+		{"challenge only", corpusSelection{Partitions: []CorpusPartition{PartitionChallenge}}, []string{"t2"}},
+		{"category", corpusSelection{Categories: []string{"subtle-bug"}}, []string{"t2"}},
+		{"only model evidence", corpusSelection{OnlyModelEvidence: true}, []string{"t1", "t2"}},
+		{"natural+challenge", corpusSelection{Partitions: []CorpusPartition{PartitionNatural, PartitionChallenge}}, []string{"t1", "t2"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := m.Select(tc.sel)
+			sort.Strings(got)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("Select(%+v) = %v; want %v", tc.sel, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatCorpusComposition_ShowsPartitionAndCategoryCounts(t *testing.T) {
+	out := formatCorpusComposition(sampleCorpusManifest().Counts())
+	for _, want := range []string{
+		"## Corpus composition",
+		"| natural | 1 |",
+		"| challenge | 1 |",
+		"| judge-validation | 1 |",
+		"| **total** | 3 |",
+		"| chat | 1 |",
+		"| subtle-bug | 1 |",
+		"| adversarial | 1 |", // judge-validation's category still appears in the composition overview
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("composition missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestFormatPartitionedQuality_SeparatesNaturalAndChallenge(t *testing.T) {
+	results := []Result{
+		{Model: "ollama/a", TraceID: "t1", Score: Score{AnswerQuality: 1.0}},
+		{Model: "ollama/a", TraceID: "t2", Score: Score{AnswerQuality: 0.0}},
+		{Model: "ollama/a", TraceID: "t3", Score: Score{AnswerQuality: 0.5}}, // judge-validation
+	}
+	traceToPartition := map[string]CorpusPartition{
+		"t1": PartitionNatural, "t2": PartitionChallenge, "t3": PartitionJudgeValidation,
+	}
+	out := formatPartitionedQuality([]string{"ollama/a"}, results, traceToPartition)
+	for _, want := range []string{
+		"## Quality by model — by partition",
+		"never averaged",
+		"### natural",
+		"### challenge",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("partitioned quality missing %q:\n%s", want, out)
+		}
+	}
+	// judge-validation must not get a model-quality section.
+	if strings.Contains(out, "### judge-validation") {
+		t.Errorf("judge-validation must be excluded from model quality:\n%s", out)
+	}
+	// natural mean = 1.00, challenge mean = 0.00; the 0.5 judge-validation row
+	// must not have been folded into either average.
+	natural := sectionBetween(out, "### natural", "### challenge")
+	if !strings.Contains(natural, "1.00") {
+		t.Errorf("natural section should show mean 1.00:\n%s", natural)
+	}
+}
+
+func TestFormatReport_WithCorpusEmitsCompositionAndPartitioned(t *testing.T) {
+	results := []Result{
+		{Model: "m", TraceID: "t1", Score: Score{AnswerQuality: 1.0}},
+		{Model: "m", TraceID: "t2", Score: Score{AnswerQuality: 0.0}},
+	}
+	counts := corpusCounts{
+		ByPartition: map[CorpusPartition]int{PartitionNatural: 1, PartitionChallenge: 1},
+		ByCategory:  map[string]int{"chat": 1, "subtle-bug": 1},
+		Total:       2,
+	}
+	out := formatReport([]string{"m"}, results, reportOptions{
+		Scorer: "manual",
+		Corpus: &corpusReportData{
+			Counts:           counts,
+			TraceToPartition: map[string]CorpusPartition{"t1": PartitionNatural, "t2": PartitionChallenge},
+		},
+	})
+	for _, want := range []string{
+		"## Corpus composition",
+		"## Quality by model — by partition",
+		"partitions are not comparable", // caveat on the combined table
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report with corpus missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// sectionBetween returns the substring of s starting at the first occurrence of
+// start up to (but excluding) the first subsequent occurrence of end. If end is
+// absent it returns to the end of s.
+func sectionBetween(s, start, end string) string {
+	i := strings.Index(s, start)
+	if i < 0 {
+		return ""
+	}
+	rest := s[i:]
+	if j := strings.Index(rest[len(start):], end); j >= 0 {
+		return rest[:len(start)+j]
+	}
+	return rest
+}
+
+func TestBuildCorpusRun_FiltersToSelectionIntersection(t *testing.T) {
+	m := sampleCorpusManifest()                           // t1 natural, t2 challenge, t3 judge-validation
+	loaded := []Trace{{ID: "t1"}, {ID: "t2"}, {ID: "t4"}} // t3 missing; t4 not in manifest
+	run, data, missing := buildCorpusRun(m, corpusSelection{}, loaded)
+
+	var runIDs []string
+	for _, tr := range run {
+		runIDs = append(runIDs, tr.ID)
+	}
+	sort.Strings(runIDs)
+	if !reflect.DeepEqual(runIDs, []string{"t1", "t2"}) {
+		t.Fatalf("run IDs = %v; want [t1 t2] (intersection of selected and loaded)", runIDs)
+	}
+	if !reflect.DeepEqual(missing, []string{"t3"}) {
+		t.Fatalf("missing = %v; want [t3] (selected but not loaded)", missing)
+	}
+	if data.Counts.Total != 2 {
+		t.Errorf("Counts.Total = %d; want 2 (only the run subset)", data.Counts.Total)
+	}
+	if data.TraceToPartition["t1"] != PartitionNatural || data.TraceToPartition["t2"] != PartitionChallenge {
+		t.Errorf("TraceToPartition = %v; want t1=natural t2=challenge", data.TraceToPartition)
+	}
+}
+
+func TestBuildCorpusRun_RespectsPartitionSelection(t *testing.T) {
+	m := sampleCorpusManifest()
+	loaded := []Trace{{ID: "t1"}, {ID: "t2"}, {ID: "t3"}}
+	run, _, _ := buildCorpusRun(m, corpusSelection{Partitions: []CorpusPartition{PartitionChallenge}}, loaded)
+	if len(run) != 1 || run[0].ID != "t2" {
+		t.Fatalf("run = %v; want only the challenge trace t2", run)
+	}
+}
+
+func TestParseCorpusPartitions(t *testing.T) {
+	if got, err := parseCorpusPartitions(""); err != nil || got != nil {
+		t.Fatalf("parseCorpusPartitions(\"\") = (%v, %v); want (nil, nil)", got, err)
+	}
+	got, err := parseCorpusPartitions("natural, challenge ")
+	if err != nil {
+		t.Fatalf("parseCorpusPartitions: %v", err)
+	}
+	if !reflect.DeepEqual(got, []CorpusPartition{PartitionNatural, PartitionChallenge}) {
+		t.Fatalf("got %v; want [natural challenge]", got)
+	}
+	if _, err := parseCorpusPartitions("bogus"); err == nil {
+		t.Fatalf("parseCorpusPartitions(bogus) accepted unknown partition; want error")
+	}
+}
+
+// Judge-validation results must NOT fold into the combined model-quality
+// aggregate (they are scorer-calibration evidence, never model workload). The
+// combined table mean must reflect only natural+challenge.
+func TestFormatReport_ExcludesJudgeValidationFromCombinedAggregate(t *testing.T) {
+	results := []Result{
+		{Model: "m", TraceID: "t1", Score: Score{AnswerQuality: 1.0}}, // natural
+		{Model: "m", TraceID: "t2", Score: Score{AnswerQuality: 0.0}}, // challenge
+		{Model: "m", TraceID: "t3", Score: Score{AnswerQuality: 0.0}}, // judge-validation
+	}
+	out := formatReport([]string{"m"}, results, reportOptions{
+		Scorer: "manual",
+		Corpus: &corpusReportData{
+			Counts: corpusCounts{
+				ByPartition: map[CorpusPartition]int{PartitionNatural: 1, PartitionChallenge: 1, PartitionJudgeValidation: 1},
+				ByCategory:  map[string]int{"chat": 3},
+				Total:       3,
+			},
+			TraceToPartition: map[string]CorpusPartition{
+				"t1": PartitionNatural, "t2": PartitionChallenge, "t3": PartitionJudgeValidation,
+			},
+		},
+	})
+	// Mean over natural+challenge only = (1.0+0.0)/2 = 0.50.
+	if !strings.Contains(out, "| m | 0.50 / 0.00 / 0.00 / 1.00 / 1.00 |") {
+		t.Errorf("combined aggregate should exclude judge-validation (mean 0.50, not 0.33):\n%s", out)
+	}
+	// The 3-value mean (0.33) would appear only if judge-validation leaked in.
+	if strings.Contains(out, "| m | 0.33") {
+		t.Errorf("judge-validation leaked into the combined aggregate (mean 0.33):\n%s", out)
+	}
+	if !strings.Contains(out, "judge-validation result(s) excluded") {
+		t.Errorf("report should note the judge-validation exclusion:\n%s", out)
+	}
+}
+
+func TestSplitCommaList(t *testing.T) {
+	if got := splitCommaList(""); got != nil {
+		t.Fatalf("splitCommaList(\"\") = %v; want nil", got)
+	}
+	got := splitCommaList(" subtle-bug , tool-use ,")
+	if !reflect.DeepEqual(got, []string{"subtle-bug", "tool-use"}) {
+		t.Fatalf("splitCommaList = %v; want [subtle-bug tool-use] (trimmed, empties dropped)", got)
+	}
+}

--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -61,6 +61,10 @@ func main() {
 	judgeTransport := flag.String("judge-transport", "", "Judge backend for -scorer llm-judge: ollama (default), openai-compat, or claude-cli (headless `claude -p`, subscription)")
 	judgeBaseURL := flag.String("judge-base-url", "", "Base URL for -judge-transport openai-compat (server root, no /v1 suffix)")
 	judgeAPIKey := flag.String("judge-api-key", "", "Bearer token for -judge-transport openai-compat; falls back to $"+judgeAPIKeyEnvVar)
+	corpusManifestPath := flag.String("corpus-manifest", "", "Path to a corpus manifest JSONL (partition/category per trace); enables partition-separated reporting")
+	corpusPartitions := flag.String("corpus-partitions", "", "Comma-separated partitions to include from the corpus manifest (natural, challenge, judge-validation; empty = all)")
+	corpusCategories := flag.String("corpus-categories", "", "Comma-separated categories to include from the corpus manifest (empty = all)")
+	corpusOnlyEvidence := flag.Bool("corpus-only-evidence", false, "Restrict the corpus run to entries flagged allowed_as_model_evidence")
 	reportPath := flag.String("report", "", "Output report path (default: stdout)")
 	ollamaURL := flag.String("ollama-url", "http://localhost:11434", "Ollama base URL")
 	timeout := flag.Duration("timeout", 5*time.Minute, "Per-replay timeout for candidate model calls")
@@ -277,6 +281,28 @@ func main() {
 		log.Fatalf("llm-bench: load traces: %v", err)
 	}
 
+	var corpusData *corpusReportData
+	if strings.TrimSpace(*corpusManifestPath) != "" {
+		manifest, err := loadManifest(*corpusManifestPath)
+		if err != nil {
+			log.Fatalf("llm-bench: load corpus manifest: %v", err)
+		}
+		parts, err := parseCorpusPartitions(*corpusPartitions)
+		if err != nil {
+			log.Fatalf("llm-bench: %v", err)
+		}
+		sel := corpusSelection{Partitions: parts, Categories: splitCommaList(*corpusCategories), OnlyModelEvidence: *corpusOnlyEvidence}
+		run, data, missing := buildCorpusRun(manifest, sel, traces)
+		for _, id := range missing {
+			fmt.Fprintf(os.Stderr, "llm-bench: corpus manifest selects trace %q not present in -traces; skipping\n", id)
+		}
+		if len(run) == 0 {
+			log.Fatalf("llm-bench: corpus selection matched no loaded traces")
+		}
+		traces = run
+		corpusData = data
+	}
+
 	traceSetHash := traceSetManifestHash(traces)
 	log.Printf("llm-bench: trace set manifest hash %s (n=%d)", traceSetHash, len(traces))
 
@@ -349,6 +375,7 @@ func main() {
 		JudgeCacheHits:       judgeCacheHits,
 		JudgeCacheMisses:     judgeCacheMisses,
 		TraceSetManifestHash: traceSetHash,
+		Corpus:               corpusData,
 	})
 
 	if *reportPath == "" {

--- a/cmd/llm-bench/main_test.go
+++ b/cmd/llm-bench/main_test.go
@@ -111,6 +111,55 @@ func TestMainPairedReportEndToEnd(t *testing.T) {
 	}
 }
 
+func TestMainCorpusManifestPartitionsReport(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"message":           map[string]string{"role": "assistant", "content": "smoke-ok"},
+			"done":              true,
+			"prompt_eval_count": 1,
+			"eval_count":        1,
+		})
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	manifest := filepath.Join(dir, "manifest.jsonl")
+	if err := writeManifest(manifest, Manifest{Entries: []ManifestEntry{
+		{TraceID: "smoke-minimal-001", Partition: PartitionNatural, Category: "chat", AllowedAsModelEvidence: true},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	report := filepath.Join(dir, "report.md")
+
+	cmd := exec.Command(os.Args[0],
+		"-traces", "testdata/smoke/minimal.json",
+		"-models", "fake",
+		"-scorer", "exact-match",
+		"-corpus-manifest", manifest,
+		"-ollama-url", server.URL,
+		"-judge-cache", "",
+		"-report", report,
+	)
+	cmd.Env = append(os.Environ(), "LLM_BENCH_TEST_MAIN=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("llm-bench -corpus-manifest failed: %v\n%s", err, out)
+	}
+	body, err := os.ReadFile(report)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	for _, want := range []string{"## Corpus composition", "## Quality by model — by partition", "### natural"} {
+		if !strings.Contains(string(body), want) {
+			t.Fatalf("corpus report missing %q:\n%s", want, body)
+		}
+	}
+}
+
 func TestResolveToolSchemaSourceStdio(t *testing.T) {
 	src, err := resolveToolSchemaSource("echo mock-server", "")
 	if err != nil {

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -10,9 +10,21 @@ import (
 
 // formatReport renders per-model aggregates as a Markdown table.
 func formatReport(models []string, results []Result, opts reportOptions) string {
+	// Per-trace detail shows every result; the combined summary aggregate,
+	// when a corpus is present, excludes judge-validation (scorer-calibration
+	// evidence — never model workload, even in the diagnostic combined view).
 	byModel := make(map[string][]Result, len(models))
 	for _, r := range results {
 		byModel[r.Model] = append(byModel[r.Model], r)
+	}
+	summaryResults := results
+	excludedJudgeValidation := 0
+	if opts.Corpus != nil {
+		summaryResults, excludedJudgeValidation = excludeJudgeValidation(results, opts.Corpus.TraceToPartition)
+	}
+	summaryByModel := make(map[string][]Result, len(models))
+	for _, r := range summaryResults {
+		summaryByModel[r.Model] = append(summaryByModel[r.Model], r)
 	}
 
 	var b strings.Builder
@@ -47,11 +59,22 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 		fmt.Fprintln(&b)
 	}
 
+	if opts.Corpus != nil {
+		b.WriteString(formatCorpusComposition(opts.Corpus.Counts))
+	}
+
 	fmt.Fprintf(&b, "## Results\n\n")
+	if opts.Corpus != nil {
+		fmt.Fprintln(&b, "> Combined across model-evidence partitions (natural + challenge) — diagnostic only; partitions are not comparable, do not cite this as a single number. See the per-partition section below.")
+		if excludedJudgeValidation > 0 {
+			fmt.Fprintf(&b, ">\n> %d judge-validation result(s) excluded from this aggregate (scorer-calibration evidence, not model workload).\n", excludedJudgeValidation)
+		}
+		fmt.Fprintln(&b)
+	}
 	fmt.Fprintf(&b, "| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | ToolSequenceMatch | ToolArgsValid (computed=N) | LatencyMs (p50 / p90, successful-only) | TotalTokens | n | Failures/total (timeout) |\n")
 	fmt.Fprintf(&b, "|---|---|---|---|---|---|---|---|\n")
 	for _, m := range models {
-		rs := byModel[m]
+		rs := summaryByModel[m]
 		agg := aggregate(rs)
 		scored := len(rs) - agg.errors
 
@@ -78,6 +101,11 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 		failuresCell := fmt.Sprintf("%d/%d (%d timeout)", agg.errors, agg.errors+scored, agg.timeouts)
 		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s | %s | %d | %s |\n",
 			markdownCell(m), qCell, toolSeqCell, toolArgsCell, latencyCell, tokensCell, scored, failuresCell)
+	}
+
+	if opts.Corpus != nil {
+		fmt.Fprintln(&b)
+		b.WriteString(formatPartitionedQuality(models, results, opts.Corpus.TraceToPartition))
 	}
 
 	fmt.Fprintf(&b, "\n## Per-trace detail\n\n")
@@ -281,6 +309,98 @@ type reportOptions struct {
 	JudgeCacheHits       int64
 	JudgeCacheMisses     int64
 	TraceSetManifestHash string
+	// Corpus, when set, makes the report corpus-aware: it adds composition
+	// counts and partition-separated quality, and captions the combined
+	// results table as not-comparable-across-partitions.
+	Corpus *corpusReportData
+}
+
+// corpusReportData carries the manifest-derived view the report needs:
+// composition counts and a trace→partition map for separation.
+type corpusReportData struct {
+	Counts           corpusCounts
+	TraceToPartition map[string]CorpusPartition
+}
+
+// formatCorpusComposition renders the manifest's partition and category counts.
+func formatCorpusComposition(c corpusCounts) string {
+	var b strings.Builder
+	fmt.Fprintln(&b, "## Corpus composition")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "| Partition | Traces |")
+	fmt.Fprintln(&b, "|---|---|")
+	for _, p := range corpusPartitionOrder {
+		fmt.Fprintf(&b, "| %s | %d |\n", p, c.ByPartition[p])
+	}
+	fmt.Fprintf(&b, "| **total** | %d |\n", c.Total)
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "| Category | Traces |")
+	fmt.Fprintln(&b, "|---|---|")
+	for _, cat := range c.sortedCategories() {
+		fmt.Fprintf(&b, "| %s | %d |\n", markdownCell(cat), c.ByCategory[cat])
+	}
+	fmt.Fprintln(&b)
+	return b.String()
+}
+
+// formatPartitionedQuality renders per-model quality separately for the natural
+// and challenge partitions. The two are never averaged into one number, and
+// judge-validation traces (scorer-calibration evidence) are excluded from model
+// quality entirely.
+func formatPartitionedQuality(models []string, results []Result, traceToPartition map[string]CorpusPartition) string {
+	byPartition := make(map[CorpusPartition][]Result)
+	unclassified := 0
+	for _, r := range results {
+		p, ok := traceToPartition[r.TraceID]
+		if !ok {
+			unclassified++
+			continue
+		}
+		byPartition[p] = append(byPartition[p], r)
+	}
+	var b strings.Builder
+	fmt.Fprintln(&b, "## Quality by model — by partition")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "> Natural and challenge corpora answer different questions and are never averaged into one number. Judge-validation traces are scorer-calibration evidence and are excluded from model quality.")
+	fmt.Fprintln(&b)
+	for _, p := range []CorpusPartition{PartitionNatural, PartitionChallenge} {
+		fmt.Fprintf(&b, "### %s\n\n", p)
+		rs := byPartition[p]
+		if len(rs) == 0 {
+			fmt.Fprintln(&b, "(no traces in this partition)")
+			fmt.Fprintln(&b)
+			continue
+		}
+		emitPartitionQualityTable(&b, models, rs)
+	}
+	if unclassified > 0 {
+		fmt.Fprintf(&b, "_%d result(s) had no manifest partition and were omitted from the partitioned view._\n\n", unclassified)
+	}
+	return b.String()
+}
+
+// emitPartitionQualityTable writes one per-model quality+failures table for a
+// single partition's results.
+func emitPartitionQualityTable(b *strings.Builder, models []string, results []Result) {
+	byModel := make(map[string][]Result, len(models))
+	for _, r := range results {
+		byModel[r.Model] = append(byModel[r.Model], r)
+	}
+	fmt.Fprintln(b, "| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | n | Failures/total (timeout) |")
+	fmt.Fprintln(b, "|---|---|---|---|")
+	for _, m := range models {
+		rs := byModel[m]
+		agg := aggregate(rs)
+		scored := len(rs) - agg.errors
+		qCell := "n/a"
+		if scored > 0 {
+			qCell = fmt.Sprintf("%.2f / %.2f / %.2f / %.2f / %.2f",
+				agg.meanQuality, agg.qualityP25, agg.qualityP50, agg.qualityP75, agg.qualityP90)
+		}
+		failuresCell := fmt.Sprintf("%d/%d (%d timeout)", agg.errors, agg.errors+scored, agg.timeouts)
+		fmt.Fprintf(b, "| %s | %s | %d | %s |\n", markdownCell(m), qCell, scored, failuresCell)
+	}
+	fmt.Fprintln(b)
 }
 
 // modelAggregate holds computed statistics for one model's result set.


### PR DESCRIPTION
Closes #139. Stacked on #145 (#138 paired-label stats) → retarget base to `develop` as the stack lands.

## Why
Round-2 needs explicit corpus partitions (natural / challenge / judge-validation) with per-category accounting, plus a manifest recording what each trace is and whether it may be cited as accepted-run model evidence. Natural and challenge answer different questions and must be reported **separately** — never averaged into one number; judge-validation is scorer-calibration evidence and must **never** count as model-workload evidence.

## What
- **`corpus.go`** — `Manifest` / `ManifestEntry` / `CorpusPartition` (closed enum). JSONL `writeManifest`/`loadManifest` round-trip with validation on load (unknown partition, empty category, duplicate trace ID, empty file). `Counts()` (by partition + category), `Select(corpusSelection)` (the builder: filter by partition/category/only-model-evidence; empty = all), `buildCorpusRun` (loaded∩selected, report data scoped to the run subset, selected-but-missing trace IDs surfaced).
- **`report.go`** — `formatCorpusComposition` (partition + category counts) and `formatPartitionedQuality` (natural and challenge in separate per-model tables, never combined into one average). **Judge-validation is excluded from model quality**: omitted from the per-partition section *and* filtered out of the combined diagnostic aggregate (with an explicit exclusion note), so it can't inflate a model-quality number. The combined table is captioned as not-comparable-across-partitions.
- **`main.go`** — `-corpus-manifest` / `-corpus-partitions` / `-corpus-categories` / `-corpus-only-evidence` wired into the run path.

## Acceptance (#139)
- ✅ Manifest round-trips.
- ✅ Report shows partition + per-category counts.
- ✅ Natural vs challenge reportable separately (never averaged).

## Testing
TDD throughout (RED→GREEN per unit). Includes round-trip, all four load-validation rejections, `Counts`/`Select` (incl. category + only-evidence), `buildCorpusRun` intersection + missing-surfacing, partitioned rendering, judge-validation exclusion from the combined aggregate, and an E2E `-corpus-manifest` binary run. A focused adversarial review (judge-validation leak into the combined aggregate; missing category CLI flag) was applied. Full module build/test green; `gofmt` + `go vet` clean.

Generated with [Claude Code](https://claude.com/claude-code)