### PR TITLE
feat(tools): Golem B1 read-only agent tools + path-containment attack suite

### DIFF
--- a/agent/tools/glob.go
+++ b/agent/tools/glob.go
@@ -1,8 +1,15 @@
 package tools
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
 	"path"
+	"sort"
 	"strings"
+
+	"github.com/kstruzzieri/go-llm/agent"
 )
 
 // matchGlob matches a slash-separated relative path against a glob pattern,
@@ -12,6 +19,97 @@ import (
 // which matches a basename at any depth.
 func matchGlob(pattern, name string) bool {
 	return matchSegments(strings.Split(pattern, "/"), strings.Split(name, "/"))
+}
+
+// Glob lists workspace paths matching a glob pattern (supports **). Directories
+// are marked with a trailing "/"; symlink entries are emitted marked and never
+// followed.
+type Glob struct {
+	ws *Workspace
+}
+
+// NewGlob builds the glob tool bound to ws.
+func NewGlob(ws *Workspace) *Glob { return &Glob{ws: ws} }
+
+type globArgs struct {
+	Pattern string `json:"pattern"`
+}
+
+// Spec is the model-facing schema.
+func (*Glob) Spec() agent.ToolSpec {
+	return agent.ToolSpec{
+		Name:        "glob",
+		Description: "List workspace paths matching a glob pattern. '*' and '?' match within one path segment; '**' matches across directories (e.g. **/*.go). Paths are relative to the root; directories end with '/'; symlinks are marked and never followed.",
+		Parameters: json.RawMessage(`{
+  "type":"object",
+  "properties":{
+    "pattern":{"type":"string","description":"glob pattern, e.g. **/*.go or cmd/*/main.go"}
+  },
+  "required":["pattern"]
+}`),
+	}
+}
+
+// Effect declares read-only, never-approval. The entry self-cap is count-based
+// (listMaxEntries), so OutputCap is a byte ceiling set well above a worst-case
+// 1000-entry render to avoid silent runtime re-truncation of long path lists.
+func (*Glob) Effect() agent.Effect {
+	return agent.Effect{Class: agent.Read, Approval: agent.ApprovalNever, OutputCap: readFileMaxBytes + markerHeadroom}
+}
+
+// Invoke walks and matches relative paths against the pattern.
+func (t *Glob) Invoke(ctx context.Context, raw json.RawMessage) (agent.ToolResult, error) {
+	var args globArgs
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return errResult("invalid arguments: " + err.Error()), nil
+	}
+	if args.Pattern == "" {
+		return errResult("pattern is required"), nil
+	}
+
+	var entries []string
+	truncated := false
+	walkErr := t.ws.walk(ctx, func(rel string, d fs.DirEntry) error {
+		if !matchGlob(args.Pattern, rel) {
+			return nil
+		}
+		if len(entries) >= listMaxEntries {
+			truncated = true
+			return fs.SkipAll
+		}
+		entries = append(entries, markEntry(rel, d))
+		return nil
+	})
+	if walkErr != nil && walkErr != fs.SkipAll {
+		return errResult("glob failed: " + walkErr.Error()), nil
+	}
+	return renderEntries(entries, truncated), nil
+}
+
+// markEntry renders a relative path with a kind marker: "/" for directories,
+// " (symlink)" for symlinks. Regular files are bare.
+func markEntry(rel string, d fs.DirEntry) string {
+	switch {
+	case d.Type()&fs.ModeSymlink != 0:
+		return rel + " (symlink)"
+	case d.IsDir():
+		return rel + "/"
+	default:
+		return rel
+	}
+}
+
+// renderEntries sorts for determinism and appends a marker when truncated.
+func renderEntries(entries []string, truncated bool) agent.ToolResult {
+	sort.Strings(entries)
+	content := strings.Join(entries, "\n")
+	if content == "" {
+		content = "no entries"
+	}
+	if truncated {
+		content += fmt.Sprintf("\n[truncated after %d entries]", listMaxEntries)
+	}
+	return agent.ToolResult{Content: content, Truncated: truncated}
 }
 
 // matchSegments matches pattern segments against name segments. Each "**"

--- a/agent/tools/glob.go
+++ b/agent/tools/glob.go
@@ -53,10 +53,10 @@ func (*Glob) Spec() agent.ToolSpec {
 }
 
 // Effect declares read-only, never-approval. The entry self-cap is count-based
-// (listMaxEntries), so OutputCap is a byte ceiling set well above a worst-case
-// 1000-entry render to avoid silent runtime re-truncation of long path lists.
+// (listMaxEntries); OutputCap is a generous byte backstop (listOutputCap) above a
+// typical 1000-entry render so the truncation marker is not runtime-cut.
 func (*Glob) Effect() agent.Effect {
-	return agent.Effect{Class: agent.Read, Approval: agent.ApprovalNever, OutputCap: readFileMaxBytes + markerHeadroom}
+	return agent.Effect{Class: agent.Read, Approval: agent.ApprovalNever, OutputCap: listOutputCap}
 }
 
 // Invoke walks and matches relative paths against the pattern.
@@ -142,10 +142,9 @@ func (*List) Spec() agent.ToolSpec {
 	}
 }
 
-// Effect declares read-only, never-approval. OutputCap is set above the count-based
-// entry self-cap, same rationale as Glob.Effect.
+// Effect declares read-only, never-approval; same OutputCap rationale as Glob.Effect.
 func (*List) Effect() agent.Effect {
-	return agent.Effect{Class: agent.Read, Approval: agent.ApprovalNever, OutputCap: readFileMaxBytes + markerHeadroom}
+	return agent.Effect{Class: agent.Read, Approval: agent.ApprovalNever, OutputCap: listOutputCap}
 }
 
 // Invoke reads a single directory level. Expected failures return IsError.

--- a/agent/tools/glob.go
+++ b/agent/tools/glob.go
@@ -1,0 +1,46 @@
+package tools
+
+import (
+	"path"
+	"strings"
+)
+
+// matchGlob matches a slash-separated relative path against a glob pattern,
+// anchored at the workspace root. "*" and "?" match within a single segment
+// (they never cross "/"); "**" matches zero or more whole segments. This is a
+// deliberately small, root-anchored matcher — unlike rag's gitignore matcher,
+// which matches a basename at any depth.
+func matchGlob(pattern, name string) bool {
+	return matchSegments(strings.Split(pattern, "/"), strings.Split(name, "/"))
+}
+
+// matchSegments matches pattern segments against name segments. Each "**"
+// fans out across every possible skip count, so the worst case is combinatorial
+// in (path-depth, number of "**" segments). In practice the matched names come
+// from a real filesystem walk (bounded directory depth) and patterns carry 1–3
+// "**", so the cost is small; this matcher is not intended for adversarial
+// unbounded pattern/path input.
+func matchSegments(pat, name []string) bool {
+	for len(pat) > 0 {
+		if pat[0] == "**" {
+			if len(pat) == 1 {
+				return true // trailing ** matches every remaining segment
+			}
+			for i := 0; i <= len(name); i++ {
+				if matchSegments(pat[1:], name[i:]) {
+					return true
+				}
+			}
+			return false
+		}
+		if len(name) == 0 {
+			return false
+		}
+		ok, err := path.Match(pat[0], name[0])
+		if err != nil || !ok {
+			return false
+		}
+		pat, name = pat[1:], name[1:]
+	}
+	return len(name) == 0
+}

--- a/agent/tools/glob.go
+++ b/agent/tools/glob.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
-	"os"
 	"path"
 	"path/filepath"
 	"sort"
@@ -157,16 +156,18 @@ func (t *List) Invoke(ctx context.Context, raw json.RawMessage) (agent.ToolResul
 	if p == "" {
 		p = "."
 	}
-	abs, err := t.ws.resolveDir(p)
+	f, err := t.ws.openDir(p)
 	if err != nil {
 		return errResult(err.Error()), nil
 	}
-	dirents, err := os.ReadDir(abs)
+	defer func() { _ = f.Close() }()
+
+	dirents, err := f.ReadDir(-1)
 	if err != nil {
 		return errResult(err.Error()), nil
 	}
 
-	relBase, err := filepath.Rel(t.ws.root, abs)
+	relBase, err := filepath.Rel(t.ws.root, f.Name())
 	if err != nil {
 		return errResult(err.Error()), nil
 	}

--- a/agent/tools/glob.go
+++ b/agent/tools/glob.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"os"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -110,6 +112,86 @@ func renderEntries(entries []string, truncated bool) agent.ToolResult {
 		content += fmt.Sprintf("\n[truncated after %d entries]", listMaxEntries)
 	}
 	return agent.ToolResult{Content: content, Truncated: truncated}
+}
+
+// List lists the immediate children of one directory under the workspace root.
+// A symlinked-directory target is rejected; symlink entries inside a real
+// directory are emitted marked and never followed.
+type List struct {
+	ws *Workspace
+}
+
+// NewList builds the list tool bound to ws.
+func NewList(ws *Workspace) *List { return &List{ws: ws} }
+
+type listArgs struct {
+	Path string `json:"path"`
+}
+
+// Spec is the model-facing schema.
+func (*List) Spec() agent.ToolSpec {
+	return agent.ToolSpec{
+		Name:        "list",
+		Description: "List the immediate entries of a directory under the workspace root (non-recursive). Defaults to the root when path is omitted. Directories end with '/'; symlinks are marked and never followed; a symlinked directory target is refused.",
+		Parameters: json.RawMessage(`{
+  "type":"object",
+  "properties":{
+    "path":{"type":"string","description":"directory relative to the root; omit or '.' for the root"}
+  }
+}`),
+	}
+}
+
+// Effect declares read-only, never-approval. OutputCap is set above the count-based
+// entry self-cap, same rationale as Glob.Effect.
+func (*List) Effect() agent.Effect {
+	return agent.Effect{Class: agent.Read, Approval: agent.ApprovalNever, OutputCap: readFileMaxBytes + markerHeadroom}
+}
+
+// Invoke reads a single directory level. Expected failures return IsError.
+func (t *List) Invoke(ctx context.Context, raw json.RawMessage) (agent.ToolResult, error) {
+	var args listArgs
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return errResult("invalid arguments: " + err.Error()), nil
+	}
+	p := args.Path
+	if p == "" {
+		p = "."
+	}
+	abs, err := t.ws.resolveDir(p)
+	if err != nil {
+		return errResult(err.Error()), nil
+	}
+	dirents, err := os.ReadDir(abs)
+	if err != nil {
+		return errResult(err.Error()), nil
+	}
+
+	relBase, err := filepath.Rel(t.ws.root, abs)
+	if err != nil {
+		return errResult(err.Error()), nil
+	}
+	base := filepath.ToSlash(relBase)
+	if base == "." {
+		base = ""
+	}
+	var entries []string
+	truncated := false
+	for _, d := range dirents {
+		if d.IsDir() && ignoreDirs[d.Name()] {
+			continue
+		}
+		if len(entries) >= listMaxEntries {
+			truncated = true
+			break
+		}
+		rel := d.Name()
+		if base != "" {
+			rel = base + "/" + d.Name()
+		}
+		entries = append(entries, markEntry(rel, d))
+	}
+	return renderEntries(entries, truncated), nil
 }
 
 // matchSegments matches pattern segments against name segments. Each "**"

