### PR TITLE
feat(llm-bench): restraint corpus growth — schema + difficulty stratification

### DIFF
--- a/cmd/llm-bench/paired.go
+++ b/cmd/llm-bench/paired.go
@@ -199,6 +199,16 @@ type baselineDelta struct {
 	Ties      int
 }
 
+// difficultyRestraint is the paired restraint evidence for one difficulty tier,
+// computed over the restraint-paired-complete subset whose traces carry that
+// Golden.Difficulty. Reuses baselineDelta — no new statistics.
+type difficultyRestraint struct {
+	Difficulty      string
+	N               int
+	PerModelMean    map[string]float64
+	BaselineSummary []baselineDelta
+}
+
 // restraintPairing is the label-free paired restraint evidence: it is derived
 // entirely from frozen artifacts (no human labels), so its completeness can
 // exceed the label-paired quality completeness. PerModelMean and BaselineSummary
@@ -213,6 +223,10 @@ type restraintPairing struct {
 	// tool-exposed subset is intentionally out of scope here.
 	ToolExposedPerModelMean map[string]float64
 	ToolExposedN            int
+	// ByDifficulty stratifies the paired restraint Δ by Golden.Difficulty over
+	// the same complete subset, in canonical tier order. Exploratory at small
+	// per-tier n; the headline remains the overall PerModelMean/BaselineSummary.
+	ByDifficulty []difficultyRestraint
 }
 
 // pairedAnalysis is the computed paired-label evidence for a corpus.
@@ -487,6 +501,7 @@ func computeRestraintPairing(arts []Artifact, lineup []string, baseline string, 
 	}
 	byCell := make(map[cellKey]cellRestraint, len(arts))
 	traceDisplay := make(map[string]string)
