### PR TITLE
feat(llm-bench): import xLAM-irrelevance as golden-empty restraint corpus

### DIFF
--- a/cmd/llm-bench/main.go
+++ b/cmd/llm-bench/main.go
@@ -40,6 +40,13 @@ func main() {
 	captureSample := flag.String("capture-sample", "", "Stratified capture spec, e.g. n=50,stratify=token-length:turn-count (mutually exclusive with -capture-limit)")
 	captureSampleSeed := flag.Int64("capture-sample-seed", 0, "Deterministic seed for -capture-sample (0 = time.Now().UnixNano())")
 
+	importXlam := flag.String("import-xlam", "", "Convert a MadeAgents/xlam-irrelevance JSON file into golden-empty restraint traces and exit (uses -import-xlam-out, -import-xlam-manifest, -import-xlam-n, -import-xlam-seed, -import-xlam-min-tools)")
+	importXlamOut := flag.String("import-xlam-out", filepath.Join("docs", "llm", "traces", "xlam-irrelevance-local"), "Output directory for -import-xlam trace files")
+	importXlamManifest := flag.String("import-xlam-manifest", filepath.Join("docs", "llm", "calibration", "xlam-irrelevance-manifest.jsonl"), "Output manifest path for -import-xlam")
+	importXlamN := flag.Int("import-xlam-n", 300, "Number of eligible records to sample for -import-xlam (<=0 = all eligible)")
+	importXlamSeed := flag.Int64("import-xlam-seed", 42, "Deterministic sampling seed for -import-xlam")
+	importXlamMinTools := flag.Int("import-xlam-min-tools", 1, "Drop -import-xlam records offering fewer than this many tools")
+
 	calibrateCapture := flag.Bool("calibrate-capture", false, "Phase 1: replay candidates and write frozen artifacts.jsonl")
 	calibrate := flag.Bool("calibrate", false, "Phase 2: re-score frozen labeled artifacts with the judge model")
 	manualReport := flag.Bool("manual-report", false, "Score frozen labeled artifacts with human labels (manual scorer) and emit a quality baseline report (uses -labels, -artifacts, -report)")
@@ -121,8 +128,11 @@ func main() {
 	if *discriminationReport {
 		modes++
 	}
+	if *importXlam != "" {
+		modes++
+	}
 	if modes > 1 {
-		log.Fatalf("llm-bench: -capture, -calibrate-capture, -calibrate, -manual-report, -paired-report, -fim-latency, -blind-render, -blind-ingest, -discrimination-report are mutually exclusive")
+		log.Fatalf("llm-bench: -capture, -calibrate-capture, -calibrate, -manual-report, -paired-report, -fim-latency, -blind-render, -blind-ingest, -discrimination-report, -import-xlam are mutually exclusive")
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -163,6 +173,22 @@ func main() {
 			log.Fatalf("llm-bench: capture wrote no traces")
 		}
 		fmt.Fprintf(os.Stderr, "llm-bench: capture wrote %d trace(s) to %s\n", len(result.Written), *captureOut)
+		return
+	}
+
+	if *importXlam != "" {
+		res, err := importXlamIrrelevance(xlamImportOptions{
+			SrcPath:      *importXlam,
+			OutDir:       *importXlamOut,
+			ManifestPath: *importXlamManifest,
+			N:            *importXlamN,
+			Seed:         *importXlamSeed,
+			MinTools:     *importXlamMinTools,
+		})
+		if err != nil {
+			log.Fatalf("llm-bench: import-xlam: %v", err)
+		}
+		fmt.Fprintf(os.Stderr, "llm-bench: import-xlam wrote %d of %d eligible trace(s) (filtered %d ineligible) to %s, manifest %s\n", res.Written, res.Eligible, res.Filtered, *importXlamOut, *importXlamManifest)
 		return
 	}
 

--- a/cmd/llm-bench/xlam_import.go
+++ b/cmd/llm-bench/xlam_import.go
@@ -95,6 +95,11 @@ type xlamImportResult struct {
 // them, converts each to a golden-empty Trace, and writes the trace files plus a
 // corpus manifest. Sampling is deterministic for a given (Seed, input).
 func importXlamIrrelevance(opts xlamImportOptions) (xlamImportResult, error) {
+	if opts.MinTools < 0 {
+		// A negative minimum would make `len(tools) < MinTools` always false,
+		// silently admitting 0-tool rows. Reject it rather than guess intent.
+		return xlamImportResult{}, fmt.Errorf("xlam import: min-tools must be >= 0, got %d", opts.MinTools)
+	}
 	data, err := os.ReadFile(opts.SrcPath)
 	if err != nil {
 		return xlamImportResult{}, fmt.Errorf("xlam import: read source: %w", err)

--- a/cmd/llm-bench/xlam_import.go
+++ b/cmd/llm-bench/xlam_import.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// xLAM-irrelevance import: convert MadeAgents/xlam-irrelevance-7.5k (CC-BY-4.0)
+// into go-llm golden-empty Traces so the label-free restraint metric scores them
+// when replayed. Each source record is an "irrelevance" case — tools offered,
+// none relevant, correct action = call nothing — so its empty `answers` IS the
+// golden-empty label, with no human authoring or sign-off needed.
+const (
+	xlamSource         = "xlam-irrelevance"
+	xlamDifficulty     = "tempting"
+	xlamFailureMode    = "irrelevant-tools-offered"
+	xlamSystemPrompt   = "You are a helpful assistant with access to the tools listed for this task. Call a tool only when it is required to answer the user's request; if none of the available tools is relevant, answer directly without calling any tool."
+	xlamGoldenCriteria = "None of the offered tools is relevant to the query; the correct behavior is to respond directly (or state it cannot help) WITHOUT calling any function."
+	xlamRationale      = "The offered tools do not match the query's intent, so no tool call is warranted; the model should answer without invoking a function."
+)
+
+// xlamRecord is one MadeAgents/xlam-irrelevance-7.5k row. Tools and Answers are
+// JSON-encoded strings (the dataset double-encodes them).
+type xlamRecord struct {
+	Query   string `json:"query"`
+	Tools   string `json:"tools"`
+	Answers string `json:"answers"`
+}
+
+// xlamRecordToTrace converts one irrelevance record into a golden-empty Trace.
+// It returns an error if the record is not an irrelevance case (non-empty
+// answers) or is malformed (empty query, unparseable tools/answers). idx seeds
+// the trace ID. The result is validated so it cannot fail the harness loader.
+func xlamRecordToTrace(rec xlamRecord, idx int) (Trace, error) {
+	query := strings.TrimSpace(rec.Query)
+	if query == "" {
+		return Trace{}, fmt.Errorf("xlam record %d: empty query", idx)
+	}
+	var answers []json.RawMessage
+	if err := json.Unmarshal([]byte(rec.Answers), &answers); err != nil {
+		return Trace{}, fmt.Errorf("xlam record %d: parse answers: %w", idx, err)
+	}
+	if len(answers) != 0 {
+		return Trace{}, fmt.Errorf("xlam record %d: %d answer(s) present — not an irrelevance case", idx, len(answers))
+	}
+	var tools []json.RawMessage
+	if err := json.Unmarshal([]byte(rec.Tools), &tools); err != nil {
+		return Trace{}, fmt.Errorf("xlam record %d: parse tools: %w", idx, err)
+	}
+	tr := Trace{
+		ID:     fmt.Sprintf("xlam-irrel-%04d", idx),
+		Source: xlamSource,
+		System: xlamSystemPrompt,
+		Tools:  tools,
+		Turns:  []Turn{{Role: "user", Content: query}},
+		Golden: Golden{
+			ToolCalls:           []string{},
+			FinalAnswerCriteria: xlamGoldenCriteria,
+			Difficulty:          xlamDifficulty,
+			RestraintRationale:  xlamRationale,
+			FailureMode:         xlamFailureMode,
+		},
+	}
+	if err := validateTrace(tr); err != nil {
+		return Trace{}, fmt.Errorf("xlam record %d: %w", idx, err)
+	}
+	return tr, nil
+}
+
+// xlamImportOptions configures importXlamIrrelevance.
+type xlamImportOptions struct {
+	SrcPath      string // path to xlam-7.5k-irrelevancek.json
+	OutDir       string // directory for emitted trace JSON files
+	ManifestPath string // path for the emitted corpus manifest JSONL
+	N            int    // sample size (<=0 or >available = all)
+	Seed         int64  // deterministic sampling seed
+	MinTools     int    // drop records with fewer than this many offered tools
+}
+
+// xlamImportResult reports the outcome of an import. Eligible counts records
+// that passed the filter (before sampling); Written is how many of those were
+// sampled and emitted; Filtered is records dropped as ineligible/malformed.
+type xlamImportResult struct {
+	Written  int
+	Eligible int
+	Filtered int
+}
+
+// importXlamIrrelevance reads the xLAM-irrelevance JSON array, keeps records with
+// at least MinTools offered tools and an empty answer set, seeded-samples N of
+// them, converts each to a golden-empty Trace, and writes the trace files plus a
+// corpus manifest. Sampling is deterministic for a given (Seed, input).
+func importXlamIrrelevance(opts xlamImportOptions) (xlamImportResult, error) {
+	data, err := os.ReadFile(opts.SrcPath)
+	if err != nil {
+		return xlamImportResult{}, fmt.Errorf("xlam import: read source: %w", err)
+	}
+	var recs []xlamRecord
+	if err := json.Unmarshal(data, &recs); err != nil {
+		return xlamImportResult{}, fmt.Errorf("xlam import: parse source: %w", err)
+	}
+
+	res := xlamImportResult{}
+	var eligible []xlamRecord
+	for _, r := range recs {
+		// Eligibility is deep: a record must pass the shallow filter AND convert
+		// cleanly (idx is irrelevant to validity). Recording convert-failures here
+		// as Filtered keeps one malformed third-party row from aborting the batch
+		// and makes the post-sample write loop's failure a true invariant.
+		if !xlamRecordEligible(r, opts.MinTools) {
+			res.Filtered++
+			continue
+		}
+		if _, err := xlamRecordToTrace(r, 0); err != nil {
+			res.Filtered++
+			continue
+		}
+		eligible = append(eligible, r)
+	}
+	res.Eligible = len(eligible)
+
+	rng := rand.New(rand.NewSource(opts.Seed))
+	rng.Shuffle(len(eligible), func(i, j int) { eligible[i], eligible[j] = eligible[j], eligible[i] })
+	if opts.N > 0 && opts.N < len(eligible) {
+		eligible = eligible[:opts.N]
+	}
+
+	if err := os.MkdirAll(opts.OutDir, 0o755); err != nil {
+		return xlamImportResult{}, fmt.Errorf("xlam import: mkdir out: %w", err)
+	}
+	// Clear prior xlam traces so the output dir always matches the new manifest
+	// (a smaller re-run must not leave orphans that a *.json replay would pick up).
+	stale, err := filepath.Glob(filepath.Join(opts.OutDir, "xlam-irrel-*.json"))
+	if err != nil {
+		return xlamImportResult{}, fmt.Errorf("xlam import: scan stale traces: %w", err)
+	}
+	for _, p := range stale {
+		if err := os.Remove(p); err != nil {
+			return xlamImportResult{}, fmt.Errorf("xlam import: remove stale %s: %w", p, err)
+		}
+	}
+	var manifest Manifest
+	for i, r := range eligible {
+		tr, err := xlamRecordToTrace(r, i)
+		if err != nil {
+			// The eligibility filter already proved each record convertible, so a
+			// failure here is a logic bug, not bad data — fail loud, don't undercount.
+			return xlamImportResult{}, fmt.Errorf("xlam import: convert eligible record %d: %w", i, err)
+		}
+		path := filepath.Join(opts.OutDir, safeTraceFilename(tr.ID)+".json")
+		blob, err := json.MarshalIndent(tr, "", "  ")
+		if err != nil {
+			return xlamImportResult{}, fmt.Errorf("xlam import: marshal %s: %w", tr.ID, err)
+		}
+		if err := os.WriteFile(path, blob, 0o600); err != nil {
+			return xlamImportResult{}, fmt.Errorf("xlam import: write %s: %w", path, err)
+		}
+		manifest.Entries = append(manifest.Entries, ManifestEntry{
+			TraceID:                tr.ID,
+			Partition:              PartitionChallenge,
+			Category:               "irrelevance",
+			Source:                 xlamSource,
+			AllowedAsModelEvidence: true,
+		})
+		res.Written++
+	}
+	if res.Written == 0 {
+		return res, fmt.Errorf("xlam import: no eligible records written (have %d records, min-tools=%d)", len(recs), opts.MinTools)
+	}
+	if err := writeManifest(opts.ManifestPath, manifest); err != nil {
+		return xlamImportResult{}, fmt.Errorf("xlam import: %w", err)
+	}
+	return res, nil
+}
+
+// xlamRecordEligible reports whether a record is a usable irrelevance case:
+// non-empty query, parseable tools with at least minTools entries, and an empty
+// answer set (the golden-empty signal).
+func xlamRecordEligible(r xlamRecord, minTools int) bool {
+	if strings.TrimSpace(r.Query) == "" {
+		return false
+	}
+	var tools []json.RawMessage
+	if err := json.Unmarshal([]byte(r.Tools), &tools); err != nil || len(tools) < minTools {
+		return false
+	}
+	var answers []json.RawMessage
+	if err := json.Unmarshal([]byte(r.Answers), &answers); err != nil || len(answers) != 0 {
+		return false
+	}
+	return true
+}

--- a/cmd/llm-bench/xlam_import.go
+++ b/cmd/llm-bench/xlam_import.go
@@ -40,16 +40,16 @@ func xlamRecordToTrace(rec xlamRecord, idx int) (Trace, error) {
 	if query == "" {
 		return Trace{}, fmt.Errorf("xlam record %d: empty query", idx)
 	}
-	var answers []json.RawMessage
-	if err := json.Unmarshal([]byte(rec.Answers), &answers); err != nil {
-		return Trace{}, fmt.Errorf("xlam record %d: parse answers: %w", idx, err)
+	answers, err := parseXlamJSONArray("answers", rec.Answers)
+	if err != nil {
+		return Trace{}, fmt.Errorf("xlam record %d: %w", idx, err)
 	}
 	if len(answers) != 0 {
 		return Trace{}, fmt.Errorf("xlam record %d: %d answer(s) present — not an irrelevance case", idx, len(answers))
 	}
-	var tools []json.RawMessage
-	if err := json.Unmarshal([]byte(rec.Tools), &tools); err != nil {
-		return Trace{}, fmt.Errorf("xlam record %d: parse tools: %w", idx, err)
+	tools, err := parseXlamJSONArray("tools", rec.Tools)
+	if err != nil {
+		return Trace{}, fmt.Errorf("xlam record %d: %w", idx, err)
 	}
 	tr := Trace{
 		ID:     fmt.Sprintf("xlam-irrel-%04d", idx),
@@ -184,13 +184,31 @@ func xlamRecordEligible(r xlamRecord, minTools int) bool {
 	if strings.TrimSpace(r.Query) == "" {
 		return false
 	}
-	var tools []json.RawMessage
-	if err := json.Unmarshal([]byte(r.Tools), &tools); err != nil || len(tools) < minTools {
+	tools, err := parseXlamJSONArray("tools", r.Tools)
+	if err != nil || len(tools) < minTools {
 		return false
 	}
-	var answers []json.RawMessage
-	if err := json.Unmarshal([]byte(r.Answers), &answers); err != nil || len(answers) != 0 {
+	answers, err := parseXlamJSONArray("answers", r.Answers)
+	if err != nil || len(answers) != 0 {
 		return false
 	}
 	return true
+}
+
+// parseXlamJSONArray decodes one of xLAM's double-encoded JSON-array fields,
+// rejecting the empty string and the JSON literal "null" up front. Both
+// unmarshal into a nil slice with no error, so without this guard a "null"
+// answers field would be read as an empty array (false golden-empty) and a
+// "null" tools field would slip through as zero-tools. A real empty array
+// ("[]") is still accepted — the min-tools / golden-empty checks own that.
+func parseXlamJSONArray(field, s string) ([]json.RawMessage, error) {
+	t := strings.TrimSpace(s)
+	if t == "" || t == "null" {
+		return nil, fmt.Errorf("%s is empty or null", field)
+	}
+	var arr []json.RawMessage
+	if err := json.Unmarshal([]byte(t), &arr); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", field, err)
+	}
+	return arr, nil
 }

--- a/cmd/llm-bench/xlam_import_test.go
+++ b/cmd/llm-bench/xlam_import_test.go
@@ -93,6 +93,9 @@ func TestXlamRecordToTraceRejectsBadInput(t *testing.T) {
 		"empty query":  {Query: "  ", Tools: sampleXlamTools, Answers: "[]"},
 		"bad tools":    {Query: "q", Tools: "not json", Answers: "[]"},
 		"bad answers":  {Query: "q", Tools: sampleXlamTools, Answers: "not json"},
+		"null answers": {Query: "q", Tools: sampleXlamTools, Answers: "null"},
+		"null tools":   {Query: "q", Tools: "null", Answers: "[]"},
+		"empty answers string": {Query: "q", Tools: sampleXlamTools, Answers: "  "},
 	} {
 		if _, err := xlamRecordToTrace(rec, 0); err == nil {
 			t.Errorf("%s: want error, got nil", name)
@@ -236,6 +239,32 @@ func TestImportXlamIrrelevanceClearsStaleTraces(t *testing.T) {
 	}
 	if _, err := os.Stat(stale); !os.IsNotExist(err) {
 		t.Errorf("stale trace %s not removed (err=%v)", stale, err)
+	}
+}
+
+func TestImportXlamIrrelevanceRejectsNullFieldsEvenAtMinToolsZero(t *testing.T) {
+	// With min-tools=0 a "null" tools/answers row must still be filtered, not
+	// imported as a zero-tool / false golden-empty trace.
+	recs := []xlamRecord{
+		{Query: "ok", Tools: sampleXlamTools, Answers: "[]"},
+		{Query: "nulltools", Tools: "null", Answers: "[]"},
+		{Query: "nullanswers", Tools: sampleXlamTools, Answers: "null"},
+	}
+	dir := t.TempDir()
+	src := filepath.Join(dir, "x.json")
+	blob, _ := json.Marshal(recs)
+	if err := os.WriteFile(src, blob, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	res, err := importXlamIrrelevance(xlamImportOptions{
+		SrcPath: src, OutDir: filepath.Join(dir, "o"), ManifestPath: filepath.Join(dir, "m.jsonl"),
+		N: 0, Seed: 1, MinTools: 0,
+	})
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if res.Written != 1 || res.Eligible != 1 || res.Filtered != 2 {
+		t.Errorf("result = %+v, want Written=1 Eligible=1 Filtered=2 (null rows filtered)", res)
 	}
 }
 

--- a/cmd/llm-bench/xlam_import_test.go
+++ b/cmd/llm-bench/xlam_import_test.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const sampleXlamTools = `[{"name":"get_weather","description":"Get weather for a city","parameters":{"city":{"description":"City name","type":"string"}}},{"name":"stock_price","description":"Look up a stock price","parameters":{"ticker":{"description":"Ticker","type":"string"}}}]`
+
+func TestXlamRecordToTraceGoldenEmpty(t *testing.T) {
+	rec := xlamRecord{
+		Query:   "Who won the 2019 NCAA Final Four?",
+		Tools:   sampleXlamTools,
+		Answers: "[]",
+	}
+	tr, err := xlamRecordToTrace(rec, 7)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if tr.ID != "xlam-irrel-0007" {
+		t.Errorf("ID = %q, want xlam-irrel-0007", tr.ID)
+	}
+	if tr.Source != xlamSource {
+		t.Errorf("Source = %q, want %q", tr.Source, xlamSource)
+	}
+	if tr.System == "" {
+		t.Error("System is empty (validateTrace would reject)")
+	}
+	if len(tr.Turns) != 1 || tr.Turns[0].Role != "user" || tr.Turns[0].Content != rec.Query {
+		t.Errorf("Turns = %+v, want one user turn with the query", tr.Turns)
+	}
+	if len(tr.Golden.ToolCalls) != 0 {
+		t.Errorf("golden.tool_calls = %v, want empty (golden-empty)", tr.Golden.ToolCalls)
+	}
+	if tr.Golden.FinalAnswerCriteria == "" {
+		t.Error("golden.final_answer_criteria empty — would be excluded from restraint pairing")
+	}
+	if tr.Golden.Difficulty != "tempting" {
+		t.Errorf("difficulty = %q, want tempting", tr.Golden.Difficulty)
+	}
+	if tr.Golden.RestraintRationale == "" || tr.Golden.FailureMode == "" {
+		t.Errorf("audit fields empty: %+v", tr.Golden)
+	}
+	if len(tr.Tools) != 2 {
+		t.Errorf("Tools len = %d, want 2", len(tr.Tools))
+	}
+	// Must survive the loader's validation (it is written then re-read by the harness).
+	if err := validateTrace(tr); err != nil {
+		t.Errorf("validateTrace rejects converted trace: %v", err)
+	}
+	// The offered tool names must be declarable (so replay exposes them).
+	names, err := declaredToolNames(tr.Tools)
+	if err != nil {
+		t.Fatalf("declaredToolNames: %v", err)
+	}
+	if _, ok := names["get_weather"]; !ok {
+		t.Errorf("declared tool names = %v, want get_weather present", names)
+	}
+}
+
+// The converted trace must score held when the candidate calls no tool, and
+// diverged when it does — i.e. it is a genuine restraint-eligible trace per the
+// existing metric (PR #178), and carries enough context for paired inclusion.
+func TestXlamConvertedTraceScoresRestraint(t *testing.T) {
+	tr, err := xlamRecordToTrace(xlamRecord{Query: "q", Tools: sampleXlamTools, Answers: "[]"}, 0)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if !restraintArtifactTraceContextValid(Artifact{TraceID: tr.ID, Trace: tr}) {
+		t.Fatal("trace lacks valid restraint context (id/rubric)")
+	}
+	held, computed := restraintSignals(tr, []Turn{{Role: "assistant", Content: "I can't help with that from the tools given."}})
+	if !computed || held != 1 {
+		t.Errorf("no-tool transcript: held=%v computed=%v, want 1/true", held, computed)
+	}
+	div, computed := restraintSignals(tr, []Turn{{Role: "assistant", ToolCalls: []ToolCall{{Name: "get_weather"}}}})
+	if !computed || div != 0 {
+		t.Errorf("tool-call transcript: held=%v computed=%v, want 0/true", div, computed)
+	}
+}
+
+func TestXlamRecordToTraceRejectsNonEmptyAnswers(t *testing.T) {
+	rec := xlamRecord{Query: "q", Tools: sampleXlamTools, Answers: `[{"name":"get_weather","arguments":{"city":"x"}}]`}
+	if _, err := xlamRecordToTrace(rec, 0); err == nil {
+		t.Fatal("want error for non-empty answers (not an irrelevance case)")
+	}
+}
+
+func TestXlamRecordToTraceRejectsBadInput(t *testing.T) {
+	for name, rec := range map[string]xlamRecord{
+		"empty query":  {Query: "  ", Tools: sampleXlamTools, Answers: "[]"},
+		"bad tools":    {Query: "q", Tools: "not json", Answers: "[]"},
+		"bad answers":  {Query: "q", Tools: sampleXlamTools, Answers: "not json"},
+	} {
+		if _, err := xlamRecordToTrace(rec, 0); err == nil {
+			t.Errorf("%s: want error, got nil", name)
+		}
+	}
+}
+
+func TestImportXlamIrrelevanceFilterSampleDeterministic(t *testing.T) {
+	// 5 records: 2 valid (>=1 tool, empty answers), 1 zero-tool, 1 non-empty answers, 1 valid.
+	recs := []xlamRecord{
+		{Query: "a", Tools: sampleXlamTools, Answers: "[]"},
+		{Query: "b", Tools: "[]", Answers: "[]"},                                  // 0 tools -> filtered
+		{Query: "c", Tools: sampleXlamTools, Answers: `[{"name":"x"}]`},           // has answer -> filtered
+		{Query: "d", Tools: sampleXlamTools, Answers: "[]"},
+		{Query: "e", Tools: sampleXlamTools, Answers: "[]"},
+	}
+	dir := t.TempDir()
+	src := filepath.Join(dir, "xlam.json")
+	blob, _ := json.Marshal(recs)
+	if err := os.WriteFile(src, blob, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	run := func(outSub string) ([]ManifestEntry, xlamImportResult) {
+		out := filepath.Join(dir, outSub)
+		mf := filepath.Join(dir, outSub+"-manifest.jsonl")
+		res, err := importXlamIrrelevance(xlamImportOptions{
+			SrcPath: src, OutDir: out, ManifestPath: mf, N: 2, Seed: 42, MinTools: 1,
+		})
+		if err != nil {
+			t.Fatalf("import: %v", err)
+		}
+		m, err := loadManifest(mf)
+		if err != nil {
+			t.Fatalf("loadManifest: %v", err)
+		}
+		return m.Entries, res
+	}
+	e1, res := run("a")
+	if res.Written != 2 || res.Eligible != 3 || res.Filtered != 2 {
+		t.Errorf("result = %+v, want Written=2 Eligible=3 Filtered=2", res)
+	}
+	if len(e1) != 2 {
+		t.Fatalf("manifest entries = %d, want 2", len(e1))
+	}
+	for _, e := range e1 {
+		if e.Category != "irrelevance" || e.Source != xlamSource || e.Partition != PartitionChallenge || !e.AllowedAsModelEvidence {
+			t.Errorf("manifest entry wrong: %+v", e)
+		}
+		// Every emitted trace loads + is golden-empty.
+		traces, err := loadTraces([]string{filepath.Join(dir, "a", e.TraceID+".json")})
+		if err != nil {
+			t.Errorf("load %s: %v", e.TraceID, err)
+			continue
+		}
+		if len(traces[0].Golden.ToolCalls) != 0 {
+			t.Errorf("%s not golden-empty", e.TraceID)
+		}
+	}
+	// Same seed -> same sampled trace IDs (determinism).
+	e2, _ := run("b")
+	if len(e2) != len(e1) {
+		t.Fatalf("determinism: lengths differ")
+	}
+	for i := range e1 {
+		if e1[i].TraceID != e2[i].TraceID {
+			t.Errorf("determinism: entry %d %q != %q", i, e1[i].TraceID, e2[i].TraceID)
+		}
+	}
+}
+
+func TestImportXlamIrrelevanceNTakesAllWhenNonPositive(t *testing.T) {
+	recs := []xlamRecord{
+		{Query: "a", Tools: sampleXlamTools, Answers: "[]"},
+		{Query: "b", Tools: sampleXlamTools, Answers: "[]"},
+	}
+	dir := t.TempDir()
+	src := filepath.Join(dir, "x.json")
+	blob, _ := json.Marshal(recs)
+	if err := os.WriteFile(src, blob, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	res, err := importXlamIrrelevance(xlamImportOptions{
+		SrcPath: src, OutDir: filepath.Join(dir, "o"), ManifestPath: filepath.Join(dir, "m.jsonl"),
+		N: 0, Seed: 1, MinTools: 1,
+	})
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if res.Written != 2 || res.Eligible != 2 {
+		t.Errorf("N<=0 should write all eligible: %+v", res)
+	}
+}
+
+func TestImportXlamIrrelevanceDeepFilterSkipsUnconvertible(t *testing.T) {
+	// Second record passes the shallow filter (one tool element, empty answers)
+	// but the tool element is not an object, so conversion (validateTrace) fails.
+	// It must be Filtered, not abort the batch.
+	recs := []xlamRecord{
+		{Query: "a", Tools: sampleXlamTools, Answers: "[]"},
+		{Query: "b", Tools: `["notanobject"]`, Answers: "[]"},
+	}
+	dir := t.TempDir()
+	src := filepath.Join(dir, "x.json")
+	blob, _ := json.Marshal(recs)
+	if err := os.WriteFile(src, blob, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	res, err := importXlamIrrelevance(xlamImportOptions{
+		SrcPath: src, OutDir: filepath.Join(dir, "o"), ManifestPath: filepath.Join(dir, "m.jsonl"),
+		N: 0, Seed: 1, MinTools: 1,
+	})
+	if err != nil {
+		t.Fatalf("one unconvertible row must not abort the batch: %v", err)
+	}
+	if res.Written != 1 || res.Eligible != 1 || res.Filtered != 1 {
+		t.Errorf("result = %+v, want Written=1 Eligible=1 Filtered=1", res)
+	}
+}
+
+func TestImportXlamIrrelevanceClearsStaleTraces(t *testing.T) {
+	recs := []xlamRecord{{Query: "a", Tools: sampleXlamTools, Answers: "[]"}}
+	dir := t.TempDir()
+	src := filepath.Join(dir, "x.json")
+	blob, _ := json.Marshal(recs)
+	if err := os.WriteFile(src, blob, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(dir, "o")
+	if err := os.MkdirAll(out, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stale := filepath.Join(out, "xlam-irrel-9999.json")
+	if err := os.WriteFile(stale, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := importXlamIrrelevance(xlamImportOptions{
+		SrcPath: src, OutDir: out, ManifestPath: filepath.Join(dir, "m.jsonl"),
+		N: 0, Seed: 1, MinTools: 1,
+	}); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("stale trace %s not removed (err=%v)", stale, err)
+	}
+}
+
+func TestImportXlamIrrelevanceErrorsWhenNoneEligible(t *testing.T) {
+	// All records filtered (0 tools), so nothing is written.
+	recs := []xlamRecord{{Query: "a", Tools: "[]", Answers: "[]"}}
+	dir := t.TempDir()
+	src := filepath.Join(dir, "x.json")
+	blob, _ := json.Marshal(recs)
+	if err := os.WriteFile(src, blob, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := importXlamIrrelevance(xlamImportOptions{
+		SrcPath: src, OutDir: filepath.Join(dir, "o"), ManifestPath: filepath.Join(dir, "m.jsonl"),
+		N: 5, Seed: 1, MinTools: 1,
+	})
+	if err == nil {
+		t.Fatal("want error when no eligible records, got nil")
+	}
+}

--- a/cmd/llm-bench/xlam_import_test.go
+++ b/cmd/llm-bench/xlam_import_test.go
@@ -268,6 +268,21 @@ func TestImportXlamIrrelevanceRejectsNullFieldsEvenAtMinToolsZero(t *testing.T) 
 	}
 }
 
+func TestImportXlamIrrelevanceRejectsNegativeMinTools(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "x.json")
+	if err := os.WriteFile(src, []byte("[]"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := importXlamIrrelevance(xlamImportOptions{
+		SrcPath: src, OutDir: filepath.Join(dir, "o"), ManifestPath: filepath.Join(dir, "m.jsonl"),
+		N: 1, Seed: 1, MinTools: -1,
+	})
+	if err == nil {
+		t.Fatal("want error for negative min-tools, got nil")
+	}
+}
+
 func TestImportXlamIrrelevanceErrorsWhenNoneEligible(t *testing.T) {
 	// All records filtered (0 tools), so nothing is written.
 	recs := []xlamRecord{{Query: "a", Tools: "[]", Answers: "[]"}}

--- a/docs/llm/real-workflow-testing.md
+++ b/docs/llm/real-workflow-testing.md
@@ -135,3 +135,27 @@ repair or drop it. Record the answer as `golden.restraint_rationale`. Restraint 
 The traces, manifest, artifacts, and reports are gitignored local evidence (see the Privacy Rule
 above). They are NOT committed; only the schema/code and this recipe are. Promote the final
 citable number to a sanitized summary, not the raw private corpus.
+
+## Alternative: import xLAM-irrelevance (skip authoring)
+
+Instead of authoring golden-empty traces by hand, convert a pre-labeled public dataset.
+`MadeAgents/xlam-irrelevance-7.5k` (HuggingFace, CC-BY-4.0) holds 7,500 "irrelevance" cases —
+tools offered, none relevant, correct action = call nothing — so its empty `answers` IS the
+golden-empty label, with no authoring or sign-off.
+
+```
+# download the dataset file (CC-BY-4.0 — attribute it in any published summary)
+curl -sL -o /tmp/xlam-irrel.json \
+  https://huggingface.co/datasets/MadeAgents/xlam-irrelevance-7.5k/resolve/main/xlam-7.5k-irrelevancek.json
+
+# convert a seeded sample into golden-empty Traces + a manifest (both gitignored)
+env -u GOROOT go run ./cmd/llm-bench -import-xlam /tmp/xlam-irrel.json
+# defaults: -import-xlam-n 300 -import-xlam-seed 42 -import-xlam-min-tools 1
+#   out: docs/llm/traces/xlam-irrelevance-local/
+#   manifest: docs/llm/calibration/xlam-irrelevance-manifest.jsonl  (partition=challenge, category=irrelevance)
+```
+
+Then replay the qwen3:8b vs qwen3.6:35b-a3b panel over the manifest with tools exposed and read
+the paired restraint report. Tradeoff vs the synthesis recipe: generic synthetic APIs, not the
+go-llm repo/MCP tools, so the claim is "tool-restraint on xLAM-irrelevance," not "on go-llm
+workflows" — fine for a domain-general restraint signal, and n is no longer the constraint.


### PR DESCRIPTION
## Summary

Adds a `-import-xlam` mode to `cmd/llm-bench` that converts the public `MadeAgents/xlam-irrelevance-7.5k` dataset (HuggingFace, CC-BY-4.0) into go-llm golden-empty restraint traces. This replaces the hand-authoring half of the restraint-corpus-growth plan: each source record is an "irrelevance" case (tools offered, none relevant, correct action = call nothing), so its empty `answers` IS the golden-empty label — growing the corpus needs no authoring and no human sign-off, and n is no longer the constraint (7,500 available).

Follows the same split as #178: this PR is the mergeable code; the converted corpus + the panel run + the finding are gitignored local evidence.

## What this changes

- `xlamRecordToTrace` converts one record (`query` + double-encoded `tools`/`answers` strings) into a validated golden-empty `Trace`: a generic `system` prompt and a fixed `final_answer_criteria` (both required — empty `system` is rejected by `validateTrace`, empty criteria would exclude the artifact from restraint pairing), `golden.tool_calls: []`, `difficulty: tempting`, `failure_mode: irrelevant-tools-offered`. Non-irrelevance rows (non-empty `answers`) are rejected.
- `importXlamIrrelevance` deep-filters to convertible records with at least `-import-xlam-min-tools` tools, seeded-samples `-import-xlam-n`, clears prior `xlam-irrel-*.json` so the output dir always matches the manifest, and writes traces + a `challenge`-partition / `irrelevance`-category manifest. Reports written / eligible / filtered honestly.
- `-import-xlam` flag (+ `-import-xlam-out`, `-import-xlam-manifest`, `-import-xlam-n`, `-import-xlam-seed`, `-import-xlam-min-tools`) wired in `main.go` as a mutually-exclusive mode.
- Runbook documents the import as a no-authoring corpus path, with the download command and the domain-fit tradeoff.

## Tradeoff (intentional)

Generic synthetic APIs, not the go-llm repo / MCP tools, so the claim is "tool-restraint on xLAM-irrelevance," not "on go-llm workflows." Fine for a domain-general restraint signal, and the run is no longer sample-starved. The go-llm-grounded synthesis path (#178 recipe) remains documented for anyone who wants the in-domain framing.

## Test plan

- `scripts/ci-local --mode pre-push`: lint 0 issues, race tests pass.
- 9 unit tests (inline fixtures, no network/private data): conversion to golden-empty, the held/diverged scoring wiring through the real metric, rejection of non-irrelevance and malformed rows, deep-filter skipping an unconvertible row without aborting the batch, stale-trace cleanup, seeded-sample determinism, N<=0 = all, and the no-eligible error.
- End-to-end against the real 7.5k file: wrote 300 of 6054 eligible (filtered 1446) golden-empty traces; all load, all golden-empty; output is gitignored.

## Local/private next

Replay the qwen3:8b vs qwen3.6:35b-a3b panel over the generated manifest with tools exposed and read the paired restraint report (overall delta + CI). Attribute xLAM-irrelevance (CC-BY-4.0) in any published summary.