--- a/agent/tools/glob_test.go
+++ b/agent/tools/glob_test.go
@@ -1,6 +1,13 @@
 package tools
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/agent"
+)
 
 func TestMatchGlob(t *testing.T) {
 	tests := []struct {
@@ -29,5 +36,71 @@ func TestMatchGlob(t *testing.T) {
 		if got := matchGlob(tt.pattern, tt.name); got != tt.want {
 			t.Errorf("matchGlob(%q, %q) = %v, want %v", tt.pattern, tt.name, got, tt.want)
 		}
+	}
+}
+
+func TestGlobMatchesAndMarksDirs(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{
+		"main.go":      "x",
+		"sub/util.go":  "y",
+		"sub/data.txt": "z",
+	})
+	g := NewGlob(mustWorkspace(t, root))
+
+	res := invoke(t, g, map[string]any{"pattern": "**/*.go"})
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", res.Content)
+	}
+	if !strings.Contains(res.Content, "main.go") || !strings.Contains(res.Content, "sub/util.go") {
+		t.Fatalf("missing go files: %q", res.Content)
+	}
+	if strings.Contains(res.Content, "data.txt") {
+		t.Fatalf("matched a non-go file: %q", res.Content)
+	}
+}
+
+func TestGlobMarksSymlinkUnresolved(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "s.txt"), []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(outside, "s.txt"), filepath.Join(root, "link.txt")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	g := NewGlob(mustWorkspace(t, root))
+	res := invoke(t, g, map[string]any{"pattern": "*.txt"})
+	if !strings.Contains(res.Content, "link.txt") || !strings.Contains(res.Content, "symlink") {
+		t.Fatalf("symlink entry should be emitted marked: %q", res.Content)
+	}
+	if strings.Contains(res.Content, "secret") {
+		t.Fatal("glob must not resolve/read the symlink target")
+	}
+}
+
+func TestGlobDoesNotDescendSymlinkedDir(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	writeTree(t, outside, map[string]string{"hidden.go": "package hidden\n"})
+	if err := os.Symlink(outside, filepath.Join(root, "linkdir")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	writeTree(t, root, map[string]string{"real.go": "package real\n"})
+	g := NewGlob(mustWorkspace(t, root))
+	res := invoke(t, g, map[string]any{"pattern": "**/*.go"})
+	if strings.Contains(res.Content, "hidden.go") || strings.Contains(res.Content, "linkdir/") {
+		t.Fatalf("glob descended into symlinked dir: %q", res.Content)
+	}
+	if !strings.Contains(res.Content, "real.go") {
+		t.Fatalf("missed real in-root match: %q", res.Content)
+	}
+}
+
+func TestGlobEffect(t *testing.T) {
+	g := NewGlob(mustWorkspace(t, t.TempDir()))
+	e := g.Effect()
+	if e.Class != agent.Read || e.Approval != agent.ApprovalNever {
+		t.Fatalf("Effect = %+v, want Read/ApprovalNever", e)
 	}
 }

--- a/agent/tools/glob_test.go
+++ b/agent/tools/glob_test.go
@@ -1,0 +1,33 @@
+package tools
+
+import "testing"
+
+func TestMatchGlob(t *testing.T) {
+	tests := []struct {
+		pattern, name string
+		want          bool
+	}{
+		{"*.go", "main.go", true},
+		{"*.go", "sub/main.go", false}, // * does not cross a separator (root-anchored)
+		{"sub/*.go", "sub/main.go", true},
+		{"**/*.go", "main.go", true},  // ** matches zero segments
+		{"**/*.go", "a/b/c.go", true}, // ** matches many segments
+		{"**", "anything/at/all.txt", true},
+		{"a/**/d.go", "a/b/c/d.go", true},
+		{"a/**/d.go", "a/d.go", true},    // ** zero segments in the middle
+		{"a/**/d.go", "x/b/d.go", false}, // anchored: must start with a/
+		{"?.txt", "a.txt", true},
+		{"?.txt", "ab.txt", false},
+		{"cmd/golem/*", "cmd/golem/main.go", true},
+		{"cmd/golem/*", "cmd/other/main.go", false},
+		{"[.go", "a.go", false},          // malformed bracket pattern: returns false, never panics
+		{"*", ".env", true},              // path.Match matches dotfiles (no shell dot-exclusion)
+		{"", "", true},                   // degenerate: both empty
+		{"**/**/*.go", "a/b/c.go", true}, // redundant ** still matches
+	}
+	for _, tt := range tests {
+		if got := matchGlob(tt.pattern, tt.name); got != tt.want {
+			t.Errorf("matchGlob(%q, %q) = %v, want %v", tt.pattern, tt.name, got, tt.want)
+		}
+	}
+}

--- a/agent/tools/glob_test.go
+++ b/agent/tools/glob_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -103,6 +104,9 @@ func TestGlobEffect(t *testing.T) {
 	if e.Class != agent.Read || e.Approval != agent.ApprovalNever {
 		t.Fatalf("Effect = %+v, want Read/ApprovalNever", e)
 	}
+	if e.OutputCap < listOutputCap {
+		t.Fatalf("OutputCap %d must be >= listOutputCap %d", e.OutputCap, listOutputCap)
+	}
 }
 
 func TestListHappyAndMarkers(t *testing.T) {
@@ -172,5 +176,75 @@ func TestListEffect(t *testing.T) {
 	e := l.Effect()
 	if e.Class != agent.Read || e.Approval != agent.ApprovalNever {
 		t.Fatalf("Effect = %+v, want Read/ApprovalNever", e)
+	}
+	if e.OutputCap < listOutputCap {
+		t.Fatalf("OutputCap %d must be >= listOutputCap %d", e.OutputCap, listOutputCap)
+	}
+}
+
+func TestGlobMarksDirectory(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{"sub/x.go": "y"})
+	g := NewGlob(mustWorkspace(t, root))
+	res := invoke(t, g, map[string]any{"pattern": "sub"})
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", res.Content)
+	}
+	if !strings.Contains(res.Content, "sub/") {
+		t.Fatalf("glob should mark a matched directory with a trailing slash: %q", res.Content)
+	}
+}
+
+func TestGlobEntryCapTruncates(t *testing.T) {
+	root := t.TempDir()
+	files := map[string]string{}
+	for i := 0; i < listMaxEntries+5; i++ {
+		files[fmt.Sprintf("f%04d.txt", i)] = "x"
+	}
+	writeTree(t, root, files)
+	g := NewGlob(mustWorkspace(t, root))
+	res := invoke(t, g, map[string]any{"pattern": "*.txt"})
+	if res.IsError {
+		t.Fatalf("entry cap should be partial success, got IsError: %s", res.Content)
+	}
+	if !res.Truncated || !strings.Contains(res.Content, "truncated") {
+		t.Fatal("glob entry cap should set Truncated and an in-band marker")
+	}
+}
+
+func TestListEntryCapTruncates(t *testing.T) {
+	root := t.TempDir()
+	files := map[string]string{}
+	for i := 0; i < listMaxEntries+5; i++ {
+		files[fmt.Sprintf("f%04d.txt", i)] = "x"
+	}
+	writeTree(t, root, files)
+	l := NewList(mustWorkspace(t, root))
+	res := invoke(t, l, map[string]any{"path": "."})
+	if res.IsError {
+		t.Fatalf("entry cap should be partial success, got IsError: %s", res.Content)
+	}
+	if !res.Truncated || !strings.Contains(res.Content, "truncated") {
+		t.Fatal("list entry cap should set Truncated and an in-band marker")
+	}
+}
+
+func TestListNestedSubdirPrefixes(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{"sub/deep.go": "y", "sub/inner/x.go": "z"})
+	l := NewList(mustWorkspace(t, root))
+	res := invoke(t, l, map[string]any{"path": "sub"})
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", res.Content)
+	}
+	if !strings.Contains(res.Content, "sub/deep.go") {
+		t.Fatalf("subdir listing should prefix entries with sub/: %q", res.Content)
+	}
+	if !strings.Contains(res.Content, "sub/inner/") {
+		t.Fatalf("subdir listing should show nested dir as sub/inner/: %q", res.Content)
+	}
+	// single-level: must not recurse into sub/inner
+	if strings.Contains(res.Content, "x.go") {
+		t.Fatalf("list must be single-level, not recursive: %q", res.Content)
 	}
 }