+	traceDifficulty := make(map[string]string)
 	for _, a := range arts {
 		value, computed := 0.0, false
 		if restraintArtifactTraceContextValid(a) {
@@ -500,6 +515,9 @@ func computeRestraintPairing(arts []Artifact, lineup []string, baseline string, 
 		tk := normalizeModelSelector(a.TraceID)
 		if _, ok := traceDisplay[tk]; !ok {
 			traceDisplay[tk] = a.TraceID
+		}
+		if _, ok := traceDifficulty[tk]; !ok {
+			traceDifficulty[tk] = a.Trace.Golden.Difficulty
 		}
 	}
 
@@ -575,7 +593,63 @@ func computeRestraintPairing(arts []Artifact, lineup []string, baseline string, 
 		bd.CILow, bd.CIHigh = bootstrapDeltaCI(deltas, seed, bootstrapN)
 		rp.BaselineSummary = append(rp.BaselineSummary, bd)
 	}
+	rp.ByDifficulty = restraintByDifficulty(completeKeys, traceDifficulty, perModel, lineup, baseline, seed, bootstrapN)
 	return rp
+}
+
+// restraintByDifficulty buckets the complete subset by trace difficulty and
+// computes a per-tier paired Δ reusing mean/bootstrapDeltaCI. completeKeys and
+// perModel[model] are index-aligned (same order). Tiers render in canonical
+// order; an empty difficulty is bucketed under "unspecified".
+func restraintByDifficulty(completeKeys []string, traceDifficulty map[string]string, perModel map[string][]float64, lineup []string, baseline string, seed int64, bootstrapN int) []difficultyRestraint {
+	order := []string{"obvious", "tempting", "adversarial", "unspecified"}
+	idxByTier := map[string][]int{}
+	for i, tk := range completeKeys {
+		tier := traceDifficulty[tk]
+		if tier == "" {
+			tier = "unspecified"
+		}
+		idxByTier[tier] = append(idxByTier[tier], i)
+	}
+	var out []difficultyRestraint
+	for _, tier := range order {
+		idxs := idxByTier[tier]
+		if len(idxs) == 0 {
+			continue
+		}
+		dr := difficultyRestraint{Difficulty: tier, N: len(idxs), PerModelMean: map[string]float64{}}
+		for _, model := range lineup {
+			vals := make([]float64, len(idxs))
+			for j, i := range idxs {
+				vals[j] = perModel[model][i]
+			}
+			dr.PerModelMean[model] = mean(vals)
+		}
+		for _, model := range lineup {
+			if model == baseline {
+				continue
+			}
+			deltas := make([]float64, len(idxs))
+			bd := baselineDelta{Model: model}
+			for j, i := range idxs {
+				d := perModel[model][i] - perModel[baseline][i]
+				deltas[j] = d
+				switch {
+				case d > 0:
+					bd.Wins++
+				case d < 0:
+					bd.Losses++
+				default:
+					bd.Ties++
+				}
+			}
+			bd.MeanDelta = mean(deltas)
+			bd.CILow, bd.CIHigh = bootstrapDeltaCI(deltas, seed, bootstrapN)
+			dr.BaselineSummary = append(dr.BaselineSummary, bd)
+		}
+		out = append(out, dr)
+	}
+	return out
 }
 
 // restraintArtifactTraceContextValid reports whether an artifact carries enough

--- a/cmd/llm-bench/paired_test.go
+++ b/cmd/llm-bench/paired_test.go
@@ -833,6 +833,12 @@ func TestComputeRestraintPairingByDifficulty(t *testing.T) {
 	if adv.BaselineSummary[0].Losses != 2 {
 		t.Errorf("adversarial losses=%d, want 2", adv.BaselineSummary[0].Losses)
 	}
+	// Per-tier per-model hold-rates: in the adversarial tier a held both (1.0),
+	// b diverged both (0.0). This is the interpretable signal the delta hides.
+	if adv.PerModelMean["a"] != 1.0 || adv.PerModelMean["b"] != 0.0 {
+		t.Errorf("adversarial PerModelMean a=%v b=%v, want 1.0/0.0",
+			adv.PerModelMean["a"], adv.PerModelMean["b"])
+	}
 }
 
 // Legacy/backfill-in-progress traces carry an empty Golden.Difficulty; they must

--- a/cmd/llm-bench/paired_test.go
+++ b/cmd/llm-bench/paired_test.go
@@ -797,3 +797,40 @@ func TestComputeRestraintPairingN8FindingShape(t *testing.T) {
 		t.Fatalf("MeanDelta = %v, want -0.125", bd.MeanDelta)
 	}
 }
+
+func TestComputeRestraintPairingByDifficulty(t *testing.T) {
+	withTools := []json.RawMessage{json.RawMessage(`{"name":"x","inputSchema":{"type":"object"}}`)}
+	held := []Turn{{Role: "assistant", Content: "ok"}}
+	diverged := []Turn{{Role: "assistant", ToolCalls: []ToolCall{{Name: "x"}}}}
+	mk := func(trace, model, diff string, tx []Turn) Artifact {
+		return Artifact{
+			TraceID: trace, CandidateModel: model,
+			Trace: Trace{ID: trace, Tools: withTools,
+				Golden: Golden{FinalAnswerSubstring: "ok", Difficulty: diff}},
+			ActualTranscript: tx,
+		}
+	}
+	// 2 obvious (both models hold) + 2 adversarial (b diverges on both, a holds).
+	arts := []Artifact{
+		mk("o0", "a", "obvious", held), mk("o0", "b", "obvious", held),
+		mk("o1", "a", "obvious", held), mk("o1", "b", "obvious", held),
+		mk("d0", "a", "adversarial", held), mk("d0", "b", "adversarial", diverged),
+		mk("d1", "a", "adversarial", held), mk("d1", "b", "adversarial", diverged),
+	}
+	rp := computeRestraintPairing(arts, []string{"a", "b"}, "a", pairedBootstrapSeed, pairedBootstrapN)
+
+	byDiff := map[string]difficultyRestraint{}
+	for _, dr := range rp.ByDifficulty {
+		byDiff[dr.Difficulty] = dr
+	}
+	if got := byDiff["obvious"]; got.N != 2 || got.BaselineSummary[0].MeanDelta != 0 {
+		t.Errorf("obvious: N=%d delta=%v, want N=2 delta=0", got.N, got.BaselineSummary[0].MeanDelta)
+	}
+	adv := byDiff["adversarial"]
+	if adv.N != 2 || adv.BaselineSummary[0].MeanDelta != -1.0 {
+		t.Errorf("adversarial: N=%d delta=%v, want N=2 delta=-1.0", adv.N, adv.BaselineSummary[0].MeanDelta)
+	}
+	if adv.BaselineSummary[0].Losses != 2 {
+		t.Errorf("adversarial losses=%d, want 2", adv.BaselineSummary[0].Losses)
+	}
+}

