### PR TITLE
refactor: extract internal/providerbootstrap from mcp (Golem v1 child A, #191)

### DIFF
--- a/internal/providerbootstrap/bootstrap.go
+++ b/internal/providerbootstrap/bootstrap.go
@@ -1,0 +1,50 @@
+// Package providerbootstrap assembles the config→providers→model-registry→router
+// wiring shared by the MCP server and the golem CLI. It owns provider
+// construction, capability overrides, and the fingerprint prober factory; it does
+// NOT own RAG, transcripts, or the server's degraded-mode startup policy.
+package providerbootstrap
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kstruzzieri/go-llm/config"
+	"github.com/kstruzzieri/go-llm/fingerprint"
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// Options configures New. Config is optional; nil synthesizes a single default
+// Ollama provider so callers can start with no discovered configuration.
+type Options struct {
+	Config            *config.Config
+	FingerprintStore  fingerprint.Store
+	OllamaURLOverride string
+	RouterOptions     []provider.RouterOption
+}
+
+// Bundle is the assembled provider stack. Warnings collects non-fatal,
+// best-effort failures (e.g. a provider whose RefreshModels failed at startup).
+type Bundle struct {
+	Config    *config.Config
+	Providers *provider.Registry
+	Models    *provider.ModelRegistry
+	Router    *provider.Router
+	Warnings  []error
+}
+
+// defaultOllamaURL is the fallback base URL for the nil-Config / default provider.
+const defaultOllamaURL = "http://localhost:11434"
+
+// New builds the provider stack. It errors only when no provider can be
+// constructed/registered or the model registry/router cannot be built.
+func New(ctx context.Context, opts Options) (*Bundle, error) {
+	return nil, fmt.Errorf("providerbootstrap: not implemented")
+}
+
+// Close releases router resources. Safe to call on a nil/zero Bundle.
+func (b *Bundle) Close() error {
+	if b == nil || b.Router == nil {
+		return nil
+	}
+	return b.Router.Close()
+}

--- a/internal/providerbootstrap/bootstrap.go
+++ b/internal/providerbootstrap/bootstrap.go
@@ -38,7 +38,52 @@ const defaultOllamaURL = "http://localhost:11434"
 // New builds the provider stack. It errors only when no provider can be
 // constructed/registered or the model registry/router cannot be built.
 func New(ctx context.Context, opts Options) (*Bundle, error) {
-	return nil, fmt.Errorf("providerbootstrap: not implemented")
+	// effCfg is the synthetic config when opts.Config is nil; reuse it for the
+	// prober factory, capability overrides, and Bundle.Config so all four see the
+	// same providers New actually built.
+	provs, _, ollamaClient, effCfg, err := buildProviders(opts.Config, opts.OllamaURLOverride)
+	if err != nil {
+		return nil, err
+	}
+
+	pReg := provider.NewRegistry()
+	registered := 0
+	var warnings []error
+	for _, p := range provs {
+		if err := pReg.Register(p); err != nil {
+			warnings = append(warnings, fmt.Errorf("register %q: %w", p.Name(), err))
+			continue
+		}
+		registered++
+		if err := pReg.RefreshModels(ctx, p.Name()); err != nil {
+			warnings = append(warnings, fmt.Errorf("refresh %q: %w", p.Name(), err))
+		}
+	}
+	if registered == 0 {
+		return nil, fmt.Errorf("providerbootstrap: no providers registered: %v", warnings)
+	}
+
+	mrOpts := []provider.ModelRegistryOption{}
+	if opts.FingerprintStore != nil {
+		mrOpts = append(mrOpts, provider.WithFingerprintProberFactory(proberFactory(effCfg, ollamaClient)))
+	}
+	mr, err := provider.NewModelRegistry(pReg, opts.FingerprintStore, mrOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("providerbootstrap: model registry: %w", err)
+	}
+	if err := installCapabilityOverrides(mr, effCfg); err != nil {
+		return nil, err
+	}
+
+	router := provider.NewRouter(mr, pReg, opts.RouterOptions...)
+
+	return &Bundle{
+		Config:    effCfg,
+		Providers: pReg,
+		Models:    mr,
+		Router:    router,
+		Warnings:  warnings,
+	}, nil
 }
 
 // Close releases router resources. Safe to call on a nil/zero Bundle.

--- a/internal/providerbootstrap/bootstrap.go
+++ b/internal/providerbootstrap/bootstrap.go
@@ -41,7 +41,7 @@ func New(ctx context.Context, opts Options) (*Bundle, error) {
 	// effCfg is the synthetic config when opts.Config is nil; reuse it for the
 	// prober factory, capability overrides, and Bundle.Config so all four see the
 	// same providers New actually built.
-	provs, ollamaClient, effCfg, err := buildProviders(opts.Config, opts.OllamaURLOverride)
+	provs, ollamaClients, effCfg, err := buildProviders(opts.Config, opts.OllamaURLOverride)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func New(ctx context.Context, opts Options) (*Bundle, error) {
 
 	mrOpts := []provider.ModelRegistryOption{}
 	if opts.FingerprintStore != nil {
-		mrOpts = append(mrOpts, provider.WithFingerprintProberFactory(proberFactory(effCfg, ollamaClient)))
+		mrOpts = append(mrOpts, provider.WithFingerprintProberFactory(proberFactory(effCfg, ollamaClients)))
 	}
 	mr, err := provider.NewModelRegistry(pReg, opts.FingerprintStore, mrOpts...)
 	if err != nil {

--- a/internal/providerbootstrap/bootstrap.go
+++ b/internal/providerbootstrap/bootstrap.go
@@ -41,7 +41,7 @@ func New(ctx context.Context, opts Options) (*Bundle, error) {
 	// effCfg is the synthetic config when opts.Config is nil; reuse it for the
 	// prober factory, capability overrides, and Bundle.Config so all four see the
 	// same providers New actually built.
-	provs, _, ollamaClient, effCfg, err := buildProviders(opts.Config, opts.OllamaURLOverride)
+	provs, ollamaClient, effCfg, err := buildProviders(opts.Config, opts.OllamaURLOverride)
 	if err != nil {
 		return nil, err
 	}
@@ -51,12 +51,12 @@ func New(ctx context.Context, opts Options) (*Bundle, error) {
 	var warnings []error
 	for _, p := range provs {
 		if err := pReg.Register(p); err != nil {
-			warnings = append(warnings, fmt.Errorf("register %q: %w", p.Name(), err))
+			warnings = append(warnings, fmt.Errorf("providerbootstrap: register %q: %w", p.Name(), err))
 			continue
 		}
 		registered++
 		if err := pReg.RefreshModels(ctx, p.Name()); err != nil {
-			warnings = append(warnings, fmt.Errorf("refresh %q: %w", p.Name(), err))
+			warnings = append(warnings, fmt.Errorf("providerbootstrap: refresh %q: %w", p.Name(), err))
 		}
 	}
 	if registered == 0 {

--- a/internal/providerbootstrap/bootstrap_test.go
+++ b/internal/providerbootstrap/bootstrap_test.go
@@ -42,7 +42,7 @@ func TestNew_NilConfigBuildsRouter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New(nil cfg) error: %v", err)
 	}
-	defer b.Close()
+	defer func() { _ = b.Close() }()
 	if b.Router == nil || b.Models == nil || b.Providers == nil {
 		t.Fatalf("New returned incomplete bundle: %+v", b)
 	}
@@ -59,7 +59,7 @@ func TestNew_ProberFactoryInstalledWithFingerprintStore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New with fp store error: %v", err)
 	}
-	defer b.Close()
+	defer func() { _ = b.Close() }()
 	if b.Models == nil {
 		t.Fatalf("expected model registry")
 	}
@@ -87,7 +87,7 @@ func TestNew_OpenAICompatConfigInstallsOverridesAndBuilds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New(openai-compat cfg) error: %v", err)
 	}
-	defer b.Close()
+	defer func() { _ = b.Close() }()
 	if b.Router == nil || b.Models == nil || b.Providers == nil {
 		t.Fatalf("New returned incomplete bundle: %+v", b)
 	}
@@ -103,7 +103,7 @@ func TestNew_BestEffortRefreshRecordsWarnings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New should tolerate refresh failure, got: %v", err)
 	}
-	defer b.Close()
+	defer func() { _ = b.Close() }()
 	if len(b.Warnings) == 0 {
 		t.Fatalf("expected a best-effort refresh warning")
 	}

--- a/internal/providerbootstrap/bootstrap_test.go
+++ b/internal/providerbootstrap/bootstrap_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"testing"
+	"time"
 
+	"github.com/kstruzzieri/go-llm/config"
 	"github.com/kstruzzieri/go-llm/fingerprint"
 	_ "modernc.org/sqlite"
 )
@@ -60,6 +62,37 @@ func TestNew_ProberFactoryInstalledWithFingerprintStore(t *testing.T) {
 	defer b.Close()
 	if b.Models == nil {
 		t.Fatalf("expected model registry")
+	}
+}
+
+func TestNew_OpenAICompatConfigInstallsOverridesAndBuilds(t *testing.T) {
+	// Exercises the openai-compat buildProvider branch (APIKey + Timeout) and the
+	// installCapabilityOverrides install path end-to-end through New. The provider
+	// URL is unreachable, so RefreshModels fails into a warning, but registration
+	// succeeds (registered > 0) and the bundle is built coherently.
+	cfg := &config.Config{
+		Providers: map[string]config.ProviderConfig{
+			"lc": {
+				APIFormat: "openai-compat",
+				BaseURL:   "http://127.0.0.1:1",
+				APIKey:    "test-key",
+				Timeout:   config.Duration{Duration: 2 * time.Second},
+			},
+		},
+		Models: map[string]config.ModelConfig{
+			"chat": {Provider: "lc", Name: "qwen", Capabilities: []string{"chat", "tool_call"}},
+		},
+	}
+	b, err := New(context.Background(), Options{Config: cfg})
+	if err != nil {
+		t.Fatalf("New(openai-compat cfg) error: %v", err)
+	}
+	defer b.Close()
+	if b.Router == nil || b.Models == nil || b.Providers == nil {
+		t.Fatalf("New returned incomplete bundle: %+v", b)
+	}
+	if b.Config != cfg {
+		t.Fatalf("Bundle.Config should be the passed config")
 	}
 }
 

--- a/internal/providerbootstrap/bootstrap_test.go
+++ b/internal/providerbootstrap/bootstrap_test.go
@@ -1,6 +1,13 @@
 package providerbootstrap
 
-import "testing"
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/fingerprint"
+	_ "modernc.org/sqlite"
+)
 
 func TestBundleCloseNilSafe(t *testing.T) {
 	var b *Bundle
@@ -9,5 +16,62 @@ func TestBundleCloseNilSafe(t *testing.T) {
 	}
 	if err := (&Bundle{}).Close(); err != nil {
 		t.Fatalf("empty Bundle.Close() = %v, want nil", err)
+	}
+}
+
+// newTestFingerprintStore creates an in-memory SQLite-backed fingerprint store
+// for testing. It registers a t.Cleanup to close the underlying DB.
+func newTestFingerprintStore(t *testing.T) fingerprint.Store {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open test fingerprint db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := fingerprint.NewStore(context.Background(), db)
+	if err != nil {
+		t.Fatalf("fingerprint.NewStore: %v", err)
+	}
+	return store
+}
+
+func TestNew_NilConfigBuildsRouter(t *testing.T) {
+	b, err := New(context.Background(), Options{})
+	if err != nil {
+		t.Fatalf("New(nil cfg) error: %v", err)
+	}
+	defer b.Close()
+	if b.Router == nil || b.Models == nil || b.Providers == nil {
+		t.Fatalf("New returned incomplete bundle: %+v", b)
+	}
+	if b.Config == nil {
+		t.Fatalf("expected synthetic Config to be set on Bundle")
+	}
+}
+
+func TestNew_ProberFactoryInstalledWithFingerprintStore(t *testing.T) {
+	// With a fingerprint store, New must wire the prober factory (parity with mcp).
+	// Assert indirectly: New succeeds and a registry was built. A deeper assertion
+	// belongs to the MCP parity suite (Task 6).
+	b, err := New(context.Background(), Options{FingerprintStore: newTestFingerprintStore(t)})
+	if err != nil {
+		t.Fatalf("New with fp store error: %v", err)
+	}
+	defer b.Close()
+	if b.Models == nil {
+		t.Fatalf("expected model registry")
+	}
+}
+
+func TestNew_BestEffortRefreshRecordsWarnings(t *testing.T) {
+	// Point ollama at an unreachable URL so RefreshModels fails; New must still
+	// succeed and record a Warning rather than error.
+	b, err := New(context.Background(), Options{OllamaURLOverride: "http://127.0.0.1:1"})
+	if err != nil {
+		t.Fatalf("New should tolerate refresh failure, got: %v", err)
+	}
+	defer b.Close()
+	if len(b.Warnings) == 0 {
+		t.Fatalf("expected a best-effort refresh warning")
 	}
 }

--- a/internal/providerbootstrap/bootstrap_test.go
+++ b/internal/providerbootstrap/bootstrap_test.go
@@ -3,11 +3,16 @@ package providerbootstrap
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/kstruzzieri/go-llm/config"
 	"github.com/kstruzzieri/go-llm/fingerprint"
+	"github.com/kstruzzieri/go-llm/provider"
 	_ "modernc.org/sqlite"
 )
 
