### PR TITLE
feat(llm-bench): tool-restraint as a first-class metric

### DIFF
--- a/cmd/llm-bench/manual_scorer.go
+++ b/cmd/llm-bench/manual_scorer.go
@@ -75,18 +75,13 @@ func (s *ManualScorer) Score(_ context.Context, trace Trace, actual Result) (Sco
 		return Score{}, fmt.Errorf("manual scorer: no human label for trace %q model %q", trace.ID, actual.Model)
 	}
 
-	toolArgsScore, toolArgsComputed, toolArgsNotes, schemaErr := scoreToolArguments(trace, actual.Transcript)
+	score, schemaErr := baseMechanicalScore(trace, actual.Transcript)
 	if schemaErr != nil {
 		return Score{}, fmt.Errorf("trace %q: compile tool schemas: %w", trace.ID, schemaErr)
 	}
-
-	return Score{
-		ToolSequenceMatch:     toolSequenceScore(trace.Golden.ToolCalls, extractToolNames(actual.Transcript)),
-		ToolArgsValid:         toolArgsScore,
-		ToolArgsValidComputed: toolArgsComputed,
-		AnswerQuality:         label.quality,
-		Notes:                 joinScoreNotes(toolArgsNotes, fmt.Sprintf("manual-label: %s", label.notes)),
-	}, nil
+	score.AnswerQuality = label.quality
+	score.Notes = joinScoreNotes(score.Notes, fmt.Sprintf("manual-label: %s", label.notes))
+	return score, nil
 }
 
 // manualReportCoverage records how completely the report covers the labels, so

