### PR TITLE
fix(compat): emit requested chat stream usage

### DIFF
--- a/compat/chat.go
+++ b/compat/chat.go
@@ -23,21 +23,27 @@ import (
 // Fields prefixed with x_ are go-llm-specific extensions; standard OpenAI
 // SDKs ignore unknown fields so the wire remains compatible.
 type ChatCompletionRequest struct {
-	Model       string             `json:"model"`
-	Messages    []ChatMessageParam `json:"messages"`
-	Stream      bool               `json:"stream,omitempty"`
-	Temperature *float64           `json:"temperature,omitempty"`
-	TopP        *float64           `json:"top_p,omitempty"`
-	MaxTokens   *int               `json:"max_tokens,omitempty"`
-	Stop        StopSequences      `json:"stop,omitempty"` // string or []string
-	Tools       []OpenAIToolParam  `json:"tools,omitempty"`
-	ToolChoice  any                `json:"tool_choice,omitempty"`
+	Model         string             `json:"model"`
+	Messages      []ChatMessageParam `json:"messages"`
+	Stream        bool               `json:"stream,omitempty"`
+	StreamOptions *StreamOptions     `json:"stream_options,omitempty"`
+	Temperature   *float64           `json:"temperature,omitempty"`
+	TopP          *float64           `json:"top_p,omitempty"`
+	MaxTokens     *int               `json:"max_tokens,omitempty"`
+	Stop          StopSequences      `json:"stop,omitempty"` // string or []string
+	Tools         []OpenAIToolParam  `json:"tools,omitempty"`
+	ToolChoice    any                `json:"tool_choice,omitempty"`
 
 	// Extensions (amendments #6, #10). All optional.
 	UseCase     string `json:"x_use_case,omitempty"`
 	Priority    *int   `json:"x_priority,omitempty"`
 	AffinityKey string `json:"x_affinity_key,omitempty"`
 	DryRun      bool   `json:"x_dry_run,omitempty"`
+}
+
+// StreamOptions mirrors OpenAI's stream_options object.
+type StreamOptions struct {
+	IncludeUsage bool `json:"include_usage,omitempty"`
 }
 
 // ChatMessageParam is a single message in an OpenAI chat request or response.
@@ -114,15 +120,15 @@ type UsageWire struct {
 }
 
 // ChatCompletionChunk is one frame of an OpenAI-shape streaming response.
-// Each chunk carries exactly one ChatChunkChoice today. Usage is not included
-// on per-chunk frames — OpenAI emits usage only on the final frame when
-// stream_options.include_usage is set, which we don't yet expose.
+// Choice chunks carry one ChatChunkChoice. When stream_options.include_usage is
+// set, the final pre-[DONE] frame carries Usage with an empty Choices array.
 type ChatCompletionChunk struct {
 	ID      string            `json:"id"`
 	Object  string            `json:"object"` // "chat.completion.chunk"
 	Created int64             `json:"created"`
 	Model   string            `json:"model"`
 	Choices []ChatChunkChoice `json:"choices"`
+	Usage   *UsageWire        `json:"usage,omitempty"`
 
 	// Extensions.
 	Thinking string `json:"x_thinking,omitempty"`
@@ -260,7 +266,8 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		rr.Tools = tools
 	}
 	if req.Stream && !req.DryRun {
-		s.serveChatStream(w, r, rr)
+		includeUsage := req.StreamOptions != nil && req.StreamOptions.IncludeUsage
+		s.serveChatStream(w, r, rr, includeUsage)
 		return
 	}
 
@@ -355,7 +362,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 //     [DONE] sentinel so clients can detect premature EOS via its absence;
 //     context.Canceled (client disconnect) is treated as normal and its
 //     log is suppressed to prevent spam.
-func (s *Server) serveChatStream(w http.ResponseWriter, r *http.Request, rr provider.RoutingRequest) {
+func (s *Server) serveChatStream(w http.ResponseWriter, r *http.Request, rr provider.RoutingRequest, includeUsage bool) {
 	rr.RequiredCaps |= provider.CapStream
 
 	release, ok := s.semaphore.acquire(rr.Priority)
@@ -385,8 +392,14 @@ func (s *Server) serveChatStream(w http.ResponseWriter, r *http.Request, rr prov
 	id := chatResponseID(r.Context())
 	created := time.Now().Unix()
 	modelID := plan.Profile.Key.String()
+	var lastUsage UsageWire
 
 	streamErr := plan.ExecuteChatStream(r.Context(), func(chunk provider.ChatResponse) error {
+		lastUsage = UsageWire{
+			PromptTokens:     chunk.Usage.PromptTokens,
+			CompletionTokens: chunk.Usage.CompletionTokens,
+			TotalTokens:      chunk.Usage.TotalTokens,
+		}
 		delta := ChatMessageParam{
 			Role:      "assistant",
 			Content:   chunk.Content,
@@ -429,6 +442,20 @@ func (s *Server) serveChatStream(w http.ResponseWriter, r *http.Request, rr prov
 			log.Printf("compat: chat stream error rid=%s: %v", requestIDFrom(r.Context()), streamErr)
 		}
 		return
+	}
+
+	if includeUsage {
+		if err := sw.writeEvent(ChatCompletionChunk{
+			ID:      id,
+			Object:  "chat.completion.chunk",
+			Created: created,
+			Model:   modelID,
+			Choices: []ChatChunkChoice{},
+			Usage:   &lastUsage,
+		}); err != nil {
+			log.Printf("compat: chat stream usage write error rid=%s: %v", requestIDFrom(r.Context()), err)
+			return
+		}
 	}
 
 	_ = sw.writeDone()

--- a/compat/chat_test.go
+++ b/compat/chat_test.go
@@ -308,6 +308,57 @@ func TestChatCompletions_Streaming(t *testing.T) {
 	}
 }
 
+func TestChatCompletions_StreamingIncludeUsage(t *testing.T) {
+	srv, teardown := newStreamingServer(t, func(ctx context.Context, req provider.ChatRequest, fn func(provider.ChatResponse) error) error {
+		if err := fn(provider.ChatResponse{Model: req.Model, Content: "hi"}); err != nil {
+			return err
+		}
+		return fn(provider.ChatResponse{
+			Model: req.Model,
+			Done:  true,
+			Usage: provider.Usage{
+				PromptTokens:     3,
+				CompletionTokens: 5,
+				TotalTokens:      8,
+			},
+		})
+	})
+	defer teardown()
+
+	body := map[string]any{
+		"model":  "ollama/qwen3:8b",
+		"stream": true,
+		"stream_options": map[string]any{
+			"include_usage": true,
+		},
+		"messages": []map[string]string{
+			{"role": "user", "content": "hi"},
+		},
+	}
+	rec := doChatRequest(t, srv, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	chunks := decodeSSEChunks(t, rec.Body.String())
+	if len(chunks) != 3 {
+		t.Fatalf("got %d chunks, want 3: %q", len(chunks), rec.Body.String())
+	}
+	final := chunks[1]
+	if final.Choices[0].FinishReason == nil || *final.Choices[0].FinishReason != "stop" {
+		t.Fatalf("finish_reason = %v, want stop", final.Choices[0].FinishReason)
+	}
+	usageChunk := chunks[2]
+	if len(usageChunk.Choices) != 0 {
+		t.Fatalf("usage chunk choices = %d, want 0", len(usageChunk.Choices))
+	}
+	if usageChunk.Usage == nil {
+		t.Fatal("usage chunk missing usage")
+	}
+	if usageChunk.Usage.PromptTokens != 3 || usageChunk.Usage.CompletionTokens != 5 || usageChunk.Usage.TotalTokens != 8 {
+		t.Fatalf("usage = %+v, want 3/5/8", *usageChunk.Usage)
+	}
+}
+
 // TestChatCompletions_Streaming_ModelQualified verifies that every streaming
 // chunk carries the qualified "provider/model" form in the Model field,
 // matching the non-streaming branch's plan.Profile.Key.String() convention.


### PR DESCRIPTION
Follow-up for the post-merge PR #163 review comment.

Fixes:
- compat chat completions now parse stream_options.include_usage.
- When requested, streaming chat emits the OpenAI-style usage-only chunk with empty choices before [DONE].

Verification:
- go test ./...