### PR TITLE
fix(openaicompat): request and validate stream usage

### DIFF
--- a/provider/openaicompat/openaicompat.go
+++ b/provider/openaicompat/openaicompat.go
@@ -252,6 +252,7 @@ func (p *Provider) ChatStream(ctx context.Context, req provider.ChatRequest, fn 
 		callbackErr    error
 		streamErr      error
 		finished       bool
+		seenUsage      bool
 		toolCalls      streamToolCallAccumulator
 	)
 
@@ -298,6 +299,7 @@ func (p *Provider) ChatStream(ctx context.Context, req provider.ChatRequest, fn 
 			lastModel = chunk.Model
 		}
 		if chunk.Usage != nil {
+			seenUsage = true
 			lastUsage = provider.Usage{
 				PromptTokens:            chunk.Usage.PromptTokens,
 				CompletionTokens:        chunk.Usage.CompletionTokens,
@@ -356,6 +358,9 @@ func (p *Provider) ChatStream(ctx context.Context, req provider.ChatRequest, fn 
 	}
 	if streamErr != nil {
 		return fmt.Errorf("provider: openaicompat: chat stream: %w", streamErr)
+	}
+	if finished && !seenUsage {
+		return fmt.Errorf("provider: openaicompat: chat stream: ended before usage chunk")
 	}
 	if finished {
 		model := lastModel

--- a/provider/openaicompat/openaicompat.go
+++ b/provider/openaicompat/openaicompat.go
@@ -336,23 +336,6 @@ func (p *Provider) ChatStream(ctx context.Context, req provider.ChatRequest, fn 
 	if callbackErr != nil {
 		return callbackErr
 	}
-	if finished {
-		model := lastModel
-		if model == "" {
-			model = req.Model
-		}
-		if err := fn(provider.ChatResponse{
-			Model:     model,
-			Provider:  p.name,
-			ToolCalls: lastToolCalls,
-			Done:      true,
-			Usage:     lastUsage,
-		}); err != nil {
-			return err
-		}
-		return nil
-	}
-
 	if ctx.Err() != nil {
 		if chunksReceived > 0 && !finished {
 			_ = parser.Flush()
@@ -373,6 +356,22 @@ func (p *Provider) ChatStream(ctx context.Context, req provider.ChatRequest, fn 
 	}
 	if streamErr != nil {
 		return fmt.Errorf("provider: openaicompat: chat stream: %w", streamErr)
+	}
+	if finished {
+		model := lastModel
+		if model == "" {
+			model = req.Model
+		}
+		if err := fn(provider.ChatResponse{
+			Model:     model,
+			Provider:  p.name,
+			ToolCalls: lastToolCalls,
+			Done:      true,
+			Usage:     lastUsage,
+		}); err != nil {
+			return err
+		}
+		return nil
 	}
 	if !finished {
 		return fmt.Errorf("provider: openaicompat: chat stream: ended before final chunk")
@@ -668,6 +667,9 @@ func toChatRequest(req provider.ChatRequest, stream bool) chatRequest {
 		Messages: msgs,
 		Stream:   stream,
 		Tools:    toWireTools(req.Tools),
+	}
+	if stream {
+		r.StreamOptions = &chatStreamOptions{IncludeUsage: true}
 	}
 	applyOptionsChat(&r, req.Options)
 	return r

--- a/provider/openaicompat/openaicompat_test.go
+++ b/provider/openaicompat/openaicompat_test.go
@@ -706,6 +706,7 @@ func TestProvider_ChatStream_RequestsUsageInStreamOptions(t *testing.T) {
 			{Model: "m", Choices: []chatChunkChoice{{
 				Delta: chatMessage{}, FinishReason: stringPtr("stop"),
 			}}},
+			chatUsageChunk(),
 		})
 	}))
 	defer srv.Close()
@@ -854,6 +855,7 @@ func TestProvider_ChatStream_SingleToolCall_AssembledOnDone(t *testing.T) {
 			{Model: "m", Choices: []chatChunkChoice{{
 				Delta: chatMessage{}, FinishReason: stringPtr("tool_calls"),
 			}}},
+			chatUsageChunk(),
 		})
 	}))
 	defer srv.Close()