--- a/cmd/llm-bench/paired_test.go
+++ b/cmd/llm-bench/paired_test.go
@@ -834,3 +834,41 @@ func TestComputeRestraintPairingByDifficulty(t *testing.T) {
 		t.Errorf("adversarial losses=%d, want 2", adv.BaselineSummary[0].Losses)
 	}
 }
+
+// Legacy/backfill-in-progress traces carry an empty Golden.Difficulty; they must
+// bucket under "unspecified" (never dropped), and tiers must render in canonical
+// order regardless of artifact order. Guards the Phase-C transition state.
+func TestComputeRestraintPairingByDifficultyUnspecifiedAndOrder(t *testing.T) {
+	withTools := []json.RawMessage{json.RawMessage(`{"name":"x","inputSchema":{"type":"object"}}`)}
+	held := []Turn{{Role: "assistant", Content: "ok"}}
+	mk := func(trace, model, diff string) Artifact {
+		return Artifact{
+			TraceID: trace, CandidateModel: model,
+			Trace: Trace{ID: trace, Tools: withTools,
+				Golden: Golden{FinalAnswerSubstring: "ok", Difficulty: diff}},
+			ActualTranscript: held,
+		}
+	}
+	// Deliberately out of canonical order; one trace has an empty difficulty.
+	arts := []Artifact{
+		mk("a0", "a", "adversarial"), mk("a0", "b", "adversarial"),
+		mk("u0", "a", ""), mk("u0", "b", ""),
+		mk("o0", "a", "obvious"), mk("o0", "b", "obvious"),
+		mk("t0", "a", "tempting"), mk("t0", "b", "tempting"),
+	}
+	rp := computeRestraintPairing(arts, []string{"a", "b"}, "a", pairedBootstrapSeed, pairedBootstrapN)
+
+	gotOrder := make([]string, 0, len(rp.ByDifficulty))
+	for _, dr := range rp.ByDifficulty {
+		gotOrder = append(gotOrder, dr.Difficulty)
+	}
+	want := []string{"obvious", "tempting", "adversarial", "unspecified"}
+	if !reflect.DeepEqual(gotOrder, want) {
+		t.Fatalf("tier order = %v, want %v", gotOrder, want)
+	}
+	for _, dr := range rp.ByDifficulty {
+		if dr.N != 1 {
+			t.Errorf("tier %q N=%d, want 1", dr.Difficulty, dr.N)
+		}
+	}
+}

