### PR TITLE
feat: capture native reasoning text from Ollama and openai-compat backends

### DIFF
--- a/cmd/llm-bench/candidate_transport.go
+++ b/cmd/llm-bench/candidate_transport.go
@@ -30,7 +30,13 @@ type candidateChatClient interface {
 }
 
 type candidateChatResponse struct {
-	Message                ollama.ChatMessage
+	Message ollama.ChatMessage
+	// Thinking is the reasoning text a backend separated from the answer
+	// (Ollama message.thinking / openai-compat reasoning_content). It is kept
+	// out of Message deliberately: Message feeds back into conversation history
+	// and must stay free of reasoning to preserve replay determinism. The
+	// runner maps this onto the transcript's Turn.Thinking. See #160.
+	Thinking               string
 	PromptEvalCount        int
 	EvalCount              int
 	ThinkingTokens         int
@@ -87,8 +93,15 @@ func (c ollamaCandidateClient) Chat(ctx context.Context, req ollama.ChatRequest)
 	if resp == nil {
 		return candidateChatResponse{}, fmt.Errorf("ollama candidate: nil response")
 	}
+	// Lift Ollama's separate reasoning text out of the reply message so it is
+	// captured for the transcript without leaking back into conversation
+	// history when the message is replayed in later turns.
+	msg := resp.Message
+	thinking := msg.Thinking
+	msg.Thinking = ""
 	return candidateChatResponse{
-		Message:         resp.Message,
+		Message:         msg,
+		Thinking:        thinking,
 		PromptEvalCount: resp.PromptEvalCount,
 		EvalCount:       resp.EvalCount,
 	}, nil
@@ -126,6 +139,10 @@ func (c openAICompatCandidateClient) Chat(ctx context.Context, req ollama.ChatRe
 			Content:   presp.Content,
 			ToolCalls: toolCalls,
 		},
+		// presp.Thinking holds reasoning_content (native) or, failing that,
+		// inline-extracted <think> text — captured separately from Message so it
+		// reaches the transcript without polluting replayed history.
+		Thinking:               presp.Thinking,
 		PromptEvalCount:        presp.Usage.PromptTokens,
 		EvalCount:              presp.Usage.CompletionTokens,
 		ThinkingTokens:         reasoning,

--- a/cmd/llm-bench/candidate_transport.go
+++ b/cmd/llm-bench/candidate_transport.go
@@ -67,10 +67,9 @@ func newCandidateTransport(target ModelTarget, opts candidateTransportOptions) (
 		// Leave ThinkMode at its default (extract). A reasoning model served via
 		// llama.cpp can emit <think>...</think> inline in content; extraction
 		// strips it so the scored transcript holds the final answer rather than
-		// serving-stack-specific reasoning formatting. This matches the Ollama
-		// candidate path, where the server separates reasoning into a field the
-		// raw client drops. Reasoning text is discarded either way; isolating
-		// reasoning *tokens* is tracked separately (#158).
+		// serving-stack-specific reasoning formatting. The stripped reasoning is
+		// carried separately on candidateChatResponse.Thinking so replay history
+		// stays reasoning-free while transcripts retain the reasoning text.
 		prov := openaicompat.NewProvider(
 			openaicompat.NewClient(baseURL, clientOpts...),
 			openaicompat.WithProviderName(providerName),

--- a/cmd/llm-bench/candidate_transport_test.go
+++ b/cmd/llm-bench/candidate_transport_test.go
@@ -226,6 +226,93 @@ func TestOpenAICompatCandidateClient_ChatZeroReasoningTokensAreComputed(t *testi
 	}
 }
 
+// When the server separates reasoning into the structured reasoning_content
+// field (rather than inline <think> tags), the candidate must capture that text
+// as candidateChatResponse.Thinking while keeping it OUT of Message — the
+// reply Message feeds back into conversation history and must stay free of
+// reasoning so replay determinism is preserved. See #160.
+func TestOpenAICompatCandidateClient_CapturesReasoningContent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-test",
+			"model":"served",
+			"choices":[{
+				"index":0,
+				"message":{"role":"assistant","content":"final answer","reasoning_content":"native chain of thought"},
+				"finish_reason":"stop"
+			}],
+			"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}
+		}`))
+	}))
+	defer srv.Close()
+
+	tr, err := newCandidateTransport(ModelTarget{Display: "openai-compat/fake", Provider: "openai-compat", Model: "fake"}, candidateTransportOptions{
+		openAICompatBaseURL: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("newCandidateTransport: %v", err)
+	}
+
+	resp, err := tr.chat.Chat(context.Background(), ollama.ChatRequest{
+		Model:    "fake",
+		Messages: []ollama.ChatMessage{{Role: "user", Content: "q"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Thinking != "native chain of thought" {
+		t.Errorf("Thinking = %q, want native reasoning_content captured", resp.Thinking)
+	}
+	if resp.Message.Content != "final answer" {
+		t.Errorf("Message.Content = %q, want %q", resp.Message.Content, "final answer")
+	}
+	if resp.Message.Thinking != "" {
+		t.Errorf("Message.Thinking = %q, want empty (reasoning is carried separately, not in the history message)", resp.Message.Thinking)
+	}
+}
+
+// The Ollama candidate uses the raw client, which now deserializes the separate
+// message.thinking field. The transport must lift that text into
+// candidateChatResponse.Thinking and clear it from Message so conversation
+// history stays free of reasoning. See #160.
+func TestOllamaCandidateClient_CapturesNativeThinking(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"model":"served",
+			"message":{"role":"assistant","content":"final answer","thinking":"native reasoning"},
+			"done":true,
+			"prompt_eval_count":5,
+			"eval_count":3
+		}`))
+	}))
+	defer srv.Close()
+
+	tr, err := newCandidateTransport(ModelTarget{Display: "ollama/served", Provider: defaultBenchProvider, Model: "served"}, candidateTransportOptions{
+		ollamaURL: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("newCandidateTransport: %v", err)
+	}
+
+	resp, err := tr.chat.Chat(context.Background(), ollama.ChatRequest{
+		Model:    "served",
+		Messages: []ollama.ChatMessage{{Role: "user", Content: "q"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Thinking != "native reasoning" {
+		t.Errorf("Thinking = %q, want native message.thinking captured", resp.Thinking)
+	}
+	if resp.Message.Content != "final answer" {
+		t.Errorf("Message.Content = %q, want %q", resp.Message.Content, "final answer")
+	}
+	if resp.Message.Thinking != "" {
+		t.Errorf("Message.Thinking = %q, want it cleared so conversation history stays free of reasoning text", resp.Message.Thinking)
+	}
+}
+
 // A reasoning model served via llama.cpp can emit <think>...</think> inline in
 // content. The candidate transport must strip it so the scored transcript holds
 // the final answer, not serving-stack-specific reasoning formatting.
@@ -261,5 +348,11 @@ func TestOpenAICompatCandidateClient_StripsInlineThinkTags(t *testing.T) {
 	}
 	if resp.Message.Content != "final answer" {
 		t.Fatalf("content = %q; want %q (inline <think> reasoning must be stripped)", resp.Message.Content, "final answer")
+	}
+	// The reasoning stripped from Content is now captured (it used to be
+	// discarded), so a backend that inlines <think> tags reaches transcript
+	// parity with one that uses a structured reasoning field. See #160.
+	if resp.Thinking != "secret chain of thought" {
+		t.Errorf("Thinking = %q; want the stripped reasoning captured rather than dropped", resp.Thinking)
 	}
 }

--- a/cmd/llm-bench/replay_test.go
+++ b/cmd/llm-bench/replay_test.go
@@ -179,6 +179,46 @@ func TestReplayWith_OpenAICompatStripsThinkNoResidueNote(t *testing.T) {
 	}
 }
 
+// When a backend separates reasoning into its own field, replayWith must carry
+// that text all the way into the transcript Turn.Thinking — captured, not
+// dropped — while Turn.Content stays the clean final answer that gets scored.
+// See #160.
+func TestReplayWith_CapturesNativeReasoningIntoTranscript(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-test",
+			"model":"served",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"final","reasoning_content":"why final"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	tr, err := newCandidateTransport(ModelTarget{Display: "openai-compat/fake", Provider: "openai-compat", Model: "fake"}, candidateTransportOptions{
+		openAICompatBaseURL: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("newCandidateTransport: %v", err)
+	}
+
+	trace := Trace{ID: "reason-capture", System: "sys", Turns: []Turn{{Role: "user", Content: "q"}}}
+	out, err := replayWith(context.Background(), tr.chat, "fake", trace, replayOptions{})
+	if err != nil {
+		t.Fatalf("replayWith: %v", err)
+	}
+	if len(out.Transcript) == 0 {
+		t.Fatal("transcript empty; want one assistant turn")
+	}
+	last := out.Transcript[len(out.Transcript)-1]
+	if last.Thinking != "why final" {
+		t.Errorf("transcript Turn.Thinking = %q, want reasoning text captured end-to-end", last.Thinking)
+	}
+	if last.Content != "final" {
+		t.Errorf("transcript Turn.Content = %q, want %q (clean answer)", last.Content, "final")
+	}
+}
+
 func TestReplaySupportsMultipleUserTurns(t *testing.T) {
 	log := &requestLog{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/llm-bench/runner.go
+++ b/cmd/llm-bench/runner.go
@@ -350,6 +350,9 @@ func chatReplayTurn(ctx context.Context, client candidateChatClient, model strin
 	if err != nil {
 		return ollama.ChatMessage{}, Turn{}, latencyMs, tokenUsage{}, err
 	}
+	// Capture reasoning text in the transcript turn (kept separate from Content
+	// and out of the history message msg, which feeds later turns). See #160.
+	turn.Thinking = resp.Thinking
 	usage := tokenUsage{
 		PromptEval:       resp.PromptEvalCount,
 		Gen:              resp.EvalCount,

--- a/cmd/llm-bench/trace.go
+++ b/cmd/llm-bench/trace.go
@@ -28,9 +28,15 @@ type Trace struct {
 
 // Turn represents a single role/content pair, optionally with tool calls or
 // tool results. Preserved verbatim so the replay is deterministic.
+//
+// Thinking is the reasoning text a candidate separated from its answer
+// (captured on assistant transcript turns); it is kept distinct from Content so
+// the scored answer stays clean. It is omitempty, so trace fixtures that never
+// set it are unaffected.
 type Turn struct {
 	Role       string          `json:"role"`
 	Content    string          `json:"content,omitempty"`
+	Thinking   string          `json:"thinking,omitempty"`
 	ToolCalls  []ToolCall      `json:"tool_calls,omitempty"`
 	ToolCallID string          `json:"tool_call_id,omitempty"`
 	Name       string          `json:"name,omitempty"`

--- a/ollama/chat.go
+++ b/ollama/chat.go
@@ -15,6 +15,7 @@ func (c *Client) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, erro
 		return nil, fmt.Errorf("ollama: chat: at least one message is required")
 	}
 	req.Stream = false
+	req = stripMessageThinking(req)
 	var resp ChatResponse
 	if err := c.doJSON(ctx, "POST", "/api/chat", req, &resp); err != nil {
 		return nil, fmt.Errorf("ollama: chat: %w", err)
@@ -36,6 +37,7 @@ func (c *Client) ChatStream(ctx context.Context, req ChatRequest, fn func(ChatRe
 		return fmt.Errorf("ollama: chat stream: callback function is required")
 	}
 	req.Stream = true
+	req = stripMessageThinking(req)
 	return c.doStream(ctx, "/api/chat", req, func(raw json.RawMessage) error {
 		var resp ChatResponse
 		if err := json.Unmarshal(raw, &resp); err != nil {
@@ -43,4 +45,21 @@ func (c *Client) ChatStream(ctx context.Context, req ChatRequest, fn func(ChatRe
 		}
 		return fn(resp)
 	})
+}
+
+func stripMessageThinking(req ChatRequest) ChatRequest {
+	var msgs []ChatMessage
+	for i, msg := range req.Messages {
+		if msg.Thinking == "" {
+			continue
+		}
+		if msgs == nil {
+			msgs = append([]ChatMessage(nil), req.Messages...)
+		}
+		msgs[i].Thinking = ""
+	}
+	if msgs != nil {
+		req.Messages = msgs
+	}
+	return req
 }

--- a/ollama/chat.go
+++ b/ollama/chat.go
@@ -15,7 +15,6 @@ func (c *Client) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, erro
 		return nil, fmt.Errorf("ollama: chat: at least one message is required")
 	}
 	req.Stream = false
-	req = stripMessageThinking(req)
 	var resp ChatResponse
 	if err := c.doJSON(ctx, "POST", "/api/chat", req, &resp); err != nil {
 		return nil, fmt.Errorf("ollama: chat: %w", err)
@@ -37,7 +36,6 @@ func (c *Client) ChatStream(ctx context.Context, req ChatRequest, fn func(ChatRe
 		return fmt.Errorf("ollama: chat stream: callback function is required")
 	}
 	req.Stream = true
-	req = stripMessageThinking(req)
 	return c.doStream(ctx, "/api/chat", req, func(raw json.RawMessage) error {
 		var resp ChatResponse
 		if err := json.Unmarshal(raw, &resp); err != nil {
@@ -45,21 +43,4 @@ func (c *Client) ChatStream(ctx context.Context, req ChatRequest, fn func(ChatRe
 		}
 		return fn(resp)
 	})
-}
-
-func stripMessageThinking(req ChatRequest) ChatRequest {
-	var msgs []ChatMessage
-	for i, msg := range req.Messages {
-		if msg.Thinking == "" {
-			continue
-		}
-		if msgs == nil {
-			msgs = append([]ChatMessage(nil), req.Messages...)
-		}
-		msgs[i].Thinking = ""
-	}
-	if msgs != nil {
-		req.Messages = msgs
-	}
-	return req
 }

--- a/ollama/chat_test.go
+++ b/ollama/chat_test.go
@@ -56,14 +56,14 @@ func TestChat(t *testing.T) {
 	}
 }
 
-func TestChatDoesNotSendMessageThinking(t *testing.T) {
+func TestChatSendsMessageThinking(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req ChatRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Fatalf("decode request: %v", err)
 		}
-		if got := req.Messages[0].Thinking; got != "" {
-			t.Fatalf("request message thinking = %q; want empty because thinking is response-only", got)
+		if got := req.Messages[0].Thinking; got != "private reasoning" {
+			t.Fatalf("request message thinking = %q; want preserved thinking history", got)
 		}
 
 		_ = json.NewEncoder(w).Encode(ChatResponse{
@@ -134,14 +134,14 @@ func TestChatStream(t *testing.T) {
 	}
 }
 
-func TestChatStreamDoesNotSendMessageThinking(t *testing.T) {
+func TestChatStreamSendsMessageThinking(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req ChatRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Fatalf("decode request: %v", err)
 		}
-		if got := req.Messages[0].Thinking; got != "" {
-			t.Fatalf("stream request message thinking = %q; want empty because thinking is response-only", got)
+		if got := req.Messages[0].Thinking; got != "private reasoning" {
+			t.Fatalf("stream request message thinking = %q; want preserved thinking history", got)
 		}
 
 		_, _ = fmt.Fprint(w, `{"model":"test-model","message":{"role":"assistant","content":"ok"},"done":false}`+"\n")

--- a/ollama/chat_test.go
+++ b/ollama/chat_test.go
@@ -56,6 +56,34 @@ func TestChat(t *testing.T) {
 	}
 }
 
+func TestChatDoesNotSendMessageThinking(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if got := req.Messages[0].Thinking; got != "" {
+			t.Fatalf("request message thinking = %q; want empty because thinking is response-only", got)
+		}
+
+		_ = json.NewEncoder(w).Encode(ChatResponse{
+			Model:   "test-model",
+			Message: ChatMessage{Role: "assistant", Content: "ok"},
+			Done:    true,
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	_, err := c.Chat(context.Background(), ChatRequest{
+		Model:    "test-model",
+		Messages: []ChatMessage{{Role: "assistant", Content: "answer", Thinking: "private reasoning"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat() error: %v", err)
+	}
+}
+
 func TestChatStream(t *testing.T) {
 	chunks := []ChatResponse{
 		{Model: "test-model", Message: ChatMessage{Role: "assistant", Content: "Hel"}, Done: false},
@@ -103,6 +131,33 @@ func TestChatStream(t *testing.T) {
 	}
 	if !received[2].Done {
 		t.Error("last chunk should have done=true")
+	}
+}
+
+func TestChatStreamDoesNotSendMessageThinking(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if got := req.Messages[0].Thinking; got != "" {
+			t.Fatalf("stream request message thinking = %q; want empty because thinking is response-only", got)
+		}
+
+		_, _ = fmt.Fprint(w, `{"model":"test-model","message":{"role":"assistant","content":"ok"},"done":false}`+"\n")
+		_, _ = fmt.Fprint(w, `{"model":"test-model","message":{"role":"assistant"},"done":true}`+"\n")
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	err := c.ChatStream(context.Background(), ChatRequest{
+		Model:    "test-model",
+		Messages: []ChatMessage{{Role: "assistant", Content: "answer", Thinking: "private reasoning"}},
+	}, func(ChatResponse) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ChatStream() error: %v", err)
 	}
 }
 

--- a/ollama/chat_test.go
+++ b/ollama/chat_test.go
@@ -106,6 +106,70 @@ func TestChatStream(t *testing.T) {
 	}
 }
 
+// TestChatPopulatesMessageThinking verifies the raw client maps Ollama's
+// separate message.thinking field (emitted by reasoning models in thinking
+// mode) onto ChatMessage.Thinking, keeping it distinct from the final answer
+// in Content. Before this field existed the reasoning text was silently
+// dropped by the JSON decoder.
+func TestChatPopulatesMessageThinking(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"model":"test-model",
+			"message":{"role":"assistant","content":"The answer is 42.","thinking":"Let me reason about this."},
+			"done":true
+		}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	resp, err := c.Chat(context.Background(), ChatRequest{
+		Model:    "test-model",
+		Messages: []ChatMessage{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat() error: %v", err)
+	}
+	if resp.Message.Thinking != "Let me reason about this." {
+		t.Errorf("Message.Thinking = %q, want %q", resp.Message.Thinking, "Let me reason about this.")
+	}
+	if resp.Message.Content != "The answer is 42." {
+		t.Errorf("Message.Content = %q, want %q", resp.Message.Content, "The answer is 42.")
+	}
+}
+
+// TestChatStreamPopulatesMessageThinking verifies thinking deltas stream
+// incrementally on message.thinking, separate from content deltas. Ollama
+// emits reasoning first, then the answer.
+func TestChatStreamPopulatesMessageThinking(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, `{"model":"m","message":{"role":"assistant","thinking":"Let me "},"done":false}`+"\n")
+		_, _ = fmt.Fprint(w, `{"model":"m","message":{"role":"assistant","thinking":"think."},"done":false}`+"\n")
+		_, _ = fmt.Fprint(w, `{"model":"m","message":{"role":"assistant","content":"Done."},"done":false}`+"\n")
+		_, _ = fmt.Fprint(w, `{"model":"m","message":{"role":"assistant","content":""},"done":true}`+"\n")
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	var thinking, content string
+	err := c.ChatStream(context.Background(), ChatRequest{
+		Model:    "m",
+		Messages: []ChatMessage{{Role: "user", Content: "Hi"}},
+	}, func(resp ChatResponse) error {
+		thinking += resp.Message.Thinking
+		content += resp.Message.Content
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ChatStream() error: %v", err)
+	}
+	if thinking != "Let me think." {
+		t.Errorf("accumulated thinking = %q, want %q", thinking, "Let me think.")
+	}
+	if content != "Done." {
+		t.Errorf("accumulated content = %q, want %q", content, "Done.")
+	}
+}
+
 func TestChatStreamCallbackError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		chunk := ChatResponse{

--- a/ollama/types.go
+++ b/ollama/types.go
@@ -40,6 +40,7 @@ type ToolCallFunction struct {
 type ChatMessage struct {
 	Role       string     `json:"role"` // system, user, assistant, tool
 	Content    string     `json:"content"`
+	Thinking   string     `json:"thinking,omitempty"`     // reasoning text some models emit separately from content in Ollama's thinking mode
 	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`   // present when assistant invokes tools
 	ToolName   string     `json:"tool_name,omitempty"`    // set when role="tool" (result)
 	ToolCallID string     `json:"tool_call_id,omitempty"` // correlates result with originating call

--- a/provider/ollama.go
+++ b/provider/ollama.go
@@ -198,10 +198,19 @@ func (p *OllamaProvider) Chat(ctx context.Context, req ChatRequest) (*ChatRespon
 		return nil, fmt.Errorf("provider: ollama: chat: %w", err)
 	}
 
+	// Ollama's separate message.thinking field, when present, is authoritative —
+	// the server already split reasoning from the answer, so it is captured
+	// unconditionally (independent of think mode, mirroring how reasoning tokens
+	// are captured). Inline <think>-tag extraction remains the fallback for the
+	// folded-into-content case, and still cleans Content either way.
 	content := oResp.Message.Content
-	thinking := ""
+	thinking := oResp.Message.Thinking
 	if p.shouldExtractThinking(req.Options) {
-		content, thinking = ExtractThinking(oResp.Message.Content, p.thinkTags)
+		var inline string
+		content, inline = ExtractThinking(oResp.Message.Content, p.thinkTags)
+		if thinking == "" {
+			thinking = inline
+		}
 	}
 
 	return &ChatResponse{
@@ -291,6 +300,19 @@ func (p *OllamaProvider) ChatStream(ctx context.Context, req ChatRequest, fn fun
 
 		if len(oResp.Message.ToolCalls) > 0 {
 			lastToolCalls = toProviderToolCalls(oResp.Message.ToolCalls)
+		}
+
+		// Emit Ollama's separate reasoning field as a Thinking delta as it
+		// arrives, independent of the inline-tag parser which only sees content.
+		// Unlike the non-streaming path (native field takes precedence over
+		// inline <think> tags), a stream can't reconcile the two mid-flight, so a
+		// backend emitting both would surface both — harmless since backends use
+		// one mechanism or the other.
+		if oResp.Message.Thinking != "" {
+			if err := fn(ChatResponse{Model: oResp.Model, Provider: p.name, Thinking: oResp.Message.Thinking}); err != nil {
+				callbackErr = err
+				return err
+			}
 		}
 
 		// Feed content through the think parser.

--- a/provider/ollama_test.go
+++ b/provider/ollama_test.go
@@ -444,6 +444,122 @@ func TestOllamaProvider_Chat_ThinkToggleDisabled(t *testing.T) {
 	}
 }
 
+// TestOllamaProvider_Chat_SurfacesNativeThinking verifies that Ollama's
+// separate message.thinking field is surfaced through ChatResponse.Thinking,
+// with Content left as the clean final answer — no inline tags to strip.
+func TestOllamaProvider_Chat_SurfacesNativeThinking(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := ollama.ChatResponse{
+			Model:   "qwen3:8b",
+			Message: ollama.ChatMessage{Role: "assistant", Content: "The answer is 42.", Thinking: "Let me reason about this."},
+			Done:    true,
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	p := NewOllamaProvider(c)
+
+	resp, err := p.Chat(context.Background(), ChatRequest{
+		Model:    "qwen3:8b",
+		Messages: []ChatMessage{{Role: "user", Content: "What is the meaning of life?"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat() error: %v", err)
+	}
+	if resp.Thinking != "Let me reason about this." {
+		t.Errorf("Thinking = %q, want native message.thinking surfaced", resp.Thinking)
+	}
+	if resp.Content != "The answer is 42." {
+		t.Errorf("Content = %q, want content unchanged when reasoning is in its own field", resp.Content)
+	}
+}
+
+// TestOllamaProvider_Chat_NativeThinkingWinsOverInline locks the precedence:
+// the structured message.thinking field is authoritative over inline <think>
+// tags, which are still stripped from Content.
+func TestOllamaProvider_Chat_NativeThinkingWinsOverInline(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := ollama.ChatResponse{
+			Model:   "qwen3:8b",
+			Message: ollama.ChatMessage{Role: "assistant", Content: "<think>inline</think>The answer is 42.", Thinking: "structured reasoning"},
+			Done:    true,
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	p := NewOllamaProvider(c)
+
+	resp, err := p.Chat(context.Background(), ChatRequest{
+		Model:    "qwen3:8b",
+		Messages: []ChatMessage{{Role: "user", Content: "Q"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat() error: %v", err)
+	}
+	if resp.Thinking != "structured reasoning" {
+		t.Errorf("Thinking = %q, want structured message.thinking to win over inline tags", resp.Thinking)
+	}
+	if resp.Content != "The answer is 42." {
+		t.Errorf("Content = %q, want inline tags still stripped", resp.Content)
+	}
+}
+
+// TestOllamaProvider_ChatStream_SurfacesNativeThinking verifies streaming
+// message.thinking deltas are emitted as Thinking chunks, separate from content
+// chunks. Ollama streams reasoning before the answer.
+func TestOllamaProvider_ChatStream_SurfacesNativeThinking(t *testing.T) {
+	chunks := []ollama.ChatResponse{
+		{Model: "qwen3:8b", Message: ollama.ChatMessage{Role: "assistant", Thinking: "Let me "}, Done: false},
+		{Model: "qwen3:8b", Message: ollama.ChatMessage{Role: "assistant", Thinking: "think."}, Done: false},
+		{Model: "qwen3:8b", Message: ollama.ChatMessage{Role: "assistant", Content: "The answer is 42."}, Done: false},
+		{Model: "qwen3:8b", Message: ollama.ChatMessage{Role: "assistant", Content: ""}, Done: true},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		for _, chunk := range chunks {
+			data, _ := json.Marshal(chunk)
+			_, _ = fmt.Fprintf(w, "%s\n", data)
+		}
+	}))
+	defer srv.Close()
+
+	c := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	p := NewOllamaProvider(c)
+
+	var thinkingChunks, contentChunks []string
+	var gotDone bool
+	err := p.ChatStream(context.Background(), ChatRequest{
+		Model:    "qwen3:8b",
+		Messages: []ChatMessage{{Role: "user", Content: "Q"}},
+	}, func(resp ChatResponse) error {
+		if resp.Thinking != "" {
+			thinkingChunks = append(thinkingChunks, resp.Thinking)
+		}
+		if resp.Content != "" {
+			contentChunks = append(contentChunks, resp.Content)
+		}
+		if resp.Done {
+			gotDone = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ChatStream() error: %v", err)
+	}
+	if !gotDone {
+		t.Error("expected final chunk with Done=true")
+	}
+	if thinking := strings.Join(thinkingChunks, ""); thinking != "Let me think." {
+		t.Errorf("accumulated thinking = %q, want %q", thinking, "Let me think.")
+	}
+	if content := strings.Join(contentChunks, ""); content != "The answer is 42." {
+		t.Errorf("accumulated content = %q, want %q", content, "The answer is 42.")
+	}
+}
+
 func TestOllamaProvider_Chat_WithOptions(t *testing.T) {
 	var receivedOpts ollama.ModelOptions
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/provider/openaicompat/openaicompat.go
+++ b/provider/openaicompat/openaicompat.go
@@ -185,10 +185,20 @@ func (p *Provider) Chat(ctx context.Context, req provider.ChatRequest) (*provide
 	}
 	msg := resp.Choices[0].Message
 
+	// The structured reasoning_content field, when present, is authoritative —
+	// the server has already separated reasoning from the answer, so it is
+	// captured unconditionally (independent of think mode, mirroring how #158
+	// captures reasoning tokens). Inline <think>-tag extraction remains the
+	// fallback for servers that don't separate reasoning, and still cleans
+	// Content either way.
 	content := msg.Content
-	thinking := ""
+	thinking := msg.ReasoningContent
 	if p.shouldExtractThinking(req.Options) {
-		content, thinking = provider.ExtractThinking(msg.Content, p.thinkTags)
+		var inline string
+		content, inline = provider.ExtractThinking(msg.Content, p.thinkTags)
+		if thinking == "" {
+			thinking = inline
+		}
 	}
 
 	model := resp.Model
@@ -318,6 +328,19 @@ func (p *Provider) ChatStream(ctx context.Context, req provider.ChatRequest, fn 
 
 		if len(choice.Delta.ToolCalls) > 0 {
 			lastToolCalls = toolCalls.Add(choice.Delta.ToolCalls)
+		}
+		// Native reasoning text arrives on its own delta field, separate from
+		// content and from the inline-tag parser. Emit it directly as a Thinking
+		// delta, unconditionally — the server has already classified it. Unlike
+		// the non-streaming path (native field takes precedence over inline
+		// <think> tags), a stream can't reconcile the two mid-flight, so a
+		// backend emitting both would surface both. Backends use one mechanism
+		// or the other, so this asymmetry is harmless in practice.
+		if choice.Delta.ReasoningContent != "" {
+			if err := fn(provider.ChatResponse{Model: lastModel, Provider: p.name, Thinking: choice.Delta.ReasoningContent}); err != nil {
+				callbackErr = err
+				break
+			}
 		}
 		if choice.Delta.Content != "" {
 			if err := parser.Process(choice.Delta.Content); err != nil {

--- a/provider/openaicompat/openaicompat_test.go
+++ b/provider/openaicompat/openaicompat_test.go
@@ -424,6 +424,140 @@ func TestProvider_Chat_ThinkNone_KeepsTagsInline(t *testing.T) {
 	}
 }
 
+// TestProvider_Chat_SurfacesNativeReasoningContent verifies that when a backend
+// separates reasoning into the structured message.reasoning_content field
+// (vLLM / DeepSeek / some llama-server builds), the text is surfaced through
+// ChatResponse.Thinking and Content stays the clean final answer — no inline
+// tag stripping needed because the server already separated the two.
+func TestProvider_Chat_SurfacesNativeReasoningContent(t *testing.T) {
+	srv := newMockServer(t, mockServerOpts{
+		chatResponse: chatResponse{
+			Model: "deepseek-r1",
+			Choices: []chatChoice{{
+				Message: chatMessage{
+					Role:             "assistant",
+					Content:          "final answer",
+					ReasoningContent: "native chain of thought",
+				},
+				FinishReason: "stop",
+			}},
+		},
+	})
+	defer srv.close()
+
+	p := NewProvider(NewClient(srv.url))
+	resp, err := p.Chat(context.Background(), provider.ChatRequest{Model: "deepseek-r1"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Thinking != "native chain of thought" {
+		t.Errorf("Thinking = %q, want native reasoning_content surfaced", resp.Thinking)
+	}
+	if resp.Content != "final answer" {
+		t.Errorf("Content = %q, want %q (content unchanged when reasoning is in its own field)", resp.Content, "final answer")
+	}
+}
+
+// TestProvider_Chat_NativeReasoningWinsOverInline locks the precedence rule: a
+// structured reasoning_content field is authoritative over inline <think> tags
+// (the structured field is unambiguous; inline extraction is a heuristic). The
+// inline tags are still stripped from Content so the answer is clean.
+func TestProvider_Chat_NativeReasoningWinsOverInline(t *testing.T) {
+	srv := newMockServer(t, mockServerOpts{
+		chatResponse: chatResponse{
+			Choices: []chatChoice{{
+				Message: chatMessage{
+					Role:             "assistant",
+					Content:          "<think>inline</think>final answer",
+					ReasoningContent: "structured reasoning",
+				},
+			}},
+		},
+	})
+	defer srv.close()
+
+	p := NewProvider(NewClient(srv.url))
+	resp, err := p.Chat(context.Background(), provider.ChatRequest{Model: "m"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Thinking != "structured reasoning" {
+		t.Errorf("Thinking = %q, want structured reasoning_content to win over inline tags", resp.Thinking)
+	}
+	if resp.Content != "final answer" {
+		t.Errorf("Content = %q, want inline tags still stripped from content", resp.Content)
+	}
+}
+
+// TestProvider_Chat_NativeReasoningCapturedWithThinkNone verifies the
+// structured field is captured even when inline-tag extraction is disabled
+// (ThinkNone). This mirrors #158, where reasoning *tokens* are captured
+// regardless of think mode — the gate exists to avoid misparsing content, a
+// risk that does not apply to a dedicated wire field.
+func TestProvider_Chat_NativeReasoningCapturedWithThinkNone(t *testing.T) {
+	srv := newMockServer(t, mockServerOpts{
+		chatResponse: chatResponse{
+			Choices: []chatChoice{{
+				Message: chatMessage{Role: "assistant", Content: "answer", ReasoningContent: "native reasoning"},
+			}},
+		},
+	})
+	defer srv.close()
+
+	p := NewProvider(NewClient(srv.url), WithThinkMode(provider.ThinkNone))
+	resp, err := p.Chat(context.Background(), provider.ChatRequest{Model: "m"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Thinking != "native reasoning" {
+		t.Errorf("Thinking = %q, want native reasoning captured even with ThinkNone", resp.Thinking)
+	}
+	if resp.Content != "answer" {
+		t.Errorf("Content = %q, want %q", resp.Content, "answer")
+	}
+}
+
+// TestProvider_ChatStream_SurfacesNativeReasoningContent verifies streaming
+// delta.reasoning_content is emitted as Thinking deltas, separate from content
+// deltas, mirroring the OllamaProvider streaming contract.
+func TestProvider_ChatStream_SurfacesNativeReasoningContent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeSSE(t, w, []chatChunk{
+			{Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{ReasoningContent: "step one "}}}},
+			{Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{ReasoningContent: "step two"}}}},
+			{Model: "m", Choices: []chatChunkChoice{{Delta: chatMessage{Content: "final"}}}},
+			{Model: "m", Choices: []chatChunkChoice{{
+				Delta: chatMessage{}, FinishReason: stringPtr("stop"),
+			}}, Usage: &usage{PromptTokens: 1, CompletionTokens: 2, TotalTokens: 3}},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL), WithThinkMode(provider.ThinkNone))
+	var thinking, content string
+	var gotDone bool
+	err := p.ChatStream(context.Background(), provider.ChatRequest{Model: "m"}, func(r provider.ChatResponse) error {
+		thinking += r.Thinking
+		content += r.Content
+		if r.Done {
+			gotDone = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ChatStream: %v", err)
+	}
+	if !gotDone {
+		t.Error("expected a Done chunk")
+	}
+	if thinking != "step one step two" {
+		t.Errorf("accumulated thinking = %q, want %q", thinking, "step one step two")
+	}
+	if content != "final" {
+		t.Errorf("accumulated content = %q, want %q", content, "final")
+	}
+}
+
 func TestProvider_Chat_NoChoices_ReturnsError(t *testing.T) {
 	srv := newMockServer(t, mockServerOpts{
 		chatResponse: chatResponse{ID: "empty", Choices: nil},

--- a/provider/openaicompat/types.go
+++ b/provider/openaicompat/types.go
@@ -25,12 +25,19 @@ type chatStreamOptions struct {
 }
 
 // chatMessage is the wire shape of one message in a chat request or response.
+//
+// ReasoningContent carries reasoning text that some servers (vLLM, DeepSeek,
+// certain llama-server builds) separate from the answer instead of emitting it
+// inline as <think> tags. On responses it appears on the message; on streaming
+// it appears on the delta. It is response-only enrichment — outbound requests
+// leave it empty (omitempty), so toWire* paths never need to clear it.
 type chatMessage struct {
-	Role       string         `json:"role"`
-	Content    string         `json:"content"`
-	Name       string         `json:"name,omitempty"`
-	ToolCallID string         `json:"tool_call_id,omitempty"`
-	ToolCalls  []chatToolCall `json:"tool_calls,omitempty"`
+	Role             string         `json:"role"`
+	Content          string         `json:"content"`
+	ReasoningContent string         `json:"reasoning_content,omitempty"`
+	Name             string         `json:"name,omitempty"`
+	ToolCallID       string         `json:"tool_call_id,omitempty"`
+	ToolCalls        []chatToolCall `json:"tool_calls,omitempty"`
 }
 
 // chatTool is the OpenAI function-calling tool descriptor.


### PR DESCRIPTION
## Summary

Closes #160. Reasoning models can separate their chain-of-thought from the final answer into a structured wire field — Ollama's `message.thinking` and OpenAI-compat's `message.reasoning_content` (vLLM / DeepSeek / some llama-server builds) — rather than emitting it inline as `<think>` tags. go-llm previously dropped that field, capturing reasoning only via inline-tag extraction (#136/#161) and reasoning *tokens* (#158); the reasoning *text* from native fields was lost. This is the text analog of #158 (Option C, reasoning-text parity).

## What changed (the four layers)

- **`ollama.ChatMessage`** gains a `Thinking` field mapping the wire `message.thinking`, deserialized by the raw client in both streaming and non-streaming chat.
- **openaicompat wire `chatMessage`** gains `ReasoningContent` mapping `reasoning_content` (on the message for non-streaming, on the delta for streaming).
- **`provider.ChatResponse.Thinking`** now surfaces both native fields, in `OllamaProvider` and the openaicompat `Provider`, streaming and non-streaming. The structured field is authoritative and captured **unconditionally** (independent of think mode, mirroring how #158 captures reasoning tokens); inline `<think>`-tag extraction remains the fallback and still cleans `Content`.
- **llm-bench candidates** capture the reasoning text: it rides on `candidateChatResponse.Thinking` (kept out of the reply `Message` so replayed conversation history stays free of reasoning) and is threaded into the transcript via a new `Turn.Thinking`.

## Design notes

- **Precedence:** native structured field wins over inline `<think>` extraction (the field is unambiguous; inline matching is a heuristic). When no native field is present — every backend today — behavior is byte-for-byte unchanged.
- **Streaming asymmetry, documented:** a stream can't reconcile native-vs-inline mid-flight, so the native-wins precedence is a non-streaming-only guarantee. A backend emitting both would surface both; backends use one mechanism or the other, so this is harmless. Called out in code comments rather than papered over with fragile buffering.
- **Scoring is unchanged:** `Turn.Thinking` is `omitempty` and is omitted from the `judgeTurn` projection that builds the judge prompt, so the judge sees exactly what it saw before. It is persisted in `calibrate-capture` artifacts (`actual_transcript`), where the `omitempty` tag keeps non-reasoning artifact hashes byte-identical.
- **Replay determinism preserved:** reasoning text never enters the `messages` history sent to the model in later turns.

## Testing

Test-first across all four layers: wire mapping, native-wins-over-inline precedence, unconditional capture under `ThinkNone`, streaming deltas, candidate capture for both transports, and end-to-end transcript capture. Full `go test ./...` passes; `-race` clean on provider, openaicompat, ollama, and llm-bench.