### PR TITLE
feat(llm-bench): separate FIM / inline-completion latency mode (#141)

### DIFF
--- a/cmd/llm-bench/fim.go
+++ b/cmd/llm-bench/fim.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+// formatFIMReport renders inline-completion latency per model, distinct from
+// chat-replay latency. The sub-second interactive regime is a different
+// measurement than chat seconds, so the two are never mixed.
+func formatFIMReport(models []string, results []FIMResult) string {
+	byModel := make(map[string][]FIMResult, len(models))
+	for _, r := range results {
+		byModel[r.Model] = append(byModel[r.Model], r)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "# llm-bench — FIM / inline-completion latency\n\n")
+	fmt.Fprintf(&b, "Generated: %s\n\n", time.Now().UTC().Format(time.RFC3339))
+	fmt.Fprintln(&b, "> Interactive regime: prefix/suffix completion with num_predict capped. This is kept separate from chat latency — the sub-second completion target is a different regime than chat seconds, so do NOT compare these numbers to chat-replay latency.")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "## FIM latency by model")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "| Model | LatencyMs (p50 / p90 / mean, successful-only) | Gen tokens (mean) | n | Failures/total |")
+	fmt.Fprintln(&b, "|---|---|---|---|---|")
+	for _, m := range models {
+		rs := byModel[m]
+		var latencies []int64
+		var genSum int64
+		failures := 0
+		for _, r := range rs {
+			if r.Err != nil {
+				failures++
+				continue
+			}
+			latencies = append(latencies, r.LatencyMs)
+			genSum += int64(r.GenTokens)
+		}
+		scored := len(latencies)
+		latCell := "n/a"
+		genCell := "n/a"
+		if scored > 0 {
+			ps := int64Percentiles(latencies, 0.5, 0.9)
+			latCell = fmt.Sprintf("%d / %d / %d", ps[0], ps[1], sumInt64(latencies)/int64(scored))
+			genCell = fmt.Sprintf("%d", genSum/int64(scored))
+		}
+		fmt.Fprintf(&b, "| %s | %s | %s | %d | %d/%d |\n",
+			markdownCell(m), latCell, genCell, scored, failures, len(rs))
+	}
+	fmt.Fprintln(&b)
+	return redactPaths(b.String())
+}
+
+// defaultFIMNumPredict bounds generation for an inline-completion measurement:
+// FIM completions are short, and the interactive regime targets sub-second
+// latency, so a small cap keeps the measurement honest.
+const defaultFIMNumPredict = 64
+
+// FIMCase is one inline-completion fixture: the code before the cursor (Prefix)
+// and after it (Suffix). The model fills the middle. Distinct from chat Traces.
+type FIMCase struct {
+	ID     string `json:"id"`
+	Prefix string `json:"prefix"`
+	Suffix string `json:"suffix"`
+}
+
+// loadFIMCases reads each path as a JSON FIMCase. A case must have an ID and at
+// least one of prefix/suffix (a completion with neither has no context).
+func loadFIMCases(paths []string) ([]FIMCase, error) {
+	cases := make([]FIMCase, 0, len(paths))
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("fim: read %q: %w", path, err)
+		}
+		var c FIMCase
+		if err := json.Unmarshal(data, &c); err != nil {
+			return nil, fmt.Errorf("fim: parse %q: %w", path, err)
+		}
+		if strings.TrimSpace(c.ID) == "" {
+			return nil, fmt.Errorf("fim: %q missing id", path)
+		}
+		if c.Prefix == "" && c.Suffix == "" {
+			return nil, fmt.Errorf("fim: case %q has neither prefix nor suffix", c.ID)
+		}
+		cases = append(cases, c)
+	}
+	return cases, nil
+}
+
+// fimGenOutput is the provider-agnostic result of one FIM generation.
+type fimGenOutput struct {
+	Text      string
+	GenTokens int
+}
+
+// fimGenerator is the transport seam for inline completion. The Ollama impl uses
+// /api/generate (prompt+suffix); the OpenAI-compat candidate transport (#136)
+// will add a llama.cpp impl (/v1/completions suffix or /infill) with no change
+// to the runner/report layer.
+type fimGenerator interface {
+	GenerateFIM(ctx context.Context, model, prefix, suffix string, numPredict int) (fimGenOutput, error)
+}
+
+// ollamaFIMGenerator drives FIM through the Ollama /api/generate endpoint.
+type ollamaFIMGenerator struct {
+	client *ollama.Client
+}
+
+func (g ollamaFIMGenerator) GenerateFIM(ctx context.Context, model, prefix, suffix string, numPredict int) (fimGenOutput, error) {
+	resp, err := g.client.Generate(ctx, ollama.GenerateRequest{
+		// Strip the bench provider prefix so Ollama receives its native model
+		// name (the report still keys on the user-facing Display selector).
+		Model:   modelSelectorWithoutBenchProvider(model),
+		Prompt:  prefix,
+		Suffix:  suffix,
+		Options: &ollama.ModelOptions{NumPredict: numPredict},
+	})
+	if err != nil {
+		return fimGenOutput{}, err
+	}
+	return fimGenOutput{Text: resp.Response, GenTokens: resp.EvalCount}, nil
+}
+
+// FIMResult is one (model, case) inline-completion measurement.
+type FIMResult struct {
+	Model     string
+	CaseID    string
+	LatencyMs int64
+	GenTokens int
+	Err       error
+}
+
+// fimRunOptions configures runFIMLatency.
+type fimRunOptions struct {
+	Generator  fimGenerator
+	Models     []string
+	Cases      []FIMCase
+	NumPredict int
+	Warmup     bool             // when true, issue one discarded generate per model before timing
+	Now        func() time.Time // injectable clock for deterministic tests; defaults to time.Now
+}
+
+// runFIMLatency measures inline-completion latency per (model, case). It warms
+// each model with one discarded call (when Warmup) so the reported latency
+// reflects the warm interactive regime, then times each case. Per-case errors
+// are recorded as result rows so a single failure never aborts the run.
+func runFIMLatency(ctx context.Context, opts fimRunOptions) []FIMResult {
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	numPredict := opts.NumPredict
+	if numPredict <= 0 {
+		numPredict = defaultFIMNumPredict
+	}
+
+	results := make([]FIMResult, 0, len(opts.Models)*len(opts.Cases))
+	for _, model := range opts.Models {
+		if opts.Warmup && len(opts.Cases) > 0 {
+			warm := opts.Cases[0]
+			_, _ = opts.Generator.GenerateFIM(ctx, model, warm.Prefix, warm.Suffix, numPredict)
+		}
+		for _, c := range opts.Cases {
+			start := now()
+			out, err := opts.Generator.GenerateFIM(ctx, model, c.Prefix, c.Suffix, numPredict)
+			latency := now().Sub(start).Milliseconds()
+			res := FIMResult{Model: model, CaseID: c.ID, LatencyMs: latency}
+			if err != nil {
+				res.Err = err
+			} else {
+				res.GenTokens = out.GenTokens
+			}
+			results = append(results, res)
+		}
+	}
+	return results
+}

