### PR TITLE
Finish provider-abstract MCP model management (#183)

### DIFF
--- a/mcp/resources.go
+++ b/mcp/resources.go
@@ -22,7 +22,7 @@ func (s *Server) registerResources() {
 	s.mcpServer.AddResource(&gomcp.Resource{
 		URI:         "go-llm://models",
 		Name:        "models",
-		Description: "List of available Ollama models with metadata",
+		Description: "List of available provider models with metadata",
 		MIMEType:    "application/json",
 	}, s.handleModelsResource)
 
@@ -117,7 +117,7 @@ func (s *Server) handleHealthResource(ctx context.Context, req *gomcp.ReadResour
 }
 
 func (s *Server) handleModelsResource(ctx context.Context, req *gomcp.ReadResourceRequest) (*gomcp.ReadResourceResult, error) {
-	models, err := s.client.ListModels(ctx)
+	models, err := s.listModels(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/mcp/resources.go
+++ b/mcp/resources.go
@@ -43,7 +43,7 @@ func (s *Server) registerResources() {
 	s.mcpServer.AddResourceTemplate(&gomcp.ResourceTemplate{
 		URITemplate: "go-llm://models/{name}",
 		Name:        "model-detail",
-		Description: "Details for a specific Ollama model",
+		Description: "Details for a specific provider model",
 		MIMEType:    "application/json",
 	}, s.handleModelDetailResource)
 
@@ -162,7 +162,7 @@ func (s *Server) handleModelDetailResource(ctx context.Context, req *gomcp.ReadR
 		return nil, gomcp.ResourceNotFoundError(req.Params.URI)
 	}
 
-	info, err := s.client.ShowModel(ctx, name)
+	info, err := s.showModel(ctx, name, "")
 	if err != nil {
 		return nil, err
 	}

--- a/mcp/resources_test.go
+++ b/mcp/resources_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -164,5 +165,43 @@ func TestModelsResourceRoutesThroughRegistry(t *testing.T) {
 	}
 	if listed[0].Provider == "" {
 		t.Errorf("provider field empty; resource did not route through the registry")
+	}
+}
+
+func TestModelDetailResourceUsesProviderRegistry(t *testing.T) {
+	openAIMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/models":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"local-fim","object":"model"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer openAIMock.Close()
+
+	cfgPath := writeOpenAICompatOnlyConfig(t, t.TempDir(), openAIMock.URL)
+	s, err := NewServer(context.Background(), WithConfig(cfgPath), WithRAGDisabled())
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	result, err := s.handleModelDetailResource(context.Background(), &gomcp.ReadResourceRequest{
+		Params: &gomcp.ReadResourceParams{URI: "go-llm://models/local-fim"},
+	})
+	if err != nil {
+		t.Fatalf("handleModelDetailResource() error = %v", err)
+	}
+
+	var info struct {
+		Provider string `json:"provider"`
+		Name     string `json:"name"`
+	}
+	if err := json.Unmarshal([]byte(result.Contents[0].Text), &info); err != nil {
+		t.Fatalf("unmarshal model detail: %v", err)
+	}
+	if info.Provider != "vllm-local" || info.Name != "local-fim" {
+		t.Fatalf("model detail = %+v, want vllm-local/local-fim", info)
 	}
 }

--- a/mcp/resources_test.go
+++ b/mcp/resources_test.go
@@ -205,3 +205,54 @@ func TestModelDetailResourceUsesProviderRegistry(t *testing.T) {
 		t.Fatalf("model detail = %+v, want vllm-local/local-fim", info)
 	}
 }
+
+func TestModelDetailResourceUsesDirectMetadataWhenListFails(t *testing.T) {
+	showHit := false
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/":
+			w.WriteHeader(http.StatusOK)
+		case "/api/tags":
+			http.Error(w, `{"error":"tags unavailable"}`, http.StatusServiceUnavailable)
+		case "/api/show":
+			showHit = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"details":{"family":"qwen3","parameter_size":"8B","quantization_level":"Q4_K_M"},"digest":"abc123","template":"{{.Prompt}}"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer mock.Close()
+
+	s, err := NewServer(context.Background(), WithOllamaURL(mock.URL), WithRAGDisabled())
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	result, err := s.handleModelDetailResource(context.Background(), &gomcp.ReadResourceRequest{
+		Params: &gomcp.ReadResourceParams{URI: "go-llm://models/qwen3:8b"},
+	})
+	if err != nil {
+		t.Fatalf("handleModelDetailResource() error = %v", err)
+	}
+	if !showHit {
+		t.Fatal("model detail resource did not fall back to direct model metadata")
+	}
+
+	var info struct {
+		Provider      string `json:"provider"`
+		Name          string `json:"name"`
+		Family        string `json:"family"`
+		ParameterSize string `json:"parameter_size"`
+	}
+	if err := json.Unmarshal([]byte(result.Contents[0].Text), &info); err != nil {
+		t.Fatalf("unmarshal model detail: %v", err)
+	}
+	if info.Provider != "ollama" || info.Name != "qwen3:8b" {
+		t.Fatalf("model detail = %+v, want ollama/qwen3:8b", info)
+	}
+	if info.Family != "qwen3" || info.ParameterSize != "8B" {
+		t.Fatalf("model detail = %+v, want qwen3 8B metadata", info)
+	}
+}

--- a/mcp/resources_test.go
+++ b/mcp/resources_test.go
@@ -129,3 +129,40 @@ func TestConfigResource(t *testing.T) {
 		t.Error("missing 'resolved' field")
 	}
 }
+
+func TestModelsResourceRoutesThroughRegistry(t *testing.T) {
+	mock := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/", "/api/tags":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"models":[{"name":"qwen3:8b","size":4700000000}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	env := newTestEnv(t, mock)
+	defer env.cleanup()
+
+	res, err := env.session.ReadResource(context.Background(), &gomcp.ReadResourceParams{
+		URI: "go-llm://models",
+	})
+	if err != nil {
+		t.Fatalf("ReadResource() error = %v", err)
+	}
+	if len(res.Contents) == 0 {
+		t.Fatalf("ReadResource() returned no contents")
+	}
+	// listedModelInfo carries a "provider" field; the old direct-ollama path
+	// (raw ollama.ModelInfo) did not. Asserting it proves we now route through
+	// s.listModels / the registry.
+	var listed []listedModelInfo
+	if err := json.Unmarshal([]byte(res.Contents[0].Text), &listed); err != nil {
+		t.Fatalf("unmarshal listed models: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("model count = %d, want 1", len(listed))
+	}
+	if listed[0].Provider == "" {
+		t.Errorf("provider field empty; resource did not route through the registry")
+	}
+}

--- a/mcp/tools_models.go
+++ b/mcp/tools_models.go
@@ -9,6 +9,7 @@ import (
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/kstruzzieri/go-llm/ollama"
 	"github.com/kstruzzieri/go-llm/provider"
 )
 
@@ -45,11 +46,15 @@ func (s *Server) registerModelTools() {
 
 	s.mcpServer.AddTool(&gomcp.Tool{
 		Name:        "pull_model",
-		Description: "Download a model from the Ollama registry.",
+		Description: "Download/install a model using a pull-capable provider.",
 		InputSchema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
-				"name": map[string]any{"type": "string", "description": "Model name to pull (e.g. qwen3:8b)"},
+				"name": map[string]any{"type": "string", "description": "Model name to pull (e.g. qwen3:8b). May also be provider/model when the provider is known."},
+				"provider": map[string]any{
+					"type":        "string",
+					"description": "Provider instance name when multiple pull-capable providers exist",
+				},
 			},
 			"required": []string{"name"},
 		},
@@ -257,9 +262,58 @@ func capabilityNames(caps provider.Capability) []string {
 	return strings.Split(caps.String(), "|")
 }
 
+// pullerForModel returns the ModelPuller that should service a pull for name,
+// or nil when the owning provider does not support pull. providerName, when
+// non-empty, is authoritative.
+func pullerForModel(reg *provider.Registry, name, providerName string) (provider.ModelPuller, error) {
+	if reg == nil {
+		return nil, nil
+	}
+	if providerName != "" {
+		p, ok := reg.Get(providerName)
+		if !ok {
+			return nil, fmt.Errorf("provider %q not found", providerName)
+		}
+		mp, ok := p.(provider.ModelPuller)
+		if !ok {
+			return nil, nil
+		}
+		return mp, nil
+	}
+
+	candidates, err := reg.ProvidersForModel(name)
+	if err == nil && len(candidates) > 0 {
+		for _, p := range candidates {
+			if mp, ok := p.(provider.ModelPuller); ok {
+				return mp, nil
+			}
+		}
+		return nil, nil
+	}
+
+	var pullers []provider.ModelPuller
+	var names []string
+	for _, name := range reg.Names() {
+		p, _ := reg.Get(name)
+		if mp, ok := p.(provider.ModelPuller); ok {
+			pullers = append(pullers, mp)
+			names = append(names, name)
+		}
+	}
+	switch len(pullers) {
+	case 0:
+		return nil, nil
+	case 1:
+		return pullers[0], nil
+	default:
+		return nil, fmt.Errorf("model %q is not advertised by any provider and multiple pull-capable providers exist (%s); pass provider", name, strings.Join(names, ", "))
+	}
+}
+
 func (s *Server) handlePullModel(ctx context.Context, req *gomcp.CallToolRequest) (*gomcp.CallToolResult, error) {
 	var args struct {
-		Name string `json:"name"`
+		Name     string `json:"name"`
+		Provider string `json:"provider,omitempty"`
 	}
 	if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
 		return toolError("validation", "invalid arguments: %v", err), nil
@@ -268,18 +322,55 @@ func (s *Server) handlePullModel(ctx context.Context, req *gomcp.CallToolRequest
 		return toolError("validation", "name must not be empty"), nil
 	}
 
-	err := s.client.PullModel(ctx, args.Name, nil)
+	puller, modelName, err := s.modelPuller(args.Name, args.Provider)
 	if err != nil {
-		return toolError("ollama", "%v", err), nil
+		return toolError("validation", "%v", err), nil
+	}
+	if puller == nil {
+		return toolError("unsupported",
+			"pull is not supported for model %q: this backend's models are file-managed (e.g. GGUF served by llama-server). Install the model file and add it to models.json instead",
+			modelName), nil
+	}
+
+	if err := puller.PullModel(ctx, modelName, nil); err != nil {
+		return toolError("provider", "%v", err), nil
 	}
 
 	// Refresh model resolution cache after successful pull.
 	if s.cfg != nil {
 		_ = s.refreshResolved(ctx) // non-fatal: partial results kept
 	}
-	// Self-heal the providerRegistry's model index so the freshly pulled
+	// Self-heal the provider registry's model index so the freshly pulled
 	// model becomes routable immediately.
 	s.refreshProviderModelIndexes(ctx)
 
-	return toolResult(fmt.Sprintf("model %q pulled successfully", args.Name)), nil
+	return toolResult(fmt.Sprintf("model %q pulled successfully", modelName)), nil
+}
+
+// modelPuller resolves the puller and normalized model name, preserving the
+// legacy (no-registry) Ollama path.
+func (s *Server) modelPuller(name, providerName string) (provider.ModelPuller, string, error) {
+	if pReg := s.providerRegistrySnapshot(); pReg != nil {
+		modelName := name
+		if providerName == "" {
+			if key, ok := s.parseKnownModelSelector(name); ok {
+				providerName = key.Provider
+				modelName = key.Model
+			}
+		}
+		puller, err := pullerForModel(pReg, modelName, providerName)
+		return puller, modelName, err
+	}
+	if s.client != nil {
+		return ollamaClientPuller{c: s.client}, name, nil
+	}
+	return nil, name, nil
+}
+
+// ollamaClientPuller adapts the legacy direct *ollama.Client to ModelPuller
+// for servers constructed without a provider registry.
+type ollamaClientPuller struct{ c *ollama.Client }
+
+func (a ollamaClientPuller) PullModel(ctx context.Context, name string, fn func(status string, completed, total int64)) error {
+	return a.c.PullModel(ctx, name, fn)
 }

--- a/mcp/tools_models.go
+++ b/mcp/tools_models.go
@@ -365,18 +365,21 @@ func (s *Server) handlePullModel(ctx context.Context, req *gomcp.CallToolRequest
 func (s *Server) modelPuller(ctx context.Context, name, providerName string) (provider.ModelPuller, string, error) {
 	if pReg := s.providerRegistrySnapshot(); pReg != nil {
 		modelName := name
-		if providerName == "" {
-			if key, ok := s.parseKnownModelSelector(name); ok {
+		if key, ok := s.parseKnownModelSelector(name); ok {
+			modelName = key.Model
+			if providerName == "" {
 				providerName = key.Provider
-				modelName = key.Model
-			} else {
-				inferredProvider, err := s.inferProviderForExplicitModel(ctx, name)
-				if err != nil {
-					return nil, modelName, err
-				}
-				if inferredProvider != "" {
-					providerName = inferredProvider
-				}
+			} else if providerName != key.Provider {
+				return nil, modelName, fmt.Errorf("provider %q does not match model selector provider %q", providerName, key.Provider)
+			}
+		}
+		if providerName == "" {
+			inferredProvider, err := s.inferProviderForExplicitModel(ctx, modelName)
+			if err != nil {
+				return nil, modelName, err
+			}
+			if inferredProvider != "" {
+				providerName = inferredProvider
 			}
 		}
 		puller, err := pullerForModel(pReg, modelName, providerName)

--- a/mcp/tools_models.go
+++ b/mcp/tools_models.go
@@ -290,10 +290,16 @@ func pullerForModel(reg *provider.Registry, name, providerName string) (provider
 
 	candidates, err := reg.ProvidersForModel(name)
 	if err == nil && len(candidates) > 0 {
-		for _, p := range candidates {
-			if mp, ok := p.(provider.ModelPuller); ok {
-				return mp, nil
+		if len(candidates) > 1 {
+			names := make([]string, 0, len(candidates))
+			for _, p := range candidates {
+				names = append(names, p.Name())
 			}
+			sort.Strings(names)
+			return nil, fmt.Errorf("model %q is advertised by multiple providers (%s); pass provider", name, strings.Join(names, ", "))
+		}
+		if mp, ok := candidates[0].(provider.ModelPuller); ok {
+			return mp, nil
 		}
 		return nil, nil
 	}
@@ -329,7 +335,7 @@ func (s *Server) handlePullModel(ctx context.Context, req *gomcp.CallToolRequest
 		return toolError("validation", "name must not be empty"), nil
 	}
 
-	puller, modelName, err := s.modelPuller(args.Name, args.Provider)
+	puller, modelName, err := s.modelPuller(ctx, args.Name, args.Provider)
 	if err != nil {
 		return toolError("validation", "%v", err), nil
 	}
@@ -356,13 +362,21 @@ func (s *Server) handlePullModel(ctx context.Context, req *gomcp.CallToolRequest
 
 // modelPuller resolves the puller and normalized model name, preserving the
 // legacy (no-registry) Ollama path.
-func (s *Server) modelPuller(name, providerName string) (provider.ModelPuller, string, error) {
+func (s *Server) modelPuller(ctx context.Context, name, providerName string) (provider.ModelPuller, string, error) {
 	if pReg := s.providerRegistrySnapshot(); pReg != nil {
 		modelName := name
 		if providerName == "" {
 			if key, ok := s.parseKnownModelSelector(name); ok {
 				providerName = key.Provider
 				modelName = key.Model
+			} else {
+				inferredProvider, err := s.inferProviderForExplicitModel(ctx, name)
+				if err != nil {
+					return nil, modelName, err
+				}
+				if inferredProvider != "" {
+					providerName = inferredProvider
+				}
 			}
 		}
 		puller, err := pullerForModel(pReg, modelName, providerName)

--- a/mcp/tools_models.go
+++ b/mcp/tools_models.go
@@ -218,6 +218,9 @@ func (s *Server) lookupProviderModelInfo(ctx context.Context, key provider.Model
 
 	models, err := pReg.RefreshModelsAndList(ctx, key.Provider)
 	if err != nil {
+		if info, ok := s.refreshProviderModelInfo(ctx, key); ok {
+			return info, nil
+		}
 		return listedModelInfo{}, err
 	}
 	for i := range models {
@@ -225,17 +228,8 @@ func (s *Server) lookupProviderModelInfo(ctx context.Context, key provider.Model
 			continue
 		}
 
-		s.mu.RLock()
-		modelRegistry := s.modelRegistry
-		s.mu.RUnlock()
-		if modelRegistry != nil {
-			profile, err := modelRegistry.Refresh(ctx, key)
-			if err == nil {
-				return listedModelInfo{
-					ModelInfo: modelInfoFromProfile(profile),
-					Provider:  key.Provider,
-				}, nil
-			}
+		if info, ok := s.refreshProviderModelInfo(ctx, key); ok {
+			return info, nil
 		}
 
 		return listedModelInfo{
@@ -243,7 +237,27 @@ func (s *Server) lookupProviderModelInfo(ctx context.Context, key provider.Model
 			Provider:  key.Provider,
 		}, nil
 	}
+	if info, ok := s.refreshProviderModelInfo(ctx, key); ok {
+		return info, nil
+	}
 	return listedModelInfo{}, fmt.Errorf("model %q not found on provider %q", key.Model, key.Provider)
+}
+
+func (s *Server) refreshProviderModelInfo(ctx context.Context, key provider.ModelKey) (listedModelInfo, bool) {
+	s.mu.RLock()
+	modelRegistry := s.modelRegistry
+	s.mu.RUnlock()
+	if modelRegistry == nil {
+		return listedModelInfo{}, false
+	}
+	profile, err := modelRegistry.Refresh(ctx, key)
+	if err != nil {
+		return listedModelInfo{}, false
+	}
+	return listedModelInfo{
+		ModelInfo: modelInfoFromProfile(profile),
+		Provider:  key.Provider,
+	}, true
 }
 
 func modelInfoFromProfile(profile *provider.ModelProfile) provider.ModelInfo {

--- a/mcp/tools_models.go
+++ b/mcp/tools_models.go
@@ -300,11 +300,11 @@ func pullerForModel(reg *provider.Registry, name, providerName string) (provider
 
 	var pullers []provider.ModelPuller
 	var names []string
-	for _, name := range reg.Names() {
-		p, _ := reg.Get(name)
+	for _, provName := range reg.Names() {
+		p, _ := reg.Get(provName)
 		if mp, ok := p.(provider.ModelPuller); ok {
 			pullers = append(pullers, mp)
-			names = append(names, name)
+			names = append(names, provName)
 		}
 	}
 	switch len(pullers) {

--- a/mcp/tools_models.go
+++ b/mcp/tools_models.go
@@ -178,6 +178,13 @@ func (s *Server) showModel(ctx context.Context, name, providerName string) (any,
 		return s.lookupProviderModelInfo(ctx, key)
 	}
 
+	// Unresolved. Only fall back to the direct Ollama client in legacy mode
+	// (no provider registry). With a registry present, hitting one hardcoded
+	// Ollama client would report the wrong backend, so return not-found.
+	if s.providerRegistrySnapshot() != nil {
+		return nil, fmt.Errorf("model %q not found in any registered provider", name)
+	}
+
 	info, err := s.client.ShowModel(ctx, name)
 	if err != nil {
 		return nil, err

--- a/mcp/tools_models_test.go
+++ b/mcp/tools_models_test.go
@@ -453,6 +453,66 @@ func TestPullerForModel_ExplicitProviderResolvesUnknownModel(t *testing.T) {
 	}
 }
 
+func TestPullModel_ExplicitProviderWithQualifiedNameNormalizesModelName(t *testing.T) {
+	rec := &recordingPullProvider{
+		fakeRouteProvider: fakeRouteProvider{name: "ollama-a"},
+	}
+	reg := provider.NewRegistry()
+	if err := reg.Register(rec); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	s := &Server{providerRegistry: reg}
+	result, err := s.handlePullModel(context.Background(), &gomcp.CallToolRequest{
+		Params: &gomcp.CallToolParamsRaw{
+			Arguments: json.RawMessage(`{"provider":"ollama-a","name":"ollama-a/qwen3:8b"}`),
+		},
+	})
+	if err != nil {
+		t.Fatalf("handlePullModel() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handlePullModel() isError = true, content = %v", extractText(result))
+	}
+	if len(rec.pulled) != 1 || rec.pulled[0] != "qwen3:8b" {
+		t.Fatalf("pulled models = %v, want [qwen3:8b]", rec.pulled)
+	}
+}
+
+func TestPullModel_ExplicitProviderRejectsMismatchedQualifiedName(t *testing.T) {
+	recA := &recordingPullProvider{
+		fakeRouteProvider: fakeRouteProvider{name: "ollama-a"},
+	}
+	recB := &recordingPullProvider{
+		fakeRouteProvider: fakeRouteProvider{name: "ollama-b"},
+	}
+	reg := provider.NewRegistry()
+	for _, p := range []*recordingPullProvider{recA, recB} {
+		if err := reg.Register(p); err != nil {
+			t.Fatalf("Register(%s): %v", p.Name(), err)
+		}
+	}
+
+	s := &Server{providerRegistry: reg}
+	result, err := s.handlePullModel(context.Background(), &gomcp.CallToolRequest{
+		Params: &gomcp.CallToolParamsRaw{
+			Arguments: json.RawMessage(`{"provider":"ollama-b","name":"ollama-a/qwen3:8b"}`),
+		},
+	})
+	if err != nil {
+		t.Fatalf("handlePullModel() error = %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("handlePullModel() isError = false, want provider mismatch")
+	}
+	if text := extractText(result); !strings.Contains(text, `provider "ollama-b" does not match model selector provider "ollama-a"`) {
+		t.Fatalf("handlePullModel() content = %q, want provider mismatch", text)
+	}
+	if len(recA.pulled) != 0 || len(recB.pulled) != 0 {
+		t.Fatalf("pulled models: ollama-a=%v ollama-b=%v, want none", recA.pulled, recB.pulled)
+	}
+}
+
 func TestPullModel_ConfigOwnedOpenAICompatDoesNotFallbackToOllama(t *testing.T) {
 	pullHit := false
 	ollamaSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -508,6 +568,16 @@ func TestPullModel_ConfigOwnedOpenAICompatDoesNotFallbackToOllama(t *testing.T) 
 	if pullHit {
 		t.Fatal("pull_model fell back to Ollama for a config-owned openai-compatible model")
 	}
+}
+
+type recordingPullProvider struct {
+	fakeRouteProvider
+	pulled []string
+}
+
+func (p *recordingPullProvider) PullModel(ctx context.Context, name string, fn func(status string, completed, total int64)) error {
+	p.pulled = append(p.pulled, name)
+	return nil
 }
 
 // With a registry present, an unresolvable model must not silently hit the

--- a/mcp/tools_models_test.go
+++ b/mcp/tools_models_test.go
@@ -10,6 +10,7 @@ import (
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/kstruzzieri/go-llm/config"
 	"github.com/kstruzzieri/go-llm/ollama"
 	"github.com/kstruzzieri/go-llm/provider"
 	"github.com/kstruzzieri/go-llm/provider/openaicompat"
@@ -401,6 +402,34 @@ func TestPullerForModel_UnknownModelWithMultiplePullersRequiresProvider(t *testi
 	}
 }
 
+func TestPullerForModel_SharedPullableModelRequiresProvider(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"models":[{"name":"qwen3:8b"}]}`))
+	}))
+	defer srv.Close()
+
+	reg := provider.NewRegistry()
+	for _, name := range []string{"ollama-a", "ollama-b"} {
+		p := provider.NewOllamaProvider(ollama.NewClient(ollama.WithBaseURL(srv.URL)),
+			provider.WithProviderName(name))
+		if err := reg.Register(p); err != nil {
+			t.Fatalf("Register(%s): %v", name, err)
+		}
+		if err := reg.AddModelToIndex("qwen3:8b", name); err != nil {
+			t.Fatalf("AddModelToIndex(%s): %v", name, err)
+		}
+	}
+
+	puller, err := pullerForModel(reg, "qwen3:8b", "")
+	if err == nil {
+		t.Fatalf("pullerForModel() error = nil, want shared-model ambiguity; puller = %#v", puller)
+	}
+	if !strings.Contains(err.Error(), "advertised by multiple providers") {
+		t.Fatalf("pullerForModel() error = %q, want advertised by multiple providers", err)
+	}
+}
+
 func TestPullerForModel_ExplicitProviderResolvesUnknownModel(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -421,6 +450,63 @@ func TestPullerForModel_ExplicitProviderResolvesUnknownModel(t *testing.T) {
 	}
 	if puller == nil {
 		t.Fatalf("pullerForModel returned nil for explicit pull-capable provider")
+	}
+}
+
+func TestPullModel_ConfigOwnedOpenAICompatDoesNotFallbackToOllama(t *testing.T) {
+	pullHit := false
+	ollamaSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/pull":
+			pullHit = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"success"}`))
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"models":[]}`))
+		}
+	}))
+	defer ollamaSrv.Close()
+
+	reg := provider.NewRegistry()
+	if err := reg.Register(provider.NewOllamaProvider(
+		ollama.NewClient(ollama.WithBaseURL(ollamaSrv.URL)),
+		provider.WithProviderName("ollama"),
+	)); err != nil {
+		t.Fatalf("Register(ollama): %v", err)
+	}
+	if err := reg.Register(openaicompat.NewProvider(
+		openaicompat.NewClient("http://127.0.0.1:1"),
+		openaicompat.WithProviderName("vllm-local"),
+	)); err != nil {
+		t.Fatalf("Register(vllm-local): %v", err)
+	}
+
+	s := &Server{
+		providerRegistry: reg,
+		cfg: &config.Config{
+			Models: map[string]config.ModelConfig{
+				"completion": {Name: "local-fim", Provider: "vllm-local"},
+			},
+		},
+	}
+
+	result, err := s.handlePullModel(context.Background(), &gomcp.CallToolRequest{
+		Params: &gomcp.CallToolParamsRaw{
+			Arguments: json.RawMessage(`{"name":"local-fim"}`),
+		},
+	})
+	if err != nil {
+		t.Fatalf("handlePullModel() error = %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("handlePullModel() isError = false, want unsupported for file-managed model")
+	}
+	if text := extractText(result); !strings.Contains(text, "pull is not supported") {
+		t.Fatalf("handlePullModel() content = %q, want pull unsupported", text)
+	}
+	if pullHit {
+		t.Fatal("pull_model fell back to Ollama for a config-owned openai-compatible model")
 	}
 }
 

--- a/mcp/tools_models_test.go
+++ b/mcp/tools_models_test.go
@@ -423,3 +423,60 @@ func TestPullerForModel_ExplicitProviderResolvesUnknownModel(t *testing.T) {
 		t.Fatalf("pullerForModel returned nil for explicit pull-capable provider")
 	}
 }
+
+// With a registry present, an unresolvable model must not silently hit the
+// direct legacy Ollama client; it should return a clear not-found error
+// instead.
+//
+// The model must genuinely fail provider resolution to exercise the guard. A
+// single-provider registry auto-resolves any unknown model to that sole
+// provider (see inferProviderForExplicitModel), so this test registers two
+// providers whose inventories are empty: resolution then returns no provider
+// and showModel reaches the fallback branch. A recording legacy client proves
+// the guard prevents the direct /api/show fallback.
+func TestShowModel_NoOllamaFallbackWhenRegistryPresent(t *testing.T) {
+	emptyInventory := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"models":[]}`))
+	}))
+	defer emptyInventory.Close()
+
+	legacyShowHit := false
+	legacySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/show" {
+			legacyShowHit = true
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"details":{}}`))
+	}))
+	defer legacySrv.Close()
+
+	reg := provider.NewRegistry()
+	for _, name := range []string{"ollama-a", "ollama-b"} {
+		p := provider.NewOllamaProvider(ollama.NewClient(ollama.WithBaseURL(emptyInventory.URL)),
+			provider.WithProviderName(name))
+		if err := reg.Register(p); err != nil {
+			t.Fatalf("Register(%s): %v", name, err)
+		}
+	}
+	mr, err := provider.NewModelRegistry(reg, nil)
+	if err != nil {
+		t.Fatalf("NewModelRegistry() error = %v", err)
+	}
+	s := &Server{
+		providerRegistry: reg,
+		modelRegistry:    mr,
+		client:           ollama.NewClient(ollama.WithBaseURL(legacySrv.URL)),
+	}
+
+	_, err = s.showModel(context.Background(), "definitely-not-a-real-model", "")
+	if err == nil {
+		t.Fatalf("showModel() error = nil, want not-found error")
+	}
+	if !strings.Contains(err.Error(), "not found in any registered provider") {
+		t.Fatalf("showModel() error = %q, want registered-provider not-found", err)
+	}
+	if legacyShowHit {
+		t.Errorf("showModel hit the direct Ollama /api/show despite a registry being present")
+	}
+}

--- a/mcp/tools_models_test.go
+++ b/mcp/tools_models_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kstruzzieri/go-llm/ollama"
 	"github.com/kstruzzieri/go-llm/provider"
+	"github.com/kstruzzieri/go-llm/provider/openaicompat"
 )
 
 func TestListModelsToolBasic(t *testing.T) {
@@ -318,5 +319,107 @@ func TestPullModelToolOllamaError(t *testing.T) {
 	}
 	if text := extractText(result); !strings.Contains(text, "ollama:") {
 		t.Errorf("error = %q, want to contain %q", text, "ollama:")
+	}
+}
+
+// pullerForModel selects the provider that owns the model when that provider is
+// a ModelPuller.
+func TestPullerForModel_OllamaIsPuller(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"models":[{"name":"qwen3:8b"}]}`))
+	}))
+	defer srv.Close()
+
+	reg := provider.NewRegistry()
+	if err := reg.Register(provider.NewOllamaProvider(ollama.NewClient(ollama.WithBaseURL(srv.URL)))); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := reg.AddModelToIndex("qwen3:8b", "ollama"); err != nil {
+		t.Fatalf("AddModelToIndex: %v", err)
+	}
+
+	puller, err := pullerForModel(reg, "qwen3:8b", "")
+	if err != nil {
+		t.Fatalf("pullerForModel() error = %v", err)
+	}
+	if puller == nil {
+		t.Fatalf("pullerForModel returned nil for an Ollama-backed model; want a puller")
+	}
+}
+
+// pullerForModel returns nil when only a file-managed (openai-compat) provider
+// owns the model — pull is unsupported there.
+func TestPullerForModel_OpenAICompatNotPuller(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"llama-3"}]}`))
+	}))
+	defer srv.Close()
+
+	reg := provider.NewRegistry()
+	oc := openaicompat.NewProvider(openaicompat.NewClient(srv.URL),
+		openaicompat.WithProviderName("llamacpp"))
+	if err := reg.Register(oc); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := reg.AddModelToIndex("llama-3", "llamacpp"); err != nil {
+		t.Fatalf("AddModelToIndex: %v", err)
+	}
+
+	puller, err := pullerForModel(reg, "llama-3", "")
+	if err != nil {
+		t.Fatalf("pullerForModel() error = %v", err)
+	}
+	if puller != nil {
+		t.Errorf("pullerForModel returned non-nil for a file-managed backend; want nil")
+	}
+}
+
+func TestPullerForModel_UnknownModelWithMultiplePullersRequiresProvider(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"models":[]}`))
+	}))
+	defer srv.Close()
+
+	reg := provider.NewRegistry()
+	for _, name := range []string{"ollama-a", "ollama-b"} {
+		p := provider.NewOllamaProvider(ollama.NewClient(ollama.WithBaseURL(srv.URL)),
+			provider.WithProviderName(name))
+		if err := reg.Register(p); err != nil {
+			t.Fatalf("Register(%s): %v", name, err)
+		}
+	}
+
+	puller, err := pullerForModel(reg, "not-yet-installed", "")
+	if err == nil {
+		t.Fatalf("pullerForModel() error = nil, want ambiguous-provider error; puller = %#v", puller)
+	}
+	if !strings.Contains(err.Error(), "multiple pull-capable providers") {
+		t.Fatalf("pullerForModel() error = %q, want multiple pull-capable providers", err)
+	}
+}
+
+func TestPullerForModel_ExplicitProviderResolvesUnknownModel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"models":[]}`))
+	}))
+	defer srv.Close()
+
+	reg := provider.NewRegistry()
+	p := provider.NewOllamaProvider(ollama.NewClient(ollama.WithBaseURL(srv.URL)),
+		provider.WithProviderName("shared-ollama"))
+	if err := reg.Register(p); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	puller, err := pullerForModel(reg, "not-yet-installed", "shared-ollama")
+	if err != nil {
+		t.Fatalf("pullerForModel() error = %v", err)
+	}
+	if puller == nil {
+		t.Fatalf("pullerForModel returned nil for explicit pull-capable provider")
 	}
 }

--- a/provider/ollama.go
+++ b/provider/ollama.go
@@ -722,3 +722,13 @@ func toProviderToolCalls(calls []ollama.ToolCall) []ToolCall {
 	}
 	return result
 }
+
+// PullModel downloads a model via the underlying Ollama client, satisfying the
+// optional ModelPuller capability. fn receives progress updates; pass nil to
+// ignore progress.
+func (p *OllamaProvider) PullModel(ctx context.Context, name string, fn func(status string, completed, total int64)) error {
+	return p.client.PullModel(ctx, name, fn)
+}
+
+// Compile-time check: OllamaProvider implements ModelPuller.
+var _ ModelPuller = (*OllamaProvider)(nil)

--- a/provider/ollama_test.go
+++ b/provider/ollama_test.go
@@ -1730,3 +1730,26 @@ func TestToOllamaGenerateRequest_NoOptions(t *testing.T) {
 		t.Errorf("expected nil Options for zero-value ModelOptions, got %+v", oReq.Options)
 	}
 }
+
+func TestOllamaProvider_PullModel(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		// Non-streaming pull (fn == nil) expects a single JSON object.
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success"}`))
+	}))
+	defer srv.Close()
+
+	p := NewOllamaProvider(ollama.NewClient(ollama.WithBaseURL(srv.URL)))
+
+	// Compile-time: OllamaProvider must satisfy ModelPuller.
+	var _ ModelPuller = p
+
+	if err := p.PullModel(context.Background(), "qwen3:8b", nil); err != nil {
+		t.Fatalf("PullModel() error = %v", err)
+	}
+	if gotPath != "/api/pull" {
+		t.Errorf("request path = %q, want /api/pull", gotPath)
+	}
+}

