### PR TITLE
feat(agent): runtime plan→act→observe loop (#61)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 .claude
+.superpowers/
 docs/plans/
 docs/spikes/
 docs/superpowers/

--- a/agent/agenttest/recorder.go
+++ b/agent/agenttest/recorder.go
@@ -1,0 +1,43 @@
+// Package agenttest provides test helpers for the agent runtime.
+package agenttest
+
+import (
+	"context"
+	"sync"
+
+	"github.com/kstruzzieri/go-llm/agent"
+)
+
+// RecorderObserver records the ordered sequence of observer callbacks so loop
+// tests can assert the exact event transcript.
+type RecorderObserver struct {
+	mu     sync.Mutex
+	Kinds  []string // "step" | "tool_call" | "token"
+	Steps  []agent.StepEvent
+	Calls  []agent.ToolCallEvent
+	Tokens []agent.TokenEvent
+}
+
+func (r *RecorderObserver) OnStep(_ context.Context, e agent.StepEvent) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.Kinds = append(r.Kinds, "step")
+	r.Steps = append(r.Steps, e)
+	return nil
+}
+
+func (r *RecorderObserver) OnToolCall(_ context.Context, e agent.ToolCallEvent) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.Kinds = append(r.Kinds, "tool_call")
+	r.Calls = append(r.Calls, e)
+	return nil
+}
+
+func (r *RecorderObserver) OnToken(_ context.Context, e agent.TokenEvent) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.Kinds = append(r.Kinds, "token")
+	r.Tokens = append(r.Tokens, e)
+	return nil
+}

--- a/agent/approval_test.go
+++ b/agent/approval_test.go
@@ -21,6 +21,16 @@ func (writeTool) Invoke(context.Context, json.RawMessage) (ToolResult, error) {
 	return ToolResult{Content: "wrote"}, nil
 }
 
