### PR TITLE
feat(llm-bench): openai-compat candidate transport (#136)

### DIFF
--- a/cmd/llm-bench/candidate_transport.go
+++ b/cmd/llm-bench/candidate_transport.go
@@ -58,10 +58,16 @@ func newCandidateTransport(target ModelTarget, opts candidateTransportOptions) (
 			clientOpts = append(clientOpts, openaicompat.WithAPIKey(key))
 		}
 		providerName := openAICompatCandidateProviderName(baseURL)
+		// Leave ThinkMode at its default (extract). A reasoning model served via
+		// llama.cpp can emit <think>...</think> inline in content; extraction
+		// strips it so the scored transcript holds the final answer rather than
+		// serving-stack-specific reasoning formatting. This matches the Ollama
+		// candidate path, where the server separates reasoning into a field the
+		// raw client drops. Reasoning text is discarded either way; isolating
+		// reasoning *tokens* is tracked separately (#158).
 		prov := openaicompat.NewProvider(
 			openaicompat.NewClient(baseURL, clientOpts...),
 			openaicompat.WithProviderName(providerName),
-			openaicompat.WithThinkMode(provider.ThinkNone),
 		)
 		return candidateTransport{chat: openAICompatCandidateClient{provider: prov}, providerName: prov.Name()}, nil
 	default:

--- a/cmd/llm-bench/candidate_transport.go
+++ b/cmd/llm-bench/candidate_transport.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+	"github.com/kstruzzieri/go-llm/provider"
+	"github.com/kstruzzieri/go-llm/provider/openaicompat"
+)
+
+type candidateTransportOptions struct {
+	ollamaURL           string
+	openAICompatBaseURL string
+	openAICompatAPIKey  string
+	timeout             time.Duration
+}
+
+type candidateTransport struct {
+	chat         candidateChatClient
+	providerName string
+}
+
+type candidateChatClient interface {
+	Chat(ctx context.Context, req ollama.ChatRequest) (candidateChatResponse, error)
+}
+
+type candidateChatResponse struct {
+	Message                ollama.ChatMessage
+	PromptEvalCount        int
+	EvalCount              int
+	ThinkingTokens         int
+	ThinkingTokensComputed bool
+}
+
+func newCandidateTransport(target ModelTarget, opts candidateTransportOptions) (candidateTransport, error) {
+	switch normalizeModelSelector(target.Provider) {
+	case defaultBenchProvider:
+		client, err := newOllamaClient(opts.ollamaURL)
+		if err != nil {
+			return candidateTransport{}, fmt.Errorf("candidate %q client: %w", target.Display, err)
+		}
+		return candidateTransport{chat: ollamaCandidateClient{client: client}, providerName: defaultBenchProvider}, nil
+	case openAICompatTransport:
+		baseURL := strings.TrimSpace(opts.openAICompatBaseURL)
+		if baseURL == "" {
+			return candidateTransport{}, fmt.Errorf("candidate %s transport requires -candidate-base-url", openAICompatTransport)
+		}
+		clientOpts := []openaicompat.ClientOption{}
+		if opts.timeout > 0 {
+			clientOpts = append(clientOpts, openaicompat.WithHTTPClient(&http.Client{Timeout: opts.timeout}))
+		}
+		if key := strings.TrimSpace(opts.openAICompatAPIKey); key != "" {
+			clientOpts = append(clientOpts, openaicompat.WithAPIKey(key))
+		}
+		providerName := openAICompatCandidateProviderName(baseURL)
+		prov := openaicompat.NewProvider(
+			openaicompat.NewClient(baseURL, clientOpts...),
+			openaicompat.WithProviderName(providerName),
+			openaicompat.WithThinkMode(provider.ThinkNone),
+		)
+		return candidateTransport{chat: openAICompatCandidateClient{provider: prov}, providerName: prov.Name()}, nil
+	default:
+		return candidateTransport{}, fmt.Errorf("%w: %q", errUnsupportedProv, target.Provider)
+	}
+}
+
+type ollamaCandidateClient struct {
+	client *ollama.Client
+}
+
+func (c ollamaCandidateClient) Chat(ctx context.Context, req ollama.ChatRequest) (candidateChatResponse, error) {
+	resp, err := c.client.Chat(ctx, req)
+	if err != nil {
+		return candidateChatResponse{}, err
+	}
+	if resp == nil {
+		return candidateChatResponse{}, fmt.Errorf("ollama candidate: nil response")
+	}
+	return candidateChatResponse{
+		Message:         resp.Message,
+		PromptEvalCount: resp.PromptEvalCount,
+		EvalCount:       resp.EvalCount,
+	}, nil
+}
+
+type openAICompatCandidateClient struct {
+	provider *openaicompat.Provider
+}
+
+func (c openAICompatCandidateClient) Chat(ctx context.Context, req ollama.ChatRequest) (candidateChatResponse, error) {
+	presp, err := c.provider.Chat(ctx, provider.ChatRequest{
+		Model:    req.Model,
+		Messages: toProviderCandidateMessages(req.Messages),
+		Tools:    toProviderCandidateTools(req.Tools),
+		Options:  toProviderCandidateOptions(req.Options),
+	})
+	if err != nil {
+		return candidateChatResponse{}, err
+	}
+	if presp == nil {
+		return candidateChatResponse{}, fmt.Errorf("openai-compat candidate: nil response")
+	}
+	toolCalls, err := toOllamaCandidateToolCalls(presp.ToolCalls)
+	if err != nil {
+		return candidateChatResponse{}, err
+	}
+	return candidateChatResponse{
+		Message: ollama.ChatMessage{
+			Role:      "assistant",
+			Content:   presp.Content,
+			ToolCalls: toolCalls,
+		},
+		PromptEvalCount: presp.Usage.PromptTokens,
+		EvalCount:       presp.Usage.CompletionTokens,
+	}, nil
+}
+
+func toProviderCandidateMessages(in []ollama.ChatMessage) []provider.ChatMessage {
+	out := make([]provider.ChatMessage, len(in))
+	for i, m := range in {
+		out[i] = provider.ChatMessage{
+			Role:       m.Role,
+			Content:    m.Content,
+			ToolName:   m.ToolName,
+			ToolCallID: m.ToolCallID,
+			ToolCalls:  toProviderCandidateToolCalls(m.ToolCalls),
+		}
+	}
+	return out
+}
+
+func toProviderCandidateTools(in []ollama.Tool) []provider.Tool {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]provider.Tool, len(in))
+	for i, t := range in {
+		out[i] = provider.Tool{
+			Type: t.Type,
+			Function: provider.ToolFunction{
+				Name:        t.Function.Name,
+				Description: t.Function.Description,
+				Parameters:  t.Function.Parameters,
+			},
+		}
+	}
+	return out
+}
+
+func toProviderCandidateOptions(opts *ollama.ModelOptions) provider.ModelOptions {
+	if opts == nil {
+		return provider.ModelOptions{}
+	}
+	temp := opts.Temperature
+	topP := opts.TopP
+	repeatPenalty := opts.RepeatPenalty
+	out := provider.ModelOptions{
+		NumPredict: opts.NumPredict,
+		NumCtx:     opts.NumCtx,
+		Stop:       opts.Stop,
+	}
+	if opts.Temperature != 0 {
+		out.Temperature = &temp
+	}
+	if opts.TopP != 0 {
+		out.TopP = &topP
+	}
+	if opts.RepeatPenalty != 0 {
+		out.RepeatPenalty = &repeatPenalty
+	}
+	return out
+}
+
+func toProviderCandidateToolCalls(in []ollama.ToolCall) []provider.ToolCall {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]provider.ToolCall, len(in))
+	for i, tc := range in {
+		args, _ := json.Marshal(tc.Function.Arguments)
+		out[i] = provider.ToolCall{
+			ID:   tc.ID,
+			Type: firstNonEmpty(tc.Type, "function"),
+			Function: provider.ToolCallFunction{
+				Index:     tc.Function.Index,
+				Name:      tc.Function.Name,
+				Arguments: args,
+			},
+		}
+	}
+	return out
+}
+
+func toOllamaCandidateToolCalls(in []provider.ToolCall) ([]ollama.ToolCall, error) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+	out := make([]ollama.ToolCall, len(in))
+	for i, tc := range in {
+		args := map[string]any{}
+		if len(tc.Function.Arguments) > 0 {
+			if err := json.Unmarshal(tc.Function.Arguments, &args); err != nil {
+				return nil, fmt.Errorf("openai-compat candidate tool %q arguments: %w", tc.Function.Name, err)
+			}
+		}
+		out[i] = ollama.ToolCall{
+			ID:   tc.ID,
+			Type: firstNonEmpty(tc.Type, "function"),
+			Function: ollama.ToolCallFunction{
+				Index:     tc.Function.Index,
+				Name:      tc.Function.Name,
+				Arguments: args,
+			},
+		}
+	}
+	return out, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/cmd/llm-bench/candidate_transport_test.go
+++ b/cmd/llm-bench/candidate_transport_test.go
@@ -131,3 +131,41 @@ func TestOpenAICompatCandidateClient_ChatTranslatesReplayRequestAndResponse(t *t
 		t.Fatalf("ThinkingTokensComputed = true; want false until provider exposes dedicated reasoning token counts")
 	}
 }