--- a/agent/tools/glob_test.go
+++ b/agent/tools/glob_test.go
@@ -104,3 +104,73 @@ func TestGlobEffect(t *testing.T) {
 		t.Fatalf("Effect = %+v, want Read/ApprovalNever", e)
 	}
 }
+
+func TestListHappyAndMarkers(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{
+		"f.txt":       "x",
+		"sub/deep.go": "y",
+	})
+	l := NewList(mustWorkspace(t, root))
+
+	res := invoke(t, l, map[string]any{"path": "."})
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", res.Content)
+	}
+	if !strings.Contains(res.Content, "f.txt") || !strings.Contains(res.Content, "sub/") {
+		t.Fatalf("list of root wrong (sub should be marked dir): %q", res.Content)
+	}
+	if strings.Contains(res.Content, "deep.go") {
+		t.Fatalf("list must be single-level, not recursive: %q", res.Content)
+	}
+}
+
+func TestListDefaultsToRoot(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{"only.txt": "x"})
+	l := NewList(mustWorkspace(t, root))
+	res := invoke(t, l, map[string]any{}) // no path
+	if res.IsError || !strings.Contains(res.Content, "only.txt") {
+		t.Fatalf("empty path should list root: %+v", res)
+	}
+}
+
+func TestListSymlinkedDirTargetRejected(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "linkdir")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	l := NewList(mustWorkspace(t, root))
+	res := invoke(t, l, map[string]any{"path": "linkdir"})
+	if !res.IsError {
+		t.Fatalf("listing a symlinked dir target must be rejected, got %q", res.Content)
+	}
+	if strings.Contains(res.Content, "secret") {
+		t.Fatal("list leaked out-of-root contents via symlinked dir")
+	}
+}
+
+func TestListMarksSymlinkEntry(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{"real.txt": "x"})
+	if err := os.Symlink(filepath.Join(root, "real.txt"), filepath.Join(root, "ptr.txt")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	l := NewList(mustWorkspace(t, root))
+	res := invoke(t, l, map[string]any{"path": "."})
+	if !strings.Contains(res.Content, "ptr.txt (symlink)") {
+		t.Fatalf("symlink entry inside a real dir should be marked, got %q", res.Content)
+	}
+}
+
+func TestListEffect(t *testing.T) {
+	l := NewList(mustWorkspace(t, t.TempDir()))
+	e := l.Effect()
+	if e.Class != agent.Read || e.Approval != agent.ApprovalNever {
+		t.Fatalf("Effect = %+v, want Read/ApprovalNever", e)
+	}
+}

--- a/agent/tools/paths.go
+++ b/agent/tools/paths.go
@@ -20,6 +20,13 @@ const (
 	searchMaxBytes   = 64 * 1024  // search: max bytes of joined output
 	listMaxEntries   = 1000       // glob/list: max emitted entries
 	markerHeadroom   = 256        // bytes reserved for an in-band truncation marker
+
+	// listOutputCap is the byte backstop for the entry-listing tools (glob, list).
+	// Their primary limit is the count cap (listMaxEntries); this byte ceiling is
+	// set generously above a typical 1000-entry render so the in-band truncation
+	// marker is not itself cut by the runtime. Paths are unbounded in theory, so a
+	// pathological tree of very long paths may still be runtime-capped.
+	listOutputCap = 512 * 1024
 )
 
 // ignoreDirs are directory names skipped during tree walks (search, glob).

--- a/agent/tools/paths.go
+++ b/agent/tools/paths.go
@@ -31,13 +31,14 @@ var ignoreDirs = map[string]bool{
 }
 
 var (
-	errEmptyRoot  = errors.New("empty workspace root")
-	errNUL        = errors.New("path contains NUL byte")
-	errAbsPath    = errors.New("absolute paths are not allowed")
-	errEscape     = errors.New("path escapes the workspace root")
-	errSymlink    = errors.New("symlinks are not followed")
-	errNotRegular = errors.New("not a regular file")
-	errNotDir     = errors.New("not a directory")
+	errEmptyRoot   = errors.New("empty workspace root")
+	errNUL         = errors.New("path contains NUL byte")
+	errAbsPath     = errors.New("absolute paths are not allowed")
+	errEscape      = errors.New("path escapes the workspace root")
+	errSymlink     = errors.New("symlinks are not followed")
+	errNotRegular  = errors.New("not a regular file")
+	errNotDir      = errors.New("not a directory")
+	errFileChanged = errors.New("file identity changed between stat and open")
 )
 
 // Workspace is the single audited chokepoint for read-only filesystem access.
@@ -114,4 +115,73 @@ func (w *Workspace) walk(ctx context.Context, fn func(rel string, d fs.DirEntry)
 		}
 		return fn(filepath.ToSlash(rel), d)
 	})
+}
+
+// resolveFile contains a path to a concrete file: cleanRel for containment, then
+// Lstat to reject symlinks (never follow) and require a regular file. The
+// returned FileInfo is the pre-open Lstat result; openRegularFile re-stats the
+// open handle and compares with os.SameFile to close the symlink-swap TOCTOU window.
+func (w *Workspace) resolveFile(p string) (string, os.FileInfo, error) {
+	abs, err := w.cleanRel(p)
+	if err != nil {
+		return "", nil, err
+	}
+	fi, err := os.Lstat(abs)
+	if err != nil {
+		return "", nil, err
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return "", nil, errSymlink
+	}
+	if !fi.Mode().IsRegular() {
+		return "", nil, errNotRegular
+	}
+	return abs, fi, nil
+}
+
+// resolveDir contains a path to a concrete directory: cleanRel, then Lstat to
+// reject a symlinked directory target (never follow) and require a real dir.
+func (w *Workspace) resolveDir(p string) (string, error) {
+	abs, err := w.cleanRel(p)
+	if err != nil {
+		return "", err
+	}
+	fi, err := os.Lstat(abs)
+	if err != nil {
+		return "", err
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return "", errSymlink
+	}
+	if !fi.IsDir() {
+		return "", errNotDir
+	}
+	return abs, nil
+}
+
+// openRegularFile is the single helper for content reads. It first resolves the
+// path through resolveFile (containment + Lstat + symlink/kind checks), then opens
+// the file and verifies the open handle still refers to the same file Lstat saw.
+// Returns errFileChanged if the open handle no longer matches the file Lstat saw
+// (e.g. a regular-file swap between Lstat and Open). Callers own the returned file
+// and must close it.
+func (w *Workspace) openRegularFile(p string) (*os.File, error) {
+	abs, lfi, err := w.resolveFile(p)
+	if err != nil {
+		return nil, err
+	}
+	f, err := os.Open(abs)
+	if err != nil {
+		return nil, err
+	}
+	sfi, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	if !os.SameFile(lfi, sfi) {
+		_ = f.Close()
+		return nil, errFileChanged
+	}
+	return f, nil
 }

--- a/agent/tools/paths.go
+++ b/agent/tools/paths.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/kstruzzieri/go-llm/agent"
 )
 
 // Shared caps and markers for the read-only file tools. Each tool also sets an
@@ -164,6 +166,22 @@ func (w *Workspace) resolveDir(p string) (string, error) {
 		return "", errNotDir
 	}
 	return abs, nil
+}
+
+// NewFileTools builds the full read-only tool set bound to a single workspace
+// root: read_file, search, glob, list. The consumer (e.g. cmd/golem) registers
+// the returned slice with the agent loop. All four are Read / ApprovalNever.
+func NewFileTools(root string) ([]agent.Tool, error) {
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		return nil, err
+	}
+	return []agent.Tool{
+		NewReadFile(ws),
+		NewSearch(ws),
+		NewGlob(ws),
+		NewList(ws),
+	}, nil
 }
 
 // openRegularFile is the single helper for content reads. It first resolves the

--- a/agent/tools/paths.go
+++ b/agent/tools/paths.go
@@ -149,23 +149,53 @@ func (w *Workspace) resolveFile(p string) (string, os.FileInfo, error) {
 }
 
 // resolveDir contains a path to a concrete directory: cleanRel, then Lstat to