@@ -915,6 +917,7 @@ func TestProvider_ChatStream_FragmentedToolCall_AssembledOnDone(t *testing.T) {
 			{Model: "m", Choices: []chatChunkChoice{{
 				Delta: chatMessage{}, FinishReason: stringPtr("tool_calls"),
 			}}},
+			chatUsageChunk(),
 		})
 	}))
 	defer srv.Close()
@@ -976,6 +979,7 @@ func TestProvider_ChatStream_FragmentedToolCall_LockedEncodingMode(t *testing.T)
 			{Model: "m", Choices: []chatChunkChoice{{
 				Delta: chatMessage{}, FinishReason: stringPtr("tool_calls"),
 			}}},
+			chatUsageChunk(),
 		})
 	}))
 	defer srv.Close()
@@ -1029,6 +1033,7 @@ func TestProvider_ChatStream_FragmentedToolCall_NilIndexUsesLastKnown(t *testing
 			{Model: "m", Choices: []chatChunkChoice{{
 				Delta: chatMessage{}, FinishReason: stringPtr("tool_calls"),
 			}}},
+			chatUsageChunk(),
 		})
 	}))
 	defer srv.Close()
@@ -1079,6 +1084,7 @@ func TestProvider_ChatStream_MultiToolFragmented_AssembledIndependently(t *testi
 			{Model: "m", Choices: []chatChunkChoice{{
 				Delta: chatMessage{}, FinishReason: stringPtr("tool_calls"),
 			}}},
+			chatUsageChunk(),
 		})
 	}))
 	defer srv.Close()
@@ -1128,6 +1134,7 @@ func TestProvider_ChatStream_FragmentedToolCall_OrderByFirstAppearance(t *testin
 			{Model: "m", Choices: []chatChunkChoice{{
 				Delta: chatMessage{}, FinishReason: stringPtr("tool_calls"),
 			}}},
+			chatUsageChunk(),
 		})
 	}))
 	defer srv.Close()
@@ -1230,6 +1237,7 @@ func TestProvider_ChatStream_MalformedChunk_Skipped(t *testing.T) {
 		_, _ = fmt.Fprintf(w, "data: %s\n\n", marshalJSON(t, chatChunk{
 			Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{}, FinishReason: stringPtr("stop")}},
 		}))
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", marshalJSON(t, chatUsageChunk()))
 		_, _ = fmt.Fprintf(w, "data: [DONE]\n\n")
 		f.Flush()
 	}))
@@ -1294,6 +1302,32 @@ func TestProvider_ChatStream_ReadErrorAfterFinishReason_ReturnsError(t *testing.
 	}
 	if sawDone {
 		t.Fatal("must not synthesize successful Done when the stream errors before usage/[DONE]")
+	}
+}
+
+func TestProvider_ChatStream_DoneWithoutUsage_ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeSSE(t, w, []chatChunk{
+			{Model: "m", Choices: []chatChunkChoice{{
+				Delta: chatMessage{}, FinishReason: stringPtr("stop"),
+			}}},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL), WithThinkMode(provider.ThinkNone))
+	var sawDone bool
+	err := p.ChatStream(context.Background(), provider.ChatRequest{Model: "m"}, func(r provider.ChatResponse) error {
+		if r.Done {
+			sawDone = true
+		}
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "ended before usage chunk") {
+		t.Fatalf("expected missing usage error, got %v", err)
+	}
+	if sawDone {
+		t.Fatal("must not synthesize successful Done when requested streaming usage is missing")
 	}
 }
 
@@ -1830,6 +1864,12 @@ func writeSSE(t *testing.T, w http.ResponseWriter, chunks []chatChunk) {
 	}
 	_, _ = fmt.Fprintf(w, "data: [DONE]\n\n")
 	flusher.Flush()
+}
+
+func chatUsageChunk() chatChunk {
+	return chatChunk{
+		Usage: &usage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2},
+	}
 }
 
 func marshalJSON(t *testing.T, v any) string {

--- a/provider/openaicompat/openaicompat_test.go
+++ b/provider/openaicompat/openaicompat_test.go
@@ -696,6 +696,36 @@ func TestProvider_ChatStream_DeliversChunksThenDone(t *testing.T) {
 	}
 }
 
