### PR TITLE
feat(llm-bench): expected-tool-call subset reporting (#140)

### DIFF
--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -306,6 +306,11 @@ func main() {
 	traceSetHash := traceSetManifestHash(traces)
 	log.Printf("llm-bench: trace set manifest hash %s (n=%d)", traceSetHash, len(traces))
 
+	toolCallExpected := make(map[string]bool, len(traces))
+	for _, tr := range traces {
+		toolCallExpected[tr.ID] = expectsToolCalls(tr)
+	}
+
 	resolvedJudgeModel := strings.TrimSpace(*judgeModel)
 	if *scorerName == "llm-judge" && resolvedJudgeModel == "" {
 		resolvedJudgeModel = defaultJudgeModelName()
@@ -376,6 +381,7 @@ func main() {
 		JudgeCacheMisses:     judgeCacheMisses,
 		TraceSetManifestHash: traceSetHash,
 		Corpus:               corpusData,
+		ToolCallExpected:     toolCallExpected,
 	})
 
 	if *reportPath == "" {

--- a/cmd/llm-bench/main_test.go
+++ b/cmd/llm-bench/main_test.go
@@ -160,6 +160,49 @@ func TestMainCorpusManifestPartitionsReport(t *testing.T) {
 	}
 }
 
+func TestMainEmitsToolUseSubsetSection(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"message":           map[string]string{"role": "assistant", "content": "smoke-ok"},
+			"done":              true,
+			"prompt_eval_count": 1,
+			"eval_count":        1,
+		})
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	report := filepath.Join(dir, "report.md")
+	cmd := exec.Command(os.Args[0],
+		"-traces", "testdata/smoke/minimal.json",
+		"-models", "fake",
+		"-scorer", "exact-match",
+		"-ollama-url", server.URL,
+		"-judge-cache", "",
+		"-report", report,
+	)
+	cmd.Env = append(os.Environ(), "LLM_BENCH_TEST_MAIN=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("llm-bench run failed: %v\n%s", err, out)
+	}
+	body, err := os.ReadFile(report)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	// The smoke trace expects no tool calls, so the subset has 0 expected pairs
+	// and the claim is insufficient — but the section must still be emitted.
+	for _, want := range []string{"## Tool-use (expected-tool-call subset)", "expected-tool-call pairs"} {
+		if !strings.Contains(string(body), want) {
+			t.Fatalf("report missing %q:\n%s", want, body)
+		}
+	}
+}
+
 func TestResolveToolSchemaSourceStdio(t *testing.T) {
 	src, err := resolveToolSchemaSource("echo mock-server", "")
 	if err != nil {

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -108,6 +108,11 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 		b.WriteString(formatPartitionedQuality(models, results, opts.Corpus.TraceToPartition))
 	}
 
+	if opts.ToolCallExpected != nil {
+		fmt.Fprintln(&b)
+		b.WriteString(formatToolUseSubset(toolUseSubsetRows(models, results, opts.ToolCallExpected)))
+	}
+
 	fmt.Fprintf(&b, "\n## Per-trace detail\n\n")
 	for _, m := range models {
 		fmt.Fprintf(&b, "### %s\n\n", markdownCell(m))
@@ -313,6 +318,10 @@ type reportOptions struct {
 	// counts and partition-separated quality, and captions the combined
 	// results table as not-comparable-across-partitions.
 	Corpus *corpusReportData
+	// ToolCallExpected maps trace ID → whether that trace's golden expects tool
+	// calls. When set, the report adds an expected-tool-call subset section so
+	// vacuous no-call rows can't masquerade as tool-use evidence.
+	ToolCallExpected map[string]bool
 }
 
 // corpusReportData carries the manifest-derived view the report needs:

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -110,7 +110,7 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 
 	if opts.ToolCallExpected != nil {
 		fmt.Fprintln(&b)
-		b.WriteString(formatToolUseSubset(toolUseSubsetRows(models, results, opts.ToolCallExpected)))
+		b.WriteString(formatToolUseSubset(toolUseSubsetRows(models, summaryResults, opts.ToolCallExpected)))
 	}
 
 	fmt.Fprintf(&b, "\n## Per-trace detail\n\n")

--- a/cmd/llm-bench/tool_subset.go
+++ b/cmd/llm-bench/tool_subset.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"strings"
 )
 
@@ -96,7 +97,7 @@ func formatToolUseSubset(rows []toolUseSubsetRow) string {
 		coverageCell := "n/a"
 		subsetCell := "n/a"
 		if r.ExpectedPairs > 0 {
-			coverageCell = fmt.Sprintf("%.0f%% (%d/%d)", r.Coverage*100, r.ComputedPairs, r.ExpectedPairs)
+			coverageCell = fmt.Sprintf("%s (%d/%d)", formatCoveragePercent(r.Coverage), r.ComputedPairs, r.ExpectedPairs)
 		}
 		if r.ComputedPairs > 0 {
 			subsetCell = fmt.Sprintf("%.2f", r.MeanArgsValid)
@@ -115,7 +116,14 @@ func toolUseClaimVerdict(expectedPairs int, coverage float64) (bool, string) {
 		return false, fmt.Sprintf("insufficient: %d expected-tool-call pairs (need >=%d)", expectedPairs, toolUseClaimMinExpectedPairs)
 	}
 	if coverage < toolUseClaimMinCoverage {
-		return false, fmt.Sprintf("insufficient: %.0f%% computed coverage (need >=%.0f%%)", coverage*100, toolUseClaimMinCoverage*100)
+		return false, fmt.Sprintf("insufficient: %s computed coverage (need >=%.0f%%)", formatCoveragePercent(coverage), toolUseClaimMinCoverage*100)
 	}
-	return true, fmt.Sprintf("supported: %d pairs, %.0f%% computed", expectedPairs, coverage*100)
+	return true, fmt.Sprintf("supported: %d pairs, %s computed", expectedPairs, formatCoveragePercent(coverage))
+}
+
+func formatCoveragePercent(coverage float64) string {
+	tenths := math.Floor(coverage*1000+1e-9) / 10
+	s := fmt.Sprintf("%.1f", tenths)
+	s = strings.TrimSuffix(s, ".0")
+	return s + "%"
 }

--- a/cmd/llm-bench/tool_subset.go
+++ b/cmd/llm-bench/tool_subset.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	// toolUseClaimMinExpectedPairs and toolUseClaimMinCoverage are the gate for
+	// citing a tool-use claim (spec §57-64): at least this many expected-tool-
+	// call (model, trace) pairs, and ToolArgsValid computed=true for at least
+	// this fraction of them. Vacuous no-call rows never count toward the subset.
+	toolUseClaimMinExpectedPairs = 10
+	toolUseClaimMinCoverage      = 0.80
+)
+
+// expectsToolCalls reports whether a trace's golden rubric expects any tool
+// calls. The expected-tool-call subset is defined by the trace, not the result,
+// so an errored or no-call replay on an expecting trace still counts as an
+// expected pair.
+func expectsToolCalls(t Trace) bool {
+	return len(t.Golden.ToolCalls) > 0
+}
+
+// toolUseSubsetRow is one model's expected-tool-call subset summary: how many
+// (model, trace) pairs expected tool calls, how many produced a computed
+// ToolArgsValid, the coverage, the mean ToolArgsValid over computed expected
+// pairs, and whether the tool-use claim is supportable.
+type toolUseSubsetRow struct {
+	Model          string
+	ExpectedPairs  int
+	ComputedPairs  int
+	Coverage       float64
+	MeanArgsValid  float64
+	ClaimSupported bool
+	ClaimReason    string
+}
+
+// toolUseSubsetRows computes the expected-tool-call subset per model. expected
+// maps trace ID → whether that trace expects tool calls (built from the trace
+// goldens). Coverage = ComputedPairs / ExpectedPairs; MeanArgsValid averages
+// only the computed expected pairs (so vacuous no-call rows can't inflate it).
+func toolUseSubsetRows(models []string, results []Result, expected map[string]bool) []toolUseSubsetRow {
+	type acc struct {
+		expectedPairs int
+		computedPairs int
+		argsSum       float64
+	}
+	byModel := make(map[string]*acc, len(models))
+	for _, m := range models {
+		byModel[m] = &acc{}
+	}
+	for _, r := range results {
+		if !expected[r.TraceID] {
+			continue
+		}
+		a, ok := byModel[r.Model]
+		if !ok {
+			continue
+		}
+		a.expectedPairs++
+		if r.Err == nil && r.Score.ToolArgsValidComputed {
+			a.computedPairs++
+			a.argsSum += r.Score.ToolArgsValid
+		}
+	}
+
+	rows := make([]toolUseSubsetRow, 0, len(models))
+	for _, m := range models {
+		a := byModel[m]
+		row := toolUseSubsetRow{Model: m, ExpectedPairs: a.expectedPairs, ComputedPairs: a.computedPairs}
+		if a.expectedPairs > 0 {
+			row.Coverage = float64(a.computedPairs) / float64(a.expectedPairs)
+		}
+		if a.computedPairs > 0 {
+			row.MeanArgsValid = a.argsSum / float64(a.computedPairs)
+		}
+		row.ClaimSupported, row.ClaimReason = toolUseClaimVerdict(a.expectedPairs, row.Coverage)
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+// formatToolUseSubset renders the expected-tool-call subset table: the honest
+// ToolArgsValid view that excludes vacuous no-call rows, with the tool-use-claim
+// verdict per model.
+func formatToolUseSubset(rows []toolUseSubsetRow) string {
+	var b strings.Builder
+	fmt.Fprintln(&b, "## Tool-use (expected-tool-call subset)")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "> ToolArgsValid overall (the Results column above) includes no-tool traces that pass by vacuous truth. This subset counts only traces whose golden expects tool calls. A tool-use claim needs >=10 expected-tool-call pairs with ToolArgsValid computed=true for >=80% of them.")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "| Model | expected-tool-call pairs | computed coverage | ToolArgsValid (subset) | tool-use claim |")
+	fmt.Fprintln(&b, "|---|---|---|---|---|")
+	for _, r := range rows {
+		coverageCell := "n/a"
+		subsetCell := "n/a"
+		if r.ExpectedPairs > 0 {
+			coverageCell = fmt.Sprintf("%.0f%% (%d/%d)", r.Coverage*100, r.ComputedPairs, r.ExpectedPairs)
+		}
+		if r.ComputedPairs > 0 {
+			subsetCell = fmt.Sprintf("%.2f", r.MeanArgsValid)
+		}
+		fmt.Fprintf(&b, "| %s | %d | %s | %s | %s |\n",
+			markdownCell(r.Model), r.ExpectedPairs, coverageCell, subsetCell, markdownCell(r.ClaimReason))
+	}
+	fmt.Fprintln(&b)
+	return b.String()
+}
+
+// toolUseClaimVerdict applies the tool-use-claim gate and returns a verdict plus
+// a human-readable reason naming the limiting factor.
+func toolUseClaimVerdict(expectedPairs int, coverage float64) (bool, string) {
+	if expectedPairs < toolUseClaimMinExpectedPairs {
+		return false, fmt.Sprintf("insufficient: %d expected-tool-call pairs (need >=%d)", expectedPairs, toolUseClaimMinExpectedPairs)
+	}
+	if coverage < toolUseClaimMinCoverage {
+		return false, fmt.Sprintf("insufficient: %.0f%% computed coverage (need >=%.0f%%)", coverage*100, toolUseClaimMinCoverage*100)
+	}
+	return true, fmt.Sprintf("supported: %d pairs, %.0f%% computed", expectedPairs, coverage*100)
+}

--- a/cmd/llm-bench/tool_subset_test.go
+++ b/cmd/llm-bench/tool_subset_test.go
@@ -119,6 +119,26 @@ func TestFormatToolUseSubset_NAWhenNoExpectedPairs(t *testing.T) {
 	}
 }
 
