### PR TITLE
Round 2A follow-up: tool canary (R-C4) exercising the ToolArgsValid path

### DIFF
--- a/cmd/llm-bench/round2_corpus_test.go
+++ b/cmd/llm-bench/round2_corpus_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -108,5 +109,54 @@ func TestRound2ChallengeCorpus_EnforcesAuthoringContract(t *testing.T) {
 		if strings.Count(blob, "```")%2 != 0 {
 			t.Errorf("trace %q has an unbalanced ``` code fence; a truncated prompt must not ship", tr.ID)
 		}
+	}
+}
+
+// TestRound2ToolCanary_ComputesToolArgsValid proves the tool path end to end:
+// the committed canary carries a real MCP tools/list snapshot (frozen into
+// trace.Tools by -capture), and the harness can compute ToolArgsValid from it.
+// A schema-valid call to the first expected tool must score 1.0. This is the
+// R-C4 pipeline-validation gate; it makes no model-quality claim (the canary is
+// judge-validation, excluded from model evidence).
+func TestRound2ToolCanary_ComputesToolArgsValid(t *testing.T) {
+	traces, err := loadTraces([]string{filepath.Join(round2ChallengeDir, "tool-canary-01.json")})
+	if err != nil {
+		t.Fatalf("load canary: %v", err)
+	}
+	tr := traces[0]
+	if len(tr.Tools) == 0 || len(tr.Golden.ToolCalls) == 0 {
+		t.Fatalf("canary must carry tool schemas and expected tool calls; tools=%d calls=%d", len(tr.Tools), len(tr.Golden.ToolCalls))
+	}
+	// The actual turn is synthesized, not replayed: this gate proves the scoring
+	// path computes from the committed schema, not what any model would emit.
+	// rag_search's only required argument is "query"; a schema-valid call.
+	actual := []Turn{{
+		Role: "assistant",
+		ToolCalls: []ToolCall{{
+			Name:      tr.Golden.ToolCalls[0],
+			Arguments: json.RawMessage(`{"query":"provider retry budget"}`),
+		}},
+	}}
+	score, computed, notes, err := scoreToolArguments(tr, actual)
+	if err != nil {
+		t.Fatalf("scoreToolArguments: %v", err)
+	}
+	if !computed {
+		t.Fatalf("ToolArgsValid not computed from the committed canary schema: %s", notes)
+	}
+	if score != 1.0 {
+		t.Fatalf("ToolArgsValid = %v; want 1.0 for a schema-valid canary call (%s)", score, notes)
+	}
+}
+
+// TestRound2ToolCanary_ExcludedFromModelEvidence pins the canary to the
+// judge-validation partition so it can never enter a model-quality view.
+func TestRound2ToolCanary_ExcludedFromModelEvidence(t *testing.T) {
+	manifest, err := loadManifest(filepath.Join(round2ChallengeDir, "corpus-manifest.jsonl"))
+	if err != nil {
+		t.Fatalf("load corpus manifest: %v", err)
+	}
+	if part := manifest.partitionByTrace()["tool-canary-01"]; part != PartitionJudgeValidation {
+		t.Fatalf("tool-canary-01 partition = %q; want judge-validation (never model evidence)", part)
 	}
 }

--- a/docs/llm/traces/round2-challenge/corpus-manifest.jsonl
+++ b/docs/llm/traces/round2-challenge/corpus-manifest.jsonl
@@ -40,4 +40,4 @@
 {"trace_id":"r2c-underspecification-01","partition":"challenge","category":"underspecification","source":"round2-challenge","allowed_as_model_evidence":true}
 {"trace_id":"r2c-underspecification-02","partition":"challenge","category":"underspecification","source":"round2-challenge","allowed_as_model_evidence":true}
 {"trace_id":"r2c-underspecification-03","partition":"challenge","category":"underspecification","source":"round2-challenge","allowed_as_model_evidence":true}
-{"trace_id":"tool-canary-01","partition":"judge-validation","category":"tool-canary","source":"round2-tool-canary","allowed_as_model_evidence":false}
+{"trace_id":"tool-canary-01","partition":"judge-validation","category":"tool-canary","source":"round2-tool-canary-fixture","allowed_as_model_evidence":false}