--- a/cmd/llm-bench/paired.go
+++ b/cmd/llm-bench/paired.go
@@ -475,6 +475,11 @@ func computePairedAnalysis(matched []matchedLabel, stale []Label, arts []Artifac
 // Callers must pass at most one artifact per (trace, model) cell;
 // computePairedAnalysis enforces this before calling, so duplicates are not
 // re-checked here.
+// Unlike the manual/calibration path (which hard-errors on missing trace context
+// via calibrationTraceFromArtifact), this path reads a.Trace directly, so an
+// artifact with a zero-value empty Trace (no Golden tool calls, no Tools) is
+// treated as restraint-eligible-and-held — the correct degenerate behavior, but
+// an intentional asymmetry.
 func computeRestraintPairing(arts []Artifact, lineup []string, baseline string, seed int64, bootstrapN int) restraintPairing {
 	type cellRestraint struct {
 		value       float64

--- a/cmd/llm-bench/paired.go
+++ b/cmd/llm-bench/paired.go
@@ -199,6 +199,22 @@ type baselineDelta struct {
 	Ties      int
 }
 
+// restraintPairing is the label-free paired restraint evidence: it is derived
+// entirely from frozen artifacts (no human labels), so its completeness can
+// exceed the label-paired quality completeness. PerModelMean and BaselineSummary
+// are over the restraint-paired-complete subset (every lineup model has an
+// artifact for the trace AND the trace is restraint-eligible). The ToolExposed*
+// fields repeat the calculation over the stricter "tools were offered" subset.
+type restraintPairing struct {
+	PerModelMean    map[string]float64
+	CompleteN       int
+	BaselineSummary []baselineDelta
+	// ToolExposed* is a compact companion (means only); a paired Δ/CI for the
+	// tool-exposed subset is intentionally out of scope here.
+	ToolExposedPerModelMean map[string]float64
+	ToolExposedN            int
+}
+
 // pairedAnalysis is the computed paired-label evidence for a corpus.
 type pairedAnalysis struct {
 	Lineup          []string           // normalized, sorted candidate models
@@ -217,6 +233,7 @@ type pairedAnalysis struct {
 	Labelers        []string           // distinct labelers on the complete subset
 	BootstrapSeed   int64
 	BootstrapN      int
+	Restraint       restraintPairing // label-free paired restraint evidence
 }
 
 // cellKey identifies a (trace, candidate-model) cell using the same
@@ -443,7 +460,115 @@ func computePairedAnalysis(matched []matchedLabel, stale []Label, arts []Artifac
 		pa.ResolutionFull = math.NaN()
 		pa.ResolutionStep = math.NaN()
 	}
+	pa.Restraint = computeRestraintPairing(arts, lineup, resolvedBaseline, seed, bootstrapN)
 	return pa, nil
+}
+
+// computeRestraintPairing builds paired restraint evidence directly from
+// artifacts, reusing cellKey/modelKey/mean/bootstrapDeltaCI — no new statistics.
+// A trace is restraint-paired-complete when every lineup model has an artifact
+// for it AND restraintSignals reports computed==true for each (eligibility is a
+// property of the trace's golden, so it holds uniformly; the per-cell flag
+// defines the restraint-eligibility subset and also excludes malformed/empty
+// artifacts as a side effect). The tool-exposed subset additionally requires
+// every cell to have had tools offered.
+// Callers must pass at most one artifact per (trace, model) cell;
+// computePairedAnalysis enforces this before calling, so duplicates are not
+// re-checked here.
+func computeRestraintPairing(arts []Artifact, lineup []string, baseline string, seed int64, bootstrapN int) restraintPairing {
+	type cellRestraint struct {
+		value       float64
+		computed    bool
+		toolExposed bool
+	}
+	byCell := make(map[cellKey]cellRestraint, len(arts))
+	traceDisplay := make(map[string]string)
+	for _, a := range arts {
+		value, computed := restraintSignals(a.Trace, a.ActualTranscript)
+		byCell[newCellKey(a.TraceID, a.CandidateModel)] = cellRestraint{
+			value:       value,
+			computed:    computed,
+			toolExposed: computed && len(a.Trace.Tools) > 0,
+		}
+		tk := normalizeModelSelector(a.TraceID)
+		if _, ok := traceDisplay[tk]; !ok {
+			traceDisplay[tk] = a.TraceID
+		}
+	}
+
+	traceKeys := make([]string, 0, len(traceDisplay))
+	for tk := range traceDisplay {
+		traceKeys = append(traceKeys, tk)
+	}
+	sort.Strings(traceKeys)
+
+	var completeKeys []string
+	perModel := make(map[string][]float64, len(lineup))
+	var teCompleteKeys []string
+	perModelTE := make(map[string][]float64, len(lineup))
+	for _, tk := range traceKeys {
+		complete, teComplete := true, true
+		for _, model := range lineup {
+			cr, ok := byCell[cellKey{trace: tk, model: modelKey(model)}]
+			if !ok || !cr.computed {
+				complete = false
+			}
+			if !ok || !cr.toolExposed {
+				teComplete = false
+			}
+		}
+		if complete {
+			completeKeys = append(completeKeys, tk)
+			for _, model := range lineup {
+				cr := byCell[cellKey{trace: tk, model: modelKey(model)}]
+				perModel[model] = append(perModel[model], cr.value)
+			}
+		}
+		if teComplete {
+			teCompleteKeys = append(teCompleteKeys, tk)
+			for _, model := range lineup {
+				cr := byCell[cellKey{trace: tk, model: modelKey(model)}]
+				perModelTE[model] = append(perModelTE[model], cr.value)
+			}
+		}
+	}
+
+	rp := restraintPairing{
+		PerModelMean:            make(map[string]float64, len(lineup)),
+		CompleteN:               len(completeKeys),
+		ToolExposedPerModelMean: make(map[string]float64, len(lineup)),
+		ToolExposedN:            len(teCompleteKeys),
+	}
+	for _, model := range lineup {
+		rp.PerModelMean[model] = mean(perModel[model])
+		rp.ToolExposedPerModelMean[model] = mean(perModelTE[model])
+	}
+
+	base := perModel[baseline]
+	for _, model := range lineup {
+		if model == baseline {
+			continue
+		}
+		vm := perModel[model]
+		deltas := make([]float64, len(completeKeys))
+		bd := baselineDelta{Model: model}
+		for idx := range completeKeys {
+			d := vm[idx] - base[idx]
+			deltas[idx] = d
+			switch {
+			case d > 0:
+				bd.Wins++
+			case d < 0:
+				bd.Losses++
+			default:
+				bd.Ties++
+			}
+		}
+		bd.MeanDelta = mean(deltas)
+		bd.CILow, bd.CIHigh = bootstrapDeltaCI(deltas, seed, bootstrapN)
+		rp.BaselineSummary = append(rp.BaselineSummary, bd)
+	}
+	return rp
 }
 
 func mean(xs []float64) float64 {

--- a/cmd/llm-bench/paired.go
+++ b/cmd/llm-bench/paired.go
@@ -578,8 +578,21 @@ func computeRestraintPairing(arts []Artifact, lineup []string, baseline string, 
 	return rp
 }
 
+// restraintArtifactTraceContextValid reports whether an artifact carries enough
+// embedded trace context to be trusted for restraint pairing. It requires a
+// matching trace ID AND a golden final-answer rubric (criteria or substring),
+// mirroring calibrationTraceFromArtifact's rubric check. The rubric guard is
+// load-bearing: a truncated artifact like Trace{ID: TraceID} with a zero-value
+// Golden has no ToolCalls, so without it restraintSignals would treat the
+// rubric-less trace as golden-empty/restraint-eligible/held and inflate the
+// paired restraint denominator. A real restraint-eligible trace always has a
+// rubric even though its Golden.ToolCalls is empty.
 func restraintArtifactTraceContextValid(a Artifact) bool {
-	return strings.TrimSpace(a.Trace.ID) != "" && a.Trace.ID == a.TraceID
+	if strings.TrimSpace(a.Trace.ID) == "" || a.Trace.ID != a.TraceID {
+		return false
+	}
+	return strings.TrimSpace(a.Trace.Golden.FinalAnswerCriteria) != "" ||
+		strings.TrimSpace(a.Trace.Golden.FinalAnswerSubstring) != ""
 }
 
 func mean(xs []float64) float64 {

--- a/cmd/llm-bench/paired.go
+++ b/cmd/llm-bench/paired.go
@@ -475,11 +475,10 @@ func computePairedAnalysis(matched []matchedLabel, stale []Label, arts []Artifac
 // Callers must pass at most one artifact per (trace, model) cell;
 // computePairedAnalysis enforces this before calling, so duplicates are not
 // re-checked here.
-// Unlike the manual/calibration path (which hard-errors on missing trace context
-// via calibrationTraceFromArtifact), this path reads a.Trace directly, so an
-// artifact with a zero-value empty Trace (no Golden tool calls, no Tools) is
-// treated as restraint-eligible-and-held — the correct degenerate behavior, but
-// an intentional asymmetry.
+// Unlike the manual/calibration path (which hard-errors on missing trace
+// context via calibrationTraceFromArtifact), this path keeps the quality report
+// available and excludes invalid trace context from restraint pairing so
+// malformed artifacts cannot inflate restraint N.
 func computeRestraintPairing(arts []Artifact, lineup []string, baseline string, seed int64, bootstrapN int) restraintPairing {
 	type cellRestraint struct {
 		value       float64
@@ -489,7 +488,10 @@ func computeRestraintPairing(arts []Artifact, lineup []string, baseline string, 
 	byCell := make(map[cellKey]cellRestraint, len(arts))
 	traceDisplay := make(map[string]string)
 	for _, a := range arts {
-		value, computed := restraintSignals(a.Trace, a.ActualTranscript)
+		value, computed := 0.0, false
+		if restraintArtifactTraceContextValid(a) {
+			value, computed = restraintSignals(a.Trace, a.ActualTranscript)
+		}
 		byCell[newCellKey(a.TraceID, a.CandidateModel)] = cellRestraint{
 			value:       value,
 			computed:    computed,
@@ -574,6 +576,10 @@ func computeRestraintPairing(arts []Artifact, lineup []string, baseline string, 
 		rp.BaselineSummary = append(rp.BaselineSummary, bd)
 	}
 	return rp
+}
+
+func restraintArtifactTraceContextValid(a Artifact) bool {
+	return strings.TrimSpace(a.Trace.ID) != "" && a.Trace.ID == a.TraceID
 }
 
 func mean(xs []float64) float64 {

--- a/cmd/llm-bench/paired_test.go
+++ b/cmd/llm-bench/paired_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"math"
 	"path/filepath"
 	"reflect"
@@ -672,4 +673,52 @@ func contains(xs []string, s string) bool {
 		}
 	}
 	return false
+}
+
+func TestComputeRestraintPairingN8FindingShape(t *testing.T) {
+	withTools := []json.RawMessage{json.RawMessage(`{"name":"x","inputSchema":{"type":"object"}}`)}
+	held := []Turn{{Role: "assistant", Content: "ok"}}
+	diverged := []Turn{{Role: "assistant", ToolCalls: []ToolCall{{Name: "x"}}}}
+	mkArt := func(trace, model string, transcript []Turn) Artifact {
+		return Artifact{
+			TraceID:          trace,
+			CandidateModel:   model,
+			Trace:            Trace{ID: trace, Tools: withTools, Golden: Golden{FinalAnswerSubstring: "ok"}},
+			ActualTranscript: transcript,
+		}
+	}
+	// 8 eligible traces. Model a diverges on 3 (t0,t1,t2); model b diverges on 4 (t0,t1,t2,t3).
+	var arts []Artifact
+	for i := 0; i < 8; i++ {
+		id := fmt.Sprintf("t%d", i)
+		aTx := held
+		if i < 3 {
+			aTx = diverged
+		}
+		bTx := held
+		if i < 4 {
+			bTx = diverged
+		}
+		arts = append(arts, mkArt(id, "a", aTx), mkArt(id, "b", bTx))
+	}
+	rp := computeRestraintPairing(arts, []string{"a", "b"}, "a", pairedBootstrapSeed, pairedBootstrapN)
+
+	if rp.CompleteN != 8 {
+		t.Fatalf("CompleteN = %d, want 8", rp.CompleteN)
+	}
+	if rp.PerModelMean["a"] != 0.625 {
+		t.Fatalf("mean[a] = %v, want 0.625 (held 5/8)", rp.PerModelMean["a"])
+	}
+	if rp.PerModelMean["b"] != 0.5 {
+		t.Fatalf("mean[b] = %v, want 0.5 (held 4/8)", rp.PerModelMean["b"])
+	}
+	// b vs baseline a: b diverges on t3 where a held → 1 loss; t0-t2 both diverged (tie);
+	// t4-t7 both held (tie). So 0W/1L/7T, mean delta -1/8 = -0.125.
+	bd := rp.BaselineSummary[0]
+	if bd.Wins != 0 || bd.Losses != 1 || bd.Ties != 7 {
+		t.Fatalf("baselineDelta W/L/T = %d/%d/%d, want 0/1/7", bd.Wins, bd.Losses, bd.Ties)
+	}
+	if bd.MeanDelta != -0.125 {
+		t.Fatalf("MeanDelta = %v, want -0.125", bd.MeanDelta)
+	}
 }

--- a/cmd/llm-bench/paired_test.go
+++ b/cmd/llm-bench/paired_test.go
@@ -677,6 +677,34 @@ func TestComputeRestraintPairingExcludesIneligible(t *testing.T) {
 	}
 }
 
+func TestComputeRestraintPairingExcludesMissingTraceContext(t *testing.T) {
+	held := []Turn{{Role: "assistant", Content: "ok"}}
+	valid := func(trace, model string) Artifact {
+		return Artifact{
+			TraceID:          trace,
+			CandidateModel:   model,
+			Trace:            Trace{ID: trace, Golden: Golden{FinalAnswerSubstring: "ok"}},
+			ActualTranscript: held,
+		}
+	}
+	missingTrace := func(trace, model string) Artifact {
+		return Artifact{
+			TraceID:          trace,
+			CandidateModel:   model,
+			Trace:            Trace{},
+			ActualTranscript: held,
+		}
+	}
+	arts := []Artifact{
+		valid("t1", "a"), valid("t1", "b"),
+		missingTrace("t2", "a"), missingTrace("t2", "b"),
+	}
+	rp := computeRestraintPairing(arts, []string{"a", "b"}, "a", pairedBootstrapSeed, pairedBootstrapN)
+	if rp.CompleteN != 1 {
+		t.Fatalf("CompleteN = %d, want 1 (missing embedded trace context excluded)", rp.CompleteN)
+	}
+}
+
 func contains(xs []string, s string) bool {
 	for _, x := range xs {
 		if x == s {

--- a/cmd/llm-bench/paired_test.go
+++ b/cmd/llm-bench/paired_test.go
@@ -505,11 +505,22 @@ func TestRunPairedReport_EndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runPairedReport: %v", err)
 	}
+	// Fixture derivation:
+	//   Quality paired-complete (M=1): only t1 has every lineup model labeled
+	//   (a2B has no label → t2 is quality-incomplete).
+	//   Restraint paired-complete (N=2): pairedTestArtifact creates traces with
+	//   empty Golden.ToolCalls, so restraintSignals returns computed=true for every
+	//   cell. Both t1 and t2 have artifacts for both models → N=2.
+	//   N > M: the fixture demonstrates the exceeds-case (label-free restraint
+	//   denominator exceeds the label-dependent quality denominator).
 	for _, want := range []string{
 		"Quality by model (paired-complete)",
 		"Completeness worklist",
 		"| t2 | ollama/b | missing-label |",
 		"Bootstrap: seed=1, n=10000",
+		"Restraint vs baseline",
+		"Restraint paired-complete: 2 trace(s) (artifact denominator)",
+		"Quality paired-complete: 1 trace(s) (label denominator)",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("runPairedReport output missing %q:\n%s", want, out)

--- a/cmd/llm-bench/paired_test.go
+++ b/cmd/llm-bench/paired_test.go
@@ -705,6 +705,42 @@ func TestComputeRestraintPairingExcludesMissingTraceContext(t *testing.T) {
 	}
 }
 
+// TestComputeRestraintPairingExcludesMissingGoldenRubric guards against a
+// truncated artifact whose embedded trace has a matching ID but no golden rubric
+// (FinalAnswerCriteria/FinalAnswerSubstring both empty). Its zero-value Golden
+// has no ToolCalls, so restraintSignals would otherwise treat it as a golden-
+// empty restraint-eligible "held" trace and inflate the paired restraint
+// denominator. A real restraint-eligible trace always carries a final-answer
+// rubric, so the absence of one marks malformed trace context to exclude.
+func TestComputeRestraintPairingExcludesMissingGoldenRubric(t *testing.T) {
+	held := []Turn{{Role: "assistant", Content: "ok"}}
+	valid := func(trace, model string) Artifact {
+		return Artifact{
+			TraceID:          trace,
+			CandidateModel:   model,
+			Trace:            Trace{ID: trace, Golden: Golden{FinalAnswerSubstring: "ok"}},
+			ActualTranscript: held,
+		}
+	}
+	// Matching ID but no golden rubric → not a real restraint-eligible trace.
+	noRubric := func(trace, model string) Artifact {
+		return Artifact{
+			TraceID:          trace,
+			CandidateModel:   model,
+			Trace:            Trace{ID: trace},
+			ActualTranscript: held,
+		}
+	}
+	arts := []Artifact{
+		valid("t1", "a"), valid("t1", "b"),
+		noRubric("t2", "a"), noRubric("t2", "b"),
+	}
+	rp := computeRestraintPairing(arts, []string{"a", "b"}, "a", pairedBootstrapSeed, pairedBootstrapN)
+	if rp.CompleteN != 1 {
+		t.Fatalf("CompleteN = %d, want 1 (rubric-less trace context excluded)", rp.CompleteN)
+	}
+}
+
 func contains(xs []string, s string) bool {
 	for _, x := range xs {
 		if x == s {

--- a/cmd/llm-bench/paired_test.go
+++ b/cmd/llm-bench/paired_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"math"
 	"path/filepath"
 	"reflect"
@@ -603,6 +604,64 @@ func TestRunPairedReport_MissingCanaryDoesNotBlock(t *testing.T) {
 	}
 	if !strings.Contains(out, "tool-canary-01") {
 		t.Fatalf("paired report does not note the excluded missing canary (audit trail):\n%s", out)
+	}
+}
+
+func TestComputeRestraintPairing(t *testing.T) {
+	withTools := []json.RawMessage{json.RawMessage(`{"name":"x","inputSchema":{"type":"object"}}`)}
+	held := []Turn{{Role: "assistant", Content: "ok"}}
+	diverged := []Turn{{Role: "assistant", ToolCalls: []ToolCall{{Name: "x"}}}}
+
+	// trace t1: both models held; trace t2: A held, B diverged. Both eligible + tool-exposed.
+	mkArt := func(trace, model string, transcript []Turn) Artifact {
+		return Artifact{
+			TraceID:          trace,
+			CandidateModel:   model,
+			Trace:            Trace{ID: trace, Tools: withTools, Golden: Golden{FinalAnswerSubstring: "ok"}},
+			ActualTranscript: transcript,
+		}
+	}
+	arts := []Artifact{
+		mkArt("t1", "a", held), mkArt("t1", "b", held),
+		mkArt("t2", "a", held), mkArt("t2", "b", diverged),
+	}
+	rp := computeRestraintPairing(arts, []string{"a", "b"}, "a", pairedBootstrapSeed, pairedBootstrapN)
+
+	if rp.CompleteN != 2 {
+		t.Fatalf("CompleteN = %d, want 2", rp.CompleteN)
+	}
+	if rp.PerModelMean["a"] != 1.0 {
+		t.Fatalf("mean[a] = %v, want 1.0", rp.PerModelMean["a"])
+	}
+	if rp.PerModelMean["b"] != 0.5 {
+		t.Fatalf("mean[b] = %v, want 0.5", rp.PerModelMean["b"])
+	}
+	if rp.ToolExposedN != 2 {
+		t.Fatalf("ToolExposedN = %d, want 2", rp.ToolExposedN)
+	}
+	if len(rp.BaselineSummary) != 1 || rp.BaselineSummary[0].Model != "b" {
+		t.Fatalf("BaselineSummary = %+v, want one entry for b", rp.BaselineSummary)
+	}
+	// b vs baseline a: t1 tie (1-1=0), t2 loss (0-1=-1) → mean -0.5, 0W/1L/1T.
+	bd := rp.BaselineSummary[0]
+	if bd.MeanDelta != -0.5 || bd.Wins != 0 || bd.Losses != 1 || bd.Ties != 1 {
+		t.Fatalf("baselineDelta = %+v, want mean=-0.5 0W/1L/1T", bd)
+	}
+}
+
+func TestComputeRestraintPairingExcludesIneligible(t *testing.T) {
+	held := []Turn{{Role: "assistant", Content: "ok"}}
+	// t1 eligible (golden empty); t2 ineligible (golden has a tool route).
+	mkArt := func(trace, model string, golden Golden) Artifact {
+		return Artifact{TraceID: trace, CandidateModel: model, Trace: Trace{ID: trace, Golden: golden}, ActualTranscript: held}
+	}
+	arts := []Artifact{
+		mkArt("t1", "a", Golden{FinalAnswerSubstring: "ok"}), mkArt("t1", "b", Golden{FinalAnswerSubstring: "ok"}),
+		mkArt("t2", "a", Golden{ToolCalls: []string{"x"}}), mkArt("t2", "b", Golden{ToolCalls: []string{"x"}}),
+	}
+	rp := computeRestraintPairing(arts, []string{"a", "b"}, "a", pairedBootstrapSeed, pairedBootstrapN)
+	if rp.CompleteN != 1 {
+		t.Fatalf("CompleteN = %d, want 1 (t2 ineligible)", rp.CompleteN)
 	}
 }
 

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -91,7 +91,7 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 		}
 		fmt.Fprintln(&b)
 	}
-	fmt.Fprintf(&b, "| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | ToolSequenceMatch | ToolArgsValid (computed=N) | Restraint (mean, diverged/eligible) | LatencyMs (p50 / p90, successful-only) | TotalTokens | n | Failures/total (timeout) |\n")
+	fmt.Fprintf(&b, "| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | ToolSequenceMatch | ToolArgsValid (computed=N) | Restraint (mean, diverged/eligible; tool-exposed if available) | LatencyMs (p50 / p90, successful-only) | TotalTokens | n | Failures/total (timeout) |\n")
 	fmt.Fprintf(&b, "|---|---|---|---|---|---|---|---|---|\n")
 	for _, m := range models {
 		rs := summaryByModel[m]
@@ -109,7 +109,8 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 		}
 		toolArgsCell := fmt.Sprintf("%s (computed=%d)",
 			metricCell(agg.meanToolArgs, agg.toolArgsComputed > 0), agg.toolArgsComputed)
-		restraintC := restraintCell(agg.meanRestraint, agg.restraintDiverged, agg.restraintComputed)
+		restraintC := restraintCell(agg.meanRestraint, agg.restraintDiverged, agg.restraintComputed,
+			agg.meanToolExposedRestraint, agg.toolExposedRestraintDiverged, agg.toolExposedRestraintComputed)
 		latencyCell := "n/a"
 		if scored > 0 {
 			latencyCell = fmt.Sprintf("%d / %d", agg.latencyP50, agg.latencyP90)
@@ -183,7 +184,7 @@ func formatManualQualityReport(models []string, results []Result, cov manualRepo
 	fmt.Fprintf(&b, "\nCoverage: %d scored, stale: %d (excluded — label hash no longer matches an artifact), scoring errors: %d.\n\n",
 		cov.Scored, cov.Stale, cov.Errored)
 	fmt.Fprintln(&b, "## Quality by model (all matched labels)")
-	fmt.Fprintln(&b, "| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | Restraint (mean, diverged/eligible) | n |")
+	fmt.Fprintln(&b, "| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | Restraint (mean, diverged/eligible; tool-exposed if available) | n |")
 	fmt.Fprintln(&b, "|---|---|---|---|")
 	for _, m := range models {
 		rs := byModel[m]
@@ -194,7 +195,8 @@ func formatManualQualityReport(models []string, results []Result, cov manualRepo
 			qCell = fmt.Sprintf("%.2f / %.2f / %.2f / %.2f / %.2f",
 				agg.meanQuality, agg.qualityP25, agg.qualityP50, agg.qualityP75, agg.qualityP90)
 		}
-		restraintC := restraintCell(agg.meanRestraint, agg.restraintDiverged, agg.restraintComputed)
+		restraintC := restraintCell(agg.meanRestraint, agg.restraintDiverged, agg.restraintComputed,
+			agg.meanToolExposedRestraint, agg.toolExposedRestraintDiverged, agg.toolExposedRestraintComputed)
 		fmt.Fprintf(&b, "| %s | %s | %s | %d |\n", markdownCell(m), qCell, restraintC, scored)
 	}
 	fmt.Fprintln(&b)
@@ -691,9 +693,13 @@ func aggregate(rs []Result) modelAggregate {
 // restraintCell renders mean restraint with its diverged/eligible counts, or
 // "n/a" when no traces were restraint-eligible (RestraintComputed == 0 for the
 // model), mirroring metricCell's not-computed sentinel.
-func restraintCell(mean float64, diverged, eligible int) string {
+func restraintCell(mean float64, diverged, eligible int, toolMean float64, toolDiverged, toolEligible int) string {
 	if eligible == 0 {
 		return "n/a"
+	}
+	if toolEligible > 0 {
+		return fmt.Sprintf("%.2f (%d/%d diverged; tool-exposed %.2f, %d/%d diverged)",
+			mean, diverged, eligible, toolMean, toolDiverged, toolEligible)
 	}
 	return fmt.Sprintf("%.2f (%d/%d diverged)", mean, diverged, eligible)
 }

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -541,6 +541,15 @@ type modelAggregate struct {
 	promptEvalTokensAvailable int
 	thinkingTokensSum         int
 	thinkingTokensAvailable   int
+
+	restraintSum                 float64 // Σ Restraint over eligible (RestraintComputed) rows
+	restraintComputed            int     // # eligible rows (primary denominator)
+	restraintDiverged            int     // # eligible rows with Restraint == 0
+	meanRestraint                float64 // restraintSum / restraintComputed (0 when none)
+	toolExposedRestraintSum      float64 // Σ over ToolExposedRestraintComputed rows
+	toolExposedRestraintComputed int     // # tool-exposed eligible rows (companion denominator)
+	toolExposedRestraintDiverged int     // # tool-exposed eligible rows with ToolExposedRestraint == 0
+	meanToolExposedRestraint     float64
 }
 
 func aggregate(rs []Result) modelAggregate {
@@ -595,6 +604,20 @@ func aggregate(rs []Result) modelAggregate {
 			a.thinkingTokensSum += r.Score.ThinkingTokens
 			a.thinkingTokensAvailable++
 		}
+		if r.Score.RestraintComputed {
+			a.restraintSum += r.Score.Restraint
+			a.restraintComputed++
+			if r.Score.Restraint == 0 {
+				a.restraintDiverged++
+			}
+		}
+		if r.Score.ToolExposedRestraintComputed {
+			a.toolExposedRestraintSum += r.Score.ToolExposedRestraint
+			a.toolExposedRestraintComputed++
+			if r.Score.ToolExposedRestraint == 0 {
+				a.toolExposedRestraintDiverged++
+			}
+		}
 	}
 	if scored > 0 {
 		a.meanQuality = qSum / float64(scored)
@@ -604,6 +627,12 @@ func aggregate(rs []Result) modelAggregate {
 	}
 	if a.toolArgsComputed > 0 {
 		a.meanToolArgs = taSum / float64(a.toolArgsComputed)
+	}
+	if a.restraintComputed > 0 {
+		a.meanRestraint = a.restraintSum / float64(a.restraintComputed)
+	}
+	if a.toolExposedRestraintComputed > 0 {
+		a.meanToolExposedRestraint = a.toolExposedRestraintSum / float64(a.toolExposedRestraintComputed)
 	}
 	if len(qVals) > 0 {
 		qPs := percentiles(qVals, 0.25, 0.5, 0.75, 0.9)

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -284,6 +284,43 @@ func formatPairedReport(pa pairedAnalysis) string {
 	}
 	fmt.Fprintln(&b)
 
+	fmt.Fprintf(&b, "## Restraint vs baseline (%s)\n\n", markdownCell(pa.Baseline))
+	fmt.Fprintln(&b, "> Tool-restraint is label-free (derived from frozen artifacts), so its paired-complete sample can exceed the quality paired-complete sample. Restraint = 1.0 held / 0.0 diverged over golden-empty (restraint-eligible) traces; higher is better.")
+	fmt.Fprintln(&b, ">")
+	fmt.Fprintln(&b, "> Win/loss/tie below is the discordant-pair table (a win = model held while the baseline diverged).")
+	fmt.Fprintln(&b)
+	fmt.Fprintf(&b, "- Quality paired-complete: %d trace(s) (label denominator)\n", pa.PerModelN)
+	fmt.Fprintf(&b, "- Restraint paired-complete: %d trace(s) (artifact denominator)\n", pa.Restraint.CompleteN)
+	if pa.Restraint.ToolExposedN > 0 {
+		fmt.Fprintf(&b, "- Tool-exposed restraint paired-complete: %d trace(s) (companion: restraint only where tools were offered)\n", pa.Restraint.ToolExposedN)
+	}
+	fmt.Fprintln(&b)
+
+	fmt.Fprintln(&b, "| Model | restraint (mean) | n |")
+	fmt.Fprintln(&b, "|---|---|---|")
+	for _, m := range pa.Lineup {
+		fmt.Fprintf(&b, "| %s | %s | %d |\n", markdownCell(m), meanCell(pa.Restraint.PerModelMean[m]), pa.Restraint.CompleteN)
+	}
+	fmt.Fprintln(&b)
+
+	fmt.Fprintln(&b, "| Model | mean restraint Δ vs baseline | 95% CI | wins | losses | ties |")
+	fmt.Fprintln(&b, "|---|---|---|---|---|---|")
+	for _, bd := range pa.Restraint.BaselineSummary {
+		fmt.Fprintf(&b, "| %s | %s | %s | %d | %d | %d |\n",
+			markdownCell(bd.Model), signedMeanCell(bd.MeanDelta), ciCell(bd.CILow, bd.CIHigh), bd.Wins, bd.Losses, bd.Ties)
+	}
+	fmt.Fprintln(&b)
+	if pa.Restraint.ToolExposedN > 0 {
+		fmt.Fprintln(&b, "Tool-exposed restraint (companion, mean over tool-offered eligible traces):")
+		fmt.Fprintln(&b)
+		fmt.Fprintln(&b, "| Model | tool-exposed restraint (mean) | n |")
+		fmt.Fprintln(&b, "|---|---|---|")
+		for _, m := range pa.Lineup {
+			fmt.Fprintf(&b, "| %s | %s | %d |\n", markdownCell(m), meanCell(pa.Restraint.ToolExposedPerModelMean[m]), pa.Restraint.ToolExposedN)
+		}
+		fmt.Fprintln(&b)
+	}
+
 	fmt.Fprintln(&b, "## Resolution diagnostic")
 	fmt.Fprintln(&b)
 	if pa.PerModelN > 0 {

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -183,8 +183,8 @@ func formatManualQualityReport(models []string, results []Result, cov manualRepo
 	fmt.Fprintf(&b, "\nCoverage: %d scored, stale: %d (excluded — label hash no longer matches an artifact), scoring errors: %d.\n\n",
 		cov.Scored, cov.Stale, cov.Errored)
 	fmt.Fprintln(&b, "## Quality by model (all matched labels)")
-	fmt.Fprintln(&b, "| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | n |")
-	fmt.Fprintln(&b, "|---|---|---|")
+	fmt.Fprintln(&b, "| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | Restraint (mean, diverged/eligible) | n |")
+	fmt.Fprintln(&b, "|---|---|---|---|")
 	for _, m := range models {
 		rs := byModel[m]
 		agg := aggregate(rs)
@@ -194,7 +194,8 @@ func formatManualQualityReport(models []string, results []Result, cov manualRepo
 			qCell = fmt.Sprintf("%.2f / %.2f / %.2f / %.2f / %.2f",
 				agg.meanQuality, agg.qualityP25, agg.qualityP50, agg.qualityP75, agg.qualityP90)
 		}
-		fmt.Fprintf(&b, "| %s | %s | %d |\n", markdownCell(m), qCell, scored)
+		restraintC := restraintCell(agg.meanRestraint, agg.restraintDiverged, agg.restraintComputed)
+		fmt.Fprintf(&b, "| %s | %s | %s | %d |\n", markdownCell(m), qCell, restraintC, scored)
 	}
 	fmt.Fprintln(&b)
 	return redactPaths(b.String())

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -91,8 +91,8 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 		}
 		fmt.Fprintln(&b)
 	}
-	fmt.Fprintf(&b, "| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | ToolSequenceMatch | ToolArgsValid (computed=N) | LatencyMs (p50 / p90, successful-only) | TotalTokens | n | Failures/total (timeout) |\n")
-	fmt.Fprintf(&b, "|---|---|---|---|---|---|---|---|\n")
+	fmt.Fprintf(&b, "| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | ToolSequenceMatch | ToolArgsValid (computed=N) | Restraint (mean, diverged/eligible) | LatencyMs (p50 / p90, successful-only) | TotalTokens | n | Failures/total (timeout) |\n")
+	fmt.Fprintf(&b, "|---|---|---|---|---|---|---|---|---|\n")
 	for _, m := range models {
 		rs := summaryByModel[m]
 		agg := aggregate(rs)
@@ -109,6 +109,7 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 		}
 		toolArgsCell := fmt.Sprintf("%s (computed=%d)",
 			metricCell(agg.meanToolArgs, agg.toolArgsComputed > 0), agg.toolArgsComputed)
+		restraintC := restraintCell(agg.meanRestraint, agg.restraintDiverged, agg.restraintComputed)
 		latencyCell := "n/a"
 		if scored > 0 {
 			latencyCell = fmt.Sprintf("%d / %d", agg.latencyP50, agg.latencyP90)
@@ -119,8 +120,8 @@ func formatReport(models []string, results []Result, opts reportOptions) string 
 		}
 
 		failuresCell := fmt.Sprintf("%d/%d (%d timeout)", agg.errors, agg.errors+scored, agg.timeouts)
-		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s | %s | %d | %s |\n",
-			markdownCell(m), qCell, toolSeqCell, toolArgsCell, latencyCell, tokensCell, scored, failuresCell)
+		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s | %s | %s | %d | %s |\n",
+			markdownCell(m), qCell, toolSeqCell, toolArgsCell, restraintC, latencyCell, tokensCell, scored, failuresCell)
 	}
 
 	if opts.Corpus != nil {
@@ -647,6 +648,16 @@ func aggregate(rs []Result) modelAggregate {
 		a.latencyP90 = lPs[1]
 	}
 	return a
+}
+
+// restraintCell renders mean restraint with its diverged/eligible counts, or
+// "n/a" when no traces were restraint-eligible (RestraintComputed == 0 for the
+// model), mirroring metricCell's not-computed sentinel.
+func restraintCell(mean float64, diverged, eligible int) string {
+	if eligible == 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.2f (%d/%d diverged)", mean, diverged, eligible)
 }
 
 // metricCell renders a metric value as either a 2-decimal number (when

--- a/cmd/llm-bench/report_test.go
+++ b/cmd/llm-bench/report_test.go
@@ -428,10 +428,10 @@ func TestAggregateRestraint(t *testing.T) {
 		}}
 	}
 	rs := []Result{
-		mk(1, true, true),   // held, tools
-		mk(0, true, true),   // diverged, tools
-		mk(1, true, false),  // held, no tools
-		mk(0, false, false), // ineligible (skipped)
+		mk(1, true, true),         // held, tools
+		mk(0, true, true),         // diverged, tools
+		mk(1, true, false),        // held, no tools
+		mk(0, false, false),       // ineligible (skipped)
 		{Err: errors.New("boom")}, // error row (skipped)
 	}
 	a := aggregate(rs)
@@ -452,5 +452,73 @@ func TestAggregateRestraint(t *testing.T) {
 	}
 	if a.meanToolExposedRestraint != 0.5 {
 		t.Fatalf("meanToolExposedRestraint = %v, want 0.5", a.meanToolExposedRestraint)
+	}
+}
+
+func TestFormatPairedReportRestraintSection(t *testing.T) {
+	pa := pairedAnalysis{
+		Lineup:         []string{"a", "b"},
+		Baseline:       "a",
+		AllTraces:      []string{"t1", "t2"},
+		PerModelMean:   map[string]float64{"a": 1, "b": 0.5},
+		PerModelN:      1, // quality paired-complete denominator
+		AllMatchedMean: map[string]float64{"a": 1, "b": 0.5},
+		AllMatchedN:    map[string]int{"a": 2, "b": 2},
+		BootstrapSeed:  pairedBootstrapSeed,
+		BootstrapN:     pairedBootstrapN,
+		Restraint: restraintPairing{
+			PerModelMean:            map[string]float64{"a": 1, "b": 0.5},
+			CompleteN:               2, // restraint's label-free denominator can differ
+			ToolExposedPerModelMean: map[string]float64{"a": 1, "b": 0.5},
+			ToolExposedN:            2,
+			BaselineSummary: []baselineDelta{
+				{Model: "b", MeanDelta: -0.5, CILow: -1, CIHigh: 0, Wins: 0, Losses: 1, Ties: 1},
+			},
+		},
+	}
+	out := formatPairedReport(pa)
+	if !strings.Contains(out, "Restraint vs baseline") {
+		t.Fatalf("paired report missing restraint section:\n%s", out)
+	}
+	if !strings.Contains(out, "Paired-complete traces: 1 of 2") {
+		t.Fatalf("paired report missing quality paired-N provenance:\n%s", out)
+	}
+	if !strings.Contains(out, "Restraint paired-complete: 2") {
+		t.Fatalf("paired report missing restraint paired-N provenance:\n%s", out)
+	}
+	if strings.Contains(out, "AnswerQuality (mean) | Restraint (mean)") {
+		t.Fatalf("paired report mixes quality and restraint denominators in one table:\n%s", out)
+	}
+	if !strings.Contains(out, "| Model | restraint (mean) | n |") {
+		t.Fatalf("paired report missing dedicated per-model restraint table:\n%s", out)
+	}
+	// b's restraint delta vs baseline a.
+	if !strings.Contains(out, "-0.50") {
+		t.Fatalf("paired report missing restraint delta:\n%s", out)
+	}
+}
+
+func TestFormatPairedReportRestraintNoEligibleTraces(t *testing.T) {
+	pa := pairedAnalysis{
+		Lineup:         []string{"a", "b"},
+		Baseline:       "a",
+		AllTraces:      []string{"t1"},
+		PerModelMean:   map[string]float64{"a": 1, "b": 1},
+		PerModelN:      1,
+		AllMatchedMean: map[string]float64{"a": 1, "b": 1},
+		AllMatchedN:    map[string]int{"a": 1, "b": 1},
+		BootstrapSeed:  pairedBootstrapSeed,
+		BootstrapN:     pairedBootstrapN,
+		Restraint: restraintPairing{
+			PerModelMean: map[string]float64{}, // no eligible traces → means absent → NaN
+			CompleteN:    0,
+		},
+	}
+	out := formatPairedReport(pa)
+	if !strings.Contains(out, "Restraint paired-complete: 0") {
+		t.Fatalf("expected restraint paired-complete 0 line:\n%s", out)
+	}
+	if !strings.Contains(out, "Restraint vs baseline") {
+		t.Fatalf("expected restraint section present even with 0 eligible:\n%s", out)
 	}
 }

--- a/cmd/llm-bench/report_test.go
+++ b/cmd/llm-bench/report_test.go
@@ -404,6 +404,20 @@ func TestFormatReportRestraintNAWhenNoneEligible(t *testing.T) {
 	}
 }
 
+func TestFormatManualQualityReportRestraintColumn(t *testing.T) {
+	results := []Result{
+		{Model: "m", TraceID: "a", Score: Score{AnswerQuality: 1, RestraintComputed: true, Restraint: 1}},
+		{Model: "m", TraceID: "b", Score: Score{AnswerQuality: 0, RestraintComputed: true, Restraint: 0}},
+	}
+	out := formatManualQualityReport([]string{"m"}, results, manualReportCoverage{Scored: 2})
+	if !strings.Contains(out, "Restraint") {
+		t.Fatalf("manual report missing Restraint header:\n%s", out)
+	}
+	if !strings.Contains(out, "0.50 (1/2 diverged)") {
+		t.Fatalf("manual report missing restraint cell:\n%s", out)
+	}
+}
+
 func TestAggregateRestraint(t *testing.T) {
 	mk := func(restraint float64, computed, toolExposed bool) Result {
 		return Result{Score: Score{

--- a/cmd/llm-bench/report_test.go
+++ b/cmd/llm-bench/report_test.go
@@ -377,3 +377,40 @@ func TestFormatReportProvenanceReportsCacheDisabledForLLMJudge(t *testing.T) {
 		t.Fatalf("expected cache-disabled signal in provenance:\n%s", report)
 	}
 }
+
+func TestAggregateRestraint(t *testing.T) {
+	mk := func(restraint float64, computed, toolExposed bool) Result {
+		return Result{Score: Score{
+			Restraint:                    restraint,
+			RestraintComputed:            computed,
+			ToolExposedRestraint:         restraint,
+			ToolExposedRestraintComputed: computed && toolExposed,
+		}}
+	}
+	rs := []Result{
+		mk(1, true, true),   // held, tools
+		mk(0, true, true),   // diverged, tools
+		mk(1, true, false),  // held, no tools
+		mk(0, false, false), // ineligible (skipped)
+		{Err: errors.New("boom")}, // error row (skipped)
+	}
+	a := aggregate(rs)
+	if a.restraintComputed != 3 {
+		t.Fatalf("restraintComputed = %d, want 3", a.restraintComputed)
+	}
+	if a.restraintDiverged != 1 {
+		t.Fatalf("restraintDiverged = %d, want 1", a.restraintDiverged)
+	}
+	if got := a.meanRestraint; got != 2.0/3.0 {
+		t.Fatalf("meanRestraint = %v, want %v", got, 2.0/3.0)
+	}
+	if a.toolExposedRestraintComputed != 2 {
+		t.Fatalf("toolExposedRestraintComputed = %d, want 2", a.toolExposedRestraintComputed)
+	}
+	if a.toolExposedRestraintDiverged != 1 {
+		t.Fatalf("toolExposedRestraintDiverged = %d, want 1", a.toolExposedRestraintDiverged)
+	}
+	if a.meanToolExposedRestraint != 0.5 {
+		t.Fatalf("meanToolExposedRestraint = %v, want 0.5", a.meanToolExposedRestraint)
+	}
+}

--- a/cmd/llm-bench/report_test.go
+++ b/cmd/llm-bench/report_test.go
@@ -270,7 +270,7 @@ func TestFormatReportSummaryMatchesTemplateColumns(t *testing.T) {
 		{Model: "m1", TraceID: "t1", Score: Score{AnswerQuality: 0.5, ToolSequenceMatch: 1, ToolArgsValid: 1, ToolArgsValidComputed: true, LatencyMs: 100, TotalTokens: 42}},
 	}, reportOptions{Scorer: "llm-judge", JudgeModel: "gemma4:31b"})
 
-	want := "| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | ToolSequenceMatch | ToolArgsValid (computed=N) | LatencyMs (p50 / p90, successful-only) | TotalTokens | n | Failures/total (timeout) |"
+	want := "| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | ToolSequenceMatch | ToolArgsValid (computed=N) | Restraint (mean, diverged/eligible) | LatencyMs (p50 / p90, successful-only) | TotalTokens | n | Failures/total (timeout) |"
 	if !strings.Contains(report, want) {
 		t.Fatalf("rendered report missing TEMPLATE column header.\nWant: %q\nGot:\n%s", want, report)
 	}
@@ -314,7 +314,7 @@ func TestFormatReportAllErrorsRowDoesNotRenderNaN(t *testing.T) {
 	// Strengthened: zero-observation rows must render n/a in the
 	// quality, toolseq, and latency cells so a casual reader cannot
 	// mistake them for genuine zero scores.
-	if !strings.Contains(report, "| m1 | n/a | n/a | n/a (computed=0) | n/a | n/a | 0 |") {
+	if !strings.Contains(report, "| m1 | n/a | n/a | n/a (computed=0) | n/a | n/a | n/a | 0 |") {
 		t.Errorf("expected all-errors row to render n/a across metric cells:\n%s", report)
 	}
 }
@@ -375,6 +375,32 @@ func TestFormatReportProvenanceReportsCacheDisabledForLLMJudge(t *testing.T) {
 	})
 	if !strings.Contains(report, "Judge cache: no activity recorded") {
 		t.Fatalf("expected cache-disabled signal in provenance:\n%s", report)
+	}
+}
+
+func TestFormatReportRestraintColumn(t *testing.T) {
+	results := []Result{
+		{Model: "m", TraceID: "a", Score: Score{AnswerQuality: 1, RestraintComputed: true, Restraint: 1}},
+		{Model: "m", TraceID: "b", Score: Score{AnswerQuality: 0, RestraintComputed: true, Restraint: 0}},
+		{Model: "m", TraceID: "c", Score: Score{AnswerQuality: 1, RestraintComputed: false}},
+	}
+	out := formatReport([]string{"m"}, results, reportOptions{})
+	if !strings.Contains(out, "Restraint") {
+		t.Fatalf("report missing Restraint header:\n%s", out)
+	}
+	// 1 of 2 eligible diverged → mean 0.50, diverged/eligible = 1/2.
+	if !strings.Contains(out, "0.50 (1/2 diverged)") {
+		t.Fatalf("report missing restraint cell %q:\n%s", "0.50 (1/2 diverged)", out)
+	}
+}
+
+func TestFormatReportRestraintNAWhenNoneEligible(t *testing.T) {
+	results := []Result{
+		{Model: "m", TraceID: "a", Score: Score{AnswerQuality: 1, RestraintComputed: false}},
+	}
+	out := formatReport([]string{"m"}, results, reportOptions{})
+	if !strings.Contains(out, "| n/a |") {
+		t.Fatalf("report should render n/a restraint cell when no eligible traces:\n%s", out)
 	}
 }
 

--- a/cmd/llm-bench/report_test.go
+++ b/cmd/llm-bench/report_test.go
@@ -270,7 +270,7 @@ func TestFormatReportSummaryMatchesTemplateColumns(t *testing.T) {
 		{Model: "m1", TraceID: "t1", Score: Score{AnswerQuality: 0.5, ToolSequenceMatch: 1, ToolArgsValid: 1, ToolArgsValidComputed: true, LatencyMs: 100, TotalTokens: 42}},
 	}, reportOptions{Scorer: "llm-judge", JudgeModel: "gemma4:31b"})
 
-	want := "| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | ToolSequenceMatch | ToolArgsValid (computed=N) | Restraint (mean, diverged/eligible) | LatencyMs (p50 / p90, successful-only) | TotalTokens | n | Failures/total (timeout) |"
+	want := "| Model | AnswerQuality (mean / p25 / p50 / p75 / p90) | ToolSequenceMatch | ToolArgsValid (computed=N) | Restraint (mean, diverged/eligible; tool-exposed if available) | LatencyMs (p50 / p90, successful-only) | TotalTokens | n | Failures/total (timeout) |"
 	if !strings.Contains(report, want) {
 		t.Fatalf("rendered report missing TEMPLATE column header.\nWant: %q\nGot:\n%s", want, report)
 	}
@@ -380,17 +380,20 @@ func TestFormatReportProvenanceReportsCacheDisabledForLLMJudge(t *testing.T) {
 
 func TestFormatReportRestraintColumn(t *testing.T) {
 	results := []Result{
-		{Model: "m", TraceID: "a", Score: Score{AnswerQuality: 1, RestraintComputed: true, Restraint: 1}},
-		{Model: "m", TraceID: "b", Score: Score{AnswerQuality: 0, RestraintComputed: true, Restraint: 0}},
-		{Model: "m", TraceID: "c", Score: Score{AnswerQuality: 1, RestraintComputed: false}},
+		{Model: "m", TraceID: "a", Score: Score{AnswerQuality: 1, RestraintComputed: true, Restraint: 1, ToolExposedRestraintComputed: true, ToolExposedRestraint: 1}},
+		{Model: "m", TraceID: "b", Score: Score{AnswerQuality: 0, RestraintComputed: true, Restraint: 0, ToolExposedRestraintComputed: true, ToolExposedRestraint: 0}},
+		{Model: "m", TraceID: "c", Score: Score{AnswerQuality: 1, RestraintComputed: true, Restraint: 1}},
+		{Model: "m", TraceID: "d", Score: Score{AnswerQuality: 1, RestraintComputed: false}},
 	}
 	out := formatReport([]string{"m"}, results, reportOptions{})
 	if !strings.Contains(out, "Restraint") {
 		t.Fatalf("report missing Restraint header:\n%s", out)
 	}
-	// 1 of 2 eligible diverged → mean 0.50, diverged/eligible = 1/2.
-	if !strings.Contains(out, "0.50 (1/2 diverged)") {
-		t.Fatalf("report missing restraint cell %q:\n%s", "0.50 (1/2 diverged)", out)
+	// Primary: 1 of 3 eligible diverged → mean 0.67. Tool-exposed companion:
+	// 1 of 2 tool-offered eligible traces diverged → mean 0.50.
+	want := "0.67 (1/3 diverged; tool-exposed 0.50, 1/2 diverged)"
+	if !strings.Contains(out, want) {
+		t.Fatalf("report missing restraint cell %q:\n%s", want, out)
 	}
 }
 
@@ -406,14 +409,15 @@ func TestFormatReportRestraintNAWhenNoneEligible(t *testing.T) {
 
 func TestFormatManualQualityReportRestraintColumn(t *testing.T) {
 	results := []Result{
-		{Model: "m", TraceID: "a", Score: Score{AnswerQuality: 1, RestraintComputed: true, Restraint: 1}},
-		{Model: "m", TraceID: "b", Score: Score{AnswerQuality: 0, RestraintComputed: true, Restraint: 0}},
+		{Model: "m", TraceID: "a", Score: Score{AnswerQuality: 1, RestraintComputed: true, Restraint: 1, ToolExposedRestraintComputed: true, ToolExposedRestraint: 1}},
+		{Model: "m", TraceID: "b", Score: Score{AnswerQuality: 0, RestraintComputed: true, Restraint: 0, ToolExposedRestraintComputed: true, ToolExposedRestraint: 0}},
+		{Model: "m", TraceID: "c", Score: Score{AnswerQuality: 1, RestraintComputed: true, Restraint: 1}},
 	}
-	out := formatManualQualityReport([]string{"m"}, results, manualReportCoverage{Scored: 2})
+	out := formatManualQualityReport([]string{"m"}, results, manualReportCoverage{Scored: 3})
 	if !strings.Contains(out, "Restraint") {
 		t.Fatalf("manual report missing Restraint header:\n%s", out)
 	}
-	if !strings.Contains(out, "0.50 (1/2 diverged)") {
+	if !strings.Contains(out, "0.67 (1/3 diverged; tool-exposed 0.50, 1/2 diverged)") {
 		t.Fatalf("manual report missing restraint cell:\n%s", out)
 	}
 }

--- a/cmd/llm-bench/report_test.go
+++ b/cmd/llm-bench/report_test.go
@@ -498,6 +498,20 @@ func TestFormatPairedReportRestraintSection(t *testing.T) {
 	}
 }
 
+func TestAggregateRestraintSkipsErrorRows(t *testing.T) {
+	rs := []Result{
+		{Score: Score{Restraint: 1, RestraintComputed: true}},
+		{Err: errors.New("boom"), Score: Score{Restraint: 0, RestraintComputed: true}}, // must be ignored
+	}
+	a := aggregate(rs)
+	if a.restraintComputed != 1 {
+		t.Fatalf("restraintComputed = %d, want 1 (error row ignored)", a.restraintComputed)
+	}
+	if a.restraintDiverged != 0 {
+		t.Fatalf("restraintDiverged = %d, want 0 (error row's diverged restraint must not count)", a.restraintDiverged)
+	}
+}
+
 func TestFormatPairedReportRestraintNoEligibleTraces(t *testing.T) {
 	pa := pairedAnalysis{
 		Lineup:         []string{"a", "b"},

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -81,12 +81,7 @@ func baseMechanicalScore(trace Trace, transcript []Turn) (Score, error) {
 	if schemaErr != nil {
 		return Score{}, schemaErr
 	}
-	restraint, restraintComputed := restraintSignals(trace, transcript)
-	toolExposedRestraint, toolExposedComputed := 0.0, false
-	if restraintComputed && len(trace.Tools) > 0 {
-		toolExposedRestraint = restraint
-		toolExposedComputed = true
-	}
+	restraint, restraintComputed, toolExposedRestraint, toolExposedComputed := restraintScoreFields(trace, transcript)
 	return Score{
 		ToolSequenceMatch:            toolSequenceScore(trace.Golden.ToolCalls, extractToolNames(transcript)),
 		ToolArgsValid:                toolArgsScore,
@@ -293,12 +288,7 @@ func (s *ExactMatchScorer) Score(_ context.Context, trace Trace, actual Result) 
 type CaptureScorer struct{}
 
 func (s *CaptureScorer) Score(_ context.Context, trace Trace, actual Result) (Score, error) {
-	restraint, restraintComputed := restraintSignals(trace, actual.Transcript)
-	toolExposedRestraint, toolExposedComputed := 0.0, false
-	if restraintComputed && len(trace.Tools) > 0 {
-		toolExposedRestraint = restraint
-		toolExposedComputed = true
-	}
+	restraint, restraintComputed, toolExposedRestraint, toolExposedComputed := restraintScoreFields(trace, actual.Transcript)
 	return Score{
 		ToolSequenceMatch:            toolSequenceScore(trace.Golden.ToolCalls, extractToolNames(actual.Transcript)),
 		Restraint:                    restraint,

--- a/cmd/llm-bench/scorer.go
+++ b/cmd/llm-bench/scorer.go
@@ -54,6 +54,49 @@ type Score struct {
 	// from "not reported".
 	ThinkingTokensComputed bool
 	Notes                  string
+	// Restraint is the tool-restraint signal: 1.0 = held (the golden expected no
+	// tool call and the candidate emitted none), 0.0 = diverged (emitted ≥1).
+	// RestraintComputed is false when restraint was not testable (the golden
+	// expected a tool route); then Restraint is a placeholder 0.0 that
+	// aggregation MUST skip — mirrors the ToolArgsValid/ToolArgsValidComputed
+	// idiom. Divergence is recoverable as RestraintComputed && Restraint == 0.
+	Restraint         float64
+	RestraintComputed bool
+	// ToolExposedRestraint is the same signal restricted to traces that actually
+	// offered tools (len(trace.Tools) > 0) — the stricter "restraint under
+	// temptation" denominator. ToolExposedRestraintComputed implies
+	// RestraintComputed. It is a companion diagnostic, not a replacement.
+	ToolExposedRestraint         float64
+	ToolExposedRestraintComputed bool
+}
+
+// baseMechanicalScore computes the scorer-independent mechanical fields shared by
+// every scorer: tool-sequence match, tool-argument validity, and the restraint
+// signals (primary + tool-exposed companion). It returns the raw schema-compile
+// error unwrapped so each caller can attach its own "trace %q: compile tool
+// schemas" context, preserving existing error messages. AnswerQuality is left to
+// the caller.
+func baseMechanicalScore(trace Trace, transcript []Turn) (Score, error) {
+	toolArgsScore, toolArgsComputed, toolArgsNotes, schemaErr := scoreToolArguments(trace, transcript)
+	if schemaErr != nil {
+		return Score{}, schemaErr
+	}
+	restraint, restraintComputed := restraintSignals(trace, transcript)
+	toolExposedRestraint, toolExposedComputed := 0.0, false
+	if restraintComputed && len(trace.Tools) > 0 {
+		toolExposedRestraint = restraint
+		toolExposedComputed = true
+	}
+	return Score{
+		ToolSequenceMatch:            toolSequenceScore(trace.Golden.ToolCalls, extractToolNames(transcript)),
+		ToolArgsValid:                toolArgsScore,
+		ToolArgsValidComputed:        toolArgsComputed,
+		Restraint:                    restraint,
+		RestraintComputed:            restraintComputed,
+		ToolExposedRestraint:         toolExposedRestraint,
+		ToolExposedRestraintComputed: toolExposedComputed,
+		Notes:                        toolArgsNotes,
+	}, nil
 }
 
 // Scorer is the pluggable strategy for evaluating a replay result.
@@ -230,16 +273,9 @@ func (s *ExactMatchScorer) Score(_ context.Context, trace Trace, actual Result) 
 		return Score{}, fmt.Errorf("trace %q: %w", trace.ID, errMissingGolden)
 	}
 
-	toolArgsScore, toolArgsComputed, toolArgsNotes, schemaErr := scoreToolArguments(trace, actual.Transcript)
+	score, schemaErr := baseMechanicalScore(trace, actual.Transcript)
 	if schemaErr != nil {
 		return Score{}, fmt.Errorf("trace %q: compile tool schemas: %w", trace.ID, schemaErr)
-	}
-
-	score := Score{
-		ToolSequenceMatch:     toolSequenceScore(trace.Golden.ToolCalls, extractToolNames(actual.Transcript)),
-		ToolArgsValid:         toolArgsScore,
-		ToolArgsValidComputed: toolArgsComputed,
-		Notes:                 toolArgsNotes,
 	}
 
 	finalText := lastAssistantContent(actual.Transcript)
@@ -257,9 +293,19 @@ func (s *ExactMatchScorer) Score(_ context.Context, trace Trace, actual Result) 
 type CaptureScorer struct{}
 
 func (s *CaptureScorer) Score(_ context.Context, trace Trace, actual Result) (Score, error) {
+	restraint, restraintComputed := restraintSignals(trace, actual.Transcript)
+	toolExposedRestraint, toolExposedComputed := 0.0, false
+	if restraintComputed && len(trace.Tools) > 0 {
+		toolExposedRestraint = restraint
+		toolExposedComputed = true
+	}
 	return Score{
-		ToolSequenceMatch: toolSequenceScore(trace.Golden.ToolCalls, extractToolNames(actual.Transcript)),
-		Notes:             "capture mode: scoring skipped",
+		ToolSequenceMatch:            toolSequenceScore(trace.Golden.ToolCalls, extractToolNames(actual.Transcript)),
+		Restraint:                    restraint,
+		RestraintComputed:            restraintComputed,
+		ToolExposedRestraint:         toolExposedRestraint,
+		ToolExposedRestraintComputed: toolExposedComputed,
+		Notes:                        "capture mode: scoring skipped",
 	}, nil
 }
 
@@ -367,16 +413,9 @@ func (s *LLMJudgeScorer) buildJudgeCall(trace Trace, actual Result) (ollama.Chat
 		return ollama.ChatRequest{}, Score{}, fmt.Errorf("trace %q: %w", trace.ID, errMissingJudgeCriteria)
 	}
 
-	toolArgsScore, toolArgsComputed, toolArgsNotes, schemaErr := scoreToolArguments(trace, actual.Transcript)
+	baseScore, schemaErr := baseMechanicalScore(trace, actual.Transcript)
 	if schemaErr != nil {
 		return ollama.ChatRequest{}, Score{}, fmt.Errorf("trace %q: compile tool schemas: %w", trace.ID, schemaErr)
-	}
-
-	baseScore := Score{
-		ToolSequenceMatch:     toolSequenceScore(trace.Golden.ToolCalls, extractToolNames(actual.Transcript)),
-		ToolArgsValid:         toolArgsScore,
-		ToolArgsValidComputed: toolArgsComputed,
-		Notes:                 toolArgsNotes,
 	}
 
 	if strings.TrimSpace(lastAssistantContent(actual.Transcript)) == "" {

--- a/cmd/llm-bench/scorer_test.go
+++ b/cmd/llm-bench/scorer_test.go
@@ -1355,6 +1355,84 @@ func TestLLMJudgeScorer_MalformedCacheHitFallsBackToJudge(t *testing.T) {
 	}
 }
 
+// TestScorersSetRestraintFields verifies each scorer populates the restraint and tool-exposed restraint signals (held / diverged / ineligible).
+func TestScorersSetRestraintFields(t *testing.T) {
+	goldenEmpty := Trace{ID: "t1", Golden: Golden{FinalAnswerSubstring: "answer"}}
+	goldenEmptyWithTools := Trace{ID: "t2", Tools: []json.RawMessage{json.RawMessage(`{"name":"x","inputSchema":{"type":"object"}}`)}, Golden: Golden{FinalAnswerSubstring: "answer"}}
+	goldenToolRouteWithTools := Trace{ID: "t3", Tools: []json.RawMessage{json.RawMessage(`{"name":"x","inputSchema":{"type":"object"}}`)}, Golden: Golden{ToolCalls: []string{"x"}, FinalAnswerSubstring: "the answer"}}
+	heldTranscript := []Turn{{Role: "assistant", Content: "the answer"}}
+	divergedTranscript := []Turn{{Role: "assistant", ToolCalls: []ToolCall{{Name: "x"}}}, {Role: "assistant", Content: "the answer"}}
+
+	t.Run("exact-match held no tools", func(t *testing.T) {
+		s := &ExactMatchScorer{}
+		got, err := s.Score(context.Background(), goldenEmpty, Result{Transcript: heldTranscript})
+		if err != nil {
+			t.Fatalf("Score: %v", err)
+		}
+		if got.Restraint != 1.0 || !got.RestraintComputed {
+			t.Fatalf("restraint = (%v, %v), want (1, true)", got.Restraint, got.RestraintComputed)
+		}
+		if got.ToolExposedRestraintComputed {
+			t.Fatalf("ToolExposedRestraintComputed = true, want false (no tools offered)")
+		}
+	})
+
+	t.Run("exact-match diverged with tools", func(t *testing.T) {
+		s := &ExactMatchScorer{}
+		got, err := s.Score(context.Background(), goldenEmptyWithTools, Result{Transcript: divergedTranscript})
+		if err != nil {
+			t.Fatalf("Score: %v", err)
+		}
+		if got.Restraint != 0.0 || !got.RestraintComputed {
+			t.Fatalf("restraint = (%v, %v), want (0, true)", got.Restraint, got.RestraintComputed)
+		}
+		if got.ToolExposedRestraint != 0.0 || !got.ToolExposedRestraintComputed {
+			t.Fatalf("tool-exposed = (%v, %v), want (0, true)", got.ToolExposedRestraint, got.ToolExposedRestraintComputed)
+		}
+	})
+
+	t.Run("golden tool route is ineligible even when tools offered", func(t *testing.T) {
+		s := &ExactMatchScorer{}
+		got, err := s.Score(context.Background(), goldenToolRouteWithTools, Result{Transcript: divergedTranscript})
+		if err != nil {
+			t.Fatalf("Score: %v", err)
+		}
+		if got.RestraintComputed {
+			t.Fatalf("RestraintComputed = true, want false (golden expects a tool route)")
+		}
+		if got.ToolExposedRestraintComputed {
+			t.Fatalf("ToolExposedRestraintComputed = true, want false (primary restraint ineligible)")
+		}
+	})
+
+	t.Run("capture scorer sets restraint", func(t *testing.T) {
+		s := &CaptureScorer{}
+		got, err := s.Score(context.Background(), goldenEmpty, Result{Transcript: heldTranscript})
+		if err != nil {
+			t.Fatalf("Score: %v", err)
+		}
+		if got.Restraint != 1.0 || !got.RestraintComputed {
+			t.Fatalf("restraint = (%v, %v), want (1, true)", got.Restraint, got.RestraintComputed)
+		}
+	})
+
+	t.Run("manual scorer sets restraint", func(t *testing.T) {
+		s, err := newManualScorer([]Label{
+			{TraceID: "t1", CandidateModel: "qwen3:8b", ExpectedAnswerQuality: 1.0},
+		})
+		if err != nil {
+			t.Fatalf("newManualScorer: %v", err)
+		}
+		got, err := s.Score(context.Background(), goldenEmpty, Result{Model: "qwen3:8b", Transcript: heldTranscript})
+		if err != nil {
+			t.Fatalf("Score: %v", err)
+		}
+		if got.Restraint != 1.0 || !got.RestraintComputed {
+			t.Fatalf("restraint = (%v, %v), want (1, true)", got.Restraint, got.RestraintComputed)
+		}
+	})
+}
+
 // TestLLMJudgeScorer_CacheHit_FreshToolSequenceMatch is the load-bearing
 // invariant of the judge-cache architecture: on a cache hit the judge MUST
 // NOT be re-invoked, but the returned Score's ToolSequenceMatch MUST come

--- a/cmd/llm-bench/tool_validation.go
+++ b/cmd/llm-bench/tool_validation.go
@@ -249,6 +249,18 @@ func restraintSignals(trace Trace, transcript []Turn) (restraint float64, comput
 	return 1, true
 }
 
+// restraintScoreFields computes the four restraint Score fields from a trace +
+// transcript: primary restraint (held/diverged) and the tool-exposed companion
+// (set only when restraint is eligible AND tools were offered). Centralizing the
+// gating keeps the scorer seam and the capture seam from drifting.
+func restraintScoreFields(trace Trace, transcript []Turn) (restraint float64, restraintComputed bool, toolExposed float64, toolExposedComputed bool) {
+	restraint, restraintComputed = restraintSignals(trace, transcript)
+	if restraintComputed && len(trace.Tools) > 0 {
+		toolExposed, toolExposedComputed = restraint, true
+	}
+	return
+}
+
 func decodeArguments(raw json.RawMessage) (any, error) {
 	if len(raw) == 0 {
 		return map[string]any{}, nil

--- a/cmd/llm-bench/tool_validation.go
+++ b/cmd/llm-bench/tool_validation.go
@@ -232,6 +232,23 @@ func assistantToolCalls(turns []Turn) []ToolCall {
 	return out
 }
 
+// restraintSignals reports whether tool-restraint was testable for this trace
+// and, if so, whether the candidate held it (emitted no tool call) or diverged
+// (emitted ≥1 tool call). Restraint is only testable when the golden expected NO
+// tool call; a tool-route trace tests tool correctness, not restraint, and
+// returns computed=false. On a golden-empty trace ANY assistant tool call is a
+// divergence — equivalent to what replayWith flags, but recomputed from the
+// transcript so the metric never depends on parsing Score.Notes.
+func restraintSignals(trace Trace, transcript []Turn) (restraint float64, computed bool) {
+	if len(trace.Golden.ToolCalls) != 0 {
+		return 0, false
+	}
+	if len(assistantToolCalls(transcript)) > 0 {
+		return 0, true
+	}
+	return 1, true
+}
+
 func decodeArguments(raw json.RawMessage) (any, error) {
 	if len(raw) == 0 {
 		return map[string]any{}, nil

--- a/cmd/llm-bench/tool_validation_test.go
+++ b/cmd/llm-bench/tool_validation_test.go
@@ -270,3 +270,54 @@ func TestValidateToolArgumentsHandlesNilArguments(t *testing.T) {
 		t.Fatalf("score=%v computed=%v; want 1.0/true (nil args = {})", score, computed)
 	}
 }
+
+func TestRestraintSignals(t *testing.T) {
+	toolCallTurn := Turn{Role: "assistant", ToolCalls: []ToolCall{{Name: "search"}}}
+	plainTurn := Turn{Role: "assistant", Content: "here is the answer"}
+
+	tests := []struct {
+		name          string
+		trace         Trace
+		transcript    []Turn
+		wantRestraint float64
+		wantComputed  bool
+	}{
+		{
+			name:          "golden-empty no tool call: held",
+			trace:         Trace{Golden: Golden{}},
+			transcript:    []Turn{plainTurn},
+			wantRestraint: 1.0,
+			wantComputed:  true,
+		},
+		{
+			name:          "golden-empty with tool call: diverged",
+			trace:         Trace{Golden: Golden{}},
+			transcript:    []Turn{toolCallTurn, plainTurn},
+			wantRestraint: 0.0,
+			wantComputed:  true,
+		},
+		{
+			name:          "golden has tool route: not testable",
+			trace:         Trace{Golden: Golden{ToolCalls: []string{"search"}}},
+			transcript:    []Turn{toolCallTurn},
+			wantRestraint: 0.0,
+			wantComputed:  false,
+		},
+		{
+			name:          "golden-empty empty transcript: held",
+			trace:         Trace{Golden: Golden{}},
+			transcript:    nil,
+			wantRestraint: 1.0,
+			wantComputed:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRestraint, gotComputed := restraintSignals(tt.trace, tt.transcript)
+			if gotRestraint != tt.wantRestraint || gotComputed != tt.wantComputed {
+				t.Fatalf("restraintSignals = (%v, %v), want (%v, %v)",
+					gotRestraint, gotComputed, tt.wantRestraint, tt.wantComputed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Surfaces **tool-restraint** as a first-class per-model llm-bench metric, on a separate axis from `AnswerQuality`, derived from a structured `Score` field (not string-matching `Score.Notes`).

Motivation: the tool-exposed run `20260615TtoolsZ` showed no AnswerQuality discrimination at n=8 because the mean conflates answer-correctness with tool-restraint — the bigger model diverged more (called tools it shouldn't) but averaging buried that in 7 ties.

What changed:
- New structured `Score` fields (`Restraint`/`RestraintComputed` + `ToolExposedRestraint`/`ToolExposedRestraintComputed`), computed once in `restraintScoreFields`/`baseMechanicalScore` and shared across all scorers. `replayWith`'s sentinel/`Notes` machinery is untouched; the metric is recomputed from the transcript so it no longer depends on parsing a note.
- Metric semantics: restraint is testable only on golden-empty traces (`held` = 1, `diverged` = 0); the tool-exposed companion restricts to traces that actually offered tools.
- Per-model aggregation into a divergence rate, skipping error and ineligible rows; restraint column added to the live report and the manual quality report.
- Label-free paired restraint computed directly from artifacts (`computeRestraintPairing`), reusing the existing bootstrap Δ/CI machinery; a dedicated paired-report section keeps the restraint denominator (artifact-paired) distinct from the quality denominator (label-paired), with win/loss/tie doubling as the discordant-pair table. Malformed/empty trace-context artifacts are excluded so they cannot inflate restraint N.

On the n=8 tool-exposed corpus the metric lands the finding directly: qwen3:8b held 5/8 = 0.625 vs qwen3.6:35b-a3b 4/8 = 0.500.

Scope is `cmd/llm-bench` only; no `models.json` role change, no `AnswerQuality` change.

## Test Plan
- [x] `env -u GOROOT go test ./...` passes
- [x] `scripts/ci-local --mode pre-push` — lint 0 issues, race tests pass
- [x] New unit tests: `restraintSignals`, per-scorer restraint fields (held/diverged/ineligible/capture), `aggregate` counters incl. error-row skip, both report columns, `computeRestraintPairing` (incl. ineligible + missing-trace-context exclusion), paired-report restraint section, and an n=8 finding-shape regression test
- [x] Per-task spec + code-quality reviews, comprehensive review, adversarial criticize-review — no merge-blocking findings

Generated with Claude Code