+
+// A reasoning model served via llama.cpp can emit <think>...</think> inline in
+// content. The candidate transport must strip it so the scored transcript holds
+// the final answer, not serving-stack-specific reasoning formatting.
+func TestOpenAICompatCandidateClient_StripsInlineThinkTags(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-test",
+			"model":"served",
+			"choices":[{
+				"index":0,
+				"message":{"role":"assistant","content":"<think>secret chain of thought</think>final answer"},
+				"finish_reason":"stop"
+			}],
+			"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}
+		}`))
+	}))
+	defer srv.Close()
+
+	tr, err := newCandidateTransport(ModelTarget{Display: "openai-compat/fake", Provider: "openai-compat", Model: "fake"}, candidateTransportOptions{
+		openAICompatBaseURL: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("newCandidateTransport: %v", err)
+	}
+
+	resp, err := tr.chat.Chat(context.Background(), ollama.ChatRequest{
+		Model:    "fake",
+		Messages: []ollama.ChatMessage{{Role: "user", Content: "q"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Message.Content != "final answer" {
+		t.Fatalf("content = %q; want %q (inline <think> reasoning must be stripped)", resp.Message.Content, "final answer")
+	}
+}

--- a/cmd/llm-bench/candidate_transport_test.go
+++ b/cmd/llm-bench/candidate_transport_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/ollama"
+)
+
+func TestNewCandidateTransport_OllamaDefault(t *testing.T) {
+	tr, err := newCandidateTransport(ModelTarget{Display: "m", Provider: "ollama", Model: "m"}, candidateTransportOptions{
+		ollamaURL: "http://localhost:11434",
+	})
+	if err != nil {
+		t.Fatalf("newCandidateTransport: %v", err)
+	}
+	if tr.providerName != defaultBenchProvider {
+		t.Fatalf("providerName = %q; want %q", tr.providerName, defaultBenchProvider)
+	}
+	if _, ok := tr.chat.(ollamaCandidateClient); !ok {
+		t.Fatalf("chat = %T; want ollamaCandidateClient", tr.chat)
+	}
+}
+
+func TestNewCandidateTransport_OpenAICompatRequiresBaseURL(t *testing.T) {
+	_, err := newCandidateTransport(ModelTarget{Display: "openai-compat/m", Provider: "openai-compat", Model: "m"}, candidateTransportOptions{})
+	if err == nil || !strings.Contains(err.Error(), "-candidate-base-url") {
+		t.Fatalf("err = %v; want missing -candidate-base-url error", err)
+	}
+}
+
+func TestNewCandidateTransport_UnknownProviderRejected(t *testing.T) {
+	_, err := newCandidateTransport(ModelTarget{Display: "x/m", Provider: "x", Model: "m"}, candidateTransportOptions{})
+	if !errors.Is(err, errUnsupportedProv) {
+		t.Fatalf("err = %v; want errUnsupportedProv", err)
+	}
+}
+
+func TestOpenAICompatCandidateClient_ChatTranslatesReplayRequestAndResponse(t *testing.T) {
+	var gotBody map[string]any
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("path = %q; want /v1/chat/completions", r.URL.Path)
+		}
+		gotAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-test",
+			"model":"served-model",
+			"choices":[{
+				"index":0,
+				"message":{
+					"role":"assistant",
+					"content":"answer needle",
+					"tool_calls":[{
+						"id":"call_1",
+						"type":"function",
+						"function":{"name":"read_file","arguments":"{\"path\":\"provider/router.go\"}"}
+					}]
+				},
+				"finish_reason":"tool_calls"
+			}],
+			"usage":{"prompt_tokens":11,"completion_tokens":7,"total_tokens":18}
+		}`))
+	}))
+	defer srv.Close()
+
+	tr, err := newCandidateTransport(ModelTarget{Display: "openai-compat/fake", Provider: "openai-compat", Model: "fake"}, candidateTransportOptions{
+		openAICompatBaseURL: srv.URL,
+		openAICompatAPIKey:  "secret",
+		timeout:             5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("newCandidateTransport: %v", err)
+	}
+
+	resp, err := tr.chat.Chat(context.Background(), ollama.ChatRequest{
+		Model: "fake",
+		Messages: []ollama.ChatMessage{
+			{Role: "system", Content: "sys"},
+			{Role: "user", Content: "Read provider/router.go"},
+			{Role: "tool", ToolName: "read_file", ToolCallID: "call_1", Content: "package provider"},
+		},
+		Tools: []ollama.Tool{{
+			Type: "function",
+			Function: ollama.ToolFunction{
+				Name:        "read_file",
+				Description: "Read a file",
+				Parameters:  json.RawMessage(`{"type":"object"}`),
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if gotAuth != "Bearer secret" {
+		t.Fatalf("Authorization = %q; want Bearer secret", gotAuth)
+	}
+	if gotBody["model"] != "fake" {
+		t.Fatalf("model = %v; want fake", gotBody["model"])
+	}
+	if _, ok := gotBody["keep_alive"]; ok {
+		t.Fatalf("openai-compat request leaked Ollama keep_alive: %#v", gotBody)
+	}
+	if resp.Message.Content != "answer needle" {
+		t.Fatalf("content = %q; want answer needle", resp.Message.Content)
+	}
+	if len(resp.Message.ToolCalls) != 1 {
+		t.Fatalf("tool calls len = %d; want 1", len(resp.Message.ToolCalls))
+	}
+	if resp.Message.ToolCalls[0].Function.Name != "read_file" {
+		t.Fatalf("tool name = %q; want read_file", resp.Message.ToolCalls[0].Function.Name)
+	}
+	if got := resp.Message.ToolCalls[0].Function.Arguments["path"]; got != "provider/router.go" {
+		t.Fatalf("tool arg path = %v; want provider/router.go", got)
+	}
+	if resp.PromptEvalCount != 11 || resp.EvalCount != 7 {
+		t.Fatalf("usage = prompt %d gen %d; want 11/7", resp.PromptEvalCount, resp.EvalCount)
+	}
+	if resp.ThinkingTokensComputed {
+		t.Fatalf("ThinkingTokensComputed = true; want false until provider exposes dedicated reasoning token counts")
+	}
+}

--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -531,6 +531,31 @@ func resolveJudgeTransportConfig(transport, baseURL, apiKey string, lookupEnv fu
 	return cfg
 }
 
+// candidateAPIKeyEnvVar is the environment variable consulted for
+// openai-compat candidate Bearer tokens when -candidate-api-key is empty.
+const candidateAPIKeyEnvVar = "LLM_BENCH_CANDIDATE_API_KEY"
+
+// candidateTransportConfig is the resolved OpenAI-compatible candidate
+// endpoint configuration. Ollama candidates ignore these values.
+type candidateTransportConfig struct {
+	baseURL string
+	apiKey  string
+}
+
+// resolveCandidateTransportConfig applies flag/env precedence for candidate
+// OpenAI-compatible endpoints. The API key flag takes precedence; when empty
+// it falls back to LLM_BENCH_CANDIDATE_API_KEY via lookupEnv.
+func resolveCandidateTransportConfig(baseURL, apiKey string, lookupEnv func(string) string) candidateTransportConfig {
+	cfg := candidateTransportConfig{
+		baseURL: strings.TrimSpace(baseURL),
+		apiKey:  strings.TrimSpace(apiKey),
+	}
+	if cfg.apiKey == "" {
+		cfg.apiKey = strings.TrimSpace(lookupEnv(candidateAPIKeyEnvVar))
+	}
+	return cfg
+}
+
 // resolveToolSchemaSource picks a tool-schema source from CLI flags.
 // Returns nil if neither flag is set; an error if both are.
 func resolveToolSchemaSource(stdioCmd, httpURL string) (toolSchemaSource, error) {

--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -66,6 +66,8 @@ func main() {
 	judgeTransport := flag.String("judge-transport", "", "Judge backend for -scorer llm-judge: ollama (default), openai-compat, or claude-cli (headless `claude -p`, subscription)")
 	judgeBaseURL := flag.String("judge-base-url", "", "Base URL for -judge-transport openai-compat (server root, no /v1 suffix)")
 	judgeAPIKey := flag.String("judge-api-key", "", "Bearer token for -judge-transport openai-compat; falls back to $"+judgeAPIKeyEnvVar)
+	candidateBaseURL := flag.String("candidate-base-url", "", "Base URL for openai-compat candidate targets (server root, no /v1 suffix)")
+	candidateAPIKey := flag.String("candidate-api-key", "", "Bearer token for openai-compat candidate targets; falls back to $"+candidateAPIKeyEnvVar)
 	corpusManifestPath := flag.String("corpus-manifest", "", "Path to a corpus manifest JSONL (partition/category per trace); enables partition-separated reporting")
 	corpusPartitions := flag.String("corpus-partitions", "", "Comma-separated partitions to include from the corpus manifest (natural, challenge, judge-validation; empty = all)")
 	corpusCategories := flag.String("corpus-categories", "", "Comma-separated categories to include from the corpus manifest (empty = all)")
@@ -74,6 +76,8 @@ func main() {
 	ollamaURL := flag.String("ollama-url", "http://localhost:11434", "Ollama base URL")
 	timeout := flag.Duration("timeout", 5*time.Minute, "Per-replay timeout for candidate model calls")
 	flag.Parse()
+
+	ct := resolveCandidateTransportConfig(*candidateBaseURL, *candidateAPIKey, os.Getenv)
 
 	modes := 0
 	if *capture {
@@ -156,9 +160,11 @@ func main() {
 			log.Fatalf("llm-bench: parse models: %v", err)
 		}
 		runner := &Runner{
-			OllamaURL: *ollamaURL,
-			Timeout:   *timeout,
-			Scorer:    &CaptureScorer{},
+			OllamaURL:           *ollamaURL,
+			OpenAICompatBaseURL: ct.baseURL,
+			OpenAICompatAPIKey:  ct.apiKey,
+			Timeout:             *timeout,
+			Scorer:              &CaptureScorer{},
 		}
 		if err := runCalibrateCapture(ctx, calibrateCaptureOptions{
 			Runner:     runner,
@@ -285,6 +291,9 @@ func main() {
 		if err != nil {
 			log.Fatalf("llm-bench: parse models: %v", err)
 		}
+		if err := validateFIMTargets(targets); err != nil {
+			log.Fatalf("llm-bench: %v", err)
+		}
 		client, err := newOllamaClient(*ollamaURL, ollama.WithTimeout(*timeout))
 		if err != nil {
 			log.Fatalf("llm-bench: client: %v", err)
@@ -407,14 +416,22 @@ func main() {
 	}
 
 	runner := &Runner{
-		OllamaURL: *ollamaURL,
-		Timeout:   *timeout,
-		Scorer:    scorer,
+		OllamaURL:           *ollamaURL,
+		OpenAICompatBaseURL: ct.baseURL,
+		OpenAICompatAPIKey:  ct.apiKey,
+		Timeout:             *timeout,
+		Scorer:              scorer,
 	}
 
 	results, err := runner.RunAll(ctx, targets, traces)
 	if err != nil {
 		log.Fatalf("llm-bench: run: %v", err)
+	}
+	candidateProviders := make(map[string]string, len(results))
+	for _, result := range results {
+		if strings.TrimSpace(result.CandidateProvider) != "" {
+			candidateProviders[result.Model] = result.CandidateProvider
+		}
 	}
 
 	var judgeCacheHits, judgeCacheMisses int64
@@ -434,6 +451,7 @@ func main() {
 		JudgeCacheHits:       judgeCacheHits,
 		JudgeCacheMisses:     judgeCacheMisses,
 		TraceSetManifestHash: traceSetHash,
+		CandidateProviders:   candidateProviders,
 		Corpus:               corpusData,
 		ToolCallExpected:     toolCallExpected,
 	})
@@ -499,6 +517,15 @@ func resolveCaptureSample(spec string) (*captureSampleSpec, error) {
 		return nil, err
 	}
 	return &parsed, nil
+}
+
+func validateFIMTargets(targets []ModelTarget) error {
+	for _, target := range targets {
+		if target.Provider != defaultBenchProvider {
+			return fmt.Errorf("-fim-latency supports only ollama candidates; got %q", target.Display)
+		}
+	}
+	return nil
 }
 
 // judgeAPIKeyEnvVar is the environment variable consulted for the openai-compat

--- a/cmd/llm-bench/main_test.go
+++ b/cmd/llm-bench/main_test.go
@@ -210,6 +210,59 @@ func TestMainEmitsToolUseSubsetSection(t *testing.T) {
 	}
 }
 
+func TestMainOpenAICompatCandidateEndToEnd(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			http.NotFound(w, r)
+			return
+		}
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-test",
+			"model":"served",
+			"choices":[{
+				"index":0,
+				"message":{"role":"assistant","content":"smoke-ok"},
+				"finish_reason":"stop"
+			}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	report := filepath.Join(dir, "report.md")
+	cmd := exec.Command(os.Args[0],
+		"-traces", "testdata/smoke/minimal.json",
+		"-models", "openai-compat/fake",
+		"-candidate-base-url", srv.URL,
+		"-candidate-api-key", "flag-key",
+		"-scorer", "exact-match",
+		"-judge-cache", "",
+		"-report", report,
+	)
+	cmd.Env = append(os.Environ(), "LLM_BENCH_TEST_MAIN=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("llm-bench openai-compat candidate failed: %v\n%s", err, out)
+	}
+	if gotAuth != "Bearer flag-key" {
+		t.Fatalf("Authorization = %q; want Bearer flag-key", gotAuth)
+	}
+	body, err := os.ReadFile(report)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	if !strings.Contains(string(body), "openai-compat/fake") {
+		t.Fatalf("report missing candidate model:\n%s", body)
+	}
+	if !strings.Contains(string(body), "Candidate providers") {
+		t.Fatalf("report missing candidate provider provenance:\n%s", body)
+	}
+}
+
 func TestMainFIMLatencyEndToEnd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/generate" {
@@ -251,6 +304,27 @@ func TestMainFIMLatencyEndToEnd(t *testing.T) {
 		if !strings.Contains(string(body), want) {
 			t.Fatalf("FIM report missing %q:\n%s", want, body)
 		}
+	}
+}
+
+func TestMainFIMLatencyRejectsOpenAICompatCandidate(t *testing.T) {
+	dir := t.TempDir()
+	casePath := filepath.Join(dir, "case.json")
+	if err := os.WriteFile(casePath, []byte(`{"id":"c1","prefix":"package main\n","suffix":"\n"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(os.Args[0],
+		"-fim-latency",
+		"-fim-cases", casePath,
+		"-models", "openai-compat/fake",
+	)
+	cmd.Env = append(os.Environ(), "LLM_BENCH_TEST_MAIN=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("llm-bench -fim-latency unexpectedly succeeded:\n%s", out)
+	}
+	if !strings.Contains(string(out), "-fim-latency supports only ollama candidates") {
+		t.Fatalf("error missing FIM provider guard:\n%s", out)
 	}
 }
 

--- a/cmd/llm-bench/main_test.go
+++ b/cmd/llm-bench/main_test.go
@@ -371,6 +371,33 @@ func TestResolveJudgeTransportConfig_APIKeyEnvFallback(t *testing.T) {
 	}
 }
 
+func TestResolveCandidateTransportConfig_APIKeyFlagWins(t *testing.T) {
+	cfg := resolveCandidateTransportConfig(" https://api.example.com ", "flag-key", func(string) string { return "env-key" })
+	if cfg.apiKey != "flag-key" {
+		t.Fatalf("apiKey = %q; want flag-key (flag overrides env)", cfg.apiKey)
+	}
+	if cfg.baseURL != "https://api.example.com" {
+		t.Fatalf("baseURL = %q; want trimmed value", cfg.baseURL)
+	}
+}
+
+func TestResolveCandidateTransportConfig_APIKeyEnvFallback(t *testing.T) {
+	calls := 0
+	cfg := resolveCandidateTransportConfig("https://x", "", func(name string) string {
+		calls++
+		if name != candidateAPIKeyEnvVar {
+			t.Errorf("looked up %q; want %q", name, candidateAPIKeyEnvVar)
+		}
+		return "env-key"
+	})
+	if cfg.apiKey != "env-key" {
+		t.Fatalf("apiKey = %q; want env-key fallback", cfg.apiKey)
+	}
+	if calls != 1 {
+		t.Fatalf("env lookups = %d; want exactly 1", calls)
+	}
+}
+
 func TestCaptureSampleAndLimitMutuallyExclusive(t *testing.T) {
 	if err := validateCaptureSampleAndLimit(10, "n=20"); err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
 		t.Fatalf("want mutex error; got %v", err)

--- a/cmd/llm-bench/replay_test.go
+++ b/cmd/llm-bench/replay_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 
@@ -78,6 +79,103 @@ func TestReplayRefusesTraceWithoutUserTurn(t *testing.T) {
 	}
 	if *called {
 		t.Error("replay reached Ollama despite refusing the trace")
+	}
+}
+
+// thinkMarkupResidueNote flags answers that still carry <think> reasoning
+// markup after extraction (e.g. a serving backend that left tags inline or
+// used non-default delimiters), so a reviewer can discount the score.
+func TestThinkMarkupResidueNote(t *testing.T) {
+	if note := thinkMarkupResidueNote("clean final answer"); note != "" {
+		t.Fatalf("clean answer: note = %q; want empty", note)
+	}
+	if note := thinkMarkupResidueNote("<think>leaked reasoning</think>"); note == "" {
+		t.Fatal("well-formed residual <think> markup: note = empty; want a divergence note")
+	}
+	if note := thinkMarkupResidueNote("<think>unclosed reasoning that extraction cannot strip"); note == "" {
+		t.Fatal("unclosed <think> markup: note = empty; want a divergence note")
+	}
+}
+
+// When the serving backend leaves reasoning markup inline (so think extraction
+// can't strip it), replayWith should annotate the result so the residue is
+// visible to reviewers rather than silently scored as the answer.
+func TestReplayWith_NotesResidualThinkMarkup(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := ollama.ChatResponse{
+			Model:           "test-model",
+			Done:            true,
+			Message:         ollama.ChatMessage{Role: "assistant", Content: "<think>unclosed reasoning leaking into the final answer"},
+			PromptEvalCount: 1,
+			EvalCount:       1,
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	trace := Trace{
+		ID:     "think-residue",
+		System: "sys",
+		Turns:  []Turn{{Role: "user", Content: "q"}},
+	}
+
+	out, err := replayWith(context.Background(), ollamaCandidateClient{client: client}, "test-model", trace, replayOptions{})
+	if err != nil {
+		t.Fatalf("replayWith: %v", err)
+	}
+
+	found := false
+	for _, note := range out.Notes {
+		if strings.Contains(note, "<think") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("out.Notes = %#v; want a note flagging residual <think> markup", out.Notes)
+	}
+}
+
+// Companion to TestReplayWith_NotesResidualThinkMarkup: a well-formed <think>
+// block on the openai-compat path is stripped by default extraction, so the
+// scored answer is clean and no residue note is recorded.
+func TestReplayWith_OpenAICompatStripsThinkNoResidueNote(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-test",
+			"model":"served",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"<think>private reasoning</think>final"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	tr, err := newCandidateTransport(ModelTarget{Display: "openai-compat/fake", Provider: "openai-compat", Model: "fake"}, candidateTransportOptions{
+		openAICompatBaseURL: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("newCandidateTransport: %v", err)
+	}
+
+	trace := Trace{
+		ID:     "think-clean",
+		System: "sys",
+		Turns:  []Turn{{Role: "user", Content: "q"}},
+	}
+	out, err := replayWith(context.Background(), tr.chat, "fake", trace, replayOptions{})
+	if err != nil {
+		t.Fatalf("replayWith: %v", err)
+	}
+	if got := lastAssistantContent(out.Transcript); got != "final" {
+		t.Fatalf("final answer = %q; want %q (think block must be stripped before scoring)", got, "final")
+	}
+	for _, note := range out.Notes {
+		if strings.Contains(note, "<think") {
+			t.Fatalf("unexpected residue note for a well-formed think block: %q", note)
+		}
 	}
 }
 

--- a/cmd/llm-bench/replay_test.go
+++ b/cmd/llm-bench/replay_test.go
@@ -179,7 +179,7 @@ func TestReplayWith_IsolatesGenAndPromptEvalTokens(t *testing.T) {
 			{Role: "user", Content: "second"},
 		},
 	}
-	out, err := replayWith(context.Background(), client, "test-model", trace, replayOptions{})
+	out, err := replayWith(context.Background(), ollamaCandidateClient{client: client}, "test-model", trace, replayOptions{})
 	if err != nil {
 		t.Fatalf("replayWith: %v", err)
 	}
@@ -542,7 +542,7 @@ func TestReplayRecordsBypassNoteWhenCandidateSkipsScriptedTools(t *testing.T) {
 		},
 	}
 
-	out, err := replayWith(context.Background(), client, "test-model", trace, replayOptions{})
+	out, err := replayWith(context.Background(), ollamaCandidateClient{client: client}, "test-model", trace, replayOptions{})
 	if err != nil {
 		t.Fatalf("replayWith() error: %v", err)
 	}
@@ -752,7 +752,7 @@ func TestReplayPropagatesNumCtxOption(t *testing.T) {
 		Turns:  []Turn{{Role: "user", Content: "hi"}},
 	}
 
-	out, err := replayWith(context.Background(), client, "test-model", trace, replayOptions{NumCtx: 32768})
+	out, err := replayWith(context.Background(), ollamaCandidateClient{client: client}, "test-model", trace, replayOptions{NumCtx: 32768})
 	if err != nil {
 		t.Fatalf("replayWith() error: %v", err)
 	}

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -37,7 +37,8 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 	}
 
 	emitCacheLine := opts.Scorer == "llm-judge"
-	emitProvenance := opts.TraceSetManifestHash != "" || emitCacheLine
+	emitCandidateProviders := len(opts.CandidateProviders) > 0
+	emitProvenance := opts.TraceSetManifestHash != "" || emitCacheLine || emitCandidateProviders
 	if emitProvenance {
 		fmt.Fprintf(&b, "## Provenance\n\n")
 		if opts.TraceSetManifestHash != "" {
@@ -45,6 +46,19 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 		}
 		if opts.Scorer == "llm-judge" && opts.JudgeProvider != "" {
 			fmt.Fprintf(&b, "- Judge provider: `%s`\n", markdownCell(opts.JudgeProvider))
+		}
+		if emitCandidateProviders {
+			var parts []string
+			for _, model := range models {
+				providerName := strings.TrimSpace(opts.CandidateProviders[model])
+				if providerName == "" {
+					continue
+				}
+				parts = append(parts, fmt.Sprintf("`%s: %s`", markdownCell(model), markdownCell(providerName)))
+			}
+			if len(parts) > 0 {
+				fmt.Fprintf(&b, "- Candidate providers: %s\n", strings.Join(parts, ", "))
+			}
 		}
 		if emitCacheLine {
 			total := opts.JudgeCacheHits + opts.JudgeCacheMisses
@@ -363,6 +377,7 @@ type reportOptions struct {
 	JudgeCacheHits       int64
 	JudgeCacheMisses     int64
 	TraceSetManifestHash string
+	CandidateProviders   map[string]string
 	// Corpus, when set, makes the report corpus-aware: it adds composition
 	// counts and partition-separated quality, and captions the combined
 	// results table as not-comparable-across-partitions.

--- a/cmd/llm-bench/report_test.go
+++ b/cmd/llm-bench/report_test.go
@@ -341,6 +341,29 @@ func TestFormatReportProvenanceBlock(t *testing.T) {
 	}
 }
 
+func TestFormatReportProvenanceReportsCandidateProviders(t *testing.T) {
+	report := formatReport([]string{"ollama/a", "openai-compat/b"}, []Result{
+		{Model: "ollama/a", TraceID: "t1", CandidateProvider: "ollama", Score: Score{AnswerQuality: 1}},
+		{Model: "openai-compat/b", TraceID: "t1", CandidateProvider: "openai-compat:abc123", Score: Score{AnswerQuality: 1}},
+	}, reportOptions{
+		TraceSetManifestHash: "sha256:test",
+		CandidateProviders: map[string]string{
+			"ollama/a":        "ollama",
+			"openai-compat/b": "openai-compat:abc123",
+		},
+	})
+
+	if !strings.Contains(report, "Candidate providers") {
+		t.Fatalf("missing candidate providers provenance:\n%s", report)
+	}
+	if !strings.Contains(report, "`ollama/a: ollama`") {
+		t.Fatalf("missing ollama candidate provider:\n%s", report)
+	}
+	if !strings.Contains(report, "`openai-compat/b: openai-compat:abc123`") {
+		t.Fatalf("missing openai-compat candidate provider:\n%s", report)
+	}
+}
+
 func TestFormatReportProvenanceReportsCacheDisabledForLLMJudge(t *testing.T) {
 	report := formatReport([]string{"m1"}, []Result{
 		{Model: "m1", TraceID: "t1", Score: Score{AnswerQuality: 0.5}},

--- a/cmd/llm-bench/run_all_test.go
+++ b/cmd/llm-bench/run_all_test.go
@@ -118,6 +118,67 @@ func TestRunAllSucceedsEndToEnd(t *testing.T) {
 	}
 }
 
+func TestRunAllOpenAICompatCandidateEndToEnd(t *testing.T) {
+	var sawChat bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			http.NotFound(w, r)
+			return
+		}
+		sawChat = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-test",
+			"model":"served",
+			"choices":[{
+				"index":0,
+				"message":{"role":"assistant","content":"answer with needle inside"},
+				"finish_reason":"stop"
+			}],
+			"usage":{"prompt_tokens":11,"completion_tokens":7,"total_tokens":18}
+		}`))
+	}))
+	defer srv.Close()
+
+	runner := &Runner{
+		OllamaURL:           "http://unused.invalid",
+		OpenAICompatBaseURL: srv.URL,
+		Timeout:             5 * time.Second,
+		Scorer:              &ExactMatchScorer{},
+	}
+
+	targets := []ModelTarget{{Display: "openai-compat/fake", Provider: "openai-compat", Model: "fake"}}
+	traces := []Trace{{
+		ID:     "t1",
+		System: "sys",
+		Turns:  []Turn{{Role: "user", Content: "q"}},
+		Golden: Golden{FinalAnswerSubstring: "needle"},
+	}}
+
+	results, err := runner.RunAll(context.Background(), targets, traces)
+	if err != nil {
+		t.Fatalf("RunAll() error: %v", err)
+	}
+	if !sawChat {
+		t.Fatalf("openai-compat chat endpoint was not called")
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Err != nil {
+		t.Fatalf("unexpected result error: %v", results[0].Err)
+	}
+	if results[0].CandidateProvider == "" || !strings.HasPrefix(results[0].CandidateProvider, openAICompatTransport+":") {
+		t.Fatalf("CandidateProvider = %q; want %s:<endpoint-id>", results[0].CandidateProvider, openAICompatTransport)
+	}
+	if got, want := results[0].Score.TotalTokens, 18; got != want {
+		t.Fatalf("TotalTokens = %d; want %d", got, want)
+	}
+	if results[0].Score.ThinkingTokensComputed {
+		t.Fatalf("ThinkingTokensComputed = true; want false for current openai-compat candidate usage")
+	}
+}
+
 type latencyPoisonScorer struct{}
 
 func (s latencyPoisonScorer) Score(context.Context, Trace, Result) (Score, error) {

--- a/cmd/llm-bench/runner.go
+++ b/cmd/llm-bench/runner.go
@@ -43,6 +43,12 @@ var (
 type Runner struct {
 	OllamaURL string
 	Timeout   time.Duration
+	// OpenAICompatBaseURL is required when any candidate target uses the
+	// openai-compat provider. Ollama candidates ignore it.
+	OpenAICompatBaseURL string
+	// OpenAICompatAPIKey is an optional Bearer token for openai-compat
+	// candidate targets. Prefer LLM_BENCH_CANDIDATE_API_KEY over shell history.
+	OpenAICompatAPIKey string
 	// PerTurnTimeout bounds a single chatReplayTurn round-trip. Zero means
 	// no per-turn bound — only Timeout applies to the whole replay. Set
 	// this when running models that may stall mid-loop to keep one bad
@@ -58,11 +64,12 @@ type Runner struct {
 
 // Result is a single (model, trace) evaluation.
 type Result struct {
-	Model      string
-	TraceID    string
-	Score      Score
-	Err        error
-	Transcript []Turn
+	Model             string
+	TraceID           string
+	CandidateProvider string
+	Score             Score
+	Err               error
+	Transcript        []Turn
 }
 
 // RunAll replays every trace against every model. Iterates models in the
@@ -77,13 +84,19 @@ func (r *Runner) RunAll(ctx context.Context, targets []ModelTarget, traces []Tra
 			return results, err
 		}
 
-		client, err := newOllamaClient(r.OllamaURL)
+		transport, err := newCandidateTransport(target, candidateTransportOptions{
+			ollamaURL:           r.OllamaURL,
+			openAICompatBaseURL: r.OpenAICompatBaseURL,
+			openAICompatAPIKey:  r.OpenAICompatAPIKey,
+			timeout:             r.Timeout,
+		})
 		if err != nil {
 			for _, trace := range traces {
 				results = append(results, Result{
-					Model:   target.Display,
-					TraceID: trace.ID,
-					Err:     fmt.Errorf("client for %q: %w", target.Display, err),
+					Model:             target.Display,
+					TraceID:           trace.ID,
+					CandidateProvider: target.Provider,
+					Err:               fmt.Errorf("client for %q: %w", target.Display, err),
 				})
 			}
 			continue
@@ -93,31 +106,32 @@ func (r *Runner) RunAll(ctx context.Context, targets []ModelTarget, traces []Tra
 			if err := ctx.Err(); err != nil {
 				return results, err
 			}
-			results = append(results, r.runOne(ctx, client, target, trace))
+			results = append(results, r.runOne(ctx, transport, target, trace))
 		}
 	}
 	return results, nil
 }
 
-func (r *Runner) runOne(ctx context.Context, client *ollama.Client, target ModelTarget, trace Trace) Result {
+func (r *Runner) runOne(ctx context.Context, transport candidateTransport, target ModelTarget, trace Trace) Result {
 	replayCtx, cancel := context.WithTimeout(ctx, r.Timeout)
 
 	opts := replayOptions{PerTurnTimeout: r.PerTurnTimeout, NumCtx: r.NumCtx}
-	out, err := replayWith(replayCtx, client, target.Model, trace, opts)
+	out, err := replayWith(replayCtx, transport.chat, target.Model, trace, opts)
 	cancel()
 	if err != nil {
-		return Result{Model: target.Display, TraceID: trace.ID, Err: err, Transcript: out.Transcript}
+		return Result{Model: target.Display, TraceID: trace.ID, CandidateProvider: transport.providerName, Err: err, Transcript: out.Transcript}
 	}
 
 	scoreStart := time.Now()
 	score, err := r.Scorer.Score(ctx, trace, Result{
-		Model:      target.Display,
-		TraceID:    trace.ID,
-		Transcript: out.Transcript,
+		Model:             target.Display,
+		TraceID:           trace.ID,
+		CandidateProvider: transport.providerName,
+		Transcript:        out.Transcript,
 	})
 	scorerMs := time.Since(scoreStart).Milliseconds()
 	if err != nil {
-		return Result{Model: target.Display, TraceID: trace.ID, Err: err, Transcript: out.Transcript}
+		return Result{Model: target.Display, TraceID: trace.ID, CandidateProvider: transport.providerName, Err: err, Transcript: out.Transcript}
 	}
 	// LatencyMs sums per-turn chat round-trips only; scorer work is
 	// excluded so llm-judge round-trips can't pollute the model-latency
@@ -139,10 +153,11 @@ func (r *Runner) runOne(ctx context.Context, client *ollama.Client, target Model
 	score.ThinkingTokensComputed = out.ThinkingComputed
 
 	return Result{
-		Model:      target.Display,
-		TraceID:    trace.ID,
-		Score:      score,
-		Transcript: out.Transcript,
+		Model:             target.Display,
+		TraceID:           trace.ID,
+		CandidateProvider: transport.providerName,
+		Score:             score,
+		Transcript:        out.Transcript,
 	}
 }
 
@@ -179,7 +194,7 @@ type replayOptions struct {
 // replay is the legacy entry point retained for tests and callers that
 // don't need the Runner-level knobs (PerTurnTimeout, NumCtx).
 func replay(ctx context.Context, client *ollama.Client, model string, trace Trace) ([]Turn, error) {
-	out, err := replayWith(ctx, client, model, trace, replayOptions{})
+	out, err := replayWith(ctx, ollamaCandidateClient{client: client}, model, trace, replayOptions{})
 	return out.Transcript, err
 }
 
@@ -207,7 +222,7 @@ func replay(ctx context.Context, client *ollama.Client, model string, trace Trac
 //
 // All accumulated divergence notes are appended to the resulting Score's
 // Notes so aggregate consumers can see why a candidate diverged.
-func replayWith(ctx context.Context, client *ollama.Client, model string, trace Trace, opts replayOptions) (replayOutput, error) {
+func replayWith(ctx context.Context, client candidateChatClient, model string, trace Trace, opts replayOptions) (replayOutput, error) {
 	if !hasUserTurn(trace.Turns) {
 		return replayOutput{}, fmt.Errorf("trace %q: %w", trace.ID, errNoUserTurn)
 	}
@@ -301,7 +316,7 @@ func hasUserTurn(turns []Turn) bool {
 	return false
 }
 
-func chatReplayTurn(ctx context.Context, client *ollama.Client, model string, messages []ollama.ChatMessage, tools []ollama.Tool, opts replayOptions) (ollama.ChatMessage, Turn, int64, tokenUsage, error) {
+func chatReplayTurn(ctx context.Context, client candidateChatClient, model string, messages []ollama.ChatMessage, tools []ollama.Tool, opts replayOptions) (ollama.ChatMessage, Turn, int64, tokenUsage, error) {
 	turnCtx := ctx
 	if opts.PerTurnTimeout > 0 {
 		var cancel context.CancelFunc
@@ -331,10 +346,12 @@ func chatReplayTurn(ctx context.Context, client *ollama.Client, model string, me
 	if err != nil {
 		return ollama.ChatMessage{}, Turn{}, latencyMs, tokenUsage{}, err
 	}
-	// Ollama reports prompt_eval_count and eval_count separately; thinking
-	// tokens are folded into eval_count (not isolable here). The OpenAI-compat
-	// candidate transport (#136) will populate Thinking from reasoning usage.
-	usage := tokenUsage{PromptEval: resp.PromptEvalCount, Gen: resp.EvalCount}
+	usage := tokenUsage{
+		PromptEval:       resp.PromptEvalCount,
+		Gen:              resp.EvalCount,
+		Thinking:         resp.ThinkingTokens,
+		ThinkingComputed: resp.ThinkingTokensComputed,
+	}
 	return msg, turn, latencyMs, usage, nil
 }
 

--- a/cmd/llm-bench/runner.go
+++ b/cmd/llm-bench/runner.go
@@ -304,6 +304,10 @@ func replayWith(ctx context.Context, client candidateChatClient, model string, t
 		}
 	}
 
+	if note := thinkMarkupResidueNote(lastAssistantContent(out.Transcript)); note != "" {
+		out.Notes = append(out.Notes, note)
+	}
+
 	return out, nil
 }
 
@@ -554,4 +558,18 @@ func appendNotes(existing string, extras []string) string {
 		return joined
 	}
 	return existing + "; " + joined
+}
+
+// thinkMarkupResidueNote returns a divergence note when a candidate's final
+// answer still contains a "<think" marker after think extraction — for example
+// an unclosed or malformed tag the default extractor's <think>...</think>
+// regex can't match, or a backend that emits reasoning inline instead of
+// separating it. The empty string means no residue. It is advisory: callers
+// append it to Score.Notes so a reviewer can discount answers polluted by
+// serving-stack reasoning formatting rather than model output.
+func thinkMarkupResidueNote(finalAnswer string) string {
+	if strings.Contains(finalAnswer, "<think") {
+		return "candidate final answer retains <think> reasoning markup; serving backend did not separate reasoning"
+	}
+	return ""
 }

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -185,12 +185,20 @@ func newJudgeTransport(opts scorerOptions) (judgeTransport, error) {
 }
 
 func openAICompatJudgeProviderName(baseURL string) string {
-	canonical := canonicalJudgeBaseURL(baseURL)
+	return openAICompatEndpointProviderName(baseURL)
+}
+
+func openAICompatCandidateProviderName(baseURL string) string {
+	return openAICompatEndpointProviderName(baseURL)
+}
+
+func openAICompatEndpointProviderName(baseURL string) string {
+	canonical := canonicalOpenAICompatBaseURL(baseURL)
 	sum := sha256.Sum256([]byte(canonical))
 	return fmt.Sprintf("%s:%s", openAICompatTransport, hex.EncodeToString(sum[:])[:12])
 }
 
-func canonicalJudgeBaseURL(raw string) string {
+func canonicalOpenAICompatBaseURL(raw string) string {
 	raw = strings.TrimSpace(raw)
 	u, err := url.Parse(raw)
 	if err != nil || u.Scheme == "" || u.Host == "" {

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -906,9 +906,12 @@ func normalizeModelSelector(s string) string {
 
 func modelSelectorWithoutBenchProvider(s string) string {
 	s = strings.TrimSpace(s)
-	prefix := defaultBenchProvider + "/"
-	if strings.HasPrefix(strings.ToLower(s), prefix) {
-		return strings.TrimSpace(s[len(prefix):])
+	lower := strings.ToLower(s)
+	for _, provider := range []string{defaultBenchProvider, openAICompatTransport} {
+		prefix := provider + "/"
+		if strings.HasPrefix(lower, prefix) {
+			return strings.TrimSpace(s[len(prefix):])
+		}
 	}
 	return s
 }

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -657,6 +657,35 @@ func TestLLMJudgeScorerRejectsNamespacedSelfJudging(t *testing.T) {
 	}
 }
 
+func TestLLMJudgeScorerRejectsOpenAICompatSelfJudging(t *testing.T) {
+	client := &fakeJudgeClient{
+		resp: &ollama.ChatResponse{Message: ollama.ChatMessage{Content: `{"answer_quality":1,"justification":"ok"}`}},
+	}
+	s, err := newLLMJudgeScorer(client, "fake", 0)
+	if err != nil {
+		t.Fatalf("newLLMJudgeScorer() error: %v", err)
+	}
+
+	trace := Trace{
+		ID:     "openai-compat-self-judge",
+		System: "sys",
+		Turns:  []Turn{{Role: "user", Content: "q"}},
+		Golden: Golden{FinalAnswerCriteria: "answer correctly"},
+	}
+	actual := Result{
+		Model:      "openai-compat/fake",
+		Transcript: []Turn{{Role: "assistant", Content: "answer"}},
+	}
+
+	_, err = s.Score(context.Background(), trace, actual)
+	if !errors.Is(err, errJudgeSelfPreference) {
+		t.Fatalf("err = %v, want errJudgeSelfPreference", err)
+	}
+	if client.called != 0 {
+		t.Fatalf("judge client called despite openai-compat self-judging guard")
+	}
+}
+
 func TestLLMJudgeScorerRequiresRubric(t *testing.T) {
 	s, err := newLLMJudgeScorer(&fakeJudgeClient{}, "gemma4:31b", 0)
 	if err != nil {
@@ -722,6 +751,15 @@ func TestValidateJudgeModelAcceptsProviderQualifiedSelector(t *testing.T) {
 	err := validateJudgeModel(context.Background(), fakeJudgeModelChecker{
 		models: []string{"gemma4:31b"},
 	}, "ollama/gemma4:31b")
+	if err != nil {
+		t.Fatalf("validateJudgeModel() error: %v", err)
+	}
+}
+
+func TestValidateJudgeModelAcceptsOpenAICompatQualifiedSelector(t *testing.T) {
+	err := validateJudgeModel(context.Background(), fakeJudgeModelChecker{
+		models: []string{"fake"},
+	}, "openai-compat/fake")
 	if err != nil {
 		t.Fatalf("validateJudgeModel() error: %v", err)
 	}

--- a/cmd/llm-bench/target.go
+++ b/cmd/llm-bench/target.go
@@ -49,9 +49,18 @@ func parseModelTarget(raw string) (ModelTarget, error) {
 		}
 	}
 
-	if target.Provider != defaultBenchProvider {
+	if !supportedCandidateProvider(target.Provider) {
 		return ModelTarget{}, fmt.Errorf("%w: %q", errUnsupportedProv, target.Provider)
 	}
 
 	return target, nil
+}
+
+func supportedCandidateProvider(provider string) bool {
+	switch provider {
+	case defaultBenchProvider, openAICompatTransport:
+		return true
+	default:
+		return false
+	}
 }

--- a/cmd/llm-bench/target_test.go
+++ b/cmd/llm-bench/target_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestParseModelTargets(t *testing.T) {
-	got, err := parseModelTargets("ollama/qwen3-coder-next:latest, gemma4:31b")
+	got, err := parseModelTargets("ollama/qwen3-coder-next:latest, gemma4:31b, openai-compat/Qwen/Qwen3-Coder")
 	if err != nil {
 		t.Fatalf("parseModelTargets() error: %v", err)
 	}
@@ -22,6 +22,11 @@ func TestParseModelTargets(t *testing.T) {
 			Display:  "gemma4:31b",
 			Provider: "ollama",
 			Model:    "gemma4:31b",
+		},
+		{
+			Display:  "openai-compat/Qwen/Qwen3-Coder",
+			Provider: "openai-compat",
+			Model:    "Qwen/Qwen3-Coder",
 		},
 	}
 

--- a/docs/llm/benchmark-plan.md
+++ b/docs/llm/benchmark-plan.md
@@ -249,6 +249,13 @@ go run ./cmd/llm-bench \
   -report ./bench-report.md
 ```
 
+Candidate answers are scored on final content only: inline `<think>...</think>`
+reasoning emitted by a server (for example llama.cpp) is stripped before
+scoring, so results reflect the answer rather than serving-stack reasoning
+formatting — matching the Ollama path, where the server separates reasoning
+into a field the harness drops. A residual `<think` marker surviving the strip
+is recorded in the result notes so a reviewer can discount that answer.
+
 - Initial target comparisons against the reference lineup in `models.json`:
   - `coding` — Qwen3-Coder-Next vs GLM-5.1 on code-gen traces (Setup 2
     experiment; see [setups.md](setups.md))

--- a/docs/llm/benchmark-plan.md
+++ b/docs/llm/benchmark-plan.md
@@ -233,9 +233,22 @@ Active labeling (`-calibrate-suggest`) is a planned follow-up.
 
 - **Currently-configured model vs candidate** on each role's captured
   traces. The harness takes `-models <provider>/<name>,...`; today only
-  `ollama` is wired (`parseModelTarget` rejects other providers), so the
-  "any model reachable through an existing `provider.Provider`" target
-  remains follow-up work alongside the multi-provider client factory.
+  `ollama` and `openai-compat` candidate transports are wired; broader
+  provider routing remains follow-up work alongside the multi-provider
+  client factory.
+
+OpenAI-compatible candidate replay uses the `openai-compat/<model>`
+selector plus an endpoint:
+
+```bash
+go run ./cmd/llm-bench \
+  -traces 'docs/llm/traces/*.json' \
+  -models 'openai-compat/Qwen/Qwen3-Coder' \
+  -candidate-base-url 'http://localhost:8080' \
+  -scorer exact-match \
+  -report ./bench-report.md
+```
+
 - Initial target comparisons against the reference lineup in `models.json`:
   - `coding` — Qwen3-Coder-Next vs GLM-5.1 on code-gen traces (Setup 2
     experiment; see [setups.md](setups.md))


### PR DESCRIPTION
## Summary
Adds an `openai-compat/<model>` candidate transport to `cmd/llm-bench` so candidates can be benchmarked against any OpenAI-compatible server (llama.cpp `llama-server`, vLLM, LM Studio, hosted APIs), not just Ollama. Builds on the judge transports from #135. Closes #136.

## What's included
- `openai-compat/<model>` selector in `parseModelTarget`; Ollama stays the default (`-models 'ollama/...'` and bare names unchanged).
- `-candidate-base-url` / `-candidate-api-key` flags, with `LLM_BENCH_CANDIDATE_API_KEY` env fallback, mirroring the judge-transport flag set.
- A `candidateTransport` seam: the Runner routes replay through Ollama or openaicompat behind a `candidateChatClient` interface; usage maps `prompt_tokens` to PromptEval and `completion_tokens` to Gen.
- Candidate provider instance identity (`openai-compat:<sha256-12>` of the canonical base URL) recorded in report provenance, consistent with the judge treatment (shared canonicalization helper).
- `-fim-latency` guarded to Ollama-only candidates (FIM uses Ollama's `/api/generate`).

## Think-tag handling
The openai-compat candidate provider extracts inline `<think>...</think>` reasoning by default, so the scored transcript holds the final answer rather than serving-stack-specific reasoning formatting. This matches the Ollama path, where the server separates reasoning into a field the raw client drops. An advisory `Score.Notes` guard flags any answer still carrying a `<think` marker after extraction.

## Tests
Unit and end-to-end coverage: request/response translation (tool calls, auth header, no Ollama `keep_alive` leak), flag/env precedence, `RunAll` and `main` end-to-end via httptest, FIM rejection, report provenance, and think-tag stripping (transport + replay) with the residue note.

## Follow-ups (separate issues, not in this PR)
- #158 — parse `usage.completion_tokens_details.reasoning_tokens` for reasoning-token isolation on openai-compat.
- #160 — capture reasoning text for cross-stack parity (`message.thinking` + `reasoning_content`).

## Verification
`./scripts/ci-local --mode pre-push`: lint reports 0 issues; `go test -race ./...` is green.

Generated with [Claude Code](https://claude.com/claude-code)