--- a/cmd/llm-bench/real_workflow_corpus_test.go
+++ b/cmd/llm-bench/real_workflow_corpus_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestRealWorkflowCorpusBalance validates the local (gitignored) grown restraint
+// corpus against the growth design (see docs/llm/real-workflow-testing.md).
+// It skips when the private manifest is absent (CI, fresh clones) OR when the
+// corpus has not yet been grown to target (authoring in progress), so it never
+// goes red in CI or mid-authoring. Once the corpus claims to be grown (>= minN
+// entries) it asserts golden-empty, audit fields, difficulty balance, and
+// archetype coverage.
+func TestRealWorkflowCorpusBalance(t *testing.T) {
+	const minN = 45
+	manifestPath := filepath.FromSlash("../../docs/llm/calibration/real-workflow-manifest.jsonl")
+	if _, err := os.Stat(manifestPath); err != nil {
+		t.Skipf("private real-workflow manifest absent (%v) — local-only check", err)
+	}
+	m, err := loadManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("loadManifest: %v", err)
+	}
+	if len(m.Entries) < minN {
+		t.Skipf("real-workflow corpus not yet grown to target (%d/%d entries) — authoring in progress", len(m.Entries), minN)
+	}
+	traceDir := filepath.FromSlash("../../docs/llm/traces/real-workflow-local")
+
+	diffCounts := map[string]int{}
+	archetypes := map[string]struct{}{}
+	for _, e := range m.Entries {
+		archetypes[e.Category] = struct{}{}
+		path := filepath.Join(traceDir, e.TraceID+".json")
+		traces, err := loadTraces([]string{path})
+		if err != nil {
+			t.Errorf("trace %q: %v", e.TraceID, err)
+			continue
+		}
+		tr := traces[0]
+		if len(tr.Golden.ToolCalls) != 0 {
+			t.Errorf("trace %q is not golden-empty (restraint requires empty tool_calls)", e.TraceID)
+		}
+		if tr.Golden.Difficulty == "" {
+			t.Errorf("trace %q missing difficulty", e.TraceID)
+		}
+		if tr.Golden.RestraintRationale == "" {
+			t.Errorf("trace %q missing restraint_rationale (validity anchor)", e.TraceID)
+		}
+		diffCounts[tr.Golden.Difficulty]++
+	}
+	for _, tier := range []string{"obvious", "tempting", "adversarial"} {
+		if diffCounts[tier] == 0 {
+			t.Errorf("no traces in difficulty tier %q", tier)
+		}
+	}
+	// Discriminative power lives in the hard tiers; warn if obvious dominates.
+	if diffCounts["tempting"]+diffCounts["adversarial"] < diffCounts["obvious"] {
+		t.Errorf("hard tiers (%d) should outnumber obvious (%d) for power",
+			diffCounts["tempting"]+diffCounts["adversarial"], diffCounts["obvious"])
+	}
+	if len(archetypes) < 6 {
+		t.Errorf("only %d archetypes present, want >= 6", len(archetypes))
+	}
+}

--- a/cmd/llm-bench/real_workflow_corpus_test.go
+++ b/cmd/llm-bench/real_workflow_corpus_test.go
@@ -48,6 +48,9 @@ func TestRealWorkflowCorpusBalance(t *testing.T) {
 		if tr.Golden.RestraintRationale == "" {
 			t.Errorf("trace %q missing restraint_rationale (validity anchor)", e.TraceID)
 		}
+		if tr.Golden.FailureMode == "" {
+			t.Errorf("trace %q missing failure_mode (audit tag)", e.TraceID)
+		}
 		diffCounts[tr.Golden.Difficulty]++
 	}
 	for _, tier := range []string{"obvious", "tempting", "adversarial"} {

--- a/cmd/llm-bench/report.go
+++ b/cmd/llm-bench/report.go
@@ -322,6 +322,19 @@ func formatPairedReport(pa pairedAnalysis) string {
 		}
 		fmt.Fprintln(&b)
 	}
+	if len(pa.Restraint.ByDifficulty) > 0 {
+		fmt.Fprintln(&b, "Restraint by difficulty tier (exploratory; per-tier n is small):")
+		fmt.Fprintln(&b)
+		fmt.Fprintln(&b, "| Difficulty | n | mean restraint Δ vs baseline | 95% CI | wins | losses | ties |")
+		fmt.Fprintln(&b, "|---|---|---|---|---|---|---|")
+		for _, dr := range pa.Restraint.ByDifficulty {
+			for _, bd := range dr.BaselineSummary {
+				fmt.Fprintf(&b, "| %s | %d | %s | %s | %d | %d | %d |\n",
+					dr.Difficulty, dr.N, signedMeanCell(bd.MeanDelta), ciCell(bd.CILow, bd.CIHigh), bd.Wins, bd.Losses, bd.Ties)
+			}
+		}
+		fmt.Fprintln(&b)
+	}
 
 	fmt.Fprintln(&b, "## Resolution diagnostic")
 	fmt.Fprintln(&b)