--- a/cmd/llm-bench/fim_test.go
+++ b/cmd/llm-bench/fim_test.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestLoadFIMCases_RoundTripsPrefixSuffix(t *testing.T) {
+	dir := t.TempDir()
+	p := writeFile(t, dir, "c1.json", `{"id":"c1","prefix":"func add(a, b int) int {\n\treturn ","suffix":"\n}"}`)
+	cases, err := loadFIMCases([]string{p})
+	if err != nil {
+		t.Fatalf("loadFIMCases: %v", err)
+	}
+	if len(cases) != 1 || cases[0].ID != "c1" || !strings.Contains(cases[0].Prefix, "return ") || cases[0].Suffix != "\n}" {
+		t.Fatalf("loaded case = %+v; want prefix/suffix round-trip", cases[0])
+	}
+}
+
+func TestLoadFIMCases_RejectsMissingPrefixAndSuffix(t *testing.T) {
+	dir := t.TempDir()
+	p := writeFile(t, dir, "bad.json", `{"id":"bad"}`)
+	if _, err := loadFIMCases([]string{p}); err == nil {
+		t.Fatalf("loadFIMCases accepted a case with neither prefix nor suffix; want error")
+	}
+}
+
+// fakeFIMGenerator records calls and advances a shared clock by a fixed step per
+// call so runFIMLatency produces deterministic latencies. Single-goroutine only:
+// runFIMLatency drives the generator sequentially, so no synchronization is
+// needed (and the unlocked clock read in the Now closure stays race-free).
+type fakeFIMGenerator struct {
+	clock     *time.Time
+	step      time.Duration
+	calls     []string // "model|prefix|suffix|numPredict"
+	failModel string   // GenerateFIM returns an error when model == failModel
+	genTokens int
+}
+
+func (f *fakeFIMGenerator) GenerateFIM(_ context.Context, model, prefix, suffix string, numPredict int) (fimGenOutput, error) {
+	f.calls = append(f.calls, fmt.Sprintf("%s|%s|%s|%d", model, prefix, suffix, numPredict))
+	*f.clock = f.clock.Add(f.step)
+	if model == f.failModel {
+		return fimGenOutput{}, errors.New("boom")
+	}
+	return fimGenOutput{Text: "completion", GenTokens: f.genTokens}, nil
+}
+
+func TestRunFIMLatency_TimesEachCaseDeterministically(t *testing.T) {
+	clock := time.Unix(0, 0)
+	gen := &fakeFIMGenerator{clock: &clock, step: 25 * time.Millisecond, genTokens: 7}
+	cases := []FIMCase{{ID: "c1", Prefix: "a", Suffix: "b"}, {ID: "c2", Prefix: "c", Suffix: "d"}}
+	results := runFIMLatency(context.Background(), fimRunOptions{
+		Generator:  gen,
+		Models:     []string{"m"},
+		Cases:      cases,
+		NumPredict: 64,
+		Warmup:     false,
+		Now:        func() time.Time { return clock },
+	})
+	if len(results) != 2 {
+		t.Fatalf("results = %d; want 2 (one per case)", len(results))
+	}
+	for _, r := range results {
+		if r.Err != nil {
+			t.Fatalf("unexpected error: %v", r.Err)
+		}
+		if r.LatencyMs != 25 {
+			t.Errorf("LatencyMs = %d; want 25 (clock step)", r.LatencyMs)
+		}
+		if r.GenTokens != 7 {
+			t.Errorf("GenTokens = %d; want 7", r.GenTokens)
+		}
+	}
+}
+
+func TestRunFIMLatency_WarmupIssuesOneDiscardedCallPerModel(t *testing.T) {
+	clock := time.Unix(0, 0)
+	gen := &fakeFIMGenerator{clock: &clock, step: time.Millisecond}
+	cases := []FIMCase{{ID: "c1", Prefix: "a", Suffix: "b"}}
+	results := runFIMLatency(context.Background(), fimRunOptions{
+		Generator: gen, Models: []string{"m"}, Cases: cases, NumPredict: 64,
+		Warmup: true, Now: func() time.Time { return clock },
+	})
+	// 1 warm-up + 1 timed case = 2 generator calls, but only 1 result row.
+	if len(gen.calls) != 2 {
+		t.Errorf("generator calls = %d; want 2 (1 warm-up + 1 case)", len(gen.calls))
+	}
+	if len(results) != 1 {
+		t.Errorf("results = %d; want 1 (warm-up is discarded)", len(results))
+	}
+}
+
+func TestRunFIMLatency_ForwardsNumPredictAndDefaults(t *testing.T) {
+	clock := time.Unix(0, 0)
+	cases := []FIMCase{{ID: "c1", Prefix: "a", Suffix: "b"}}
+
+	explicit := &fakeFIMGenerator{clock: &clock, step: time.Millisecond}
+	runFIMLatency(context.Background(), fimRunOptions{
+		Generator: explicit, Models: []string{"m"}, Cases: cases,
+		NumPredict: 32, Warmup: false, Now: func() time.Time { return clock },
+	})
+	if len(explicit.calls) != 1 || !strings.HasSuffix(explicit.calls[0], "|32") {
+		t.Fatalf("explicit numPredict not forwarded; calls=%v", explicit.calls)
+	}
+
+	defaulted := &fakeFIMGenerator{clock: &clock, step: time.Millisecond}
+	runFIMLatency(context.Background(), fimRunOptions{
+		Generator: defaulted, Models: []string{"m"}, Cases: cases,
+		NumPredict: 0, Warmup: false, Now: func() time.Time { return clock },
+	})
+	if len(defaulted.calls) != 1 || !strings.HasSuffix(defaulted.calls[0], "|64") {
+		t.Fatalf("numPredict<=0 should default to 64; calls=%v", defaulted.calls)
+	}
+}
+
+func TestRunFIMLatency_PerCaseErrorRecordedAndRunContinues(t *testing.T) {
+	clock := time.Unix(0, 0)
+	gen := &fakeFIMGenerator{clock: &clock, step: time.Millisecond, failModel: "m"}
+	results := runFIMLatency(context.Background(), fimRunOptions{
+		Generator: gen, Models: []string{"m"}, Cases: []FIMCase{{ID: "c1", Prefix: "a", Suffix: "b"}},
+		NumPredict: 64, Warmup: false, Now: func() time.Time { return clock },
+	})
+	if len(results) != 1 || results[0].Err == nil {
+		t.Fatalf("expected one errored result row; got %+v", results)
+	}
+}
+
+func TestFormatFIMReport_ShowsLatencySeparateFromChat(t *testing.T) {
+	results := []FIMResult{
+		{Model: "m", CaseID: "c1", LatencyMs: 20, GenTokens: 5},
+		{Model: "m", CaseID: "c2", LatencyMs: 40, GenTokens: 7},
+	}
+	out := formatFIMReport([]string{"m"}, results)
+	for _, want := range []string{
+		"FIM",
+		"separate from chat",
+		"| m | 20 / 40 / 30 | 6 | 2 | 0/2 |",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("FIM report missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestFormatFIMReport_CountsFailuresAndExcludesFromLatency(t *testing.T) {
+	results := []FIMResult{
+		{Model: "m", CaseID: "c1", LatencyMs: 30, GenTokens: 4},
+		{Model: "m", CaseID: "c2", Err: errors.New("boom")},
+	}
+	out := formatFIMReport([]string{"m"}, results)
+	// One success (latency 30), one failure → latency reflects only the success.
+	if !strings.Contains(out, "| m | 30 / 30 / 30 | 4 | 1 | 1/2 |") {
+		t.Errorf("FIM report should exclude failures from latency and count them:\n%s", out)
+	}
+}

--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -43,6 +43,10 @@ func main() {
 	calibrate := flag.Bool("calibrate", false, "Phase 2: re-score frozen labeled artifacts with the judge model")
 	manualReport := flag.Bool("manual-report", false, "Score frozen labeled artifacts with human labels (manual scorer) and emit a quality baseline report (uses -labels, -artifacts, -report)")
 	pairedReport := flag.Bool("paired-report", false, "Emit the paired-label report: paired-complete means, completeness worklist, win/loss/tie matrix, bootstrap delta CIs, resolution diagnostic (uses -labels, -artifacts, -baseline, -report)")
+	fimLatency := flag.Bool("fim-latency", false, "Measure FIM / inline-completion latency separately from chat latency (uses -fim-cases, -models, -fim-num-predict, -fim-warmup, -report)")
+	fimCases := flag.String("fim-cases", "", "Glob for FIM case JSON files (prefix/suffix), required with -fim-latency")
+	fimNumPredict := flag.Int("fim-num-predict", defaultFIMNumPredict, "Max tokens to generate per FIM completion (interactive regime is short)")
+	fimWarmup := flag.Bool("fim-warmup", true, "Issue one discarded generate per model before timing so FIM latency reflects the warm regime")
 	baseline := flag.String("baseline", "", "Baseline model selector for -paired-report deltas (default: first lineup model, derived from artifacts)")
 	labelsPath := flag.String("labels", filepath.Join("docs", "llm", "calibration", "labels.jsonl"), "Path to labels.jsonl (Phase 2)")
 	labelsOut := flag.String("labels-out", filepath.Join("docs", "llm", "calibration", "artifacts.jsonl"), "Output path for -calibrate-capture artifacts.jsonl")
@@ -86,8 +90,11 @@ func main() {
 	if *pairedReport {
 		modes++
 	}
+	if *fimLatency {
+		modes++
+	}
 	if modes > 1 {
-		log.Fatalf("llm-bench: -capture, -calibrate-capture, -calibrate, -manual-report, -paired-report are mutually exclusive")
+		log.Fatalf("llm-bench: -capture, -calibrate-capture, -calibrate, -manual-report, -paired-report, -fim-latency are mutually exclusive")
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -255,6 +262,52 @@ func main() {
 			log.Fatalf("llm-bench: write report: %v", err)
 		}
 		fmt.Fprintf(os.Stderr, "llm-bench: paired-label report written to %s\n", *reportPath)
+		return
+	}
+
+	if *fimLatency {
+		if *fimCases == "" || *modelsArg == "" {
+			log.Fatalf("llm-bench: -fim-latency requires -fim-cases and -models")
+		}
+		casePaths, err := filepath.Glob(*fimCases)
+		if err != nil {
+			log.Fatalf("llm-bench: glob %q: %v", *fimCases, err)
+		}
+		if len(casePaths) == 0 {
+			log.Fatalf("llm-bench: no FIM cases matched %q", *fimCases)
+		}
+		cases, err := loadFIMCases(casePaths)
+		if err != nil {
+			log.Fatalf("llm-bench: load FIM cases: %v", err)
+		}
+		targets, err := parseModelTargets(*modelsArg)
+		if err != nil {
+			log.Fatalf("llm-bench: parse models: %v", err)
+		}
+		client, err := newOllamaClient(*ollamaURL)
+		if err != nil {
+			log.Fatalf("llm-bench: client: %v", err)
+		}
+		models := make([]string, 0, len(targets))
+		for _, target := range targets {
+			models = append(models, target.Display)
+		}
+		results := runFIMLatency(ctx, fimRunOptions{
+			Generator:  ollamaFIMGenerator{client: client},
+			Models:     models,
+			Cases:      cases,
+			NumPredict: *fimNumPredict,
+			Warmup:     *fimWarmup,
+		})
+		report := formatFIMReport(models, results)
+		if *reportPath == "" {
+			fmt.Print(report)
+			return
+		}
+		if err := os.WriteFile(*reportPath, []byte(report), 0o600); err != nil {
+			log.Fatalf("llm-bench: write report: %v", err)
+		}
+		fmt.Fprintf(os.Stderr, "llm-bench: FIM latency report written to %s\n", *reportPath)
 		return
 	}
 

--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/kstruzzieri/go-llm/config"
+	"github.com/kstruzzieri/go-llm/ollama"
 )
 
 func main() {
@@ -284,7 +285,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("llm-bench: parse models: %v", err)
 		}
-		client, err := newOllamaClient(*ollamaURL)
+		client, err := newOllamaClient(*ollamaURL, ollama.WithTimeout(*timeout))
 		if err != nil {
 			log.Fatalf("llm-bench: client: %v", err)
 		}

--- a/cmd/llm-bench/main_test.go
+++ b/cmd/llm-bench/main_test.go
@@ -208,6 +208,50 @@ func TestMainEmitsToolUseSubsetSection(t *testing.T) {
 	}
 }
 
+func TestMainFIMLatencyEndToEnd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/generate" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"model":      "fake",
+			"response":   "  return a + b",
+			"done":       true,
+			"eval_count": 5,
+		})
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	casePath := filepath.Join(dir, "c1.json")
+	if err := os.WriteFile(casePath, []byte(`{"id":"c1","prefix":"func add(a,b int) int {\n","suffix":"\n}"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	report := filepath.Join(dir, "fim.md")
+	cmd := exec.Command(os.Args[0],
+		"-fim-latency",
+		"-fim-cases", casePath,
+		"-models", "fake",
+		"-ollama-url", server.URL,
+		"-report", report,
+	)
+	cmd.Env = append(os.Environ(), "LLM_BENCH_TEST_MAIN=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("llm-bench -fim-latency failed: %v\n%s", err, out)
+	}
+	body, err := os.ReadFile(report)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	for _, want := range []string{"FIM / inline-completion latency", "separate from chat", "## FIM latency by model"} {
+		if !strings.Contains(string(body), want) {
+			t.Fatalf("FIM report missing %q:\n%s", want, body)
+		}
+	}
+}
+
 func TestResolveToolSchemaSourceStdio(t *testing.T) {
 	src, err := resolveToolSchemaSource("echo mock-server", "")
 	if err != nil {

--- a/cmd/llm-bench/main_test.go
+++ b/cmd/llm-bench/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestMain(m *testing.M) {
@@ -249,6 +251,56 @@ func TestMainFIMLatencyEndToEnd(t *testing.T) {
 		if !strings.Contains(string(body), want) {
 			t.Fatalf("FIM report missing %q:\n%s", want, body)
 		}
+	}
+}
+
+func TestMainFIMLatencyUsesTimeoutFlag(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/generate" {
+			http.NotFound(w, r)
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"model":      "fake",
+			"response":   "late",
+			"done":       true,
+			"eval_count": 1,
+		})
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	casePath := filepath.Join(dir, "c1.json")
+	if err := os.WriteFile(casePath, []byte(`{"id":"c1","prefix":"func add(a,b int) int {\n","suffix":"\n}"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	report := filepath.Join(dir, "fim.md")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0],
+		"-fim-latency",
+		"-fim-cases", casePath,
+		"-models", "fake",
+		"-ollama-url", server.URL,
+		"-timeout", "20ms",
+		"-fim-warmup=false",
+		"-report", report,
+	)
+	cmd.Env = append(os.Environ(), "LLM_BENCH_TEST_MAIN=1")
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("llm-bench -fim-latency ignored -timeout and was killed by test deadline: %v\n%s", ctx.Err(), out)
+	}
+	if err != nil {
+		t.Fatalf("llm-bench -fim-latency failed: %v\n%s", err, out)
+	}
+	body, err := os.ReadFile(report)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	if !strings.Contains(string(body), "| fake | n/a | n/a | 0 | 1/1 |") {
+		t.Fatalf("FIM report should record the timed-out generation as a failure:\n%s", body)
 	}
 }
 


