### PR TITLE
Preserve rendered prompts on prefix idempotent retries

### DIFF
--- a/transcript/stitch.go
+++ b/transcript/stitch.go
@@ -31,8 +31,9 @@ type candidate struct {
 
 // stitchDecision is the outcome of decideStitch.
 type stitchDecision struct {
-	targetID string
-	status   string
+	targetID         string
+	status           string
+	preserveRendered bool
 }
 
 // forkID returns the content-addressed id of a forked sibling of key. Because
@@ -87,7 +88,7 @@ func decideStitch(key string, incoming []conversation.Message, candidates []cand
 		}
 	}
 	if longer != nil {
-		return stitchDecision{targetID: longer.id, status: statusIdempotent}
+		return stitchDecision{targetID: longer.id, status: statusIdempotent, preserveRendered: true}
 	}
 
 	// 5. All diverge.

--- a/transcript/stitch_test.go
+++ b/transcript/stitch_test.go
@@ -35,6 +35,9 @@ func TestDecideStitch_Idempotent(t *testing.T) {
 	if dec.status != statusIdempotent || dec.targetID != "k" {
 		t.Errorf("got %+v, want {k idempotent}", dec)
 	}
+	if dec.preserveRendered {
+		t.Errorf("preserveRendered = true for exact idempotent retry; want false so rendered can refresh")
+	}
 }
 
 func TestDecideStitch_Extended(t *testing.T) {
@@ -50,6 +53,9 @@ func TestDecideStitch_ShorterIncomingNoShrink(t *testing.T) {
 	dec := decideStitch("k", msgs("a", "b"), []candidate{c}, time.UnixMilli(1000), defaultLeaseWindow, defaultShortThreshold)
 	if dec.status != statusIdempotent || dec.targetID != "k" {
 		t.Errorf("got %+v, want {k idempotent} (no shrink)", dec)
+	}
+	if !dec.preserveRendered {
+		t.Errorf("preserveRendered = false for shorter incoming retry; want true to avoid shrinking rendered_messages")
 	}
 }
 

--- a/transcript/store.go
+++ b/transcript/store.go
@@ -375,9 +375,24 @@ func (s *Store) upsertCanonical(ctx context.Context, dec stitchDecision, key, so
 
 	case statusIdempotent:
 		// No shrink: refresh recency + provenance, keep the stored canonical
-		// messages. rendered is still call-specific, so refresh it to the latest
+		// messages. Exact re-records refresh rendered to the latest
 		// model-visible request (or clear it when the latest call has no distinct
-		// rendered prompt) to keep capture aligned with latest_call_id.
+		// rendered prompt). Prefix re-sends of an earlier turn preserve the
+		// existing rendered snapshot so capture cannot shrink a longer
+		// conversation to the shorter rendered retry.
+		if dec.preserveRendered {
+			if _, err := s.db.ExecContext(ctx,
+				`UPDATE conversations SET
+				    updated_at = ?, latest_call_id = ?, stitch_status = ?,
+				    conversation_key = CASE WHEN conversation_key = '' THEN ? ELSE conversation_key END,
+				    identity_source = CASE WHEN identity_source = '' THEN ? ELSE identity_source END
+				  WHERE id = ?`,
+				now, callID, statusIdempotent, key, source, dec.targetID,
+			); err != nil {
+				return fmt.Errorf("transcript: idempotent update: %w", err)
+			}
+			return nil
+		}
 		if _, err := s.db.ExecContext(ctx,
 			`UPDATE conversations SET
 			    updated_at = ?, latest_call_id = ?, stitch_status = ?,

--- a/transcript/store_test.go
+++ b/transcript/store_test.go
@@ -325,6 +325,92 @@ func TestRecord_IdempotentRefreshesLatestRenderedMessages(t *testing.T) {
 	}
 }
 
+func TestRecord_PrefixIdempotentPreservesLongerRenderedMessages(t *testing.T) {
+	s, _ := Open(context.Background(), ":memory:")
+	defer func() { _ = s.Close() }()
+
+	req1 := []conversation.Message{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "q1"},
+	}
+	resp1 := conversation.Message{Role: "assistant", Content: "a1"}
+	if err := s.Record(context.Background(), RecordInput{
+		ConversationID: "rag-prefix",
+		Request:        req1,
+		RenderedRequest: []conversation.Message{
+			{Role: "system", Content: "Relevant context from the codebase:\n\nchunk A"},
+			{Role: "system", Content: "sys"},
+			{Role: "user", Content: "q1"},
+		},
+		Response: resp1,
+	}); err != nil {
+		t.Fatalf("record first turn: %v", err)
+	}
+
+	req2 := []conversation.Message{
+		{Role: "system", Content: "sys"},
+		{Role: "user", Content: "q1"},
+		{Role: "assistant", Content: "a1"},
+		{Role: "user", Content: "q2"},
+	}
+	if err := s.Record(context.Background(), RecordInput{
+		ConversationID: "rag-prefix",
+		Request:        req2,
+		RenderedRequest: []conversation.Message{
+			{Role: "system", Content: "Relevant context from the codebase:\n\nchunk B"},
+			{Role: "system", Content: "sys"},
+			{Role: "user", Content: "q1"},
+			{Role: "assistant", Content: "a1"},
+			{Role: "user", Content: "q2"},
+		},
+		Response: conversation.Message{Role: "assistant", Content: "a2"},
+	}); err != nil {
+		t.Fatalf("record second turn: %v", err)
+	}
+
+	if err := s.Record(context.Background(), RecordInput{
+		ConversationID: "rag-prefix",
+		Request:        req1,
+		RenderedRequest: []conversation.Message{
+			{Role: "system", Content: "Relevant context from the codebase:\n\nchunk retry"},
+			{Role: "system", Content: "sys"},
+			{Role: "user", Content: "q1"},
+		},
+		Response: resp1,
+	}); err != nil {
+		t.Fatalf("record prefix retry: %v", err)
+	}
+
+	var messagesJSON, renderedJSON, status string
+	if err := s.db.QueryRow(`SELECT messages, rendered_messages, stitch_status FROM conversations WHERE id = ?`, "rag-prefix").
+		Scan(&messagesJSON, &renderedJSON, &status); err != nil {
+		t.Fatalf("read conversation: %v", err)
+	}
+	if status != statusIdempotent {
+		t.Fatalf("stitch_status = %q; want %q", status, statusIdempotent)
+	}
+	var canonical []conversation.Message
+	if err := json.Unmarshal([]byte(messagesJSON), &canonical); err != nil {
+		t.Fatalf("unmarshal canonical: %v", err)
+	}
+	if len(canonical) != 5 || canonical[4].Content != "a2" {
+		t.Fatalf("canonical messages = %+v, want longer stored conversation preserved", canonical)
+	}
+	var rendered []conversation.Message
+	if err := json.Unmarshal([]byte(renderedJSON), &rendered); err != nil {
+		t.Fatalf("unmarshal rendered: %v", err)
+	}
+	if len(rendered) != 6 {
+		t.Fatalf("rendered messages len = %d; want longer rendered conversation preserved (%+v)", len(rendered), rendered)
+	}
+	if rendered[0].Content != "Relevant context from the codebase:\n\nchunk B" {
+		t.Fatalf("rendered[0] = %+v, want longer turn's RAG context, not prefix retry", rendered[0])
+	}
+	if rendered[5].Role != "assistant" || rendered[5].Content != "a2" {
+		t.Fatalf("rendered final = %+v, want longer rendered assistant answer", rendered[5])
+	}
+}
+
 func TestRecord_DivergentSessionsForkUnderSameKey(t *testing.T) {
 	s, _ := Open(context.Background(), ":memory:")
 	defer func() { _ = s.Close() }()


### PR DESCRIPTION
## Summary

Follow-up to PR #175. Fixes the post-merge review finding that a prefix/idempotent retry with a distinct `RenderedRequest` could shrink `rendered_messages` even though canonical `messages` intentionally preserves the longer conversation.

## Change

- `decideStitch` now marks prefix idempotent retries with `preserveRendered`.
- `statusIdempotent` still refreshes/clears `rendered_messages` for exact re-records.
- `statusIdempotent` preserves existing `rendered_messages` for no-shrink prefix retries, preventing capture from exporting a shorter rendered prompt than the stored canonical conversation.
- Added unit coverage for both decision cases and an end-to-end store regression for first turn → second turn → first-turn retry with a different RAG chunk.

## Validation

- `go test ./transcript -run 'TestRecord_(PrefixIdempotentPreservesLongerRenderedMessages|IdempotentRefreshesLatestRenderedMessages|ExtendsPreservesLatestRenderedMessages)|TestDecideStitch_(Idempotent|ShorterIncomingNoShrink)'`
- `go test ./transcript`
- `go test ./cmd/llm-bench ./mcp ./transcript`
- Push hook: lint 0 issues, race tests pass, compile smoke pass