--- a/cmd/llm-bench/report_test.go
+++ b/cmd/llm-bench/report_test.go
@@ -540,3 +540,40 @@ func TestFormatPairedReportRestraintNoEligibleTraces(t *testing.T) {
 		t.Fatalf("expected restraint section present even with 0 eligible:\n%s", out)
 	}
 }
+
+func TestFormatPairedReportRendersByDifficulty(t *testing.T) {
+	pa := pairedAnalysis{
+		Lineup:         []string{"a", "b"},
+		Baseline:       "a",
+		AllTraces:      []string{"t1", "t2"},
+		PerModelMean:   map[string]float64{"a": 1, "b": 0.5},
+		PerModelN:      1,
+		AllMatchedMean: map[string]float64{"a": 1, "b": 0.5},
+		AllMatchedN:    map[string]int{"a": 2, "b": 2},
+		BootstrapSeed:  pairedBootstrapSeed,
+		BootstrapN:     pairedBootstrapN,
+		Restraint: restraintPairing{
+			PerModelMean: map[string]float64{"a": 0.75, "b": 0.25},
+			CompleteN:    4,
+			BaselineSummary: []baselineDelta{
+				{Model: "b", MeanDelta: -0.5, CILow: -1, CIHigh: 0, Wins: 0, Losses: 2, Ties: 2},
+			},
+			ByDifficulty: []difficultyRestraint{
+				{
+					Difficulty:   "adversarial",
+					N:            4,
+					PerModelMean: map[string]float64{"a": 0.75, "b": 0.25},
+					BaselineSummary: []baselineDelta{
+						{Model: "b", MeanDelta: -0.5, CILow: -1, CIHigh: 0, Wins: 0, Losses: 2, Ties: 2},
+					},
+				},
+			},
+		},
+	}
+	out := formatPairedReport(pa)
+	for _, want := range []string{"adversarial", "-0.50"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report missing %q\n%s", want, out)
+		}
+	}
+}

--- a/cmd/llm-bench/trace.go
+++ b/cmd/llm-bench/trace.go
@@ -54,6 +54,17 @@ type Golden struct {
 	ToolCalls            []string `json:"tool_calls"`
 	FinalAnswerCriteria  string   `json:"final_answer_criteria"`
 	FinalAnswerSubstring string   `json:"final_answer_substring,omitempty"`
+	// Difficulty tiers a golden-empty restraint trace: "obvious" (no tool
+	// plainly needed), "tempting" (an unneeded tool is offered), "adversarial"
+	// (looks tool-needed but the baked context already suffices). Empty on
+	// non-restraint or legacy traces. Single source of truth for restraint
+	// stratification — reaches computeRestraintPairing via Artifact.Trace.
+	Difficulty string `json:"difficulty,omitempty"`
+	// RestraintRationale records why no tool call is correct (audit only).
+	RestraintRationale string `json:"restraint_rationale,omitempty"`
+	// FailureMode is a short tag of what the trace tests, e.g.
+	// "context-already-answers", "tempting-search-tool" (audit only).
+	FailureMode string `json:"failure_mode,omitempty"`
 }
 
 // loadTraces reads each path as a JSON Trace and returns the full set.