+func TestProvider_ChatStream_RequestsUsageInStreamOptions(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		writeSSE(t, w, []chatChunk{
+			{Model: "m", Choices: []chatChunkChoice{{
+				Delta: chatMessage{}, FinishReason: stringPtr("stop"),
+			}}},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL), WithThinkMode(provider.ThinkNone))
+	if err := p.ChatStream(context.Background(), provider.ChatRequest{Model: "m"}, func(provider.ChatResponse) error {
+		return nil
+	}); err != nil {
+		t.Fatalf("ChatStream: %v", err)
+	}
+
+	streamOptions, ok := gotBody["stream_options"].(map[string]any)
+	if !ok {
+		t.Fatalf("stream_options missing or wrong type in request body: %#v", gotBody)
+	}
+	if streamOptions["include_usage"] != true {
+		t.Fatalf("stream_options.include_usage = %#v, want true", streamOptions["include_usage"])
+	}
+}
+
 // TestProvider_ChatStream_ParsesReasoningTokens verifies the streaming Chat
 // path surfaces reasoning tokens from the final chunk's usage block. Per the
 // OpenAI streaming spec, usage is only emitted on the terminal chunk (when
@@ -1234,6 +1264,36 @@ func TestProvider_ChatStream_SSEReadError_ReturnsError(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "sse read") {
 		t.Fatalf("expected propagated SSE read error, got %v", err)
+	}
+}
+
+func TestProvider_ChatStream_ReadErrorAfterFinishReason_ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", marshalJSON(t, chatChunk{
+			Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{}, FinishReason: stringPtr("stop")}},
+		}))
+		flusher.Flush()
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", strings.Repeat("x", 1024*1024+1))
+		flusher.Flush()
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL), WithThinkMode(provider.ThinkNone))
+	var sawDone bool
+	err := p.ChatStream(context.Background(), provider.ChatRequest{Model: "m"}, func(r provider.ChatResponse) error {
+		if r.Done {
+			sawDone = true
+		}
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "sse read") {
+		t.Fatalf("expected propagated SSE read error after finish_reason, got %v", err)
+	}
+	if sawDone {
+		t.Fatal("must not synthesize successful Done when the stream errors before usage/[DONE]")
 	}
 }
 

--- a/provider/openaicompat/types.go
+++ b/provider/openaicompat/types.go
@@ -9,14 +9,19 @@ import "encoding/json"
 // chatRequest is the outbound shape for POST /v1/chat/completions. Only the
 // fields go-llm sends are declared; OpenAI ignores unknown request fields.
 type chatRequest struct {
-	Model       string        `json:"model"`
-	Messages    []chatMessage `json:"messages"`
-	Stream      bool          `json:"stream,omitempty"`
-	Temperature *float64      `json:"temperature,omitempty"`
-	TopP        *float64      `json:"top_p,omitempty"`
-	MaxTokens   int           `json:"max_tokens,omitempty"`
-	Stop        []string      `json:"stop,omitempty"`
-	Tools       []chatTool    `json:"tools,omitempty"`
+	Model         string             `json:"model"`
+	Messages      []chatMessage      `json:"messages"`
+	Stream        bool               `json:"stream,omitempty"`
+	StreamOptions *chatStreamOptions `json:"stream_options,omitempty"`
+	Temperature   *float64           `json:"temperature,omitempty"`
+	TopP          *float64           `json:"top_p,omitempty"`
+	MaxTokens     int                `json:"max_tokens,omitempty"`
+	Stop          []string           `json:"stop,omitempty"`
+	Tools         []chatTool         `json:"tools,omitempty"`
+}
+
+type chatStreamOptions struct {
+	IncludeUsage bool `json:"include_usage,omitempty"`
 }
 
 // chatMessage is the wire shape of one message in a chat request or response.


### PR DESCRIPTION
Follow-up for PR #162 review comments after merge.

Fixes:
- ChatStream now requests stream_options.include_usage=true so OpenAI-compatible servers send the terminal usage chunk.
- ChatStream now returns read/context errors observed after finish_reason before synthesizing a successful Done response.

Verification:
- go test ./...