### PR TITLE
[codex] Honor corpus model-evidence gaps

### DIFF
--- a/cmd/llm-bench/corpus.go
+++ b/cmd/llm-bench/corpus.go
@@ -233,6 +233,10 @@ func buildCorpusRun(m Manifest, sel corpusSelection, loaded []Trace) (run []Trac
 	for _, tr := range loaded {
 		loadedByID[tr.ID] = tr
 	}
+	manifestByID := make(map[string]ManifestEntry, len(m.Entries))
+	for _, e := range m.Entries {
+		manifestByID[e.TraceID] = e
+	}
 	keep := make(map[string]struct{})
 	for _, id := range m.Select(sel) {
 		if tr, ok := loadedByID[id]; ok {
@@ -242,24 +246,50 @@ func buildCorpusRun(m Manifest, sel corpusSelection, loaded []Trace) (run []Trac
 			missing = append(missing, id)
 		}
 	}
+	var unclassifiedLoaded []string
+	for _, tr := range loaded {
+		if _, ok := manifestByID[tr.ID]; !ok {
+			unclassifiedLoaded = append(unclassifiedLoaded, tr.ID)
+		}
+	}
 	sub := m.entriesFor(keep)
 	data = &corpusReportData{
-		Counts:           sub.Counts(),
-		TraceToPartition: sub.partitionByTrace(),
+		Counts:               sub.Counts(),
+		TraceToPartition:     sub.partitionByTrace(),
+		TraceToModelEvidence: sub.modelEvidenceByTrace(),
+		MissingSelected:      append([]string(nil), missing...),
+		UnclassifiedLoaded:   unclassifiedLoaded,
 	}
 	return run, data, missing
 }
 
-// excludeJudgeValidation returns results whose trace is NOT in the
-// judge-validation partition, plus the count excluded. Judge-validation traces
-// are scorer-calibration evidence and must never enter model-quality
-// aggregates, so the combined summary table filters them out.
-func excludeJudgeValidation(results []Result, traceToPartition map[string]CorpusPartition) ([]Result, int) {
+type corpusResultExclusions struct {
+	JudgeValidation  int
+	NonModelEvidence int
+	Unclassified     int
+}
+
+// modelEvidenceResults returns only results that may enter model-quality
+// aggregates. Corpus reports exclude judge-validation, loaded-without-manifest,
+// and manifest rows explicitly marked not allowed as model evidence.
+func modelEvidenceResults(results []Result, data *corpusReportData) ([]Result, corpusResultExclusions) {
+	if data == nil {
+		return results, corpusResultExclusions{}
+	}
 	var kept []Result
-	excluded := 0
+	var excluded corpusResultExclusions
 	for _, r := range results {
-		if traceToPartition[r.TraceID] == PartitionJudgeValidation {
-			excluded++
+		p, ok := data.TraceToPartition[r.TraceID]
+		if !ok {
+			excluded.Unclassified++
+			continue
+		}
+		if p == PartitionJudgeValidation {
+			excluded.JudgeValidation++
+			continue
+		}
+		if !data.allowsModelEvidence(r.TraceID) {
+			excluded.NonModelEvidence++
 			continue
 		}
 		kept = append(kept, r)
@@ -272,6 +302,16 @@ func (m Manifest) partitionByTrace() map[string]CorpusPartition {
 	out := make(map[string]CorpusPartition, len(m.Entries))
 	for _, e := range m.Entries {
 		out[e.TraceID] = e.Partition
+	}
+	return out
+}
+
+// modelEvidenceByTrace maps each trace ID to whether it may contribute to
+// accepted-run model-quality evidence.
+func (m Manifest) modelEvidenceByTrace() map[string]bool {
+	out := make(map[string]bool, len(m.Entries))
+	for _, e := range m.Entries {
+		out[e.TraceID] = e.AllowedAsModelEvidence
 	}
 	return out
 }

--- a/cmd/llm-bench/corpus_test.go
+++ b/cmd/llm-bench/corpus_test.go
@@ -147,7 +147,10 @@ func TestFormatPartitionedQuality_SeparatesNaturalAndChallenge(t *testing.T) {
 	traceToPartition := map[string]CorpusPartition{
 		"t1": PartitionNatural, "t2": PartitionChallenge, "t3": PartitionJudgeValidation,
 	}
-	out := formatPartitionedQuality([]string{"ollama/a"}, results, traceToPartition)
+	out := formatPartitionedQuality([]string{"ollama/a"}, results, &corpusReportData{
+		TraceToPartition:     traceToPartition,
+		TraceToModelEvidence: map[string]bool{"t1": true, "t2": true, "t3": false},
+	})
 	for _, want := range []string{
 		"## Quality by model — by partition",
 		"never averaged",
@@ -294,6 +297,72 @@ func TestFormatReport_ExcludesJudgeValidationFromCombinedAggregate(t *testing.T)
 	}
 	if !strings.Contains(out, "judge-validation result(s) excluded") {
 		t.Errorf("report should note the judge-validation exclusion:\n%s", out)
+	}
+}
+
+func TestFormatReport_ExcludesNonEvidenceNaturalChallengeFromModelQuality(t *testing.T) {
+	results := []Result{
+		{Model: "m", TraceID: "t1", Score: Score{AnswerQuality: 1.0}}, // natural evidence
+		{Model: "m", TraceID: "t2", Score: Score{AnswerQuality: 0.0}}, // natural, but not model evidence
+	}
+	out := formatReport([]string{"m"}, results, reportOptions{
+		Scorer: "manual",
+		Corpus: &corpusReportData{
+			Counts: corpusCounts{
+				ByPartition: map[CorpusPartition]int{PartitionNatural: 2},
+				ByCategory:  map[string]int{"chat": 2},
+				Total:       2,
+			},
+			TraceToPartition:     map[string]CorpusPartition{"t1": PartitionNatural, "t2": PartitionNatural},
+			TraceToModelEvidence: map[string]bool{"t1": true, "t2": false},
+		},
+	})
+	resultsSection := sectionBetween(out, "## Results", "## Quality by model")
+	if !strings.Contains(resultsSection, "| m | 1.00 / 1.00 / 1.00 / 1.00 / 1.00 |") {
+		t.Errorf("combined aggregate should include only allowed model evidence:\n%s", resultsSection)
+	}
+	if strings.Contains(resultsSection, "| m | 0.50") {
+		t.Errorf("non-evidence natural/challenge row leaked into model quality:\n%s", resultsSection)
+	}
+	if !strings.Contains(out, "non-model-evidence result(s) excluded") {
+		t.Errorf("report should note non-model-evidence exclusions:\n%s", out)
+	}
+	natural := sectionBetween(out, "### natural", "### challenge")
+	if !strings.Contains(natural, "| m | 1.00 / 1.00 / 1.00 / 1.00 / 1.00 | 1 |") {
+		t.Errorf("natural partition quality should include only t1 evidence row:\n%s", natural)
+	}
+}
+
+func TestBuildCorpusRun_ReportDataSurfacesMissingAndUnclassified(t *testing.T) {
+	m := sampleCorpusManifest()                           // t1 natural, t2 challenge, t3 judge-validation
+	loaded := []Trace{{ID: "t1"}, {ID: "t2"}, {ID: "t4"}} // t3 missing; t4 not in manifest
+	run, data, missing := buildCorpusRun(m, corpusSelection{}, loaded)
+
+	if len(run) != 2 {
+		t.Fatalf("run length = %d; want 2 selected loaded traces", len(run))
+	}
+	if !reflect.DeepEqual(missing, []string{"t3"}) {
+		t.Fatalf("missing = %v; want [t3]", missing)
+	}
+	if !reflect.DeepEqual(data.MissingSelected, []string{"t3"}) {
+		t.Fatalf("data.MissingSelected = %v; want [t3]", data.MissingSelected)
+	}
+	if !reflect.DeepEqual(data.UnclassifiedLoaded, []string{"t4"}) {
+		t.Fatalf("data.UnclassifiedLoaded = %v; want [t4]", data.UnclassifiedLoaded)
+	}
+
+	out := formatReport([]string{"m"}, []Result{
+		{Model: "m", TraceID: "t1", Score: Score{AnswerQuality: 1.0}},
+		{Model: "m", TraceID: "t2", Score: Score{AnswerQuality: 0.0}},
+	}, reportOptions{Scorer: "manual", Corpus: data})
+	for _, want := range []string{
+		"## Corpus selection gaps",
+		"| selected-but-missing | t3 |",
+		"| loaded-without-manifest | t4 |",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report missing %q:\n%s", want, out)
+		}
 	}
 }
 

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -11,16 +11,15 @@ import (
 // formatReport renders per-model aggregates as a Markdown table.
 func formatReport(models []string, results []Result, opts reportOptions) string {
 	// Per-trace detail shows every result; the combined summary aggregate,
-	// when a corpus is present, excludes judge-validation (scorer-calibration
-	// evidence — never model workload, even in the diagnostic combined view).
+	// when a corpus is present, includes only rows allowed as model evidence.
 	byModel := make(map[string][]Result, len(models))
 	for _, r := range results {
 		byModel[r.Model] = append(byModel[r.Model], r)
 	}
 	summaryResults := results
-	excludedJudgeValidation := 0
+	var corpusExclusions corpusResultExclusions
 	if opts.Corpus != nil {
-		summaryResults, excludedJudgeValidation = excludeJudgeValidation(results, opts.Corpus.TraceToPartition)
+		summaryResults, corpusExclusions = modelEvidenceResults(results, opts.Corpus)
 	}
 	summaryByModel := make(map[string][]Result, len(models))
 	for _, r := range summaryResults {
@@ -61,13 +60,20 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 
 	if opts.Corpus != nil {
 		b.WriteString(formatCorpusComposition(opts.Corpus.Counts))
+		b.WriteString(formatCorpusSelectionGaps(opts.Corpus))
 	}
 
 	fmt.Fprintf(&b, "## Results\n\n")
 	if opts.Corpus != nil {
 		fmt.Fprintln(&b, "> Combined across model-evidence partitions (natural + challenge) — diagnostic only; partitions are not comparable, do not cite this as a single number. See the per-partition section below.")
-		if excludedJudgeValidation > 0 {
-			fmt.Fprintf(&b, ">\n> %d judge-validation result(s) excluded from this aggregate (scorer-calibration evidence, not model workload).\n", excludedJudgeValidation)
+		if corpusExclusions.JudgeValidation > 0 {
+			fmt.Fprintf(&b, ">\n> %d judge-validation result(s) excluded from this aggregate (scorer-calibration evidence, not model workload).\n", corpusExclusions.JudgeValidation)
+		}
+		if corpusExclusions.NonModelEvidence > 0 {
+			fmt.Fprintf(&b, ">\n> %d non-model-evidence result(s) excluded from this aggregate.\n", corpusExclusions.NonModelEvidence)
+		}
+		if corpusExclusions.Unclassified > 0 {
+			fmt.Fprintf(&b, ">\n> %d unclassified result(s) excluded from this aggregate (no corpus manifest entry).\n", corpusExclusions.Unclassified)
 		}
 		fmt.Fprintln(&b)
 	}
@@ -105,7 +111,7 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 
 	if opts.Corpus != nil {
 		fmt.Fprintln(&b)
-		b.WriteString(formatPartitionedQuality(models, results, opts.Corpus.TraceToPartition))
+		b.WriteString(formatPartitionedQuality(models, results, opts.Corpus))
 	}
 
 	if opts.ToolCallExpected != nil {
@@ -368,10 +374,20 @@ type reportOptions struct {
 }
 
 // corpusReportData carries the manifest-derived view the report needs:
-// composition counts and a trace→partition map for separation.
+// composition counts, model-evidence eligibility, and corpus selection gaps.
 type corpusReportData struct {
-	Counts           corpusCounts
-	TraceToPartition map[string]CorpusPartition
+	Counts               corpusCounts
+	TraceToPartition     map[string]CorpusPartition
+	TraceToModelEvidence map[string]bool
+	MissingSelected      []string
+	UnclassifiedLoaded   []string
+}
+
+func (d *corpusReportData) allowsModelEvidence(traceID string) bool {
+	if d == nil || d.TraceToModelEvidence == nil {
+		return true
+	}
+	return d.TraceToModelEvidence[traceID]
 }
 
 // formatCorpusComposition renders the manifest's partition and category counts.
@@ -395,17 +411,44 @@ func formatCorpusComposition(c corpusCounts) string {
 	return b.String()
 }
 
+func formatCorpusSelectionGaps(data *corpusReportData) string {
+	if data == nil || (len(data.MissingSelected) == 0 && len(data.UnclassifiedLoaded) == 0) {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintln(&b, "## Corpus selection gaps")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "| Gap | Trace |")
+	fmt.Fprintln(&b, "|---|---|")
+	for _, id := range data.MissingSelected {
+		fmt.Fprintf(&b, "| selected-but-missing | %s |\n", markdownCell(id))
+	}
+	for _, id := range data.UnclassifiedLoaded {
+		fmt.Fprintf(&b, "| loaded-without-manifest | %s |\n", markdownCell(id))
+	}
+	fmt.Fprintln(&b)
+	return b.String()
+}
+
 // formatPartitionedQuality renders per-model quality separately for the natural
 // and challenge partitions. The two are never averaged into one number, and
 // judge-validation traces (scorer-calibration evidence) are excluded from model
 // quality entirely.
-func formatPartitionedQuality(models []string, results []Result, traceToPartition map[string]CorpusPartition) string {
+func formatPartitionedQuality(models []string, results []Result, data *corpusReportData) string {
 	byPartition := make(map[CorpusPartition][]Result)
 	unclassified := 0
+	nonModelEvidence := 0
 	for _, r := range results {
-		p, ok := traceToPartition[r.TraceID]
+		p, ok := data.TraceToPartition[r.TraceID]
 		if !ok {
 			unclassified++
+			continue
+		}
+		if p == PartitionJudgeValidation {
+			continue
+		}
+		if !data.allowsModelEvidence(r.TraceID) {
+			nonModelEvidence++
 			continue
 		}
 		byPartition[p] = append(byPartition[p], r)
@@ -413,7 +456,7 @@ func formatPartitionedQuality(models []string, results []Result, traceToPartitio
 	var b strings.Builder
 	fmt.Fprintln(&b, "## Quality by model — by partition")
 	fmt.Fprintln(&b)
-	fmt.Fprintln(&b, "> Natural and challenge corpora answer different questions and are never averaged into one number. Judge-validation traces are scorer-calibration evidence and are excluded from model quality.")
+	fmt.Fprintln(&b, "> Natural and challenge corpora answer different questions and are never averaged into one number. Judge-validation and non-model-evidence traces are excluded from model quality.")
 	fmt.Fprintln(&b)
 	for _, p := range []CorpusPartition{PartitionNatural, PartitionChallenge} {
 		fmt.Fprintf(&b, "### %s\n\n", p)
@@ -427,6 +470,9 @@ func formatPartitionedQuality(models []string, results []Result, traceToPartitio
 	}
 	if unclassified > 0 {
 		fmt.Fprintf(&b, "_%d result(s) had no manifest partition and were omitted from the partitioned view._\n\n", unclassified)
+	}
+	if nonModelEvidence > 0 {
+		fmt.Fprintf(&b, "_%d non-model-evidence result(s) omitted from partitioned model quality._\n\n", nonModelEvidence)
 	}
 	return b.String()
 }


### PR DESCRIPTION
## What
- Excludes natural/challenge rows marked `allowed_as_model_evidence=false` from model-quality aggregates.
- Surfaces selected-but-missing and loaded-without-manifest corpus gaps in reports.
- Applies the model-evidence-filtered result set to the tool-use subset section.

## Why
The corpus manifest plan treats `allowed_as_model_evidence` and unclassified/missing corpus gaps as load-bearing reporting controls. This follow-up closes those edge cases so accepted-run evidence cannot be inflated by non-evidence rows and corpus selection gaps are visible.

## Validation
- `go test ./cmd/llm-bench -count=1`
- `go vet ./...`
- `git diff --check`
- `go test ./...`