### PR TITLE
Refresh rendered prompts on idempotent transcript writes

### DIFF
--- a/transcript/store.go
+++ b/transcript/store.go
@@ -374,14 +374,18 @@ func (s *Store) upsertCanonical(ctx context.Context, dec stitchDecision, key, so
 		return nil
 
 	case statusIdempotent:
-		// No shrink: refresh recency + provenance, keep the stored messages.
+		// No shrink: refresh recency + provenance, keep the stored canonical
+		// messages. rendered is still call-specific, so refresh it to the latest
+		// model-visible request (or clear it when the latest call has no distinct
+		// rendered prompt) to keep capture aligned with latest_call_id.
 		if _, err := s.db.ExecContext(ctx,
 			`UPDATE conversations SET
 			    updated_at = ?, latest_call_id = ?, stitch_status = ?,
+			    rendered_messages = ?,
 			    conversation_key = CASE WHEN conversation_key = '' THEN ? ELSE conversation_key END,
 			    identity_source = CASE WHEN identity_source = '' THEN ? ELSE identity_source END
 			  WHERE id = ?`,
-			now, callID, statusIdempotent, key, source, dec.targetID,
+			now, callID, statusIdempotent, rendered, key, source, dec.targetID,
 		); err != nil {
 			return fmt.Errorf("transcript: idempotent update: %w", err)
 		}

--- a/transcript/store_test.go
+++ b/transcript/store_test.go
@@ -253,6 +253,78 @@ func TestRecord_ExtendsPreservesLatestRenderedMessages(t *testing.T) {
 	}
 }
 
+func TestRecord_IdempotentRefreshesLatestRenderedMessages(t *testing.T) {
+	s, _ := Open(context.Background(), ":memory:")
+	defer func() { _ = s.Close() }()
+
+	req := []conversation.Message{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "q1"},
+	}
+	resp := conversation.Message{Role: "assistant", Content: "a1"}
+	renderedA := []conversation.Message{
+		{Role: "system", Content: "Relevant context from the codebase:\n\nchunk A"},
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "q1"},
+	}
+	renderedB := []conversation.Message{
+		{Role: "system", Content: "Relevant context from the codebase:\n\nchunk B"},
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "q1"},
+	}
+
+	if err := s.Record(context.Background(), RecordInput{
+		ConversationID:  "rag-retry",
+		Request:         req,
+		RenderedRequest: renderedA,
+		Response:        resp,
+	}); err != nil {
+		t.Fatalf("record first render: %v", err)
+	}
+	if err := s.Record(context.Background(), RecordInput{
+		ConversationID:  "rag-retry",
+		Request:         req,
+		RenderedRequest: renderedB,
+		Response:        resp,
+	}); err != nil {
+		t.Fatalf("record idempotent render refresh: %v", err)
+	}
+
+	var renderedJSON, status string
+	if err := s.db.QueryRow(`SELECT rendered_messages, stitch_status FROM conversations WHERE id = ?`, "rag-retry").
+		Scan(&renderedJSON, &status); err != nil {
+		t.Fatalf("read refreshed render: %v", err)
+	}
+	if status != statusIdempotent {
+		t.Fatalf("stitch_status = %q; want %q", status, statusIdempotent)
+	}
+	var rendered []conversation.Message
+	if err := json.Unmarshal([]byte(renderedJSON), &rendered); err != nil {
+		t.Fatalf("unmarshal refreshed render: %v", err)
+	}
+	if len(rendered) != 4 || rendered[0].Content != "Relevant context from the codebase:\n\nchunk B" || rendered[3].Content != "a1" {
+		t.Fatalf("rendered messages = %+v, want latest chunk B plus response", rendered)
+	}
+
+	if err := s.Record(context.Background(), RecordInput{
+		ConversationID: "rag-retry",
+		Request:        req,
+		Response:       resp,
+	}); err != nil {
+		t.Fatalf("record idempotent render clear: %v", err)
+	}
+	if err := s.db.QueryRow(`SELECT rendered_messages, stitch_status FROM conversations WHERE id = ?`, "rag-retry").
+		Scan(&renderedJSON, &status); err != nil {
+		t.Fatalf("read cleared render: %v", err)
+	}
+	if status != statusIdempotent {
+		t.Fatalf("stitch_status after clear = %q; want %q", status, statusIdempotent)
+	}
+	if renderedJSON != "" {
+		t.Fatalf("rendered_messages after no-render retry = %q; want cleared", renderedJSON)
+	}
+}
+
 func TestRecord_DivergentSessionsForkUnderSameKey(t *testing.T) {
 	s, _ := Open(context.Background(), ":memory:")
 	defer func() { _ = s.Close() }()


### PR DESCRIPTION
## Summary

Follow-up to PR #174. Fixes the post-merge review finding that idempotent transcript writes refreshed `updated_at` / `latest_call_id` but left `rendered_messages` stale.

## Change

- `statusIdempotent` now refreshes `rendered_messages` with the latest call-specific rendered prompt.
- If the latest idempotent retry has no distinct rendered prompt, `rendered_messages` is cleared so capture falls back to canonical messages instead of exporting stale RAG context.
- Added a regression that records the same canonical request/response with chunk A, then chunk B, then no rendered prompt, verifying the row first refreshes to chunk B and then clears.

## Validation

- `go test ./transcript -run 'TestRecord_IdempotentRefreshesLatestRenderedMessages|TestRecord_ExtendsPreservesLatestRenderedMessages'`
- `go test ./transcript`
- `go test ./cmd/llm-bench ./mcp ./transcript`
- Push hook: lint 0 issues, race tests pass, compile smoke pass
