### PR TITLE
test(llm-bench): guard for hard restraint probe corpus (A5/B4/C3)

### DIFF
--- a/cmd/llm-bench/restraint_hard_corpus_test.go
+++ b/cmd/llm-bench/restraint_hard_corpus_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRestraintHardCorpusBalance validates the local (gitignored) hard
+// "tempting-but-unneeded" restraint probe against its design
+// (docs/superpowers/specs/2026-06-17-hard-restraint-corpus-design.md).
+// It SKIPS when the private manifest is absent (CI, fresh clones) OR while
+// authoring is in progress (< 12 entries), so it never goes red in CI or
+// mid-authoring. Once the probe is complete (>= 12) it asserts the fixed
+// A5/B4/C3 archetype mix, the 5-tempting/7-adversarial difficulty split,
+// manifest shape, replay-decodable tool schemas, golden-empty + non-empty
+// tools, and the audit fields that anchor validity.
+func TestRestraintHardCorpusBalance(t *testing.T) {
+	const wantN = 12
+	manifestPath := filepath.FromSlash("../../docs/llm/calibration/restraint-hard-manifest.jsonl")
+	if _, err := os.Stat(manifestPath); err != nil {
+		t.Skipf("private restraint-hard manifest absent (%v) — local-only check", err)
+	}
+	rawManifest, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	m, err := loadManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("loadManifest: %v", err)
+	}
+	if len(m.Entries) < wantN {
+		t.Skipf("restraint-hard probe not complete (%d/%d) — authoring in progress", len(m.Entries), wantN)
+	}
+	if len(m.Entries) != wantN {
+		t.Fatalf("manifest has %d entries, want exactly %d for the probe", len(m.Entries), wantN)
+	}
+	// difficulty must live only on golden.difficulty (single source of truth);
+	// checked on the complete probe so it never trips the mid-authoring skip above.
+	if strings.Contains(string(rawManifest), `"difficulty"`) {
+		t.Errorf("manifest must not duplicate difficulty; golden.difficulty is the single source of truth")
+	}
+	traceDir := filepath.FromSlash("../../docs/llm/traces/restraint-hard-local")
+
+	// Fixed probe shape from the spec.
+	wantCategory := map[string]int{"complete-diff-review": 5, "excerpt-explain": 4, "artifact-diagnose": 3}
+	wantDifficulty := map[string]int{"tempting": 5, "adversarial": 7}
+	gotCategory := map[string]int{}
+	gotDifficulty := map[string]int{}
+
+	for _, e := range m.Entries {
+		if e.Partition != PartitionChallenge {
+			t.Errorf("trace %q partition = %q, want %q", e.TraceID, e.Partition, PartitionChallenge)
+		}
+		if e.Source != "restraint-hard-local" {
+			t.Errorf("trace %q manifest source = %q, want restraint-hard-local", e.TraceID, e.Source)
+		}
+		if !e.AllowedAsModelEvidence {
+			t.Errorf("trace %q must be allowed_as_model_evidence=true", e.TraceID)
+		}
+		if _, ok := wantCategory[e.Category]; !ok {
+			t.Errorf("trace %q has unexpected category %q", e.TraceID, e.Category)
+		}
+		path := filepath.Join(traceDir, e.TraceID+".json")
+		traces, err := loadTraces([]string{path})
+		if err != nil {
+			t.Errorf("trace %q: %v", e.TraceID, err)
+			continue
+		}
+		if len(traces) != 1 {
+			t.Errorf("trace %q: loadTraces returned %d traces from %s, want 1", e.TraceID, len(traces), path)
+			continue
+		}
+		tr := traces[0]
+		if tr.ID != e.TraceID {
+			t.Errorf("trace file %q has id %q; manifest/filename and trace id must agree (artifacts key on the trace id)", e.TraceID, tr.ID)
+		}
+		if tr.Source != "restraint-hard-local" {
+			t.Errorf("trace %q source = %q, want restraint-hard-local", e.TraceID, tr.Source)
+		}
+		if len(tr.Tools) == 0 {
+			t.Errorf("trace %q has no tools (restraint metric only counts tool-exposed traces)", e.TraceID)
+		} else if _, err := decodeTraceTools(tr.Tools); err != nil {
+			t.Errorf("trace %q tools do not decode for replay: %v", e.TraceID, err)
+		}
+		if len(tr.Golden.ToolCalls) != 0 {
+			t.Errorf("trace %q is not golden-empty", e.TraceID)
+		}
+		switch tr.Golden.Difficulty {
+		case "tempting", "adversarial":
+		default:
+			t.Errorf("trace %q difficulty %q not in {tempting,adversarial} for A/B/C probe", e.TraceID, tr.Golden.Difficulty)
+		}
+		if tr.Golden.RestraintRationale == "" {
+			t.Errorf("trace %q missing restraint_rationale (validity anchor)", e.TraceID)
+		}
+		if tr.Golden.FailureMode == "" {
+			t.Errorf("trace %q missing failure_mode (temptation vector)", e.TraceID)
+		}
+		if tr.Golden.FinalAnswerSubstring == "" {
+			t.Errorf("trace %q missing final_answer_substring (keeps it AQ-labelable later)", e.TraceID)
+		}
+		gotCategory[e.Category]++
+		gotDifficulty[tr.Golden.Difficulty]++
+	}
+
+	for cat, want := range wantCategory {
+		if gotCategory[cat] != want {
+			t.Errorf("category %q: got %d traces, want %d", cat, gotCategory[cat], want)
+		}
+	}
+	for cat, got := range gotCategory {
+		if _, ok := wantCategory[cat]; !ok {
+			t.Errorf("unexpected category %q has %d traces", cat, got)
+		}
+	}
+	for diff, want := range wantDifficulty {
+		if gotDifficulty[diff] != want {
+			t.Errorf("difficulty %q: got %d, want %d", diff, gotDifficulty[diff], want)
+		}
+	}
+	for diff, got := range gotDifficulty {
+		if _, ok := wantDifficulty[diff]; !ok {
+			t.Errorf("unexpected difficulty %q has %d traces", diff, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds one skip-guarded guard test for the hard "tempting-but-unneeded" restraint
probe corpus. The corpus itself (12 traces, manifest, prereg, run artifacts,
finding) is gitignored/private, so this PR is code-only, consistent with the
xLAM importer PRs (#179/#180).

`TestRestraintHardCorpusBalance` skips when the private manifest is absent (CI,
fresh clones) or while authoring is in progress (< 12 entries), so it never goes
red in CI or mid-authoring. Once the probe is complete it asserts:

- the fixed A5/B4/C3 archetype mix (complete-diff-review / excerpt-explain / artifact-diagnose)
- the 5-tempting / 7-adversarial difficulty split
- manifest shape (challenge partition, source, allowed_as_model_evidence)
- trace/manifest id agreement (artifacts key on the trace id)
- replay-decodable tool schemas, golden-empty traces with non-empty tools
- the audit fields that anchor restraint-label validity (rationale, failure_mode, final_answer_substring)
- difficulty stays single-sourced on `golden.difficulty` (rejected if duplicated in the manifest)

No schema or metric code changes; this rides on the shipped Trace/Golden/ManifestEntry
schema and the restraint metric.

Probe outcome (for context; data is private): the hard corpus breaks the xLAM
saturation (33% discordant vs 2%) but produces a directional null between
qwen3:8b and qwen3.6:35b-a3b (b=c=2, restraint Delta +0.00). Divergence audited
to be genuine over-verification, zero label noise.

## Test Plan

- [x] `go test ./cmd/llm-bench -run TestRestraintHardCorpusBalance` passes locally with the complete 12-trace corpus
- [x] Test SKIPs cleanly with the corpus absent (CI / fresh clone)
- [x] `scripts/ci-local --mode pre-push`: lint 0 issues, race tests pass
- [x] gofmt + go vet clean

Generated with [Claude Code](https://claude.com/claude-code)