--- a/provider/puller.go
+++ b/provider/puller.go
@@ -1,0 +1,14 @@
+package provider
+
+import "context"
+
+// ModelPuller is an optional capability for providers that can download or
+// install models on demand (e.g. Ollama's registry pull). Providers whose
+// models are file-managed — llama.cpp/openai-compat GGUF files served by
+// llama-server — do not implement it; callers must treat a failed type
+// assertion as "pull unsupported for this backend".
+type ModelPuller interface {
+	// PullModel downloads the named model. fn receives progress updates;
+	// pass nil to ignore progress.
+	PullModel(ctx context.Context, name string, fn func(status string, completed, total int64)) error
+}


### PR DESCRIPTION
## Summary

Finishes the provider-abstraction of MCP model *management* so a llama.cpp-primary (openai-compat) setup reports the correct models and capabilities. Inference was already provider-abstracted via `provider.Router`; model management was the last place with a hardcoded `*ollama.Client` coupling. Resolves #183.

## Changes

- `go-llm://models` resource now routes through `s.listModels` (the provider registry) instead of calling the Ollama client directly, so it returns provider-tagged models for any backend.
- `go-llm://models/{name}` resource now routes through `s.showModel` provider resolution, fixing the same hidden Ollama coupling for openai-compat backends.
- New optional `provider.ModelPuller` capability interface. `OllamaProvider` implements it (registry pull); file-managed backends (llama.cpp/openai-compat GGUF) deliberately do not.
- `pull_model` tool is now provider-aware via a deterministic `pullerForModel` selector:
  - provider-owned models pull via their owning provider,
  - an unknown model auto-pulls only when exactly one pull-capable provider exists,
  - multiple pull-capable providers require an explicit `provider` argument (new optional tool input),
  - file-managed backends return a clear "pull unsupported" message instead of a misrouted Ollama pull.
  - The legacy no-registry Ollama path is preserved via an adapter.
- `show_model` returns a clear not-found error when a registry is present but the model cannot be resolved, instead of silently falling back to a single hardcoded Ollama client.

## Testing

- `go build ./...`, `go vet ./provider/ ./mcp/`, `go test -race ./provider/ ./mcp/` all pass.
- New unit tests cover registry-routed resources, `OllamaProvider.PullModel`, the four `pullerForModel` selection cases (owned-puller, file-managed/non-puller, ambiguous multi-puller, explicit-provider), and the show_model no-fallback guard.

Generated with Claude Code