+func TestFormatToolUseSubset_BorderlineCoverageDoesNotRoundUpToGate(t *testing.T) {
+	coverage := float64(35) / float64(44)
+	_, reason := toolUseClaimVerdict(44, coverage)
+	out := formatToolUseSubset([]toolUseSubsetRow{{
+		Model:          "m",
+		ExpectedPairs:  44,
+		ComputedPairs:  35,
+		Coverage:       coverage,
+		MeanArgsValid:  1.0,
+		ClaimSupported: false,
+		ClaimReason:    reason,
+	}})
+	if !strings.Contains(out, "| m | 44 | 79.5% (35/44) | 1.00 | insufficient: 79.5% computed coverage (need >=80%) |") {
+		t.Fatalf("borderline coverage should not round up to the 80%% gate:\n%s", out)
+	}
+	if strings.Contains(out, "80% (35/44)") || strings.Contains(out, "insufficient: 80% computed coverage") {
+		t.Fatalf("borderline coverage rounded up to the gate:\n%s", out)
+	}
+}
+
 func TestFormatReport_EmitsToolUseSubsetOnlyWhenExpectedMapSet(t *testing.T) {
 	results := []Result{
 		{Model: "m", TraceID: "t1", Score: Score{AnswerQuality: 1.0, ToolArgsValid: 1.0, ToolArgsValidComputed: true}},

--- a/cmd/llm-bench/tool_subset_test.go
+++ b/cmd/llm-bench/tool_subset_test.go
@@ -137,3 +137,34 @@ func TestFormatReport_EmitsToolUseSubsetOnlyWhenExpectedMapSet(t *testing.T) {
 		t.Errorf("subset section must appear when ToolCallExpected is set:\n%s", withMap)
 	}
 }
+
+func TestFormatReport_ToolUseSubsetExcludesJudgeValidation(t *testing.T) {
+	results := []Result{
+		{Model: "m", TraceID: "natural-tool", Score: Score{AnswerQuality: 1.0, ToolArgsValid: 1.0, ToolArgsValidComputed: true}},
+		{Model: "m", TraceID: "judge-tool", Score: Score{AnswerQuality: 1.0, ToolArgsValid: 1.0, ToolArgsValidComputed: true}},
+	}
+	out := formatReport([]string{"m"}, results, reportOptions{
+		Scorer: "exact-match",
+		Corpus: &corpusReportData{
+			Counts: corpusCounts{
+				ByPartition: map[CorpusPartition]int{PartitionNatural: 1, PartitionJudgeValidation: 1},
+				ByCategory:  map[string]int{"tool-use": 2},
+				Total:       2,
+			},
+			TraceToPartition: map[string]CorpusPartition{
+				"natural-tool": PartitionNatural,
+				"judge-tool":   PartitionJudgeValidation,
+			},
+		},
+		ToolCallExpected: map[string]bool{
+			"natural-tool": true,
+			"judge-tool":   true,
+		},
+	})
+	if !strings.Contains(out, "| m | 1 | 100% (1/1) | 1.00 |") {
+		t.Fatalf("tool-use subset should count only model-evidence expected-tool rows:\n%s", out)
+	}
+	if strings.Contains(out, "| m | 2 | 100% (2/2) |") {
+		t.Fatalf("judge-validation row leaked into the tool-use subset:\n%s", out)
+	}
+}

--- a/cmd/llm-bench/tool_subset_test.go
+++ b/cmd/llm-bench/tool_subset_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestExpectsToolCalls(t *testing.T) {
+	if !expectsToolCalls(Trace{Golden: Golden{ToolCalls: []string{"search"}}}) {
+		t.Errorf("trace with golden tool calls should expect tool calls")
+	}
+	if expectsToolCalls(Trace{Golden: Golden{}}) {
+		t.Errorf("trace with no golden tool calls should not expect tool calls")
+	}
+}
+
+// The expected-tool-call subset must exclude vacuous no-call rows: a no-tool
+// trace returns ToolArgsValid=1.0/computed=true by vacuous truth, but it is not
+// an expected pair and must not inflate the subset.
+func TestToolUseSubsetRows_ExcludesVacuousRows(t *testing.T) {
+	results := []Result{
+		{Model: "m", TraceID: "t1", Score: Score{ToolArgsValid: 1.0, ToolArgsValidComputed: true}},  // expected, computed
+		{Model: "m", TraceID: "t2", Score: Score{ToolArgsValid: 0.0, ToolArgsValidComputed: false}}, // expected, made none
+		{Model: "m", TraceID: "t3", Score: Score{ToolArgsValid: 1.0, ToolArgsValidComputed: true}},  // vacuous (not expected)
+	}
+	expected := map[string]bool{"t1": true, "t2": true, "t3": false}
+	rows := toolUseSubsetRows([]string{"m"}, results, expected)
+	if len(rows) != 1 {
+		t.Fatalf("rows = %+v; want 1", rows)
+	}
+	r := rows[0]
+	if r.ExpectedPairs != 2 {
+		t.Errorf("ExpectedPairs = %d; want 2 (t1, t2 — not the vacuous t3)", r.ExpectedPairs)
+	}
+	if r.ComputedPairs != 1 {
+		t.Errorf("ComputedPairs = %d; want 1 (only t1 computed)", r.ComputedPairs)
+	}
+	if r.Coverage != 0.5 {
+		t.Errorf("Coverage = %v; want 0.5", r.Coverage)
+	}
+	if r.MeanArgsValid != 1.0 {
+		t.Errorf("MeanArgsValid = %v; want 1.0 (over the one computed expected pair)", r.MeanArgsValid)
+	}
+	if r.ClaimSupported {
+		t.Errorf("ClaimSupported should be false with only 2 expected pairs")
+	}
+}
+
+// An errored replay on an expected-tool-call trace is an expected pair that is
+// not computed — it must lower coverage, not vanish.
+func TestToolUseSubsetRows_ErroredExpectedRowCountsAgainstCoverage(t *testing.T) {
+	results := []Result{
+		{Model: "m", TraceID: "t1", Score: Score{ToolArgsValid: 1.0, ToolArgsValidComputed: true}},
+		{Model: "m", TraceID: "t2", Err: errors.New("boom")}, // expected trace, errored -> not computed
+	}
+	expected := map[string]bool{"t1": true, "t2": true}
+	rows := toolUseSubsetRows([]string{"m"}, results, expected)
+	r := rows[0]
+	if r.ExpectedPairs != 2 || r.ComputedPairs != 1 {
+		t.Fatalf("ExpectedPairs/ComputedPairs = %d/%d; want 2/1 (errored expected row counts as not-computed)", r.ExpectedPairs, r.ComputedPairs)
+	}
+}
+
+func TestToolUseSubsetRows_ClaimGate(t *testing.T) {
+	// 10 expected pairs, all computed and valid -> supported.
+	var ok []Result
+	expectedAll := map[string]bool{}
+	for i := 0; i < 10; i++ {
+		id := string(rune('a' + i))
+		ok = append(ok, Result{Model: "m", TraceID: id, Score: Score{ToolArgsValid: 1.0, ToolArgsValidComputed: true}})
+		expectedAll[id] = true
+	}
+	if r := toolUseSubsetRows([]string{"m"}, ok, expectedAll)[0]; !r.ClaimSupported {
+		t.Errorf("10 computed expected pairs should support the claim; got %+v", r)
+	}
+
+	// 10 expected pairs but only 6 computed (coverage 0.6 < 0.8) -> not supported.
+	var weak []Result
+	expectedWeak := map[string]bool{}
+	for i := 0; i < 10; i++ {
+		id := string(rune('a' + i))
+		computed := i < 6
+		weak = append(weak, Result{Model: "m", TraceID: id, Score: Score{ToolArgsValid: 1.0, ToolArgsValidComputed: computed}})
+		expectedWeak[id] = true
+	}
+	r := toolUseSubsetRows([]string{"m"}, weak, expectedWeak)[0]
+	if r.ClaimSupported {
+		t.Errorf("0.6 coverage should NOT support the claim; got %+v", r)
+	}
+	if !strings.Contains(r.ClaimReason, "80%") && !strings.Contains(r.ClaimReason, "coverage") {
+		t.Errorf("ClaimReason should explain the coverage shortfall; got %q", r.ClaimReason)
+	}
+}
+
+func TestFormatToolUseSubset_ShowsOverallVsSubsetDistinction(t *testing.T) {
+	rows := []toolUseSubsetRow{
+		{Model: "m", ExpectedPairs: 2, ComputedPairs: 1, Coverage: 0.5, MeanArgsValid: 1.0,
+			ClaimSupported: false, ClaimReason: "insufficient: 2 expected-tool-call pairs (need >=10)"},
+	}
+	out := formatToolUseSubset(rows)
+	for _, want := range []string{
+		"## Tool-use (expected-tool-call subset)",
+		"vacuous",
+		"expected-tool-call pairs",
+		"| m | 2 | 50% (1/2) | 1.00 | insufficient: 2 expected-tool-call pairs (need >=10) |",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("tool-use subset missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestFormatToolUseSubset_NAWhenNoExpectedPairs(t *testing.T) {
+	rows := []toolUseSubsetRow{{Model: "m", ExpectedPairs: 0, ClaimReason: "insufficient: 0 expected-tool-call pairs (need >=10)"}}
+	out := formatToolUseSubset(rows)
+	if !strings.Contains(out, "| m | 0 | n/a | n/a |") {
+		t.Errorf("zero expected pairs should render n/a coverage and subset:\n%s", out)
+	}
+}
+
+func TestFormatReport_EmitsToolUseSubsetOnlyWhenExpectedMapSet(t *testing.T) {
+	results := []Result{
+		{Model: "m", TraceID: "t1", Score: Score{AnswerQuality: 1.0, ToolArgsValid: 1.0, ToolArgsValidComputed: true}},
+	}
+	// Without the map: no subset section (back-compat).
+	plain := formatReport([]string{"m"}, results, reportOptions{Scorer: "exact-match"})
+	if strings.Contains(plain, "expected-tool-call subset") {
+		t.Errorf("subset section must not appear without ToolCallExpected:\n%s", plain)
+	}
+	// With the map: section present.
+	withMap := formatReport([]string{"m"}, results, reportOptions{
+		Scorer:           "exact-match",
+		ToolCallExpected: map[string]bool{"t1": true},
+	})
+	if !strings.Contains(withMap, "## Tool-use (expected-tool-call subset)") {
+		t.Errorf("subset section must appear when ToolCallExpected is set:\n%s", withMap)
+	}
+}


### PR DESCRIPTION
Closes #140. Stacked on #146 (#139 corpus manifest) → retarget base to `develop` as the stack lands.

## Why
The tool-arg validator returns `ToolArgsValid=1.0, computed=true` for the "no calls expected, none made" case (vacuous truth). So the overall `ToolArgsValid` overstates tool-calling correctness whenever the corpus is mostly no-tool traces. The acceptance gate requires an expected-tool-call subset view.

## What
- **`tool_subset.go`** — `expectsToolCalls(trace)` defines the subset by the **trace** golden (`len(Golden.ToolCalls) > 0`), not the result. `toolUseSubsetRows` reports per model: expected-tool-call pairs, computed coverage, and the subset mean `ToolArgsValid` (over computed expected pairs only). `toolUseClaimVerdict` gates a citable tool-use claim at **≥10 expected pairs AND ≥80% computed coverage**, naming the limiting factor when unmet.
- **`report.go`** — `reportOptions.ToolCallExpected`; when set, `formatReport` adds the subset section. The overall `ToolArgsValid` column is unchanged and reported alongside, so the vacuous-vs-honest gap is explicit.
- **`main.go`** — builds the `traceID→expectsToolCalls` map from the (post-corpus-filter) traces.

Defining the subset by trace (not a `Score` field) means an **errored** replay on an expected-tool-call trace correctly counts as an expected-but-not-computed pair and lowers coverage, rather than silently dropping out of the denominator.

## Acceptance (#140)
- ✅ Report distinguishes overall vs expected-tool-call-subset coverage.
- ✅ Matches the tool-call requirement in `docs/llm/harness-results.md` (≥10 pairs, ≥80% computed).

## Testing
TDD throughout: vacuous-row exclusion, errored expected rows count against coverage, division-by-zero → n/a rendering, exact 10-pair / 80%-coverage gate boundaries, additive-only report extension, and an E2E binary run. Adversarial review found no real issues. Full module build/test green; `gofmt` + `go vet` clean.

Generated with [Claude Code](https://claude.com/claude-code)