@@ -62,6 +67,92 @@ func TestNew_ProberFactoryInstalledWithFingerprintStore(t *testing.T) {
 	defer func() { _ = b.Close() }()
 	if b.Models == nil {
 		t.Fatalf("expected model registry")
+	}
+}
+
+func TestNew_FingerprintStoreUsesProviderSpecificOllamaClient(t *testing.T) {
+	ctx := context.Background()
+	var providerASawProviderBModel atomic.Bool
+	providerA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tags":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"models":[{"name":"a-model"}]}`))
+		case "/api/show":
+			var body struct {
+				Name string `json:"name"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, "bad show request", http.StatusBadRequest)
+				return
+			}
+			if body.Name == "b-model" {
+				providerASawProviderBModel.Store(true)
+				http.Error(w, "wrong provider", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"details":{"family":"qwen3","parameter_size":"8B"},"capabilities":["completion"]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer providerA.Close()
+
+	var providerBShowCalls atomic.Int32
+	providerB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tags":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"models":[{"name":"b-model"}]}`))
+		case "/api/show":
+			var body struct {
+				Name string `json:"name"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, "bad show request", http.StatusBadRequest)
+				return
+			}
+			if body.Name != "b-model" {
+				http.Error(w, "unexpected model", http.StatusNotFound)
+				return
+			}
+			providerBShowCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"details":{"family":"qwen3","parameter_size":"8B"},"capabilities":["completion"]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer providerB.Close()
+
+	cfg := &config.Config{
+		Providers: map[string]config.ProviderConfig{
+			"a": {APIFormat: "ollama", BaseURL: providerA.URL},
+			"b": {APIFormat: "ollama", BaseURL: providerB.URL},
+		},
+		Models: map[string]config.ModelConfig{
+			"chat": {Provider: "b", Name: "b-model", Type: "dense"},
+		},
+	}
+	bundle, err := New(ctx, Options{Config: cfg, FingerprintStore: newTestFingerprintStore(t)})
+	if err != nil {
+		t.Fatalf("New(multi-ollama cfg) error: %v", err)
+	}
+	defer func() { _ = bundle.Close() }()
+
+	profile, err := bundle.Models.Lookup(ctx, provider.ModelKey{Provider: "b", Model: "b-model"})
+	if err != nil {
+		t.Fatalf("Lookup(b/b-model) error = %v", err)
+	}
+	if !profile.Caps.Has(provider.CapChat) {
+		t.Fatalf("profile caps = %v, want chat capability from provider B", profile.Caps)
+	}
+	if providerASawProviderBModel.Load() {
+		t.Fatal("provider B fingerprint probe used provider A's Ollama client")
+	}
+	if got := providerBShowCalls.Load(); got < 3 {
+		t.Fatalf("provider B /api/show calls = %d, want startup, runtime lookup, and fingerprint probe", got)
 	}
 }
 

--- a/internal/providerbootstrap/bootstrap_test.go
+++ b/internal/providerbootstrap/bootstrap_test.go
@@ -1,0 +1,13 @@
+package providerbootstrap
+
+import "testing"
+
+func TestBundleCloseNilSafe(t *testing.T) {
+	var b *Bundle
+	if err := b.Close(); err != nil {
+		t.Fatalf("nil Bundle.Close() = %v, want nil", err)
+	}
+	if err := (&Bundle{}).Close(); err != nil {
+		t.Fatalf("empty Bundle.Close() = %v, want nil", err)
+	}
+}

--- a/internal/providerbootstrap/capabilities.go
+++ b/internal/providerbootstrap/capabilities.go
@@ -1,0 +1,144 @@
+package providerbootstrap
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/kstruzzieri/go-llm/config"
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// capabilitiesForKey returns the configured capabilities for a model key:
+// explicit Capabilities when set, else ResolvedCapabilities. Nil when unknown.
+func capabilitiesForKey(cfg *config.Config, key provider.ModelKey) []string {
+	if cfg == nil {
+		return nil
+	}
+	roles := make([]string, 0, len(cfg.Models))
+	for role := range cfg.Models {
+		roles = append(roles, role)
+	}
+	sort.Strings(roles)
+	for _, role := range roles {
+		m := cfg.Models[role]
+		if m.Provider != key.Provider || m.Name != key.Model {
+			continue
+		}
+		if len(m.Capabilities) > 0 {
+			out := make([]string, len(m.Capabilities))
+			copy(out, m.Capabilities)
+			return out
+		}
+		return m.ResolvedCapabilities()
+	}
+	return nil
+}
+
+// capabilityOverrideEntry holds the per-key data used for conflict detection
+// inside buildCapabilityOverrides.
+type capabilityOverrideEntry struct {
+	role   string
+	caps   []string
+	parsed provider.Capability
+}
+
+// buildCapabilityOverrides computes the capability overrides declared in
+// models.json, keyed by provider.ModelKey. It errors on conflicting
+// declarations for the same key. Returns an empty (non-nil) map when cfg is
+// nil or declares none. Pure (no registry side effect) so it is directly
+// unit-testable.
+func buildCapabilityOverrides(cfg *config.Config) (map[provider.ModelKey][]string, error) {
+	out := make(map[provider.ModelKey][]string)
+	if cfg == nil {
+		return out, nil
+	}
+
+	overrides := make(map[provider.ModelKey]capabilityOverrideEntry)
+	roles := make([]string, 0, len(cfg.Models))
+	for role := range cfg.Models {
+		roles = append(roles, role)
+	}
+	sort.Strings(roles)
+	for _, role := range roles {
+		m := cfg.Models[role]
+		if m.Provider == "" || m.Name == "" {
+			continue
+		}
+		caps := m.Capabilities
+		if len(caps) == 0 {
+			pCfg, ok := cfg.Providers[m.Provider]
+			if !ok {
+				continue
+			}
+			apiFormat := pCfg.APIFormat
+			if apiFormat == "" {
+				apiFormat = "ollama"
+			}
+			if apiFormat != "openai-compat" {
+				continue
+			}
+			caps = m.ResolvedCapabilities()
+		}
+		if len(caps) == 0 {
+			continue
+		}
+		parsedCaps, err := provider.ParseCapsStrict(caps)
+		if err != nil {
+			return nil, fmt.Errorf("providerbootstrap: model %q capability override for %s/%s: %w", role, m.Provider, m.Name, err)
+		}
+
+		key := provider.ModelKey{Provider: m.Provider, Model: m.Name}
+		if existing, ok := overrides[key]; ok {
+			if existing.parsed != parsedCaps {
+				return nil, fmt.Errorf(
+					"providerbootstrap: conflicting capability overrides for %s/%s: model %q declares %v, model %q declares %v",
+					key.Provider,
+					key.Model,
+					existing.role,
+					existing.caps,
+					role,
+					caps,
+				)
+			}
+			continue
+		}
+
+		copied := make([]string, len(caps))
+		copy(copied, caps)
+		overrides[key] = capabilityOverrideEntry{
+			role:   role,
+			caps:   copied,
+			parsed: parsedCaps,
+		}
+	}
+
+	for key, entry := range overrides {
+		out[key] = entry.caps
+	}
+	return out, nil
+}
+
+// installCapabilityOverrides installs the computed overrides onto the registry.
+// No-op when mr/cfg is nil or there are no overrides.
+func installCapabilityOverrides(mr *provider.ModelRegistry, cfg *config.Config) error {
+	if mr == nil || cfg == nil {
+		return nil
+	}
+	overrides, err := buildCapabilityOverrides(cfg)
+	if err != nil {
+		return err
+	}
+	if len(overrides) == 0 {
+		return nil
+	}
+	mr.SetCapabilityOverride(func(key provider.ModelKey) []string {
+		caps, ok := overrides[key]
+		if !ok {
+			return nil
+		}
+		out := make([]string, len(caps))
+		copy(out, caps)
+		return out
+	})
+	return nil
+}

--- a/internal/providerbootstrap/capabilities_test.go
+++ b/internal/providerbootstrap/capabilities_test.go
@@ -1,0 +1,62 @@
+package providerbootstrap
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/config"
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+func TestCapabilitiesForKey_ExplicitCaps(t *testing.T) {
+	cfg := &config.Config{Models: map[string]config.ModelConfig{
+		"chat": {Provider: "lc", Name: "qwen", Capabilities: []string{"chat", "tool_call"}},
+	}}
+	got := capabilitiesForKey(cfg, provider.ModelKey{Provider: "lc", Model: "qwen"})
+	if !reflect.DeepEqual(got, []string{"chat", "tool_call"}) {
+		t.Fatalf("caps = %v", got)
+	}
+}
+
+func TestCapabilitiesForKey_UnknownKeyNil(t *testing.T) {
+	cfg := &config.Config{Models: map[string]config.ModelConfig{}}
+	if got := capabilitiesForKey(cfg, provider.ModelKey{Provider: "x", Model: "y"}); got != nil {
+		t.Fatalf("caps = %v, want nil", got)
+	}
+}
+
+func TestBuildCapabilityOverrides_OpenAICompatModel(t *testing.T) {
+	cfg := &config.Config{
+		Providers: map[string]config.ProviderConfig{"lc": {APIFormat: "openai-compat"}},
+		Models: map[string]config.ModelConfig{
+			"chat": {Provider: "lc", Name: "qwen", Capabilities: []string{"chat", "tool_call"}},
+		},
+	}
+	got, err := buildCapabilityOverrides(cfg)
+	if err != nil {
+		t.Fatalf("buildCapabilityOverrides: %v", err)
+	}
+	caps := got[provider.ModelKey{Provider: "lc", Model: "qwen"}]
+	if !reflect.DeepEqual(caps, []string{"chat", "tool_call"}) {
+		t.Fatalf("override caps = %v", caps)
+	}
+}
+
+func TestBuildCapabilityOverrides_ConflictErrors(t *testing.T) {
+	cfg := &config.Config{
+		Providers: map[string]config.ProviderConfig{"lc": {APIFormat: "openai-compat"}},
+		Models: map[string]config.ModelConfig{
+			"chat":   {Provider: "lc", Name: "qwen", Capabilities: []string{"chat"}},
+			"review": {Provider: "lc", Name: "qwen", Capabilities: []string{"chat", "tool_call"}},
+		},
+	}
+	if _, err := buildCapabilityOverrides(cfg); err == nil {
+		t.Fatalf("expected conflict error for divergent caps on same key")
+	}
+}
+
+func TestInstallCapabilityOverrides_NilSafe(t *testing.T) {
+	if err := installCapabilityOverrides(nil, nil); err != nil {
+		t.Fatalf("installCapabilityOverrides(nil,nil) = %v, want nil", err)
+	}
+}

--- a/internal/providerbootstrap/fingerprint.go
+++ b/internal/providerbootstrap/fingerprint.go
@@ -1,0 +1,66 @@
+package providerbootstrap
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kstruzzieri/go-llm/config"
+	"github.com/kstruzzieri/go-llm/fingerprint/probers"
+	"github.com/kstruzzieri/go-llm/ollama"
+	"github.com/kstruzzieri/go-llm/provider"
+	"github.com/kstruzzieri/go-llm/provider/openaicompat"
+)
+
+// proberFactory builds the provider-aware fingerprint prober factory. The
+// ollamaClient is reused for ollama-format probers (mirrors mcp's s.client).
+func proberFactory(cfg *config.Config, ollamaClient *ollama.Client) provider.FingerprintProberFactory {
+	return func(ctx context.Context, key provider.ModelKey, runtime *provider.ModelInfo, p provider.Provider) (*provider.FingerprintProberSpec, error) {
+		apiFormat := "ollama"
+		if cfg != nil {
+			pc, ok := cfg.Providers[key.Provider]
+			if !ok {
+				return nil, nil
+			}
+			apiFormat = pc.APIFormat
+			if apiFormat == "" {
+				apiFormat = "ollama"
+			}
+		}
+
+		caps := capabilitiesForKey(cfg, key)
+		in := probers.ProberFactoryInput{
+			APIFormat:    apiFormat,
+			OllamaClient: ollamaClient,
+			Capabilities: caps,
+		}
+		if apiFormat == "openai-compat" {
+			oc, ok := p.(*openaicompat.Provider)
+			if !ok {
+				return nil, fmt.Errorf("providerbootstrap: fingerprint prober for %s/%s: provider has type %T, want *openaicompat.Provider", key.Provider, key.Model, p)
+			}
+			in.OpenAICompatProvider = oc
+		}
+
+		prober, err := probers.NewProberForAPIFormat(in)
+		if err != nil {
+			return nil, err
+		}
+		return &provider.FingerprintProberSpec{
+			Prober:      prober,
+			ModelDigest: fingerprintDigestForModel(key, runtime, caps),
+		}, nil
+	}
+}
+
+// fingerprintDigestForModel returns the canonical model digest for fingerprint
+// cache keying. Mirrors mcp.fingerprintDigestForModel exactly.
+func fingerprintDigestForModel(key provider.ModelKey, runtime *provider.ModelInfo, caps []string) string {
+	if runtime != nil && runtime.Digest != "" {
+		return runtime.Digest
+	}
+	if len(caps) > 0 {
+		return "config-caps:" + strings.Join(caps, ",")
+	}
+	return key.String()
+}

--- a/internal/providerbootstrap/fingerprint.go
+++ b/internal/providerbootstrap/fingerprint.go
@@ -12,9 +12,10 @@ import (
 	"github.com/kstruzzieri/go-llm/provider/openaicompat"
 )
 
-// proberFactory builds the provider-aware fingerprint prober factory. The
-// ollamaClient is reused for ollama-format probers (mirrors mcp's s.client).
-func proberFactory(cfg *config.Config, ollamaClient *ollama.Client) provider.FingerprintProberFactory {
+// proberFactory builds the provider-aware fingerprint prober factory. Ollama
+// clients are keyed by provider name so multi-Ollama configs probe the same
+// backend that owns the requested model key.
+func proberFactory(cfg *config.Config, ollamaClients map[string]*ollama.Client) provider.FingerprintProberFactory {
 	return func(ctx context.Context, key provider.ModelKey, runtime *provider.ModelInfo, p provider.Provider) (*provider.FingerprintProberSpec, error) {
 		apiFormat := "ollama"
 		if cfg != nil {
@@ -31,7 +32,7 @@ func proberFactory(cfg *config.Config, ollamaClient *ollama.Client) provider.Fin
 		caps := capabilitiesForKey(cfg, key)
 		in := probers.ProberFactoryInput{
 			APIFormat:    apiFormat,
-			OllamaClient: ollamaClient,
+			OllamaClient: ollamaClients[key.Provider],
 			Capabilities: caps,
 		}
 		if apiFormat == "openai-compat" {

--- a/internal/providerbootstrap/fingerprint_test.go
+++ b/internal/providerbootstrap/fingerprint_test.go
@@ -1,0 +1,57 @@
+package providerbootstrap
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/config"
+	"github.com/kstruzzieri/go-llm/ollama"
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+func TestProberFactory_OllamaKeyBuildsProber(t *testing.T) {
+	cfg := &config.Config{Providers: map[string]config.ProviderConfig{
+		"ollama": {APIFormat: "ollama", BaseURL: "http://localhost:11434"},
+	}}
+	factory := proberFactory(cfg, ollama.NewClient())
+	op := provider.NewOllamaProvider(ollama.NewClient(), provider.WithProviderName("ollama"))
+	spec, err := factory(context.Background(), provider.ModelKey{Provider: "ollama", Model: "qwen"}, nil, op)
+	if err != nil {
+		t.Fatalf("factory error: %v", err)
+	}
+	if spec == nil || spec.Prober == nil {
+		t.Fatalf("expected non-nil prober spec")
+	}
+}
+
+func TestProberFactory_UnknownProviderReturnsNil(t *testing.T) {
+	cfg := &config.Config{Providers: map[string]config.ProviderConfig{}}
+	factory := proberFactory(cfg, ollama.NewClient())
+	spec, err := factory(context.Background(), provider.ModelKey{Provider: "missing", Model: "m"}, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec != nil {
+		t.Fatalf("expected nil spec for unknown provider")
+	}
+}
+
+func TestProberFactory_OpenAICompatWrongTypeErrors(t *testing.T) {
+	cfg := &config.Config{Providers: map[string]config.ProviderConfig{
+		"lc": {APIFormat: "openai-compat", BaseURL: "http://localhost:8080"},
+	}}
+	factory := proberFactory(cfg, ollama.NewClient())
+	op := provider.NewOllamaProvider(ollama.NewClient(), provider.WithProviderName("lc"))
+	if _, err := factory(context.Background(), provider.ModelKey{Provider: "lc", Model: "m"}, nil, op); err == nil {
+		t.Fatalf("expected type-mismatch error when openai-compat provider is not *openaicompat.Provider")
+	}
+}
+
+func TestFingerprintDigestForModel(t *testing.T) {
+	if got := fingerprintDigestForModel(provider.ModelKey{Provider: "p", Model: "m"}, nil, []string{"chat"}); got != "config-caps:chat" {
+		t.Fatalf("digest = %q", got)
+	}
+	if got := fingerprintDigestForModel(provider.ModelKey{Provider: "p", Model: "m"}, nil, nil); got != "p/m" {
+		t.Fatalf("digest = %q, want p/m", got)
+	}
+}

--- a/internal/providerbootstrap/fingerprint_test.go
+++ b/internal/providerbootstrap/fingerprint_test.go
@@ -13,7 +13,7 @@ func TestProberFactory_OllamaKeyBuildsProber(t *testing.T) {
 	cfg := &config.Config{Providers: map[string]config.ProviderConfig{
 		"ollama": {APIFormat: "ollama", BaseURL: "http://localhost:11434"},
 	}}
-	factory := proberFactory(cfg, ollama.NewClient())
+	factory := proberFactory(cfg, map[string]*ollama.Client{"ollama": ollama.NewClient()})
 	op := provider.NewOllamaProvider(ollama.NewClient(), provider.WithProviderName("ollama"))
 	spec, err := factory(context.Background(), provider.ModelKey{Provider: "ollama", Model: "qwen"}, nil, op)
 	if err != nil {
@@ -26,7 +26,7 @@ func TestProberFactory_OllamaKeyBuildsProber(t *testing.T) {
 
 func TestProberFactory_UnknownProviderReturnsNil(t *testing.T) {
 	cfg := &config.Config{Providers: map[string]config.ProviderConfig{}}
-	factory := proberFactory(cfg, ollama.NewClient())
+	factory := proberFactory(cfg, map[string]*ollama.Client{"ollama": ollama.NewClient()})
 	spec, err := factory(context.Background(), provider.ModelKey{Provider: "missing", Model: "m"}, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -40,7 +40,7 @@ func TestProberFactory_OpenAICompatWrongTypeErrors(t *testing.T) {
 	cfg := &config.Config{Providers: map[string]config.ProviderConfig{
 		"lc": {APIFormat: "openai-compat", BaseURL: "http://localhost:8080"},
 	}}
-	factory := proberFactory(cfg, ollama.NewClient())
+	factory := proberFactory(cfg, map[string]*ollama.Client{"ollama": ollama.NewClient()})
 	op := provider.NewOllamaProvider(ollama.NewClient(), provider.WithProviderName("lc"))
 	if _, err := factory(context.Background(), provider.ModelKey{Provider: "lc", Model: "m"}, nil, op); err == nil {
 		t.Fatalf("expected type-mismatch error when openai-compat provider is not *openaicompat.Provider")

--- a/internal/providerbootstrap/providers.go
+++ b/internal/providerbootstrap/providers.go
@@ -1,0 +1,96 @@
+package providerbootstrap
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+
+	"github.com/kstruzzieri/go-llm/config"
+	"github.com/kstruzzieri/go-llm/ollama"
+	"github.com/kstruzzieri/go-llm/provider"
+	"github.com/kstruzzieri/go-llm/provider/openaicompat"
+)
+
+// buildProviders constructs every configured provider (sorted by config key).
+// It returns the registered providers, the ollama provider + its client (for the
+// fingerprint prober; nil when no ollama provider is configured), and the
+// EFFECTIVE config (the synthetic one when cfg==nil, else cfg) so callers reuse a
+// single coherent config. nil cfg synthesizes one default ollama provider at
+// override (or defaultOllamaURL). A non-nil cfg with zero Providers is an error
+// (mcp parity).
+func buildProviders(cfg *config.Config, override string) ([]provider.Provider, provider.Provider, *ollama.Client, *config.Config, error) {
+	effective := cfg
+	if cfg == nil {
+		url := override
+		if url == "" {
+			url = defaultOllamaURL
+		}
+		effective = &config.Config{Providers: map[string]config.ProviderConfig{
+			"ollama": {BaseURL: url, APIFormat: "ollama"},
+		}}
+	} else if len(cfg.Providers) == 0 {
+		return nil, nil, nil, nil, fmt.Errorf("providerbootstrap: no providers configured")
+	}
+
+	keys := make([]string, 0, len(effective.Providers))
+	for key := range effective.Providers {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	registered := make([]provider.Provider, 0, len(keys))
+	var ollamaProv provider.Provider
+	var ollamaClient *ollama.Client
+	for _, key := range keys {
+		if err := config.ValidateProviderName(key); err != nil {
+			return nil, nil, nil, nil, fmt.Errorf("providerbootstrap: provider config: %w", err)
+		}
+		pc := effective.Providers[key]
+		if pc.APIFormat == "" {
+			pc.APIFormat = "ollama"
+		}
+		// Explicit override pins the ollama base URL (mirrors mcp WithOllamaURL).
+		if key == "ollama" && pc.APIFormat == "ollama" && override != "" {
+			pc.BaseURL = override
+		}
+		prov, client, err := buildProvider(key, pc)
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+		registered = append(registered, prov)
+		if pc.APIFormat == "ollama" && client != nil {
+			if key == "ollama" || ollamaProv == nil {
+				ollamaProv, ollamaClient = prov, client
+			}
+		}
+	}
+	return registered, ollamaProv, ollamaClient, effective, nil
+}
+
+// buildProvider constructs one provider from its config. For ollama it also
+// returns the underlying client so the prober factory can reuse it.
+func buildProvider(key string, cfg config.ProviderConfig) (provider.Provider, *ollama.Client, error) {
+	switch cfg.APIFormat {
+	case "", "ollama":
+		opts := []ollama.Option{ollama.WithBaseURL(cfg.BaseURL)}
+		if cfg.Timeout.Duration > 0 {
+			opts = append(opts, ollama.WithTimeout(cfg.Timeout.Duration))
+		}
+		client := ollama.NewClient(opts...)
+		return provider.NewOllamaProvider(client, provider.WithProviderName(key)), client, nil
+	case "openai-compat":
+		copts := []openaicompat.ClientOption{}
+		if cfg.Timeout.Duration > 0 {
+			copts = append(copts, openaicompat.WithHTTPClient(&http.Client{Timeout: cfg.Timeout.Duration}))
+		}
+		if cfg.APIKey != "" {
+			copts = append(copts, openaicompat.WithAPIKey(cfg.APIKey))
+		}
+		return openaicompat.NewProvider(
+			openaicompat.NewClient(cfg.BaseURL, copts...),
+			openaicompat.WithProviderName(key),
+		), nil, nil
+	default:
+		return nil, nil, fmt.Errorf("providerbootstrap: provider %q: unsupported api_format %q", key, cfg.APIFormat)
+	}
+}

--- a/internal/providerbootstrap/providers.go
+++ b/internal/providerbootstrap/providers.go
@@ -12,12 +12,12 @@ import (
 )
 
 // buildProviders constructs every configured provider (sorted by config key).
-// It returns the registered providers, the ollama client (for the fingerprint
-// prober; nil when no ollama provider is configured), and the EFFECTIVE config
-// (the synthetic one when cfg==nil, else cfg) so callers reuse a single coherent
+// It returns the registered providers, the ollama clients keyed by provider name
+// (for provider-specific fingerprint probers), and the EFFECTIVE config (the
+// synthetic one when cfg==nil, else cfg) so callers reuse a single coherent
 // config. nil cfg synthesizes one default ollama provider at override (or
 // defaultOllamaURL). A non-nil cfg with zero Providers is an error (mcp parity).
-func buildProviders(cfg *config.Config, override string) ([]provider.Provider, *ollama.Client, *config.Config, error) {
+func buildProviders(cfg *config.Config, override string) ([]provider.Provider, map[string]*ollama.Client, *config.Config, error) {
 	effective := cfg
 	if cfg == nil {
 		url := override
@@ -38,7 +38,7 @@ func buildProviders(cfg *config.Config, override string) ([]provider.Provider, *
 	sort.Strings(keys)
 
 	registered := make([]provider.Provider, 0, len(keys))
-	var ollamaClient *ollama.Client
+	ollamaClients := make(map[string]*ollama.Client)
 	for _, key := range keys {
 		if err := config.ValidateProviderName(key); err != nil {
 			return nil, nil, nil, fmt.Errorf("providerbootstrap: provider config: %w", err)
@@ -57,12 +57,10 @@ func buildProviders(cfg *config.Config, override string) ([]provider.Provider, *
 		}
 		registered = append(registered, prov)
 		if pc.APIFormat == "ollama" && client != nil {
-			if key == "ollama" || ollamaClient == nil {
-				ollamaClient = client
-			}
+			ollamaClients[key] = client
 		}
 	}
-	return registered, ollamaClient, effective, nil
+	return registered, ollamaClients, effective, nil
 }
 
 // buildProvider constructs one provider from its config. For ollama it also

--- a/internal/providerbootstrap/providers.go
+++ b/internal/providerbootstrap/providers.go
@@ -12,13 +12,12 @@ import (
 )
 
 // buildProviders constructs every configured provider (sorted by config key).
-// It returns the registered providers, the ollama provider + its client (for the
-// fingerprint prober; nil when no ollama provider is configured), and the
-// EFFECTIVE config (the synthetic one when cfg==nil, else cfg) so callers reuse a
-// single coherent config. nil cfg synthesizes one default ollama provider at
-// override (or defaultOllamaURL). A non-nil cfg with zero Providers is an error
-// (mcp parity).
-func buildProviders(cfg *config.Config, override string) ([]provider.Provider, provider.Provider, *ollama.Client, *config.Config, error) {
+// It returns the registered providers, the ollama client (for the fingerprint
+// prober; nil when no ollama provider is configured), and the EFFECTIVE config
+// (the synthetic one when cfg==nil, else cfg) so callers reuse a single coherent
+// config. nil cfg synthesizes one default ollama provider at override (or
+// defaultOllamaURL). A non-nil cfg with zero Providers is an error (mcp parity).
+func buildProviders(cfg *config.Config, override string) ([]provider.Provider, *ollama.Client, *config.Config, error) {
 	effective := cfg
 	if cfg == nil {
 		url := override
@@ -29,7 +28,7 @@ func buildProviders(cfg *config.Config, override string) ([]provider.Provider, p
 			"ollama": {BaseURL: url, APIFormat: "ollama"},
 		}}
 	} else if len(cfg.Providers) == 0 {
-		return nil, nil, nil, nil, fmt.Errorf("providerbootstrap: no providers configured")
+		return nil, nil, nil, fmt.Errorf("providerbootstrap: no providers configured")
 	}
 
 	keys := make([]string, 0, len(effective.Providers))
@@ -39,11 +38,10 @@ func buildProviders(cfg *config.Config, override string) ([]provider.Provider, p
 	sort.Strings(keys)
 
 	registered := make([]provider.Provider, 0, len(keys))
-	var ollamaProv provider.Provider
 	var ollamaClient *ollama.Client
 	for _, key := range keys {
 		if err := config.ValidateProviderName(key); err != nil {
-			return nil, nil, nil, nil, fmt.Errorf("providerbootstrap: provider config: %w", err)
+			return nil, nil, nil, fmt.Errorf("providerbootstrap: provider config: %w", err)
 		}
 		pc := effective.Providers[key]
 		if pc.APIFormat == "" {
@@ -55,16 +53,16 @@ func buildProviders(cfg *config.Config, override string) ([]provider.Provider, p
 		}
 		prov, client, err := buildProvider(key, pc)
 		if err != nil {
-			return nil, nil, nil, nil, err
+			return nil, nil, nil, err
 		}
 		registered = append(registered, prov)
 		if pc.APIFormat == "ollama" && client != nil {
-			if key == "ollama" || ollamaProv == nil {
-				ollamaProv, ollamaClient = prov, client
+			if key == "ollama" || ollamaClient == nil {
+				ollamaClient = client
 			}
 		}
 	}
-	return registered, ollamaProv, ollamaClient, effective, nil
+	return registered, ollamaClient, effective, nil
 }
 
 // buildProvider constructs one provider from its config. For ollama it also

--- a/internal/providerbootstrap/providers_test.go
+++ b/internal/providerbootstrap/providers_test.go
@@ -1,0 +1,82 @@
+package providerbootstrap
+
+import (
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/config"
+)
+
+// buildProviders returns (providers, ollamaProvider, ollamaClient, effectiveConfig, error).
+// nil cfg synthesizes one default ollama provider AND a synthetic effective config;
+// a non-nil cfg with zero Providers is an error (mcp parity).
+
+func TestBuildProviders_NilConfigSynthesizesDefaultOllamaAndEffectiveConfig(t *testing.T) {
+	provs, ollamaProv, ollamaClient, eff, err := buildProviders(nil, "")
+	if err != nil {
+		t.Fatalf("buildProviders(nil) error: %v", err)
+	}
+	if len(provs) != 1 || provs[0].Name() != "ollama" {
+		t.Fatalf("providers = %v, want [ollama]", provs)
+	}
+	if ollamaProv == nil || ollamaClient == nil {
+		t.Fatalf("expected ollama provider+client to be captured")
+	}
+	if eff == nil {
+		t.Fatalf("expected synthetic effective config, got nil")
+	}
+	if _, ok := eff.Providers["ollama"]; !ok {
+		t.Fatalf("synthetic effective config missing the ollama provider: %+v", eff.Providers)
+	}
+}
+
+func TestBuildProviders_OverrideURLAppliesToDefault(t *testing.T) {
+	_, _, _, eff, err := buildProviders(nil, "http://127.0.0.1:9999")
+	if err != nil {
+		t.Fatalf("buildProviders override error: %v", err)
+	}
+	if got := eff.Providers["ollama"].BaseURL; got != "http://127.0.0.1:9999" {
+		t.Fatalf("default ollama BaseURL = %q, want the override", got)
+	}
+}
+
+func TestBuildProviders_ConfigProvidersSortedAndNamed(t *testing.T) {
+	cfg := &config.Config{Providers: map[string]config.ProviderConfig{
+		"zeta":  {APIFormat: "openai-compat", BaseURL: "http://localhost:8081"},
+		"alpha": {APIFormat: "ollama", BaseURL: "http://localhost:11434"},
+	}}
+	provs, _, _, eff, err := buildProviders(cfg, "")
+	if err != nil {
+		t.Fatalf("buildProviders error: %v", err)
+	}
+	if len(provs) != 2 || provs[0].Name() != "alpha" || provs[1].Name() != "zeta" {
+		t.Fatalf("providers not sorted by key: %v", provs)
+	}
+	if eff != cfg {
+		t.Fatalf("effective config should be the passed config when non-nil")
+	}
+}
+
+func TestBuildProviders_EmptyConfigProvidersErrors(t *testing.T) {
+	cfg := &config.Config{Providers: map[string]config.ProviderConfig{}}
+	if _, _, _, _, err := buildProviders(cfg, ""); err == nil {
+		t.Fatalf("expected error for non-nil config with zero providers")
+	}
+}
+
+func TestBuildProviders_BadProviderNameErrors(t *testing.T) {
+	cfg := &config.Config{Providers: map[string]config.ProviderConfig{
+		"with/slash": {APIFormat: "ollama", BaseURL: "http://x"},
+	}}
+	if _, _, _, _, err := buildProviders(cfg, ""); err == nil {
+		t.Fatalf("expected error for invalid provider name")
+	}
+}
+
+func TestBuildProviders_UnsupportedAPIFormatErrors(t *testing.T) {
+	cfg := &config.Config{Providers: map[string]config.ProviderConfig{
+		"x": {APIFormat: "grpc-weird"},
+	}}
+	if _, _, _, _, err := buildProviders(cfg, ""); err == nil {
+		t.Fatalf("expected error for unsupported api_format")
+	}
+}

--- a/internal/providerbootstrap/providers_test.go
+++ b/internal/providerbootstrap/providers_test.go
@@ -6,20 +6,20 @@ import (
 	"github.com/kstruzzieri/go-llm/config"
 )
 
-// buildProviders returns (providers, ollamaProvider, ollamaClient, effectiveConfig, error).
+// buildProviders returns (providers, ollamaClient, effectiveConfig, error).
 // nil cfg synthesizes one default ollama provider AND a synthetic effective config;
 // a non-nil cfg with zero Providers is an error (mcp parity).
 
 func TestBuildProviders_NilConfigSynthesizesDefaultOllamaAndEffectiveConfig(t *testing.T) {
-	provs, ollamaProv, ollamaClient, eff, err := buildProviders(nil, "")
+	provs, ollamaClient, eff, err := buildProviders(nil, "")
 	if err != nil {
 		t.Fatalf("buildProviders(nil) error: %v", err)
 	}
 	if len(provs) != 1 || provs[0].Name() != "ollama" {
 		t.Fatalf("providers = %v, want [ollama]", provs)
 	}
-	if ollamaProv == nil || ollamaClient == nil {
-		t.Fatalf("expected ollama provider+client to be captured")
+	if ollamaClient == nil {
+		t.Fatalf("expected ollama client to be captured")
 	}
 	if eff == nil {
 		t.Fatalf("expected synthetic effective config, got nil")
@@ -30,7 +30,7 @@ func TestBuildProviders_NilConfigSynthesizesDefaultOllamaAndEffectiveConfig(t *t
 }
 
 func TestBuildProviders_OverrideURLAppliesToDefault(t *testing.T) {
-	_, _, _, eff, err := buildProviders(nil, "http://127.0.0.1:9999")
+	_, _, eff, err := buildProviders(nil, "http://127.0.0.1:9999")
 	if err != nil {
 		t.Fatalf("buildProviders override error: %v", err)
 	}
@@ -44,7 +44,7 @@ func TestBuildProviders_ConfigProvidersSortedAndNamed(t *testing.T) {
 		"zeta":  {APIFormat: "openai-compat", BaseURL: "http://localhost:8081"},
 		"alpha": {APIFormat: "ollama", BaseURL: "http://localhost:11434"},
 	}}
-	provs, _, _, eff, err := buildProviders(cfg, "")
+	provs, _, eff, err := buildProviders(cfg, "")
 	if err != nil {
 		t.Fatalf("buildProviders error: %v", err)
 	}
@@ -58,7 +58,7 @@ func TestBuildProviders_ConfigProvidersSortedAndNamed(t *testing.T) {
 
 func TestBuildProviders_EmptyConfigProvidersErrors(t *testing.T) {
 	cfg := &config.Config{Providers: map[string]config.ProviderConfig{}}
-	if _, _, _, _, err := buildProviders(cfg, ""); err == nil {
+	if _, _, _, err := buildProviders(cfg, ""); err == nil {
 		t.Fatalf("expected error for non-nil config with zero providers")
 	}
 }
@@ -67,7 +67,7 @@ func TestBuildProviders_BadProviderNameErrors(t *testing.T) {
 	cfg := &config.Config{Providers: map[string]config.ProviderConfig{
 		"with/slash": {APIFormat: "ollama", BaseURL: "http://x"},
 	}}
-	if _, _, _, _, err := buildProviders(cfg, ""); err == nil {
+	if _, _, _, err := buildProviders(cfg, ""); err == nil {
 		t.Fatalf("expected error for invalid provider name")
 	}
 }
@@ -76,7 +76,7 @@ func TestBuildProviders_UnsupportedAPIFormatErrors(t *testing.T) {
 	cfg := &config.Config{Providers: map[string]config.ProviderConfig{
 		"x": {APIFormat: "grpc-weird"},
 	}}
-	if _, _, _, _, err := buildProviders(cfg, ""); err == nil {
+	if _, _, _, err := buildProviders(cfg, ""); err == nil {
 		t.Fatalf("expected error for unsupported api_format")
 	}
 }

--- a/internal/providerbootstrap/providers_test.go
+++ b/internal/providerbootstrap/providers_test.go
@@ -6,19 +6,19 @@ import (
 	"github.com/kstruzzieri/go-llm/config"
 )
 
-// buildProviders returns (providers, ollamaClient, effectiveConfig, error).
+// buildProviders returns (providers, ollamaClients, effectiveConfig, error).
 // nil cfg synthesizes one default ollama provider AND a synthetic effective config;
 // a non-nil cfg with zero Providers is an error (mcp parity).
 
 func TestBuildProviders_NilConfigSynthesizesDefaultOllamaAndEffectiveConfig(t *testing.T) {
-	provs, ollamaClient, eff, err := buildProviders(nil, "")
+	provs, ollamaClients, eff, err := buildProviders(nil, "")
 	if err != nil {
 		t.Fatalf("buildProviders(nil) error: %v", err)
 	}
 	if len(provs) != 1 || provs[0].Name() != "ollama" {
 		t.Fatalf("providers = %v, want [ollama]", provs)
 	}
-	if ollamaClient == nil {
+	if ollamaClients["ollama"] == nil {
 		t.Fatalf("expected ollama client to be captured")
 	}
 	if eff == nil {

--- a/mcp/fingerprint_prober_factory_test.go
+++ b/mcp/fingerprint_prober_factory_test.go
@@ -100,7 +100,7 @@ func TestEnsureModelRegistry_ProfilesOpenAICompatWithConfiguredCapabilities(t *t
 		},
 	}
 
-	if err := s.ensureModelRegistry(); err != nil {
+	if err := s.ensureModelRegistry(ctx); err != nil {
 		t.Fatalf("ensureModelRegistry() error = %v", err)
 	}
 	profile, err := s.modelRegistry.Lookup(ctx, provider.ModelKey{Provider: "local-openai", Model: "llama-local"})

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -451,6 +452,13 @@ func (s *Server) ensureModelRegistry(ctx context.Context) error {
 	if warmthSource != nil {
 		s.warmthSource = warmthSource
 		s.ollamaProv = providerForName(bundle.Providers, "ollama")
+	}
+	// Surface best-effort bootstrap failures (a provider that failed to register
+	// or refresh its model index) rather than silently dropping Bundle.Warnings.
+	// Non-fatal: the registry/router were still built. Logged only for the bundle
+	// we install (the lost-race bundle's warnings belong to a discarded stack).
+	for _, w := range bundle.Warnings {
+		log.Printf("mcp: model registry init: %v", w)
 	}
 	return nil
 }

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -64,9 +64,10 @@ type Server struct {
 	completer        *completion.Provider
 	modelRegistry    *provider.ModelRegistry
 	providerRegistry *provider.Registry
-	ollamaProv       provider.Provider
-	router           routeEngine
-	warmthSource     provider.WarmthSource
+	ollamaProv       provider.Provider // default "ollama"-format provider when warmth is wired; set for parity assertions, no production reader
+
+	router       routeEngine
+	warmthSource provider.WarmthSource
 
 	ollamaAvailable bool
 	closed          bool

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -231,16 +231,23 @@ func NewServer(ctx context.Context, opts ...Option) (*Server, error) {
 	if err := s.ensureModelRegistry(ctx); err != nil {
 		return nil, err
 	}
+	cleanupStartupFailure := func() {
+		if err := s.Close(); err != nil {
+			log.Printf("mcp: cleanup after startup failure: %v", err)
+		}
+	}
 
 	// Step 4: Open RAG store if not disabled (before model resolution
 	// so that rebuildDerivedClients can wire up indexer/retriever).
 	if !s.ragDisabled && s.ragPath != "" {
 		parentDir := filepath.Dir(s.ragPath)
 		if err := os.MkdirAll(parentDir, 0o755); err != nil {
+			cleanupStartupFailure()
 			return nil, fmt.Errorf("mcp: create RAG directory %q: %w", parentDir, err)
 		}
 		store, err := rag.NewSQLiteStore(s.ragPath)
 		if err != nil {
+			cleanupStartupFailure()
 			return nil, fmt.Errorf("mcp: open RAG store: %w", err)
 		}
 		s.store = store
@@ -249,21 +256,15 @@ func NewServer(ctx context.Context, opts ...Option) (*Server, error) {
 	// Step 4b: open the optional transcript store (off unless WithTranscriptStore
 	// is set). Failure is fatal: the caller explicitly asked to persist here.
 	if s.transcriptDBPath != "" {
-		cleanupTranscriptStartupFailure := func() {
-			if s.store != nil {
-				_ = s.store.Close()
-				s.store = nil
-			}
-		}
 		if dir := filepath.Dir(s.transcriptDBPath); dir != "" && dir != "." {
 			if err := os.MkdirAll(dir, 0o700); err != nil {
-				cleanupTranscriptStartupFailure()
+				cleanupStartupFailure()
 				return nil, fmt.Errorf("mcp: create transcript directory %q: %w", dir, err)
 			}
 		}
 		ts, err := transcript.Open(ctx, s.transcriptDBPath)
 		if err != nil {
-			cleanupTranscriptStartupFailure()
+			cleanupStartupFailure()
 			return nil, fmt.Errorf("mcp: open transcript store: %w", err)
 		}
 		s.transcriptStore = ts
@@ -426,6 +427,9 @@ func (s *Server) ensureModelRegistry(ctx context.Context) error {
 		RouterOptions:     routerOpts,
 	})
 	if err != nil {
+		if warmthSource != nil {
+			_ = warmthSource.Close()
+		}
 		return fmt.Errorf("mcp: model registry unavailable: %w", err)
 	}
 

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 	"sync"
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -19,10 +18,9 @@ import (
 	"github.com/kstruzzieri/go-llm/completion"
 	"github.com/kstruzzieri/go-llm/config"
 	"github.com/kstruzzieri/go-llm/fingerprint"
-	"github.com/kstruzzieri/go-llm/fingerprint/probers"
+	"github.com/kstruzzieri/go-llm/internal/providerbootstrap"
 	"github.com/kstruzzieri/go-llm/ollama"
 	"github.com/kstruzzieri/go-llm/provider"
-	"github.com/kstruzzieri/go-llm/provider/openaicompat"
 	"github.com/kstruzzieri/go-llm/rag"
 	"github.com/kstruzzieri/go-llm/transcript"
 )
@@ -224,9 +222,11 @@ func NewServer(ctx context.Context, opts ...Option) (*Server, error) {
 	// Step 3: Check Ollama availability (non-fatal, degraded mode on failure).
 	s.ollamaAvailable = s.client.IsAvailable(ctx)
 
-	// Step 3b: Build the provider-level model registry even in degraded mode
-	// so explicit completion requests can recover once Ollama comes back.
-	if err := s.ensureModelRegistry(); err != nil {
+	// Step 3b: Build the provider-level model registry (and Router/warmth) even
+	// in degraded mode so explicit completion requests can recover once Ollama
+	// comes back. ensureModelRegistry now owns the full bootstrap, including the
+	// warmth source and Router, so the old Step 4c block is gone.
+	if err := s.ensureModelRegistry(ctx); err != nil {
 		return nil, err
 	}
 
@@ -265,25 +265,6 @@ func NewServer(ctx context.Context, opts ...Option) (*Server, error) {
 			return nil, fmt.Errorf("mcp: open transcript store: %w", err)
 		}
 		s.transcriptStore = ts
-	}
-
-	// Step 4c: build warmth source and Router after fallible store setup.
-	// NewRouter does not perform network I/O, so this is safe even when
-	// local providers are unreachable. The warmth source's polling goroutine
-	// starts immediately and is fail-open when the default Ollama instance
-	// is registered.
-	if s.modelRegistry != nil && s.providerRegistry != nil {
-		opts := []provider.RouterOption{}
-		if s.ollamaProv != nil && s.ollamaProv.Name() == "ollama" {
-			s.warmthSource = provider.NewOllamaWarmthSource(s.ollamaURL, "ollama")
-			opts = append(opts, provider.WithWarmthSource(s.warmthSource))
-		}
-		s.router = provider.NewRouter(s.modelRegistry, s.providerRegistry, opts...)
-		// Best-effort: populate the providerRegistry's model index for every
-		// registered provider so model-name lookup and Recommend can produce
-		// candidates. Failures are tolerated; refreshResolved and list_models
-		// also self-heal on later calls.
-		s.refreshProviderModelIndexes(ctx)
 	}
 
 	// Step 5: Resolve models and rebuild derived clients (non-fatal).
@@ -409,7 +390,13 @@ func (s *Server) rebuildDerivedClients(ctx context.Context) {
 	s.mu.Unlock()
 }
 
-func (s *Server) ensureModelRegistry() error {
+// ensureModelRegistry lazily assembles the provider/model-registry/router stack
+// via internal/providerbootstrap and installs it under the server lock. It is
+// ctx-aware so bootstrap's best-effort RefreshModels honors cancellation. The
+// install is coherent: on losing the init race, the freshly built bundle is
+// discarded by closing it (which stops its warmth source) so fields are never
+// spliced across two bundles.
+func (s *Server) ensureModelRegistry(ctx context.Context) error {
 	s.mu.RLock()
 	if s.modelRegistry != nil && s.providerRegistry != nil {
 		s.mu.RUnlock()
@@ -417,274 +404,84 @@ func (s *Server) ensureModelRegistry() error {
 	}
 	s.mu.RUnlock()
 
-	pReg := provider.NewRegistry()
-	registered, ollamaProv, err := s.configuredProviders()
-	if err != nil {
-		return err
+	override := ""
+	if s.ollamaURLExplicit {
+		override = s.ollamaURL
 	}
-	for _, p := range registered {
-		if err := pReg.Register(p); err != nil {
-			return fmt.Errorf("mcp: model registry unavailable: %w", err)
-		}
+	routerOpts := []provider.RouterOption{}
+	var warmthSource *provider.OllamaWarmthSource
+	// Warmth source is wired only for the default "ollama" provider, matching the
+	// prior NewServer Step 4c predicate (s.ollamaProv.Name()=="ollama").
+	if providerConfigHasDefaultOllama(s.cfg) {
+		warmthSource = provider.NewOllamaWarmthSource(s.ollamaURL, "ollama")
+		routerOpts = append(routerOpts, provider.WithWarmthSource(warmthSource))
 	}
-	mrOpts := []provider.ModelRegistryOption{}
-	if s.fingerprintStore != nil {
-		mrOpts = append(mrOpts, provider.WithFingerprintProberFactory(s.fingerprintProberFactory()))
-	}
-	mr, err := provider.NewModelRegistry(pReg, s.fingerprintStore, mrOpts...)
+
+	bundle, err := providerbootstrap.New(ctx, providerbootstrap.Options{
+		Config:            s.cfg,
+		FingerprintStore:  s.fingerprintStore,
+		OllamaURLOverride: override,
+		RouterOptions:     routerOpts,
+	})
 	if err != nil {
 		return fmt.Errorf("mcp: model registry unavailable: %w", err)
 	}
-	if err := s.installCapabilityOverrides(mr); err != nil {
-		return err
-	}
 
 	s.mu.Lock()
-	if s.ollamaProv == nil {
-		s.ollamaProv = ollamaProv
-	}
-	if s.providerRegistry == nil {
-		s.providerRegistry = pReg
-	}
-	if s.modelRegistry == nil {
-		s.modelRegistry = mr
-	}
-	s.mu.Unlock()
-	return nil
-}
-
-func (s *Server) fingerprintProberFactory() provider.FingerprintProberFactory {
-	return func(ctx context.Context, key provider.ModelKey, runtime *provider.ModelInfo, p provider.Provider) (*provider.FingerprintProberSpec, error) {
-		apiFormat := "ollama"
-		if s.cfg != nil {
-			cfg, ok := s.cfg.Providers[key.Provider]
-			if !ok {
-				return nil, nil
-			}
-			apiFormat = cfg.APIFormat
-			if apiFormat == "" {
-				apiFormat = "ollama"
-			}
-		}
-
-		caps := s.configuredCapabilitiesForKey(key)
-		in := probers.ProberFactoryInput{
-			APIFormat:    apiFormat,
-			OllamaClient: s.client,
-			Capabilities: caps,
-		}
-		if apiFormat == "openai-compat" {
-			oc, ok := p.(*openaicompat.Provider)
-			if !ok {
-				return nil, fmt.Errorf("mcp: fingerprint prober for %s/%s: provider has type %T, want *openaicompat.Provider", key.Provider, key.Model, p)
-			}
-			in.OpenAICompatProvider = oc
-		}
-
-		prober, err := probers.NewProberForAPIFormat(in)
-		if err != nil {
-			return nil, err
-		}
-		return &provider.FingerprintProberSpec{
-			Prober:      prober,
-			ModelDigest: fingerprintDigestForModel(key, runtime, caps),
-		}, nil
-	}
-}
-
-func (s *Server) configuredCapabilitiesForKey(key provider.ModelKey) []string {
-	if s.cfg == nil {
+	defer s.mu.Unlock()
+	// Lost the init race: another goroutine already installed a stack. Discard
+	// ours coherently — close the unused router (which stops our warmth source)
+	// — and keep theirs. Never splice fields across two bundles.
+	if s.modelRegistry != nil && s.providerRegistry != nil {
+		_ = bundle.Close()
 		return nil
 	}
-	roles := make([]string, 0, len(s.cfg.Models))
-	for role := range s.cfg.Models {
-		roles = append(roles, role)
-	}
-	sort.Strings(roles)
-	for _, role := range roles {
-		m := s.cfg.Models[role]
-		if m.Provider != key.Provider || m.Name != key.Model {
-			continue
-		}
-		if len(m.Capabilities) > 0 {
-			out := make([]string, len(m.Capabilities))
-			copy(out, m.Capabilities)
-			return out
-		}
-		return m.ResolvedCapabilities()
+	// Won: install the whole stack from THIS bundle.
+	s.providerRegistry = bundle.Providers
+	s.modelRegistry = bundle.Models
+	s.router = bundle.Router
+	// Only assign when present: storing a typed-nil *OllamaWarmthSource into the
+	// provider.WarmthSource interface field would make s.warmthSource a non-nil
+	// interface holding a nil pointer, breaking the "no warmth source" invariant
+	// the prior Step 4c code preserved by assigning inside the predicate branch.
+	// The same guard mirrors the configuredProviders invariant for ollamaProv:
+	// it is the "ollama"-named provider ONLY when that provider is ollama-format
+	// (an openai-compat provider named "ollama" leaves both fields nil).
+	if warmthSource != nil {
+		s.warmthSource = warmthSource
+		s.ollamaProv = providerForName(bundle.Providers, "ollama")
 	}
 	return nil
 }
 
-func fingerprintDigestForModel(key provider.ModelKey, runtime *provider.ModelInfo, caps []string) string {
-	if runtime != nil && runtime.Digest != "" {
-		return runtime.Digest
+// providerConfigHasDefaultOllama reports whether the effective config exposes an
+// "ollama"-named provider speaking the ollama api_format. It reproduces the
+// prior NewServer Step 4c predicate (s.ollamaProv != nil &&
+// s.ollamaProv.Name() == "ollama"): a nil config synthesizes the default ollama
+// provider, and a non-nil config qualifies only when its "ollama" entry is
+// ollama-format (an openai-compat provider named "ollama" must NOT match).
+func providerConfigHasDefaultOllama(cfg *config.Config) bool {
+	if cfg == nil {
+		return true
 	}
-	if len(caps) > 0 {
-		return "config-caps:" + strings.Join(caps, ",")
+	pCfg, ok := cfg.Providers["ollama"]
+	if !ok {
+		return false
 	}
-	return key.String()
+	return providerConfigIsOllama(pCfg)
 }
 
-func (s *Server) configuredProviders() ([]provider.Provider, provider.Provider, error) {
-	providerConfigs := map[string]config.ProviderConfig{}
-	if s.cfg == nil {
-		providerConfigs["ollama"] = config.ProviderConfig{
-			BaseURL:   s.ollamaURL,
-			APIFormat: "ollama",
-		}
-	} else {
-		if len(s.cfg.Providers) == 0 {
-			return nil, nil, fmt.Errorf("mcp: model registry unavailable: no providers configured")
-		}
-		for key, cfg := range s.cfg.Providers {
-			providerConfigs[key] = cfg
-		}
-	}
-
-	keys := make([]string, 0, len(providerConfigs))
-	for key := range providerConfigs {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-
-	registered := make([]provider.Provider, 0, len(keys))
-	var ollamaProv provider.Provider
-	for _, key := range keys {
-		if err := config.ValidateProviderName(key); err != nil {
-			return nil, nil, fmt.Errorf("mcp: provider config: %w", err)
-		}
-		cfg := providerConfigs[key]
-		if cfg.APIFormat == "" {
-			cfg.APIFormat = "ollama"
-		}
-		if key == "ollama" && cfg.APIFormat == "ollama" && s.ollamaURLExplicit {
-			cfg.BaseURL = s.ollamaURL
-		}
-
-		prov, err := configuredProvider(key, cfg)
-		if err != nil {
-			return nil, nil, err
-		}
-		registered = append(registered, prov)
-		if cfg.APIFormat == "ollama" && key == "ollama" {
-			ollamaProv = prov
-		}
-	}
-	return registered, ollamaProv, nil
-}
-
-func configuredProvider(key string, cfg config.ProviderConfig) (provider.Provider, error) {
-	switch cfg.APIFormat {
-	case "", "ollama":
-		opts := []ollama.Option{ollama.WithBaseURL(cfg.BaseURL)}
-		if cfg.Timeout.Duration > 0 {
-			opts = append(opts, ollama.WithTimeout(cfg.Timeout.Duration))
-		}
-		return provider.NewOllamaProvider(
-			ollama.NewClient(opts...),
-			provider.WithProviderName(key),
-		), nil
-	case "openai-compat":
-		opts := []openaicompat.ClientOption{}
-		if cfg.Timeout.Duration > 0 {
-			opts = append(opts, openaicompat.WithHTTPClient(&http.Client{Timeout: cfg.Timeout.Duration}))
-		}
-		if cfg.APIKey != "" {
-			opts = append(opts, openaicompat.WithAPIKey(cfg.APIKey))
-		}
-		return openaicompat.NewProvider(
-			openaicompat.NewClient(cfg.BaseURL, opts...),
-			openaicompat.WithProviderName(key),
-		), nil
-	default:
-		return nil, fmt.Errorf("mcp: provider %q: unsupported api_format %q", key, cfg.APIFormat)
-	}
-}
-
-type capabilityOverrideEntry struct {
-	role   string
-	caps   []string
-	parsed provider.Capability
-}
-
-func (s *Server) installCapabilityOverrides(mr *provider.ModelRegistry) error {
-	if mr == nil || s.cfg == nil {
+// providerForName returns the registered provider whose Name() == name, or nil
+// if no such provider exists or the registry is nil.
+func providerForName(reg *provider.Registry, name string) provider.Provider {
+	if reg == nil {
 		return nil
 	}
-
-	overrides := make(map[provider.ModelKey]capabilityOverrideEntry)
-	roles := make([]string, 0, len(s.cfg.Models))
-	for role := range s.cfg.Models {
-		roles = append(roles, role)
-	}
-	sort.Strings(roles)
-	for _, role := range roles {
-		m := s.cfg.Models[role]
-		if m.Provider == "" || m.Name == "" {
-			continue
-		}
-		caps := m.Capabilities
-		if len(caps) == 0 {
-			pCfg, ok := s.cfg.Providers[m.Provider]
-			if !ok {
-				continue
-			}
-			apiFormat := pCfg.APIFormat
-			if apiFormat == "" {
-				apiFormat = "ollama"
-			}
-			if apiFormat != "openai-compat" {
-				continue
-			}
-			caps = m.ResolvedCapabilities()
-		}
-		if len(caps) == 0 {
-			continue
-		}
-		parsedCaps, err := provider.ParseCapsStrict(caps)
-		if err != nil {
-			return fmt.Errorf("mcp: model %q capability override for %s/%s: %w", role, m.Provider, m.Name, err)
-		}
-
-		key := provider.ModelKey{Provider: m.Provider, Model: m.Name}
-		if existing, ok := overrides[key]; ok {
-			if existing.parsed != parsedCaps {
-				return fmt.Errorf(
-					"mcp: conflicting capability overrides for %s/%s: model %q declares %v, model %q declares %v",
-					key.Provider,
-					key.Model,
-					existing.role,
-					existing.caps,
-					role,
-					caps,
-				)
-			}
-			continue
-		}
-
-		copied := make([]string, len(caps))
-		copy(copied, caps)
-		overrides[key] = capabilityOverrideEntry{
-			role:   role,
-			caps:   copied,
-			parsed: parsedCaps,
-		}
-	}
-	if len(overrides) == 0 {
+	p, ok := reg.Get(name)
+	if !ok {
 		return nil
 	}
-
-	mr.SetCapabilityOverride(func(key provider.ModelKey) []string {
-		entry, ok := overrides[key]
-		if !ok {
-			return nil
-		}
-		out := make([]string, len(entry.caps))
-		copy(out, entry.caps)
-		return out
-	})
-	return nil
+	return p
 }
 
 // Completer returns the current FIM completion provider (may be nil).
@@ -700,7 +497,7 @@ func (s *Server) Completer() *completion.Provider {
 // ProviderConfig. Returns an error when the registry is unavailable, the
 // lookup fails, or the model does not support native FIM at runtime.
 func (s *Server) newCompletionProvider(ctx context.Context, model, providerName string) (*completion.Provider, error) {
-	if err := s.ensureModelRegistry(); err != nil {
+	if err := s.ensureModelRegistry(ctx); err != nil {
 		return nil, err
 	}
 

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -589,6 +590,67 @@ func TestNewServerWithoutAutoDiscoveredConfigContinues(t *testing.T) {
 	}
 	if s.ollamaProv == nil {
 		t.Fatal("ollamaProv = nil, want provider initialized in degraded mode")
+	}
+}
+
+func TestNewServerClosesBootstrapResourcesOnTranscriptStartupFailure(t *testing.T) {
+	psStarted := make(chan struct{})
+	psDone := make(chan struct{})
+	releasePS := make(chan struct{})
+	var psOnce sync.Once
+	var psDoneOnce sync.Once
+
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/":
+			w.WriteHeader(http.StatusOK)
+		case "/api/tags":
+			select {
+			case <-psStarted:
+			case <-time.After(2 * time.Second):
+				http.Error(w, "warmth poll did not start", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"models":[]}`))
+		case "/api/ps":
+			psOnce.Do(func() { close(psStarted) })
+			select {
+			case <-r.Context().Done():
+				psDoneOnce.Do(func() { close(psDone) })
+			case <-releasePS:
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer func() {
+		close(releasePS)
+		mock.Close()
+	}()
+
+	cfgPath := writeTestConfig(t, t.TempDir(), mock.URL)
+	blockingParent := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blockingParent, []byte("file"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", blockingParent, err)
+	}
+
+	_, err := NewServer(context.Background(),
+		WithConfig(cfgPath),
+		WithRAGDisabled(),
+		WithTranscriptStore(filepath.Join(blockingParent, "transcripts.db")),
+	)
+	if err == nil {
+		t.Fatal("NewServer() error = nil, want transcript startup failure")
+	}
+	if !strings.Contains(err.Error(), "create transcript directory") {
+		t.Fatalf("NewServer() error = %q, want transcript directory failure", err)
+	}
+
+	select {
+	case <-psDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("warmth poll was not cancelled after startup failure")
 	}
 }
 

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -101,17 +101,24 @@ func TestConfiguredProvidersDoesNotOverrideOpenAICompatProviderNamedOllama(t *te
 		},
 	}
 