--- a/docs/llm/traces/round2-challenge/tool-canary-01.json
+++ b/docs/llm/traces/round2-challenge/tool-canary-01.json
@@ -1,0 +1,482 @@
+{
+  "id": "tool-canary-01",
+  "source": "round2-tool-canary-fixture",
+  "captured_at": "2025-06-09T12:00:00Z",
+  "system": "You are a code assistant with access to a repository search tool. Use rag_search to ground answers in the codebase before replying.",
+  "tools": [
+    {
+      "description": "Analyze a trading strategy's performance metrics.",
+      "inputSchema": {
+        "properties": {
+          "metrics": {
+            "description": "Strategy metrics (e.g. sharpe_ratio, max_drawdown)",
+            "type": "object"
+          },
+          "model": {
+            "description": "Model name (uses configured analysis default if omitted)",
+            "type": "string"
+          },
+          "name": {
+            "description": "Strategy name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "metrics"
+        ],
+        "type": "object"
+      },
+      "name": "analyze_strategy"
+    },
+    {
+      "description": "Analyze ML training metrics and provide insights.",
+      "inputSchema": {
+        "properties": {
+          "metrics": {
+            "description": "TrainingMetrics JSON (epoch, loss, loss_history, reward_mean, etc.)",
+            "type": "object"
+          },
+          "model": {
+            "description": "Model name (uses configured analysis default if omitted)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "metrics"
+        ],
+        "type": "object"
+      },
+      "name": "analyze_training"
+    },
+    {
+      "description": "Chat completion with optional RAG context. Returns the assistant's response.",
+      "inputSchema": {
+        "properties": {
+          "conversation_id": {
+            "description": "Optional stable id to group calls of one conversation; omit to derive identity from message content",
+            "type": "string"
+          },
+          "messages": {
+            "description": "Chat messages (each with role and content)",
+            "items": {
+              "properties": {
+                "content": {
+                  "type": "string"
+                },
+                "role": {
+                  "enum": [
+                    "system",
+                    "user",
+                    "assistant",
+                    "tool"
+                  ],
+                  "type": "string"
+                },
+                "tool_call_id": {
+                  "type": "string"
+                },
+                "tool_calls": {
+                  "type": "array"
+                },
+                "tool_name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "role",
+                "content"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "model": {
+            "description": "Model name (uses configured default if omitted)",
+            "type": "string"
+          },
+          "rag_top_k": {
+            "description": "Number of RAG results (default: 5)",
+            "type": "integer"
+          },
+          "temperature": {
+            "description": "Sampling temperature",
+            "type": "number"
+          },
+          "use_rag": {
+            "description": "Prepend RAG context from the vector store",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "messages"
+        ],
+        "type": "object"
+      },
+      "name": "chat"
+    },
+    {
+      "description": "Review code using the local LLM with optional RAG context from the codebase.",
+      "inputSchema": {
+        "properties": {
+          "code": {
+            "description": "Code to review",
+            "type": "string"
+          },
+          "focus": {
+            "description": "Focus area (e.g. security, performance)",
+            "type": "string"
+          },
+          "language": {
+            "description": "Programming language",
+            "type": "string"
+          },
+          "model": {
+            "description": "Model name (uses configured analysis default if omitted)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "type": "object"
+      },
+      "name": "code_review"
+    },
+    {
+      "description": "Compare multiple trading strategies side by side.",
+      "inputSchema": {
+        "properties": {
+          "model": {
+            "description": "Model name (uses configured analysis default if omitted)",
+            "type": "string"
+          },
+          "strategies": {
+            "description": "Map of strategy name to metrics object",
+            "type": "object"
+          }
+        },
+        "required": [
+          "strategies"
+        ],
+        "type": "object"
+      },
+      "name": "compare_strategies"
+    },
+    {
+      "description": "Fill-in-the-middle code completion. Returns the generated code to insert between prefix and suffix.",
+      "inputSchema": {
+        "properties": {
+          "file_path": {
+            "description": "File path for language detection",
+            "type": "string"
+          },
+          "language": {
+            "description": "Language hint (auto-detected from file_path if omitted)",
+            "type": "string"
+          },
+          "max_tokens": {
+            "description": "Maximum tokens to generate (default: 128)",
+            "type": "integer"
+          },
+          "model": {
+            "description": "Model name (uses configured completion default if omitted)",
+            "type": "string"
+          },
+          "prefix": {
+            "description": "Code before the cursor",
+            "type": "string"
+          },
+          "suffix": {
+            "description": "Code after the cursor",
+            "type": "string"
+          }
+        },
+        "required": [
+          "prefix",
+          "suffix"
+        ],
+        "type": "object"
+      },
+      "name": "complete_code"
+    },
+    {
+      "description": "Generate an embedding vector for a single text.",
+      "inputSchema": {
+        "properties": {
+          "model": {
+            "description": "Embedding model (uses configured default if omitted)",
+            "type": "string"
+          },
+          "text": {
+            "description": "Text to embed",
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "type": "object"
+      },
+      "name": "embed"
+    },
+    {
+      "description": "Generate embeddings for multiple texts (max 100).",
+      "inputSchema": {
+        "properties": {
+          "model": {
+            "description": "Embedding model (uses configured default if omitted)",
+            "type": "string"
+          },
+          "texts": {
+            "description": "Texts to embed (max 100)",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "texts"
+        ],
+        "type": "object"
+      },
+      "name": "embed_batch"
+    },
+    {
+      "description": "Explain a detected ML training anomaly.",
+      "inputSchema": {
+        "properties": {
+          "anomaly": {
+            "description": "AnomalyInfo JSON (type, severity, description, metrics)",
+            "type": "object"
+          },
+          "model": {
+            "description": "Model name (uses configured analysis default if omitted)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "anomaly"
+        ],
+        "type": "object"
+      },
+      "name": "explain_anomaly"
+    },
+    {
+      "description": "Explain a code snippet using the local LLM.",
+      "inputSchema": {
+        "properties": {
+          "code": {
+            "description": "Code to explain",
+            "type": "string"
+          },
+          "model": {
+            "description": "Model name (uses configured analysis default if omitted)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "type": "object"
+      },
+      "name": "explain_code"
+    },
+    {
+      "description": "Raw text generation without chat formatting. Returns the generated text.",
+      "inputSchema": {
+        "properties": {
+          "max_tokens": {
+            "description": "Maximum tokens to generate",
+            "type": "integer"
+          },
+          "model": {
+            "description": "Model name (uses configured chat default if omitted)",
+            "type": "string"
+          },
+          "prompt": {
+            "description": "The prompt to generate from",
+            "type": "string"
+          },
+          "system": {
+            "description": "System prompt",
+            "type": "string"
+          },
+          "temperature": {
+            "description": "Sampling temperature",
+            "type": "number"
+          }
+        },
+        "required": [
+          "prompt"
+        ],
+        "type": "object"
+      },
+      "name": "generate"
+    },
+    {
+      "description": "List all available provider models. Also refreshes the model resolution cache.",
+      "inputSchema": {
+        "properties": {},
+        "type": "object"
+      },
+      "name": "list_models"
+    },
+    {
+      "description": "Download a model from the Ollama registry.",
+      "inputSchema": {
+        "properties": {
+          "name": {
+            "description": "Model name to pull (e.g. qwen3:8b)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "name": "pull_model"
+    },
+    {
+      "description": "Remove all chunks for a source from the vector store.",
+      "inputSchema": {
+        "properties": {
+          "source": {
+            "description": "Source identifier to delete",
+            "type": "string"
+          }
+        },
+        "required": [
+          "source"
+        ],
+        "type": "object"
+      },
+      "name": "rag_delete"
+    },
+    {
+      "description": "Index all supported files in a directory tree into the RAG vector store.",
+      "inputSchema": {
+        "properties": {
+          "concurrency": {
+            "description": "Number of concurrent workers (default: 4)",
+            "type": "integer"
+          },
+          "extensions": {
+            "description": "File extensions to include (e.g. [\".go\", \".py\"])",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "path": {
+            "description": "Directory path to index",
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "type": "object"
+      },
+      "name": "rag_index_directory"
+    },
+    {
+      "description": "Index a single file into the RAG vector store.",
+      "inputSchema": {
+        "properties": {
+          "path": {
+            "description": "File path to index",
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "type": "object"
+      },
+      "name": "rag_index_file"
+    },
+    {
+      "description": "Search the RAG index for relevant chunks.",
+      "inputSchema": {
+        "properties": {
+          "query": {
+            "description": "Search query",
+            "type": "string"
+          },
+          "top_k": {
+            "description": "Number of results (default: 5)",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object"
+      },
+      "name": "rag_search"
+    },
+    {
+      "description": "Get vector store statistics (chunk count, source count, dimensions, storage size).",
+      "inputSchema": {
+        "properties": {},
+        "type": "object"
+      },
+      "name": "rag_stats"
+    },
+    {
+      "description": "Get detailed information about a specific model.",
+      "inputSchema": {
+        "properties": {
+          "name": {
+            "description": "Model name (e.g. qwen3:8b)",
+            "type": "string"
+          },
+          "provider": {
+            "description": "Provider instance name when the model name is ambiguous",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "name": "show_model"
+    }
+  ],
+  "turns": [
+    {
+      "role": "user",
+      "content": "Where is the provider retry budget configured in this repository?"
+    },
+    {
+      "role": "assistant",
+      "content": "Let me search the repository for the retry budget configuration.",
+      "tool_calls": [
+        {
+          "name": "rag_search",
+          "arguments": {
+            "query": "provider retry budget configuration",
+            "top_k": 5
+          }
+        }
+      ]
+    },
+    {
+      "role": "tool",
+      "content": "provider/router.go: RetryBudget defaults to three attempts and is set via RouterConfig.RetryBudget.",
+      "tool_call_id": "call_1",
+      "name": "rag_search"
+    }
+  ],
+  "golden": {
+    "tool_calls": [
+      "rag_search"
+    ],
+    "final_answer_criteria": "Assistant answer should satisfy the captured final assistant response.",
+    "final_answer_substring": "The provider retry budget is configured in provider/router.go through RouterConfig.RetryBudget, which defaults to three attempts."
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to PR #167. Lands the deferred Round 2A tool canary (R-C4): a committed trace that proves the never-otherwise-exercised tool path end to end -- MCP tools/list snapshot -> frozen trace.Tools -> scoreToolArguments -> ToolArgsValid -- without making any tool-use quality claim.

## How the canary was produced

Sourced via the REAL `-capture` path: a fixture conversation DB (one rag_search tool-call turn) plus a live `go-llm-mcp` tools/list snapshot frozen into trace.Tools by redactToolSchemas. The conversation rows are a fixture (`source: round2-tool-canary-fixture`); the tools/list -> trace.Tools -> scoreToolArguments path is genuinely real. A real conversation DB was not used because none with the go-llm conversation schema and a tool-call turn exists, and public-repo safety plus reproducibility matter more here than organic prompt provenance.

## What's included

- `docs/llm/traces/round2-challenge/tool-canary-01.json` -- captured trace carrying the real 18-tool snapshot (incl. rag_search), `golden.tool_calls: [rag_search]`, sanitized (no abs paths / secrets / PII).
- `corpus-manifest.jsonl` -- canary entry source set to `round2-tool-canary-fixture` (partition judge-validation, non-evidence; the entry itself already shipped in PR #167).
- `cmd/llm-bench/round2_corpus_test.go` -- `TestRound2ToolCanary_ComputesToolArgsValid` (a schema-valid rag_search call scores ToolArgsValid 1.0 from the committed schema; asserts both computed and score) and `TestRound2ToolCanary_ExcludedFromModelEvidence` (canary pinned to judge-validation).

## Scope and claims

- Pipeline validation only -- the canary is judge-validation and excluded from every model-evidence view (Manifest.Select honors -corpus-only-evidence). No tool-use quality is claimed; full tool-use quality remains Round 2B.
- The golden final answer lives in `final_answer_substring` (standard capture shape), not as a turn.

## Testing

`go test ./...` passes; `go build ./cmd/llm-bench/ ./cmd/go-llm-mcp/` clean; `gofmt`/`go vet` clean. No fixture DB or capture output committed.

Generated with Claude Code