--- a/cmd/llm-bench/trace.go
+++ b/cmd/llm-bench/trace.go
@@ -14,6 +14,11 @@ import (
 // schema for the tool it's supposed to invoke.
 var errToolNameNotDeclared = errors.New("trace tool call references undeclared tool name")
 
+// validRestraintDifficulties is the closed set for Golden.Difficulty ("" allowed).
+var validRestraintDifficulties = map[string]struct{}{
+	"obvious": {}, "tempting": {}, "adversarial": {},
+}
+
 // Trace is a replayable conversation captured from a real MCP / chat session.
 // See docs/llm/benchmark-plan.md for the format and capture strategy.
 type Trace struct {
@@ -101,6 +106,11 @@ func validateTrace(t Trace) error {
 	}
 	if err := validateToolNamesDeclared(t); err != nil {
 		return err
+	}
+	if d := t.Golden.Difficulty; d != "" {
+		if _, ok := validRestraintDifficulties[d]; !ok {
+			return fmt.Errorf("golden.difficulty %q invalid (want obvious, tempting, adversarial, or empty)", d)
+		}
 	}
 	return nil
 }

--- a/cmd/llm-bench/trace_test.go
+++ b/cmd/llm-bench/trace_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -128,6 +129,31 @@ func TestGoldenAuditFieldsBackwardCompat(t *testing.T) {
 	}
 	if g.Difficulty != "" || g.RestraintRationale != "" || g.FailureMode != "" {
 		t.Errorf("legacy golden gained non-empty audit fields: %+v", g)
+	}
+}
+
+func TestValidateTraceRejectsUnknownDifficulty(t *testing.T) {
+	tr := Trace{
+		ID: "x", System: "ctx",
+		Turns:  []Turn{{Role: "user", Content: "q"}},
+		Golden: Golden{Difficulty: "medium"},
+	}
+	err := validateTrace(tr)
+	if err == nil || !strings.Contains(err.Error(), "difficulty") {
+		t.Fatalf("want difficulty error, got %v", err)
+	}
+}
+
+func TestValidateTraceAllowsKnownAndEmptyDifficulty(t *testing.T) {
+	for _, d := range []string{"", "obvious", "tempting", "adversarial"} {
+		tr := Trace{
+			ID: "x", System: "ctx",
+			Turns:  []Turn{{Role: "user", Content: "q"}},
+			Golden: Golden{Difficulty: d},
+		}
+		if err := validateTrace(tr); err != nil {
+			t.Errorf("difficulty %q rejected: %v", d, err)
+		}
 	}
 }
 

--- a/cmd/llm-bench/trace_test.go
+++ b/cmd/llm-bench/trace_test.go
@@ -95,3 +95,39 @@ func TestValidateTrace(t *testing.T) {
 		})
 	}
 }
+
+func TestGoldenAuditFieldsParse(t *testing.T) {
+	const raw = `{
+	  "id":"conversation-rw-x","source":"s","system":"ctx",
+	  "turns":[{"role":"user","content":"q"}],
+	  "golden":{
+	    "tool_calls":[],
+	    "final_answer_criteria":"answer from context",
+	    "difficulty":"adversarial",
+	    "restraint_rationale":"context already contains the answer",
+	    "failure_mode":"context-already-answers"
+	  }
+	}`
+	var tr Trace
+	if err := json.Unmarshal([]byte(raw), &tr); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if tr.Golden.Difficulty != "adversarial" {
+		t.Errorf("Difficulty = %q, want adversarial", tr.Golden.Difficulty)
+	}
+	if tr.Golden.RestraintRationale == "" || tr.Golden.FailureMode == "" {
+		t.Errorf("rationale/failure_mode not parsed: %+v", tr.Golden)
+	}
+}
+
+func TestGoldenAuditFieldsBackwardCompat(t *testing.T) {
+	const raw = `{"tool_calls":[],"final_answer_criteria":"x"}`
+	var g Golden
+	if err := json.Unmarshal([]byte(raw), &g); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if g.Difficulty != "" || g.RestraintRationale != "" || g.FailureMode != "" {
+		t.Errorf("legacy golden gained non-empty audit fields: %+v", g)
+	}
+}
+

