### PR TITLE
feat(llm-bench): isolate generation vs prompt-eval (and thinking) tokens (#142)

### DIFF
--- a/cmd/llm-bench/main_test.go
+++ b/cmd/llm-bench/main_test.go
@@ -196,7 +196,12 @@ func TestMainEmitsToolUseSubsetSection(t *testing.T) {
 	}
 	// The smoke trace expects no tool calls, so the subset has 0 expected pairs
 	// and the claim is insufficient — but the section must still be emitted.
-	for _, want := range []string{"## Tool-use (expected-tool-call subset)", "expected-tool-call pairs"} {
+	// The mock reports eval_count/prompt_eval_count, so the token breakdown must
+	// isolate gen vs prompt-eval (not just a combined total).
+	for _, want := range []string{
+		"## Tool-use (expected-tool-call subset)", "expected-tool-call pairs",
+		"## Token breakdown (gen vs prompt-eval)",
+	} {
 		if !strings.Contains(string(body), want) {
 			t.Fatalf("report missing %q:\n%s", want, body)
 		}

--- a/cmd/llm-bench/replay_test.go
+++ b/cmd/llm-bench/replay_test.go
@@ -145,6 +145,55 @@ func TestReplaySupportsMultipleUserTurns(t *testing.T) {
 	}
 }
 
+// replayWith must isolate prompt-eval and generation tokens (not just a
+// combined total) and accumulate each across turns; TotalTokens stays the sum
+// for back-compat.
+func TestReplayWith_IsolatesGenAndPromptEvalTokens(t *testing.T) {
+	log := &requestLog{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollama.ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		log.append(req)
+		resp := ollama.ChatResponse{
+			Model:           "test-model",
+			Done:            true,
+			Message:         ollama.ChatMessage{Role: "assistant", Content: "ans"},
+			PromptEvalCount: 10,
+			EvalCount:       20,
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	trace := Trace{
+		ID:     "two-turn",
+		System: "sys",
+		Turns: []Turn{
+			{Role: "user", Content: "first"},
+			{Role: "assistant", Content: "captured ack"},
+			{Role: "user", Content: "second"},
+		},
+	}
+	out, err := replayWith(context.Background(), client, "test-model", trace, replayOptions{})
+	if err != nil {
+		t.Fatalf("replayWith: %v", err)
+	}
+	if out.PromptEvalTokens != 20 {
+		t.Errorf("PromptEvalTokens = %d; want 20 (10 x 2 turns)", out.PromptEvalTokens)
+	}
+	if out.GenTokens != 40 {
+		t.Errorf("GenTokens = %d; want 40 (20 x 2 turns)", out.GenTokens)
+	}
+	if out.TotalTokens != 60 {
+		t.Errorf("TotalTokens = %d; want 60 (prompt+gen, back-compat)", out.TotalTokens)
+	}
+}
+
 func TestReplayInjectsFrozenToolResults(t *testing.T) {
 	log := &requestLog{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -322,7 +322,7 @@ func formatTokenBreakdown(models []string, results []Result) string {
 	fmt.Fprintln(&b)
 	fmt.Fprintln(&b, "> Generation (eval_count) vs prompt-eval (prompt_eval_count) tokens. Thinking tokens are shown only when the provider isolates them — Ollama folds reasoning into generation, so attribute latency to output/token volume, not thinking; the OpenAI-compat transport reports reasoning tokens when the model exposes them.")
 	fmt.Fprintln(&b)
-	fmt.Fprintln(&b, "| Model | Gen tokens (sum / mean) | Prompt-eval tokens (sum / mean) | Thinking tokens (sum / mean) | n |")
+	fmt.Fprintln(&b, "| Model | Gen tokens (sum / mean, n) | Prompt-eval tokens (sum / mean, n) | Thinking tokens (sum / mean, n) | Successful rows |")
 	fmt.Fprintln(&b, "|---|---|---|---|---|")
 	for _, m := range models {
 		rs := byModel[m]
@@ -339,13 +339,14 @@ func formatTokenBreakdown(models []string, results []Result) string {
 	return b.String()
 }
 
-// tokenSumMeanCell renders "sum / mean" for a token aggregate, or "n/a" when no
-// rows reported that token kind (so an unavailable metric never shows a fake 0).
+// tokenSumMeanCell renders "sum / mean (n=available)" for a token aggregate, or
+// "n/a" when no rows reported that token kind (so an unavailable metric never
+// shows a fake 0).
 func tokenSumMeanCell(sum, available int) string {
 	if available == 0 {
 		return "n/a"
 	}
-	return fmt.Sprintf("%d / %d", sum, sum/available)
+	return fmt.Sprintf("%d / %d (n=%d)", sum, sum/available, available)
 }
 
 // reportOptions carries metadata that formatReport embeds in report headers.

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -113,6 +113,9 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 		b.WriteString(formatToolUseSubset(toolUseSubsetRows(models, results, opts.ToolCallExpected)))
 	}
 
+	fmt.Fprintln(&b)
+	b.WriteString(formatTokenBreakdown(models, results))
+
 	fmt.Fprintf(&b, "\n## Per-trace detail\n\n")
 	for _, m := range models {
 		fmt.Fprintf(&b, "### %s\n\n", markdownCell(m))
@@ -306,6 +309,45 @@ func joinMarkdownCells(xs []string) string {
 	return strings.Join(cells, ", ")
 }
 
+// formatTokenBreakdown renders per-model generation vs prompt-eval token sums
+// and means (and thinking when the provider isolates it), so latency drivers can
+// be attributed to generation rather than total volume.
+func formatTokenBreakdown(models []string, results []Result) string {
+	byModel := make(map[string][]Result, len(models))
+	for _, r := range results {
+		byModel[r.Model] = append(byModel[r.Model], r)
+	}
+	var b strings.Builder
+	fmt.Fprintln(&b, "## Token breakdown (gen vs prompt-eval)")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "> Generation (eval_count) vs prompt-eval (prompt_eval_count) tokens. Thinking tokens are shown only when the provider isolates them — Ollama folds reasoning into generation, so attribute latency to output/token volume, not thinking; the OpenAI-compat transport reports reasoning tokens when the model exposes them.")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "| Model | Gen tokens (sum / mean) | Prompt-eval tokens (sum / mean) | Thinking tokens (sum / mean) | n |")
+	fmt.Fprintln(&b, "|---|---|---|---|---|")
+	for _, m := range models {
+		rs := byModel[m]
+		agg := aggregate(rs)
+		scored := len(rs) - agg.errors
+		fmt.Fprintf(&b, "| %s | %s | %s | %s | %d |\n",
+			markdownCell(m),
+			tokenSumMeanCell(agg.genTokensSum, agg.genTokensAvailable),
+			tokenSumMeanCell(agg.promptEvalTokensSum, agg.promptEvalTokensAvailable),
+			tokenSumMeanCell(agg.thinkingTokensSum, agg.thinkingTokensAvailable),
+			scored)
+	}
+	fmt.Fprintln(&b)
+	return b.String()
+}
+
+// tokenSumMeanCell renders "sum / mean" for a token aggregate, or "n/a" when no
+// rows reported that token kind (so an unavailable metric never shows a fake 0).
+func tokenSumMeanCell(sum, available int) string {
+	if available == 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%d / %d", sum, sum/available)
+}
+
 // reportOptions carries metadata that formatReport embeds in report headers.
 type reportOptions struct {
 	Scorer               string
@@ -430,6 +472,13 @@ type modelAggregate struct {
 	meanScorerLatencyMs  int64
 	totalTokensSum       int
 	totalTokensAvailable int
+
+	genTokensSum              int
+	genTokensAvailable        int
+	promptEvalTokensSum       int
+	promptEvalTokensAvailable int
+	thinkingTokensSum         int
+	thinkingTokensAvailable   int
 }
 
 func aggregate(rs []Result) modelAggregate {
@@ -464,6 +513,25 @@ func aggregate(rs []Result) modelAggregate {
 		if r.Score.TotalTokens > 0 {
 			a.totalTokensSum += r.Score.TotalTokens
 			a.totalTokensAvailable++
+		}
+		if r.Score.GenTokens > 0 {
+			a.genTokensSum += r.Score.GenTokens
+			a.genTokensAvailable++
+		}
+		if r.Score.PromptEvalTokens > 0 {
+			a.promptEvalTokensSum += r.Score.PromptEvalTokens
+			a.promptEvalTokensAvailable++
+		}
+		// Thinking uses the explicit Computed flag, NOT a >0 guard like gen and
+		// prompt-eval. Those use >0 only as a proxy for "reported" (a real
+		// generation always has >0 tokens, so 0 means missing). Thinking has a
+		// genuine availability signal, so a computed 0 is a REAL measurement
+		// (reasoning ran/was off and produced nothing) that must render as 0/0,
+		// letting a reader tell "measured zero reasoning" from "provider does
+		// not isolate reasoning" (n/a).
+		if r.Score.ThinkingTokensComputed {
+			a.thinkingTokensSum += r.Score.ThinkingTokens
+			a.thinkingTokensAvailable++
 		}
 	}
 	if scored > 0 {

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -114,7 +114,7 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 	}
 
 	fmt.Fprintln(&b)
-	b.WriteString(formatTokenBreakdown(models, results))
+	b.WriteString(formatTokenBreakdown(models, summaryResults))
 
 	fmt.Fprintf(&b, "\n## Per-trace detail\n\n")
 	for _, m := range models {

--- a/cmd/llm-bench/report_test.go
+++ b/cmd/llm-bench/report_test.go
@@ -141,6 +141,85 @@ func TestAggregateSumsTokens(t *testing.T) {
 	}
 }
 
+func TestAggregateSumsGenAndPromptEvalTokens(t *testing.T) {
+	rs := []Result{
+		{Score: Score{GenTokens: 100, PromptEvalTokens: 40, TotalTokens: 140}},
+		{Score: Score{GenTokens: 0, PromptEvalTokens: 0, TotalTokens: 0}}, // unavailable — does NOT count
+		{Score: Score{GenTokens: 50, PromptEvalTokens: 20, TotalTokens: 70}},
+	}
+	agg := aggregate(rs)
+	if agg.genTokensSum != 150 || agg.genTokensAvailable != 2 {
+		t.Errorf("gen tokens sum/available = %d/%d; want 150/2", agg.genTokensSum, agg.genTokensAvailable)
+	}
+	if agg.promptEvalTokensSum != 60 || agg.promptEvalTokensAvailable != 2 {
+		t.Errorf("prompt-eval tokens sum/available = %d/%d; want 60/2", agg.promptEvalTokensSum, agg.promptEvalTokensAvailable)
+	}
+}
+
+func TestAggregateSumsThinkingTokensOnlyWhenComputed(t *testing.T) {
+	rs := []Result{
+		{Score: Score{GenTokens: 100, ThinkingTokens: 30, ThinkingTokensComputed: true}},
+		{Score: Score{GenTokens: 50, ThinkingTokens: 0, ThinkingTokensComputed: false}}, // Ollama: not exposed
+	}
+	agg := aggregate(rs)
+	if agg.thinkingTokensSum != 30 || agg.thinkingTokensAvailable != 1 {
+		t.Errorf("thinking tokens sum/available = %d/%d; want 30/1 (only computed rows count)", agg.thinkingTokensSum, agg.thinkingTokensAvailable)
+	}
+}
+
+func TestFormatTokenBreakdown_ShowsGenVsPromptEval(t *testing.T) {
+	results := []Result{
+		{Model: "m", TraceID: "t1", Score: Score{GenTokens: 100, PromptEvalTokens: 40, TotalTokens: 140}},
+		{Model: "m", TraceID: "t2", Score: Score{GenTokens: 50, PromptEvalTokens: 20, TotalTokens: 70}},
+	}
+	out := formatTokenBreakdown([]string{"m"}, results)
+	for _, want := range []string{
+		"## Token breakdown (gen vs prompt-eval)",
+		"thinking",
+		"| m | 150 / 75 | 60 / 30 | n/a | 2 |",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("token breakdown missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestFormatTokenBreakdown_ShowsThinkingWhenComputed(t *testing.T) {
+	results := []Result{
+		{Model: "m", TraceID: "t1", Score: Score{GenTokens: 100, PromptEvalTokens: 40, ThinkingTokens: 30, ThinkingTokensComputed: true}},
+	}
+	out := formatTokenBreakdown([]string{"m"}, results)
+	if !strings.Contains(out, "| m | 100 / 100 | 40 / 40 | 30 / 30 | 1 |") {
+		t.Errorf("thinking column should populate when computed:\n%s", out)
+	}
+}
+
+// Thinking has an explicit computed flag, so unlike gen/prompt-eval (where 0 is
+// treated as "not reported"), a computed thinking value of 0 is a REAL
+// measurement and must render as 0/0, not n/a — this lets a reader distinguish
+// "measured zero reasoning" from "provider does not isolate reasoning".
+func TestFormatTokenBreakdown_ComputedZeroThinkingIsRealZeroNotNA(t *testing.T) {
+	results := []Result{
+		{Model: "m", TraceID: "t1", Score: Score{GenTokens: 100, PromptEvalTokens: 40, ThinkingTokens: 0, ThinkingTokensComputed: true}},
+	}
+	out := formatTokenBreakdown([]string{"m"}, results)
+	if !strings.Contains(out, "| m | 100 / 100 | 40 / 40 | 0 / 0 | 1 |") {
+		t.Errorf("computed thinking=0 must render as a real 0/0 (measured), not n/a:\n%s", out)
+	}
+}
+
+func TestFormatReport_EmitsTokenBreakdownAndNoNaN(t *testing.T) {
+	out := formatReport([]string{"m"}, []Result{
+		{Model: "m", TraceID: "t1", Score: Score{GenTokens: 10, PromptEvalTokens: 5, TotalTokens: 15}},
+	}, reportOptions{Scorer: "exact-match"})
+	if !strings.Contains(out, "## Token breakdown (gen vs prompt-eval)") {
+		t.Errorf("report should include the token breakdown section:\n%s", out)
+	}
+	if strings.Contains(out, "NaN") {
+		t.Errorf("token breakdown must never render NaN:\n%s", out)
+	}
+}
+
 func TestFormatReportSummaryMatchesTemplateColumns(t *testing.T) {
 	report := formatReport([]string{"m1"}, []Result{
 		{Model: "m1", TraceID: "t1", Score: Score{AnswerQuality: 0.5, ToolSequenceMatch: 1, ToolArgsValid: 1, ToolArgsValidComputed: true, LatencyMs: 100, TotalTokens: 42}},

--- a/cmd/llm-bench/report_test.go
+++ b/cmd/llm-bench/report_test.go
@@ -220,6 +220,35 @@ func TestFormatReport_EmitsTokenBreakdownAndNoNaN(t *testing.T) {
 	}
 }
 
+func TestFormatReport_TokenBreakdownExcludesJudgeValidation(t *testing.T) {
+	results := []Result{
+		{Model: "m", TraceID: "natural", Score: Score{GenTokens: 100, PromptEvalTokens: 40, TotalTokens: 140}},
+		{Model: "m", TraceID: "challenge", Score: Score{GenTokens: 50, PromptEvalTokens: 20, TotalTokens: 70}},
+		{Model: "m", TraceID: "judge", Score: Score{GenTokens: 1000, PromptEvalTokens: 500, TotalTokens: 1500}},
+	}
+	out := formatReport([]string{"m"}, results, reportOptions{
+		Scorer: "exact-match",
+		Corpus: &corpusReportData{
+			Counts: corpusCounts{
+				ByPartition: map[CorpusPartition]int{PartitionNatural: 1, PartitionChallenge: 1, PartitionJudgeValidation: 1},
+				ByCategory:  map[string]int{"chat": 3},
+				Total:       3,
+			},
+			TraceToPartition: map[string]CorpusPartition{
+				"natural":   PartitionNatural,
+				"challenge": PartitionChallenge,
+				"judge":     PartitionJudgeValidation,
+			},
+		},
+	})
+	if !strings.Contains(out, "| m | 150 / 75 | 60 / 30 | n/a | 2 |") {
+		t.Fatalf("token breakdown should aggregate only natural+challenge rows:\n%s", out)
+	}
+	if strings.Contains(out, "| m | 1150 /") {
+		t.Fatalf("judge-validation tokens leaked into token breakdown:\n%s", out)
+	}
+}
+
 func TestFormatReportSummaryMatchesTemplateColumns(t *testing.T) {
 	report := formatReport([]string{"m1"}, []Result{
 		{Model: "m1", TraceID: "t1", Score: Score{AnswerQuality: 0.5, ToolSequenceMatch: 1, ToolArgsValid: 1, ToolArgsValidComputed: true, LatencyMs: 100, TotalTokens: 42}},

--- a/cmd/llm-bench/report_test.go
+++ b/cmd/llm-bench/report_test.go
@@ -176,10 +176,26 @@ func TestFormatTokenBreakdown_ShowsGenVsPromptEval(t *testing.T) {
 	for _, want := range []string{
 		"## Token breakdown (gen vs prompt-eval)",
 		"thinking",
-		"| m | 150 / 75 | 60 / 30 | n/a | 2 |",
+		"| m | 150 / 75 (n=2) | 60 / 30 (n=2) | n/a | 2 |",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("token breakdown missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestFormatTokenBreakdown_ShowsTokenAvailabilityDenominators(t *testing.T) {
+	results := []Result{
+		{Model: "m", TraceID: "reported", Score: Score{GenTokens: 100, PromptEvalTokens: 40, TotalTokens: 140}},
+		{Model: "m", TraceID: "unreported", Score: Score{AnswerQuality: 1.0}},
+	}
+	out := formatTokenBreakdown([]string{"m"}, results)
+	for _, want := range []string{
+		"| Model | Gen tokens (sum / mean, n) | Prompt-eval tokens (sum / mean, n) | Thinking tokens (sum / mean, n) | Successful rows |",
+		"| m | 100 / 100 (n=1) | 40 / 40 (n=1) | n/a | 2 |",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("token breakdown missing availability denominator %q:\n%s", want, out)
 		}
 	}
 }
@@ -189,7 +205,7 @@ func TestFormatTokenBreakdown_ShowsThinkingWhenComputed(t *testing.T) {
 		{Model: "m", TraceID: "t1", Score: Score{GenTokens: 100, PromptEvalTokens: 40, ThinkingTokens: 30, ThinkingTokensComputed: true}},
 	}
 	out := formatTokenBreakdown([]string{"m"}, results)
-	if !strings.Contains(out, "| m | 100 / 100 | 40 / 40 | 30 / 30 | 1 |") {
+	if !strings.Contains(out, "| m | 100 / 100 (n=1) | 40 / 40 (n=1) | 30 / 30 (n=1) | 1 |") {
 		t.Errorf("thinking column should populate when computed:\n%s", out)
 	}
 }
@@ -203,7 +219,7 @@ func TestFormatTokenBreakdown_ComputedZeroThinkingIsRealZeroNotNA(t *testing.T) 
 		{Model: "m", TraceID: "t1", Score: Score{GenTokens: 100, PromptEvalTokens: 40, ThinkingTokens: 0, ThinkingTokensComputed: true}},
 	}
 	out := formatTokenBreakdown([]string{"m"}, results)
-	if !strings.Contains(out, "| m | 100 / 100 | 40 / 40 | 0 / 0 | 1 |") {
+	if !strings.Contains(out, "| m | 100 / 100 (n=1) | 40 / 40 (n=1) | 0 / 0 (n=1) | 1 |") {
 		t.Errorf("computed thinking=0 must render as a real 0/0 (measured), not n/a:\n%s", out)
 	}
 }
@@ -241,7 +257,7 @@ func TestFormatReport_TokenBreakdownExcludesJudgeValidation(t *testing.T) {
 			},
 		},
 	})
-	if !strings.Contains(out, "| m | 150 / 75 | 60 / 30 | n/a | 2 |") {
+	if !strings.Contains(out, "| m | 150 / 75 (n=2) | 60 / 30 (n=2) | n/a | 2 |") {
 		t.Fatalf("token breakdown should aggregate only natural+challenge rows:\n%s", out)
 	}
 	if strings.Contains(out, "| m | 1150 /") {

--- a/cmd/llm-bench/runner.go
+++ b/cmd/llm-bench/runner.go
@@ -133,6 +133,10 @@ func (r *Runner) runOne(ctx context.Context, client *ollama.Client, target Model
 	// without polluting the target model latency metric.
 	score.ScorerLatencyMs = scorerMs
 	score.TotalTokens = out.TotalTokens
+	score.PromptEvalTokens = out.PromptEvalTokens
+	score.GenTokens = out.GenTokens
+	score.ThinkingTokens = out.ThinkingTokens
+	score.ThinkingTokensComputed = out.ThinkingComputed
 
 	return Result{
 		Model:      target.Display,
@@ -142,12 +146,27 @@ func (r *Runner) runOne(ctx context.Context, client *ollama.Client, target Model
 	}
 }
 
+// tokenUsage is the per-turn token breakdown reported by the provider. Gen and
+// PromptEval map to Ollama eval_count/prompt_eval_count and to OpenAI-compat
+// usage.completion_tokens/prompt_tokens. ThinkingComputed is false when the
+// provider does not isolate reasoning tokens (e.g. Ollama folds them into Gen).
+type tokenUsage struct {
+	PromptEval       int
+	Gen              int
+	Thinking         int
+	ThinkingComputed bool
+}
+
 // replayOutput bundles the side effects of a single replay.
 type replayOutput struct {
-	Transcript      []Turn
-	Notes           []string
-	TurnLatenciesMs []int64
-	TotalTokens     int
+	Transcript       []Turn
+	Notes            []string
+	TurnLatenciesMs  []int64
+	TotalTokens      int // prompt-eval + gen (back-compat)
+	PromptEvalTokens int
+	GenTokens        int
+	ThinkingTokens   int
+	ThinkingComputed bool // true once any turn reported isolated thinking tokens
 }
 
 // replayOptions are the per-replay knobs threaded down from Runner.
@@ -220,12 +239,18 @@ func replayWith(ctx context.Context, client *ollama.Client, model string, trace 
 				i++
 			}
 
-			msg, actualTurn, latencyMs, tokens, err := chatReplayTurn(ctx, client, model, messages, tools, opts)
+			msg, actualTurn, latencyMs, usage, err := chatReplayTurn(ctx, client, model, messages, tools, opts)
 			out.TurnLatenciesMs = append(out.TurnLatenciesMs, latencyMs)
 			if err != nil {
 				return out, err
 			}
-			out.TotalTokens += tokens
+			out.PromptEvalTokens += usage.PromptEval
+			out.GenTokens += usage.Gen
+			out.TotalTokens += usage.PromptEval + usage.Gen
+			if usage.ThinkingComputed {
+				out.ThinkingTokens += usage.Thinking
+				out.ThinkingComputed = true
+			}
 			messages = append(messages, msg)
 			out.Transcript = append(out.Transcript, actualTurn)
 
@@ -276,7 +301,7 @@ func hasUserTurn(turns []Turn) bool {
 	return false
 }
 
-func chatReplayTurn(ctx context.Context, client *ollama.Client, model string, messages []ollama.ChatMessage, tools []ollama.Tool, opts replayOptions) (ollama.ChatMessage, Turn, int64, int, error) {
+func chatReplayTurn(ctx context.Context, client *ollama.Client, model string, messages []ollama.ChatMessage, tools []ollama.Tool, opts replayOptions) (ollama.ChatMessage, Turn, int64, tokenUsage, error) {
 	turnCtx := ctx
 	if opts.PerTurnTimeout > 0 {
 		var cancel context.CancelFunc
@@ -298,16 +323,19 @@ func chatReplayTurn(ctx context.Context, client *ollama.Client, model string, me
 	resp, err := client.Chat(turnCtx, req)
 	latencyMs := time.Since(start).Milliseconds()
 	if err != nil {
-		return ollama.ChatMessage{}, Turn{}, latencyMs, 0, err
+		return ollama.ChatMessage{}, Turn{}, latencyMs, tokenUsage{}, err
 	}
 
 	msg := normalizeAssistantMessage(resp.Message)
 	turn, err := assistantTurnFromMessage(msg)
 	if err != nil {
-		return ollama.ChatMessage{}, Turn{}, latencyMs, 0, err
+		return ollama.ChatMessage{}, Turn{}, latencyMs, tokenUsage{}, err
 	}
-	tokens := resp.PromptEvalCount + resp.EvalCount
-	return msg, turn, latencyMs, tokens, nil
+	// Ollama reports prompt_eval_count and eval_count separately; thinking
+	// tokens are folded into eval_count (not isolable here). The OpenAI-compat
+	// candidate transport (#136) will populate Thinking from reasoning usage.
+	usage := tokenUsage{PromptEval: resp.PromptEvalCount, Gen: resp.EvalCount}
+	return msg, turn, latencyMs, usage, nil
 }
 
 func normalizeAssistantMessage(msg ollama.ChatMessage) ollama.ChatMessage {

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -44,8 +44,16 @@ type Score struct {
 	LatencyMs             int64   // sum of all chat round-trips for this replay
 	TurnLatenciesMs       []int64 // per-turn breakdown; len == number of chat round-trips
 	ScorerLatencyMs       int64   // wall-clock time spent in the active scorer
-	TotalTokens           int
-	Notes                 string
+	TotalTokens           int     // prompt-eval + generation tokens (kept for back-compat)
+	PromptEvalTokens      int     // tokens in the prompt (Ollama prompt_eval_count / OpenAI usage.prompt_tokens)
+	GenTokens             int     // tokens generated (Ollama eval_count / OpenAI usage.completion_tokens)
+	ThinkingTokens        int     // reasoning tokens when the provider isolates them; see ThinkingTokensComputed
+	// ThinkingTokensComputed is false when the provider does not separately
+	// expose thinking tokens (e.g. Ollama folds them into GenTokens). It mirrors
+	// the ToolArgsValidComputed idiom so the report can distinguish "no thinking"
+	// from "not reported".
+	ThinkingTokensComputed bool
+	Notes                  string
 }
 
 // Scorer is the pluggable strategy for evaluating a replay result.


### PR DESCRIPTION
Closes #142. Stacked on #147 (#140 tool-subset) → retarget base to `develop` as the stack lands.

## Why
The harness recorded only a combined `TotalTokens` (prompt-eval + gen), so latency-driver claims could only be stated as total token volume, not generation specifically.

**llama.cpp note:** the token model is deliberately **provider-agnostic** (semantic gen/prompt/thinking roles, not Ollama wire names) because candidates are moving to llama.cpp (OpenAI-compat). Ollama maps `prompt_eval_count→prompt`, `eval_count→gen` and folds reasoning into gen; llama.cpp's OpenAI-compat `usage` will map `prompt_tokens→prompt`, `completion_tokens→gen`, `reasoning_tokens→thinking` with **zero changes** to the metrics/report layer. The candidate transport that lights this up for llama.cpp is GH #136 (next).

## What
- **`scorer.go`** — `Score` gains `PromptEvalTokens`, `GenTokens`, `ThinkingTokens`, `ThinkingTokensComputed`; `TotalTokens` kept (= prompt + gen) for back-compat.
- **`runner.go`** — `tokenUsage` struct; `chatReplayTurn` returns it; `replayWith` accumulates each separately; `runTrace` sets the Score fields.
- **`report.go`** — `aggregate` tracks gen/prompt/thinking sums + availability; `formatTokenBreakdown` section shows gen vs prompt-eval (and thinking when computed). Thinking uses the explicit `Computed` flag (not a `>0` proxy) so a **measured** 0 reads as a real `0/0`, distinguishable from `n/a` ("provider does not isolate reasoning") — which is exactly what thinking-on/off role-tuning needs.

## Acceptance (#142)
- ✅ Report shows gen vs prompt-eval token counts (and thinking when the provider exposes them), not just a combined total.

## Testing
TDD throughout: separate gen/prompt accumulation across turns, `TotalTokens` back-compat, thinking summed only when computed, computed-zero renders real `0/0`, n/a (never NaN) when unavailable, and a live-run E2E. Adversarial review (one finding on the thinking/gen asymmetry) resolved by documenting + testing the principled divergence. Full module build/test green; `gofmt` + `go vet` clean.

Generated with [Claude Code](https://claude.com/claude-code)