-// reject a symlinked directory target (never follow) and require a real dir.
-func (w *Workspace) resolveDir(p string) (string, error) {
+// reject a symlinked directory target (never follow) and require a real dir. The
+// returned FileInfo is the pre-open Lstat result; openDir re-stats the open handle
+// and compares with os.SameFile to close the symlink-swap TOCTOU window.
+func (w *Workspace) resolveDir(p string) (string, os.FileInfo, error) {
 	abs, err := w.cleanRel(p)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	fi, err := os.Lstat(abs)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	if fi.Mode()&os.ModeSymlink != 0 {
-		return "", errSymlink
+		return "", nil, errSymlink
 	}
 	if !fi.IsDir() {
-		return "", errNotDir
+		return "", nil, errNotDir
 	}
-	return abs, nil
+	return abs, fi, nil
+}
+
+// openDir is the single helper for directory listing. It resolves the path
+// through resolveDir (containment + Lstat + symlink/kind checks), opens the
+// directory, and verifies the open handle still refers to the same directory
+// Lstat saw — closing the final-component symlink-swap TOCTOU window that a bare
+// resolveDir+os.ReadDir would leave (os.ReadDir follows a final-component symlink).
+// It returns errFileChanged if the identity no longer matches. Callers own the
+// returned file and must close it; read entries via f.ReadDir.
+func (w *Workspace) openDir(p string) (*os.File, error) {
+	abs, lfi, err := w.resolveDir(p)
+	if err != nil {
+		return nil, err
+	}
+	f, err := os.Open(abs)
+	if err != nil {
+		return nil, err
+	}
+	sfi, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	if !os.SameFile(lfi, sfi) {
+		_ = f.Close()
+		return nil, errFileChanged
+	}
+	return f, nil
 }
 
 // NewFileTools builds the full read-only tool set bound to a single workspace

--- a/agent/tools/paths.go
+++ b/agent/tools/paths.go
@@ -1,0 +1,117 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Shared caps and markers for the read-only file tools. Each tool also sets an
+// explicit Effect.OutputCap above its self-cap, because the runtime default
+// (agent/types.go defaultOutputCap = 64 KiB) would otherwise silently truncate
+// larger results in agent/dispatch.go capOutput.
+const (
+	readFileMaxBytes = 256 * 1024 // read_file content ceiling
+	searchMaxMatches = 200        // search: max match lines
+	searchMaxBytes   = 64 * 1024  // search: max bytes of joined output
+	listMaxEntries   = 1000       // glob/list: max emitted entries
+	markerHeadroom   = 256        // bytes reserved for an in-band truncation marker
+)
+
+// ignoreDirs are directory names skipped during tree walks (search, glob).
+var ignoreDirs = map[string]bool{
+	".git":         true,
+	"vendor":       true,
+	"node_modules": true,
+	".superpowers": true,
+}
+
+var (
+	errEmptyRoot  = errors.New("empty workspace root")
+	errNUL        = errors.New("path contains NUL byte")
+	errAbsPath    = errors.New("absolute paths are not allowed")
+	errEscape     = errors.New("path escapes the workspace root")
+	errSymlink    = errors.New("symlinks are not followed")
+	errNotRegular = errors.New("not a regular file")
+	errNotDir     = errors.New("not a directory")
+)
+
+// Workspace is the single audited chokepoint for read-only filesystem access.
+// The canonical root is resolved once at construction; no path component is ever
+// resolved through a symlink afterwards (v1 symlink policy: never follow).
+type Workspace struct {
+	root string // canonical absolute root, post-EvalSymlinks, no trailing separator
+}
+
+// NewWorkspace canonicalizes root via filepath.EvalSymlinks so the root itself
+// may legitimately be a symlinked path while no later access follows a symlink.
+func NewWorkspace(root string) (*Workspace, error) {
+	if root == "" {
+		return nil, errEmptyRoot
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("tools: abs root: %w", err)
+	}
+	canon, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return nil, fmt.Errorf("tools: resolve root: %w", err)
+	}
+	return &Workspace{root: canon}, nil
+}
+
+// underRoot reports whether a cleaned absolute candidate is the root or strictly
+// under it. The separator-terminated prefix check prevents a sibling like
+// "/x/rootx" from passing for root "/x/root".
+func (w *Workspace) underRoot(candidate string) bool {
+	if candidate == w.root {
+		return true
+	}
+	return strings.HasPrefix(candidate, w.root+string(os.PathSeparator))
+}
+
+// cleanRel rejects NUL bytes and absolute inputs, joins (and cleans) the input
+// against the canonical root, and verifies containment. It does NOT touch the
+// filesystem — kind/symlink checks are the caller's job (resolveFile/resolveDir).
+func (w *Workspace) cleanRel(p string) (string, error) {
+	if strings.IndexByte(p, 0) >= 0 {
+		return "", errNUL
+	}
+	if filepath.IsAbs(p) {
+		return "", errAbsPath
+	}
+	joined := filepath.Join(w.root, p) // Join cleans ".." segments
+	if !w.underRoot(joined) {
+		return "", errEscape
+	}
+	return joined, nil
+}
+
+// walk drives filepath.WalkDir from the canonical root, skipping ignore-set
+// directories and never descending symlinks (WalkDir does not follow them).
+// fn receives slash-normalized relative paths. ctx cancellation aborts the walk.
+func (w *Workspace) walk(ctx context.Context, fn func(rel string, d fs.DirEntry) error) error {
+	return filepath.WalkDir(w.root, func(abs string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if cerr := ctx.Err(); cerr != nil {
+			return cerr
+		}
+		if d.IsDir() && ignoreDirs[d.Name()] {
+			return fs.SkipDir
+		}
+		rel, rerr := filepath.Rel(w.root, abs)
+		if rerr != nil {
+			return rerr
+		}
+		if rel == "." {
+			return nil // skip the root entry itself
+		}
+		return fn(filepath.ToSlash(rel), d)
+	})
+}

--- a/agent/tools/paths.go
+++ b/agent/tools/paths.go
@@ -101,6 +101,43 @@ func (w *Workspace) cleanRel(p string) (string, error) {
 	return joined, nil
 }
 
+// rejectSymlinkAncestors verifies every parent component below the workspace
+// root is a real directory. A final-component Lstat is not enough because
+// os.Open("linkdir/file") would otherwise follow the intermediate symlink.
+func (w *Workspace) rejectSymlinkAncestors(abs string) error {
+	abs = filepath.Clean(abs)
+	if !w.underRoot(abs) {
+		return errEscape
+	}
+	rel, err := filepath.Rel(w.root, abs)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(rel)
+	if dir == "." || dir == "" {
+		return nil
+	}
+
+	cur := w.root
+	for _, part := range strings.Split(dir, string(os.PathSeparator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		cur = filepath.Join(cur, part)
+		fi, err := os.Lstat(cur)
+		if err != nil {
+			return err
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return errSymlink
+		}
+		if !fi.IsDir() {
+			return errNotDir
+		}
+	}
+	return nil
+}
+
 // walk drives filepath.WalkDir from the canonical root, skipping ignore-set
 // directories and never descending symlinks (WalkDir does not follow them).
 // fn receives slash-normalized relative paths. ctx cancellation aborts the walk.
@@ -126,13 +163,17 @@ func (w *Workspace) walk(ctx context.Context, fn func(rel string, d fs.DirEntry)
 	})
 }
 