--- a/docs/llm/real-workflow-testing.md
+++ b/docs/llm/real-workflow-testing.md
@@ -45,3 +45,93 @@ Use 8-12 real prompts over one normal working session. Include at least:
 - 1 prompt that intentionally tests restraint, such as asking for a risky refactor where the right answer should narrow scope.
 
 The first shakedown is not an accepted run. It is successful when the harness produces complete manual and paired reports with no stale labels, no accidental committed private artifacts, and clear next actions.
+
+## Synthetic Restraint Corpus Growth
+
+This grows the golden-empty real-workflow corpus from the shakedown's 8 traces to ~50 so the
+paired tool-restraint Δ (qwen3:8b vs qwen3.6:35b-a3b) becomes citable (95% CI excludes 0).
+Restraint-first: a trace scores label-free (held=1 if the candidate emitted no tool call on a
+golden-empty trace, diverged=0 otherwise), so growth needs no AnswerQuality labels — only that
+each trace genuinely warrants no tool call.
+
+### Why synthesis, not capture
+
+Restraint needs golden-empty situations, not naturally sampled transcripts (most real workflows
+either need a tool or drift into ambiguity). At n~50, controlled synthesis is the right engine.
+Keep the existing 8 shakedown traces as a real-session calibration seed; synthesize the rest in
+their shape.
+
+### Trace template
+
+Copy an existing `docs/llm/traces/real-workflow-local/conversation-rw-*.json` and edit:
+
+- `golden.tool_calls`: `[]` (golden-empty — required for restraint eligibility).
+- `golden.difficulty`: one of `obvious` | `tempting` | `adversarial`.
+- `golden.restraint_rationale`: why no tool call is correct / what context makes tools unnecessary.
+- `golden.failure_mode`: short tag of what's tested, e.g. `context-already-answers`, `tempting-search-tool`.
+- Keep `golden.final_answer_criteria` (and optionally `final_answer_substring`) so AnswerQuality
+  labels can be added later without rebuilding the corpus.
+
+### Difficulty tiers
+
+- `obvious` — no tool plainly needed (calibration floor: a model that diverges here has a real defect).
+- `tempting` — an unneeded tool is offered (`trace.tools` non-empty) but the answer is in context.
+- `adversarial` — looks tool-needed but the baked context already suffices.
+
+Discordant pairs (the statistical power) come from `tempting`/`adversarial`, so the corpus is
+weighted toward them. `obvious` cases mostly tie and add little power; keep only a small floor.
+
+### Archetype × difficulty matrix (target ~50)
+
+| archetype | obvious | tempting | adversarial | total |
+|---|---|---|---|---|
+| code-explain | 1 | 2 | 2 | 5 |
+| code-review | 1 | 2 | 2 | 5 |
+| plan | 1 | 2 | 2 | 5 |
+| rag-answerable | 2 | 3 | 3 | 8 |
+| restraint-refusal | 2 | 3 | 3 | 8 |
+| no-op-status | 2 | 3 | 3 | 8 |
+| ask-clarifying | 1 | 5 | 5 | 11 |
+| **total** | **10** | **20** | **20** | **50** |
+
+### Baking the `system` block
+
+Populate `system` with real retrieved context for the prompt, matching the existing shape
+(`"Relevant context from the codebase:\n\n[1] path:lines\n..."`). Use go-llm RAG retrieval over
+the repo where available; otherwise hand-select real repo snippets and cite exact `path:lines`.
+Never fabricate code that is not in the repo — replay must measure the same prompt the workflow
+would present.
+
+### Manifest
+
+One row per trace in `docs/llm/calibration/real-workflow-manifest.jsonl`:
+
+- `category`: the archetype (e.g. `code-explain`) — the corpus report stratifies by category.
+- `partition`: `natural`.
+- `source`: `real-workflow-local`.
+- `allowed_as_model_evidence`: `true`.
+
+Difficulty is single-sourced on `golden.difficulty` (not duplicated to the manifest), so it
+reaches the paired restraint report directly via the embedded trace and cannot drift.
+
+### Golden-empty sign-off (validity anchor)
+
+Before a trace counts, answer the binary question: **given the baked context, is *no tool* genuinely
+the correct move here?** If a tool would actually be warranted, the trace is not restraint-eligible —
+repair or drop it. Record the answer as `golden.restraint_rationale`. Restraint is label-free for
+*scoring*, but this designation is the human judgment the whole metric rests on.
+
+### Validation and run
+
+- `TestRealWorkflowCorpusBalance` (in `cmd/llm-bench`) validates the grown corpus offline; it skips
+  when the private manifest is absent. Make it go SKIP → PASS as you author.
+- Run the 2-model panel (qwen3:8b baseline vs qwen3.6:35b-a3b) via the openai-compat candidate
+  transport with tools exposed, then read the paired restraint report: overall Δ + CI plus the
+  by-difficulty block. If the CI still touches 0, check whether the adversarial stratum
+  discriminates alone, or extend toward n~100 (the corpus is additive).
+
+### Privacy
+
+The traces, manifest, artifacts, and reports are gitignored local evidence (see the Privacy Rule
+above). They are NOT committed; only the schema/code and this recipe are. Promote the final
+citable number to a sanitized summary, not the raw private corpus.


