### PR TITLE
[codex] Fix real workflow replay capture

### DIFF
--- a/cmd/llm-bench/capture.go
+++ b/cmd/llm-bench/capture.go
@@ -337,7 +337,7 @@ func conversationToTrace(conv conversation.Conversation, source, fallbackSystem 
 }
 
 func conversationTurns(messages []conversation.Message, fallbackSystem string, redactor redactor) (string, []Turn, string, error) {
-	var system string
+	var systemParts []string
 	var turns []Turn
 	sawUser := false
 	finalAssistantIndex, finalAnswer := capturedFinalAnswer(messages, redactor)
@@ -349,8 +349,8 @@ func conversationTurns(messages []conversation.Message, fallbackSystem string, r
 		}
 
 		if role == "system" {
-			if system == "" {
-				system = redactor.Redact(msg.Content)
+			if content := strings.TrimSpace(redactor.Redact(msg.Content)); content != "" {
+				systemParts = append(systemParts, content)
 			}
 			continue
 		}
@@ -377,6 +377,7 @@ func conversationTurns(messages []conversation.Message, fallbackSystem string, r
 		turns = append(turns, turn)
 	}
 
+	system := strings.Join(systemParts, "\n\n")
 	if system == "" {
 		system = redactor.Redact(strings.TrimSpace(fallbackSystem))
 	}

--- a/cmd/llm-bench/capture.go
+++ b/cmd/llm-bench/capture.go
@@ -337,7 +337,13 @@ func conversationToTrace(conv conversation.Conversation, source, fallbackSystem 
 }
 
 func conversationTurns(messages []conversation.Message, fallbackSystem string, redactor redactor) (string, []Turn, string, error) {
+	// Preserve every distinct system message in model-visible order so a
+	// RAG-injected context prefix and the original system prompt both survive
+	// into the replayed prompt. Verbatim duplicates (e.g. a system message
+	// re-injected on re-capture) are collapsed; content is never truncated,
+	// because a faithful replay must send the same prompt the model saw.
 	var systemParts []string
+	seenSystem := make(map[string]bool)
 	var turns []Turn
 	sawUser := false
 	finalAssistantIndex, finalAnswer := capturedFinalAnswer(messages, redactor)
@@ -349,7 +355,8 @@ func conversationTurns(messages []conversation.Message, fallbackSystem string, r
 		}
 
 		if role == "system" {
-			if content := strings.TrimSpace(redactor.Redact(msg.Content)); content != "" {
+			if content := strings.TrimSpace(redactor.Redact(msg.Content)); content != "" && !seenSystem[content] {
+				seenSystem[content] = true
 				systemParts = append(systemParts, content)
 			}
 			continue

--- a/cmd/llm-bench/capture.go
+++ b/cmd/llm-bench/capture.go
@@ -75,7 +75,44 @@ func runCapture(ctx context.Context, opts captureOptions) (captureResult, error)
 	}
 	defer func() { _ = db.Close() }()
 
-	return captureConversations(ctx, &captureConversationReader{db: db}, opts)
+	// Prefer the effective (RAG-included) prompt when the transcript store
+	// recorded one; fall back to the canonical messages for older DBs or
+	// conversations with no distinct rendered request.
+	messagesCol := "messages"
+	if has, herr := columnExists(ctx, db, "conversations", "rendered_messages"); herr != nil {
+		return captureResult{}, fmt.Errorf("inspect capture db %q: %w", opts.DBPath, herr)
+	} else if has {
+		messagesCol = "CASE WHEN rendered_messages != '' THEN rendered_messages ELSE messages END"
+	}
+
+	return captureConversations(ctx, &captureConversationReader{db: db, messagesCol: messagesCol}, opts)
+}
+
+// columnExists reports whether table has a column named col. table is always a
+// trusted literal, so interpolating it into the PRAGMA is safe.
+func columnExists(ctx context.Context, db *sql.DB, table, col string) (bool, error) {
+	rows, err := db.QueryContext(ctx, "PRAGMA table_info("+table+")")
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var (
+			cid       int
+			name      string
+			ctype     string
+			notnull   int
+			dfltValue sql.NullString
+			pk        int
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dfltValue, &pk); err != nil {
+			return false, err
+		}
+		if name == col {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
 }
 
 func openReadOnlySQLite(path string) (*sql.DB, error) {
@@ -100,6 +137,9 @@ func openReadOnlySQLite(path string) (*sql.DB, error) {
 
 type captureConversationReader struct {
 	db *sql.DB
+	// messagesCol is the SQL expression that yields the message JSON to capture
+	// (a trusted literal: either "messages" or a rendered-preferring CASE).
+	messagesCol string
 }
 
 func (r *captureConversationReader) List(ctx context.Context) ([]conversation.Summary, error) {
@@ -142,8 +182,12 @@ func (r *captureConversationReader) Load(ctx context.Context, id string) (*conve
 	var messagesJSON string
 	var createdMs, updatedMs int64
 
+	messagesCol := r.messagesCol
+	if messagesCol == "" {
+		messagesCol = "messages"
+	}
 	err := r.db.QueryRowContext(ctx,
-		`SELECT id, title, messages, created_at, updated_at FROM conversations WHERE id = ?`,
+		`SELECT id, title, `+messagesCol+`, created_at, updated_at FROM conversations WHERE id = ?`,
 		id,
 	).Scan(&conv.ID, &conv.Title, &messagesJSON, &createdMs, &updatedMs)
 	if err != nil {

--- a/cmd/llm-bench/capture_test.go
+++ b/cmd/llm-bench/capture_test.go
@@ -139,6 +139,30 @@ func TestConversationToTraceUsesFallbackSystem(t *testing.T) {
 	}
 }
 
+func TestConversationToTraceCombinesMultipleSystemMessages(t *testing.T) {
+	conv := conversation.Conversation{
+		ID: "multi-system",
+		Messages: []conversation.Message{
+			{Role: "system", Content: "Relevant context from the codebase:\n\nretrieved chunk"},
+			{Role: "system", Content: "original system"},
+			{Role: "user", Content: "question"},
+			{Role: "assistant", Content: "answer"},
+		},
+	}
+
+	trace, err := conversationToTrace(conv, "test-source", "", defaultRedactor(), nil, false)
+	if err != nil {
+		t.Fatalf("conversationToTrace() error = %v", err)
+	}
+	want := "Relevant context from the codebase:\n\nretrieved chunk\n\noriginal system"
+	if trace.System != want {
+		t.Fatalf("trace.System = %q; want %q", trace.System, want)
+	}
+	if len(trace.Turns) != 1 || trace.Turns[0].Role != "user" || trace.Turns[0].Content != "question" {
+		t.Fatalf("trace.Turns = %#v, want single user turn", trace.Turns)
+	}
+}
+
 func TestConversationToTraceRejectsMalformedConversations(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/cmd/llm-bench/capture_test.go
+++ b/cmd/llm-bench/capture_test.go
@@ -185,6 +185,49 @@ func TestConversationToTraceDeduplicatesRepeatedSystemMessages(t *testing.T) {
 	}
 }
 
+// TestCaptureFallsBackToMessagesWhenNoRenderedColumn covers a legacy/foreign
+// conversations DB that predates the rendered_messages column: capture must
+// detect its absence and read the canonical messages without erroring.
+func TestCaptureFallsBackToMessagesWhenNoRenderedColumn(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if _, err := db.Exec(`CREATE TABLE conversations (
+		id TEXT PRIMARY KEY, title TEXT NOT NULL DEFAULT '', messages TEXT NOT NULL,
+		created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`); err != nil {
+		t.Fatalf("create legacy table: %v", err)
+	}
+	msgs := `[{"role":"system","content":"legacy sys"},{"role":"user","content":"q"},{"role":"assistant","content":"a"}]`
+	if _, err := db.Exec(`INSERT INTO conversations (id, title, messages, created_at, updated_at) VALUES (?,?,?,?,?)`,
+		"legacy-1", "t", msgs, 1, 1); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	res, err := runCapture(context.Background(), captureOptions{DBPath: path, OutputDir: t.TempDir(), Source: "test"})
+	if err != nil {
+		t.Fatalf("runCapture on legacy DB: %v", err)
+	}
+	if len(res.Written) != 1 {
+		t.Fatalf("written = %d; want 1", len(res.Written))
+	}
+	data, err := os.ReadFile(res.Written[0])
+	if err != nil {
+		t.Fatalf("read trace: %v", err)
+	}
+	var trace Trace
+	if err := json.Unmarshal(data, &trace); err != nil {
+		t.Fatalf("unmarshal trace: %v", err)
+	}
+	if trace.System != "legacy sys" {
+		t.Fatalf("trace.System = %q; want canonical messages fallback", trace.System)
+	}
+}
+
 func TestConversationToTraceRejectsMalformedConversations(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/cmd/llm-bench/capture_test.go
+++ b/cmd/llm-bench/capture_test.go
@@ -163,6 +163,28 @@ func TestConversationToTraceCombinesMultipleSystemMessages(t *testing.T) {
 	}
 }
 
+func TestConversationToTraceDeduplicatesRepeatedSystemMessages(t *testing.T) {
+	conv := conversation.Conversation{
+		ID: "dup-system",
+		Messages: []conversation.Message{
+			{Role: "system", Content: "shared preamble"},
+			{Role: "system", Content: "shared preamble"},
+			{Role: "system", Content: "original system"},
+			{Role: "user", Content: "question"},
+			{Role: "assistant", Content: "answer"},
+		},
+	}
+
+	trace, err := conversationToTrace(conv, "test-source", "", defaultRedactor(), nil, false)
+	if err != nil {
+		t.Fatalf("conversationToTrace() error = %v", err)
+	}
+	want := "shared preamble\n\noriginal system"
+	if trace.System != want {
+		t.Fatalf("trace.System = %q; want %q (verbatim duplicate system messages must collapse)", trace.System, want)
+	}
+}
+
 func TestConversationToTraceRejectsMalformedConversations(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/cmd/llm-bench/capture_transcript_roundtrip_test.go
+++ b/cmd/llm-bench/capture_transcript_roundtrip_test.go
@@ -3,7 +3,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kstruzzieri/go-llm/conversation"
@@ -43,5 +46,59 @@ func TestCaptureReadsTranscriptStoreOutput(t *testing.T) {
 	}
 	if len(res.Written) != 1 || len(res.Skipped) != 0 {
 		t.Fatalf("written=%d skipped=%d, want 1 written / 0 skipped", len(res.Written), len(res.Skipped))
+	}
+}
+
+func TestCaptureTranscriptRoundTripPreservesEffectiveSystemContext(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "conv.db")
+	ts, err := transcript.Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("open transcript: %v", err)
+	}
+	if err := ts.Record(context.Background(), transcript.RecordInput{
+		ConversationID: "rag-effective",
+		Request: []conversation.Message{
+			{Role: "system", Content: "Relevant context from the codebase:\n\nretrieved chunk"},
+			{Role: "system", Content: "original system"},
+			{Role: "user", Content: "question"},
+		},
+		Response: conversation.Message{Role: "assistant", Content: "answer"},
+		Model:    "qwen3:8b",
+		Provider: "fake",
+	}); err != nil {
+		t.Fatalf("record transcript: %v", err)
+	}
+	if err := ts.Close(); err != nil {
+		t.Fatalf("close transcript: %v", err)
+	}
+
+	outDir := t.TempDir()
+	res, err := runCapture(context.Background(), captureOptions{
+		DBPath:    path,
+		OutputDir: outDir,
+		Source:    "test",
+	})
+	if err != nil {
+		t.Fatalf("runCapture: %v", err)
+	}
+	if len(res.Written) != 1 {
+		t.Fatalf("written = %d; want 1", len(res.Written))
+	}
+	data, err := os.ReadFile(res.Written[0])
+	if err != nil {
+		t.Fatalf("read trace: %v", err)
+	}
+	var trace Trace
+	if err := json.Unmarshal(data, &trace); err != nil {
+		t.Fatalf("unmarshal trace: %v", err)
+	}
+	if !strings.Contains(trace.System, "Relevant context from the codebase") {
+		t.Fatalf("trace.System = %q, want effective RAG context", trace.System)
+	}
+	if !strings.Contains(trace.System, "original system") {
+		t.Fatalf("trace.System = %q, want original system prompt", trace.System)
+	}
+	if len(trace.Turns) != 1 || trace.Turns[0].Content != "question" {
+		t.Fatalf("trace turns = %#v, want single user question", trace.Turns)
 	}
 }

--- a/cmd/llm-bench/capture_transcript_roundtrip_test.go
+++ b/cmd/llm-bench/capture_transcript_roundtrip_test.go
@@ -57,7 +57,13 @@ func TestCaptureTranscriptRoundTripPreservesEffectiveSystemContext(t *testing.T)
 	}
 	if err := ts.Record(context.Background(), transcript.RecordInput{
 		ConversationID: "rag-effective",
+		// Canonical request stays RAG-free (identity/stitching); the effective
+		// model-visible request with the retrieved context rides in RenderedRequest.
 		Request: []conversation.Message{
+			{Role: "system", Content: "original system"},
+			{Role: "user", Content: "question"},
+		},
+		RenderedRequest: []conversation.Message{
 			{Role: "system", Content: "Relevant context from the codebase:\n\nretrieved chunk"},
 			{Role: "system", Content: "original system"},
 			{Role: "user", Content: "question"},

--- a/cmd/llm-bench/replay_test.go
+++ b/cmd/llm-bench/replay_test.go
@@ -733,6 +733,58 @@ func TestReplayScoresToolCallOnPlainChatTraceAsDivergence(t *testing.T) {
 	}
 }
 
+// TestReplayDivergenceDoesNotLeakContentToScorer guards against a candidate
+// earning a passing score on a failed-restraint divergence: when the candidate
+// emits a tool call AND prose that happens to contain the golden answer, the
+// recorded turn must not expose that prose as the final answer, or the
+// exact-match scorer / calibration artifact would grade the divergence as
+// correct. The tool call is the answer here, and it is a divergence.
+func TestReplayDivergenceDoesNotLeakContentToScorer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := ollama.ChatResponse{
+			Model: "test-model",
+			Message: ollama.ChatMessage{
+				Role:    "assistant",
+				Content: "The answer is 4.",
+				ToolCalls: []ollama.ToolCall{
+					{
+						ID:       "candidate-call",
+						Type:     "function",
+						Function: ollama.ToolCallFunction{Name: "read_file", Arguments: map[string]any{"path": "x"}},
+					},
+				},
+			},
+			Done: true,
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	trace := Trace{
+		ID:     "diverged-with-prose",
+		System: "sys",
+		Tools: []json.RawMessage{
+			json.RawMessage(`{"name":"read_file","description":"Read a file","inputSchema":{"type":"object"}}`),
+		},
+		Turns:  []Turn{{Role: "user", Content: "Just answer directly: what is 2+2?"}},
+		Golden: Golden{ToolCalls: []string{}, FinalAnswerSubstring: "4"},
+	}
+
+	out, err := replayWith(context.Background(), ollamaCandidateClient{client: client}, "test-model", trace, replayOptions{})
+	if err != nil {
+		t.Fatalf("replayWith() error = %v, want nil", err)
+	}
+	if got := lastAssistantContent(out.Transcript); strings.Contains(got, "4") {
+		t.Fatalf("divergence leaked scorable content %q; want no golden-matching final answer", got)
+	}
+	if len(out.Transcript) != 1 || len(out.Transcript[0].ToolCalls) != 1 {
+		t.Fatalf("transcript = %#v, want the candidate's tool call retained for forensics", out.Transcript)
+	}
+}
+
 func TestReplayPreservesToolsForScriptedToolTrace(t *testing.T) {
 	log := &requestLog{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/llm-bench/replay_test.go
+++ b/cmd/llm-bench/replay_test.go
@@ -609,8 +609,8 @@ func TestReplayScoresToolCallForScriptedPlainTextReplyAsDivergence(t *testing.T)
 	if len(out.Transcript) != 1 || len(out.Transcript[0].ToolCalls) != 1 {
 		t.Fatalf("transcript = %#v, want candidate tool-call turn recorded", out.Transcript)
 	}
-	if out.Transcript[0].Content != "" {
-		t.Fatalf("divergent tool-call content = %q, want stripped content", out.Transcript[0].Content)
+	if out.Transcript[0].Content != plainChatToolDivergenceFinal {
+		t.Fatalf("divergent tool-call content = %q, want marker %q", out.Transcript[0].Content, plainChatToolDivergenceFinal)
 	}
 	requests := log.snapshot()
 	if len(requests) != 1 || len(requests[0].Tools) != 1 {
@@ -787,8 +787,18 @@ func TestReplayDivergenceDoesNotLeakContentToScorer(t *testing.T) {
 	if got := lastAssistantContent(out.Transcript); strings.Contains(got, "4") {
 		t.Fatalf("divergence leaked scorable content %q; want no golden-matching final answer", got)
 	}
+	if got := lastAssistantContent(out.Transcript); strings.TrimSpace(got) == "" {
+		t.Fatalf("divergence final answer is empty; llm-judge would reject it")
+	}
 	if len(out.Transcript) != 1 || len(out.Transcript[0].ToolCalls) != 1 {
 		t.Fatalf("transcript = %#v, want the candidate's tool call retained for forensics", out.Transcript)
+	}
+	judge, err := newLLMJudgeScorer(&fakeJudgeClient{}, "gemma4:31b", 0)
+	if err != nil {
+		t.Fatalf("newLLMJudgeScorer: %v", err)
+	}
+	if _, _, err := judge.buildJudgeCall(trace, Result{Model: "qwen3:8b", TraceID: trace.ID, Transcript: out.Transcript}); err != nil {
+		t.Fatalf("buildJudgeCall rejected scoreable divergence: %v", err)
 	}
 }
 

--- a/cmd/llm-bench/replay_test.go
+++ b/cmd/llm-bench/replay_test.go
@@ -549,11 +549,11 @@ func TestReplayErrorsWhenCandidateToolCallDoesNotMatchFrozenResult(t *testing.T)
 	}
 }
 
-// TestReplayErrorsWhenCandidateCallsToolForPlainTextScript guards the
-// sentinel correction: a candidate that emits tool calls against a
-// scripted plain-text assistant turn is a *mismatch*, not a missing
-// tool result.
-func TestReplayErrorsWhenCandidateCallsToolForPlainTextScript(t *testing.T) {
+// TestReplayScoresToolCallForScriptedPlainTextReplyAsDivergence guards the
+// scoreable-divergence path for fixtures that include a scripted plain-text
+// assistant turn. The candidate still faced tools, so reaching for one is a
+// failed-restraint answer to score, not a dropped replay error.
+func TestReplayScoresToolCallForScriptedPlainTextReplyAsDivergence(t *testing.T) {
 	log := &requestLog{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req ollama.ChatRequest
@@ -593,18 +593,25 @@ func TestReplayErrorsWhenCandidateCallsToolForPlainTextScript(t *testing.T) {
 			{Role: "user", Content: "What is 2+2?"},
 			{Role: "assistant", Content: "4"},
 		},
+		Golden: Golden{
+			ToolCalls:            []string{},
+			FinalAnswerSubstring: "4",
+		},
 	}
 
-	_, err := replay(context.Background(), client, "test-model", trace)
-	if !errors.Is(err, errToolCallMismatch) {
-		t.Fatalf("err = %v, want errToolCallMismatch", err)
+	out, err := replayWith(context.Background(), ollamaCandidateClient{client: client}, "test-model", trace, replayOptions{})
+	if err != nil {
+		t.Fatalf("replayWith() error = %v, want nil (divergence is scored, not errored)", err)
 	}
-	if errors.Is(err, errMissingToolResult) {
-		t.Fatalf("err = %v, must not be errMissingToolResult", err)
+	if len(out.Notes) == 0 {
+		t.Fatalf("expected a divergence note when candidate called a tool for scripted plain-text reply")
 	}
-	// The mismatch must be reachable for the right reason: the candidate was
-	// actually offered the tool. A suppressed-tools replay could never trigger
-	// this path with a real model.
+	if len(out.Transcript) != 1 || len(out.Transcript[0].ToolCalls) != 1 {
+		t.Fatalf("transcript = %#v, want candidate tool-call turn recorded", out.Transcript)
+	}
+	if out.Transcript[0].Content != "" {
+		t.Fatalf("divergent tool-call content = %q, want stripped content", out.Transcript[0].Content)
+	}
 	requests := log.snapshot()
 	if len(requests) != 1 || len(requests[0].Tools) != 1 {
 		t.Fatalf("candidate must be given the declared tool; sent %#v", requests)

--- a/cmd/llm-bench/replay_test.go
+++ b/cmd/llm-bench/replay_test.go
@@ -604,6 +604,106 @@ func TestReplayErrorsWhenCandidateCallsToolForPlainTextScript(t *testing.T) {
 	}
 }
 
+func TestReplayOmitsToolsForPlainCapturedChatTrace(t *testing.T) {
+	log := &requestLog{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollama.ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		log.append(req)
+		resp := ollama.ChatResponse{
+			Model:   "test-model",
+			Message: ollama.ChatMessage{Role: "assistant", Content: "plain answer"},
+			Done:    true,
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	trace := Trace{
+		ID:     "captured-plain-chat",
+		System: "sys",
+		Tools: []json.RawMessage{
+			json.RawMessage(`{"name":"read_file","description":"Read a file","inputSchema":{"type":"object"}}`),
+		},
+		Turns: []Turn{{Role: "user", Content: "Explain the replay flow"}},
+		Golden: Golden{
+			ToolCalls:            []string{},
+			FinalAnswerSubstring: "plain answer",
+		},
+	}
+
+	out, err := replayWith(context.Background(), ollamaCandidateClient{client: client}, "test-model", trace, replayOptions{})
+	if err != nil {
+		t.Fatalf("replayWith() error = %v", err)
+	}
+	if len(out.Transcript) != 1 || out.Transcript[0].Content != "plain answer" {
+		t.Fatalf("transcript = %#v, want one plain assistant answer", out.Transcript)
+	}
+	requests := log.snapshot()
+	if len(requests) != 1 {
+		t.Fatalf("requests = %d, want 1", len(requests))
+	}
+	if len(requests[0].Tools) != 0 {
+		t.Fatalf("plain captured-chat replay sent %d tools; want 0", len(requests[0].Tools))
+	}
+}
+
+func TestReplayPreservesToolsForScriptedToolTrace(t *testing.T) {
+	log := &requestLog{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollama.ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		log.append(req)
+		resp := ollama.ChatResponse{
+			Model:   "test-model",
+			Message: ollama.ChatMessage{Role: "assistant", Content: "I can answer without tools"},
+			Done:    true,
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	trace := Trace{
+		ID:     "scripted-tool-trace",
+		System: "sys",
+		Tools: []json.RawMessage{
+			json.RawMessage(`{"name":"read_file","description":"Read","inputSchema":{"type":"object"}}`),
+		},
+		Turns: []Turn{
+			{Role: "user", Content: "Read provider/router.go"},
+			{Role: "assistant", ToolCalls: []ToolCall{{Name: "read_file", Arguments: json.RawMessage(`{"path":"provider/router.go"}`)}}},
+			{Role: "tool", Name: "read_file", Content: "package provider"},
+			{Role: "assistant", Content: "scripted summary"},
+		},
+		Golden: Golden{ToolCalls: []string{"read_file"}, FinalAnswerSubstring: "scripted summary"},
+	}
+
+	out, err := replayWith(context.Background(), ollamaCandidateClient{client: client}, "test-model", trace, replayOptions{})
+	if err != nil {
+		t.Fatalf("replayWith() error = %v", err)
+	}
+	if len(out.Notes) == 0 {
+		t.Fatalf("expected bypass note when candidate skipped scripted tool route")
+	}
+	requests := log.snapshot()
+	if len(requests) != 1 {
+		t.Fatalf("requests = %d, want 1", len(requests))
+	}
+	if len(requests[0].Tools) != 1 {
+		t.Fatalf("scripted tool replay sent %d tools; want 1", len(requests[0].Tools))
+	}
+}
+
 // TestReplayErrorsWhenCandidateCallsToolWithNoScriptedAssistant guards
 // the second sentinel-taxonomy fix: when the trace has no scripted
 // assistant turn after the user turn, a candidate tool call yields
@@ -844,7 +944,8 @@ func TestReplayForwardsTraceTools(t *testing.T) {
 		Tools: []json.RawMessage{
 			json.RawMessage(`{"name":"read_file","description":"Read a file from disk","inputSchema":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}}`),
 		},
-		Turns: []Turn{{Role: "user", Content: "Read provider/router.go"}},
+		Turns:  []Turn{{Role: "user", Content: "Read provider/router.go"}},
+		Golden: Golden{ToolCalls: []string{"read_file"}},
 	}
 
 	transcript, err := replay(context.Background(), client, "test-model", trace)

--- a/cmd/llm-bench/replay_test.go
+++ b/cmd/llm-bench/replay_test.go
@@ -602,9 +602,22 @@ func TestReplayErrorsWhenCandidateCallsToolForPlainTextScript(t *testing.T) {
 	if errors.Is(err, errMissingToolResult) {
 		t.Fatalf("err = %v, must not be errMissingToolResult", err)
 	}
+	// The mismatch must be reachable for the right reason: the candidate was
+	// actually offered the tool. A suppressed-tools replay could never trigger
+	// this path with a real model.
+	requests := log.snapshot()
+	if len(requests) != 1 || len(requests[0].Tools) != 1 {
+		t.Fatalf("candidate must be given the declared tool; sent %#v", requests)
+	}
 }
 
-func TestReplayOmitsToolsForPlainCapturedChatTrace(t *testing.T) {
+// TestReplayExposesToolsForPlainCapturedChatTrace verifies replay forwards the
+// captured tool schemas even when the original conversation answered in plain
+// text. The candidate must face the same tool temptation the real workflow
+// presented; stripping the tools would silently measure an easier, tool-free
+// task. Here the candidate exercises restraint and answers directly, which is a
+// clean pass.
+func TestReplayExposesToolsForPlainCapturedChatTrace(t *testing.T) {
 	log := &requestLog{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req ollama.ChatRequest
@@ -644,12 +657,79 @@ func TestReplayOmitsToolsForPlainCapturedChatTrace(t *testing.T) {
 	if len(out.Transcript) != 1 || out.Transcript[0].Content != "plain answer" {
 		t.Fatalf("transcript = %#v, want one plain assistant answer", out.Transcript)
 	}
+	if len(out.Notes) != 0 {
+		t.Fatalf("notes = %#v, want none for a clean plain-text replay", out.Notes)
+	}
 	requests := log.snapshot()
 	if len(requests) != 1 {
 		t.Fatalf("requests = %d, want 1", len(requests))
 	}
-	if len(requests[0].Tools) != 0 {
-		t.Fatalf("plain captured-chat replay sent %d tools; want 0", len(requests[0].Tools))
+	if len(requests[0].Tools) != 1 {
+		t.Fatalf("plain captured-chat replay sent %d tools; want 1 (tools must stay exposed)", len(requests[0].Tools))
+	}
+}
+
+// TestReplayScoresToolCallOnPlainChatTraceAsDivergence verifies that when a
+// candidate calls a tool on a captured plain-chat trace (no scripted tool
+// route, no frozen tool result), replay records a scored divergence instead of
+// hard-erroring. This keeps one scored artifact per (trace, model) pair while
+// preserving the failed-restraint signal: the candidate's tool-call turn lands
+// in the transcript (so the scorer grades it low) and a Note explains why.
+func TestReplayScoresToolCallOnPlainChatTraceAsDivergence(t *testing.T) {
+	log := &requestLog{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollama.ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		log.append(req)
+		resp := ollama.ChatResponse{
+			Model: "test-model",
+			Message: ollama.ChatMessage{
+				Role: "assistant",
+				ToolCalls: []ollama.ToolCall{
+					{
+						ID:       "candidate-call",
+						Type:     "function",
+						Function: ollama.ToolCallFunction{Name: "read_file", Arguments: map[string]any{"path": "x"}},
+					},
+				},
+			},
+			Done: true,
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := ollama.NewClient(ollama.WithBaseURL(srv.URL))
+	trace := Trace{
+		ID:     "captured-plain-chat-diverged",
+		System: "sys",
+		Tools: []json.RawMessage{
+			json.RawMessage(`{"name":"read_file","description":"Read a file","inputSchema":{"type":"object"}}`),
+		},
+		Turns: []Turn{{Role: "user", Content: "Just answer directly: what is 2+2?"}},
+		Golden: Golden{
+			ToolCalls:            []string{},
+			FinalAnswerSubstring: "4",
+		},
+	}
+
+	out, err := replayWith(context.Background(), ollamaCandidateClient{client: client}, "test-model", trace, replayOptions{})
+	if err != nil {
+		t.Fatalf("replayWith() error = %v, want nil (divergence is scored, not errored)", err)
+	}
+	if len(out.Notes) == 0 {
+		t.Fatalf("expected a divergence note when candidate called a tool on a plain-chat trace")
+	}
+	if len(out.Transcript) != 1 || len(out.Transcript[0].ToolCalls) != 1 {
+		t.Fatalf("transcript = %#v, want the candidate's tool-call turn recorded", out.Transcript)
+	}
+	requests := log.snapshot()
+	if len(requests) != 1 || len(requests[0].Tools) != 1 {
+		t.Fatalf("replay must still expose the captured tool; sent %#v", requests)
 	}
 }
 
@@ -705,9 +785,12 @@ func TestReplayPreservesToolsForScriptedToolTrace(t *testing.T) {
 }
 
 // TestReplayErrorsWhenCandidateCallsToolWithNoScriptedAssistant guards
-// the second sentinel-taxonomy fix: when the trace has no scripted
-// assistant turn after the user turn, a candidate tool call yields
-// errMissingScriptedAssistant, not errMissingToolResult.
+// the malformed-fixture case: a trace that *expected* a tool route
+// (Golden.ToolCalls is set) but has no scripted assistant turn after the
+// user turn to supply frozen results. A candidate tool call there yields
+// errMissingScriptedAssistant, not errMissingToolResult. (For a plain-chat
+// trace with no expected tool route, the same shape is instead scored as a
+// divergence — see TestReplayScoresToolCallOnPlainChatTraceAsDivergence.)
 func TestReplayErrorsWhenCandidateCallsToolWithNoScriptedAssistant(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := ollama.ChatResponse{
@@ -740,6 +823,10 @@ func TestReplayErrorsWhenCandidateCallsToolWithNoScriptedAssistant(t *testing.T)
 		Turns: []Turn{
 			{Role: "user", Content: "Read it"},
 		},
+		// Golden expects a tool route, but no scripted assistant turn supplies
+		// the frozen result: a malformed fixture, which must error rather than
+		// be silently scored.
+		Golden: Golden{ToolCalls: []string{"read_file"}},
 	}
 
 	_, err := replay(context.Background(), client, "test-model", trace)
@@ -944,8 +1031,7 @@ func TestReplayForwardsTraceTools(t *testing.T) {
 		Tools: []json.RawMessage{
 			json.RawMessage(`{"name":"read_file","description":"Read a file from disk","inputSchema":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}}`),
 		},
-		Turns:  []Turn{{Role: "user", Content: "Read provider/router.go"}},
-		Golden: Golden{ToolCalls: []string{"read_file"}},
+		Turns: []Turn{{Role: "user", Content: "Read provider/router.go"}},
 	}
 
 	transcript, err := replay(context.Background(), client, "test-model", trace)

--- a/cmd/llm-bench/runner.go
+++ b/cmd/llm-bench/runner.go
@@ -191,6 +191,25 @@ type replayOptions struct {
 	NumCtx         int
 }
 
+func replayShouldExposeTools(trace Trace) bool {
+	if len(trace.Golden.ToolCalls) > 0 {
+		return true
+	}
+	for _, turn := range trace.Turns {
+		if turn.Role == "assistant" && len(turn.ToolCalls) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func toolsForReplay(trace Trace, tools []ollama.Tool) []ollama.Tool {
+	if replayShouldExposeTools(trace) {
+		return tools
+	}
+	return nil
+}
+
 // replay is the legacy entry point retained for tests and callers that
 // don't need the Runner-level knobs (PerTurnTimeout, NumCtx).
 func replay(ctx context.Context, client *ollama.Client, model string, trace Trace) ([]Turn, error) {
@@ -230,10 +249,11 @@ func replayWith(ctx context.Context, client candidateChatClient, model string, t
 	messages := []ollama.ChatMessage{
 		{Role: "system", Content: trace.System},
 	}
-	tools, err := decodeTraceTools(trace.Tools)
+	decodedTools, err := decodeTraceTools(trace.Tools)
 	if err != nil {
 		return replayOutput{}, fmt.Errorf("trace %q: %w", trace.ID, err)
 	}
+	tools := toolsForReplay(trace, decodedTools)
 
 	out := replayOutput{}
 	for i := 0; i < len(trace.Turns); {

--- a/cmd/llm-bench/runner.go
+++ b/cmd/llm-bench/runner.go
@@ -293,27 +293,8 @@ func replayWith(ctx context.Context, client candidateChatClient, model string, t
 			}
 
 			if expectedIndex == -1 {
-				// A captured plain-chat trace (no scripted tool route) has no
-				// frozen tool result to feed back, so replay cannot continue
-				// deterministically once the candidate reaches for a tool. That
-				// choice is a real divergence (failed restraint), not a harness
-				// error: record it as a scored divergence so exactly one artifact
-				// per (trace, model) pair is still written. The candidate's
-				// tool-call turn is already in out.Transcript, so the scorer grades
-				// it (there is no final answer to match -> low quality).
 				if len(trace.Golden.ToolCalls) == 0 {
-					// The tool call IS the (divergent) answer. Strip any prose the
-					// candidate emitted alongside it so a stray sentence that
-					// happens to contain the golden substring cannot be scored as a
-					// correct final answer; the tool call stays on the turn for
-					// forensics and the Note records the divergence.
-					if n := len(out.Transcript); n > 0 {
-						out.Transcript[n-1].Content = ""
-					}
-					out.Notes = append(out.Notes,
-						fmt.Sprintf("trace %q user turn %d: candidate called %d tool(s) on a plain-chat trace with no scripted tool route; scored as divergence",
-							trace.ID, userIndex, len(msg.ToolCalls)))
-					return out, nil
+					return scorePlainChatToolDivergence(out, trace.ID, userIndex, len(msg.ToolCalls), "no scripted tool route"), nil
 				}
 				// A trace that genuinely expected a tool route but lacks the
 				// scripted assistant turn is a malformed fixture: surface it.
@@ -321,6 +302,9 @@ func replayWith(ctx context.Context, client candidateChatClient, model string, t
 					trace.ID, userIndex, len(msg.ToolCalls), errMissingScriptedAssistant)
 			}
 			if len(expected.ToolCalls) == 0 {
+				if len(trace.Golden.ToolCalls) == 0 {
+					return scorePlainChatToolDivergence(out, trace.ID, userIndex, len(msg.ToolCalls), "scripted plain-text reply"), nil
+				}
 				return out, fmt.Errorf("trace %q assistant turn %d: candidate emitted %d tool call(s) for plain-text scripted reply: %w",
 					trace.ID, expectedIndex, len(msg.ToolCalls), errToolCallMismatch)
 			}
@@ -340,6 +324,26 @@ func replayWith(ctx context.Context, client candidateChatClient, model string, t
 	}
 
 	return out, nil
+}
+
+func scorePlainChatToolDivergence(out replayOutput, traceID string, userIndex, toolCallCount int, reason string) replayOutput {
+	// A captured plain-chat trace (no expected tool route) has no frozen tool
+	// result to feed back, so replay cannot continue deterministically once the
+	// candidate reaches for a tool. That choice is a real divergence (failed
+	// restraint), not a harness error: record it as a scored divergence so
+	// exactly one artifact per (trace, model) pair is still written.
+	//
+	// The tool call IS the divergent answer. Strip any prose the candidate
+	// emitted alongside it so a stray sentence that happens to contain the
+	// golden substring cannot be scored as a correct final answer; the tool call
+	// stays on the turn for forensics and the Note records the divergence.
+	if n := len(out.Transcript); n > 0 {
+		out.Transcript[n-1].Content = ""
+	}
+	out.Notes = append(out.Notes,
+		fmt.Sprintf("trace %q user turn %d: candidate called %d tool(s) on a plain-chat trace (%s); scored as divergence",
+			traceID, userIndex, toolCallCount, reason))
+	return out
 }
 
 func hasUserTurn(turns []Turn) bool {

--- a/cmd/llm-bench/runner.go
+++ b/cmd/llm-bench/runner.go
@@ -302,6 +302,14 @@ func replayWith(ctx context.Context, client candidateChatClient, model string, t
 				// tool-call turn is already in out.Transcript, so the scorer grades
 				// it (there is no final answer to match -> low quality).
 				if len(trace.Golden.ToolCalls) == 0 {
+					// The tool call IS the (divergent) answer. Strip any prose the
+					// candidate emitted alongside it so a stray sentence that
+					// happens to contain the golden substring cannot be scored as a
+					// correct final answer; the tool call stays on the turn for
+					// forensics and the Note records the divergence.
+					if n := len(out.Transcript); n > 0 {
+						out.Transcript[n-1].Content = ""
+					}
 					out.Notes = append(out.Notes,
 						fmt.Sprintf("trace %q user turn %d: candidate called %d tool(s) on a plain-chat trace with no scripted tool route; scored as divergence",
 							trace.ID, userIndex, len(msg.ToolCalls)))

--- a/cmd/llm-bench/runner.go
+++ b/cmd/llm-bench/runner.go
@@ -16,6 +16,8 @@ import (
 // in RunAll actually keeps the model warm across all of a target's traces.
 const benchKeepAlive = "30m"
 
+const plainChatToolDivergenceFinal = "__LLM_BENCH_TOOL_DIVERGENCE_8F3E0B2C__"
+
 // Sentinel errors so tests assert on identity rather than message text.
 var (
 	errNoUserTurn               = errors.New("trace has no user turn")
@@ -333,12 +335,15 @@ func scorePlainChatToolDivergence(out replayOutput, traceID string, userIndex, t
 	// restraint), not a harness error: record it as a scored divergence so
 	// exactly one artifact per (trace, model) pair is still written.
 	//
-	// The tool call IS the divergent answer. Strip any prose the candidate
-	// emitted alongside it so a stray sentence that happens to contain the
-	// golden substring cannot be scored as a correct final answer; the tool call
-	// stays on the turn for forensics and the Note records the divergence.
+	// The tool call IS the divergent answer. Replace any prose the candidate
+	// emitted alongside it with a deterministic marker so a stray sentence that
+	// happens to contain the golden substring cannot be scored as a correct
+	// final answer. The marker is non-empty so llm-judge can still score the
+	// failed-restraint output instead of rejecting the replay as malformed. The
+	// tool call stays on the turn for forensics and the Note records the
+	// divergence.
 	if n := len(out.Transcript); n > 0 {
-		out.Transcript[n-1].Content = ""
+		out.Transcript[n-1].Content = plainChatToolDivergenceFinal
 	}
 	out.Notes = append(out.Notes,
 		fmt.Sprintf("trace %q user turn %d: candidate called %d tool(s) on a plain-chat trace (%s); scored as divergence",

--- a/cmd/llm-bench/runner.go
+++ b/cmd/llm-bench/runner.go
@@ -191,25 +191,6 @@ type replayOptions struct {
 	NumCtx         int
 }
 
-func replayShouldExposeTools(trace Trace) bool {
-	if len(trace.Golden.ToolCalls) > 0 {
-		return true
-	}
-	for _, turn := range trace.Turns {
-		if turn.Role == "assistant" && len(turn.ToolCalls) > 0 {
-			return true
-		}
-	}
-	return false
-}
-
-func toolsForReplay(trace Trace, tools []ollama.Tool) []ollama.Tool {
-	if replayShouldExposeTools(trace) {
-		return tools
-	}
-	return nil
-}
-
 // replay is the legacy entry point retained for tests and callers that
 // don't need the Runner-level knobs (PerTurnTimeout, NumCtx).
 func replay(ctx context.Context, client *ollama.Client, model string, trace Trace) ([]Turn, error) {
@@ -232,7 +213,10 @@ func replay(ctx context.Context, client *ollama.Client, model string, trace Trac
 //   - Candidate emits tool calls when the scripted turn was plain text:
 //     errToolCallMismatch.
 //   - Candidate emits tool calls when there is no scripted assistant turn
-//     after the user turn: errMissingScriptedAssistant.
+//     after the user turn: for a captured plain-chat trace (Golden.ToolCalls
+//     empty) this is recorded as a scored divergence (Notes annotation, replay
+//     ends, low quality); for a trace that expected a tool route it is the
+//     errMissingScriptedAssistant malformed-fixture error.
 //   - Candidate emits plain text when the scripted route used tools:
 //     scripted tool group is skipped and a Notes annotation records the
 //     bypass; the candidate's reply replaces the scripted final answer.
@@ -249,11 +233,14 @@ func replayWith(ctx context.Context, client candidateChatClient, model string, t
 	messages := []ollama.ChatMessage{
 		{Role: "system", Content: trace.System},
 	}
-	decodedTools, err := decodeTraceTools(trace.Tools)
+	// Tools are always exposed exactly as captured: a faithful replay must
+	// present the candidate with the same tool temptation the original workflow
+	// did. Whether the candidate (mis)uses them is the signal we measure, not
+	// something to suppress.
+	tools, err := decodeTraceTools(trace.Tools)
 	if err != nil {
 		return replayOutput{}, fmt.Errorf("trace %q: %w", trace.ID, err)
 	}
-	tools := toolsForReplay(trace, decodedTools)
 
 	out := replayOutput{}
 	for i := 0; i < len(trace.Turns); {
@@ -306,6 +293,22 @@ func replayWith(ctx context.Context, client candidateChatClient, model string, t
 			}
 
 			if expectedIndex == -1 {
+				// A captured plain-chat trace (no scripted tool route) has no
+				// frozen tool result to feed back, so replay cannot continue
+				// deterministically once the candidate reaches for a tool. That
+				// choice is a real divergence (failed restraint), not a harness
+				// error: record it as a scored divergence so exactly one artifact
+				// per (trace, model) pair is still written. The candidate's
+				// tool-call turn is already in out.Transcript, so the scorer grades
+				// it (there is no final answer to match -> low quality).
+				if len(trace.Golden.ToolCalls) == 0 {
+					out.Notes = append(out.Notes,
+						fmt.Sprintf("trace %q user turn %d: candidate called %d tool(s) on a plain-chat trace with no scripted tool route; scored as divergence",
+							trace.ID, userIndex, len(msg.ToolCalls)))
+					return out, nil
+				}
+				// A trace that genuinely expected a tool route but lacks the
+				// scripted assistant turn is a malformed fixture: surface it.
 				return out, fmt.Errorf("trace %q user turn %d: candidate emitted %d tool call(s) with no scripted assistant turn to match: %w",
 					trace.ID, userIndex, len(msg.ToolCalls), errMissingScriptedAssistant)
 			}

--- a/docs/llm/real-workflow-testing.md
+++ b/docs/llm/real-workflow-testing.md
@@ -23,11 +23,17 @@ Default local paths:
 
 Replay acceptance for this shakedown is stricter than "the command exits":
 `-calibrate-capture` should produce one artifact per retained `(trace, model)`
-pair. A missing-artifact gap caused by `errMissingScriptedAssistant` means a
-plain captured-chat trace exposed tools during replay without scripted tool
-results; fix replay policy before reading model quality. RAG-backed prompts
-must capture the model-visible retrieved context, otherwise replay measures a
-different prompt than the original workflow.
+pair. Replay always exposes the captured tool schemas, so a candidate faces the
+same tool temptation the real workflow presented. If the candidate calls a tool
+on a plain captured-chat trace (no scripted tool route), replay records that as
+a scored divergence (a `Notes` annotation, graded low) rather than dropping the
+pair — the artifact is still written, and a model that reaches for a tool when
+it should answer directly is penalized, not hidden. A genuine
+`errMissingScriptedAssistant` now only signals a malformed fixture (a trace
+whose golden expects a tool route but lacks the scripted assistant turn); fix
+the fixture before reading model quality. RAG-backed prompts must capture the
+model-visible retrieved context, otherwise replay measures a different prompt
+than the original workflow.
 
 ## First Shakedown Scope
 

--- a/docs/llm/real-workflow-testing.md
+++ b/docs/llm/real-workflow-testing.md
@@ -21,6 +21,14 @@ Default local paths:
 3. Capture: export a small redacted trace corpus from the transcript DB.
 4. Measure: replay a small model panel, blind-label outputs, and compare reports.
 
+Replay acceptance for this shakedown is stricter than "the command exits":
+`-calibrate-capture` should produce one artifact per retained `(trace, model)`
+pair. A missing-artifact gap caused by `errMissingScriptedAssistant` means a
+plain captured-chat trace exposed tools during replay without scripted tool
+results; fix replay policy before reading model quality. RAG-backed prompts
+must capture the model-visible retrieved context, otherwise replay measures a
+different prompt than the original workflow.
+
 ## First Shakedown Scope
 
 Use 8-12 real prompts over one normal working session. Include at least:

--- a/mcp/tools_chat.go
+++ b/mcp/tools_chat.go
@@ -153,7 +153,7 @@ func (s *Server) handleChat(ctx context.Context, req *gomcp.CallToolRequest) (*g
 	if err != nil {
 		return toolError("ollama", "%v", err), nil
 	}
-	s.persistTranscript(ctx, req, args, resp)
+	s.persistTranscript(ctx, req, args, messages, resp)
 	return toolResult(resp.Content), nil
 }
 
@@ -207,15 +207,18 @@ func toProviderToolCalls(in []ollama.ToolCall) []provider.ToolCall {
 
 // persistTranscript records a successful chat call to the transcript store when
 // one is configured. Best-effort: any failure is logged and never surfaces to
-// the caller. The original args.Messages (pre-RAG) are recorded; the ephemeral
-// RAG-injected system message is intentionally excluded.
-func (s *Server) persistTranscript(ctx context.Context, req *gomcp.CallToolRequest, args chatArgs, resp *provider.ChatResponse) {
+// the caller. requestMessages should be the exact model-visible messages used
+// for the successful response; callers pass args.Messages only as a fallback.
+func (s *Server) persistTranscript(ctx context.Context, req *gomcp.CallToolRequest, args chatArgs, requestMessages []ollama.ChatMessage, resp *provider.ChatResponse) {
 	store := s.transcriptStoreSnapshot()
 	if store == nil {
 		return
 	}
 
-	reqMsgs, err := conversation.FromChatMessages(args.Messages)
+	if len(requestMessages) == 0 {
+		requestMessages = args.Messages
+	}
+	reqMsgs, err := conversation.FromChatMessages(requestMessages)
 	if err != nil {
 		log.Printf("mcp: transcript skip (convert request): %v", err)
 		return

--- a/mcp/tools_chat.go
+++ b/mcp/tools_chat.go
@@ -157,6 +157,26 @@ func (s *Server) handleChat(ctx context.Context, req *gomcp.CallToolRequest) (*g
 	return toolResult(resp.Content), nil
 }
 
+// chatMessagesEqual reports whether two chat-message slices are equivalent for
+// transcript purposes (role, text, and tool linkage). Used to decide whether an
+// effective request differs from the canonical history enough to record it as a
+// distinct RenderedRequest.
+func chatMessagesEqual(a, b []ollama.ChatMessage) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Role != b[i].Role ||
+			a[i].Content != b[i].Content ||
+			a[i].ToolName != b[i].ToolName ||
+			a[i].ToolCallID != b[i].ToolCallID ||
+			len(a[i].ToolCalls) != len(b[i].ToolCalls) {
+			return false
+		}
+	}
+	return true
+}
+
 // lastUserMessage returns the content of the last message with role "user".
 func lastUserMessage(msgs []ollama.ChatMessage) string {
 	for i := len(msgs) - 1; i >= 0; i-- {
@@ -207,27 +227,37 @@ func toProviderToolCalls(in []ollama.ToolCall) []provider.ToolCall {
 
 // persistTranscript records a successful chat call to the transcript store when
 // one is configured. Best-effort: any failure is logged and never surfaces to
-// the caller. requestMessages should be the exact model-visible messages used
-// for the successful response; callers pass args.Messages only as a fallback.
+// the caller. requestMessages is the exact model-visible request used for the
+// successful response (e.g. with RAG context prepended).
 //
-// The effective prompt is recorded verbatim, including any RAG-injected system
-// context, so replay measures the same prompt the model actually saw rather
-// than the pre-retrieval caller messages. This is intentional: the transcript
-// DB is local and unredacted by design (see WithTranscriptStore) and must not
-// be committed or shared; redaction happens at capture export, not here.
+// The canonical Request is the pre-RAG caller history (args.Messages): it alone
+// drives conversation identity and stitching, so it must stay stable across the
+// turns of one session — recording a per-turn RAG system message there would
+// fork the session. The effective request (requestMessages), when it differs,
+// is recorded separately as RenderedRequest so replay still measures the prompt
+// the model actually saw. The transcript DB is local and unredacted by design
+// (see WithTranscriptStore) and must not be committed or shared; redaction
+// happens at capture export, not here.
 func (s *Server) persistTranscript(ctx context.Context, req *gomcp.CallToolRequest, args chatArgs, requestMessages []ollama.ChatMessage, resp *provider.ChatResponse) {
 	store := s.transcriptStoreSnapshot()
 	if store == nil {
 		return
 	}
 
-	if len(requestMessages) == 0 {
-		requestMessages = args.Messages
-	}
-	reqMsgs, err := conversation.FromChatMessages(requestMessages)
+	reqMsgs, err := conversation.FromChatMessages(args.Messages)
 	if err != nil {
 		log.Printf("mcp: transcript skip (convert request): %v", err)
 		return
+	}
+	// Only carry a distinct rendered request when retrieval (or similar) changed
+	// the effective prompt; otherwise it is identical to the canonical history.
+	var rendered []conversation.Message
+	if len(requestMessages) > 0 && !chatMessagesEqual(requestMessages, args.Messages) {
+		rendered, err = conversation.FromChatMessages(requestMessages)
+		if err != nil {
+			log.Printf("mcp: transcript skip (convert rendered request): %v", err)
+			return
+		}
 	}
 
 	var toolCalls json.RawMessage
@@ -248,8 +278,9 @@ func (s *Server) persistTranscript(ctx context.Context, req *gomcp.CallToolReque
 	}
 
 	in := transcript.RecordInput{
-		ConversationID: strings.TrimSpace(args.ConversationID),
-		Request:        reqMsgs,
+		ConversationID:  strings.TrimSpace(args.ConversationID),
+		Request:         reqMsgs,
+		RenderedRequest: rendered,
 		Response: conversation.Message{
 			Role:      "assistant",
 			Content:   resp.Content,

--- a/mcp/tools_chat.go
+++ b/mcp/tools_chat.go
@@ -209,6 +209,12 @@ func toProviderToolCalls(in []ollama.ToolCall) []provider.ToolCall {
 // one is configured. Best-effort: any failure is logged and never surfaces to
 // the caller. requestMessages should be the exact model-visible messages used
 // for the successful response; callers pass args.Messages only as a fallback.
+//
+// The effective prompt is recorded verbatim, including any RAG-injected system
+// context, so replay measures the same prompt the model actually saw rather
+// than the pre-retrieval caller messages. This is intentional: the transcript
+// DB is local and unredacted by design (see WithTranscriptStore) and must not
+// be committed or shared; redaction happens at capture export, not here.
 func (s *Server) persistTranscript(ctx context.Context, req *gomcp.CallToolRequest, args chatArgs, requestMessages []ollama.ChatMessage, resp *provider.ChatResponse) {
 	store := s.transcriptStoreSnapshot()
 	if store == nil {

--- a/mcp/tools_chat_transcript_test.go
+++ b/mcp/tools_chat_transcript_test.go
@@ -223,8 +223,8 @@ func TestPersistTranscript_MultiTurnRAGStitchesIntoOneConversation(t *testing.T)
 		t.Fatalf("conversations = %d; want 1 (RAG chunks must not fork the session)", count)
 	}
 
-	var messagesJSON, status string
-	if err := db.QueryRow(`SELECT messages, stitch_status FROM conversations`).Scan(&messagesJSON, &status); err != nil {
+	var messagesJSON, renderedJSON, status string
+	if err := db.QueryRow(`SELECT messages, rendered_messages, stitch_status FROM conversations`).Scan(&messagesJSON, &renderedJSON, &status); err != nil {
 		t.Fatalf("read conversation: %v", err)
 	}
 	if status != "extended" {
@@ -241,6 +241,20 @@ func TestPersistTranscript_MultiTurnRAGStitchesIntoOneConversation(t *testing.T)
 		if strings.Contains(m.Content, "Relevant context from the codebase") {
 			t.Fatalf("canonical history leaked RAG context: %+v", stored)
 		}
+	}
+
+	var rendered []conversation.Message
+	if err := json.Unmarshal([]byte(renderedJSON), &rendered); err != nil {
+		t.Fatalf("unmarshal rendered messages: %v", err)
+	}
+	if len(rendered) != 6 {
+		t.Fatalf("rendered messages len = %d; want 6 (RAG,q1,a1,q2,a2) (%+v)", len(rendered), rendered)
+	}
+	if rendered[0].Content != "Relevant context from the codebase:\n\nchunk B" {
+		t.Fatalf("rendered[0] = %+v, want latest RAG context from extended turn", rendered[0])
+	}
+	if rendered[5].Role != "assistant" || rendered[5].Content != "a2" {
+		t.Fatalf("rendered final = %+v, want second assistant answer", rendered[5])
 	}
 }
 

--- a/mcp/tools_chat_transcript_test.go
+++ b/mcp/tools_chat_transcript_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kstruzzieri/go-llm/conversation"
 	"github.com/kstruzzieri/go-llm/ollama"
+	"github.com/kstruzzieri/go-llm/provider"
 	"github.com/kstruzzieri/go-llm/transcript"
 
 	_ "modernc.org/sqlite"
@@ -92,6 +93,59 @@ func TestHandleChat_PersistsTranscript(t *testing.T) {
 	}
 	if !routeOutcome.Valid || !json.Valid([]byte(routeOutcome.String)) {
 		t.Errorf("route_outcome_json = %v, want valid JSON", routeOutcome)
+	}
+}
+
+func TestPersistTranscript_RecordsEffectiveMessagesForReplay(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "conv.db")
+	ts, err := transcript.Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("open transcript: %v", err)
+	}
+	s := &Server{transcriptStore: ts}
+
+	args := chatArgs{
+		ConversationID: "conv-rag",
+		Messages: []ollama.ChatMessage{
+			{Role: "system", Content: "original system"},
+			{Role: "user", Content: "question"},
+		},
+	}
+	effective := []ollama.ChatMessage{
+		{Role: "system", Content: "Relevant context from the codebase:\n\nretrieved chunk"},
+		{Role: "system", Content: "original system"},
+		{Role: "user", Content: "question"},
+	}
+	s.persistTranscript(context.Background(), &gomcp.CallToolRequest{}, args, effective, &provider.ChatResponse{
+		Content:  "answer",
+		Model:    "qwen3:8b",
+		Provider: "fake",
+	})
+	_ = ts.Close()
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open read handle: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	defer func() { _ = db.Close() }()
+
+	var messagesJSON string
+	if err := db.QueryRow(`SELECT messages FROM conversations WHERE id = ?`, "conv-rag").Scan(&messagesJSON); err != nil {
+		t.Fatalf("read canonical messages: %v", err)
+	}
+	var stored []conversation.Message
+	if err := json.Unmarshal([]byte(messagesJSON), &stored); err != nil {
+		t.Fatalf("unmarshal canonical messages: %v", err)
+	}
+	if len(stored) != 4 {
+		t.Fatalf("stored messages len = %d; want 4 (%+v)", len(stored), stored)
+	}
+	if stored[0].Role != "system" || stored[0].Content != "Relevant context from the codebase:\n\nretrieved chunk" {
+		t.Fatalf("stored[0] = %+v, want injected RAG system context", stored[0])
+	}
+	if stored[3].Role != "assistant" || stored[3].Content != "answer" {
+		t.Fatalf("stored final = %+v, want assistant answer", stored[3])
 	}
 }
 

--- a/mcp/tools_chat_transcript_test.go
+++ b/mcp/tools_chat_transcript_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -96,7 +97,7 @@ func TestHandleChat_PersistsTranscript(t *testing.T) {
 	}
 }
 
-func TestPersistTranscript_RecordsEffectiveMessagesForReplay(t *testing.T) {
+func TestPersistTranscript_KeepsRAGOutOfCanonicalButInRendered(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "conv.db")
 	ts, err := transcript.Open(context.Background(), path)
 	if err != nil {
@@ -130,22 +131,116 @@ func TestPersistTranscript_RecordsEffectiveMessagesForReplay(t *testing.T) {
 	db.SetMaxOpenConns(1)
 	defer func() { _ = db.Close() }()
 
-	var messagesJSON string
-	if err := db.QueryRow(`SELECT messages FROM conversations WHERE id = ?`, "conv-rag").Scan(&messagesJSON); err != nil {
+	var messagesJSON, renderedJSON string
+	if err := db.QueryRow(`SELECT messages, rendered_messages FROM conversations WHERE id = ?`, "conv-rag").Scan(&messagesJSON, &renderedJSON); err != nil {
 		t.Fatalf("read canonical messages: %v", err)
+	}
+
+	// Canonical messages must stay RAG-free so identity and stitching are stable.
+	var canonical []conversation.Message
+	if err := json.Unmarshal([]byte(messagesJSON), &canonical); err != nil {
+		t.Fatalf("unmarshal canonical messages: %v", err)
+	}
+	if len(canonical) != 3 {
+		t.Fatalf("canonical messages len = %d; want 3 (RAG excluded) (%+v)", len(canonical), canonical)
+	}
+	if canonical[0].Role != "system" || canonical[0].Content != "original system" {
+		t.Fatalf("canonical[0] = %+v, want original system prompt without RAG", canonical[0])
+	}
+	if canonical[2].Role != "assistant" || canonical[2].Content != "answer" {
+		t.Fatalf("canonical final = %+v, want assistant answer", canonical[2])
+	}
+
+	// Rendered messages carry the effective RAG-injected prompt for replay.
+	var rendered []conversation.Message
+	if err := json.Unmarshal([]byte(renderedJSON), &rendered); err != nil {
+		t.Fatalf("unmarshal rendered messages: %v", err)
+	}
+	if len(rendered) != 4 {
+		t.Fatalf("rendered messages len = %d; want 4 (RAG included) (%+v)", len(rendered), rendered)
+	}
+	if rendered[0].Role != "system" || rendered[0].Content != "Relevant context from the codebase:\n\nretrieved chunk" {
+		t.Fatalf("rendered[0] = %+v, want injected RAG system context", rendered[0])
+	}
+}
+
+// TestPersistTranscript_MultiTurnRAGStitchesIntoOneConversation is the
+// regression for the forked-session bug: when use_rag returns different chunks
+// across turns of one session (no explicit conversation_id), persisting the
+// pre-RAG canonical request must keep both turns in a single stitched
+// conversation instead of forking on the per-turn RAG system message.
+func TestPersistTranscript_MultiTurnRAGStitchesIntoOneConversation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "conv.db")
+	ts, err := transcript.Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("open transcript: %v", err)
+	}
+	s := &Server{transcriptStore: ts}
+
+	// Turn 1: retrieval chunk A.
+	s.persistTranscript(context.Background(), &gomcp.CallToolRequest{},
+		chatArgs{Messages: []ollama.ChatMessage{
+			{Role: "system", Content: "sys"},
+			{Role: "user", Content: "q1"},
+		}},
+		[]ollama.ChatMessage{
+			{Role: "system", Content: "Relevant context from the codebase:\n\nchunk A"},
+			{Role: "system", Content: "sys"},
+			{Role: "user", Content: "q1"},
+		},
+		&provider.ChatResponse{Content: "a1", Model: "qwen3:8b", Provider: "fake"})
+
+	// Turn 2: same session continues, retrieval now returns chunk B.
+	s.persistTranscript(context.Background(), &gomcp.CallToolRequest{},
+		chatArgs{Messages: []ollama.ChatMessage{
+			{Role: "system", Content: "sys"},
+			{Role: "user", Content: "q1"},
+			{Role: "assistant", Content: "a1"},
+			{Role: "user", Content: "q2"},
+		}},
+		[]ollama.ChatMessage{
+			{Role: "system", Content: "Relevant context from the codebase:\n\nchunk B"},
+			{Role: "system", Content: "sys"},
+			{Role: "user", Content: "q1"},
+			{Role: "assistant", Content: "a1"},
+			{Role: "user", Content: "q2"},
+		},
+		&provider.ChatResponse{Content: "a2", Model: "qwen3:8b", Provider: "fake"})
+	_ = ts.Close()
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open read handle: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	defer func() { _ = db.Close() }()
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM conversations`).Scan(&count); err != nil {
+		t.Fatalf("count conversations: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("conversations = %d; want 1 (RAG chunks must not fork the session)", count)
+	}
+
+	var messagesJSON, status string
+	if err := db.QueryRow(`SELECT messages, stitch_status FROM conversations`).Scan(&messagesJSON, &status); err != nil {
+		t.Fatalf("read conversation: %v", err)
+	}
+	if status != "extended" {
+		t.Fatalf("stitch_status = %q; want extended", status)
 	}
 	var stored []conversation.Message
 	if err := json.Unmarshal([]byte(messagesJSON), &stored); err != nil {
-		t.Fatalf("unmarshal canonical messages: %v", err)
+		t.Fatalf("unmarshal messages: %v", err)
 	}
-	if len(stored) != 4 {
-		t.Fatalf("stored messages len = %d; want 4 (%+v)", len(stored), stored)
+	if len(stored) != 5 {
+		t.Fatalf("stitched messages len = %d; want 5 (sys,q1,a1,q2,a2) (%+v)", len(stored), stored)
 	}
-	if stored[0].Role != "system" || stored[0].Content != "Relevant context from the codebase:\n\nretrieved chunk" {
-		t.Fatalf("stored[0] = %+v, want injected RAG system context", stored[0])
-	}
-	if stored[3].Role != "assistant" || stored[3].Content != "answer" {
-		t.Fatalf("stored final = %+v, want assistant answer", stored[3])
+	for _, m := range stored {
+		if strings.Contains(m.Content, "Relevant context from the codebase") {
+			t.Fatalf("canonical history leaked RAG context: %+v", stored)
+		}
 	}
 }
 

--- a/transcript/identity.go
+++ b/transcript/identity.go
@@ -16,16 +16,24 @@ const (
 )
 
 // RecordInput is one chat call to persist. Request is the original user-facing
-// history (any RAG-injected system message already excluded by the caller);
+// history (any RAG-injected system message MUST be excluded by the caller);
 // Response is the assistant turn that answered it.
+//
+// Request alone drives identity (conversationKey) and stitching (decideStitch),
+// so it must stay stable across the turns of one session — an ephemeral
+// RAG-injected system message that changes per turn would fork the session.
+// RenderedRequest optionally carries the exact model-visible request (including
+// that RAG context) for replay fidelity; it never participates in identity or
+// stitching and is persisted separately for capture.
 type RecordInput struct {
-	ConversationID string                 // explicit id from the chat tool arg; "" if absent
-	Request        []conversation.Message // original user-facing history
-	Response       conversation.Message   // assistant turn: content + tool_calls when present
-	Model          string                 // model that served the call; "" if unknown
-	Provider       string                 // provider instance that served the call; "" if unknown
-	RouteOutcome   json.RawMessage        // optional serialized RouteOutcome; nil ok
-	SessionHint    string                 // stable MCP session/client id; "" when unavailable
+	ConversationID  string                 // explicit id from the chat tool arg; "" if absent
+	Request         []conversation.Message // original user-facing history; RAG excluded
+	RenderedRequest []conversation.Message // optional effective model-visible request (RAG included); empty => same as Request
+	Response        conversation.Message   // assistant turn: content + tool_calls when present
+	Model           string                 // model that served the call; "" if unknown
+	Provider        string                 // provider instance that served the call; "" if unknown
+	RouteOutcome    json.RawMessage        // optional serialized RouteOutcome; nil ok
+	SessionHint     string                 // stable MCP session/client id; "" when unavailable
 }
 
 // conversationKey derives the base conversation key and its identity source

--- a/transcript/migration.go
+++ b/transcript/migration.go
@@ -38,7 +38,8 @@ const createConversationsTable = `CREATE TABLE IF NOT EXISTS conversations (
 	identity_source  TEXT NOT NULL DEFAULT '',
 	latest_call_id   TEXT NOT NULL DEFAULT '',
 	message_count    INTEGER NOT NULL DEFAULT 0,
-	stitch_status    TEXT NOT NULL DEFAULT ''
+	stitch_status    TEXT NOT NULL DEFAULT '',
+	rendered_messages TEXT NOT NULL DEFAULT ''
 )`
 
 const createConvKeyIndex = `CREATE INDEX IF NOT EXISTS idx_conversations_key
@@ -55,6 +56,7 @@ var auditColumns = []struct{ name, ddl string }{
 	{"latest_call_id", "TEXT NOT NULL DEFAULT ''"},
 	{"message_count", "INTEGER NOT NULL DEFAULT 0"},
 	{"stitch_status", "TEXT NOT NULL DEFAULT ''"},
+	{"rendered_messages", "TEXT NOT NULL DEFAULT ''"},
 }
 
 // migrate ensures both tables, their indexes, and the conversations audit

--- a/transcript/store.go
+++ b/transcript/store.go
@@ -251,16 +251,36 @@ func (s *Store) insertRaw(ctx context.Context, r rawRow) error {
 // swallowed by Record (the raw row remains the durable source of truth).
 func (s *Store) project(ctx context.Context, callID, key, source string, in RecordInput, now int64) error {
 	incoming := append(append([]conversation.Message{}, in.Request...), in.Response)
+	rendered, err := renderedIncomingJSON(in)
+	if err != nil {
+		return err
+	}
 
 	candidates, err := s.loadCandidates(ctx, key)
 	if err != nil {
 		return err
 	}
 	dec := decideStitch(key, incoming, candidates, time.UnixMilli(now), s.leaseWindow, s.shortThreshold)
-	if err := s.upsertCanonical(ctx, dec, key, source, callID, incoming, now); err != nil {
+	if err := s.upsertCanonical(ctx, dec, key, source, callID, incoming, rendered, now); err != nil {
 		return err
 	}
 	return s.finalizeRawOK(ctx, callID, dec, key)
+}
+
+// renderedIncomingJSON returns the JSON of the effective model-visible
+// conversation (RenderedRequest + Response) for replay capture, or "" when no
+// distinct rendered request was supplied — capture then falls back to the
+// canonical messages. The rendered form never feeds identity or stitching.
+func renderedIncomingJSON(in RecordInput) (string, error) {
+	if len(in.RenderedRequest) == 0 {
+		return "", nil
+	}
+	rendered := append(append([]conversation.Message{}, in.RenderedRequest...), in.Response)
+	b, err := json.Marshal(rendered)
+	if err != nil {
+		return "", fmt.Errorf("transcript: marshal rendered messages: %w", err)
+	}
+	return string(b), nil
 }
 
 // loadCandidates returns every canonical row sharing the base key (base + forked
@@ -304,7 +324,7 @@ func (s *Store) loadCandidates(ctx context.Context, key string) ([]candidate, er
 // INSERT a new row; extended overwrites messages (longer history); idempotent
 // refreshes recency/provenance only (never shrinks). Legacy rows (audit columns
 // defaulted to ”) are backfilled when touched.
-func (s *Store) upsertCanonical(ctx context.Context, dec stitchDecision, key, source, callID string, incoming []conversation.Message, now int64) error {
+func (s *Store) upsertCanonical(ctx context.Context, dec stitchDecision, key, source, callID string, incoming []conversation.Message, rendered string, now int64) error {
 	switch dec.status {
 	case statusCreated, statusForked:
 		msgsJSON, err := json.Marshal(incoming)
@@ -318,10 +338,11 @@ func (s *Store) upsertCanonical(ctx context.Context, dec stitchDecision, key, so
 		if _, err := s.db.ExecContext(ctx,
 			`INSERT INTO conversations
 			   (id, title, messages, created_at, updated_at,
-			    conversation_key, identity_source, latest_call_id, message_count, stitch_status)
-			 VALUES (?,?,?,?,?,?,?,?,?,?)`,
+			    conversation_key, identity_source, latest_call_id, message_count, stitch_status,
+			    rendered_messages)
+			 VALUES (?,?,?,?,?,?,?,?,?,?,?)`,
 			dec.targetID, conversationTitle(incoming), string(msgsJSON), now, now,
-			key, identity, callID, len(incoming), dec.status,
+			key, identity, callID, len(incoming), dec.status, rendered,
 		); err != nil {
 			return fmt.Errorf("transcript: insert canonical: %w", err)
 		}
@@ -332,11 +353,15 @@ func (s *Store) upsertCanonical(ctx context.Context, dec stitchDecision, key, so
 		if err != nil {
 			return fmt.Errorf("transcript: marshal canonical messages: %w", err)
 		}
+		// A single rendered request can only stand in for a single-call
+		// conversation; once the history grows, clear it so capture falls back
+		// to the (RAG-free) canonical messages rather than a stale latest render.
 		if _, err := s.db.ExecContext(ctx,
 			`UPDATE conversations SET
 			    messages = ?, updated_at = ?, latest_call_id = ?,
 			    message_count = ?, stitch_status = ?,
 			    conversation_key = ?,
+			    rendered_messages = '',
 			    identity_source = CASE WHEN identity_source = '' THEN ? ELSE identity_source END,
 			    title = CASE WHEN title = '' THEN ? ELSE title END
 			  WHERE id = ?`,

--- a/transcript/store.go
+++ b/transcript/store.go
@@ -353,20 +353,21 @@ func (s *Store) upsertCanonical(ctx context.Context, dec stitchDecision, key, so
 		if err != nil {
 			return fmt.Errorf("transcript: marshal canonical messages: %w", err)
 		}
-		// A single rendered request can only stand in for a single-call
-		// conversation; once the history grows, clear it so capture falls back
-		// to the (RAG-free) canonical messages rather than a stale latest render.
+		// rendered is either the latest full model-visible history for this call
+		// (when RAG or similar prompt rendering changed the request) or empty,
+		// which intentionally clears any previous rendered snapshot rather than
+		// preserving stale context from an older turn.
 		if _, err := s.db.ExecContext(ctx,
 			`UPDATE conversations SET
 			    messages = ?, updated_at = ?, latest_call_id = ?,
 			    message_count = ?, stitch_status = ?,
 			    conversation_key = ?,
-			    rendered_messages = '',
+			    rendered_messages = ?,
 			    identity_source = CASE WHEN identity_source = '' THEN ? ELSE identity_source END,
 			    title = CASE WHEN title = '' THEN ? ELSE title END
 			  WHERE id = ?`,
 			string(msgsJSON), now, callID, len(incoming), statusExtended,
-			key, source, conversationTitle(incoming), dec.targetID,
+			key, rendered, source, conversationTitle(incoming), dec.targetID,
 		); err != nil {
 			return fmt.Errorf("transcript: extend canonical: %w", err)
 		}

--- a/transcript/store_test.go
+++ b/transcript/store_test.go
@@ -183,6 +183,76 @@ func TestRecord_ExtendsAcrossTurns(t *testing.T) {
 	}
 }
 
+func TestRecord_ExtendsPreservesLatestRenderedMessages(t *testing.T) {
+	s, _ := Open(context.Background(), ":memory:")
+	defer func() { _ = s.Close() }()
+
+	if err := s.Record(context.Background(), RecordInput{
+		ConversationID: "rag-conv",
+		Request: []conversation.Message{
+			{Role: "system", Content: "sys"},
+			{Role: "user", Content: "q1"},
+		},
+		RenderedRequest: []conversation.Message{
+			{Role: "system", Content: "Relevant context from the codebase:\n\nchunk A"},
+			{Role: "system", Content: "sys"},
+			{Role: "user", Content: "q1"},
+		},
+		Response: conversation.Message{Role: "assistant", Content: "a1"},
+	}); err != nil {
+		t.Fatalf("record first turn: %v", err)
+	}
+	if err := s.Record(context.Background(), RecordInput{
+		ConversationID: "rag-conv",
+		Request: []conversation.Message{
+			{Role: "system", Content: "sys"},
+			{Role: "user", Content: "q1"},
+			{Role: "assistant", Content: "a1"},
+			{Role: "user", Content: "q2"},
+		},
+		RenderedRequest: []conversation.Message{
+			{Role: "system", Content: "Relevant context from the codebase:\n\nchunk B"},
+			{Role: "system", Content: "sys"},
+			{Role: "user", Content: "q1"},
+			{Role: "assistant", Content: "a1"},
+			{Role: "user", Content: "q2"},
+		},
+		Response: conversation.Message{Role: "assistant", Content: "a2"},
+	}); err != nil {
+		t.Fatalf("record second turn: %v", err)
+	}
+
+	var messagesJSON, renderedJSON, status string
+	if err := s.db.QueryRow(`SELECT messages, rendered_messages, stitch_status FROM conversations WHERE id = ?`, "rag-conv").
+		Scan(&messagesJSON, &renderedJSON, &status); err != nil {
+		t.Fatalf("read conversation: %v", err)
+	}
+	if status != statusExtended {
+		t.Fatalf("stitch_status = %q; want %q", status, statusExtended)
+	}
+	var canonical []conversation.Message
+	if err := json.Unmarshal([]byte(messagesJSON), &canonical); err != nil {
+		t.Fatalf("unmarshal canonical: %v", err)
+	}
+	if len(canonical) != 5 || canonical[0].Content != "sys" || canonical[4].Content != "a2" {
+		t.Fatalf("canonical messages = %+v, want RAG-free full conversation", canonical)
+	}
+
+	var rendered []conversation.Message
+	if err := json.Unmarshal([]byte(renderedJSON), &rendered); err != nil {
+		t.Fatalf("unmarshal rendered: %v", err)
+	}
+	if len(rendered) != 6 {
+		t.Fatalf("rendered messages len = %d; want 6 (%+v)", len(rendered), rendered)
+	}
+	if rendered[0].Content != "Relevant context from the codebase:\n\nchunk B" {
+		t.Fatalf("rendered[0] = %+v, want latest RAG context from extended turn", rendered[0])
+	}
+	if rendered[5].Role != "assistant" || rendered[5].Content != "a2" {
+		t.Fatalf("rendered final = %+v, want latest assistant answer", rendered[5])
+	}
+}
+
 func TestRecord_DivergentSessionsForkUnderSameKey(t *testing.T) {
 	s, _ := Open(context.Background(), ":memory:")
 	defer func() { _ = s.Close() }()


### PR DESCRIPTION
## Summary

Fixes the real-workflow capture/replay path so calibration capture produces one artifact per retained `(trace, model)` pair, while keeping replay faithful to the captured task.

An earlier revision of this branch suppressed tool exposure for plain captured-chat traces. That removed the stimulus instead of measuring the response: 16 of 17 real-workflow traces each captured 19 MCP tools that were silently stripped at replay, including `conversation-rw-restraint-08` whose entire purpose is to test tool discipline. This revision keeps tools exposed and handles the divergence as a scored outcome.

## Changes

- Always expose the captured tool schemas during replay; a candidate faces the same tool temptation the real workflow presented.
- When a candidate calls a tool on a plain captured-chat trace (no scripted tool route), record a scored divergence (`Notes` annotation, graded low) instead of dropping the pair with `errMissingScriptedAssistant`. The artifact is still written and a model that wrongly reaches for a tool is penalized, not hidden.
- `errMissingScriptedAssistant` now fires only for a malformed fixture: a trace whose golden expects a tool route but lacks the scripted assistant turn.
- Persist the effective model-visible chat messages, including RAG-injected system context, for transcript capture. Documented that the transcript DB is unredacted-local by design (redaction happens at capture export, not at persistence).
- Preserve multiple system messages during transcript-to-trace capture; collapse verbatim duplicates; never truncate.
- Add and refresh regression tests for tool exposure, the tool-call divergence path, the malformed-fixture error, transcript persistence, RAG context capture, and system-message dedup.
- Document the stricter shakedown acceptance criteria.

## Root Cause

Captured chat traces include the tool schemas the MCP server exposed, even when the original conversation answered in plain text. The prior replay either exposed those tools and hard-errored when the candidate called one with no frozen result (`errMissingScriptedAssistant`, producing a missing-artifact gap), or stripped the tools entirely and measured an easier, tool-free task. Neither preserves fidelity. The fix keeps tools exposed and scores the divergence, so exactly one artifact per retained pair is written without altering the captured prompt.

RAG-backed transcript capture also recorded only the caller-supplied messages, not the effective prompt after retrieved context was injected, so replay could measure a different prompt than the original workflow.

## Validation

- `go test ./cmd/llm-bench ./mcp ./transcript`: pass (`653 passed in 3 packages`)
- `go test ./...`: pass
- `scripts/ci-local --mode pre-push`: lint 0 issues, race tests pass, compile smoke pass

## Fresh Shakedown Result

Fresh local-Ollama relabel run: `20260615TtoolsZ`

- Source workflow: 8 prompts completed
- Capture: 8 traces written
- Captured tools: every fresh trace has 19 tool schemas
- Calibration capture: 16 artifacts written for 8 traces x 2 models
- `errMissingScriptedAssistant`: not present
- Tool-call divergences scored as low-quality outputs:
  - `ollama/qwen3:8b`: 3 of 8 traces
  - `ollama/qwen3.6:35b-a3b`: 4 of 8 traces
- Blind ingest: 16 labels, 0 unscored/skipped
- Paired-complete traces: 8 of 8

Quality by model:

| Model | AnswerQuality mean | n |
|---|---:|---:|
| `ollama/qwen3:8b` | 0.44 | 8 |
| `ollama/qwen3.6:35b-a3b` | 0.38 | 8 |

Paired comparison vs baseline `ollama/qwen3:8b`:

| Model | mean Δ vs baseline | 95% CI | wins | losses | ties |
|---|---:|---:|---:|---:|---:|
| `ollama/qwen3.6:35b-a3b` | -0.06 | [-0.19, +0.00] | 0 | 1 | 7 |

Interpretation: this run verifies the restored-tool replay path is complete and scoreable. It is not strong evidence of model discrimination; one rubric step moves a model mean by 0.06 at n=8.
