### PR TITLE
chore(ci-local): run checks from the module root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ docs/spikes/
 docs/superpowers/
 docs/llm/traces/
 .DS_Store
+/.worktrees/
 
 # llm-bench harness — local artifacts
 /llm-bench

--- a/scripts/ci-local
+++ b/scripts/ci-local
@@ -61,6 +61,14 @@ case "$mode" in
     ;;
 esac
 
+# Run from the module root so `golangci-lint run` and `go test ./...` resolve
+# packages regardless of the caller's working directory. golangci-lint lints
+# the module subtree rooted at the CWD; invoked from a Go-free directory (for
+# example scripts/), it aborts with "no go files to analyze". Resolving the
+# root via git keeps the checks correct from any invocation path.
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
 require_cmd golangci-lint
 require_cmd go
 

--- a/scripts/ci-local
+++ b/scripts/ci-local
@@ -62,11 +62,12 @@ case "$mode" in
 esac
 
 # Run from the module root so `golangci-lint run` and `go test ./...` resolve
-# packages regardless of the caller's working directory. golangci-lint lints
-# the module subtree rooted at the CWD; invoked from a Go-free directory (for
-# example scripts/), it aborts with "no go files to analyze". Resolving the
-# root via git keeps the checks correct from any invocation path.
-repo_root="$(git rev-parse --show-toplevel)"
+# packages regardless of the caller's working directory. Resolve the root from
+# this script's location, not the caller's CWD, so absolute-path invocations
+# from outside the repo cannot select the wrong enclosing git checkout.
+require_cmd git
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(git -C "$script_dir" rev-parse --show-toplevel)"
 cd "$repo_root"
 
 require_cmd golangci-lint


### PR DESCRIPTION
## Problem
`golangci-lint run` lints the Go package subtree rooted at the **current working directory**. The repo root has no `.go` files directly (everything lives in `ollama/`, `provider/`, …), and `scripts/ci-local` invokes `golangci-lint run` with no path argument and no `cd`. From the repo root that recurses correctly (`0 issues`), but invoked from a Go-free directory — e.g. `cd scripts && ./ci-local` — the resolved package set is empty and golangci-lint aborts:

```
Running error: context loading failed: no go files to analyze: running `go mod tidy` may solve the problem
```

The error is a package-loading artifact, not a real lint/build failure — the module is healthy.

## Fix
`cd` to the git top-level after argument parsing, so both `golangci-lint run` and `go test ./...` resolve packages from any invocation path. `--help` still works from anywhere because the `cd` runs after arg parsing.

## Verification
`cd scripts && bash ./ci-local --mode pre-push` (the previously-failing scenario):

```
==> lint
0 issues.
==> race tests
ok  github.com/kstruzzieri/go-llm/...   (all packages)
EXIT=0
```

Generated with [Claude Code](https://claude.com/claude-code)