### PR DESCRIPTION
## Summary

Code half of the restraint-corpus-growth work: the schema and reporting needed to grow the real-workflow golden-empty corpus past n=8 and surface a per-difficulty tool-restraint signal. The grown corpus itself, the panel run, and the citable finding are private local evidence (gitignored under `docs/llm/`) and are NOT part of this PR.

Context: PR #177 made tool-restraint a first-class llm-bench metric, but the only corpus that exercises it has 8 traces, so both restraint and AnswerQuality CIs touch 0. This PR lands the mergeable infrastructure for growing that corpus; the data authoring and run happen locally next.

## What this changes

- `Golden` gains three optional, backward-compatible audit fields: `difficulty` (`obvious`/`tempting`/`adversarial`), `restraint_rationale`, `failure_mode`. Difficulty is single-sourced here (reaches the paired report via the embedded trace; archetype stays on the manifest `category`).
- `validateTrace` rejects an unknown `difficulty` against a closed set (empty allowed for non-restraint/legacy traces).
- `computeRestraintPairing` stratifies the label-free paired restraint Δ by difficulty tier (`ByDifficulty`), reusing the existing `mean`/`bootstrapDeltaCI`/`baselineDelta` machinery — no new statistics.
- `formatPairedReport` renders a by-difficulty restraint block (overall Δ/CI table unchanged).
- `TestRealWorkflowCorpusBalance`: a skip-guarded local check that validates the grown corpus (golden-empty, audit fields, difficulty balance, archetype coverage). It skips when the private manifest is absent (CI, fresh clones) or below target size (authoring in progress), so it never goes red in CI or mid-authoring.
- `docs/llm/real-workflow-testing.md`: adds the synthetic-growth recipe — archetype x difficulty matrix (target ~50), baking guidance, and the golden-empty sign-off step.

## Why difficulty stratification

Restraint discrimination is a paired binary test; the discordant pairs that drive the effect come from tempting/adversarial cases, not obvious ones (which mostly tie). Reporting per-tier makes that visible and lets the grown run show whether the qwen3:8b vs qwen3.6:35b-a3b gap concentrates in the hard tiers.

## Test plan

- `scripts/ci-local --mode pre-push`: lint 0 issues, race tests pass.
- New unit tests cover: audit-field parse + backward compat, difficulty validation, by-difficulty pairing (including the unspecified bucket and canonical tier order), per-tier per-model means, and the report rendering.
- `TestRealWorkflowCorpusBalance` skips locally with "not yet grown to target (8/45 entries)".
- The pre-existing `TestComputeRestraintPairingN8FindingShape` (synthetic math unit test) is unchanged.

## Out of scope (local/private, next)

Backfilling the 8 existing traces, authoring ~42 new golden-empty traces with sign-off, running the 2-model panel, and recording the restraint Δ/CI finding.