+type defaultWriteTool struct{}
+
+func (defaultWriteTool) Spec() ToolSpec {
+	return ToolSpec{Name: "writer", Parameters: json.RawMessage(`{}`)}
+}
+func (defaultWriteTool) Effect() Effect { return Effect{Class: Write} }
+func (defaultWriteTool) Invoke(context.Context, json.RawMessage) (ToolResult, error) {
+	return ToolResult{Content: "wrote"}, nil
+}
+
 func writeCallSeq() []ModelResult {
 	return []ModelResult{
 		{Response: provider.ChatResponse{ToolCalls: []provider.ToolCall{{
@@ -40,6 +50,18 @@ func TestNilApproverDeniesWriteTool(t *testing.T) {
 	}
 	if !res.ToolCalls[0].Denied {
 		t.Fatalf("nil approver must deny a Write tool, got %+v", res.ToolCalls[0])
+	}
+}
+
+func TestNilApproverDeniesDefaultWriteTool(t *testing.T) {
+	mc := &scriptedCaller{responses: writeCallSeq()}
+	o := newTestOrchestrator(mc)
+	res, err := o.Run(context.Background(), Request{Goal: "q", Tools: []Tool{defaultWriteTool{}}}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !res.ToolCalls[0].Denied {
+		t.Fatalf("nil approver must deny a zero-policy Write tool, got %+v", res.ToolCalls[0])
 	}
 }
 

--- a/agent/approval_test.go
+++ b/agent/approval_test.go
@@ -1,0 +1,69 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+type writeTool struct{ planPreview string }
+
+func (writeTool) Spec() ToolSpec { return ToolSpec{Name: "writer", Parameters: json.RawMessage(`{}`)} }
+func (writeTool) Effect() Effect {
+	return Effect{Class: Write, Approval: ApprovalOnWrite}
+}
+func (w writeTool) Plan(context.Context, json.RawMessage) (ToolPlan, error) {
+	return ToolPlan{Effect: Effect{Class: Write, Approval: ApprovalOnWrite}, Preview: w.planPreview}, nil
+}
+func (writeTool) Invoke(context.Context, json.RawMessage) (ToolResult, error) {
+	return ToolResult{Content: "wrote"}, nil
+}
+
+func writeCallSeq() []ModelResult {
+	return []ModelResult{
+		{Response: provider.ChatResponse{ToolCalls: []provider.ToolCall{{
+			ID: "1", Type: "function",
+			Function: provider.ToolCallFunction{Name: "writer", Arguments: json.RawMessage(`{}`)},
+		}}}},
+		{Response: provider.ChatResponse{Content: "ok", Done: true}},
+	}
+}
+
+func TestNilApproverDeniesWriteTool(t *testing.T) {
+	mc := &scriptedCaller{responses: writeCallSeq()}
+	o := newTestOrchestrator(mc)
+	res, err := o.Run(context.Background(), Request{Goal: "q", Tools: []Tool{writeTool{}}}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !res.ToolCalls[0].Denied {
+		t.Fatalf("nil approver must deny a Write tool, got %+v", res.ToolCalls[0])
+	}
+}
+
+type capturingApprover struct {
+	gotPreview string
+	allow      bool
+}
+
+func (c *capturingApprover) Approve(_ context.Context, _ provider.ToolCall, preview string) (bool, error) {
+	c.gotPreview = preview
+	return c.allow, nil
+}
+
+func TestApproverReceivesPlanPreview(t *testing.T) {
+	ap := &capturingApprover{allow: true}
+	mc := &scriptedCaller{responses: writeCallSeq()}
+	o := newTestOrchestrator(mc)
+	_, err := o.Run(context.Background(), Request{
+		Goal: "q", Tools: []Tool{writeTool{planPreview: "DIFF: +1 -0"}}, Approver: ap,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if ap.gotPreview != "DIFF: +1 -0" {
+		t.Fatalf("approver preview = %q, want plan preview", ap.gotPreview)
+	}
+}

--- a/agent/compaction_test.go
+++ b/agent/compaction_test.go
@@ -1,0 +1,123 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// TestRecencyCompactorEvictsCompletedChainMidLoop proves a completed tool chain
+// is evictable even when no plain (no-tool-call) assistant message follows it —
+// the realistic shape of an in-progress agent transcript.
+func TestRecencyCompactorEvictsCompletedChainMidLoop(t *testing.T) {
+	chain := func(id, content string) []Message {
+		return []Message{
+			{ChatMessage: provider.ChatMessage{Role: "assistant", ToolCalls: []provider.ToolCall{{
+				ID: id, Type: "function",
+				Function: provider.ToolCallFunction{Name: "t", Arguments: json.RawMessage(`{}`)},
+			}}}, Segment: Elastic},
+			{ChatMessage: provider.ChatMessage{Role: "tool", ToolCallID: id, ToolName: "t", Content: content}, Segment: Elastic},
+		}
+	}
+	msgs := []Message{pinned("user", "G")}
+	msgs = append(msgs, chain("c1", "OLDRESULT")...) // oldest completed chain
+	msgs = append(msgs, chain("c2", "NEWRESULT")...) // newest completed chain
+	st := State{Messages: msgs}
+
+	rc := RecencyCompactor{Estimate: runeEstimator}
+	// Budget one token under the full total forces exactly one group to drop;
+	// the oldest completed chain (c1) must be the one evicted.
+	out, rep, err := rc.Compact(context.Background(), st, TokenBudget{Input: rc.total(st) - 1})
+	if err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	if rep.DroppedCount != 1 {
+		t.Fatalf("DroppedCount = %d, want 1", rep.DroppedCount)
+	}
+	for _, m := range out.Messages {
+		if m.ToolCallID == "c1" || (len(m.ToolCalls) > 0 && m.ToolCalls[0].ID == "c1") {
+			t.Fatalf("oldest completed chain c1 must be evicted, got %+v", out.Messages)
+		}
+	}
+	// atomicity: goal + the c2 chain (assistant + tool) survive, nothing orphaned
+	if len(out.Messages) != 3 {
+		t.Fatalf("want goal + c2 chain (3 messages), got %+v", out.Messages)
+	}
+}
+
+// TestRecencyCompactorPreservesUnresolvedTail proves a chain whose tool_calls
+// are not all answered yet is never dropped (would orphan a tool_call_id).
+func TestRecencyCompactorPreservesUnresolvedTail(t *testing.T) {
+	// assistant requests TWO tool calls but only ONE result is present -> unresolved.
+	asst := Message{ChatMessage: provider.ChatMessage{
+		Role: "assistant",
+		ToolCalls: []provider.ToolCall{
+			{ID: "a", Type: "function", Function: provider.ToolCallFunction{Name: "t", Arguments: json.RawMessage(`{}`)}},
+			{ID: "b", Type: "function", Function: provider.ToolCallFunction{Name: "t", Arguments: json.RawMessage(`{}`)}},
+		},
+	}, Segment: Elastic}
+	onlyResult := Message{ChatMessage: provider.ChatMessage{Role: "tool", ToolCallID: "a", ToolName: "t", Content: "R"}, Segment: Elastic}
+	st := State{Messages: []Message{pinned("user", "G"), asst, onlyResult}}
+
+	rc := RecencyCompactor{Estimate: runeEstimator}
+	out, _, err := rc.Compact(context.Background(), st, TokenBudget{Input: 1}) // brutally tight
+	if err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	// the unresolved tail cannot be dropped, so it survives despite the tiny budget
+	foundAsst, foundResult := false, false
+	for _, m := range out.Messages {
+		if len(m.ToolCalls) == 2 {
+			foundAsst = true
+		}
+		if m.ToolCallID == "a" {
+			foundResult = true
+		}
+	}
+	if !foundAsst || !foundResult {
+		t.Fatalf("unresolved tail must be preserved, got %+v", out.Messages)
+	}
+}
+
+// bulkyTool returns a large observation so a tool turn blows past a tight budget.
+type bulkyTool struct{}
+
+func (bulkyTool) Spec() ToolSpec { return ToolSpec{Name: "bulky", Parameters: json.RawMessage(`{}`)} }
+func (bulkyTool) Effect() Effect { return Effect{Class: Read} } // default cap (64KiB), not truncated
+func (bulkyTool) Invoke(context.Context, json.RawMessage) (ToolResult, error) {
+	return ToolResult{Content: strings.Repeat("X", 400)}, nil
+}
+
+// TestRunEmitsCompactionEvent drives a tool-heavy loop under a tight input
+// ceiling so Assemble actually compacts, and asserts the compaction event fires.
+func TestRunEmitsCompactionEvent(t *testing.T) {
+	bulkyCall := provider.ChatResponse{ToolCalls: []provider.ToolCall{{
+		ID: "1", Type: "function",
+		Function: provider.ToolCallFunction{Name: "bulky", Arguments: json.RawMessage(`{}`)},
+	}}}
+	mc := &scriptedCaller{responses: []ModelResult{
+		{Response: bulkyCall},
+		{Response: bulkyCall},
+		{Response: provider.ChatResponse{Content: "done", Done: true}},
+	}}
+	o := newTestOrchestrator(mc)
+	res, err := o.Run(context.Background(), Request{
+		Goal: "q", Budget: Budget{InputCeiling: 80}, Tools: []Tool{bulkyTool{}},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	saw := false
+	for _, e := range res.Events {
+		if e.Kind == "compaction" {
+			saw = true
+			break
+		}
+	}
+	if !saw {
+		t.Fatalf("expected a compaction event in Result.Events, got %+v", res.Events)
+	}
+}

--- a/agent/compactor.go
+++ b/agent/compactor.go
@@ -1,0 +1,164 @@
+package agent
+
+import "context"
+
+// TokenBudget is the input-token budget available to the State messages
+// (system + transcript), already net of tool-schema tokens.
+type TokenBudget struct {
+	Input int
+}
+
+// CompactionReport describes what a Compact call did.
+type CompactionReport struct {
+	Strategy     string
+	DroppedCount int
+	TokensBefore int
+	TokensAfter  int
+}
+
+// Compactor fits a transcript into a token budget.
+type Compactor interface {
+	Compact(ctx context.Context, state State, budget TokenBudget) (State, CompactionReport, error)
+}
+
+// RecencyCompactor drops oldest completed tool-call chains first, preserves
+// pinned messages and unresolved tool tails, and never calls a model.
+type RecencyCompactor struct {
+	Estimate func(string) int // conversation.TokenEstimator; len/4 default when nil
+}
+
+func (rc RecencyCompactor) estimate(s string) int {
+	if rc.Estimate != nil {
+		return rc.Estimate(s)
+	}
+	return (len(s) + 3) / 4
+}
+
+func (rc RecencyCompactor) messageCost(m Message) int {
+	n := rc.estimate(m.Content)
+	for _, tc := range m.ToolCalls {
+		n += rc.estimate(tc.ID)
+		n += rc.estimate(tc.Type)
+		n += rc.estimate(tc.Function.Name)
+		n += rc.estimate(string(tc.Function.Arguments))
+	}
+	n += rc.estimate(m.ToolName)
+	n += rc.estimate(m.ToolCallID)
+	return n
+}
+
+func (rc RecencyCompactor) total(st State) int {
+	n := rc.estimate(st.System)
+	for _, m := range st.Messages {
+		n += rc.messageCost(m)
+	}
+	return n
+}
+
+type compactionGroupKind int
+
+const (
+	groupPinned compactionGroupKind = iota
+	groupCompletedTool
+	groupUnresolvedTool
+	groupPlainElastic
+)
+
+type compactionGroup struct {
+	msgs   []Message
+	tokens int
+	kind   compactionGroupKind
+	drop   bool
+}
+
+// chainAt returns the inclusive end index of the message group starting at i:
+// an assistant message with ToolCalls plus the contiguous tool results that
+// follow it. For a plain message it returns i.
+func chainAt(msgs []Message, i int) int {
+	if len(msgs[i].ToolCalls) == 0 {
+		return i
+	}
+	end := i
+	for end+1 < len(msgs) && msgs[end+1].Role == "tool" {
+		end++
+	}
+	return end
+}
+
+func classifyGroup(msgs []Message, start, end int) compactionGroupKind {
+	for _, m := range msgs[start : end+1] {
+		if m.Segment == Pinned {
+			return groupPinned
+		}
+	}
+	if len(msgs[start].ToolCalls) == 0 {
+		return groupPlainElastic
+	}
+	// A chain is complete once the model has received tool observations and
+	// produced a following assistant message with no new tool calls.
+	if end+1 < len(msgs) && msgs[end+1].Role == "assistant" && len(msgs[end+1].ToolCalls) == 0 {
+		return groupCompletedTool
+	}
+	return groupUnresolvedTool
+}
+
+func (rc RecencyCompactor) groups(st State) []compactionGroup {
+	out := make([]compactionGroup, 0, len(st.Messages))
+	for i := 0; i < len(st.Messages); {
+		end := chainAt(st.Messages, i)
+		tokens := 0
+		for _, m := range st.Messages[i : end+1] {
+			tokens += rc.messageCost(m)
+		}
+		out = append(out, compactionGroup{
+			msgs:   st.Messages[i : end+1],
+			tokens: tokens,
+			kind:   classifyGroup(st.Messages, i, end),
+		})
+		i = end + 1
+	}
+	return out
+}
+
+func (rc RecencyCompactor) Compact(_ context.Context, st State, b TokenBudget) (State, CompactionReport, error) {
+	before := rc.total(st)
+	if before <= b.Input {
+		return st, CompactionReport{Strategy: "recency", TokensBefore: before, TokensAfter: before}, nil
+	}
+
+	groups := rc.groups(st)
+	remaining := before
+	dropped := 0
+	dropKind := func(kind compactionGroupKind) {
+		for i := range groups {
+			if remaining <= b.Input {
+				return
+			}
+			if groups[i].kind == kind {
+				groups[i].drop = true
+				remaining -= groups[i].tokens
+				dropped++
+			}
+		}
+	}
+
+	// Completed tool-call chains are verbose and reconstructable from later
+	// assistant observations, so they are evicted before plain chat history.
+	dropKind(groupCompletedTool)
+	dropKind(groupPlainElastic)
+
+	out := State{System: st.System}
+	for _, g := range groups {
+		if !g.drop {
+			out.Messages = append(out.Messages, g.msgs...)
+		}
+	}
+
+	after := rc.total(out)
+	return out, CompactionReport{
+		Strategy:     "recency",
+		DroppedCount: dropped,
+		TokensBefore: before,
+		TokensAfter:  after,
+	}, nil
+}

--- a/agent/compactor.go
+++ b/agent/compactor.go
@@ -94,9 +94,14 @@ func classifyGroup(msgs []Message, start, end int) compactionGroupKind {
 	if len(msgs[start].ToolCalls) == 0 {
 		return groupPlainElastic
 	}
-	// A chain is complete once the model has received tool observations and
-	// produced a following assistant message with no new tool calls.
-	if end+1 < len(msgs) && msgs[end+1].Role == "assistant" && len(msgs[end+1].ToolCalls) == 0 {
+	// A tool chain is completed (safe to evict) once every tool_call in the
+	// assistant message has a matching tool result within the chain: the model
+	// has the observations, and the whole atomic group drops together without
+	// orphaning a tool_call_id. A chain missing results is an unresolved tail
+	// (e.g. mid-dispatch) and must never be dropped. chainAt bundles the
+	// assistant with its contiguous tool results, so the result count is end-start.
+	resultCount := end - start
+	if resultCount >= len(msgs[start].ToolCalls) {
 		return groupCompletedTool
 	}
 	return groupUnresolvedTool

--- a/agent/compactor_test.go
+++ b/agent/compactor_test.go
@@ -1,0 +1,163 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// fixed estimator: 1 token per rune of Content, ignores role overhead.
+func runeEstimator(s string) int { return len([]rune(s)) }
+
+func pinned(role, content string) Message {
+	return Message{ChatMessage: provider.ChatMessage{Role: role, Content: content}, Segment: Pinned}
+}
+func elastic(role, content string) Message {
+	return Message{ChatMessage: provider.ChatMessage{Role: role, Content: content}, Segment: Elastic}
+}
+
+func TestRecencyCompactorKeepsPinnedDropsOldestElastic(t *testing.T) {
+	st := State{
+		System: "", // empty so token math is exactly the message contents
+		Messages: []Message{
+			pinned("user", "GOAL"),        // 4 (pinned, always kept)
+			elastic("assistant", "OLD"),   // 3 (oldest, dropped)
+			elastic("user", "MIDDLE"),     // 6
+			elastic("assistant", "NEWER"), // 5
+		},
+	}
+	// budget = GOAL(4) + MIDDLE(6) + NEWER(5) = 15; OLD must be evicted.
+	rc := RecencyCompactor{Estimate: runeEstimator}
+	out, rep, err := rc.Compact(context.Background(), st, TokenBudget{Input: 4 + 6 + 5})
+	if err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	if rep.DroppedCount != 1 {
+		t.Fatalf("DroppedCount = %d, want 1", rep.DroppedCount)
+	}
+	if len(out.Messages) != 3 || out.Messages[0].Content != "GOAL" {
+		t.Fatalf("pinned goal must survive, got %+v", out.Messages)
+	}
+	for _, m := range out.Messages {
+		if m.Content == "OLD" {
+			t.Fatal("oldest elastic message should have been dropped")
+		}
+	}
+	if rep.Strategy != "recency" || rep.TokensAfter > rep.TokensBefore {
+		t.Fatalf("bad report: %+v", rep)
+	}
+}
+
+func TestRecencyCompactorDropsToolChainsAtomically(t *testing.T) {
+	asst := Message{ChatMessage: provider.ChatMessage{
+		Role: "assistant",
+		ToolCalls: []provider.ToolCall{{
+			ID: "c1", Type: "function",
+			Function: provider.ToolCallFunction{Name: "search", Arguments: json.RawMessage(`{"q":"x"}`)},
+		}},
+	}, Segment: Elastic}
+	toolResult := Message{ChatMessage: provider.ChatMessage{
+		Role: "tool", ToolName: "search", ToolCallID: "c1", Content: "RESULT-DATA",
+	}, Segment: Elastic}
+
+	st := State{
+		System: "", // empty so token math is exactly the message contents
+		Messages: []Message{
+			pinned("user", "GOAL"),
+			asst, toolResult, // oldest completed chain — must drop together
+			elastic("assistant", "FINAL-ANSWER"),
+		},
+	}
+	// budget = GOAL(4) + FINAL-ANSWER(12) = 16; the [asst,toolResult] chain
+	// includes prompt-visible tool fields and is evicted atomically.
+	rc := RecencyCompactor{Estimate: runeEstimator}
+	out, _, err := rc.Compact(context.Background(), st, TokenBudget{Input: 4 + len("FINAL-ANSWER")})
+	if err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	for _, m := range out.Messages {
+		if m.Role == "tool" || len(m.ToolCalls) > 0 {
+			t.Fatalf("partial tool chain survived: %+v", out.Messages)
+		}
+	}
+}
+
+func TestRecencyCompactorCountsPromptVisibleToolFields(t *testing.T) {
+	asst := Message{ChatMessage: provider.ChatMessage{
+		Role: "assistant",
+		ToolCalls: []provider.ToolCall{{
+			ID: "expensive-call-id", Type: "function",
+			Function: provider.ToolCallFunction{Name: "search", Arguments: json.RawMessage(`{"query":"long"}`)},
+		}},
+	}, Segment: Elastic}
+	toolResult := Message{ChatMessage: provider.ChatMessage{
+		Role: "tool", ToolName: "search", ToolCallID: "expensive-call-id",
+	}, Segment: Elastic}
+	st := State{
+		Messages: []Message{
+			pinned("user", "G"),
+			asst, toolResult, // completed chain has no Content, but still costs tokens
+			elastic("assistant", "FINAL"),
+		},
+	}
+
+	rc := RecencyCompactor{Estimate: runeEstimator}
+	out, _, err := rc.Compact(context.Background(), st, TokenBudget{Input: len("G") + len("FINAL")})
+	if err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	if len(out.Messages) != 2 || out.Messages[1].Content != "FINAL" {
+		t.Fatalf("tool fields must count toward budget and force chain eviction, got %+v", out.Messages)
+	}
+}
+
+func TestRecencyCompactorDropsCompletedToolChainsBeforePlainHistory(t *testing.T) {
+	asst := Message{ChatMessage: provider.ChatMessage{
+		Role: "assistant",
+		ToolCalls: []provider.ToolCall{{
+			ID: "c1", Type: "function",
+			Function: provider.ToolCallFunction{Name: "search", Arguments: json.RawMessage(`{}`)},
+		}},
+	}, Segment: Elastic}
+	toolResult := Message{ChatMessage: provider.ChatMessage{
+		Role: "tool", ToolName: "search", ToolCallID: "c1", Content: "TOOLRESULT",
+	}, Segment: Elastic}
+	st := State{Messages: []Message{
+		pinned("user", "G"),
+		elastic("assistant", "PLAIN"),
+		asst, toolResult,
+		elastic("assistant", "FINAL"),
+	}}
+
+	rc := RecencyCompactor{Estimate: runeEstimator}
+	out, _, err := rc.Compact(context.Background(), st, TokenBudget{Input: len("G") + len("PLAIN") + len("FINAL")})
+	if err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	if len(out.Messages) != 3 || out.Messages[1].Content != "PLAIN" || out.Messages[2].Content != "FINAL" {
+		t.Fatalf("completed tool chain should drop before plain history, got %+v", out.Messages)
+	}
+}
+
+func TestRecencyCompactorPreservesOriginalOrder(t *testing.T) {
+	st := State{Messages: []Message{
+		elastic("assistant", "DROP"),
+		elastic("assistant", "KEEP"),
+		pinned("user", "PIN"),
+		elastic("assistant", "NEW"),
+	}}
+	rc := RecencyCompactor{Estimate: runeEstimator}
+	out, _, err := rc.Compact(context.Background(), st, TokenBudget{Input: len("KEEP") + len("PIN") + len("NEW")})
+	if err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	got := []string{out.Messages[0].Content, out.Messages[1].Content, out.Messages[2].Content}
+	want := []string{"KEEP", "PIN", "NEW"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order = %v, want %v", got, want)
+		}
+	}
+}

--- a/agent/context_manager.go
+++ b/agent/context_manager.go
@@ -38,6 +38,12 @@ func turnBudget(b Budget) TokenBudget {
 	if ceiling <= 0 {
 		ceiling = defaultInputCeiling
 	}
+	if b.OutputReserve > 0 {
+		ceiling -= b.OutputReserve
+	}
+	if ceiling < 0 {
+		ceiling = 0
+	}
 	return TokenBudget{Input: ceiling}
 }
 
@@ -81,5 +87,9 @@ func (m ContextManager) Assemble(ctx context.Context, st State, toolSchemaTokens
 	if report.DroppedCount > 0 {
 		compactions = 1
 	}
-	return out, Pressure{UsedPct: used, Evicted: report.DroppedCount, Compactions: compactions}, nil
+	pressure := Pressure{UsedPct: used, Evicted: report.DroppedCount, Compactions: compactions}
+	if after > budget.Input {
+		return out, pressure, ErrContextExhausted
+	}
+	return out, pressure, nil
 }

--- a/agent/context_manager.go
+++ b/agent/context_manager.go
@@ -1,0 +1,85 @@
+package agent
+
+import "context"
+
+// defaultInputCeiling is a conservative fallback when Budget.InputCeiling is 0.
+const defaultInputCeiling = 8192
+
+// ContextManager assembles and bounds the prompt each turn. It is a pure
+// function over State, tool-schema token count, and budget.
+type ContextManager struct {
+	Compactor Compactor
+	Estimate  func(string) int // token estimator; len/4 when nil
+}
+
+func (m ContextManager) estimate(s string) int {
+	if m.Estimate != nil {
+		return m.Estimate(s)
+	}
+	return (len(s) + 3) / 4
+}
+
+func normalizeContextManager(m ContextManager) ContextManager {
+	if m.Compactor == nil {
+		m.Compactor = RecencyCompactor{Estimate: m.Estimate}
+	}
+	return m
+}
+
+func (m ContextManager) messageCost(msg Message) int {
+	return RecencyCompactor{Estimate: m.Estimate}.messageCost(msg)
+}
+
+// turnBudget resolves the per-turn input ceiling from the run Budget, applying
+// the conservative default when unset. Tool-schema accounting happens in
+// Assemble, which subtracts the pinned schema cost from this ceiling.
+func turnBudget(b Budget) TokenBudget {
+	ceiling := b.InputCeiling
+	if ceiling <= 0 {
+		ceiling = defaultInputCeiling
+	}
+	return TokenBudget{Input: ceiling}
+}
+
+func (m ContextManager) pinnedTokens(st State, toolSchemaTokens int) int {
+	n := m.estimate(st.System) + toolSchemaTokens
+	for _, msg := range st.Messages {
+		if msg.Segment == Pinned {
+			n += m.messageCost(msg)
+		}
+	}
+	return n
+}
+
+func (m ContextManager) totalTokens(st State, toolSchemaTokens int) int {
+	n := m.estimate(st.System) + toolSchemaTokens
+	for _, msg := range st.Messages {
+		n += m.messageCost(msg)
+	}
+	return n
+}
+
+// Assemble bounds the transcript to fit the budget. toolSchemaTokens is the
+// pinned cost of the active tool schemas (not stored in State).
+func (m ContextManager) Assemble(ctx context.Context, st State, toolSchemaTokens int, budget TokenBudget) (State, Pressure, error) {
+	m = normalizeContextManager(m)
+	if m.pinnedTokens(st, toolSchemaTokens) > budget.Input {
+		return st, Pressure{}, ErrContextExhausted
+	}
+	// Compactor fits the State messages into the budget left after tool schemas.
+	stateBudget := TokenBudget{Input: budget.Input - toolSchemaTokens}
+	out, report, err := m.Compactor.Compact(ctx, st, stateBudget)
+	if err != nil {
+		return st, Pressure{}, err
+	}
+	after := m.totalTokens(out, toolSchemaTokens)
+	used := 0.0
+	if budget.Input > 0 {
+		used = float64(after) / float64(budget.Input)
+	}
+	compactions := 0
+	if report.DroppedCount > 0 {
+		compactions = 1
+	}
+	return out, Pressure{UsedPct: used, Evicted: report.DroppedCount, Compactions: compactions}, nil
+}

--- a/agent/context_manager_test.go
+++ b/agent/context_manager_test.go
@@ -1,0 +1,65 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestTurnBudgetUsesDefaultWhenZero(t *testing.T) {
+	b := turnBudget(Budget{})
+	if b.Input <= 0 {
+		t.Fatal("zero InputCeiling must fall back to a positive default")
+	}
+}
+
+func TestAssemblePinnedOverflowReturnsErr(t *testing.T) {
+	m := ContextManager{Compactor: RecencyCompactor{Estimate: runeEstimator}, Estimate: runeEstimator}
+	st := State{System: "system-prompt", Messages: []Message{pinned("user", "a-very-long-goal")}}
+	// budget smaller than pinned tokens => exhausted.
+	_, _, err := m.Assemble(context.Background(), st, 0, TokenBudget{Input: 3})
+	if err == nil || !errors.Is(err, ErrContextExhausted) {
+		t.Fatalf("want ErrContextExhausted, got %v", err)
+	}
+}
+
+func TestAssembleCountsToolSchemaAsPinned(t *testing.T) {
+	m := ContextManager{Compactor: RecencyCompactor{Estimate: runeEstimator}, Estimate: runeEstimator}
+	st := State{System: "s", Messages: []Message{pinned("user", "g")}}
+	// system(1)+goal(1)=2 fits in 5, but tool schema of 10 pushes pinned over.
+	_, _, err := m.Assemble(context.Background(), st, 10, TokenBudget{Input: 5})
+	if !errors.Is(err, ErrContextExhausted) {
+		t.Fatalf("tool schema tokens must count toward pinned; got %v", err)
+	}
+}
+
+func TestAssembleCompactsElastic(t *testing.T) {
+	m := ContextManager{Compactor: RecencyCompactor{Estimate: runeEstimator}, Estimate: runeEstimator}
+	st := State{System: "s", Messages: []Message{
+		pinned("user", "g"),
+		elastic("assistant", "oldold"),
+		elastic("user", "new"),
+	}}
+	out, pr, err := m.Assemble(context.Background(), st, 0, TokenBudget{Input: 1 + 1 + 3})
+	if err != nil {
+		t.Fatalf("Assemble: %v", err)
+	}
+	if pr.Evicted == 0 {
+		t.Fatal("expected at least one eviction recorded in Pressure")
+	}
+	if len(out.Messages) != 2 {
+		t.Fatalf("want goal + newest elastic, got %+v", out.Messages)
+	}
+}
+
+func TestContextManagerZeroValueUsesDefaultCompactor(t *testing.T) {
+	var m ContextManager
+	st := State{Messages: []Message{pinned("user", "goal")}}
+	out, _, err := m.Assemble(context.Background(), st, 0, TokenBudget{Input: 100})
+	if err != nil {
+		t.Fatalf("zero-value ContextManager should use defaults: %v", err)
+	}
+	if len(out.Messages) != 1 || out.Messages[0].Content != "goal" {
+		t.Fatalf("unexpected assembled state: %+v", out.Messages)
+	}
+}

--- a/agent/context_manager_test.go
+++ b/agent/context_manager_test.go
@@ -63,17 +63,21 @@ func TestAssembleCompactsElastic(t *testing.T) {
 }
 
 func TestAssembleReturnsErrWhenCompactedStateStillOverBudget(t *testing.T) {
+	// An unresolved tail (2 tool_calls, only 1 result present) can never be
+	// dropped. Even after evicting all droppable groups the state won't fit in a
+	// budget that only covers the pinned goal.
 	m := ContextManager{Compactor: RecencyCompactor{Estimate: runeEstimator}, Estimate: runeEstimator}
 	st := State{Messages: []Message{
 		pinned("user", "goal"),
-		elastic("user", "do"),
 		{
 			ChatMessage: provider.ChatMessage{
 				Role: "assistant",
-				ToolCalls: []provider.ToolCall{{
-					ID: "c1", Type: "function",
-					Function: provider.ToolCallFunction{Name: "search", Arguments: json.RawMessage(`{}`)},
-				}},
+				ToolCalls: []provider.ToolCall{
+					{ID: "c1", Type: "function",
+						Function: provider.ToolCallFunction{Name: "search", Arguments: json.RawMessage(`{}`)}},
+					{ID: "c2", Type: "function",
+						Function: provider.ToolCallFunction{Name: "search", Arguments: json.RawMessage(`{}`)}},
+				},
 			},
 			Segment: Elastic,
 		},
@@ -88,6 +92,8 @@ func TestAssembleReturnsErrWhenCompactedStateStillOverBudget(t *testing.T) {
 		},
 	}}
 
+	// Budget only covers the pinned goal; the unresolved tail (2 calls, 1 result)
+	// cannot be dropped, so Assemble must return ErrContextExhausted.
 	_, _, err := m.Assemble(context.Background(), st, 0, TokenBudget{Input: len("goal") + 1})
 	if !errors.Is(err, ErrContextExhausted) {
 		t.Fatalf("want ErrContextExhausted when compaction cannot fit, got %v", err)

--- a/agent/context_manager_test.go
+++ b/agent/context_manager_test.go
@@ -2,14 +2,24 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
+
+	"github.com/kstruzzieri/go-llm/provider"
 )
 
 func TestTurnBudgetUsesDefaultWhenZero(t *testing.T) {
 	b := turnBudget(Budget{})
 	if b.Input <= 0 {
 		t.Fatal("zero InputCeiling must fall back to a positive default")
+	}
+}
+
+func TestTurnBudgetSubtractsOutputReserve(t *testing.T) {
+	b := turnBudget(Budget{InputCeiling: 100, OutputReserve: 25})
+	if b.Input != 75 {
+		t.Fatalf("Input = %d, want 75", b.Input)
 	}
 }
 
@@ -49,6 +59,38 @@ func TestAssembleCompactsElastic(t *testing.T) {
 	}
 	if len(out.Messages) != 2 {
 		t.Fatalf("want goal + newest elastic, got %+v", out.Messages)
+	}
+}
+
+func TestAssembleReturnsErrWhenCompactedStateStillOverBudget(t *testing.T) {
+	m := ContextManager{Compactor: RecencyCompactor{Estimate: runeEstimator}, Estimate: runeEstimator}
+	st := State{Messages: []Message{
+		pinned("user", "goal"),
+		elastic("user", "do"),
+		{
+			ChatMessage: provider.ChatMessage{
+				Role: "assistant",
+				ToolCalls: []provider.ToolCall{{
+					ID: "c1", Type: "function",
+					Function: provider.ToolCallFunction{Name: "search", Arguments: json.RawMessage(`{}`)},
+				}},
+			},
+			Segment: Elastic,
+		},
+		{
+			ChatMessage: provider.ChatMessage{
+				Role:       "tool",
+				Content:    "tool-result-too-large",
+				ToolName:   "search",
+				ToolCallID: "c1",
+			},
+			Segment: Elastic,
+		},
+	}}
+
+	_, _, err := m.Assemble(context.Background(), st, 0, TokenBudget{Input: len("goal") + 1})
+	if !errors.Is(err, ErrContextExhausted) {
+		t.Fatalf("want ErrContextExhausted when compaction cannot fit, got %v", err)
 	}
 }
 

--- a/agent/coverage_test.go
+++ b/agent/coverage_test.go
@@ -1,0 +1,95 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// bigOutputTool returns content larger than its OutputCap so the runtime must truncate.
+type bigOutputTool struct{}
+
+func (bigOutputTool) Spec() ToolSpec { return ToolSpec{Name: "big", Parameters: json.RawMessage(`{}`)} }
+func (bigOutputTool) Effect() Effect { return Effect{Class: Read, OutputCap: 8} }
+func (bigOutputTool) Invoke(context.Context, json.RawMessage) (ToolResult, error) {
+	return ToolResult{Content: strings.Repeat("A", 100)}, nil
+}
+
+func TestDispatchTruncatesOutputCap(t *testing.T) {
+	mc := &scriptedCaller{responses: []ModelResult{
+		{Response: provider.ChatResponse{ToolCalls: []provider.ToolCall{{
+			ID: "1", Type: "function",
+			Function: provider.ToolCallFunction{Name: "big", Arguments: json.RawMessage(`{}`)},
+		}}}},
+		{Response: provider.ChatResponse{Content: "done", Done: true}},
+	}}
+	o := newTestOrchestrator(mc)
+	res, err := o.Run(context.Background(), Request{Goal: "q", Tools: []Tool{bigOutputTool{}}}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.StopReason != Completed {
+		t.Fatalf("stop = %v", res.StopReason)
+	}
+}
+
+// blockingTool blocks until its context is cancelled, proving the runtime enforces the timeout.
+type blockingTool struct{}
+
+func (blockingTool) Spec() ToolSpec {
+	return ToolSpec{Name: "block", Parameters: json.RawMessage(`{}`)}
+}
+func (blockingTool) Effect() Effect { return Effect{Class: Read, Timeout: 20 * time.Millisecond} }
+func (blockingTool) Invoke(ctx context.Context, _ json.RawMessage) (ToolResult, error) {
+	<-ctx.Done()
+	return ToolResult{}, ctx.Err()
+}
+
+func TestDispatchEnforcesTimeout(t *testing.T) {
+	mc := &scriptedCaller{responses: []ModelResult{
+		{Response: provider.ChatResponse{ToolCalls: []provider.ToolCall{{
+			ID: "1", Type: "function",
+			Function: provider.ToolCallFunction{Name: "block", Arguments: json.RawMessage(`{}`)},
+		}}}},
+		{Response: provider.ChatResponse{Content: "done", Done: true}},
+	}}
+	o := newTestOrchestrator(mc)
+	// The blocking tool's Invoke returns ctx.Err() (a tool error) once the per-call
+	// timeout fires; that becomes an IsError observation and the loop continues.
+	res, err := o.Run(context.Background(), Request{Goal: "q", Tools: []Tool{blockingTool{}}}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.ToolCalls) != 1 || !res.ToolCalls[0].IsError {
+		t.Fatalf("timeout must surface as an IsError observation, got %+v", res.ToolCalls)
+	}
+}
+
+// routeOutcomeObserver captures the RouteOutcome delivered to OnStep.
+type routeOutcomeObserver struct{ got *provider.RouteOutcome }
+
+func (o *routeOutcomeObserver) OnStep(_ context.Context, e StepEvent) error {
+	o.got = e.RouteOutcome
+	return nil
+}
+func (*routeOutcomeObserver) OnToolCall(context.Context, ToolCallEvent) error { return nil }
+func (*routeOutcomeObserver) OnToken(context.Context, TokenEvent) error       { return nil }
+
+func TestStepEventCarriesRouteOutcome(t *testing.T) {
+	outcome := &provider.RouteOutcome{}
+	mc := &scriptedCaller{responses: []ModelResult{
+		{Response: provider.ChatResponse{Content: "x", Done: true}, RouteOutcome: outcome},
+	}}
+	o := newTestOrchestrator(mc)
+	obs := &routeOutcomeObserver{}
+	if _, err := o.Run(context.Background(), Request{Goal: "q"}, obs); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if obs.got != outcome {
+		t.Fatal("StepEvent.RouteOutcome must carry the captured route outcome")
+	}
+}

--- a/agent/dispatch.go
+++ b/agent/dispatch.go
@@ -22,9 +22,10 @@ func (o *Orchestrator) runToolCalls(ctx context.Context, res *Result, state *Sta
 		res.Events = append(res.Events, EventRecord{Step: step, Kind: "tool_result"})
 		state.Messages = append(state.Messages, toolObservation(call, out))
 		gov.observe(call, out)
-	}
-	if sr, tripped := gov.stopReason(); tripped {
-		res.StopReason = sr
+		if sr, tripped := gov.stopReason(); tripped {
+			res.StopReason = sr
+			return nil
+		}
 	}
 	return nil
 }

--- a/agent/dispatch.go
+++ b/agent/dispatch.go
@@ -1,0 +1,114 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+func (o *Orchestrator) runToolCalls(ctx context.Context, res *Result, state *State,
+	reg *toolRegistry, calls []provider.ToolCall, approver Approver, obs Observer, step int,
+	gov *restraintGovernor) error {
+
+	for _, call := range calls {
+		res.Events = append(res.Events, EventRecord{Step: step, Kind: "tool_call"})
+		out, rec, err := o.dispatch(ctx, reg, call, approver, obs, step)
+		if err != nil {
+			return err
+		}
+		res.ToolCalls = append(res.ToolCalls, rec)
+		res.Events = append(res.Events, EventRecord{Step: step, Kind: "tool_result"})
+		state.Messages = append(state.Messages, toolObservation(call, out))
+		gov.observe(call, out)
+	}
+	if gov.tripped() {
+		res.StopReason = ToolErrorCapReached
+	}
+	return nil
+}
+
+func (o *Orchestrator) dispatch(ctx context.Context, reg *toolRegistry, call provider.ToolCall,
+	approver Approver, obs Observer, step int) (ToolResult, ToolCallRecord, error) {
+
+	name := call.Function.Name
+	rec := ToolCallRecord{Step: step, Name: name}
+
+	tool, ok := reg.lookup(name)
+	if !ok {
+		rec.IsError = true
+		return ToolResult{IsError: true, Content: "unknown tool: " + name}, rec, nil
+	}
+	if !json.Valid(call.Function.Arguments) {
+		rec.IsError = true
+		return ToolResult{IsError: true, Content: "malformed tool arguments (not valid JSON)"}, rec, nil
+	}
+
+	effect := tool.Effect()
+	var preview string
+	if pt, ok := tool.(PlanningTool); ok {
+		plan, err := pt.Plan(ctx, call.Function.Arguments)
+		if err != nil {
+			rec.IsError = true
+			return ToolResult{IsError: true, Content: "plan failed: " + err.Error()}, rec, nil
+		}
+		effect, preview = plan.Effect, plan.Preview
+	}
+	effect = normalizeEffect(effect)
+
+	if needsApproval(effect.Approval, effect.Class) {
+		ok, err := approve(ctx, approver, call, preview)
+		if err != nil {
+			return ToolResult{}, rec, err // ctx cancel / approver failure propagates
+		}
+		if !ok {
+			rec.IsError, rec.Denied = true, true
+			return ToolResult{IsError: true, Content: "tool call denied by approver"}, rec, nil
+		}
+	}
+
+	if err := obs.OnToolCall(ctx, ToolCallEvent{Step: step, Call: call, Effect: effect, Preview: preview}); err != nil {
+		return ToolResult{}, rec, err
+	}
+
+	cctx, cancel := context.WithTimeout(ctx, effect.Timeout)
+	defer cancel()
+	out, err := tool.Invoke(cctx, call.Function.Arguments)
+	if err != nil {
+		rec.IsError = true
+		return ToolResult{IsError: true, Content: err.Error()}, rec, nil
+	}
+	out = capOutput(out, effect.OutputCap)
+	rec.IsError = out.IsError
+	return out, rec, nil
+}
+
+// approve applies the fail-safe: a nil approver denies any call that reaches it
+// (read-only tools never reach it because needsApproval is false for them).
+func approve(ctx context.Context, approver Approver, call provider.ToolCall, preview string) (bool, error) {
+	if approver == nil {
+		return false, nil
+	}
+	return approver.Approve(ctx, call, preview)
+}
+
+func capOutput(r ToolResult, cap int) ToolResult {
+	if cap > 0 && len(r.Content) > cap {
+		r.Content = r.Content[:cap]
+		r.Truncated = true
+	}
+	return r
+}
+
+func toolObservation(call provider.ToolCall, r ToolResult) Message {
+	return Message{
+		ChatMessage: provider.ChatMessage{
+			Role:       "tool",
+			Content:    r.Content,
+			ToolName:   call.Function.Name,
+			ToolCallID: call.ID,
+		},
+		Segment: Elastic,
+		Attrib:  r.Attrib,
+	}
+}

--- a/agent/dispatch.go
+++ b/agent/dispatch.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"unicode/utf8"
 
 	"github.com/kstruzzieri/go-llm/provider"
 )
@@ -92,9 +93,14 @@ func approve(ctx context.Context, approver Approver, call provider.ToolCall, pre
 	return approver.Approve(ctx, call, preview)
 }
 
-func capOutput(r ToolResult, cap int) ToolResult {
-	if cap > 0 && len(r.Content) > cap {
-		r.Content = r.Content[:cap]
+func capOutput(r ToolResult, limit int) ToolResult {
+	if limit > 0 && len(r.Content) > limit {
+		end := limit
+		// back up to a UTF-8 rune boundary so we never emit a split rune
+		for end > 0 && !utf8.RuneStart(r.Content[end]) {
+			end--
+		}
+		r.Content = r.Content[:end]
 		r.Truncated = true
 	}
 	return r

--- a/agent/dispatch.go
+++ b/agent/dispatch.go
@@ -23,8 +23,8 @@ func (o *Orchestrator) runToolCalls(ctx context.Context, res *Result, state *Sta
 		state.Messages = append(state.Messages, toolObservation(call, out))
 		gov.observe(call, out)
 	}
-	if gov.tripped() {
-		res.StopReason = ToolErrorCapReached
+	if sr, tripped := gov.stopReason(); tripped {
+		res.StopReason = sr
 	}
 	return nil
 }

--- a/agent/dispatch_test.go
+++ b/agent/dispatch_test.go
@@ -1,0 +1,61 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+type echoTool struct{ name string }
+
+func (e echoTool) Spec() ToolSpec {
+	return ToolSpec{Name: e.name, Parameters: json.RawMessage(`{"type":"object"}`)}
+}
+func (echoTool) Effect() Effect { return Effect{Class: Read, Approval: ApprovalNever} }
+func (echoTool) Invoke(_ context.Context, args json.RawMessage) (ToolResult, error) {
+	return ToolResult{Content: "tool-said:" + string(args)}, nil
+}
+
+func TestRunDispatchesToolThenAnswers(t *testing.T) {
+	mc := &scriptedCaller{responses: []ModelResult{
+		{Response: provider.ChatResponse{ToolCalls: []provider.ToolCall{{
+			ID: "1", Type: "function",
+			Function: provider.ToolCallFunction{Name: "echo", Arguments: json.RawMessage(`{"x":1}`)},
+		}}}},
+		{Response: provider.ChatResponse{Content: "done", Done: true}},
+	}}
+	o := newTestOrchestrator(mc)
+	res, err := o.Run(context.Background(), Request{Goal: "q", Tools: []Tool{echoTool{name: "echo"}}}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Answer != "done" || res.StopReason != Completed {
+		t.Fatalf("got answer=%q stop=%v", res.Answer, res.StopReason)
+	}
+	if len(res.ToolCalls) != 1 || res.ToolCalls[0].Name != "echo" || res.ToolCalls[0].IsError {
+		t.Fatalf("expected one successful echo call, got %+v", res.ToolCalls)
+	}
+	if len(res.Events) < 4 || res.Events[1].Kind != "tool_call" || res.Events[2].Kind != "tool_result" {
+		t.Fatalf("expected ordered tool_call/tool_result events, got %+v", res.Events)
+	}
+}
+
+func TestUnknownToolBecomesObservation(t *testing.T) {
+	mc := &scriptedCaller{responses: []ModelResult{
+		{Response: provider.ChatResponse{ToolCalls: []provider.ToolCall{{
+			ID: "1", Type: "function",
+			Function: provider.ToolCallFunction{Name: "nope", Arguments: json.RawMessage(`{}`)},
+		}}}},
+		{Response: provider.ChatResponse{Content: "recovered", Done: true}},
+	}}
+	o := newTestOrchestrator(mc)
+	res, err := o.Run(context.Background(), Request{Goal: "q"}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Answer != "recovered" || !res.ToolCalls[0].IsError {
+		t.Fatalf("unknown tool must yield IsError observation, got %+v", res.ToolCalls)
+	}
+}

--- a/agent/doc.go
+++ b/agent/doc.go
@@ -13,4 +13,16 @@
 //
 // Retrieval is a Tool (see agent/tools.Retrieve), never a hardcoded stage.
 // Provider selection, scoring, and budgeting stay in the provider layer.
+//
+// Resource use and contracts:
+//
+//   - Result.Steps, Result.Events, and the internal transcript grow with the
+//     number of steps taken (bounded by Request.MaxSteps). Each StepRecord
+//     retains the full provider.ChatResponse for that turn; consumers that set
+//     a large MaxSteps should budget memory accordingly.
+//   - Token counts are approximate: the ContextManager re-estimates the
+//     transcript each turn with a len/4 heuristic, not the provider's exact
+//     tokenization.
+//   - Effect.Scope is advisory; the runtime does not enforce path/cwd limits.
+//     A tool must enforce its own scope.
 package agent

--- a/agent/doc.go
+++ b/agent/doc.go
@@ -1,0 +1,16 @@
+// Package agent implements the go-llm agent runtime: a dynamic
+// plan -> act -> observe loop driven by local models through provider.Router.
+//
+// The loop is the Orchestrator. Run is the blocking primitive; an Observer
+// receives serial, in-order callbacks for live output. Five seams have working
+// defaults and accept injected replacements:
+//
+//   - Observer     — live deltas (OnStep / OnToolCall / OnToken)
+//   - ModelCaller  — the model seam; NewRouterModelCaller adapts provider.Router
+//   - Tool         — effect-aware unit; optional PlanningTool for pre-invoke gating
+//   - Compactor    — RecencyCompactor fits the transcript to the token budget
+//   - token estimator — conversation.TokenEstimator (len/4 default)
+//
+// Retrieval is a Tool (see agent/tools.Retrieve), never a hardcoded stage.
+// Provider selection, scoring, and budgeting stay in the provider layer.
+package agent

--- a/agent/governor_test.go
+++ b/agent/governor_test.go
@@ -168,3 +168,55 @@ func (toolCallAbortObserver) OnToolCall(context.Context, ToolCallEvent) error {
 	return errors.New("stop")
 }
 func (toolCallAbortObserver) OnToken(context.Context, TokenEvent) error { return nil }
+
+// pollingTool returns a DIFFERENT result on each call for identical args,
+// simulating a status/poll that makes progress.
+type pollingTool struct{ n int }
+
+func (*pollingTool) Spec() ToolSpec { return ToolSpec{Name: "poll", Parameters: json.RawMessage(`{}`)} }
+func (*pollingTool) Effect() Effect { return Effect{Class: Read} }
+func (p *pollingTool) Invoke(context.Context, json.RawMessage) (ToolResult, error) {
+	p.n++
+	return ToolResult{Content: fmt.Sprintf("status-%d", p.n)}, nil
+}
+
+func TestGovernorAllowsProgressingRepeatedCalls(t *testing.T) {
+	// Same tool + identical args called 5x, but each result differs (progress).
+	// Must NOT trip the governor; the run completes when the model answers.
+	resps := make([]ModelResult, 6)
+	for i := range 5 {
+		resps[i] = ModelResult{Response: provider.ChatResponse{ToolCalls: []provider.ToolCall{{
+			ID: "1", Type: "function",
+			Function: provider.ToolCallFunction{Name: "poll", Arguments: json.RawMessage(`{}`)},
+		}}}}
+	}
+	resps[5] = ModelResult{Response: provider.ChatResponse{Content: "done", Done: true}}
+	o := newTestOrchestrator(&scriptedCaller{responses: resps})
+	res, err := o.Run(context.Background(), Request{Goal: "q", MaxSteps: 10, Tools: []Tool{&pollingTool{}}}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.StopReason != Completed {
+		t.Fatalf("progressing repeats must not trip the governor, got %v", res.StopReason)
+	}
+}
+
+func TestGovernorStopsStuckIdenticalCalls(t *testing.T) {
+	// echoTool returns an identical result for identical args -> no progress ->
+	// the no-progress repeat guard trips with RepeatLimitReached (not ToolErrorCap).
+	resps := make([]ModelResult, 10)
+	for i := range resps {
+		resps[i] = ModelResult{Response: provider.ChatResponse{ToolCalls: []provider.ToolCall{{
+			ID: "1", Type: "function",
+			Function: provider.ToolCallFunction{Name: "echo", Arguments: json.RawMessage(`{}`)},
+		}}}}
+	}
+	o := newTestOrchestrator(&scriptedCaller{responses: resps})
+	res, err := o.Run(context.Background(), Request{Goal: "q", MaxSteps: 10, Tools: []Tool{echoTool{name: "echo"}}}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.StopReason != RepeatLimitReached {
+		t.Fatalf("stuck identical calls must trip RepeatLimitReached, got %v", res.StopReason)
+	}
+}

--- a/agent/governor_test.go
+++ b/agent/governor_test.go
@@ -1,0 +1,149 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+type erroringTool struct{}
+
+func (erroringTool) Spec() ToolSpec { return ToolSpec{Name: "boom", Parameters: json.RawMessage(`{}`)} }
+func (erroringTool) Effect() Effect { return Effect{Class: Read} }
+func (erroringTool) Invoke(context.Context, json.RawMessage) (ToolResult, error) {
+	return ToolResult{}, errors.New("kaboom")
+}
+
+func loopToolCall() provider.ChatResponse {
+	return provider.ChatResponse{ToolCalls: []provider.ToolCall{{
+		ID: "1", Type: "function",
+		Function: provider.ToolCallFunction{Name: "boom", Arguments: json.RawMessage(`{}`)},
+	}}}
+}
+
+func TestConsecutiveToolErrorsStop(t *testing.T) {
+	// model keeps calling the failing tool forever.
+	resps := make([]ModelResult, 10)
+	for i := range resps {
+		resps[i] = ModelResult{Response: loopToolCall()}
+	}
+	mc := &scriptedCaller{responses: resps}
+	o := newTestOrchestrator(mc)
+	res, err := o.Run(context.Background(), Request{Goal: "q", Tools: []Tool{erroringTool{}}}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.StopReason != ToolErrorCapReached {
+		t.Fatalf("stop = %v, want ToolErrorCapReached", res.StopReason)
+	}
+}
+
+func TestStepCapStop(t *testing.T) {
+	// non-failing tool, distinct args each step (so the repeat governor does not
+	// trip); the model never answers, so MaxSteps must bound the loop.
+	resps := make([]ModelResult, 10)
+	for i := range resps {
+		resps[i] = ModelResult{Response: provider.ChatResponse{ToolCalls: []provider.ToolCall{{
+			ID: "1", Type: "function",
+			Function: provider.ToolCallFunction{
+				Name: "echo", Arguments: json.RawMessage(fmt.Sprintf(`{"i":%d}`, i)),
+			},
+		}}}}
+	}
+	mc := &scriptedCaller{responses: resps}
+	o := newTestOrchestrator(mc)
+	res, err := o.Run(context.Background(), Request{Goal: "q", MaxSteps: 3, Tools: []Tool{echoTool{name: "echo"}}}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.StopReason != StepCapReached {
+		t.Fatalf("stop = %v, want StepCapReached", res.StopReason)
+	}
+}
+
+func TestBudgetCapStop(t *testing.T) {
+	// each tool turn reports 50 tokens; TotalTokens cap of 60 trips after step 1.
+	resps := make([]ModelResult, 10)
+	for i := range resps {
+		resps[i] = ModelResult{Response: provider.ChatResponse{
+			Usage: provider.Usage{TotalTokens: 50},
+			ToolCalls: []provider.ToolCall{{
+				ID: "1", Type: "function",
+				Function: provider.ToolCallFunction{
+					Name: "echo", Arguments: json.RawMessage(fmt.Sprintf(`{"i":%d}`, i)),
+				},
+			}},
+		}}
+	}
+	mc := &scriptedCaller{responses: resps}
+	o := newTestOrchestrator(mc)
+	res, err := o.Run(context.Background(), Request{
+		Goal: "q", Budget: Budget{TotalTokens: 60}, Tools: []Tool{echoTool{name: "echo"}},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.StopReason != BudgetReached {
+		t.Fatalf("stop = %v, want BudgetReached", res.StopReason)
+	}
+}
+
+func TestObserverStepErrorAborts(t *testing.T) {
+	mc := &scriptedCaller{responses: []ModelResult{
+		{Response: provider.ChatResponse{Content: "x", Done: true}},
+	}}
+	o := newTestOrchestrator(mc)
+	_, err := o.Run(context.Background(), Request{Goal: "q"}, stepAbortObserver{})
+	if err == nil {
+		t.Fatal("OnStep error must abort Run")
+	}
+}
+
+func TestObserverTokenErrorAborts(t *testing.T) {
+	mc := &scriptedCaller{responses: []ModelResult{
+		{Response: provider.ChatResponse{Content: "streamed", Done: true}},
+	}}
+	o := newTestOrchestrator(mc)
+	_, err := o.Run(context.Background(), Request{Goal: "q"}, tokenAbortObserver{})
+	if err == nil {
+		t.Fatal("OnToken error must abort Run")
+	}
+}
+
+func TestObserverToolCallErrorAborts(t *testing.T) {
+	mc := &scriptedCaller{responses: []ModelResult{
+		{Response: provider.ChatResponse{ToolCalls: []provider.ToolCall{{
+			ID: "1", Type: "function",
+			Function: provider.ToolCallFunction{Name: "echo", Arguments: json.RawMessage(`{}`)},
+		}}}},
+	}}
+	o := newTestOrchestrator(mc)
+	_, err := o.Run(context.Background(), Request{Goal: "q", Tools: []Tool{echoTool{name: "echo"}}}, toolCallAbortObserver{})
+	if err == nil {
+		t.Fatal("OnToolCall error must abort Run")
+	}
+}
+
+type stepAbortObserver struct{}
+
+func (stepAbortObserver) OnStep(context.Context, StepEvent) error         { return errors.New("stop") }
+func (stepAbortObserver) OnToolCall(context.Context, ToolCallEvent) error { return nil }
+func (stepAbortObserver) OnToken(context.Context, TokenEvent) error       { return nil }
+
+type tokenAbortObserver struct{}
+
+func (tokenAbortObserver) OnStep(context.Context, StepEvent) error         { return nil }
+func (tokenAbortObserver) OnToolCall(context.Context, ToolCallEvent) error { return nil }
+func (tokenAbortObserver) OnToken(context.Context, TokenEvent) error       { return errors.New("stop") }
+
+type toolCallAbortObserver struct{}
+
+func (toolCallAbortObserver) OnStep(context.Context, StepEvent) error { return nil }
+func (toolCallAbortObserver) OnToolCall(context.Context, ToolCallEvent) error {
+	return errors.New("stop")
+}
+func (toolCallAbortObserver) OnToken(context.Context, TokenEvent) error { return nil }

--- a/agent/governor_test.go
+++ b/agent/governor_test.go
@@ -92,6 +92,27 @@ func TestBudgetCapStop(t *testing.T) {
 	}
 }
 
+func TestBudgetCapStopOnFinalAnswer(t *testing.T) {
+	mc := &scriptedCaller{responses: []ModelResult{
+		{Response: provider.ChatResponse{
+			Content: "final",
+			Done:    true,
+			Usage:   provider.Usage{TotalTokens: 75},
+		}},
+	}}
+	o := newTestOrchestrator(mc)
+	res, err := o.Run(context.Background(), Request{Goal: "q", Budget: Budget{TotalTokens: 60}}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Answer != "final" {
+		t.Fatalf("answer = %q, want final", res.Answer)
+	}
+	if res.StopReason != BudgetReached {
+		t.Fatalf("stop = %v, want BudgetReached", res.StopReason)
+	}
+}
+
 func TestObserverStepErrorAborts(t *testing.T) {
 	mc := &scriptedCaller{responses: []ModelResult{
 		{Response: provider.ChatResponse{Content: "x", Done: true}},

--- a/agent/governor_test.go
+++ b/agent/governor_test.go
@@ -169,6 +169,48 @@ func (toolCallAbortObserver) OnToolCall(context.Context, ToolCallEvent) error {
 }
 func (toolCallAbortObserver) OnToken(context.Context, TokenEvent) error { return nil }
 
+type countingTool struct{ n int }
+
+func (*countingTool) Spec() ToolSpec {
+	return ToolSpec{Name: "count", Parameters: json.RawMessage(`{}`)}
+}
+func (*countingTool) Effect() Effect { return Effect{Class: Read} }
+func (c *countingTool) Invoke(context.Context, json.RawMessage) (ToolResult, error) {
+	c.n++
+	return ToolResult{Content: "same-result"}, nil
+}
+
+func TestGovernorStopsDispatchingWithinToolCallBatch(t *testing.T) {
+	calls := make([]provider.ToolCall, defaultToolErrorCap+2)
+	for i := range calls {
+		calls[i] = provider.ToolCall{
+			ID:   fmt.Sprintf("%d", i),
+			Type: "function",
+			Function: provider.ToolCallFunction{
+				Name:      "count",
+				Arguments: json.RawMessage(`{}`),
+			},
+		}
+	}
+	tool := &countingTool{}
+	o := newTestOrchestrator(&scriptedCaller{responses: []ModelResult{
+		{Response: provider.ChatResponse{ToolCalls: calls}},
+	}})
+	res, err := o.Run(context.Background(), Request{Goal: "q", Tools: []Tool{tool}}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if tool.n != defaultToolErrorCap {
+		t.Fatalf("invocations = %d, want %d", tool.n, defaultToolErrorCap)
+	}
+	if len(res.ToolCalls) != defaultToolErrorCap {
+		t.Fatalf("tool call records = %d, want %d", len(res.ToolCalls), defaultToolErrorCap)
+	}
+	if res.StopReason != RepeatLimitReached {
+		t.Fatalf("stop = %v, want RepeatLimitReached", res.StopReason)
+	}
+}
+
 // pollingTool returns a DIFFERENT result on each call for identical args,
 // simulating a status/poll that makes progress.
 type pollingTool struct{ n int }

--- a/agent/hardening_test.go
+++ b/agent/hardening_test.go
@@ -1,0 +1,74 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+func TestNewToolRegistryRejectsNilTool(t *testing.T) {
+	if _, err := newToolRegistry([]Tool{nil}); err == nil {
+		t.Fatal("nil tool must error, not panic")
+	}
+}
+
+func TestRunRejectsEmptyGoal(t *testing.T) {
+	o := newTestOrchestrator(&scriptedCaller{})
+	if _, err := o.Run(context.Background(), Request{Goal: ""}, nil); err == nil {
+		t.Fatal("empty goal must error")
+	}
+}
+
+type capturingCaller struct {
+	got  provider.ChatRequest
+	resp ModelResult
+}
+
+func (c *capturingCaller) Chat(_ context.Context, req provider.ChatRequest,
+	_ func(provider.ChatResponse) error) (ModelResult, error) {
+	c.got = req
+	return c.resp, nil
+}
+
+func TestRunWiresOutputReserveToNumPredict(t *testing.T) {
+	cc := &capturingCaller{resp: ModelResult{Response: provider.ChatResponse{Content: "done", Done: true}}}
+	o := New(cc, ContextManager{Compactor: RecencyCompactor{Estimate: runeEstimator}, Estimate: runeEstimator})
+	if _, err := o.Run(context.Background(), Request{Goal: "q", Budget: Budget{OutputReserve: 256}}, nil); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if cc.got.Options.NumPredict != 256 {
+		t.Fatalf("NumPredict = %d, want 256 (OutputReserve must be forwarded)", cc.got.Options.NumPredict)
+	}
+}
+
+type multiChunkCaller struct{}
+
+func (multiChunkCaller) Chat(_ context.Context, _ provider.ChatRequest,
+	onToken func(provider.ChatResponse) error) (ModelResult, error) {
+	for _, c := range []string{"a", "b", "c"} {
+		if onToken != nil {
+			if err := onToken(provider.ChatResponse{Content: c}); err != nil {
+				return ModelResult{}, err
+			}
+		}
+	}
+	return ModelResult{Response: provider.ChatResponse{Content: "abc", Done: true}}, nil
+}
+
+func TestRunBoundsTokenEventsPerStep(t *testing.T) {
+	o := New(multiChunkCaller{}, ContextManager{Compactor: RecencyCompactor{Estimate: runeEstimator}, Estimate: runeEstimator})
+	res, err := o.Run(context.Background(), Request{Goal: "q"}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	n := 0
+	for _, e := range res.Events {
+		if e.Kind == "token" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("want exactly 1 token event for a single streaming step, got %d", n)
+	}
+}

--- a/agent/loop_e2e_test.go
+++ b/agent/loop_e2e_test.go
@@ -1,0 +1,68 @@
+package agent_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/agent"
+	"github.com/kstruzzieri/go-llm/agent/agenttest"
+	"github.com/kstruzzieri/go-llm/agent/tools"
+	"github.com/kstruzzieri/go-llm/provider"
+	"github.com/kstruzzieri/go-llm/rag"
+)
+
+type scripted struct {
+	responses []agent.ModelResult
+	calls     int
+}
+
+func (s *scripted) Chat(_ context.Context, _ provider.ChatRequest,
+	onToken func(provider.ChatResponse) error) (agent.ModelResult, error) {
+	r := s.responses[s.calls]
+	s.calls++
+	if onToken != nil && r.Response.Content != "" {
+		if err := onToken(provider.ChatResponse{Content: r.Response.Content}); err != nil {
+			return agent.ModelResult{}, err
+		}
+	}
+	return r, nil
+}
+
+type fakeRetriever struct{}
+
+func (fakeRetriever) Retrieve(context.Context, string, int) ([]rag.SearchResult, error) {
+	return []rag.SearchResult{{Chunk: rag.Chunk{StableKey: "k", Content: "ctx"}, Score: 1}}, nil
+}
+func (fakeRetriever) BuildContext([]rag.SearchResult, int) string { return "ctx" }
+
+func TestEndToEndRetrieveThenAnswer(t *testing.T) {
+	mc := &scripted{responses: []agent.ModelResult{
+		{Response: provider.ChatResponse{ToolCalls: []provider.ToolCall{{
+			ID: "1", Type: "function",
+			Function: provider.ToolCallFunction{Name: "retrieve", Arguments: json.RawMessage(`{"query":"x"}`)},
+		}}}},
+		{Response: provider.ChatResponse{Content: "final", Done: true}},
+	}}
+	o := agent.New(mc, agent.ContextManager{
+		Compactor: agent.RecencyCompactor{},
+	})
+	rec := &agenttest.RecorderObserver{}
+	res, err := o.Run(context.Background(), agent.Request{
+		Goal:  "explain x",
+		Tools: []agent.Tool{tools.Retrieve{R: fakeRetriever{}, K: 3}},
+	}, rec)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Answer != "final" || res.StopReason != agent.Completed {
+		t.Fatalf("got answer=%q stop=%v", res.Answer, res.StopReason)
+	}
+	// observer saw: step (tool turn), tool_call, token, step (final turn).
+	if len(rec.Kinds) < 4 || rec.Kinds[0] != "step" || rec.Kinds[1] != "tool_call" || rec.Kinds[2] != "token" {
+		t.Fatalf("unexpected event order: %v", rec.Kinds)
+	}
+	if len(res.ToolCalls) != 1 || res.ToolCalls[0].Name != "retrieve" {
+		t.Fatalf("expected one retrieve call: %+v", res.ToolCalls)
+	}
+}

--- a/agent/model_caller.go
+++ b/agent/model_caller.go
@@ -1,0 +1,74 @@
+package agent
+
+import (
+	"context"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// ModelCaller is the model seam. The default adapter routes the "agent"
+// use-case through provider.Router; tests inject a fake.
+type ModelCaller interface {
+	Chat(ctx context.Context, req provider.ChatRequest,
+		onToken func(provider.ChatResponse) error) (ModelResult, error)
+}
+
+// ModelResult is the accumulated response plus captured route telemetry.
+type ModelResult struct {
+	Response     provider.ChatResponse
+	RouteOutcome *provider.RouteOutcome
+}
+
+// planExecutor is the minimal slice of *provider.RoutePlan the adapter needs;
+// abstracting it lets tests fake the streaming execution.
+type planExecutor interface {
+	ExecuteChatStream(ctx context.Context, fn func(provider.ChatResponse) error) error
+}
+
+type routerModelCaller struct {
+	route func(ctx context.Context, rr provider.RoutingRequest) (planExecutor, error)
+}
+
+// NewRouterModelCaller wires the default adapter to a concrete provider.Router.
+func NewRouterModelCaller(r *provider.Router) ModelCaller {
+	return &routerModelCaller{
+		route: func(ctx context.Context, rr provider.RoutingRequest) (planExecutor, error) {
+			return r.Route(ctx, rr)
+		},
+	}
+}
+
+func (m *routerModelCaller) Chat(ctx context.Context, req provider.ChatRequest,
+	onToken func(provider.ChatResponse) error) (ModelResult, error) {
+
+	rr := provider.RoutingRequest{
+		UseCase:      "agent",
+		Messages:     req.Messages,
+		Tools:        req.Tools,
+		Options:      req.Options,
+		RequiredCaps: provider.CapChat | provider.CapStream,
+	}
+	if len(req.Tools) > 0 {
+		rr.RequiredCaps |= provider.CapToolCall
+	}
+
+	plan, err := m.route(ctx, rr)
+	if err != nil {
+		return ModelResult{}, err
+	}
+
+	var outcome *provider.RouteOutcome
+	wrapped, getFinal := provider.Collect(func(chunk provider.ChatResponse) error {
+		if chunk.RouteOutcome != nil {
+			outcome = chunk.RouteOutcome
+		}
+		if onToken != nil {
+			return onToken(chunk)
+		}
+		return nil
+	})
+	execErr := plan.ExecuteChatStream(ctx, wrapped)
+	final := getFinal()
+	final.RouteOutcome = outcome
+	return ModelResult{Response: final, RouteOutcome: outcome}, execErr
+}

--- a/agent/model_caller.go
+++ b/agent/model_caller.go
@@ -42,11 +42,12 @@ func (m *routerModelCaller) Chat(ctx context.Context, req provider.ChatRequest,
 	onToken func(provider.ChatResponse) error) (ModelResult, error) {
 
 	rr := provider.RoutingRequest{
-		UseCase:      "agent",
-		Messages:     req.Messages,
-		Tools:        req.Tools,
-		Options:      req.Options,
-		RequiredCaps: provider.CapChat | provider.CapStream,
+		UseCase:        "agent",
+		Messages:       req.Messages,
+		Tools:          req.Tools,
+		Options:        req.Options,
+		ExpectedOutput: req.Options.NumPredict,
+		RequiredCaps:   provider.CapChat | provider.CapStream,
 	}
 	if len(req.Tools) > 0 {
 		rr.RequiredCaps |= provider.CapToolCall

--- a/agent/model_caller_test.go
+++ b/agent/model_caller_test.go
@@ -68,3 +68,21 @@ func TestRouterModelCallerAddsToolCapWhenToolsPresent(t *testing.T) {
 		t.Fatal("CapToolCall must be required when tools are present")
 	}
 }
+
+func TestRouterModelCallerUsesNumPredictAsExpectedOutput(t *testing.T) {
+	var gotReq provider.RoutingRequest
+	mc := &routerModelCaller{
+		route: func(_ context.Context, rr provider.RoutingRequest) (planExecutor, error) {
+			gotReq = rr
+			return fakePlan{}, nil
+		},
+	}
+	_, err := mc.Chat(context.Background(),
+		provider.ChatRequest{Options: provider.ModelOptions{NumPredict: 256}}, nil)
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if gotReq.ExpectedOutput != 256 {
+		t.Fatalf("ExpectedOutput = %d, want 256", gotReq.ExpectedOutput)
+	}
+}

--- a/agent/model_caller_test.go
+++ b/agent/model_caller_test.go
@@ -1,0 +1,70 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// fakePlan emits two content deltas then a Done chunk carrying RouteOutcome.
+type fakePlan struct {
+	outcome *provider.RouteOutcome
+}
+
+func (p fakePlan) ExecuteChatStream(_ context.Context, fn func(provider.ChatResponse) error) error {
+	if err := fn(provider.ChatResponse{Content: "Hel"}); err != nil {
+		return err
+	}
+	if err := fn(provider.ChatResponse{Content: "lo"}); err != nil {
+		return err
+	}
+	return fn(provider.ChatResponse{Done: true, RouteOutcome: p.outcome})
+}
+
+func TestRouterModelCallerCapturesRouteOutcomeAndStreams(t *testing.T) {
+	outcome := &provider.RouteOutcome{}
+	mc := &routerModelCaller{
+		route: func(context.Context, provider.RoutingRequest) (planExecutor, error) {
+			return fakePlan{outcome: outcome}, nil
+		},
+	}
+	var streamed string
+	res, err := mc.Chat(context.Background(), provider.ChatRequest{}, func(c provider.ChatResponse) error {
+		streamed += c.Content
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if streamed != "Hello" {
+		t.Fatalf("streamed = %q, want %q", streamed, "Hello")
+	}
+	if res.Response.Content != "Hello" {
+		t.Fatalf("final content = %q, want accumulated 'Hello'", res.Response.Content)
+	}
+	if res.RouteOutcome != outcome {
+		t.Fatal("RouteOutcome must be captured from the Done chunk")
+	}
+}
+
+func TestRouterModelCallerAddsToolCapWhenToolsPresent(t *testing.T) {
+	var gotReq provider.RoutingRequest
+	mc := &routerModelCaller{
+		route: func(_ context.Context, rr provider.RoutingRequest) (planExecutor, error) {
+			gotReq = rr
+			return fakePlan{}, nil
+		},
+	}
+	_, err := mc.Chat(context.Background(),
+		provider.ChatRequest{Tools: []provider.Tool{{Type: "function"}}}, nil)
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if gotReq.UseCase != "agent" {
+		t.Fatalf("UseCase = %q, want agent", gotReq.UseCase)
+	}
+	if gotReq.RequiredCaps&provider.CapToolCall == 0 {
+		t.Fatal("CapToolCall must be required when tools are present")
+	}
+}

--- a/agent/observer.go
+++ b/agent/observer.go
@@ -1,0 +1,51 @@
+package agent
+
+import (
+	"context"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// Observer receives live deltas during Run. Callbacks are invoked serially in
+// loop order, in the calling goroutine; returning an error aborts Run and
+// propagates. Result is the canonical final state.
+type Observer interface {
+	OnStep(ctx context.Context, e StepEvent) error
+	OnToolCall(ctx context.Context, e ToolCallEvent) error
+	OnToken(ctx context.Context, e TokenEvent) error
+}
+
+// StepEvent reports a completed model turn.
+type StepEvent struct {
+	Index        int
+	Response     provider.ChatResponse
+	RouteOutcome *provider.RouteOutcome
+	Pressure     Pressure
+}
+
+// ToolCallEvent reports a tool about to be invoked (post-approval).
+type ToolCallEvent struct {
+	Step    int
+	Call    provider.ToolCall
+	Effect  Effect
+	Preview string
+}
+
+// TokenEvent reports a streamed content delta from the model.
+type TokenEvent struct {
+	Step    int
+	Content string
+}
+
+type nopObserver struct{}
+
+func (nopObserver) OnStep(context.Context, StepEvent) error         { return nil }
+func (nopObserver) OnToolCall(context.Context, ToolCallEvent) error { return nil }
+func (nopObserver) OnToken(context.Context, TokenEvent) error       { return nil }
+
+func normalizeObserver(o Observer) Observer {
+	if o == nil {
+		return nopObserver{}
+	}
+	return o
+}

--- a/agent/observer_test.go
+++ b/agent/observer_test.go
@@ -1,0 +1,22 @@
+package agent
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNormalizeObserverNilIsNoop(t *testing.T) {
+	obs := normalizeObserver(nil)
+	if obs == nil {
+		t.Fatal("normalizeObserver(nil) must return a non-nil no-op")
+	}
+	if err := obs.OnStep(context.Background(), StepEvent{}); err != nil {
+		t.Fatalf("no-op OnStep must not error: %v", err)
+	}
+	if err := obs.OnToolCall(context.Background(), ToolCallEvent{}); err != nil {
+		t.Fatalf("no-op OnToolCall must not error: %v", err)
+	}
+	if err := obs.OnToken(context.Background(), TokenEvent{}); err != nil {
+		t.Fatalf("no-op OnToken must not error: %v", err)
+	}
+}

--- a/agent/orchestrator.go
+++ b/agent/orchestrator.go
@@ -1,0 +1,152 @@
+package agent
+
+import (
+	"context"
+	"errors"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// Orchestrator runs the plan->act->observe loop.
+type Orchestrator struct {
+	model  ModelCaller
+	ctxMgr ContextManager
+}
+
+// New constructs an Orchestrator from a ModelCaller and ContextManager.
+func New(model ModelCaller, ctxMgr ContextManager) *Orchestrator {
+	return &Orchestrator{model: model, ctxMgr: normalizeContextManager(ctxMgr)}
+}
+
+func initState(req Request) State {
+	return State{
+		System: req.System,
+		Messages: []Message{
+			{ChatMessage: provider.ChatMessage{Role: "user", Content: req.Goal}, Segment: Pinned},
+		},
+	}
+}
+
+func buildChatRequest(st State, specs []provider.Tool) provider.ChatRequest {
+	msgs := make([]provider.ChatMessage, 0, len(st.Messages)+1)
+	if st.System != "" {
+		msgs = append(msgs, provider.ChatMessage{Role: "system", Content: st.System})
+	}
+	for _, m := range st.Messages {
+		msgs = append(msgs, m.ChatMessage)
+	}
+	return provider.ChatRequest{Messages: msgs, Tools: specs, Stream: true}
+}
+
+// Run executes the loop until the model produces a final answer or a cap is hit.
+func (o *Orchestrator) Run(ctx context.Context, req Request, obs Observer) (Result, error) {
+	obs = normalizeObserver(obs)
+	maxSteps := req.MaxSteps
+	if maxSteps <= 0 {
+		maxSteps = defaultMaxSteps
+	}
+	reg, err := newToolRegistry(req.Tools)
+	if err != nil {
+		return Result{}, err
+	}
+	specs := reg.providerSpecs()
+	toolSchemaTokens := o.ctxMgr.estimate(toolSchemaString(specs))
+	budget := turnBudget(req.Budget)
+
+	state := initState(req)
+	gov := &restraintGovernor{} // per-Run loop state; never shared across Run calls
+	var res Result
+
+	for step := 0; step < maxSteps; step++ {
+		assembled, pressure, err := o.ctxMgr.Assemble(ctx, state, toolSchemaTokens, budget)
+		if err != nil {
+			return res, err
+		}
+
+		modelResult, err := o.model.Chat(ctx, buildChatRequest(assembled, specs), func(c provider.ChatResponse) error {
+			if c.Content == "" {
+				return nil
+			}
+			res.Events = append(res.Events, EventRecord{Step: step, Kind: "token"})
+			return obs.OnToken(ctx, TokenEvent{Step: step, Content: c.Content})
+		})
+		if err != nil {
+			return res, err
+		}
+		resp := modelResult.Response
+
+		res.Steps = append(res.Steps, StepRecord{
+			Index: step, Response: resp, RouteOutcome: modelResult.RouteOutcome, Pressure: pressure,
+		})
+		res.Events = append(res.Events, EventRecord{Step: step, Kind: "step"})
+		res.Usage = addUsage(res.Usage, resp.Usage)
+		if err := obs.OnStep(ctx, StepEvent{
+			Index: step, Response: resp, RouteOutcome: modelResult.RouteOutcome, Pressure: pressure,
+		}); err != nil {
+			return res, err
+		}
+
+		if len(resp.ToolCalls) == 0 {
+			res.Answer = resp.Content
+			res.StopReason = Completed
+			res.Events = append(res.Events, EventRecord{Step: step, Kind: "stop"})
+			return res, nil
+		}
+
+		// Tool dispatch is implemented in Task 8.
+		state.Messages = append(state.Messages, assistantMessage(resp))
+		if err := o.runToolCalls(ctx, &res, &state, reg, resp.ToolCalls, req.Approver, obs, step, gov); err != nil {
+			return res, err
+		}
+		if res.StopReason == ToolErrorCapReached || res.StopReason == BudgetReached {
+			res.Events = append(res.Events, EventRecord{Step: step, Kind: "stop"})
+			return res, nil
+		}
+	}
+	res.StopReason = StepCapReached
+	res.Events = append(res.Events, EventRecord{Step: maxSteps, Kind: "stop"})
+	return res, nil
+}
+
+func assistantMessage(resp provider.ChatResponse) Message {
+	return Message{ChatMessage: provider.ChatMessage{
+		Role: "assistant", Content: resp.Content, ToolCalls: resp.ToolCalls,
+	}, Segment: Elastic}
+}
+
+func addUsage(a, b provider.Usage) provider.Usage {
+	a.PromptTokens += b.PromptTokens
+	a.CompletionTokens += b.CompletionTokens
+	a.TotalTokens += b.TotalTokens
+	return a
+}
+
+func toolSchemaString(specs []provider.Tool) string {
+	s := ""
+	for _, sp := range specs {
+		s += sp.Function.Name + sp.Function.Description + string(sp.Function.Parameters)
+	}
+	return s
+}
+
+// restraintGovernor bounds runaway loops with a weak local model. Per-Run state.
+type restraintGovernor struct {
+	consecutiveErrors int
+}
+
+func (g *restraintGovernor) observe(_ provider.ToolCall, out ToolResult) {
+	if out.IsError {
+		g.consecutiveErrors++
+	} else {
+		g.consecutiveErrors = 0
+	}
+}
+
+func (g *restraintGovernor) tripped() bool { return g.consecutiveErrors >= defaultToolErrorCap }
+
+var errToolDispatchNotLinked = errors.New("agent: tool dispatch not linked")
+
+// fail-closed placeholder — replaced in Task 8
+func (o *Orchestrator) runToolCalls(context.Context, *Result, *State, *toolRegistry, []provider.ToolCall, Approver, Observer, int, *restraintGovernor) error {
+	return errToolDispatchNotLinked
+}

--- a/agent/orchestrator.go
+++ b/agent/orchestrator.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/kstruzzieri/go-llm/provider"
@@ -27,7 +28,7 @@ func initState(req Request) State {
 	}
 }
 
-func buildChatRequest(st State, specs []provider.Tool) provider.ChatRequest {
+func buildChatRequest(st State, specs []provider.Tool, outputReserve int) provider.ChatRequest {
 	msgs := make([]provider.ChatMessage, 0, len(st.Messages)+1)
 	if st.System != "" {
 		msgs = append(msgs, provider.ChatMessage{Role: "system", Content: st.System})
@@ -35,12 +36,19 @@ func buildChatRequest(st State, specs []provider.Tool) provider.ChatRequest {
 	for _, m := range st.Messages {
 		msgs = append(msgs, m.ChatMessage)
 	}
-	return provider.ChatRequest{Messages: msgs, Tools: specs, Stream: true}
+	req := provider.ChatRequest{Messages: msgs, Tools: specs, Stream: true}
+	if outputReserve > 0 {
+		req.Options.NumPredict = outputReserve
+	}
+	return req
 }
 
 // Run executes the loop until the model produces a final answer or a cap is hit.
 func (o *Orchestrator) Run(ctx context.Context, req Request, obs Observer) (Result, error) {
 	obs = normalizeObserver(obs)
+	if req.Goal == "" {
+		return Result{}, fmt.Errorf("agent: empty goal")
+	}
 	maxSteps := req.MaxSteps
 	if maxSteps <= 0 {
 		maxSteps = defaultMaxSteps
@@ -66,11 +74,15 @@ func (o *Orchestrator) Run(ctx context.Context, req Request, obs Observer) (Resu
 			res.Events = append(res.Events, EventRecord{Step: step, Kind: "compaction"})
 		}
 
-		modelResult, err := o.model.Chat(ctx, buildChatRequest(assembled, specs), func(c provider.ChatResponse) error {
+		tokenLogged := false
+		modelResult, err := o.model.Chat(ctx, buildChatRequest(assembled, specs, req.Budget.OutputReserve), func(c provider.ChatResponse) error {
 			if c.Content == "" {
 				return nil
 			}
-			res.Events = append(res.Events, EventRecord{Step: step, Kind: "token"})
+			if !tokenLogged {
+				res.Events = append(res.Events, EventRecord{Step: step, Kind: "token"})
+				tokenLogged = true
+			}
 			return obs.OnToken(ctx, TokenEvent{Step: step, Content: c.Content})
 		})
 		if err != nil {

--- a/agent/orchestrator.go
+++ b/agent/orchestrator.go
@@ -62,6 +62,9 @@ func (o *Orchestrator) Run(ctx context.Context, req Request, obs Observer) (Resu
 		if err != nil {
 			return res, err
 		}
+		if pressure.Compactions > 0 {
+			res.Events = append(res.Events, EventRecord{Step: step, Kind: "compaction"})
+		}
 
 		modelResult, err := o.model.Chat(ctx, buildChatRequest(assembled, specs), func(c provider.ChatResponse) error {
 			if c.Content == "" {

--- a/agent/orchestrator.go
+++ b/agent/orchestrator.go
@@ -101,6 +101,11 @@ func (o *Orchestrator) Run(ctx context.Context, req Request, obs Observer) (Resu
 			res.Events = append(res.Events, EventRecord{Step: step, Kind: "stop"})
 			return res, nil
 		}
+		if req.Budget.TotalTokens > 0 && res.Usage.TotalTokens >= req.Budget.TotalTokens {
+			res.StopReason = BudgetReached
+			res.Events = append(res.Events, EventRecord{Step: step, Kind: "stop"})
+			return res, nil
+		}
 	}
 	res.StopReason = StepCapReached
 	res.Events = append(res.Events, EventRecord{Step: maxSteps, Kind: "stop"})
@@ -131,14 +136,24 @@ func toolSchemaString(specs []provider.Tool) string {
 // restraintGovernor bounds runaway loops with a weak local model. Per-Run state.
 type restraintGovernor struct {
 	consecutiveErrors int
+	lastSig           string
+	repeatCount       int
 }
 
-func (g *restraintGovernor) observe(_ provider.ToolCall, out ToolResult) {
+func (g *restraintGovernor) observe(call provider.ToolCall, out ToolResult) {
 	if out.IsError {
 		g.consecutiveErrors++
 	} else {
 		g.consecutiveErrors = 0
 	}
+	sig := call.Function.Name + "\x00" + string(call.Function.Arguments)
+	if sig == g.lastSig {
+		g.repeatCount++
+	} else {
+		g.lastSig, g.repeatCount = sig, 1
+	}
 }
 
-func (g *restraintGovernor) tripped() bool { return g.consecutiveErrors >= defaultToolErrorCap }
+func (g *restraintGovernor) tripped() bool {
+	return g.consecutiveErrors >= defaultToolErrorCap || g.repeatCount >= defaultToolErrorCap
+}

--- a/agent/orchestrator.go
+++ b/agent/orchestrator.go
@@ -88,7 +88,11 @@ func (o *Orchestrator) Run(ctx context.Context, req Request, obs Observer) (Resu
 
 		if len(resp.ToolCalls) == 0 {
 			res.Answer = resp.Content
-			res.StopReason = Completed
+			if budgetExceeded(res.Usage, req.Budget) {
+				res.StopReason = BudgetReached
+			} else {
+				res.StopReason = Completed
+			}
 			res.Events = append(res.Events, EventRecord{Step: step, Kind: "stop"})
 			return res, nil
 		}
@@ -101,7 +105,7 @@ func (o *Orchestrator) Run(ctx context.Context, req Request, obs Observer) (Resu
 			res.Events = append(res.Events, EventRecord{Step: step, Kind: "stop"})
 			return res, nil
 		}
-		if req.Budget.TotalTokens > 0 && res.Usage.TotalTokens >= req.Budget.TotalTokens {
+		if budgetExceeded(res.Usage, req.Budget) {
 			res.StopReason = BudgetReached
 			res.Events = append(res.Events, EventRecord{Step: step, Kind: "stop"})
 			return res, nil
@@ -123,6 +127,10 @@ func addUsage(a, b provider.Usage) provider.Usage {
 	a.CompletionTokens += b.CompletionTokens
 	a.TotalTokens += b.TotalTokens
 	return a
+}
+
+func budgetExceeded(u provider.Usage, b Budget) bool {
+	return b.TotalTokens > 0 && u.TotalTokens >= b.TotalTokens
 }
 
 func toolSchemaString(specs []provider.Tool) string {

--- a/agent/orchestrator.go
+++ b/agent/orchestrator.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"errors"
 
 	"github.com/kstruzzieri/go-llm/provider"
 )
@@ -143,10 +142,3 @@ func (g *restraintGovernor) observe(_ provider.ToolCall, out ToolResult) {
 }
 
 func (g *restraintGovernor) tripped() bool { return g.consecutiveErrors >= defaultToolErrorCap }
-
-var errToolDispatchNotLinked = errors.New("agent: tool dispatch not linked")
-
-// fail-closed placeholder — replaced in Task 8
-func (o *Orchestrator) runToolCalls(context.Context, *Result, *State, *toolRegistry, []provider.ToolCall, Approver, Observer, int, *restraintGovernor) error {
-	return errToolDispatchNotLinked
-}

--- a/agent/orchestrator.go
+++ b/agent/orchestrator.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
 	"strings"
 
 	"github.com/kstruzzieri/go-llm/provider"
@@ -116,7 +117,7 @@ func (o *Orchestrator) Run(ctx context.Context, req Request, obs Observer) (Resu
 		if err := o.runToolCalls(ctx, &res, &state, reg, resp.ToolCalls, req.Approver, obs, step, gov); err != nil {
 			return res, err
 		}
-		if res.StopReason == ToolErrorCapReached || res.StopReason == BudgetReached {
+		if res.StopReason != Completed {
 			res.Events = append(res.Events, EventRecord{Step: step, Kind: "stop"})
 			return res, nil
 		}
@@ -127,7 +128,7 @@ func (o *Orchestrator) Run(ctx context.Context, req Request, obs Observer) (Resu
 		}
 	}
 	res.StopReason = StepCapReached
-	res.Events = append(res.Events, EventRecord{Step: maxSteps, Kind: "stop"})
+	res.Events = append(res.Events, EventRecord{Step: maxSteps - 1, Kind: "stop"})
 	return res, nil
 }
 
@@ -159,10 +160,26 @@ func toolSchemaString(specs []provider.Tool) string {
 }
 
 // restraintGovernor bounds runaway loops with a weak local model. Per-Run state.
+// It stops a run on too many consecutive tool errors, or on a tool call that
+// repeats with no progress (identical name+args AND identical result).
 type restraintGovernor struct {
 	consecutiveErrors int
-	lastSig           string
+	lastSig           uint64
+	hasSig            bool
 	repeatCount       int
+}
+
+// toolCallSignature hashes the call identity together with its result so that a
+// repeated call whose result CHANGES (e.g. polling that makes progress) is not
+// mistaken for a stuck loop. Only identical call + identical result repeats.
+func toolCallSignature(call provider.ToolCall, out ToolResult) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(call.Function.Name))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write(call.Function.Arguments)
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(out.Content))
+	return h.Sum64()
 }
 
 func (g *restraintGovernor) observe(call provider.ToolCall, out ToolResult) {
@@ -171,14 +188,22 @@ func (g *restraintGovernor) observe(call provider.ToolCall, out ToolResult) {
 	} else {
 		g.consecutiveErrors = 0
 	}
-	sig := call.Function.Name + "\x00" + string(call.Function.Arguments)
-	if sig == g.lastSig {
+	sig := toolCallSignature(call, out)
+	if g.hasSig && sig == g.lastSig {
 		g.repeatCount++
 	} else {
-		g.lastSig, g.repeatCount = sig, 1
+		g.lastSig, g.hasSig, g.repeatCount = sig, true, 1
 	}
 }
 
-func (g *restraintGovernor) tripped() bool {
-	return g.consecutiveErrors >= defaultToolErrorCap || g.repeatCount >= defaultToolErrorCap
+// stopReason reports the cap the governor hit, if any. Consecutive tool errors
+// take precedence over no-progress repeats. The bool is false when not tripped.
+func (g *restraintGovernor) stopReason() (StopReason, bool) {
+	if g.consecutiveErrors >= defaultToolErrorCap {
+		return ToolErrorCapReached, true
+	}
+	if g.repeatCount >= defaultToolErrorCap {
+		return RepeatLimitReached, true
+	}
+	return Completed, false
 }

--- a/agent/orchestrator.go
+++ b/agent/orchestrator.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"strings"
 
 	"github.com/kstruzzieri/go-llm/provider"
 )
@@ -92,7 +93,6 @@ func (o *Orchestrator) Run(ctx context.Context, req Request, obs Observer) (Resu
 			return res, nil
 		}
 
-		// Tool dispatch is implemented in Task 8.
 		state.Messages = append(state.Messages, assistantMessage(resp))
 		if err := o.runToolCalls(ctx, &res, &state, reg, resp.ToolCalls, req.Approver, obs, step, gov); err != nil {
 			return res, err
@@ -126,11 +126,13 @@ func addUsage(a, b provider.Usage) provider.Usage {
 }
 
 func toolSchemaString(specs []provider.Tool) string {
-	s := ""
+	var b strings.Builder
 	for _, sp := range specs {
-		s += sp.Function.Name + sp.Function.Description + string(sp.Function.Parameters)
+		b.WriteString(sp.Function.Name)
+		b.WriteString(sp.Function.Description)
+		b.Write(sp.Function.Parameters)
 	}
-	return s
+	return b.String()
 }
 
 // restraintGovernor bounds runaway loops with a weak local model. Per-Run state.

--- a/agent/orchestrator_test.go
+++ b/agent/orchestrator_test.go
@@ -1,0 +1,64 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// scriptedCaller returns queued responses in order, one per Chat call.
+type scriptedCaller struct {
+	responses []ModelResult
+	calls     int
+}
+
+func (s *scriptedCaller) Chat(_ context.Context, _ provider.ChatRequest,
+	onToken func(provider.ChatResponse) error) (ModelResult, error) {
+	r := s.responses[s.calls]
+	s.calls++
+	if onToken != nil {
+		if err := onToken(provider.ChatResponse{Content: r.Response.Content}); err != nil {
+			return ModelResult{}, err
+		}
+	}
+	return r, nil
+}
+
+func newTestOrchestrator(mc ModelCaller) *Orchestrator {
+	return New(mc, ContextManager{
+		Compactor: RecencyCompactor{Estimate: runeEstimator},
+		Estimate:  runeEstimator,
+	})
+}
+
+func TestRunSingleStepFinalAnswer(t *testing.T) {
+	mc := &scriptedCaller{responses: []ModelResult{
+		{Response: provider.ChatResponse{Content: "the answer", Done: true}, RouteOutcome: &provider.RouteOutcome{}},
+	}}
+	o := newTestOrchestrator(mc)
+	res, err := o.Run(context.Background(), Request{Goal: "q"}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Answer != "the answer" || res.StopReason != Completed {
+		t.Fatalf("got answer=%q stop=%v", res.Answer, res.StopReason)
+	}
+	if len(res.Steps) != 1 || res.Steps[0].RouteOutcome == nil {
+		t.Fatalf("expected one step with RouteOutcome, got %+v", res.Steps)
+	}
+}
+
+func TestRunWithZeroValueContextManagerUsesDefaults(t *testing.T) {
+	mc := &scriptedCaller{responses: []ModelResult{
+		{Response: provider.ChatResponse{Content: "ok", Done: true}},
+	}}
+	o := New(mc, ContextManager{})
+	res, err := o.Run(context.Background(), Request{Goal: "q"}, nil)
+	if err != nil {
+		t.Fatalf("Run with zero-value ContextManager: %v", err)
+	}
+	if res.Answer != "ok" {
+		t.Fatalf("answer = %q, want ok", res.Answer)
+	}
+}

--- a/agent/tool.go
+++ b/agent/tool.go
@@ -1,0 +1,153 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// Tool is the effect-aware unit the loop drives.
+type Tool interface {
+	Spec() ToolSpec
+	Effect() Effect
+	Invoke(ctx context.Context, args json.RawMessage) (ToolResult, error)
+}
+
+// PlanningTool is optionally implemented by tools that can pre-compute a
+// per-call effect/preview BEFORE invocation so approval can gate mutation.
+type PlanningTool interface {
+	Plan(ctx context.Context, args json.RawMessage) (ToolPlan, error)
+}
+
+// ToolSpec is the model-facing schema; maps to provider.ToolFunction.
+type ToolSpec struct {
+	Name        string
+	Description string
+	Parameters  json.RawMessage // JSON Schema
+}
+
+// ToolPlan is the narrowed per-call effect plus an optional preview/diff.
+type ToolPlan struct {
+	Effect  Effect
+	Preview string
+}
+
+// ToolResult is the outcome fed back as a tool-role observation.
+type ToolResult struct {
+	Content   string
+	IsError   bool
+	Preview   string
+	Truncated bool
+	Attrib    *RetrievalAttribution // set by retrieval-style tools; copied to Message.Attrib
+}
+
+// Effect is the static, conservative upper bound for a tool.
+type Effect struct {
+	Class     EffectClass
+	Scope     Scope
+	Timeout   time.Duration
+	OutputCap int
+	Approval  ApprovalPolicy
+}
+
+// Scope bounds the paths / cwd a tool may touch (advisory in #61).
+type Scope struct {
+	Paths []string
+	CWD   string
+}
+
+// EffectClass is an orthogonal bitset.
+type EffectClass uint8
+
+const (
+	Read EffectClass = 1 << iota
+	Write
+	Exec
+	Network
+)
+
+func (c EffectClass) Has(x EffectClass) bool { return c&x != 0 }
+func (c EffectClass) IsMutating() bool       { return c.Has(Write) || c.Has(Exec) }
+
+// ApprovalPolicy decides whether a call needs consumer approval.
+type ApprovalPolicy uint8
+
+const (
+	ApprovalNever ApprovalPolicy = iota
+	ApprovalOnWrite
+	ApprovalAlways
+)
+
+// Approver gates a tool call before invocation.
+type Approver interface {
+	Approve(ctx context.Context, call provider.ToolCall, preview string) (bool, error)
+}
+
+func needsApproval(p ApprovalPolicy, c EffectClass) bool {
+	switch p {
+	case ApprovalAlways:
+		return true
+	case ApprovalOnWrite:
+		return c.IsMutating()
+	default:
+		return false
+	}
+}
+
+// normalizeEffect fills zero values with safe defaults. A zero timeout/cap
+// must never mean "cancel immediately" / "return nothing".
+func normalizeEffect(e Effect) Effect {
+	if e.Timeout <= 0 {
+		e.Timeout = defaultToolTimeout
+	}
+	if e.OutputCap <= 0 {
+		e.OutputCap = defaultOutputCap
+	}
+	return e
+}
+
+// toolRegistry indexes tools by name and converts specs to provider.Tool.
+type toolRegistry struct {
+	byName map[string]Tool
+	order  []string
+}
+
+func newToolRegistry(tools []Tool) (*toolRegistry, error) {
+	r := &toolRegistry{byName: make(map[string]Tool, len(tools))}
+	for _, t := range tools {
+		name := t.Spec().Name
+		if name == "" {
+			return nil, fmt.Errorf("agent: tool with empty name")
+		}
+		if _, dup := r.byName[name]; dup {
+			return nil, fmt.Errorf("agent: duplicate tool name %q", name)
+		}
+		r.byName[name] = t
+		r.order = append(r.order, name)
+	}
+	return r, nil
+}
+
+func (r *toolRegistry) lookup(name string) (Tool, bool) {
+	t, ok := r.byName[name]
+	return t, ok
+}
+
+func (r *toolRegistry) providerSpecs() []provider.Tool {
+	specs := make([]provider.Tool, 0, len(r.order))
+	for _, name := range r.order {
+		s := r.byName[name].Spec()
+		specs = append(specs, provider.Tool{
+			Type: "function",
+			Function: provider.ToolFunction{
+				Name:        s.Name,
+				Description: s.Description,
+				Parameters:  s.Parameters,
+			},
+		})
+	}
+	return specs
+}

--- a/agent/tool.go
+++ b/agent/tool.go
@@ -46,14 +46,18 @@ type ToolResult struct {
 
 // Effect is the static, conservative upper bound for a tool.
 type Effect struct {
-	Class     EffectClass
+	Class EffectClass
+	// Scope is ADVISORY ONLY: the runtime does NOT enforce path/cwd limits in
+	// this version. A tool must enforce its own scope. It is metadata for
+	// consumers and future mutating-tool gating.
 	Scope     Scope
 	Timeout   time.Duration
 	OutputCap int
 	Approval  ApprovalPolicy
 }
 
-// Scope bounds the paths / cwd a tool may touch (advisory in #61).
+// Scope bounds the paths / cwd a tool may touch. Advisory only — see Effect.Scope;
+// the runtime does not enforce it.
 type Scope struct {
 	Paths []string
 	CWD   string
@@ -120,7 +124,10 @@ type toolRegistry struct {
 
 func newToolRegistry(tools []Tool) (*toolRegistry, error) {
 	r := &toolRegistry{byName: make(map[string]Tool, len(tools))}
-	for _, t := range tools {
+	for i, t := range tools {
+		if t == nil {
+			return nil, fmt.Errorf("agent: nil tool at index %d", i)
+		}
 		name := t.Spec().Name
 		if name == "" {
 			return nil, fmt.Errorf("agent: tool with empty name")

--- a/agent/tool.go
+++ b/agent/tool.go
@@ -83,7 +83,11 @@ func (c EffectClass) IsMutating() bool { return c.Has(Write) || c.Has(Exec) }
 type ApprovalPolicy uint8
 
 const (
-	ApprovalNever ApprovalPolicy = iota
+	// ApprovalDefault is the safe zero value: mutating tools require approval,
+	// read-only tools do not.
+	ApprovalDefault ApprovalPolicy = iota
+	// ApprovalNever explicitly bypasses approval.
+	ApprovalNever
 	ApprovalOnWrite
 	ApprovalAlways
 )
@@ -97,10 +101,12 @@ func needsApproval(p ApprovalPolicy, c EffectClass) bool {
 	switch p {
 	case ApprovalAlways:
 		return true
+	case ApprovalNever:
+		return false
 	case ApprovalOnWrite:
 		return c.IsMutating()
 	default:
-		return false
+		return c.IsMutating()
 	}
 }
 

--- a/agent/tool.go
+++ b/agent/tool.go
@@ -69,8 +69,11 @@ const (
 	Network
 )
 
+// Has reports whether every bit in x is set on c.
 func (c EffectClass) Has(x EffectClass) bool { return c&x != 0 }
-func (c EffectClass) IsMutating() bool       { return c.Has(Write) || c.Has(Exec) }
+
+// IsMutating reports whether the class includes Write or Exec.
+func (c EffectClass) IsMutating() bool { return c.Has(Write) || c.Has(Exec) }
 
 // ApprovalPolicy decides whether a call needs consumer approval.
 type ApprovalPolicy uint8

--- a/agent/tool_test.go
+++ b/agent/tool_test.go
@@ -1,0 +1,86 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+type fakeTool struct {
+	name   string
+	effect Effect
+}
+
+func (f fakeTool) Spec() ToolSpec {
+	return ToolSpec{Name: f.name, Description: "d", Parameters: json.RawMessage(`{"type":"object"}`)}
+}
+func (f fakeTool) Effect() Effect { return f.effect }
+func (f fakeTool) Invoke(context.Context, json.RawMessage) (ToolResult, error) {
+	return ToolResult{Content: "ok"}, nil
+}
+
+func TestEffectClassHasAndMutating(t *testing.T) {
+	e := Effect{Class: Read | Network}
+	if !e.Class.Has(Read) || !e.Class.Has(Network) {
+		t.Fatal("expected Read|Network bits set")
+	}
+	if e.Class.Has(Write) || e.Class.IsMutating() {
+		t.Fatal("Read|Network must not be mutating")
+	}
+	if !(Effect{Class: Write}).Class.IsMutating() || !(Effect{Class: Exec}).Class.IsMutating() {
+		t.Fatal("Write and Exec must be mutating")
+	}
+}
+
+func TestNormalizeEffectDefaults(t *testing.T) {
+	got := normalizeEffect(Effect{Class: Read})
+	if got.Timeout != defaultToolTimeout {
+		t.Fatalf("timeout = %v, want default %v", got.Timeout, defaultToolTimeout)
+	}
+	if got.OutputCap != defaultOutputCap {
+		t.Fatalf("cap = %d, want default %d", got.OutputCap, defaultOutputCap)
+	}
+	keep := normalizeEffect(Effect{Class: Read, Timeout: time.Second, OutputCap: 10})
+	if keep.Timeout != time.Second || keep.OutputCap != 10 {
+		t.Fatal("explicit non-zero values must be preserved")
+	}
+}
+
+func TestNeedsApproval(t *testing.T) {
+	if needsApproval(ApprovalNever, Write) {
+		t.Fatal("Never => no approval")
+	}
+	if !needsApproval(ApprovalAlways, Read) {
+		t.Fatal("Always => approval even for Read")
+	}
+	if needsApproval(ApprovalOnWrite, Read) {
+		t.Fatal("OnWrite + Read => no approval")
+	}
+	if !needsApproval(ApprovalOnWrite, Write) {
+		t.Fatal("OnWrite + Write => approval")
+	}
+}
+
+func TestRegistryLookupAndProviderSpecs(t *testing.T) {
+	reg, err := newToolRegistry([]Tool{fakeTool{name: "a"}, fakeTool{name: "b"}})
+	if err != nil {
+		t.Fatalf("newToolRegistry: %v", err)
+	}
+	if _, ok := reg.lookup("a"); !ok {
+		t.Fatal("expected tool a")
+	}
+	if _, ok := reg.lookup("missing"); ok {
+		t.Fatal("missing must not resolve")
+	}
+	specs := reg.providerSpecs()
+	if len(specs) != 2 || specs[0].Type != "function" || specs[0].Function.Name == "" {
+		t.Fatalf("bad provider specs: %+v", specs)
+	}
+}
+
+func TestRegistryRejectsDuplicateNames(t *testing.T) {
+	if _, err := newToolRegistry([]Tool{fakeTool{name: "x"}, fakeTool{name: "x"}}); err == nil {
+		t.Fatal("duplicate tool names must error")
+	}
+}

--- a/agent/tools/retrieve.go
+++ b/agent/tools/retrieve.go
@@ -9,6 +9,11 @@ import (
 	"github.com/kstruzzieri/go-llm/rag"
 )
 
+const (
+	defaultRetrieveK         = 5
+	defaultRetrieveMaxTokens = 2048
+)
+
 // retriever is the minimal slice of *rag.Retriever the tool needs; abstracting
 // it keeps the tool unit-testable with a fake.
 type retriever interface {
@@ -61,11 +66,11 @@ func (t Retrieve) Invoke(ctx context.Context, raw json.RawMessage) (agent.ToolRe
 		k = t.K
 	}
 	if k <= 0 {
-		k = 5
+		k = defaultRetrieveK
 	}
 	maxTokens := t.MaxTokens
 	if maxTokens <= 0 {
-		maxTokens = 2048
+		maxTokens = defaultRetrieveMaxTokens
 	}
 
 	results, err := t.R.Retrieve(ctx, args.Query, k)

--- a/agent/tools/retrieve.go
+++ b/agent/tools/retrieve.go
@@ -1,0 +1,88 @@
+// Package tools provides built-in read-only agent.Tool implementations.
+package tools
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/kstruzzieri/go-llm/agent"
+	"github.com/kstruzzieri/go-llm/rag"
+)
+
+// retriever is the minimal slice of *rag.Retriever the tool needs; abstracting
+// it keeps the tool unit-testable with a fake.
+type retriever interface {
+	Retrieve(ctx context.Context, query string, k int) ([]rag.SearchResult, error)
+	BuildContext(results []rag.SearchResult, maxTokens int) string
+}
+
+// Retrieve is the reference read-only retrieval built-in. #95 swaps SearchMulti
+// behind the same retriever seam without changing the agent.Tool contract.
+type Retrieve struct {
+	R         retriever
+	K         int // default top-k when the call omits k
+	MaxTokens int // BuildContext budget; 0 => a sane default
+}
+
+type retrieveArgs struct {
+	Query string `json:"query"`
+	K     int    `json:"k"`
+}
+
+func (Retrieve) Spec() agent.ToolSpec {
+	return agent.ToolSpec{
+		Name:        "retrieve",
+		Description: "Retrieve relevant code/context chunks for a natural-language query.",
+		Parameters: json.RawMessage(`{
+  "type":"object",
+  "properties":{
+    "query":{"type":"string","description":"what to search for"},
+    "k":{"type":"integer","description":"max results"}
+  },
+  "required":["query"]
+}`),
+	}
+}
+
+func (t Retrieve) Effect() agent.Effect {
+	return agent.Effect{Class: agent.Read, Approval: agent.ApprovalNever}
+}
+
+func (t Retrieve) Invoke(ctx context.Context, raw json.RawMessage) (agent.ToolResult, error) {
+	var args retrieveArgs
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return agent.ToolResult{IsError: true, Content: "invalid arguments: " + err.Error()}, nil
+	}
+	if args.Query == "" {
+		return agent.ToolResult{IsError: true, Content: "query is required"}, nil
+	}
+	k := args.K
+	if k <= 0 {
+		k = t.K
+	}
+	if k <= 0 {
+		k = 5
+	}
+	maxTokens := t.MaxTokens
+	if maxTokens <= 0 {
+		maxTokens = 2048
+	}
+
+	results, err := t.R.Retrieve(ctx, args.Query, k)
+	if err != nil {
+		return agent.ToolResult{IsError: true, Content: "retrieval failed: " + err.Error()}, nil
+	}
+	content := t.R.BuildContext(results, maxTokens)
+
+	attrib := &agent.RetrievalAttribution{Sources: make([]agent.RetrievedSource, 0, len(results))}
+	for _, r := range results {
+		attrib.Sources = append(attrib.Sources, agent.RetrievedSource{
+			StableKey: r.Chunk.StableKey,
+			Source:    r.Chunk.Source,
+			StartLine: r.Chunk.StartLine,
+			EndLine:   r.Chunk.EndLine,
+			Score:     r.Score,
+		})
+	}
+	return agent.ToolResult{Content: content, Attrib: attrib}, nil
+}

--- a/agent/tools/retrieve_test.go
+++ b/agent/tools/retrieve_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/kstruzzieri/go-llm/agent"
@@ -57,5 +58,59 @@ func TestRetrieveMalformedArgsIsError(t *testing.T) {
 	}
 	if !out.IsError {
 		t.Fatal("malformed args must yield IsError observation")
+	}
+}
+
+type capturingRetriever struct {
+	gotK         int
+	gotMaxTokens int
+	err          error
+}
+
+func (c *capturingRetriever) Retrieve(_ context.Context, _ string, k int) ([]rag.SearchResult, error) {
+	c.gotK = k
+	if c.err != nil {
+		return nil, c.err
+	}
+	return []rag.SearchResult{{Chunk: rag.Chunk{StableKey: "k", Content: "x"}}}, nil
+}
+func (c *capturingRetriever) BuildContext(_ []rag.SearchResult, maxTokens int) string {
+	c.gotMaxTokens = maxTokens
+	return "x"
+}
+
+func TestRetrieveEmptyQueryIsError(t *testing.T) {
+	tool := Retrieve{R: &capturingRetriever{}, K: 4}
+	out, err := tool.Invoke(context.Background(), json.RawMessage(`{"query":""}`))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if !out.IsError {
+		t.Fatal("empty query must yield an IsError observation")
+	}
+}
+
+func TestRetrieveKAndMaxTokensDefaults(t *testing.T) {
+	cr := &capturingRetriever{}
+	tool := Retrieve{R: cr} // K and MaxTokens both zero -> defaults
+	if _, err := tool.Invoke(context.Background(), json.RawMessage(`{"query":"hi"}`)); err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if cr.gotK != defaultRetrieveK {
+		t.Fatalf("k = %d, want default %d", cr.gotK, defaultRetrieveK)
+	}
+	if cr.gotMaxTokens != defaultRetrieveMaxTokens {
+		t.Fatalf("maxTokens = %d, want default %d", cr.gotMaxTokens, defaultRetrieveMaxTokens)
+	}
+}
+
+func TestRetrieveBackendErrorIsError(t *testing.T) {
+	tool := Retrieve{R: &capturingRetriever{err: errors.New("boom")}, K: 4}
+	out, err := tool.Invoke(context.Background(), json.RawMessage(`{"query":"hi"}`))
+	if err != nil {
+		t.Fatalf("Invoke should not hard-error: %v", err)
+	}
+	if !out.IsError {
+		t.Fatal("backend error must yield an IsError observation")
 	}
 }

--- a/agent/tools/retrieve_test.go
+++ b/agent/tools/retrieve_test.go
@@ -1,0 +1,61 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/agent"
+	"github.com/kstruzzieri/go-llm/rag"
+)
+
+type fakeRetriever struct {
+	results []rag.SearchResult
+}
+
+func (f fakeRetriever) Retrieve(context.Context, string, int) ([]rag.SearchResult, error) {
+	return f.results, nil
+}
+func (f fakeRetriever) BuildContext(results []rag.SearchResult, _ int) string {
+	out := ""
+	for _, r := range results {
+		out += r.Chunk.Content + "\n"
+	}
+	return out
+}
+
+func TestRetrieveReturnsContextAndAttribution(t *testing.T) {
+	fr := fakeRetriever{results: []rag.SearchResult{
+		{Chunk: rag.Chunk{StableKey: "k1", Source: "a.go", StartLine: 1, EndLine: 5, Content: "hello"}, Score: 0.9},
+	}}
+	tool := Retrieve{R: fr, K: 4, MaxTokens: 1000}
+
+	if tool.Spec().Name != "retrieve" {
+		t.Fatalf("spec name = %q", tool.Spec().Name)
+	}
+	if tool.Effect().Class != agent.Read || tool.Effect().Approval != agent.ApprovalNever {
+		t.Fatalf("retrieve must be Read/ApprovalNever, got %+v", tool.Effect())
+	}
+
+	out, err := tool.Invoke(context.Background(), json.RawMessage(`{"query":"hi"}`))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if out.Content == "" || out.IsError {
+		t.Fatalf("expected content, got %+v", out)
+	}
+	if out.Attrib == nil || len(out.Attrib.Sources) != 1 || out.Attrib.Sources[0].StableKey != "k1" {
+		t.Fatalf("expected attribution for k1, got %+v", out.Attrib)
+	}
+}
+
+func TestRetrieveMalformedArgsIsError(t *testing.T) {
+	tool := Retrieve{R: fakeRetriever{}, K: 4}
+	out, err := tool.Invoke(context.Background(), json.RawMessage(`{"query":}`))
+	if err != nil {
+		t.Fatalf("Invoke should not hard-error: %v", err)
+	}
+	if !out.IsError {
+		t.Fatal("malformed args must yield IsError observation")
+	}
+}

--- a/agent/types.go
+++ b/agent/types.go
@@ -1,5 +1,3 @@
-// Package agent implements a dynamic plan->act->observe runtime loop that
-// drives local models through provider.Router. See doc.go for an overview.
 package agent
 
 import (

--- a/agent/types.go
+++ b/agent/types.go
@@ -57,15 +57,14 @@ type Budget struct {
 	TotalTokens   int // 0 = unbounded whole-run cap
 }
 
-// Request is the unit of work handed to Run. The Tools and Approver fields are
-// added in a later task, once the Tool and Approver types exist in this package
-// (types.go and tool.go are mutually dependent within one package; adding the
-// fields later keeps each task independently compilable).
+// Request is the unit of work handed to Run.
 type Request struct {
 	Goal     string
 	System   string
+	Tools    []Tool
 	MaxSteps int // 0 => defaultMaxSteps
 	Budget   Budget
+	Approver Approver // nil => fail-safe (auto Read, deny Write/Exec)
 }
 
 // Segment tags a message as always-present (Pinned) or compactable (Elastic).

--- a/agent/types.go
+++ b/agent/types.go
@@ -1,0 +1,144 @@
+// Package agent implements a dynamic plan->act->observe runtime loop that
+// drives local models through provider.Router. See doc.go for an overview.
+package agent
+
+import (
+	"errors"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// Tunable defaults. All are overridable via Request fields where exposed.
+const (
+	defaultMaxSteps     = 16
+	defaultToolTimeout  = 30 * time.Second
+	defaultOutputCap    = 64 * 1024 // bytes of tool output fed back to the model
+	defaultToolErrorCap = 3         // consecutive tool errors / repeats before stop
+)
+
+// ErrContextExhausted is returned when the pinned segment (system + goal +
+// tool schemas) alone exceeds the input budget. The runtime never silently
+// truncates the goal; selecting a bigger-context model is the provider's job.
+var ErrContextExhausted = errors.New("agent: context exhausted (pinned segment exceeds budget)")
+
+// StopReason explains why Run returned. A non-Completed reason is still a
+// successful (non-error) return; the caller inspects Result.
+type StopReason int
+
+const (
+	Completed StopReason = iota
+	StepCapReached
+	BudgetReached
+	ToolErrorCapReached
+)
+
+func (s StopReason) String() string {
+	switch s {
+	case Completed:
+		return "completed"
+	case StepCapReached:
+		return "step_cap_reached"
+	case BudgetReached:
+		return "budget_reached"
+	case ToolErrorCapReached:
+		return "tool_error_cap_reached"
+	default:
+		return "unknown"
+	}
+}
+
+// Budget holds run-level token caps the consumer sets. InputCeiling is the
+// authoritative per-turn input ceiling (the concrete model is unknown until the
+// router selects one). Zero falls back to a conservative default.
+type Budget struct {
+	InputCeiling  int
+	OutputReserve int
+	TotalTokens   int // 0 = unbounded whole-run cap
+}
+
+// Request is the unit of work handed to Run. The Tools and Approver fields are
+// added in a later task, once the Tool and Approver types exist in this package
+// (types.go and tool.go are mutually dependent within one package; adding the
+// fields later keeps each task independently compilable).
+type Request struct {
+	Goal     string
+	System   string
+	MaxSteps int // 0 => defaultMaxSteps
+	Budget   Budget
+}
+
+// Segment tags a message as always-present (Pinned) or compactable (Elastic).
+type Segment int
+
+const (
+	Elastic Segment = iota
+	Pinned
+)
+
+// Message wraps a provider chat message with runtime-only metadata.
+type Message struct {
+	provider.ChatMessage
+	Segment Segment
+	Attrib  *RetrievalAttribution
+}
+
+// State is the canonical transcript the Orchestrator owns.
+type State struct {
+	System   string
+	Messages []Message
+}
+
+// RetrievalAttribution credits the sources a retrieval-style tool returned.
+type RetrievalAttribution struct {
+	Sources []RetrievedSource
+}
+
+// RetrievedSource identifies one retrieved chunk for downstream feedback.
+type RetrievedSource struct {
+	StableKey string
+	Source    string
+	StartLine int
+	EndLine   int
+	Score     float64
+}
+
+// Pressure is the per-turn context-budget telemetry (#63 seam).
+type Pressure struct {
+	UsedPct     float64
+	Evicted     int
+	Compactions int
+}
+
+// StepRecord is the durable per-turn truth. RouteOutcome is captured
+// separately because provider.Collect does not copy it.
+type StepRecord struct {
+	Index        int
+	Response     provider.ChatResponse
+	RouteOutcome *provider.RouteOutcome
+	Pressure     Pressure
+}
+
+// EventRecord is a lightweight ordered log entry for replay/eval.
+type EventRecord struct {
+	Step int
+	Kind string // "token" | "step" | "tool_call" | "tool_result" | "compaction" | "stop"
+}
+
+// ToolCallRecord captures one dispatched tool call and its outcome.
+type ToolCallRecord struct {
+	Step    int
+	Name    string
+	IsError bool
+	Denied  bool
+}
+
+// Result is the canonical final state of a run.
+type Result struct {
+	Answer     string
+	Steps      []StepRecord
+	Events     []EventRecord
+	Usage      provider.Usage
+	ToolCalls  []ToolCallRecord
+	StopReason StopReason
+}

--- a/agent/types.go
+++ b/agent/types.go
@@ -29,6 +29,7 @@ const (
 	StepCapReached
 	BudgetReached
 	ToolErrorCapReached
+	RepeatLimitReached
 )
 
 func (s StopReason) String() string {
@@ -41,6 +42,8 @@ func (s StopReason) String() string {
 		return "budget_reached"
 	case ToolErrorCapReached:
 		return "tool_error_cap_reached"
+	case RepeatLimitReached:
+		return "repeat_limit_reached"
 	default:
 		return "unknown"
 	}

--- a/agent/types.go
+++ b/agent/types.go
@@ -50,7 +50,8 @@ func (s StopReason) String() string {
 // authoritative per-turn input ceiling (the concrete model is unknown until the
 // router selects one). Zero falls back to a conservative default.
 type Budget struct {
-	InputCeiling  int
+	InputCeiling int
+	// OutputReserve caps generation: forwarded to the model request as Options.NumPredict when > 0.
 	OutputReserve int
 	TotalTokens   int // 0 = unbounded whole-run cap
 }

--- a/agent/types.go
+++ b/agent/types.go
@@ -51,7 +51,9 @@ func (s StopReason) String() string {
 // router selects one). Zero falls back to a conservative default.
 type Budget struct {
 	InputCeiling int
-	// OutputReserve caps generation: forwarded to the model request as Options.NumPredict when > 0.
+	// OutputReserve reserves room for the model's answer. It is forwarded to the
+	// model request as Options.NumPredict when > 0 (capping generation) and is
+	// also subtracted from the per-turn input ceiling during assembly.
 	OutputReserve int
 	TotalTokens   int // 0 = unbounded whole-run cap
 }

--- a/agent/types_test.go
+++ b/agent/types_test.go
@@ -1,0 +1,32 @@
+package agent
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestStopReasonString(t *testing.T) {
+	cases := map[StopReason]string{
+		Completed:           "completed",
+		StepCapReached:      "step_cap_reached",
+		BudgetReached:       "budget_reached",
+		ToolErrorCapReached: "tool_error_cap_reached",
+	}
+	for sr, want := range cases {
+		if got := sr.String(); got != want {
+			t.Fatalf("StopReason(%d).String() = %q, want %q", sr, got, want)
+		}
+	}
+}
+
+func TestErrContextExhaustedIsSentinel(t *testing.T) {
+	if !errors.Is(ErrContextExhausted, ErrContextExhausted) {
+		t.Fatal("ErrContextExhausted must be a comparable sentinel error")
+	}
+}
+
+func TestDefaultConsts(t *testing.T) {
+	if defaultMaxSteps <= 0 || defaultToolTimeout <= 0 || defaultOutputCap <= 0 || defaultToolErrorCap <= 0 {
+		t.Fatal("defaults must be positive")
+	}
+}

--- a/agent/types_test.go
+++ b/agent/types_test.go
@@ -11,6 +11,7 @@ func TestStopReasonString(t *testing.T) {
 		StepCapReached:      "step_cap_reached",
 		BudgetReached:       "budget_reached",
 		ToolErrorCapReached: "tool_error_cap_reached",
+		RepeatLimitReached:  "repeat_limit_reached",
 	}
 	for sr, want := range cases {
 		if got := sr.String(); got != want {


### PR DESCRIPTION
## Summary

New `agent/` package: the dynamic plan -> act -> observe runtime loop that sits above `provider.Router` (epic #57, core #61). The loop is model-driven (the model decides each step), not a fixed condense/retrieve/rerank/generate pipeline; retrieval is a tool the loop may call, never a hardcoded stage.

Five consumer-owned seams, each with a working default and injectable for tests:

- Execution API: blocking primitive `Run(ctx, Request, Observer) (Result, error)` with serial, in-loop-order `Observer` callbacks (`OnStep`/`OnToolCall`/`OnToken`); callback errors abort and propagate; `nil` observer valid; `Result` is canonical. Matches the existing `ChatStream`/`RoutePlan`/`ollama` streaming contract; a pull/channel adapter is deferred.
- `ModelCaller`: the model seam. The default adapter routes the `agent` use-case through `provider.Router` (`Route` + `ExecuteChatStream` + `Collect`) and captures `RouteOutcome` from the terminal chunk that `Collect` does not copy. Provider selection, scoring, and budgeting stay in the provider layer.
- `Tool` + optional `PlanningTool`: effect-aware tools. `Effect` carries a read/write/exec/network bitset, scope, timeout, output cap, and approval policy from day one so mutating tools land non-breaking; `PlanningTool.Plan` provides a pre-invoke effect/preview so approval can gate mutation. A fail-safe `Approver` denies write/exec when no approver is set. This PR ships read-only tools only.
- `ContextManager` + `RecencyCompactor`: a pure assembler that bounds the transcript to a token budget. Eviction drops completed tool-call chains before plain history, never orphans a tool_call_id, never drops pinned or unresolved tool tails, and counts prompt-visible tool fields. Pinned overflow returns a typed `ErrContextExhausted`.
- Token estimation via the existing `conversation.TokenEstimator` (len/4 default).

Retrieval is realized as a built-in `agent/tools.Retrieve` over `rag.Retriever` (agentic retrieval folded into the one loop; no separate package, no second orchestrator). #95 (`SearchMulti`) and #98 (MCP) deepen the same seam without changing the `Tool` contract.

Runtime guards: per-call timeout and rune-safe output cap (runtime-enforced, not by tool convention), restraint governor (consecutive-error + repeated-call detection), and step / token-budget / context caps. A cap is a successful return (`Result.StopReason`), not an error. Per-step telemetry (`RouteOutcome`, `Pressure`) and a lightweight replay event log are exposed for the future telemetry sink (#63).

Deferred to follow-ups against these seams: summarizing compactor (#58), auxiliary model roles (#60), grounding/verification (#62), telemetry sink (#63), MCP tool ingestion (#64), AGENTS.md loader (#65), read-only FS built-ins (#185).

## Test Plan

- [x] `go test ./agent/...` — table-driven unit tests, no live model dependency
- [x] `go test -race ./agent/...` — clean, no race warnings
- [x] `go build ./...` and `go vet ./agent/...` — clean
- [x] `gofmt -l agent/` — clean
- [x] `agent/` does not import `jsonschema/v6` (dependency policy: llm-bench only)
- [ ] Reviewer: confirm the layer boundary holds — provider selection/scoring/budget stay in `provider.Router`; the agent only asks it to route the `agent` use-case

Generated with [Claude Code](https://claude.com/claude-code)