### PR DESCRIPTION
Closes #141. Stacked on #148 (#142 token isolation) → retarget base to `develop` as the stack lands.

## Why
Chat/analysis latency (seconds, thinking on) is a different regime from inline-completion (FIM) latency (sub-second target). The harness only measured chat-style replay latency, which says nothing about completion responsiveness.

**llama.cpp note:** the transport is behind a `fimGenerator` seam so the planned OpenAI-compat candidate transport (GH #136) can add a llama-server FIM impl (`/v1/completions` with `suffix`, or `/infill`) with **zero changes** to the runner/report layer. No Ollama types cross the seam.

## What
- **`fim.go`** — `FIMCase{ID,Prefix,Suffix}` + `loadFIMCases`; `fimGenerator` interface (`GenerateFIM`) with `ollamaFIMGenerator` (uses `/api/generate`, strips the bench prefix to the native model name). `runFIMLatency` warms each model with one discarded call (default on, so latency reflects the warm interactive regime), then times each case; per-case errors are recorded as rows and excluded from the latency aggregate (never aborts). `formatFIMReport` shows p50/p90/mean latency + gen-token mean + failures, captioned as a **separate regime from chat latency** (don't compare the numbers).
- **`main.go`** — `-fim-latency` mode + `-fim-cases` / `-fim-num-predict` (default 64) / `-fim-warmup` (default true), mutually exclusive with the other modes.

## Acceptance (#141)
- ✅ FIM latency measurable and reported separately from chat-replay latency.

## Testing
TDD throughout with a deterministic clock (injected `Now` + a fake generator that advances it): per-case timing, warm-up issues one discarded call, per-case errors recorded, `num_predict` forwarded + `<=0` defaults, latency excludes failures with no NaN, and a live-run E2E against a mock `/api/generate`. Adversarial review (two test-only findings) resolved. Full module build/test green incl. `-race`; `gofmt` + `go vet` clean.

Generated with [Claude Code](https://claude.com/claude-code)