-// resolveFile contains a path to a concrete file: cleanRel for containment, then
-// Lstat to reject symlinks (never follow) and require a regular file. The
-// returned FileInfo is the pre-open Lstat result; openRegularFile re-stats the
-// open handle and compares with os.SameFile to close the symlink-swap TOCTOU window.
+// resolveFile contains a path to a concrete file: cleanRel for containment,
+// Lstat checks for every parent component, then final Lstat to reject symlinks
+// (never follow) and require a regular file. The returned FileInfo is the
+// pre-open Lstat result; openRegularFile re-stats the open handle and compares
+// with os.SameFile to close the final-component symlink-swap TOCTOU window.
 func (w *Workspace) resolveFile(p string) (string, os.FileInfo, error) {
 	abs, err := w.cleanRel(p)
 	if err != nil {
+		return "", nil, err
+	}
+	if err := w.rejectSymlinkAncestors(abs); err != nil {
 		return "", nil, err
 	}
 	fi, err := os.Lstat(abs)
@@ -148,13 +189,17 @@ func (w *Workspace) resolveFile(p string) (string, os.FileInfo, error) {
 	return abs, fi, nil
 }
 
-// resolveDir contains a path to a concrete directory: cleanRel, then Lstat to
-// reject a symlinked directory target (never follow) and require a real dir. The
-// returned FileInfo is the pre-open Lstat result; openDir re-stats the open handle
-// and compares with os.SameFile to close the symlink-swap TOCTOU window.
+// resolveDir contains a path to a concrete directory: cleanRel, Lstat checks for
+// every parent component, then final Lstat to reject a symlinked directory
+// target (never follow) and require a real dir. The returned FileInfo is the
+// pre-open Lstat result; openDir re-stats the open handle and compares with
+// os.SameFile to close the final-component symlink-swap TOCTOU window.
 func (w *Workspace) resolveDir(p string) (string, os.FileInfo, error) {
 	abs, err := w.cleanRel(p)
 	if err != nil {
+		return "", nil, err
+	}
+	if err := w.rejectSymlinkAncestors(abs); err != nil {
 		return "", nil, err
 	}
 	fi, err := os.Lstat(abs)

--- a/agent/tools/paths_test.go
+++ b/agent/tools/paths_test.go
@@ -229,6 +229,31 @@ func TestOpenRegularFileRejectsSymlink(t *testing.T) {
 	}
 }
 
+func TestResolveFileRejectsIntermediateSymlink(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("TOPSECRET"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "linkdir")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := ws.resolveFile("linkdir/secret.txt"); !errors.Is(err, errSymlink) {
+		t.Fatalf("resolveFile through intermediate symlink: got %v, want errSymlink", err)
+	}
+	if f, err := ws.openRegularFile("linkdir/secret.txt"); !errors.Is(err, errSymlink) {
+		if err == nil {
+			_ = f.Close()
+		}
+		t.Fatalf("openRegularFile through intermediate symlink: got %v, want errSymlink", err)
+	}
+}
+
 func TestResolveDirRejectsSymlinkTarget(t *testing.T) {
 	root := t.TempDir()
 	outside := t.TempDir()
@@ -259,6 +284,31 @@ func TestResolveDirRejectsSymlinkTarget(t *testing.T) {
 	}
 	if _, _, err := ws.resolveDir("f.txt"); !errors.Is(err, errNotDir) {
 		t.Fatalf("resolveDir on a regular file: got %v, want errNotDir", err)
+	}
+}
+
+func TestResolveDirRejectsIntermediateSymlink(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Mkdir(filepath.Join(outside, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "linkdir")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := ws.resolveDir("linkdir/nested"); !errors.Is(err, errSymlink) {
+		t.Fatalf("resolveDir through intermediate symlink: got %v, want errSymlink", err)
+	}
+	if f, err := ws.openDir("linkdir/nested"); !errors.Is(err, errSymlink) {
+		if err == nil {
+			_ = f.Close()
+		}
+		t.Fatalf("openDir through intermediate symlink: got %v, want errSymlink", err)
 	}
 }
 

--- a/agent/tools/paths_test.go
+++ b/agent/tools/paths_test.go
@@ -248,16 +248,16 @@ func TestResolveDirRejectsSymlinkTarget(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := ws.resolveDir("."); err != nil {
+	if _, _, err := ws.resolveDir("."); err != nil {
 		t.Fatalf("resolveDir(root) errored: %v", err)
 	}
-	if _, err := ws.resolveDir("real"); err != nil {
+	if _, _, err := ws.resolveDir("real"); err != nil {
 		t.Fatalf("resolveDir(real subdir) errored: %v", err)
 	}
-	if _, err := ws.resolveDir("linkdir"); !errors.Is(err, errSymlink) {
+	if _, _, err := ws.resolveDir("linkdir"); !errors.Is(err, errSymlink) {
 		t.Fatalf("resolveDir on symlinked dir: got %v, want errSymlink", err)
 	}
-	if _, err := ws.resolveDir("f.txt"); !errors.Is(err, errNotDir) {
+	if _, _, err := ws.resolveDir("f.txt"); !errors.Is(err, errNotDir) {
 		t.Fatalf("resolveDir on a regular file: got %v, want errNotDir", err)
 	}
 }

--- a/agent/tools/paths_test.go
+++ b/agent/tools/paths_test.go
@@ -1,0 +1,150 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWorkspaceCleanRelContainment(t *testing.T) {
+	root := t.TempDir()
+	// a real file inside root so happy paths resolve
+	if err := os.WriteFile(filepath.Join(root, "ok.txt"), []byte("hi"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		t.Fatalf("NewWorkspace: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr error // nil => expect success
+	}{
+		{"simple file", "ok.txt", nil},
+		{"nested clean", "a/b/c.txt", nil},
+		{"root dot", ".", nil},
+		{"parent escape", "../../etc/passwd", errEscape},
+		{"absolute escape", "/etc/passwd", errAbsPath},
+		{"midpath escape", "a/../../b", errEscape},
+		{"nul byte", "foo\x00bar", errNUL},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ws.cleanRel(tt.input)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("cleanRel(%q) error = %v, want %v", tt.input, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("cleanRel(%q) unexpected error: %v", tt.input, err)
+			}
+			if !ws.underRoot(got) {
+				t.Fatalf("cleanRel(%q) = %q not under root %q", tt.input, got, ws.root)
+			}
+		})
+	}
+}
+
+func TestWorkspaceUnderRootPrefixSibling(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "root")
+	sibling := filepath.Join(parent, "rootx") // shares "root" prefix but is NOT under root
+	for _, d := range []string{root, sibling} {
+		if err := os.Mkdir(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Use ws.root (canonical) for in-root assertions: on macOS /var→/private/var
+	// means filepath.Join(root,"f.txt") differs from the canonicalized ws.root prefix.
+	siblingCanon, err := filepath.EvalSymlinks(sibling)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ws.underRoot(filepath.Join(siblingCanon, "f.txt")) {
+		t.Fatalf("underRoot leaked across prefix-sibling: %q accepted", siblingCanon)
+	}
+	if !ws.underRoot(filepath.Join(ws.root, "f.txt")) {
+		t.Fatalf("underRoot rejected a real in-root path")
+	}
+	if !ws.underRoot(ws.root) {
+		t.Fatalf("underRoot rejected the root itself")
+	}
+}
+
+func TestNewWorkspaceCanonicalizesRoot(t *testing.T) {
+	real := t.TempDir()
+	link := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	ws, err := NewWorkspace(link) // root itself may legitimately be a symlinked path
+	if err != nil {
+		t.Fatalf("NewWorkspace(symlinked root): %v", err)
+	}
+	realCanon, _ := filepath.EvalSymlinks(real)
+	if ws.root != realCanon {
+		t.Fatalf("root not canonicalized: got %q want %q", ws.root, realCanon)
+	}
+}
+
+func TestNewWorkspaceErrors(t *testing.T) {
+	if _, err := NewWorkspace(""); err == nil {
+		t.Fatal("empty root should error")
+	}
+	if _, err := NewWorkspace(filepath.Join(t.TempDir(), "does-not-exist")); err == nil {
+		t.Fatal("non-existent root should error")
+	}
+}
+
+func TestWorkspaceWalk(t *testing.T) {
+	root := t.TempDir()
+	for _, dir := range []string{".git", "sub"} {
+		if err := os.Mkdir(filepath.Join(root, dir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	files := map[string]string{
+		"a.txt":       "x",
+		".git/config": "y",
+		"sub/b.txt":   "z",
+	}
+	for rel, body := range files {
+		if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(rel)), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[string]bool{}
+	if err := ws.walk(context.Background(), func(rel string, d fs.DirEntry) error {
+		seen[rel] = true
+		return nil
+	}); err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	if !seen["a.txt"] || !seen["sub/b.txt"] {
+		t.Fatalf("walk missed expected files: %v", seen)
+	}
+	if seen["."] {
+		t.Fatal("walk should skip the root '.' entry")
+	}
+	for rel := range seen {
+		if strings.HasPrefix(rel, ".git") {
+			t.Fatalf("walk did not skip the ignore-set .git dir: saw %q", rel)
+		}
+	}
+}

--- a/agent/tools/paths_test.go
+++ b/agent/tools/paths_test.go
@@ -148,3 +148,114 @@ func TestWorkspaceWalk(t *testing.T) {
 		}
 	}
 }
+
+func TestResolveFileRejectsSymlinkAndKind(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	reg := filepath.Join(root, "reg.txt")
+	if err := os.WriteFile(reg, []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	secret := filepath.Join(outside, "secret.txt")
+	if err := os.WriteFile(secret, []byte("TOPSECRET"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(root, "evil")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if err := os.Symlink(reg, filepath.Join(root, "ptr")); err != nil {
+		t.Fatal(err)
+	}
+
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := ws.resolveFile("reg.txt"); err != nil {
+		t.Fatalf("resolveFile on regular file errored: %v", err)
+	}
+	if _, _, err := ws.resolveFile("sub"); !errors.Is(err, errNotRegular) {
+		t.Fatalf("resolveFile on a directory: got %v, want errNotRegular", err)
+	}
+	// "evil" is an in-root symlink whose target is OUTSIDE root; rejected as a
+	// symlink by Lstat, not by containment (cleanRel passes the in-root link path).
+	if _, _, err := ws.resolveFile("evil"); !errors.Is(err, errSymlink) {
+		t.Fatalf("resolveFile on out-of-root-pointing symlink: got %v, want errSymlink", err)
+	}
+	// "ptr" is an in-root symlink to an in-root file; still never followed.
+	if _, _, err := ws.resolveFile("ptr"); !errors.Is(err, errSymlink) {
+		t.Fatalf("resolveFile on in-root symlink: got %v, want errSymlink", err)
+	}
+	if _, _, err := ws.resolveFile("missing.txt"); err == nil {
+		t.Fatal("resolveFile on missing file should error")
+	}
+}
+
+func TestOpenRegularFileRejectsSymlink(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "reg.txt"), []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	secret := filepath.Join(outside, "secret.txt")
+	if err := os.WriteFile(secret, []byte("TOPSECRET"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(root, "evil")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := ws.openRegularFile("reg.txt")
+	if err != nil {
+		t.Fatalf("openRegularFile on regular file errored: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if f, err := ws.openRegularFile("evil"); !errors.Is(err, errSymlink) {
+		if err == nil {
+			_ = f.Close()
+		}
+		t.Fatalf("openRegularFile on symlink: got %v, want errSymlink", err)
+	}
+}
+
+func TestResolveDirRejectsSymlinkTarget(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "real"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkDir := filepath.Join(root, "linkdir")
+	if err := os.Symlink(outside, linkDir); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	regFile := filepath.Join(root, "f.txt")
+	if err := os.WriteFile(regFile, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ws.resolveDir("."); err != nil {
+		t.Fatalf("resolveDir(root) errored: %v", err)
+	}
+	if _, err := ws.resolveDir("real"); err != nil {
+		t.Fatalf("resolveDir(real subdir) errored: %v", err)
+	}
+	if _, err := ws.resolveDir("linkdir"); !errors.Is(err, errSymlink) {
+		t.Fatalf("resolveDir on symlinked dir: got %v, want errSymlink", err)
+	}
+	if _, err := ws.resolveDir("f.txt"); !errors.Is(err, errNotDir) {
+		t.Fatalf("resolveDir on a regular file: got %v, want errNotDir", err)
+	}
+}

--- a/agent/tools/paths_test.go
+++ b/agent/tools/paths_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/kstruzzieri/go-llm/agent"
 )
 
 func TestWorkspaceCleanRelContainment(t *testing.T) {
@@ -257,5 +259,35 @@ func TestResolveDirRejectsSymlinkTarget(t *testing.T) {
 	}
 	if _, err := ws.resolveDir("f.txt"); !errors.Is(err, errNotDir) {
 		t.Fatalf("resolveDir on a regular file: got %v, want errNotDir", err)
+	}
+}
+
+func TestNewFileTools(t *testing.T) {
+	tools, err := NewFileTools(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFileTools: %v", err)
+	}
+	want := map[string]bool{"read_file": false, "search": false, "glob": false, "list": false}
+	for _, tl := range tools {
+		name := tl.Spec().Name
+		if _, ok := want[name]; !ok {
+			t.Fatalf("unexpected tool %q", name)
+		}
+		want[name] = true
+		// every B1 tool must be exactly Read / ApprovalNever
+		if e := tl.Effect(); e.Class != agent.Read || e.Approval != agent.ApprovalNever {
+			t.Fatalf("tool %q Effect = %+v, want Read/ApprovalNever", name, e)
+		}
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Fatalf("NewFileTools missing %q", name)
+		}
+	}
+}
+
+func TestNewFileToolsBadRoot(t *testing.T) {
+	if _, err := NewFileTools(filepath.Join(t.TempDir(), "nope")); err == nil {
+		t.Fatal("NewFileTools on a non-existent root should error")
 	}
 }

--- a/agent/tools/readfile.go
+++ b/agent/tools/readfile.go
@@ -1,0 +1,138 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/kstruzzieri/go-llm/agent"
+)
+
+const binarySniffBytes = 8 * 1024 // NUL-sniff window
+
+// ReadFile reads a single file confined to the workspace root. Symlinks are
+// never followed; the read is TOCTOU-hardened via Workspace.openRegularFile.
+type ReadFile struct {
+	ws *Workspace
+}
+
+// NewReadFile builds the read_file tool bound to ws.
+func NewReadFile(ws *Workspace) *ReadFile { return &ReadFile{ws: ws} }
+
+type readFileArgs struct {
+	Path      string `json:"path"`
+	StartLine int    `json:"start_line"`
+	EndLine   int    `json:"end_line"`
+}
+
+// Spec is the model-facing schema.
+func (*ReadFile) Spec() agent.ToolSpec {
+	return agent.ToolSpec{
+		Name:        "read_file",
+		Description: "Read a UTF-8 text file from the workspace. Optional 1-based inclusive start_line/end_line. Paths are relative to the workspace root; escaping the root or following a symlink is refused.",
+		Parameters: json.RawMessage(`{
+  "type":"object",
+  "properties":{
+    "path":{"type":"string","description":"file path relative to the workspace root"},
+    "start_line":{"type":"integer","description":"1-based first line (optional)"},
+    "end_line":{"type":"integer","description":"1-based last line, inclusive (optional)"}
+  },
+  "required":["path"]
+}`),
+	}
+}
+
+// Effect declares read-only, never-approval, with an OutputCap above the 256 KiB
+// self-cap so the runtime (default 64 KiB) does not re-truncate the result.
+func (*ReadFile) Effect() agent.Effect {
+	return agent.Effect{
+		Class:     agent.Read,
+		Approval:  agent.ApprovalNever,
+		OutputCap: readFileMaxBytes + markerHeadroom,
+	}
+}
+
+// Invoke reads the file. All expected failures return (ToolResult{IsError:true}, nil).
+func (t *ReadFile) Invoke(ctx context.Context, raw json.RawMessage) (agent.ToolResult, error) {
+	var args readFileArgs
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return errResult("invalid arguments: " + err.Error()), nil
+	}
+	if args.Path == "" {
+		return errResult("path is required"), nil
+	}
+	if args.StartLine < 0 || args.EndLine < 0 {
+		return errResult("invalid line range: negative line number"), nil
+	}
+	if args.StartLine == 0 && args.EndLine > 0 {
+		return errResult("invalid line range: end_line set without start_line"), nil
+	}
+	if args.StartLine > 0 && args.EndLine > 0 && args.EndLine < args.StartLine {
+		return errResult(fmt.Sprintf("invalid line range: end_line %d < start_line %d", args.EndLine, args.StartLine)), nil
+	}
+
+	f, err := t.ws.openRegularFile(args.Path)
+	if err != nil {
+		return errResult(err.Error()), nil
+	}
+	defer func() { _ = f.Close() }()
+
+	// Read at most readFileMaxBytes+1 so we can detect overflow.
+	buf, err := io.ReadAll(io.LimitReader(f, int64(readFileMaxBytes+1)))
+	if err != nil {
+		return errResult(err.Error()), nil
+	}
+	sniff := buf
+	if len(sniff) > binarySniffBytes {
+		sniff = sniff[:binarySniffBytes]
+	}
+	if bytes.IndexByte(sniff, 0) >= 0 {
+		return errResult("binary file (NUL byte detected); refusing to read"), nil
+	}
+
+	truncated := false
+	if len(buf) > readFileMaxBytes {
+		buf = buf[:readFileMaxBytes]
+		truncated = true
+	}
+	content := string(buf)
+
+	if args.StartLine > 0 {
+		content, err = sliceLines(content, args.StartLine, args.EndLine)
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+	}
+	if truncated {
+		content += fmt.Sprintf("\n[truncated after %d bytes]", readFileMaxBytes)
+	}
+	return agent.ToolResult{Content: content, Truncated: truncated}, nil
+}
+
+// sliceLines returns lines [start,end] (1-based, inclusive). end<=0 means EOF.
+// Note: the returned slice is newline-joined WITHOUT a trailing newline, so a
+// ranged read of a file's final lines drops the file's trailing newline; a
+// whole-file read (no range) preserves the original bytes verbatim.
+func sliceLines(content string, start, end int) (string, error) {
+	lines := strings.Split(content, "\n")
+	// a trailing newline yields a final empty element; drop it for counting
+	if n := len(lines); n > 0 && lines[n-1] == "" {
+		lines = lines[:n-1]
+	}
+	if start > len(lines) {
+		return "", fmt.Errorf("invalid line range: start_line %d exceeds file length %d", start, len(lines))
+	}
+	last := end
+	if last <= 0 || last > len(lines) {
+		last = len(lines)
+	}
+	return strings.Join(lines[start-1:last], "\n"), nil
+}
+
+// errResult is the shared IsError constructor for tool-level failures.
+func errResult(msg string) agent.ToolResult {
+	return agent.ToolResult{IsError: true, Content: msg}
+}

--- a/agent/tools/readfile_test.go
+++ b/agent/tools/readfile_test.go
@@ -1,0 +1,185 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/agent"
+)
+
+func mustWorkspace(t *testing.T, root string) *Workspace {
+	t.Helper()
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		t.Fatalf("NewWorkspace: %v", err)
+	}
+	return ws
+}
+
+func invoke(t *testing.T, tool agent.Tool, args any) agent.ToolResult {
+	t.Helper()
+	raw, err := json.Marshal(args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := tool.Invoke(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Invoke returned a Go error (should be IsError ToolResult): %v", err)
+	}
+	return res
+}
+
+func TestReadFileHappyPath(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("line1\nline2\nline3\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rf := NewReadFile(mustWorkspace(t, root))
+
+	res := invoke(t, rf, map[string]any{"path": "a.txt"})
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", res.Content)
+	}
+	if !strings.Contains(res.Content, "line2") {
+		t.Fatalf("content missing: %q", res.Content)
+	}
+}
+
+func TestReadFileLineRange(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("l1\nl2\nl3\nl4\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rf := NewReadFile(mustWorkspace(t, root))
+
+	res := invoke(t, rf, map[string]any{"path": "a.txt", "start_line": 2, "end_line": 3})
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", res.Content)
+	}
+	if res.Content != "l2\nl3" && res.Content != "l2\nl3\n" {
+		t.Fatalf("range wrong: %q", res.Content)
+	}
+	if strings.Contains(res.Content, "l1") || strings.Contains(res.Content, "l4") {
+		t.Fatalf("range leaked extra lines: %q", res.Content)
+	}
+}
+
+func TestReadFileInvalidLineRange(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("l1\nl2\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rf := NewReadFile(mustWorkspace(t, root))
+
+	for _, args := range []map[string]any{
+		{"path": "a.txt", "start_line": 0, "end_line": 1}, // end set, start unset/0
+		{"path": "a.txt", "start_line": 3, "end_line": 2}, // end < start
+		{"path": "a.txt", "start_line": 99},               // start beyond EOF
+	} {
+		res := invoke(t, rf, args)
+		if !res.IsError {
+			t.Fatalf("args %v should be IsError, got %q", args, res.Content)
+		}
+	}
+}
+
+func TestReadFileEscapeIsError(t *testing.T) {
+	rf := NewReadFile(mustWorkspace(t, t.TempDir()))
+	res := invoke(t, rf, map[string]any{"path": "../../etc/passwd"})
+	if !res.IsError {
+		t.Fatalf("escape must be IsError, got %q", res.Content)
+	}
+}
+
+func TestReadFileBinaryRejected(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "bin"), []byte("ab\x00cd"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rf := NewReadFile(mustWorkspace(t, root))
+	res := invoke(t, rf, map[string]any{"path": "bin"})
+	if !res.IsError {
+		t.Fatalf("binary file must be IsError, got %q", res.Content)
+	}
+}
+
+func TestReadFileOversizeTruncatesNotError(t *testing.T) {
+	root := t.TempDir()
+	big := strings.Repeat("x", readFileMaxBytes+5000)
+	if err := os.WriteFile(filepath.Join(root, "big.txt"), []byte(big), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rf := NewReadFile(mustWorkspace(t, root))
+	res := invoke(t, rf, map[string]any{"path": "big.txt"})
+	if res.IsError {
+		t.Fatalf("oversize should be a successful partial, got IsError: %s", res.Content)
+	}
+	if !res.Truncated {
+		t.Fatal("oversize should set Truncated")
+	}
+	if !strings.Contains(res.Content, "truncated") {
+		t.Fatalf("oversize should carry an in-band truncation marker, got tail: %q", res.Content[len(res.Content)-80:])
+	}
+}
+
+func TestReadFileSymlinkRejected(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "secret.txt")
+	if err := os.WriteFile(secret, []byte("TOPSECRET"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(root, "evil")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	rf := NewReadFile(mustWorkspace(t, root))
+	res := invoke(t, rf, map[string]any{"path": "evil"})
+	if !res.IsError {
+		t.Fatalf("symlink must be IsError, got %q", res.Content)
+	}
+	if strings.Contains(res.Content, "TOPSECRET") {
+		t.Fatal("symlink leaked out-of-root contents")
+	}
+}
+
+func TestReadFileEndLineBeyondEOFClamps(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("l1\nl2\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rf := NewReadFile(mustWorkspace(t, root))
+	res := invoke(t, rf, map[string]any{"path": "a.txt", "start_line": 1, "end_line": 999})
+	if res.IsError {
+		t.Fatalf("end_line beyond EOF must clamp, not error: %s", res.Content)
+	}
+	if !strings.Contains(res.Content, "l1") || !strings.Contains(res.Content, "l2") {
+		t.Fatalf("clamped range should include all lines: %q", res.Content)
+	}
+}
+
+func TestReadFileEmptyFileWithStartLine(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "empty.txt"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rf := NewReadFile(mustWorkspace(t, root))
+	res := invoke(t, rf, map[string]any{"path": "empty.txt", "start_line": 1})
+	if !res.IsError {
+		t.Fatalf("empty file with start_line=1 should be IsError (start beyond EOF), got %q", res.Content)
+	}
+}
+
+func TestReadFileEffect(t *testing.T) {
+	rf := NewReadFile(mustWorkspace(t, t.TempDir()))
+	e := rf.Effect()
+	if e.Class != agent.Read || e.Approval != agent.ApprovalNever {
+		t.Fatalf("Effect = %+v, want Read/ApprovalNever", e)
+	}
+	if e.OutputCap <= readFileMaxBytes {
+		t.Fatalf("OutputCap %d must exceed self-cap %d to avoid runtime re-truncation", e.OutputCap, readFileMaxBytes)
+	}
+}

--- a/agent/tools/search.go
+++ b/agent/tools/search.go
@@ -1,0 +1,152 @@
+package tools
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"regexp"
+	"strings"
+
+	"github.com/kstruzzieri/go-llm/agent"
+)
+
+// Search greps the workspace tree with RE2. It skips ignore-set directories,
+// binary files (NUL sniff), and symlink entries (never read or descended).
+type Search struct {
+	ws *Workspace
+}
+
+// NewSearch builds the search tool bound to ws.
+func NewSearch(ws *Workspace) *Search { return &Search{ws: ws} }
+
+type searchArgs struct {
+	Pattern string `json:"pattern"`
+	Regex   bool   `json:"regex"`
+}
+
+// Spec is the model-facing schema.
+func (*Search) Spec() agent.ToolSpec {
+	return agent.ToolSpec{
+		Name:        "search",
+		Description: "Search file contents under the workspace root. Literal substring by default; set regex:true for an RE2 pattern. Returns path:line: text. Skips .git, vendor, node_modules, .superpowers, binary files, and symlinks.",
+		Parameters: json.RawMessage(`{
+  "type":"object",
+  "properties":{
+    "pattern":{"type":"string","description":"text to find (literal unless regex:true)"},
+    "regex":{"type":"boolean","description":"treat pattern as an RE2 regular expression"}
+  },
+  "required":["pattern"]
+}`),
+	}
+}
+
+// Effect declares read-only, never-approval, with OutputCap above the byte self-cap.
+func (*Search) Effect() agent.Effect {
+	return agent.Effect{
+		Class:     agent.Read,
+		Approval:  agent.ApprovalNever,
+		OutputCap: searchMaxBytes + markerHeadroom,
+	}
+}
+
+// Invoke walks and matches. Expected failures return (ToolResult{IsError:true}, nil).
+func (t *Search) Invoke(ctx context.Context, raw json.RawMessage) (agent.ToolResult, error) {
+	var args searchArgs
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return errResult("invalid arguments: " + err.Error()), nil
+	}
+	if args.Pattern == "" {
+		return errResult("pattern is required"), nil
+	}
+	expr := args.Pattern
+	if !args.Regex {
+		expr = regexp.QuoteMeta(args.Pattern)
+	}
+	re, err := regexp.Compile(expr)
+	if err != nil {
+		return errResult("invalid regex: " + err.Error()), nil
+	}
+
+	var out strings.Builder
+	matches := 0
+	truncated := false
+
+	walkErr := t.ws.walk(ctx, func(rel string, d fs.DirEntry) error {
+		if d.IsDir() {
+			return nil
+		}
+		if d.Type()&fs.ModeSymlink != 0 {
+			return nil // never read a symlink
+		}
+		fileTruncated, err := t.searchFile(rel, re, &out, &matches)
+		if err != nil {
+			return err
+		}
+		if fileTruncated {
+			truncated = true
+			return fs.SkipAll
+		}
+		return nil
+	})
+	if walkErr != nil && walkErr != fs.SkipAll {
+		return errResult("search failed: " + walkErr.Error()), nil
+	}
+
+	content := strings.TrimRight(out.String(), "\n")
+	if matches == 0 {
+		content = "no matches"
+	}
+	if truncated {
+		content += fmt.Sprintf("\n[truncated after %d matches / %d bytes]", searchMaxMatches, searchMaxBytes)
+	}
+	return agent.ToolResult{Content: content, Truncated: truncated}, nil
+}
+
+// searchFile opens one file (TOCTOU-hardened), skips it if binary or unreadable,
+// and appends matching lines. It returns true when a cap was reached (the caller
+// stops the walk). The file is closed before returning — never deferred to the
+// end of the walk — so large trees do not exhaust descriptors.
+func (t *Search) searchFile(rel string, re *regexp.Regexp, out *strings.Builder, matches *int) (bool, error) {
+	f, err := t.ws.openRegularFile(rel)
+	if err != nil {
+		return false, nil // unreadable or raced file: skip, not fatal
+	}
+	defer func() { _ = f.Close() }()
+
+	sniff := make([]byte, binarySniffBytes)
+	n, err := f.Read(sniff)
+	if err != nil && err != io.EOF {
+		return false, nil
+	}
+	if bytes.IndexByte(sniff[:n], 0) >= 0 {
+		return false, nil // binary: skip
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return false, nil
+	}
+
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	line := 0
+	for sc.Scan() {
+		line++
+		text := sc.Text()
+		if !re.MatchString(text) {
+			continue
+		}
+		entry := fmt.Sprintf("%s:%d: %s\n", rel, line, text)
+		if *matches >= searchMaxMatches || out.Len()+len(entry) > searchMaxBytes {
+			return true, nil
+		}
+		out.WriteString(entry)
+		(*matches)++
+	}
+	if err := sc.Err(); err != nil {
+		return false, nil // overlong/unreadable line: skip rest of file, not fatal
+	}
+	return false, nil
+}

--- a/agent/tools/search_test.go
+++ b/agent/tools/search_test.go
@@ -1,0 +1,211 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/agent"
+)
+
+func writeTree(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	for rel, body := range files {
+		p := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestSearchLiteralMatch(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{
+		"a.go":     "package main\nfunc Foo() {}\n",
+		"sub/b.go": "var Foo = 1\n",
+		"c.txt":    "nothing here\n",
+	})
+	s := NewSearch(mustWorkspace(t, root))
+	res := invoke(t, s, map[string]any{"pattern": "Foo"})
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", res.Content)
+	}
+	if !strings.Contains(res.Content, "a.go:2:") || !strings.Contains(res.Content, "sub/b.go:1:") {
+		t.Fatalf("missing matches with slash paths: %q", res.Content)
+	}
+	if strings.Contains(res.Content, "c.txt") {
+		t.Fatalf("matched a file it should not: %q", res.Content)
+	}
+}
+
+func TestSearchRegexAndBadRegex(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{"a.go": "func Bar() {}\nfunc Baz() {}\n"})
+	s := NewSearch(mustWorkspace(t, root))
+
+	res := invoke(t, s, map[string]any{"pattern": "Ba[rz]", "regex": true})
+	if res.IsError || !strings.Contains(res.Content, "Bar") || !strings.Contains(res.Content, "Baz") {
+		t.Fatalf("regex match failed: %+v", res)
+	}
+	bad := invoke(t, s, map[string]any{"pattern": "(unclosed", "regex": true})
+	if !bad.IsError {
+		t.Fatalf("invalid regex should be IsError, got %q", bad.Content)
+	}
+}
+
+func TestSearchSkipsBinaryAndIgnoreDirs(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{
+		"keep.go":        "needle here\n",
+		".git/config":    "needle in git\n",
+		"node_modules/x": "needle in deps\n",
+	})
+	if err := os.WriteFile(filepath.Join(root, "bin"), []byte("nee\x00dle"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s := NewSearch(mustWorkspace(t, root))
+	res := invoke(t, s, map[string]any{"pattern": "needle"})
+	if strings.Contains(res.Content, ".git") || strings.Contains(res.Content, "node_modules") {
+		t.Fatalf("ignore set not honored: %q", res.Content)
+	}
+	if strings.Contains(res.Content, "bin:") {
+		t.Fatalf("binary file not skipped: %q", res.Content)
+	}
+	if !strings.Contains(res.Content, "keep.go") {
+		t.Fatalf("missed the real match: %q", res.Content)
+	}
+}
+
+func TestSearchBinarySniffCoversFullWindow(t *testing.T) {
+	root := t.TempDir()
+	// NUL appears after the default 4 KiB bufio.Reader buffer size. The tool must
+	// still treat this as binary by sniffing the full binarySniffBytes window.
+	body := strings.Repeat("x", 5000) + "\x00needle\n"
+	if err := os.WriteFile(filepath.Join(root, "bin.txt"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s := NewSearch(mustWorkspace(t, root))
+	res := invoke(t, s, map[string]any{"pattern": "needle"})
+	if strings.Contains(res.Content, "bin.txt") || strings.Contains(res.Content, "needle") {
+		t.Fatalf("binary file with late NUL should be skipped, got %q", res.Content)
+	}
+}
+
+func TestSearchSkipsSymlinkedFile(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "secret.txt")
+	if err := os.WriteFile(secret, []byte("needle SECRET\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(root, "link.txt")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	writeTree(t, root, map[string]string{"real.txt": "needle real\n"})
+	s := NewSearch(mustWorkspace(t, root))
+	res := invoke(t, s, map[string]any{"pattern": "needle"})
+	if strings.Contains(res.Content, "SECRET") || strings.Contains(res.Content, "link.txt") {
+		t.Fatalf("symlinked file leaked into search: %q", res.Content)
+	}
+	if !strings.Contains(res.Content, "real.txt") {
+		t.Fatalf("missed the real match: %q", res.Content)
+	}
+}
+
+func TestSearchDoesNotDescendSymlinkedDir(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	writeTree(t, outside, map[string]string{"hidden.txt": "needle SECRET\n"})
+	if err := os.Symlink(outside, filepath.Join(root, "linkdir")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	writeTree(t, root, map[string]string{"real.txt": "needle real\n"})
+	s := NewSearch(mustWorkspace(t, root))
+	res := invoke(t, s, map[string]any{"pattern": "needle"})
+	if strings.Contains(res.Content, "SECRET") || strings.Contains(res.Content, "hidden.txt") || strings.Contains(res.Content, "linkdir") {
+		t.Fatalf("search descended into symlinked dir or leaked it: %q", res.Content)
+	}
+	if !strings.Contains(res.Content, "real.txt") {
+		t.Fatalf("missed the real match: %q", res.Content)
+	}
+}
+
+func TestSearchMatchCapTruncates(t *testing.T) {
+	root := t.TempDir()
+	var b strings.Builder
+	for i := 0; i < searchMaxMatches+50; i++ {
+		b.WriteString("hit\n")
+	}
+	writeTree(t, root, map[string]string{"many.txt": b.String()})
+	s := NewSearch(mustWorkspace(t, root))
+	res := invoke(t, s, map[string]any{"pattern": "hit"})
+	if res.IsError {
+		t.Fatalf("cap should be partial success, got IsError: %s", res.Content)
+	}
+	if !res.Truncated || !strings.Contains(res.Content, "truncated") {
+		t.Fatal("match cap should set Truncated and an in-band marker")
+	}
+}
+
+func TestSearchEffect(t *testing.T) {
+	s := NewSearch(mustWorkspace(t, t.TempDir()))
+	e := s.Effect()
+	if e.Class != agent.Read || e.Approval != agent.ApprovalNever {
+		t.Fatalf("Effect = %+v, want Read/ApprovalNever", e)
+	}
+	if e.OutputCap <= searchMaxBytes {
+		t.Fatalf("OutputCap %d must exceed searchMaxBytes %d to avoid runtime re-truncation", e.OutputCap, searchMaxBytes)
+	}
+}
+
+func TestSearchEmptyPattern(t *testing.T) {
+	s := NewSearch(mustWorkspace(t, t.TempDir()))
+	res := invoke(t, s, map[string]any{"pattern": ""})
+	if !res.IsError {
+		t.Fatalf("empty pattern should be IsError, got %q", res.Content)
+	}
+}
+
+func TestSearchLiteralQuotesMetacharacters(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{"a.txt": "axb\na.b\n"})
+	s := NewSearch(mustWorkspace(t, root))
+	// literal "a.b" must match the line "a.b" but NOT "axb" (the '.' is escaped).
+	res := invoke(t, s, map[string]any{"pattern": "a.b"})
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", res.Content)
+	}
+	if !strings.Contains(res.Content, ":2: a.b") {
+		t.Fatalf("literal pattern should match the a.b line: %q", res.Content)
+	}
+	if strings.Contains(res.Content, "axb") {
+		t.Fatalf("literal '.' must not match 'x' (QuoteMeta): %q", res.Content)
+	}
+}
+
+func TestSearchByteCapTruncates(t *testing.T) {
+	root := t.TempDir()
+	// ~100 matching lines, each ~1 KiB, so total output exceeds searchMaxBytes
+	// (64 KiB) well before the 200-match cap — exercises the byte-cap path.
+	var b strings.Builder
+	long := strings.Repeat("x", 1000)
+	for i := 0; i < 100; i++ {
+		b.WriteString("needle" + long + "\n")
+	}
+	writeTree(t, root, map[string]string{"big.txt": b.String()})
+	s := NewSearch(mustWorkspace(t, root))
+	res := invoke(t, s, map[string]any{"pattern": "needle"})
+	if res.IsError {
+		t.Fatalf("byte cap should be partial success, got IsError: %s", res.Content)
+	}
+	if !res.Truncated || !strings.Contains(res.Content, "truncated") {
+		t.Fatal("byte cap should set Truncated and an in-band marker")
+	}
+	if len(res.Content) > searchMaxBytes+markerHeadroom {
+		t.Fatalf("output %d exceeds searchMaxBytes+markerHeadroom %d", len(res.Content), searchMaxBytes+markerHeadroom)
+	}
+}


### PR DESCRIPTION
## Summary

Golem v1 child B1 (#194): four read-only `agent.Tool` built-ins that confine all filesystem access to a workspace root, with a path-containment + symlink attack suite as the security core. Purely additive (new `agent/tools/` files only), independent of child A (`internal/providerbootstrap`), parallel-safe. No new external dependencies (stdlib only).

## Tools

- `read_file` — relative-path read; optional 1-based inclusive line range; 256 KiB cap with in-band truncation marker; binary (NUL) reject.
- `search` — RE2 grep over the tree (literal default, `regex:true` for RE2); match + byte caps; skips binary files, symlinks, and the ignore set (`.git`, `vendor`, `node_modules`, `.superpowers`).
- `glob` — root-anchored pattern match with `**` support (bespoke matcher, not the gitignore-anchored one); directory and symlink markers; entry cap.
- `list` — single-level directory listing; symlinked-directory target rejected; symlink entries marked, never followed.

`NewFileTools(root)` assembles all four for the consumer (`cmd/golem`). Every tool is `Effect{Read, ApprovalNever}` with an explicit `OutputCap` above its self-cap so the runtime default (64 KiB) cannot silently re-truncate.

## Security model (the point of B1)

- Single audited chokepoint: a `Workspace` value whose canonical root is resolved once via `filepath.EvalSymlinks` (the root itself may legitimately be a symlinked path; nothing after follows a symlink).
- `cleanRel` + `underRoot` containment: rejects `..` traversal, absolute paths, NUL bytes, and prefix-sibling escapes (`/x/root` vs `/x/rootx`) — pure path math, no filesystem access.
- v1 never follows a symlink anywhere.
- TOCTOU-hardened content access: `openRegularFile` and `openDir` both do `Lstat -> Open -> Stat -> os.SameFile` on the open handle, so a final-component symlink swapped in after the check cannot redirect the read (closes the window symmetrically for file reads and directory reads).
- Every expected failure (escape, NUL, missing file, symlink, invalid regex, binary read) returns `ToolResult{IsError:true}` — never a Go error, never a panic, never an out-of-root read; the agent run continues. Caps are partial successes (`Truncated:true` + in-band marker).

## Test Plan

- [x] Path-containment attack suite on `cleanRel`/`underRoot` (`..`, absolute, midpath, NUL, prefix-sibling, symlinked root).
- [x] Symlink policy: file + dir, in-root + out-of-root targets rejected/never-followed; no descent into symlinked dirs (search + glob); no entry-name leak (list).
- [x] Cap taxonomy: oversize/match/byte/entry caps are `Truncated` partials with in-band markers; invalid input is `IsError`.
- [x] Exact `Effect{Read, ApprovalNever}` + `OutputCap` regression per tool.
- [x] `go test ./... -race` green; `go vet ./...` clean; `golangci-lint run ./...` 0 issues.

Closes #194.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>