### PR TITLE
fix(llm-bench): emit provider-envelope tools from xLAM import

### DIFF
--- a/cmd/llm-bench/xlam_import.go
+++ b/cmd/llm-bench/xlam_import.go
@@ -47,9 +47,17 @@ func xlamRecordToTrace(rec xlamRecord, idx int) (Trace, error) {
 	if len(answers) != 0 {
 		return Trace{}, fmt.Errorf("xlam record %d: %d answer(s) present — not an irrelevance case", idx, len(answers))
 	}
-	tools, err := parseXlamJSONArray("tools", rec.Tools)
+	rawTools, err := parseXlamJSONArray("tools", rec.Tools)
 	if err != nil {
 		return Trace{}, fmt.Errorf("xlam record %d: %w", idx, err)
+	}
+	tools := make([]json.RawMessage, 0, len(rawTools))
+	for j, rt := range rawTools {
+		pt, err := xlamToolToProviderTool(rt)
+		if err != nil {
+			return Trace{}, fmt.Errorf("xlam record %d tool %d: %w", idx, j, err)
+		}
+		tools = append(tools, pt)
 	}
 	tr := Trace{
 		ID:     fmt.Sprintf("xlam-irrel-%04d", idx),
@@ -198,6 +206,40 @@ func xlamRecordEligible(r xlamRecord, minTools int) bool {
 		return false
 	}
 	return true
+}
+
+// xlamToolToProviderTool rewrites one xLAM tool definition ({name, description,
+// parameters}) into the provider/function envelope the replay path expects
+// ({type:function, function:{name, description, parameters}}), wrapping the xLAM
+// parameter map as a JSON-schema object. xLAM's bare-name shape would otherwise
+// route through decodeTraceTool's MCP branch, which reads `inputSchema` and
+// rejects the tool with "schema must be a JSON object".
+func xlamToolToProviderTool(raw json.RawMessage) (json.RawMessage, error) {
+	var t struct {
+		Name        string          `json:"name"`
+		Description string          `json:"description"`
+		Parameters  json.RawMessage `json:"parameters"`
+	}
+	if err := json.Unmarshal(raw, &t); err != nil {
+		return nil, fmt.Errorf("decode tool: %w", err)
+	}
+	if strings.TrimSpace(t.Name) == "" {
+		return nil, fmt.Errorf("tool missing name")
+	}
+	var props any = map[string]any{}
+	if len(t.Parameters) > 0 {
+		if err := json.Unmarshal(t.Parameters, &props); err != nil {
+			return nil, fmt.Errorf("tool %q parameters: %w", t.Name, err)
+		}
+	}
+	return json.Marshal(map[string]any{
+		"type": "function",
+		"function": map[string]any{
+			"name":        t.Name,
+			"description": t.Description,
+			"parameters":  map[string]any{"type": "object", "properties": props},
+		},
+	})
 }
 
 // parseXlamJSONArray decodes one of xLAM's double-encoded JSON-array fields,

--- a/cmd/llm-bench/xlam_import.go
+++ b/cmd/llm-bench/xlam_import.go
@@ -226,10 +226,17 @@ func xlamToolToProviderTool(raw json.RawMessage) (json.RawMessage, error) {
 	if strings.TrimSpace(t.Name) == "" {
 		return nil, fmt.Errorf("tool missing name")
 	}
-	var props any = map[string]any{}
+	// Unmarshal into a map so the emitted `properties` is always a well-formed
+	// JSON-Schema object: a non-object parameters value errors out (drops the
+	// trace via the eligibility filter), and the JSON literal "null" decodes to a
+	// nil map, which we normalize to {} rather than emit `properties:null`.
+	props := map[string]any{}
 	if len(t.Parameters) > 0 {
 		if err := json.Unmarshal(t.Parameters, &props); err != nil {
 			return nil, fmt.Errorf("tool %q parameters: %w", t.Name, err)
+		}
+		if props == nil {
+			props = map[string]any{}
 		}
 	}
 	return json.Marshal(map[string]any{

--- a/cmd/llm-bench/xlam_import_test.go
+++ b/cmd/llm-bench/xlam_import_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -78,6 +79,30 @@ func TestXlamConvertedTraceScoresRestraint(t *testing.T) {
 	div, computed := restraintSignals(tr, []Turn{{Role: "assistant", ToolCalls: []ToolCall{{Name: "get_weather"}}}})
 	if !computed || div != 0 {
 		t.Errorf("tool-call transcript: held=%v computed=%v, want 0/true", div, computed)
+	}
+}
+
+// The real replay path decodes tools via decodeTraceTools (not the looser
+// declaredToolNames), which routes bare-name tools through the MCP branch and
+// reads `inputSchema`. xLAM tools carry `parameters`, so the converter must emit
+// a shape decodeTraceTools accepts — otherwise every replay fails on tool decode.
+func TestXlamConvertedToolsDecodeForReplay(t *testing.T) {
+	tr, err := xlamRecordToTrace(xlamRecord{Query: "q", Tools: sampleXlamTools, Answers: "[]"}, 0)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	tools, err := decodeTraceTools(tr.Tools)
+	if err != nil {
+		t.Fatalf("decodeTraceTools rejected converted tools: %v", err)
+	}
+	if len(tools) != 2 {
+		t.Fatalf("decoded %d tools, want 2", len(tools))
+	}
+	if strings.TrimSpace(tools[0].Function.Name) == "" {
+		t.Errorf("decoded tool missing function name: %+v", tools[0])
+	}
+	if len(tools[0].Function.Parameters) == 0 {
+		t.Errorf("decoded tool missing parameters schema: %+v", tools[0])
 	}
 }
 

--- a/cmd/llm-bench/xlam_import_test.go
+++ b/cmd/llm-bench/xlam_import_test.go
@@ -145,6 +145,26 @@ func TestXlamToolToProviderTool(t *testing.T) {
 	if _, err := xlamToolToProviderTool(json.RawMessage(`{"description":"d","parameters":{}}`)); err == nil {
 		t.Error("want error for tool missing name")
 	}
+
+	// "parameters": null must normalize to an empty object schema, not properties:null.
+	out, err = xlamToolToProviderTool(json.RawMessage(`{"name":"h","description":"d","parameters":null}`))
+	if err != nil {
+		t.Fatalf("null-params convert: %v", err)
+	}
+	if err := json.Unmarshal(out, &env); err != nil {
+		t.Fatalf("null-params unmarshal: %v", err)
+	}
+	if props, ok := env.Function.Parameters["properties"].(map[string]any); !ok || props == nil {
+		t.Errorf("null parameters did not normalize to empty object: %+v", env.Function.Parameters["properties"])
+	}
+	if tools, err := decodeTraceTools([]json.RawMessage{out}); err != nil || len(tools) != 1 {
+		t.Errorf("null-params tool failed to decode: %v", err)
+	}
+
+	// Non-object parameters (an array) is malformed source → error (trace dropped upstream).
+	if _, err := xlamToolToProviderTool(json.RawMessage(`{"name":"i","parameters":[1,2]}`)); err == nil {
+		t.Error("want error for non-object parameters")
+	}
 }
 
 func TestXlamRecordToTraceRejectsNonEmptyAnswers(t *testing.T) {

--- a/cmd/llm-bench/xlam_import_test.go
+++ b/cmd/llm-bench/xlam_import_test.go
@@ -106,6 +106,47 @@ func TestXlamConvertedToolsDecodeForReplay(t *testing.T) {
 	}
 }
 
+func TestXlamToolToProviderTool(t *testing.T) {
+	// Happy path: wraps xLAM parameters as a JSON-schema object under function.
+	out, err := xlamToolToProviderTool(json.RawMessage(`{"name":"f","description":"d","parameters":{"x":{"type":"string"}}}`))
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	var env struct {
+		Type     string `json:"type"`
+		Function struct {
+			Name       string         `json:"name"`
+			Parameters map[string]any `json:"parameters"`
+		} `json:"function"`
+	}
+	if err := json.Unmarshal(out, &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	if env.Type != "function" || env.Function.Name != "f" {
+		t.Errorf("envelope = %+v, want type=function name=f", env)
+	}
+	if env.Function.Parameters["type"] != "object" {
+		t.Errorf("parameters.type = %v, want object", env.Function.Parameters["type"])
+	}
+	if _, ok := env.Function.Parameters["properties"]; !ok {
+		t.Errorf("parameters missing properties: %+v", env.Function.Parameters)
+	}
+
+	// No-parameters tool still yields a valid object schema (empty properties).
+	out, err = xlamToolToProviderTool(json.RawMessage(`{"name":"g","description":"d"}`))
+	if err != nil {
+		t.Fatalf("no-params convert: %v", err)
+	}
+	if tools, err := decodeTraceTools([]json.RawMessage{out}); err != nil || len(tools) != 1 {
+		t.Errorf("no-params tool failed to decode: %v (n=%d)", err, len(tools))
+	}
+
+	// Missing name is an error.
+	if _, err := xlamToolToProviderTool(json.RawMessage(`{"description":"d","parameters":{}}`)); err == nil {
+		t.Error("want error for tool missing name")
+	}
+}
+
 func TestXlamRecordToTraceRejectsNonEmptyAnswers(t *testing.T) {
 	rec := xlamRecord{Query: "q", Tools: sampleXlamTools, Answers: `[{"name":"get_weather","arguments":{"city":"x"}}]`}
 	if _, err := xlamRecordToTrace(rec, 0); err == nil {


### PR DESCRIPTION
## Summary

Bug fix on top of #179: the xLAM importer emitted tool schemas in a shape the replay path rejects, so every restraint replay failed on tool decode (`ollama: NewToolRaw "...": schema must be a JSON object`). Found while running the qwen3:8b vs qwen3.6:35b-a3b panel over the imported corpus — all 600 replays failed.

## Root cause

xLAM tools are `{name, description, parameters}`. The converter passed them through raw. `decodeTraceTool` (runner.go) routes a bare-`name` tool through its MCP branch, which reads `inputSchema` / `input_schema` — absent here, since xLAM uses `parameters`. `NewToolRaw` then gets an empty schema and errors.

The original unit test only exercised `declaredToolNames` (which tolerates the bare shape), not `decodeTraceTools` (the actual replay path), so it missed this.

## Fix

`xlamToolToProviderTool` rewrites each xLAM tool into the provider/function envelope `{type:function, function:{name, description, parameters:{type:object, properties:<xlam params>}}}`, which `decodeTraceTool`'s provider branch accepts. Adds a regression test that runs the converted tools through `decodeTraceTools` and asserts they decode with names and parameter schemas.

## Test plan

- `scripts/ci-local --mode pre-push`: lint 0 issues, race tests pass.
- New `TestXlamConvertedToolsDecodeForReplay` reproduces the failure (red before fix) and passes after.
- Regenerated the local corpus and confirmed a real trace's tool carries `function.parameters`; relaunched the panel (replays now proceed past tool decode).
