### PR TITLE
Round-2 frontier-challenge run (inconclusive) + partial-capture failure surfacing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,7 @@ docs/llm/traces/*
 /llm-bench
 docs/llm/calibration/*.jsonl
 docs/llm/calibration/*.json
+docs/llm/calibration/*.txt
+docs/llm/calibration/*.md
 docs/llm/calibration/reports/
+docs/llm/calibration/round2-capture/

--- a/cmd/llm-bench/calibration.go
+++ b/cmd/llm-bench/calibration.go
@@ -129,6 +129,9 @@ func runCalibrateCapture(ctx context.Context, opts calibrateCaptureOptions) (ret
 	for _, r := range results {
 		if r.Err != nil {
 			// Skip failed runs — they cannot be labeled coherently.
+			// Surface the per-pair reason: a silently dropped result makes a
+			// partial corpus look complete and hides timeout-vs-refusal.
+			fmt.Fprintf(os.Stderr, "calibrate-capture: skipped %s/%s: %v\n", r.TraceID, r.Model, r.Err)
 			failed++
 			continue
 		}
@@ -150,6 +153,12 @@ func runCalibrateCapture(ctx context.Context, opts calibrateCaptureOptions) (ret
 	}
 	if len(artifacts) == 0 {
 		return fmt.Errorf("calibrate-capture: no artifacts written; %d results returned, %d failed", len(results), failed)
+	}
+	if failed > 0 {
+		// Partial capture is a valid best-effort outcome (the caller can gap-fill
+		// the missing pairs), so this is a warning, not an error — but it must be
+		// loud: a partial corpus that prints only the success line reads as complete.
+		fmt.Fprintf(os.Stderr, "calibrate-capture: WARNING partial capture — wrote %d artifact(s), %d of %d runs failed\n", len(artifacts), failed, len(results))
 	}
 
 	if err := os.MkdirAll(filepath.Dir(opts.OutputPath), 0o755); err != nil {

--- a/cmd/llm-bench/calibration_test.go
+++ b/cmd/llm-bench/calibration_test.go
@@ -123,6 +123,15 @@ func TestRunCalibrateCapture_PartialCaptureProceedsWithSuccessfulResults(t *test
 	}
 	targets := []ModelTarget{{Display: "ollama/cand", Provider: "ollama", Model: "cand"}}
 
+	stderrPath := filepath.Join(dir, "stderr.txt")
+	stderrFile, err := os.Create(stderrPath)
+	if err != nil {
+		t.Fatalf("create stderr capture: %v", err)
+	}
+	oldStderr := os.Stderr
+	os.Stderr = stderrFile
+	defer func() { os.Stderr = oldStderr }()
+
 	// A partial capture (some pairs failed) is a best-effort success: the
 	// successful artifacts are written so the operator can gap-fill the rest,
 	// and runCalibrateCapture warns rather than erroring.
@@ -130,6 +139,24 @@ func TestRunCalibrateCapture_PartialCaptureProceedsWithSuccessfulResults(t *test
 		Runner: runner, Targets: targets, Traces: traces, OutputPath: out,
 	}); err != nil {
 		t.Fatalf("runCalibrateCapture (partial) err = %v; want nil (best-effort)", err)
+	}
+	os.Stderr = oldStderr
+	if err := stderrFile.Close(); err != nil {
+		t.Fatalf("close stderr capture: %v", err)
+	}
+	stderr, err := os.ReadFile(stderrPath)
+	if err != nil {
+		t.Fatalf("read stderr capture: %v", err)
+	}
+	stderrText := string(stderr)
+	for _, want := range []string{
+		"calibrate-capture: skipped t2/ollama/cand: context deadline exceeded",
+		"calibrate-capture: WARNING partial capture",
+		"wrote 2 artifact(s), 1 of 3 runs failed",
+	} {
+		if !strings.Contains(stderrText, want) {
+			t.Fatalf("stderr missing %q:\n%s", want, stderrText)
+		}
 	}
 
 	f, err := os.Open(out)

--- a/cmd/llm-bench/calibration_test.go
+++ b/cmd/llm-bench/calibration_test.go
@@ -108,6 +108,52 @@ func TestRunCalibrateCapture_FailsWhenNoArtifactsWritten(t *testing.T) {
 	}
 }
 
+func TestRunCalibrateCapture_PartialCaptureProceedsWithSuccessfulResults(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "artifacts.jsonl")
+	runner := &fakeRunner{results: []Result{
+		{Model: "ollama/cand", TraceID: "t1", Transcript: []Turn{{Role: "assistant", Content: "answer one"}}},
+		{Model: "ollama/cand", TraceID: "t2", Err: fmt.Errorf("context deadline exceeded")},
+		{Model: "ollama/cand", TraceID: "t3", Transcript: []Turn{{Role: "assistant", Content: "answer three"}}},
+	}}
+	traces := []Trace{
+		{ID: "t1", System: "s", Turns: []Turn{{Role: "user", Content: "u1"}}, Golden: Golden{FinalAnswerCriteria: "c"}},
+		{ID: "t2", System: "s", Turns: []Turn{{Role: "user", Content: "u2"}}, Golden: Golden{FinalAnswerCriteria: "c"}},
+		{ID: "t3", System: "s", Turns: []Turn{{Role: "user", Content: "u3"}}, Golden: Golden{FinalAnswerCriteria: "c"}},
+	}
+	targets := []ModelTarget{{Display: "ollama/cand", Provider: "ollama", Model: "cand"}}
+
+	// A partial capture (some pairs failed) is a best-effort success: the
+	// successful artifacts are written so the operator can gap-fill the rest,
+	// and runCalibrateCapture warns rather than erroring.
+	if err := runCalibrateCapture(context.Background(), calibrateCaptureOptions{
+		Runner: runner, Targets: targets, Traces: traces, OutputPath: out,
+	}); err != nil {
+		t.Fatalf("runCalibrateCapture (partial) err = %v; want nil (best-effort)", err)
+	}
+
+	f, err := os.Open(out)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	got := map[string]bool{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var a Artifact
+		if err := json.Unmarshal(scanner.Bytes(), &a); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		got[a.TraceID] = true
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(got) != 2 || !got["t1"] || !got["t3"] {
+		t.Fatalf("captured traces = %v; want only t1 and t3 (t2 failed)", got)
+	}
+}
+
 func TestRunCalibrateCapture_DuplicateTraceIDRejectedBeforeReplay(t *testing.T) {
 	dir := t.TempDir()
 	out := filepath.Join(dir, "artifacts.jsonl")

--- a/docs/llm/benchmarks/2026-06-10-round-2-frontier-challenge.md
+++ b/docs/llm/benchmarks/2026-06-10-round-2-frontier-challenge.md
@@ -1,0 +1,171 @@
+<!--
+Per spec docs/superpowers/specs/2026-05-25-harness-followups-design.md section 5.2:
+Do NOT paste raw prompts, transcripts, judge justifications, or error
+messages into this file. Only sanitized aggregates + provenance. Raw traces,
+labels, artifacts, worksheets, and run logs are gitignored.
+
+STATUS: inconclusive Round-2 frontier-vs-local diagnostic. Not an accepted run
+and not promoted to docs/llm/harness-results.md because the challenge partition
+failed the de-saturation validity gate.
+-->
+
+# round-2-frontier-challenge - 2026-06-10
+
+> **Verdict - read first.** This run is **inconclusive** for the
+> frontier-vs-local question. GLM-5.1 reached 1.00 on the challenge partition,
+> so the corpus failed the de-saturation gate and does not characterize GLM's
+> ceiling. GLM's measured edge over the strongest local models is a one-trace
+> difference, at the corpus resolution limit. The next useful step is a harder
+> Round-3 challenge corpus, not latency or judge-calibration work on this
+> saturated corpus.
+
+## Provenance
+
+- **Harness/docs commit during labeling**: `f1be673` on `develop`; workspace
+  was dirty during the local labeling/doc pass, so this run is not eligible for
+  accepted-run promotion.
+- **Machine**: MacBook Pro M3 Max, 128 GB unified memory.
+- **Trace set**: Round-2 natural + challenge evidence set.
+  - Natural partition: **24** trace IDs, **119** scored artifacts.
+  - Challenge partition: **18** trace IDs, **90** scored artifacts.
+  - `tool-canary-01` is a judge-validation fixture and excluded from
+    model-evidence math.
+  - `gemma4:31b` x `conversation-fa-m01` timed out during capture, so the
+    scored artifact count is **209**, not 210.
+- **Corpus manifest hash**:
+  `sha256:44204a6758dceb2ae3599f7698648c8fed2ac15a892c3fd5446d6c02a8abc200`
+- **Models under test**:
+  `ollama/gemma4:31b`, `ollama/qwen3-coder-next:latest`,
+  `ollama/qwen3.6:35b-a3b`, `ollama/qwen3:8b`,
+  `openai-compat/glm-5.1`.
+- **Scorer**: `manual` via blind worksheet.
+  - Artifact manifest hash:
+    `sha256:1ecb611cc37631544ca8f99351ea7cf4035c368884df362c4175ffd4bfd6245f`
+  - Label manifest hash:
+    `sha256:faa0f99dd1aa3638ce3ce4bde4606814652eb44b5c8c7e6eaaa0b5e4b0b0dd96`
+  - Valid labeled artifacts: **209**.
+  - Stale / missing labels: **0 stale**, **0 unscored/skipped**.
+  - Label score distribution: **173 x 1.0 / 28 x 0.5 / 8 x 0.0**.
+  - Labeler: `manual`.
+- **Latency**: not measured in this pass. Frozen artifacts carry no timing.
+
+Exact commands used for the checked aggregates:
+
+```bash
+llm-bench -blind-ingest \
+  -worksheet docs/llm/calibration/worksheet.round2.txt \
+  -artifacts docs/llm/calibration/artifacts.round2.jsonl \
+  -labels-out docs/llm/calibration/labels.round2.jsonl \
+  -labeler manual
+
+llm-bench -manual-report \
+  -labels docs/llm/calibration/labels.round2.jsonl \
+  -artifacts docs/llm/calibration/artifacts.round2.jsonl \
+  -corpus-manifest docs/llm/traces/round2-challenge/corpus-manifest.jsonl \
+  -corpus-partitions natural -corpus-only-evidence \
+  -report docs/llm/calibration/q-natural.md
+
+llm-bench -manual-report \
+  -labels docs/llm/calibration/labels.round2.jsonl \
+  -artifacts docs/llm/calibration/artifacts.round2.jsonl \
+  -corpus-manifest docs/llm/traces/round2-challenge/corpus-manifest.jsonl \
+  -corpus-partitions challenge -corpus-only-evidence \
+  -report docs/llm/calibration/q-challenge.md
+
+llm-bench -paired-report \
+  -labels docs/llm/calibration/labels.round2.jsonl \
+  -artifacts docs/llm/calibration/artifacts.round2.jsonl \
+  -corpus-manifest docs/llm/traces/round2-challenge/corpus-manifest.jsonl \
+  -corpus-partitions challenge -corpus-only-evidence \
+  -baseline ollama/qwen3-coder-next:latest \
+  -report docs/llm/calibration/paired-coder.md
+```
+
+## Validity Gates
+
+| Gate | Verdict | Evidence |
+| --- | --- | --- |
+| No-trivia upper bound | PASS | Every challenge trace has at least one candidate scored 1.0. |
+| De-saturation | FAIL | `openai-compat/glm-5.1` challenge mean is **1.00**. |
+| Floor separation | PASS | `qwen3:8b` is lowest at **0.72**; gap to GLM is **0.28**, above the 0.15 bar. |
+
+Because de-saturation failed, the challenge partition is too easy for the top
+frontier candidate and cannot support a robust frontier-vs-local conclusion.
+
+## Results
+
+Quality is the human label (`expected_answer_quality`) over frozen artifacts.
+Natural and challenge partitions are reported separately and are not averaged.
+
+### Natural Partition
+
+| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | n |
+| --- | --- | --- |
+| `ollama/gemma4:31b` | 0.96 / 1.00 / 1.00 / 1.00 / 1.00 | 23 |
+| `ollama/qwen3-coder-next:latest` | 0.88 / 0.50 / 1.00 / 1.00 / 1.00 | 24 |
+| `ollama/qwen3.6:35b-a3b` | 0.90 / 1.00 / 1.00 / 1.00 / 1.00 | 24 |
+| `ollama/qwen3:8b` | 0.77 / 0.50 / 1.00 / 1.00 / 1.00 | 24 |
+| `openai-compat/glm-5.1` | 0.94 / 1.00 / 1.00 / 1.00 / 1.00 | 24 |
+
+The natural partition preserves the prior local-run shape: qwen8 remains the
+floor, qwen3.6/coder remain near 0.90, and gemma remains near the top. This
+supports serving-parity for the OpenAI-compatible GLM path, but it is not a
+frontier decision by itself.
+
+### Challenge Partition
+
+| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | n |
+| --- | --- | --- |
+| `openai-compat/glm-5.1` | **1.00 / 1.00 / 1.00 / 1.00 / 1.00** | 18 |
+| `ollama/gemma4:31b` | 0.97 / 1.00 / 1.00 / 1.00 / 1.00 | 18 |
+| `ollama/qwen3-coder-next:latest` | 0.94 / 1.00 / 1.00 / 1.00 / 1.00 | 18 |
+| `ollama/qwen3.6:35b-a3b` | 0.89 / 1.00 / 1.00 / 1.00 / 1.00 | 18 |
+| `ollama/qwen3:8b` | 0.72 / 0.50 / 1.00 / 1.00 / 1.00 | 18 |
+
+Paired challenge statistics with `qwen3-coder-next` as baseline:
+
+| Model | mean delta vs coder | 95% CI | wins | losses | ties |
+| --- | --- | --- | --- | --- | --- |
+| `openai-compat/glm-5.1` | +0.06 | [+0.00, +0.17] | 1 | 0 | 17 |
+| `ollama/gemma4:31b` | +0.03 | [+0.00, +0.08] | 1 | 0 | 17 |
+| `ollama/qwen3.6:35b-a3b` | -0.06 | [-0.28, +0.11] | 1 | 2 | 15 |
+| `ollama/qwen3:8b` | -0.22 | [-0.42, -0.06] | 0 | 5 | 13 |
+
+Resolution diagnostic: over 18 paired challenge traces, one full label flip
+(0 <-> 1) moves a model mean by **0.06**; one rubric step (0.5) moves it by
+**0.03**. GLM's measured +0.06 edge over coder is exactly one full-label unit
+on this corpus.
+
+## Signal Diagnosis
+
+- **12 / 18 challenge traces are saturated**: every candidate scored 1.0.
+  They validate solvability but provide no ranking signal.
+- **Only 6 / 18 challenge traces discriminate at all**, and most of that
+  discrimination separates `qwen3:8b` from the field rather than separating
+  the frontier from the strongest local models.
+- **GLM's frontier edge is single-trace-fragile**:
+  `r2c-subtle-correctness-01` is the only GLM-vs-coder and GLM-vs-gemma
+  separating trace. GLM ties coder and gemma on the other 17 challenge traces.
+- **GLM's true ceiling is uncharacterized** because the top candidate is fully
+  saturated at 1.00.
+
+## R7 / R8 Deferral
+
+- **R7 local-judge calibration** is deferred. It gates a future Round-3 judge
+  path, but this Round-2 corpus already failed de-saturation under manual
+  labels. Calibrating a judge against a saturated corpus would not change the
+  quality verdict.
+- **R8 latency pass** is deferred. Latency cannot rescue a quality comparison
+  that is below or at the +0.05 bar and one-label-fragile. A latency pass is
+  useful only after a harder corpus produces a robust quality delta.
+
+## Conclusion
+
+- **Headline verdict**: **inconclusive - corpus needs harder challenge traces**.
+- **No second-backend investment is justified by this run**. GLM-5.1 did not
+  clear a robust >=0.05 quality-improvement bar on measurable evidence; its
+  observed edge is a one-label effect on an over-easy challenge set.
+- **Next step**: loop back to corpus construction before Round 3. Replace or
+  enrich the saturated challenge traces with cases that discriminate among
+  GLM, gemma, coder, and qwen3.6, while retaining solvability from committed
+  rubrics and blind labeling.

--- a/docs/llm/recommendation.md
+++ b/docs/llm/recommendation.md
@@ -26,6 +26,13 @@ These specific IDs are **the reference lineup**, not a contract. `go-llm`
 has no hard-coded model list: the router, registry, and every consumer
 read from `models.json`.
 
+The latest frontier probe,
+[2026-06-10 Round-2 frontier challenge](benchmarks/2026-06-10-round-2-frontier-challenge.md),
+was **inconclusive**: GLM-5.1 saturated the challenge partition at 1.00, so the
+corpus failed the de-saturation validity gate and did not justify a
+second-backend investment. The current lineup remains unchanged pending a
+harder Round-3 corpus.
+
 ### How to verify
 
 To rerun the accepted workflow against the same local evidence, use the
@@ -36,8 +43,9 @@ IDs). The accepted traces, labels, and artifacts are gitignored local
 files; for a new run, capture your own corpus via
 `llm-bench -capture -mcp-stdio-command "..."`, then label and run the
 manual-report path. The accepted run is a plain-chat baseline — a
-tool-use or agent ranking requires a tool-bearing corpus, which is
-Round-2 work.
+tool-use or agent ranking requires a tool-bearing corpus. The Round-2
+frontier challenge was useful as a diagnostic but was not accepted because
+its challenge partition was too easy for the frontier candidate.
 
 ## Customizing the lineup
 
@@ -177,7 +185,10 @@ enforces they stay identical.
 
 Setup 2 (GLM-5.1 in LM Studio) and Setup 3 (MiniMax M2.7) from
 [setups.md](setups.md) remain candidate upgrades. They're deferred,
-not rejected. The benchmark harness
+not rejected. The Round-2 GLM-5.1 probe was inconclusive because the
+challenge corpus saturated at the top model; the next GLM/MiniMax attempt
+needs a harder corpus before latency or provider-integration work can change
+the decision. The benchmark harness
 ([benchmark-plan.md](benchmark-plan.md)) is the decision gate: if a
 frontier non-Ollama model demonstrates, on an accepted harness run
 (acceptance criteria in


### PR DESCRIPTION
## Summary

Completes the Round-2 operator runbook (R1-R8) and records the result. The Round-2 challenge-enriched run is an **inconclusive diagnostic**, not an accepted run: GLM-5.1 reached 1.00 on the challenge partition and failed the de-saturation validity gate, so it is **not** promoted to `harness-results.md`.

Also fixes a silent-failure in the capture pipeline that this run exposed.

## What's here

- **`fix(llm-bench)`** — `runCalibrateCapture` discarded each failed pair's error and treated a partial capture as success (exit 0). It now logs each skipped pair's reason and emits a loud partial-capture WARNING when proceeding with an incomplete set. Exit semantics unchanged (partial capture stays best-effort so the operator can gap-fill). New regression test covers the partial path.
- **`docs(llm)`** — new benchmark artifact `docs/llm/benchmarks/2026-06-10-round-2-frontier-challenge.md` (verdict, validity gates, per-partition aggregates, single-trace-fragility diagnosis, R7/R8 deferral rationale); `recommendation.md` points at it and keeps Setup 2/3 deferred.
- **`.gitignore`** — ignore the Round-2 run outputs (`round2-capture/`, worksheet `.txt`, report `.md`); they embed private trace content and must never be committed.

## Run outcome

| Validity gate | Verdict |
|---|---|
| No-trivia upper bound | PASS — every challenge trace has >=1 candidate at 1.0 |
| De-saturation (<1.00) | FAIL — GLM-5.1 challenge mean = 1.00 |
| Floor separation | PASS — qwen3:8b 0.72 lowest, gap 0.28 >= 0.15 |

- Challenge means: GLM 1.00, gemma 0.97, coder 0.94, qwen3.6 0.89, qwen3:8b 0.72.
- 12 of 18 challenge traces are saturated (all 5 models score 1.0); GLM's paired edge over the top locals rests on a single trace, at the corpus resolution limit and below the standing +0.05 bar.
- Natural anchor held vs run 1 (Ollama serving parity preserved the comparison).
- Capture coverage 209/210: `gemma4:31b x conversation-fa-m01` timed out (dense 31B on the largest trace); recorded as a timeout, not a data gap.

Verdict: inconclusive on frontier-vs-local. Next step is a harder Round-3 challenge corpus, not latency or judge-calibration work on a saturated corpus.

## Test plan

- `go test ./...` — all pass (includes the new `TestRunCalibrateCapture_PartialCaptureProceedsWithSuccessfulResults`).
- `gofmt`/`go vet` clean on changed files.
- Benchmark doc is ASCII-only, carries the no-raw-content header, and all numbers cross-check against the gitignored run reports; corpus-manifest hash verified.

## Notes

- Raw traces, artifacts, labels, worksheet, and reports are gitignored (private) by design; only sanitized aggregates + provenance are committed.
- R7 (Round-3-gated judge calibration) and R8 (separate latency pass) are deferred with rationale in the benchmark doc — both are moot until the corpus de-saturates.

Generated with Claude Code