### PR TITLE
fix(llm-bench): honor timeout for ollama candidates + real-workflow runbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ docs/llm/calibration/*.txt
 docs/llm/calibration/*.md
 docs/llm/calibration/reports/
 docs/llm/calibration/round2-capture/
+docs/llm/traces/real-workflow-local/
+docs/llm/calibration/fim-cases/
+docs/llm/calibration/real-workflow-capture/

--- a/cmd/llm-bench/candidate_transport.go
+++ b/cmd/llm-bench/candidate_transport.go
@@ -46,7 +46,11 @@ type candidateChatResponse struct {
 func newCandidateTransport(target ModelTarget, opts candidateTransportOptions) (candidateTransport, error) {
 	switch normalizeModelSelector(target.Provider) {
 	case defaultBenchProvider:
-		client, err := newOllamaClient(opts.ollamaURL)
+		var clientOpts []ollama.Option
+		if opts.timeout > 0 {
+			clientOpts = append(clientOpts, ollama.WithTimeout(opts.timeout))
+		}
+		client, err := newOllamaClient(opts.ollamaURL, clientOpts...)
 		if err != nil {
 			return candidateTransport{}, fmt.Errorf("candidate %q client: %w", target.Display, err)
 		}

--- a/cmd/llm-bench/candidate_transport_test.go
+++ b/cmd/llm-bench/candidate_transport_test.go
@@ -28,6 +28,50 @@ func TestNewCandidateTransport_OllamaDefault(t *testing.T) {
 	}
 }
 
+// The Ollama candidate transport must honor candidateTransportOptions.timeout
+// the same way the openai-compat branch does. The Ollama client defaults to a
+// 5-minute HTTP timeout, so a dropped opts.timeout silently caps every Ollama
+// candidate at 5 minutes regardless of -timeout. That bit gemma4:31b on a long
+// RAG-baked replay prefill: the request exceeded the default header timeout and
+// the cell was dropped even though -timeout was 20m. See real-workflow shakedown.
+func TestOllamaCandidateClient_HonorsTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Sleep well past opts.timeout before writing any headers. With the
+		// timeout honored, the client aborts the request; with it dropped, the
+		// client waits out the default 5-minute window and the request succeeds.
+		time.Sleep(1 * time.Second)
+		_, _ = w.Write([]byte(`{"model":"served","message":{"role":"assistant","content":"late"},"done":true}`))
+	}))
+	defer srv.Close()
+
+	tr, err := newCandidateTransport(ModelTarget{Display: "ollama/served", Provider: defaultBenchProvider, Model: "served"}, candidateTransportOptions{
+		ollamaURL: srv.URL,
+		timeout:   50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("newCandidateTransport: %v", err)
+	}
+
+	start := time.Now()
+	_, err = tr.chat.Chat(context.Background(), ollama.ChatRequest{
+		Model:    "served",
+		Messages: []ollama.ChatMessage{{Role: "user", Content: "q"}},
+	})
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatalf("Chat returned nil error after %v; want a timeout error (opts.timeout was ignored)", elapsed)
+	}
+	// Assert it was the HTTP client timeout that fired, not some unrelated
+	// error that happens to be non-nil — otherwise the test could pass for the
+	// wrong reason and stop guarding the timeout wiring.
+	if !strings.Contains(err.Error(), "deadline exceeded") && !strings.Contains(err.Error(), "Client.Timeout") {
+		t.Fatalf("Chat error = %v; want an HTTP client timeout (deadline exceeded / Client.Timeout)", err)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("Chat took %v; want it aborted near the 50ms opts.timeout (timeout not honored)", elapsed)
+	}
+}
+
 func TestNewCandidateTransport_OpenAICompatRequiresBaseURL(t *testing.T) {
 	_, err := newCandidateTransport(ModelTarget{Display: "openai-compat/m", Provider: "openai-compat", Model: "m"}, candidateTransportOptions{})
 	if err == nil || !strings.Contains(err.Error(), "-candidate-base-url") {

--- a/docs/llm/real-workflow-testing.md
+++ b/docs/llm/real-workflow-testing.md
@@ -1,0 +1,33 @@
+# Real Workflow Testing with go-llm and llm-bench
+
+This runbook is the small-loop path before accepted benchmark runs or Round-3 corpus work. It verifies that go-llm can be used in real MCP workflows and that llm-bench can capture, replay, label, and report those workflows.
+
+## Privacy Rule
+
+The transcript database, captured traces, worksheets, labels, artifacts, and reports are local evidence. Do not commit them unless a later review explicitly sanitizes and promotes a summary document.
+
+Default local paths:
+
+- Transcript DB: `~/.local/share/go-llm/workflow-testing/conversations.sqlite`
+- RAG DB: `~/.local/share/go-llm/workflow-testing/rag.sqlite`
+- Captured traces: `docs/llm/traces/real-workflow-local/`
+- Calibration artifacts: `docs/llm/calibration/artifacts.real-workflow.jsonl`
+- Manual labels: `docs/llm/calibration/labels.real-workflow.jsonl`
+
+## Four-Stage Loop
+
+1. Smoke: prove `cmd/llm-bench` can call local models and score a checked-in trace.
+2. Use: run `cmd/go-llm-mcp` with transcript persistence and exercise real tasks.
+3. Capture: export a small redacted trace corpus from the transcript DB.
+4. Measure: replay a small model panel, blind-label outputs, and compare reports.
+
+## First Shakedown Scope
+
+Use 8-12 real prompts over one normal working session. Include at least:
+
+- 3 code-review or code-explanation prompts.
+- 2 RAG/search prompts if RAG is enabled.
+- 2 planning/debugging prompts that require multi-step reasoning.
+- 1 prompt that intentionally tests restraint, such as asking for a risky refactor where the right answer should narrow scope.
+
+The first shakedown is not an accepted run. It is successful when the harness produces complete manual and paired reports with no stale labels, no accidental committed private artifacts, and clear next actions.


### PR DESCRIPTION
## Summary

Two changes that came out of a real-workflow shakedown of the `go-llm` + `llm-bench` calibration loop:

1. **Bug fix — ollama candidates now honor `-timeout`.** The ollama candidate transport built its client without forwarding `candidateTransportOptions.timeout`, so ollama candidates were hard-capped at the ollama package default of 5 minutes regardless of `-timeout`. The openai-compat branch already wired the timeout; the ollama branch did not. `-timeout` only bounded the replay context deadline while the shorter HTTP client timeout fired first.
2. **Docs — real-workflow testing runbook.** A small-loop runbook (smoke → use → capture → measure) for exercising go-llm in real MCP workflows before accepted benchmark runs, plus `.gitignore` rules keeping local transcript/trace/label/report evidence out of the repo.

## Why it matters

The timeout gap surfaced during a real-workflow calibration panel: `gemma4:31b` on a long RAG-baked replay prefill exceeded the 5-minute header timeout and its heaviest cells were dropped (partial 23/24 capture) even though `-timeout` was 20m. It is silent and asymmetric — it only bites the largest model on the longest-prefill input. After the fix, the panel captured cleanly and the loop produced complete manual and paired reports with significant model separation. Detailed run evidence is kept local per the runbook's privacy rule.

## Changes

- `cmd/llm-bench/candidate_transport.go` — forward `ollama.WithTimeout(opts.timeout)` when `opts.timeout > 0`, mirroring the openai-compat branch's `>0` guard (zero keeps the library default).
- `cmd/llm-bench/candidate_transport_test.go` — regression test `TestOllamaCandidateClient_HonorsTimeout`: an ollama candidate aborts on a short `opts.timeout` with a client-timeout error.
- `docs/llm/real-workflow-testing.md` — testing runbook.
- `.gitignore` — ignore local calibration evidence.

## Testing

- `go test ./cmd/llm-bench/...` — pass (includes the new regression test, RED→GREEN verified).
- `go build ./...` — OK.
- `go test ./...` — green.
- `go vet` + `gofmt` — clean.

Generated with Claude Code