-	registered, ollamaProv, err := s.configuredProviders()
-	if err != nil {
-		t.Fatalf("configuredProviders() error = %v", err)
+	// Black-box parity guard over providerbootstrap wiring: an openai-compat
+	// provider named "ollama" must reach its own base URL, must NOT inherit the
+	// WithOllamaURL override, and must leave s.ollamaProv nil (so the warmth
+	// source is not wired for it).
+	if err := s.ensureModelRegistry(context.Background()); err != nil {
+		t.Fatalf("ensureModelRegistry() error = %v", err)
 	}
-	if ollamaProv != nil {
+	if s.ollamaProv != nil {
 		t.Fatal("ollamaProv = non-nil, want nil for openai-compatible provider named ollama")
 	}
-	if len(registered) != 1 {
-		t.Fatalf("registered providers = %d, want 1", len(registered))
+	if s.warmthSource != nil {
+		t.Fatal("warmthSource = non-nil, want nil for openai-compatible provider named ollama")
 	}
-	models, err := registered[0].Models(context.Background())
+	prov, ok := s.providerRegistry.Get("ollama")
+	if !ok {
+		t.Fatal("provider \"ollama\" not registered")
+	}
+	models, err := prov.Models(context.Background())
 	if err != nil {
 		t.Fatalf("Models() error = %v", err)
 	}
@@ -126,7 +133,7 @@ func TestConfiguredProvidersDoesNotOverrideOpenAICompatProviderNamedOllama(t *te
 	}
 }
 
-func TestConfiguredProvidersRejectsInvalidProviderKeys(t *testing.T) {
+func TestEnsureModelRegistryRejectsInvalidProviderKeys(t *testing.T) {
 	tests := []struct {
 		name    string
 		key     string
@@ -154,9 +161,9 @@ func TestConfiguredProvidersRejectsInvalidProviderKeys(t *testing.T) {
 				},
 			}
 
-			_, _, err := s.configuredProviders()
+			err := s.ensureModelRegistry(context.Background())
 			if err == nil {
-				t.Fatal("configuredProviders() error = nil, want invalid provider key error")
+				t.Fatal("ensureModelRegistry() error = nil, want invalid provider key error")
 			}
 			if !strings.Contains(err.Error(), tt.wantErr) {
 				t.Fatalf("error = %q, want substring %q", err.Error(), tt.wantErr)

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -130,6 +131,70 @@ func TestConfiguredProvidersDoesNotOverrideOpenAICompatProviderNamedOllama(t *te
 	}
 	if overrideHit.Load() {
 		t.Fatal("WithOllamaURL override was incorrectly applied to openai-compatible provider named ollama")
+	}
+}
+
+func TestEnsureModelRegistryConcurrentInitInstallsExactlyOneStack(t *testing.T) {
+	// Drive the double-checked-locking init race directly: many goroutines call
+	// ensureModelRegistry at once. Losers must discard their freshly built bundle
+	// (close it) and keep the winner's; the installed stack must be coherent and
+	// fields must never be spliced across bundles. Run under -race to catch any
+	// unsynchronized access. A mock openai-compat endpoint gives New real work.
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/models" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"m","object":"model"}]}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer mock.Close()
+
+	s := &Server{
+		ollamaURL: "http://127.0.0.1:0",
+		cfg: &config.Config{
+			Providers: map[string]config.ProviderConfig{
+				"lc": {BaseURL: mock.URL, APIFormat: "openai-compat"},
+			},
+		},
+	}
+	defer func() {
+		if s.router != nil {
+			_ = s.router.Close()
+		}
+	}()
+
+	const goroutines = 16
+	var wg sync.WaitGroup
+	errs := make([]error, goroutines)
+	start := make(chan struct{})
+	for i := range goroutines {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			errs[idx] = s.ensureModelRegistry(context.Background())
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("goroutine %d: ensureModelRegistry() error = %v", i, err)
+		}
+	}
+	if s.router == nil || s.modelRegistry == nil || s.providerRegistry == nil {
+		t.Fatalf("expected a coherent installed stack, got router=%v models=%v providers=%v",
+			s.router, s.modelRegistry, s.providerRegistry)
+	}
+	// A subsequent call must take the fast path and not replace the stack.
+	installed := s.providerRegistry
+	if err := s.ensureModelRegistry(context.Background()); err != nil {
+		t.Fatalf("post-init ensureModelRegistry() error = %v", err)
+	}
+	if s.providerRegistry != installed {
+		t.Fatal("provider registry was replaced after init; fast path did not hold")
 	}
 }
 


### PR DESCRIPTION
## Summary

Extracts the config -> providers -> ModelRegistry -> Router wiring out of `mcp/server.go` into a new internal package `internal/providerbootstrap`, with MCP behavior preserved. This is child A of the Golem v1 epic (#185, issue #191): the package becomes the shared assembly seam that both the MCP server and the upcoming `cmd/golem` CLI consume.

## What moved

A new pure-assembly package `internal/providerbootstrap`:

- `New(ctx, Options) (*Bundle, error)` builds a `*provider.Registry`, `*provider.ModelRegistry`, and `*provider.Router` from a `*config.Config`.
- `Options{Config, FingerprintStore, OllamaURLOverride, RouterOptions}`. `RouterOptions` is how MCP passes its `WithWarmthSource` through; the golem CLI will pass none.
- `Bundle{Config, Providers, Models, Router, Warnings}` with a nil-safe `Close()` that releases router resources (and stops the warmth source).
- Moved verbatim from `mcp/server.go` (rebound from the `*Server` receiver to package functions over `Options`/`*config.Config`): provider construction (`buildProviders`/`buildProvider`), capability overrides (`capabilitiesForKey`/`buildCapabilityOverrides`/`installCapabilityOverrides`), and the fingerprint prober factory + digest (`proberFactory`/`fingerprintDigestForModel`).

## Behavior

- nil `Config` synthesizes a single default ollama provider (at `OllamaURLOverride` or `http://localhost:11434`); a non-nil `Config` with zero providers is an error (MCP parity).
- `buildProviders` returns the effective config (synthetic when nil, else the passed config) so the prober factory, capability overrides, and `Bundle.Config` all see the same providers.
- Best-effort `RefreshModels` per provider: failures are collected into `Bundle.Warnings` (non-fatal); `New` errors only when zero providers register or the registry/router cannot be built. MCP logs these warnings instead of discarding them.

## MCP rewire (parity)

- `ensureModelRegistry` now takes `ctx` (so bootstrap's `RefreshModels` is cancelable), builds the warmth source locally, passes it via `RouterOptions`, and installs the bundle's fields coherently under the lock. On a lost init race it discards its own bundle via `Close()` and keeps the winner's, never splicing fields across two bundles.
- The old NewServer Step 4c router-build block is deleted; the per-request self-heal paths are unchanged.
- Deleted the now-duplicated private helpers from `mcp/server.go`; the existing MCP test suite is the parity guard and continues to pass.
- Fixed a typed-nil-interface trap surfaced during the rewire: the warmth source is assigned only when non-nil, preserving the "no warmth source" invariant for an openai-compat provider named "ollama".

## Tests

- New package: provider construction (sort/validate/error paths), capability-override conflict detection, prober factory type-mismatch + digest, and `New` (nil-config, openai-compat config + override install, best-effort-refresh warnings).
- MCP: rewrote two helper-targeting tests as black-box assertions on `Server` behavior, and added a concurrent `ensureModelRegistry` test that exercises the lost-race init path under `-race`.
- `go test ./...`, `go vet ./...`, `-race` on both changed packages, and golangci-lint all pass.
