### PR TITLE
feat(golem): minimal read-only REPL + wiring (Golem v1 B2, #192)

### DIFF
--- a/cmd/golem/config.go
+++ b/cmd/golem/config.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/kstruzzieri/go-llm/config"
+)
+
+// chainPlan is the resolved agent-routing strategy. Exactly one of chain or
+// useRecommend is meaningful; both are zero only when resolveAgentChain also
+// returns an error, so callers must check err before reading these fields.
+type chainPlan struct {
+	chain        []string // strict PreferredChain when non-empty
+	useRecommend bool     // true => empty-Model recommend (defaults.agent unset or nil cfg)
+}
+
+// loadConfig applies golem's config-discovery rules. An explicit path that
+// fails to load is fatal; auto-discovery that finds nothing returns (nil, nil)
+// so the caller passes Config:nil to providerbootstrap.New (default Ollama).
+func loadConfig(path string) (*config.Config, error) {
+	if path != "" {
+		cfg, err := config.Load(path)
+		if err != nil {
+			return nil, fmt.Errorf("golem: load config %q: %w", path, err)
+		}
+		return cfg, nil
+	}
+	cfg, err := config.Default()
+	if err != nil {
+		if errors.Is(err, config.ErrConfigNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("golem: discover config: %w", err)
+	}
+	return cfg, nil
+}
+
+// resolveAgentChain gates strict-chain vs recommend on the EFFECTIVE config
+// (bundle.Config). defaults.agent absent (or nil cfg) => recommend; present
+// and resolvable => strict chain; present but unresolvable => fatal.
+func resolveAgentChain(cfg *config.Config) (chainPlan, error) {
+	if cfg == nil {
+		return chainPlan{useRecommend: true}, nil
+	}
+	if _, ok := cfg.Defaults["agent"]; !ok {
+		return chainPlan{useRecommend: true}, nil
+	}
+	chain, err := cfg.RoleFallbackChain("agent")
+	if err != nil {
+		return chainPlan{}, fmt.Errorf("golem: resolve agent chain: %w", err)
+	}
+	return chainPlan{chain: chain}, nil
+}

--- a/cmd/golem/config_test.go
+++ b/cmd/golem/config_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/config"
+)
+
+func TestResolveAgentChain_Present(t *testing.T) {
+	cfg := &config.Config{
+		Providers: map[string]config.ProviderConfig{"ollama": {}},
+		Models: map[string]config.ModelConfig{
+			"primary": {Name: "m1", Provider: "ollama", Fallbacks: []string{"backup"}},
+			"backup":  {Name: "m2", Provider: "ollama"},
+		},
+		Defaults: map[string]string{"agent": "primary"},
+	}
+	plan, err := resolveAgentChain(cfg)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if plan.useRecommend {
+		t.Error("useRecommend = true, want chain")
+	}
+	want := []string{"ollama/m1", "ollama/m2"}
+	if len(plan.chain) != 2 || plan.chain[0] != want[0] || plan.chain[1] != want[1] {
+		t.Errorf("chain = %v, want %v", plan.chain, want)
+	}
+}
+
+func TestResolveAgentChain_AbsentUsesRecommend(t *testing.T) {
+	cfg := &config.Config{
+		Models:   map[string]config.ModelConfig{"primary": {Name: "m1", Provider: "ollama"}},
+		Defaults: map[string]string{},
+	}
+	plan, err := resolveAgentChain(cfg)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if !plan.useRecommend || len(plan.chain) != 0 {
+		t.Errorf("plan = %+v, want useRecommend with empty chain", plan)
+	}
+}
+
+func TestResolveAgentChain_NilConfigUsesRecommend(t *testing.T) {
+	plan, err := resolveAgentChain(nil)
+	if err != nil || !plan.useRecommend {
+		t.Errorf("nil cfg: plan=%+v err=%v, want useRecommend", plan, err)
+	}
+}
+
+func TestResolveAgentChain_MisconfiguredFatal(t *testing.T) {
+	cfg := &config.Config{
+		Models:   map[string]config.ModelConfig{"primary": {Name: "m1", Provider: "ollama", Fallbacks: []string{"ghost"}}},
+		Defaults: map[string]string{"agent": "primary"},
+	}
+	if _, err := resolveAgentChain(cfg); err == nil {
+		t.Fatal("err = nil for unknown fallback role, want fatal")
+	}
+}
+
+func TestResolveAgentChain_EmptyAgentKeyFatal(t *testing.T) {
+	// Key present but mapping to "" is misconfiguration, not "unset": the
+	// presence check passes, RoleFallbackChain("agent") then fails on role "".
+	cfg := &config.Config{
+		Models:   map[string]config.ModelConfig{"primary": {Name: "m1", Provider: "ollama"}},
+		Defaults: map[string]string{"agent": ""},
+	}
+	if _, err := resolveAgentChain(cfg); err == nil {
+		t.Fatal("err = nil for empty agent role, want fatal")
+	}
+}
+
+func TestLoadConfig_ExplicitBadPathFatal(t *testing.T) {
+	if _, err := loadConfig("/nonexistent/path/models.json"); err == nil {
+		t.Fatal("err = nil for nonexistent explicit config path, want fatal")
+	}
+}

--- a/cmd/golem/doc.go
+++ b/cmd/golem/doc.go
@@ -1,5 +1,6 @@
 // Command golem is a minimal read-only terminal coding agent. It wires the
 // shared provider/router bootstrap and the read-only file tools into an
 // agent.Orchestrator and drives it from a line-based REPL. v1 never mutates
-// the project: only read, search, glob, and list tools are exposed.
+// the project: file inspection tools are always exposed, and retrieve can be
+// enabled for a prebuilt RAG index.
 package main

--- a/cmd/golem/doc.go
+++ b/cmd/golem/doc.go
@@ -1,0 +1,5 @@
+// Command golem is a minimal read-only terminal coding agent. It wires the
+// shared provider/router bootstrap and the read-only file tools into an
+// agent.Orchestrator and drives it from a line-based REPL. v1 never mutates
+// the project: only read, search, glob, and list tools are exposed.
+package main

--- a/cmd/golem/main.go
+++ b/cmd/golem/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/cmd/golem/main.go
+++ b/cmd/golem/main.go
@@ -1,3 +1,163 @@
 package main
 
-func main() {}
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	"github.com/kstruzzieri/go-llm/agent"
+	"github.com/kstruzzieri/go-llm/internal/providerbootstrap"
+)
+
+type flags struct {
+	configPath    string
+	root          string
+	ollamaURL     string
+	maxSteps      int
+	inputCeiling  int
+	outputReserve int
+	noColor       bool
+}
+
+func parseFlags(args []string) (flags, error) {
+	var f flags
+	fs := flag.NewFlagSet("golem", flag.ContinueOnError)
+	fs.StringVar(&f.configPath, "config", "", "path to models.json (default: auto-discover)")
+	fs.StringVar(&f.root, "root", ".", "workspace root the tools are scoped to")
+	fs.StringVar(&f.ollamaURL, "ollama-url", "", "override Ollama base URL")
+	fs.IntVar(&f.maxSteps, "max-steps", 0, "max agent steps per prompt (0 => default 16)")
+	fs.IntVar(&f.inputCeiling, "input-ceiling", 0, "token input ceiling (0 => default)")
+	fs.IntVar(&f.outputReserve, "output-reserve", 0, "token output reserve")
+	fs.BoolVar(&f.noColor, "no-color", false, "disable dim ANSI footers")
+	if err := fs.Parse(args); err != nil {
+		return flags{}, err
+	}
+	return f, nil
+}
+
+type startupInfo struct {
+	workspace       string
+	useRecommend    bool
+	bootstrapWarns  []error
+	preflightWarns  []string
+	retrieveOmitted bool
+}
+
+// startupNotices renders the human-facing startup lines (written to stderr).
+func startupNotices(info startupInfo) []string {
+	var out []string
+	out = append(out, "workspace: "+info.workspace)
+	if info.useRecommend {
+		out = append(out, "no defaults.agent configured; using model recommendation (run will route to the recommended model)")
+	}
+	for _, w := range info.bootstrapWarns {
+		out = append(out, "warning: "+w.Error())
+	}
+	for _, w := range info.preflightWarns {
+		out = append(out, "warning: "+w)
+	}
+	if info.retrieveOmitted {
+		out = append(out, "retrieve unavailable: no RAG index configured; using file/search tools")
+	}
+	return out
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr); err != nil {
+		// -h / -help: the flag package already printed usage to stderr; help
+		// is not a failure, so exit cleanly without a spurious "golem:" line.
+		if errors.Is(err, flag.ErrHelp) {
+			return
+		}
+		_, _ = fmt.Fprintf(os.Stderr, "golem: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
+	f, err := parseFlags(args)
+	if err != nil {
+		return err
+	}
+
+	root, err := filepath.Abs(f.root)
+	if err != nil {
+		return fmt.Errorf("resolve root: %w", err)
+	}
+
+	cfg, err := loadConfig(f.configPath)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	bundle, err := providerbootstrap.New(ctx, providerbootstrap.Options{
+		Config:            cfg, // nil => default Ollama provider
+		OllamaURLOverride: f.ollamaURL,
+	})
+	if err != nil {
+		return fmt.Errorf("bootstrap providers: %w", err)
+	}
+	defer func() { _ = bundle.Close() }()
+
+	plan, err := resolveAgentChain(bundle.Config)
+	if err != nil {
+		return err
+	}
+
+	warns, err := preflightToolCapable(ctx, bundle.Models, plan.chain)
+	if err != nil {
+		return err
+	}
+
+	// retrieve resolution is Task 9; until then it is always omitted.
+	tools, err := buildTools(root, nil)
+	if err != nil {
+		return err
+	}
+	retrieveOmitted := true
+
+	for _, line := range startupNotices(startupInfo{
+		workspace:       root,
+		useRecommend:    plan.useRecommend,
+		bootstrapWarns:  bundle.Warnings,
+		preflightWarns:  warns,
+		retrieveOmitted: retrieveOmitted,
+	}) {
+		_, _ = fmt.Fprintln(stderr, line)
+	}
+
+	caller := newRouterChainCaller(bundle.Router, plan.chain)
+	sess := &replSession{
+		orch:            agent.New(caller, agent.ContextManager{}),
+		tools:           tools,
+		baseSystem:      golemSystemPrompt,
+		maxSteps:        f.maxSteps,
+		budget:          agent.Budget{InputCeiling: f.inputCeiling, OutputReserve: f.outputReserve},
+		color:           !f.noColor,
+		retrieveOmitted: retrieveOmitted,
+	}
+	if sess.maxSteps == 0 {
+		sess.maxSteps = 16 // mirror agent defaultMaxSteps so the footer's k/max is accurate
+	}
+
+	interrupts := make(chan struct{}, 1)
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	go func() {
+		for range sigCh {
+			select {
+			case interrupts <- struct{}{}:
+			default:
+			}
+		}
+	}()
+
+	return runREPL(ctx, stdin, stdout, interrupts, sess)
+}

--- a/cmd/golem/main.go
+++ b/cmd/golem/main.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"syscall"
 
 	"github.com/kstruzzieri/go-llm/agent"
 	"github.com/kstruzzieri/go-llm/internal/providerbootstrap"
@@ -162,7 +161,7 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 
 	interrupts := make(chan struct{}, 1)
 	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(sigCh, interruptSignals()...)
 	defer signal.Stop(sigCh)
 	go func() {
 		for range sigCh {
@@ -174,4 +173,8 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 	}()
 
 	return runREPL(ctx, stdin, stdout, interrupts, sess)
+}
+
+func interruptSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
 }

--- a/cmd/golem/main.go
+++ b/cmd/golem/main.go
@@ -18,6 +18,7 @@ type flags struct {
 	configPath    string
 	root          string
 	ollamaURL     string
+	ragDB         string
 	maxSteps      int
 	inputCeiling  int
 	outputReserve int
@@ -30,6 +31,7 @@ func parseFlags(args []string) (flags, error) {
 	fs.StringVar(&f.configPath, "config", "", "path to models.json (default: auto-discover)")
 	fs.StringVar(&f.root, "root", ".", "workspace root the tools are scoped to")
 	fs.StringVar(&f.ollamaURL, "ollama-url", "", "override Ollama base URL")
+	fs.StringVar(&f.ragDB, "rag-db", "", "path to a prebuilt RAG SQLite DB to enable the retrieve tool")
 	fs.IntVar(&f.maxSteps, "max-steps", 0, "max agent steps per prompt (0 => default 16)")
 	fs.IntVar(&f.inputCeiling, "input-ceiling", 0, "token input ceiling (0 => default)")
 	fs.IntVar(&f.outputReserve, "output-reserve", 0, "token output reserve")
@@ -115,12 +117,15 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 		return err
 	}
 
-	// retrieve resolution is Task 9; until then it is always omitted.
-	tools, err := buildTools(root, nil)
+	var retrieve agent.Tool
+	if t, ok := resolveRetriever(ctx, bundle.Config, bundle.Router, f.ragDB); ok {
+		retrieve = t
+	}
+	tools, err := buildTools(root, retrieve)
 	if err != nil {
 		return err
 	}
-	retrieveOmitted := true
+	retrieveOmitted := retrieve == nil
 
 	for _, line := range startupNotices(startupInfo{
 		workspace:       root,

--- a/cmd/golem/main.go
+++ b/cmd/golem/main.go
@@ -43,11 +43,12 @@ func parseFlags(args []string) (flags, error) {
 }
 
 type startupInfo struct {
-	workspace       string
-	useRecommend    bool
-	bootstrapWarns  []error
-	preflightWarns  []string
-	retrieveOmitted bool
+	workspace         string
+	useRecommend      bool
+	bootstrapWarns    []error
+	preflightWarns    []string
+	retrieveOmitted   bool
+	retrieveRequested bool // -rag-db was given; suppress the generic no-index notice
 }
 
 // startupNotices renders the human-facing startup lines (written to stderr).
@@ -63,7 +64,10 @@ func startupNotices(info startupInfo) []string {
 	for _, w := range info.preflightWarns {
 		out = append(out, "warning: "+w)
 	}
-	if info.retrieveOmitted {
+	// The generic no-index notice is only meaningful when retrieve was NOT
+	// requested. When -rag-db was given but failed, a specific "retrieve
+	// disabled: ..." warning above already explains why.
+	if info.retrieveOmitted && !info.retrieveRequested {
 		out = append(out, "retrieve unavailable: no RAG index configured; using file/search tools")
 	}
 	return out
@@ -118,7 +122,11 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 	}
 
 	var retrieve agent.Tool
-	if t, ok := resolveRetriever(ctx, bundle.Config, bundle.Router, f.ragDB); ok {
+	if t, rerr := resolveRetriever(ctx, bundle.Config, bundle.Router, f.ragDB); rerr != nil {
+		// -rag-db was given but retrieve could not be enabled: surface why
+		// instead of swallowing it behind the generic "no RAG index" notice.
+		warns = append(warns, "retrieve disabled: "+rerr.Error())
+	} else {
 		retrieve = t
 	}
 	tools, err := buildTools(root, retrieve)
@@ -128,11 +136,12 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 	retrieveOmitted := retrieve == nil
 
 	for _, line := range startupNotices(startupInfo{
-		workspace:       root,
-		useRecommend:    plan.useRecommend,
-		bootstrapWarns:  bundle.Warnings,
-		preflightWarns:  warns,
-		retrieveOmitted: retrieveOmitted,
+		workspace:         root,
+		useRecommend:      plan.useRecommend,
+		bootstrapWarns:    bundle.Warnings,
+		preflightWarns:    warns,
+		retrieveOmitted:   retrieveOmitted,
+		retrieveRequested: f.ragDB != "",
 	}) {
 		_, _ = fmt.Fprintln(stderr, line)
 	}

--- a/cmd/golem/main_test.go
+++ b/cmd/golem/main_test.go
@@ -28,6 +28,22 @@ func TestStartupNotices(t *testing.T) {
 	}
 }
 
+func TestStartupNotices_RequestedRetrieveSuppressesGenericLine(t *testing.T) {
+	got := startupNotices(startupInfo{
+		workspace:         "/r",
+		retrieveOmitted:   true,
+		retrieveRequested: true,
+		preflightWarns:    []string{`retrieve disabled: rag-db "/x.db": no such file or directory`},
+	})
+	joined := strings.Join(got, "\n")
+	if !strings.Contains(joined, "retrieve disabled:") {
+		t.Errorf("expected the specific retrieve-disabled reason, got:\n%s", joined)
+	}
+	if strings.Contains(joined, "no RAG index configured") {
+		t.Errorf("generic no-index line must be suppressed when -rag-db was requested, got:\n%s", joined)
+	}
+}
+
 func TestParseFlags_Defaults(t *testing.T) {
 	f, err := parseFlags([]string{})
 	if err != nil {

--- a/cmd/golem/main_test.go
+++ b/cmd/golem/main_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestStartupNotices(t *testing.T) {
+	got := startupNotices(startupInfo{
+		workspace:       "/abs/root",
+		useRecommend:    true,
+		bootstrapWarns:  []error{errors.New("provider lab: refresh models failed")},
+		preflightWarns:  []string{`agent fallback "ollama/m1" is not tool-capable (chat|stream|tool_call)`},
+		retrieveOmitted: true,
+	})
+	joined := strings.Join(got, "\n")
+	for _, want := range []string{
+		"workspace: /abs/root",
+		"no defaults.agent configured; using model recommendation",
+		"warning: provider lab: refresh models failed",
+		"ollama/m1",
+		"retrieve unavailable: no RAG index configured; using file/search tools",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("notices missing %q in:\n%s", want, joined)
+		}
+	}
+}
+
+func TestParseFlags_Defaults(t *testing.T) {
+	f, err := parseFlags([]string{})
+	if err != nil {
+		t.Fatalf("parseFlags: %v", err)
+	}
+	if f.root != "." {
+		t.Errorf("root = %q, want \".\"", f.root)
+	}
+}
+
+func TestParseFlags_Overrides(t *testing.T) {
+	f, err := parseFlags([]string{"-root", "/x", "-config", "/c/models.json", "-no-color", "-max-steps", "8"})
+	if err != nil {
+		t.Fatalf("parseFlags: %v", err)
+	}
+	if f.root != "/x" || f.configPath != "/c/models.json" || !f.noColor || f.maxSteps != 8 {
+		t.Errorf("flags = %+v, unexpected", f)
+	}
+}

--- a/cmd/golem/main_test.go
+++ b/cmd/golem/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -61,5 +62,13 @@ func TestParseFlags_Overrides(t *testing.T) {
 	}
 	if f.root != "/x" || f.configPath != "/c/models.json" || !f.noColor || f.maxSteps != 8 {
 		t.Errorf("flags = %+v, unexpected", f)
+	}
+}
+
+func TestInterruptSignalsExcludeSIGTERM(t *testing.T) {
+	for _, sig := range interruptSignals() {
+		if sig == syscall.SIGTERM {
+			t.Fatal("SIGTERM must keep Go's default process-termination behavior")
+		}
 	}
 }

--- a/cmd/golem/modelcaller.go
+++ b/cmd/golem/modelcaller.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/kstruzzieri/go-llm/agent"
 	"github.com/kstruzzieri/go-llm/provider"
@@ -74,4 +76,71 @@ func (m *chainModelCaller) Chat(ctx context.Context, req provider.ChatRequest, o
 	final := getFinal()
 	final.RouteOutcome = outcome
 	return agent.ModelResult{Response: final, RouteOutcome: outcome}, execErr
+}
+
+// capChecker is the narrow subset of *provider.ModelRegistry the preflight needs.
+type capChecker interface {
+	Lookup(ctx context.Context, key provider.ModelKey) (*provider.ModelProfile, error)
+	LookupAny(ctx context.Context, model string) ([]*provider.ModelProfile, error)
+	Recommend(ctx context.Context, opts provider.RecommendOpts) ([]*provider.ModelProfile, error)
+}
+
+const toolRouteCaps = provider.CapChat | provider.CapStream | provider.CapToolCall
+
+func profileToolCapable(p *provider.ModelProfile) bool {
+	// Capability.Has tests c&flag == flag across all bits, so reusing the
+	// toolRouteCaps mask keeps the required-capability set defined in one place.
+	return p != nil && p.Caps.Has(toolRouteCaps)
+}
+
+func parseSelector(sel string) (provider.ModelKey, bool) {
+	pname, model, ok := strings.Cut(sel, "/")
+	if !ok {
+		return provider.ModelKey{}, false
+	}
+	return provider.ModelKey{Provider: pname, Model: model}, true
+}
+
+// preflightToolCapable verifies the agent chain can route a tool-capable model.
+// It returns warnings for each configured entry that cannot (the Router may
+// still reach them on fallback), and an error only when NO entry — or, for an
+// empty chain, the recommend set — can satisfy chat|stream|tool_call. Pure
+// registry lookup; never makes a live model call.
+func preflightToolCapable(ctx context.Context, reg capChecker, chain []string) (warnings []string, err error) {
+	if len(chain) == 0 {
+		profs, rerr := reg.Recommend(ctx, provider.RecommendOpts{RequiredCaps: toolRouteCaps})
+		if rerr != nil {
+			return nil, fmt.Errorf("golem: tool-capability preflight (recommend): %w", rerr)
+		}
+		if len(profs) == 0 {
+			return nil, fmt.Errorf("golem: no tool-capable model available (require chat|stream|tool_call)")
+		}
+		return nil, nil
+	}
+
+	capable := 0
+	for _, sel := range chain {
+		ok := false
+		if key, parsed := parseSelector(sel); parsed {
+			if p, lerr := reg.Lookup(ctx, key); lerr == nil && profileToolCapable(p) {
+				ok = true
+			}
+		} else if profs, lerr := reg.LookupAny(ctx, sel); lerr == nil {
+			for _, p := range profs {
+				if profileToolCapable(p) {
+					ok = true
+					break
+				}
+			}
+		}
+		if ok {
+			capable++
+		} else {
+			warnings = append(warnings, fmt.Sprintf("agent fallback %q is not tool-capable (chat|stream|tool_call)", sel))
+		}
+	}
+	if capable == 0 {
+		return warnings, fmt.Errorf("golem: no entry in the agent chain is tool-capable (chat|stream|tool_call): %v", chain)
+	}
+	return warnings, nil
 }

--- a/cmd/golem/modelcaller.go
+++ b/cmd/golem/modelcaller.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+
+	"github.com/kstruzzieri/go-llm/agent"
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// chatStreamer is the minimal slice of *provider.RoutePlan the caller needs;
+// mirrors agent.planExecutor (which is unexported, so we redeclare it here).
+type chatStreamer interface {
+	ExecuteChatStream(ctx context.Context, fn func(provider.ChatResponse) error) error
+}
+
+// chainModelCaller is an agent.ModelCaller that routes strictly down a
+// configured fallback chain. When chain is non-empty it pins
+// RoutingRequest.PreferredChain + StrictChain so the Router never appends a
+// global-recommend tail — a coding agent must know which model answered. When
+// chain is empty it falls back to the empty-Model recommend behavior of
+// agent.NewRouterModelCaller.
+type chainModelCaller struct {
+	chain []string
+	route func(ctx context.Context, rr provider.RoutingRequest) (chatStreamer, error)
+}
+
+// newRouterChainCaller builds a chainModelCaller backed by a live Router.
+func newRouterChainCaller(r *provider.Router, chain []string) agent.ModelCaller {
+	return &chainModelCaller{
+		chain: chain,
+		route: func(ctx context.Context, rr provider.RoutingRequest) (chatStreamer, error) {
+			plan, err := r.Route(ctx, rr)
+			if err != nil {
+				return nil, err // avoid wrapping a nil *RoutePlan in a non-nil interface
+			}
+			return plan, nil
+		},
+	}
+}
+
+func (m *chainModelCaller) Chat(ctx context.Context, req provider.ChatRequest, onToken func(provider.ChatResponse) error) (agent.ModelResult, error) {
+	rr := provider.RoutingRequest{
+		UseCase:        "agent",
+		Messages:       req.Messages,
+		Tools:          req.Tools,
+		Options:        req.Options,
+		ExpectedOutput: req.Options.NumPredict,
+		RequiredCaps:   provider.CapChat | provider.CapStream,
+	}
+	if len(req.Tools) > 0 {
+		rr.RequiredCaps |= provider.CapToolCall
+	}
+	if len(m.chain) > 0 {
+		rr.PreferredChain = m.chain
+		rr.StrictChain = true
+	}
+
+	plan, err := m.route(ctx, rr)
+	if err != nil {
+		return agent.ModelResult{}, err
+	}
+
+	var outcome *provider.RouteOutcome
+	wrapped, getFinal := provider.Collect(func(chunk provider.ChatResponse) error {
+		if chunk.RouteOutcome != nil {
+			outcome = chunk.RouteOutcome
+		}
+		if onToken != nil {
+			return onToken(chunk)
+		}
+		return nil
+	})
+	execErr := plan.ExecuteChatStream(ctx, wrapped)
+	final := getFinal()
+	final.RouteOutcome = outcome
+	return agent.ModelResult{Response: final, RouteOutcome: outcome}, execErr
+}

--- a/cmd/golem/modelcaller_test.go
+++ b/cmd/golem/modelcaller_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/agent"
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// fakePlan is a chatStreamer that emits one chunk carrying a RouteOutcome.
+type fakePlan struct {
+	outcome *provider.RouteOutcome
+}
+
+func (p fakePlan) ExecuteChatStream(ctx context.Context, fn func(provider.ChatResponse) error) error {
+	return fn(provider.ChatResponse{Content: "hi", RouteOutcome: p.outcome})
+}
+
+func TestChainModelCaller_SetsChainAndCaps(t *testing.T) {
+	var captured provider.RoutingRequest
+	outcome := &provider.RouteOutcome{ActualModel: provider.ModelKey{Provider: "ollama", Model: "m1"}}
+	mc := &chainModelCaller{
+		chain: []string{"ollama/m1", "ollama/m2"},
+		route: func(ctx context.Context, rr provider.RoutingRequest) (chatStreamer, error) {
+			captured = rr
+			return fakePlan{outcome: outcome}, nil
+		},
+	}
+
+	res, err := mc.Chat(context.Background(),
+		provider.ChatRequest{
+			Messages: []provider.ChatMessage{{Role: "user", Content: "hello"}},
+			Tools:    []provider.Tool{{}},
+		}, nil)
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	if captured.UseCase != "agent" {
+		t.Errorf("UseCase = %q, want agent", captured.UseCase)
+	}
+	wantCaps := provider.CapChat | provider.CapStream | provider.CapToolCall
+	if captured.RequiredCaps != wantCaps {
+		t.Errorf("RequiredCaps = %v, want %v", captured.RequiredCaps, wantCaps)
+	}
+	if !captured.StrictChain {
+		t.Error("StrictChain = false, want true")
+	}
+	if len(captured.PreferredChain) != 2 || captured.PreferredChain[0] != "ollama/m1" {
+		t.Errorf("PreferredChain = %v, want [ollama/m1 ollama/m2]", captured.PreferredChain)
+	}
+	if res.RouteOutcome == nil || res.RouteOutcome.ActualModel.Model != "m1" {
+		t.Errorf("RouteOutcome not captured: %+v", res.RouteOutcome)
+	}
+}
+
+func TestChainModelCaller_NoTools_DropsToolCallCap(t *testing.T) {
+	var captured provider.RoutingRequest
+	mc := &chainModelCaller{
+		chain: []string{"ollama/m1"},
+		route: func(ctx context.Context, rr provider.RoutingRequest) (chatStreamer, error) {
+			captured = rr
+			return fakePlan{}, nil
+		},
+	}
+	if _, err := mc.Chat(context.Background(), provider.ChatRequest{}, nil); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if captured.RequiredCaps != provider.CapChat|provider.CapStream {
+		t.Errorf("RequiredCaps = %v, want chat|stream", captured.RequiredCaps)
+	}
+	if captured.RequiredCaps&provider.CapToolCall != 0 {
+		t.Error("CapToolCall set without tools")
+	}
+}
+
+func TestChainModelCaller_EmptyChain_UsesRecommend(t *testing.T) {
+	var captured provider.RoutingRequest
+	mc := &chainModelCaller{
+		chain: nil,
+		route: func(ctx context.Context, rr provider.RoutingRequest) (chatStreamer, error) {
+			captured = rr
+			return fakePlan{}, nil
+		},
+	}
+	if _, err := mc.Chat(context.Background(), provider.ChatRequest{Tools: []provider.Tool{{}}}, nil); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if captured.StrictChain {
+		t.Error("StrictChain = true with empty chain, want false (recommend)")
+	}
+	if len(captured.PreferredChain) != 0 {
+		t.Errorf("PreferredChain = %v, want empty", captured.PreferredChain)
+	}
+}
+
+// Compile-time assertion: chainModelCaller satisfies agent.ModelCaller.
+var _ agent.ModelCaller = (*chainModelCaller)(nil)

--- a/cmd/golem/preflight_test.go
+++ b/cmd/golem/preflight_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+type fakeReg struct {
+	byKey     map[provider.ModelKey]provider.Capability
+	recommend []provider.Capability
+}
+
+func (f fakeReg) Lookup(ctx context.Context, key provider.ModelKey) (*provider.ModelProfile, error) {
+	c, ok := f.byKey[key]
+	if !ok {
+		return nil, context.Canceled // any non-nil error; preflight treats lookup error as "not capable"
+	}
+	return &provider.ModelProfile{Caps: c}, nil
+}
+
+func (f fakeReg) LookupAny(ctx context.Context, model string) ([]*provider.ModelProfile, error) {
+	var out []*provider.ModelProfile
+	for k, c := range f.byKey {
+		if k.Model == model {
+			out = append(out, &provider.ModelProfile{Caps: c})
+		}
+	}
+	return out, nil
+}
+
+func (f fakeReg) Recommend(ctx context.Context, opts provider.RecommendOpts) ([]*provider.ModelProfile, error) {
+	var out []*provider.ModelProfile
+	for _, c := range f.recommend {
+		out = append(out, &provider.ModelProfile{Caps: c})
+	}
+	return out, nil
+}
+
+const fullCaps = provider.CapChat | provider.CapStream | provider.CapToolCall
+
+func TestPreflight_HeadCapable(t *testing.T) {
+	reg := fakeReg{byKey: map[provider.ModelKey]provider.Capability{
+		{Provider: "ollama", Model: "m1"}: fullCaps,
+	}}
+	warns, err := preflightToolCapable(context.Background(), reg, []string{"ollama/m1"})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if len(warns) != 0 {
+		t.Errorf("warnings = %v, want none", warns)
+	}
+}
+
+func TestPreflight_PrimaryIncapableFallbackCapable(t *testing.T) {
+	reg := fakeReg{byKey: map[provider.ModelKey]provider.Capability{
+		{Provider: "ollama", Model: "m1"}: provider.CapChat | provider.CapStream, // no tool_call
+		{Provider: "ollama", Model: "m2"}: fullCaps,
+	}}
+	warns, err := preflightToolCapable(context.Background(), reg, []string{"ollama/m1", "ollama/m2"})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if len(warns) != 1 || !strings.Contains(warns[0], "ollama/m1") {
+		t.Errorf("warnings = %v, want one naming ollama/m1", warns)
+	}
+}
+
+func TestPreflight_NoneCapable(t *testing.T) {
+	reg := fakeReg{byKey: map[provider.ModelKey]provider.Capability{
+		{Provider: "ollama", Model: "m1"}: provider.CapChat | provider.CapStream,
+	}}
+	_, err := preflightToolCapable(context.Background(), reg, []string{"ollama/m1"})
+	if err == nil {
+		t.Fatal("err = nil, want failure (no tool-capable entry)")
+	}
+}
+
+func TestPreflight_EmptyChain_UsesRecommend(t *testing.T) {
+	ok := fakeReg{recommend: []provider.Capability{fullCaps}}
+	if _, err := preflightToolCapable(context.Background(), ok, nil); err != nil {
+		t.Fatalf("recommend-capable err = %v, want nil", err)
+	}
+	empty := fakeReg{recommend: nil}
+	if _, err := preflightToolCapable(context.Background(), empty, nil); err == nil {
+		t.Fatal("empty recommend err = nil, want failure")
+	}
+}
+
+// TestPreflight_BareModelNotFound exercises the unparseable-selector branch: a
+// bare model name (no "/") routes through LookupAny, which returns nothing here,
+// so the entry is not tool-capable and — being the only entry — fails the gate.
+func TestPreflight_BareModelNotFound(t *testing.T) {
+	reg := fakeReg{byKey: map[provider.ModelKey]provider.Capability{
+		{Provider: "ollama", Model: "other"}: fullCaps,
+	}}
+	warns, err := preflightToolCapable(context.Background(), reg, []string{"ghost"})
+	if err == nil {
+		t.Fatal("err = nil for bare model with no capable match, want failure")
+	}
+	if len(warns) != 1 || !strings.Contains(warns[0], "ghost") {
+		t.Errorf("warnings = %v, want one naming ghost", warns)
+	}
+}

--- a/cmd/golem/render.go
+++ b/cmd/golem/render.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/kstruzzieri/go-llm/agent"
@@ -20,6 +21,7 @@ type renderer struct {
 	now      func() time.Time
 	lastMark time.Time
 	runStart time.Time
+	lastNL   bool
 }
 
 func newRenderer(out io.Writer, color bool, maxSteps int, now func() time.Time) *renderer {
@@ -27,11 +29,14 @@ func newRenderer(out io.Writer, color bool, maxSteps int, now func() time.Time) 
 		now = time.Now
 	}
 	start := now()
-	return &renderer{out: out, color: color, maxSteps: maxSteps, now: now, lastMark: start, runStart: start}
+	return &renderer{out: out, color: color, maxSteps: maxSteps, now: now, lastMark: start, runStart: start, lastNL: true}
 }
 
 func (r *renderer) OnToken(_ context.Context, e agent.TokenEvent) error {
 	_, err := io.WriteString(r.out, e.Content)
+	if err == nil && e.Content != "" {
+		r.lastNL = strings.HasSuffix(e.Content, "\n")
+	}
 	return err
 }
 
@@ -40,9 +45,15 @@ func (r *renderer) OnToolCall(_ context.Context, e agent.ToolCallEvent) error {
 	// so the line reads "> name" rather than "> name ".
 	if args := string(e.Call.Function.Arguments); args != "" {
 		_, err := fmt.Fprintf(r.out, "\n> %s %s\n", e.Call.Function.Name, args)
+		if err == nil {
+			r.lastNL = true
+		}
 		return err
 	}
 	_, err := fmt.Fprintf(r.out, "\n> %s\n", e.Call.Function.Name)
+	if err == nil {
+		r.lastNL = true
+	}
 	return err
 }
 
@@ -72,9 +83,17 @@ func (r *renderer) finalFooter(res agent.Result) {
 }
 
 func (r *renderer) writeDim(line string) error {
+	if !r.lastNL {
+		if _, err := io.WriteString(r.out, "\n"); err != nil {
+			return err
+		}
+	}
 	if r.color {
 		line = "\x1b[2m" + line + "\x1b[0m"
 	}
 	_, err := io.WriteString(r.out, line+"\n")
+	if err == nil {
+		r.lastNL = true
+	}
 	return err
 }

--- a/cmd/golem/render.go
+++ b/cmd/golem/render.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/agent"
+)
+
+// renderer is an append-only agent.Observer for a terminal. It streams tokens,
+// prints a one-line tool-call notice, a dim per-step footer, and (via
+// finalFooter) a dim summary after Run. It deliberately omits a tool-RESULT
+// line: that requires the agent.ToolResultObserver seam, added in B3.
+type renderer struct {
+	out      io.Writer
+	color    bool
+	maxSteps int
+	now      func() time.Time
+	lastMark time.Time
+	runStart time.Time
+}
+
+func newRenderer(out io.Writer, color bool, maxSteps int, now func() time.Time) *renderer {
+	if now == nil {
+		now = time.Now
+	}
+	start := now()
+	return &renderer{out: out, color: color, maxSteps: maxSteps, now: now, lastMark: start, runStart: start}
+}
+
+func (r *renderer) OnToken(_ context.Context, e agent.TokenEvent) error {
+	_, err := io.WriteString(r.out, e.Content)
+	return err
+}
+
+func (r *renderer) OnToolCall(_ context.Context, e agent.ToolCallEvent) error {
+	// Some tools take no arguments; omit the trailing space when args are empty
+	// so the line reads "> name" rather than "> name ".
+	if args := string(e.Call.Function.Arguments); args != "" {
+		_, err := fmt.Fprintf(r.out, "\n> %s %s\n", e.Call.Function.Name, args)
+		return err
+	}
+	_, err := fmt.Fprintf(r.out, "\n> %s\n", e.Call.Function.Name)
+	return err
+}
+
+func (r *renderer) OnStep(_ context.Context, e agent.StepEvent) error {
+	t := r.now()
+	lat := t.Sub(r.lastMark).Seconds()
+	r.lastMark = t
+	model := "?"
+	if e.RouteOutcome != nil {
+		model = e.RouteOutcome.ActualModel.String()
+	}
+	line := fmt.Sprintf("%s · %.1fs · ctx %.0f%% · step %d/%d",
+		model, lat, e.Pressure.UsedPct*100, e.Index+1, r.maxSteps)
+	return r.writeDim(line)
+}
+
+func (r *renderer) finalFooter(res agent.Result) {
+	total := r.now().Sub(r.runStart).Seconds()
+	line := fmt.Sprintf("done · %d steps · %.1fs · %d tok",
+		len(res.Steps), total, res.Usage.TotalTokens)
+	if res.StopReason != agent.Completed {
+		// Double space (not " · ") deliberately sets the stop reason apart from
+		// the metric fields above it — it is a status suffix, not another metric.
+		line += "  stopped: " + res.StopReason.String()
+	}
+	_ = r.writeDim(line)
+}
+
+func (r *renderer) writeDim(line string) error {
+	if r.color {
+		line = "\x1b[2m" + line + "\x1b[0m"
+	}
+	_, err := io.WriteString(r.out, line+"\n")
+	return err
+}

--- a/cmd/golem/render_test.go
+++ b/cmd/golem/render_test.go
@@ -57,6 +57,24 @@ func TestRenderer_FinalFooter_Stopped(t *testing.T) {
 	}
 }
 
+func TestRenderer_OnStepStartsNewLineAfterUnterminatedToken(t *testing.T) {
+	var buf bytes.Buffer
+	clock := time.Unix(0, 0)
+	r := newRenderer(&buf, false, 16, func() time.Time { return clock })
+
+	if err := r.OnToken(context.Background(), agent.TokenEvent{Content: "answer"}); err != nil {
+		t.Fatalf("OnToken: %v", err)
+	}
+	if err := r.OnStep(context.Background(), agent.StepEvent{Index: 0, Pressure: agent.Pressure{}}); err != nil {
+		t.Fatalf("OnStep: %v", err)
+	}
+
+	want := "answer\n? · 0.0s · ctx 0% · step 1/16\n"
+	if buf.String() != want {
+		t.Errorf("step footer after unterminated token = %q, want %q", buf.String(), want)
+	}
+}
+
 func TestRenderer_FinalFooter_Completed_NoStoppedSuffix(t *testing.T) {
 	var buf bytes.Buffer
 	clock := time.Unix(0, 0)

--- a/cmd/golem/render_test.go
+++ b/cmd/golem/render_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/agent"
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+func TestRenderer_StreamToolStepFinal(t *testing.T) {
+	var buf bytes.Buffer
+	clock := time.Unix(0, 0)
+	r := newRenderer(&buf, false, 16, func() time.Time { return clock })
+
+	ctx := context.Background()
+	_ = r.OnToken(ctx, agent.TokenEvent{Step: 0, Content: "hello "})
+	_ = r.OnToken(ctx, agent.TokenEvent{Step: 0, Content: "world"})
+	_ = r.OnToolCall(ctx, agent.ToolCallEvent{
+		Step: 0,
+		Call: provider.ToolCall{Function: provider.ToolCallFunction{
+			Name: "read_file", Arguments: json.RawMessage(`{"path":"a.txt"}`),
+		}},
+	})
+	clock = clock.Add(1500 * time.Millisecond)
+	_ = r.OnStep(ctx, agent.StepEvent{
+		Index:        0,
+		RouteOutcome: &provider.RouteOutcome{ActualModel: provider.ModelKey{Provider: "ollama", Model: "gemma4:31b"}},
+		Pressure:     agent.Pressure{UsedPct: 0.45},
+	})
+
+	got := buf.String()
+	want := "hello world" +
+		"\n> read_file {\"path\":\"a.txt\"}\n" +
+		"ollama/gemma4:31b · 1.5s · ctx 45% · step 1/16\n"
+	if got != want {
+		t.Errorf("output mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestRenderer_FinalFooter_Stopped(t *testing.T) {
+	var buf bytes.Buffer
+	clock := time.Unix(0, 0)
+	r := newRenderer(&buf, false, 16, func() time.Time { return clock })
+	clock = clock.Add(3 * time.Second)
+	r.finalFooter(agent.Result{
+		Steps:      make([]agent.StepRecord, 2),
+		Usage:      provider.Usage{TotalTokens: 128},
+		StopReason: agent.StepCapReached,
+	})
+	want := "done · 2 steps · 3.0s · 128 tok  stopped: step_cap_reached\n"
+	if buf.String() != want {
+		t.Errorf("final footer = %q, want %q", buf.String(), want)
+	}
+}
+
+func TestRenderer_FinalFooter_Completed_NoStoppedSuffix(t *testing.T) {
+	var buf bytes.Buffer
+	clock := time.Unix(0, 0)
+	r := newRenderer(&buf, false, 16, func() time.Time { return clock })
+	clock = clock.Add(2 * time.Second)
+	r.finalFooter(agent.Result{
+		Steps:      make([]agent.StepRecord, 1),
+		Usage:      provider.Usage{TotalTokens: 42},
+		StopReason: agent.Completed,
+	})
+	want := "done · 1 steps · 2.0s · 42 tok\n"
+	if buf.String() != want {
+		t.Errorf("completed footer = %q, want %q (no stopped suffix)", buf.String(), want)
+	}
+}
+
+func TestRenderer_OnStep_NilRouteOutcome_RendersQuestionMark(t *testing.T) {
+	var buf bytes.Buffer
+	clock := time.Unix(0, 0)
+	r := newRenderer(&buf, false, 16, func() time.Time { return clock })
+	if err := r.OnStep(context.Background(), agent.StepEvent{Index: 0, Pressure: agent.Pressure{}}); err != nil {
+		t.Fatalf("OnStep: %v", err)
+	}
+	want := "? · 0.0s · ctx 0% · step 1/16\n"
+	if buf.String() != want {
+		t.Errorf("nil-RouteOutcome footer = %q, want %q", buf.String(), want)
+	}
+}
+
+func TestRenderer_OnToolCall_NoArgs_OmitsTrailingSpace(t *testing.T) {
+	var buf bytes.Buffer
+	r := newRenderer(&buf, false, 16, func() time.Time { return time.Unix(0, 0) })
+	if err := r.OnToolCall(context.Background(), agent.ToolCallEvent{
+		Call: provider.ToolCall{Function: provider.ToolCallFunction{Name: "list"}},
+	}); err != nil {
+		t.Fatalf("OnToolCall: %v", err)
+	}
+	if buf.String() != "\n> list\n" {
+		t.Errorf("no-args tool line = %q, want %q", buf.String(), "\n> list\n")
+	}
+}
+
+func TestRenderer_Color_WrapsFooter(t *testing.T) {
+	var buf bytes.Buffer
+	clock := time.Unix(0, 0)
+	r := newRenderer(&buf, true, 16, func() time.Time { return clock })
+	_ = r.OnStep(context.Background(), agent.StepEvent{Index: 0, Pressure: agent.Pressure{}})
+	got := buf.String()
+	if got[:4] != "\x1b[2m" || got[len(got)-5:] != "\x1b[0m\n" {
+		t.Errorf("color footer not dim-wrapped: %q", got)
+	}
+}

--- a/cmd/golem/repl.go
+++ b/cmd/golem/repl.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/agent"
+)
+
+// golemSystemPrompt is the read-only capability framing sent on every turn.
+const golemSystemPrompt = "You are Golem, a read-only terminal coding assistant for this workspace. " +
+	"Use the available read-only tools to inspect files before answering repo-specific questions; " +
+	"do not claim to modify files, run shell commands, install packages, or change project state. " +
+	"Keep answers concise, cite file paths and line numbers when they matter, and say when the available evidence is insufficient."
+
+// replSession holds the per-process state the REPL needs.
+type replSession struct {
+	orch            *agent.Orchestrator
+	tools           []agent.Tool
+	baseSystem      string
+	maxSteps        int
+	budget          agent.Budget
+	color           bool
+	clock           func() time.Time
+	retrieveOmitted bool // when true, /tools appends the omission note
+
+	lastModel string // last routed ActualModel for /model
+}
+
+// runREPL reads lines from in, dispatching slash commands and running every
+// other line as an agent goal. A value on interrupts cancels the in-flight Run
+// without ending the loop. EOF (Ctrl-D) returns nil.
+func runREPL(ctx context.Context, in io.Reader, out io.Writer, interrupts <-chan struct{}, sess *replSession) error {
+	sc := bufio.NewScanner(in)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for {
+		_, _ = fmt.Fprint(out, "golem> ")
+		if !sc.Scan() {
+			_, _ = fmt.Fprintln(out)
+			return sc.Err()
+		}
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "/") {
+			if exit := dispatchSlash(out, sess, line); exit {
+				return nil
+			}
+			continue
+		}
+		runOnce(ctx, out, interrupts, sess, line)
+	}
+}
+
+func runOnce(ctx context.Context, out io.Writer, interrupts <-chan struct{}, sess *replSession, line string) {
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Drain a stale interrupt that arrived while the REPL was idle at the
+	// prompt, so a Ctrl-C the user typed before this prompt does not cancel it.
+	if interrupts != nil {
+		select {
+		case <-interrupts:
+		default:
+		}
+	}
+
+	// Watch for an interrupt for the duration of this run.
+	done := make(chan struct{})
+	defer close(done)
+	if interrupts != nil {
+		go func() {
+			select {
+			case <-interrupts:
+				cancel()
+			case <-done:
+			}
+		}()
+	}
+
+	rend := newRenderer(out, sess.color, sess.maxSteps, sess.clock)
+	req := agent.Request{
+		Goal:     line,
+		System:   sess.baseSystem,
+		Tools:    sess.tools,
+		MaxSteps: sess.maxSteps,
+		Budget:   sess.budget,
+		Approver: nil, // read-only => runtime auto-approves Read, denies Write/Exec
+	}
+	res, err := sess.orch.Run(runCtx, req, rend)
+	if err != nil {
+		if runCtx.Err() != nil {
+			_, _ = fmt.Fprintln(out, "\ncanceled")
+			return
+		}
+		_, _ = fmt.Fprintf(out, "\nerror: %v\n", err)
+		return
+	}
+	if m := lastRoutedModel(res); m != "" {
+		sess.lastModel = m
+	}
+	rend.finalFooter(res)
+}
+
+// lastRoutedModel returns the ActualModel of the last step that carried a
+// RouteOutcome, or "" if none did.
+func lastRoutedModel(res agent.Result) string {
+	for i := len(res.Steps) - 1; i >= 0; i-- {
+		if oc := res.Steps[i].RouteOutcome; oc != nil {
+			return oc.ActualModel.String()
+		}
+	}
+	return ""
+}
+
+// dispatchSlash handles a slash command; returns true to exit the REPL.
+func dispatchSlash(out io.Writer, sess *replSession, line string) bool {
+	cmd := strings.Fields(line)[0]
+	switch cmd {
+	case "/exit", "/quit":
+		return true
+	case "/help":
+		_, _ = fmt.Fprint(out, golemHelp)
+	case "/clear":
+		_, _ = fmt.Fprintln(out, "no session history in this build")
+	case "/model":
+		if sess.lastModel == "" {
+			_, _ = fmt.Fprintln(out, "not yet routed")
+		} else {
+			_, _ = fmt.Fprintln(out, sess.lastModel)
+		}
+	case "/tools":
+		for _, t := range sess.tools {
+			_, _ = fmt.Fprintf(out, "%s (%s)\n", t.Spec().Name, effectClassName(t.Effect().Class))
+		}
+		if sess.retrieveOmitted {
+			_, _ = fmt.Fprintln(out, "retrieve omitted: no RAG index configured")
+		}
+	default:
+		_, _ = fmt.Fprintf(out, "unknown command: %s (try /help)\n", cmd)
+	}
+	return false
+}
+
+const golemHelp = `commands:
+  /help          show this help
+  /tools         list registered tools and their effect class
+  /model         show the last routed model
+  /clear         (no session history in this build)
+  /exit, /quit   leave golem
+any other line is sent to the agent as a goal.
+`

--- a/cmd/golem/repl_test.go
+++ b/cmd/golem/repl_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/agent"
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// scriptCaller returns queued responses in order; each Chat call pops one.
+type scriptCaller struct {
+	responses []agent.ModelResult
+	i         int
+	block     chan struct{} // when non-nil, Chat waits on ctx or this before responding
+}
+
+func (s *scriptCaller) Chat(ctx context.Context, req provider.ChatRequest, onToken func(provider.ChatResponse) error) (agent.ModelResult, error) {
+	if s.block != nil {
+		select {
+		case <-ctx.Done():
+			return agent.ModelResult{}, ctx.Err()
+		case <-s.block:
+		}
+	}
+	if s.i >= len(s.responses) {
+		return agent.ModelResult{Response: provider.ChatResponse{Content: "done"}}, nil
+	}
+	r := s.responses[s.i]
+	s.i++
+	if onToken != nil {
+		_ = onToken(r.Response)
+	}
+	return r, nil
+}
+
+func newTestSession(t *testing.T, caller agent.ModelCaller, root string) *replSession {
+	t.Helper()
+	tools, err := buildTools(root, nil)
+	if err != nil {
+		t.Fatalf("buildTools: %v", err)
+	}
+	return &replSession{
+		orch:       agent.New(caller, agent.ContextManager{}),
+		tools:      tools,
+		baseSystem: golemSystemPrompt,
+		maxSteps:   16,
+		clock:      func() time.Time { return time.Unix(0, 0) },
+	}
+}
+
+func TestREPL_EndToEndReadOnly(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "hello.txt"), []byte("hi there"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Turn 1: model asks to read hello.txt. Turn 2: model gives the final answer.
+	toolCall := provider.ChatResponse{
+		ToolCalls: []provider.ToolCall{{
+			ID: "c1", Type: "function",
+			Function: provider.ToolCallFunction{Name: "read_file", Arguments: json.RawMessage(`{"path":"hello.txt"}`)},
+		}},
+	}
+	finalAns := provider.ChatResponse{Content: "the file says hi there"}
+	caller := &scriptCaller{responses: []agent.ModelResult{{Response: toolCall}, {Response: finalAns}}}
+
+	var out strings.Builder
+	in := strings.NewReader("read hello.txt\n")
+	sess := newTestSession(t, caller, root)
+
+	if err := runREPL(context.Background(), in, &out, nil, sess); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, `> read_file {"path":"hello.txt"}`) {
+		t.Errorf("missing tool-call line in:\n%s", got)
+	}
+	if !strings.Contains(got, "the file says hi there") {
+		t.Errorf("missing final answer in:\n%s", got)
+	}
+	if !strings.Contains(got, "done · 2 steps") {
+		t.Errorf("missing/incorrect final footer in:\n%s", got)
+	}
+}
+
+func TestREPL_SlashCommands(t *testing.T) {
+	root := t.TempDir()
+	caller := &scriptCaller{}
+	var out strings.Builder
+	in := strings.NewReader("/help\n/tools\n/model\n/clear\n/bogus\n/exit\n")
+	sess := newTestSession(t, caller, root)
+
+	if err := runREPL(context.Background(), in, &out, nil, sess); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{"read_file", "(read)", "not yet routed", "no session history in this build", "unknown command"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("slash output missing %q in:\n%s", want, got)
+		}
+	}
+	if caller.i != 0 {
+		t.Errorf("model called %d times for slash-only input, want 0", caller.i)
+	}
+}
+
+func TestREPL_CtrlCCancelsRunKeepsREPL(t *testing.T) {
+	root := t.TempDir()
+	caller := &scriptCaller{block: make(chan struct{})} // never unblocked => Chat waits on ctx
+	var out strings.Builder
+	in := strings.NewReader("long running\n")
+	interrupts := make(chan struct{}, 1)
+	sess := newTestSession(t, caller, root)
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		interrupts <- struct{}{}
+	}()
+
+	if err := runREPL(context.Background(), in, &out, interrupts, sess); err != nil {
+		t.Fatalf("runREPL should not error on cancel: %v", err)
+	}
+	if !strings.Contains(out.String(), "canceled") {
+		t.Errorf("expected a cancel notice, got:\n%s", out.String())
+	}
+}

--- a/cmd/golem/retrieve_test.go
+++ b/cmd/golem/retrieve_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kstruzzieri/go-llm/config"
 	"github.com/kstruzzieri/go-llm/provider"
+	"github.com/kstruzzieri/go-llm/rag"
 )
 
 func embedCfg() *config.Config {
@@ -55,12 +56,65 @@ func TestResolveRetriever_ErrorsWhenDBMissing(t *testing.T) {
 func TestEmbeddingSelector(t *testing.T) {
 	cfg := &config.Config{
 		Defaults: map[string]string{"embedding": "emb"},
-		Models:   map[string]config.ModelConfig{"emb": {Name: "nomic", Provider: "ollama"}},
+		Models: map[string]config.ModelConfig{
+			"emb":    {Name: "nomic", Provider: "ollama", Fallbacks: []string{"backup"}},
+			"backup": {Name: "nomic-fallback", Provider: "ollama"},
+		},
 	}
-	if got := embeddingSelector(cfg); got != "ollama/nomic" {
-		t.Errorf("embeddingSelector = %q, want ollama/nomic", got)
+	got, err := embeddingChain(cfg)
+	if err != nil {
+		t.Fatalf("embeddingChain: %v", err)
 	}
-	if got := embeddingSelector(&config.Config{Defaults: map[string]string{}}); got != "" {
-		t.Errorf("embeddingSelector with no default = %q, want empty", got)
+	want := []string{"ollama/nomic", "ollama/nomic-fallback"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("embeddingChain = %v, want %v", got, want)
+	}
+	if got, err := embeddingChain(&config.Config{Defaults: map[string]string{}}); err == nil || got != nil {
+		t.Errorf("embeddingChain with no default = %v, %v; want nil, error", got, err)
 	}
 }
+
+type fakeEmbedPlan struct {
+	resp *provider.EmbedResponse
+}
+
+func (p fakeEmbedPlan) ExecuteEmbed(context.Context) (*provider.EmbedResponse, error) {
+	return p.resp, nil
+}
+
+func TestChainEmbedderRoutesWithPreferredChain(t *testing.T) {
+	var captured provider.RoutingRequest
+	embedder := newChainEmbedder(func(ctx context.Context, rr provider.RoutingRequest) (embedExecutor, error) {
+		captured = rr
+		return fakeEmbedPlan{resp: &provider.EmbedResponse{
+			Model:      "nomic-fallback",
+			Provider:   "ollama",
+			Embeddings: [][]float64{{1, 2, 3}},
+			RouteOutcome: &provider.RouteOutcome{
+				ActualModel: provider.ModelKey{Provider: "ollama", Model: "nomic-fallback"},
+			},
+		}}, nil
+	}, []string{"ollama/nomic", "ollama/nomic-fallback"})
+
+	res, err := embedder.Embed(context.Background(), "ollama/nomic", []string{"query"})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if captured.Model != "" {
+		t.Errorf("RoutingRequest.Model = %q, want empty so chain controls selection", captured.Model)
+	}
+	if !captured.StrictChain {
+		t.Error("StrictChain = false, want true")
+	}
+	if len(captured.PreferredChain) != 2 || captured.PreferredChain[1] != "ollama/nomic-fallback" {
+		t.Errorf("PreferredChain = %v, want embedding fallback chain", captured.PreferredChain)
+	}
+	if captured.RequiredCaps != provider.CapEmbed {
+		t.Errorf("RequiredCaps = %v, want CapEmbed", captured.RequiredCaps)
+	}
+	if res.VectorSpaceID != "ollama/nomic-fallback" {
+		t.Errorf("VectorSpaceID = %q, want actual routed model", res.VectorSpaceID)
+	}
+}
+
+var _ rag.Embedder = newChainEmbedder(nil, nil)

--- a/cmd/golem/retrieve_test.go
+++ b/cmd/golem/retrieve_test.go
@@ -16,30 +16,39 @@ func embedCfg() *config.Config {
 	}
 }
 
-func TestResolveRetriever_OmittedWhenNilRouter(t *testing.T) {
-	tool, ok := resolveRetriever(context.Background(), embedCfg(), nil, filepath.Join(t.TempDir(), "x.db"))
-	if ok || tool != nil {
-		t.Errorf("expected omission for nil router, got ok=%v tool=%v", ok, tool)
+func TestResolveRetriever_NilWhenNotRequested(t *testing.T) {
+	// dbPath == "" => retrieve was not requested: omit quietly, NO error.
+	tool, err := resolveRetriever(context.Background(), embedCfg(), &provider.Router{}, "")
+	if tool != nil || err != nil {
+		t.Errorf("not-requested should be (nil, nil), got tool=%v err=%v", tool, err)
 	}
 }
 
-func TestResolveRetriever_OmittedWhenNoEmbeddingDefault(t *testing.T) {
-	// Non-nil router + non-empty dbPath so execution reaches (and stops at) the
-	// embedding-default guard rather than an earlier short-circuit.
+func TestResolveRetriever_ErrorsWhenNoProvider(t *testing.T) {
+	// -rag-db given but no router => requested-but-failed: surface an error.
+	tool, err := resolveRetriever(context.Background(), embedCfg(), nil, filepath.Join(t.TempDir(), "x.db"))
+	if tool != nil || err == nil {
+		t.Errorf("nil router with -rag-db should error, got tool=%v err=%v", tool, err)
+	}
+}
+
+func TestResolveRetriever_ErrorsWhenNoEmbeddingDefault(t *testing.T) {
+	// Non-nil router + non-empty dbPath so execution reaches the embedding-default
+	// guard; with no defaults.embedding it is requested-but-failed.
 	cfg := &config.Config{Defaults: map[string]string{}}
-	tool, ok := resolveRetriever(context.Background(), cfg, &provider.Router{}, "/some/path.db")
-	if ok || tool != nil {
-		t.Errorf("expected omission with no defaults.embedding, got ok=%v tool=%v", ok, tool)
+	tool, err := resolveRetriever(context.Background(), cfg, &provider.Router{}, "/some/path.db")
+	if tool != nil || err == nil {
+		t.Errorf("no defaults.embedding with -rag-db should error, got tool=%v err=%v", tool, err)
 	}
 }
 
-func TestResolveRetriever_OmittedWhenDBMissing(t *testing.T) {
-	// Non-nil router + resolvable embedding default so execution reaches the
-	// os.Stat existence check; the missing path is the condition under test.
-	// The zero-value router is never dereferenced because os.Stat fails first.
-	tool, ok := resolveRetriever(context.Background(), embedCfg(), &provider.Router{}, filepath.Join(t.TempDir(), "missing.db"))
-	if ok || tool != nil {
-		t.Errorf("expected omission for missing DB file, got ok=%v tool=%v", ok, tool)
+func TestResolveRetriever_ErrorsWhenDBMissing(t *testing.T) {
+	// Resolvable embedding default so execution reaches the os.Stat existence
+	// check; the missing path is the condition under test. The zero-value router
+	// is never dereferenced because os.Stat fails first.
+	tool, err := resolveRetriever(context.Background(), embedCfg(), &provider.Router{}, filepath.Join(t.TempDir(), "missing.db"))
+	if tool != nil || err == nil {
+		t.Errorf("missing -rag-db file should error, got tool=%v err=%v", tool, err)
 	}
 }
 

--- a/cmd/golem/retrieve_test.go
+++ b/cmd/golem/retrieve_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/config"
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+func embedCfg() *config.Config {
+	return &config.Config{
+		Defaults: map[string]string{"embedding": "emb"},
+		Models:   map[string]config.ModelConfig{"emb": {Name: "nomic", Provider: "ollama"}},
+	}
+}
+
+func TestResolveRetriever_OmittedWhenNilRouter(t *testing.T) {
+	tool, ok := resolveRetriever(context.Background(), embedCfg(), nil, filepath.Join(t.TempDir(), "x.db"))
+	if ok || tool != nil {
+		t.Errorf("expected omission for nil router, got ok=%v tool=%v", ok, tool)
+	}
+}
+
+func TestResolveRetriever_OmittedWhenNoEmbeddingDefault(t *testing.T) {
+	// Non-nil router + non-empty dbPath so execution reaches (and stops at) the
+	// embedding-default guard rather than an earlier short-circuit.
+	cfg := &config.Config{Defaults: map[string]string{}}
+	tool, ok := resolveRetriever(context.Background(), cfg, &provider.Router{}, "/some/path.db")
+	if ok || tool != nil {
+		t.Errorf("expected omission with no defaults.embedding, got ok=%v tool=%v", ok, tool)
+	}
+}
+
+func TestResolveRetriever_OmittedWhenDBMissing(t *testing.T) {
+	// Non-nil router + resolvable embedding default so execution reaches the
+	// os.Stat existence check; the missing path is the condition under test.
+	// The zero-value router is never dereferenced because os.Stat fails first.
+	tool, ok := resolveRetriever(context.Background(), embedCfg(), &provider.Router{}, filepath.Join(t.TempDir(), "missing.db"))
+	if ok || tool != nil {
+		t.Errorf("expected omission for missing DB file, got ok=%v tool=%v", ok, tool)
+	}
+}
+
+func TestEmbeddingSelector(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: map[string]string{"embedding": "emb"},
+		Models:   map[string]config.ModelConfig{"emb": {Name: "nomic", Provider: "ollama"}},
+	}
+	if got := embeddingSelector(cfg); got != "ollama/nomic" {
+		t.Errorf("embeddingSelector = %q, want ollama/nomic", got)
+	}
+	if got := embeddingSelector(&config.Config{Defaults: map[string]string{}}); got != "" {
+		t.Errorf("embeddingSelector with no default = %q, want empty", got)
+	}
+}

--- a/cmd/golem/tools.go
+++ b/cmd/golem/tools.go
@@ -36,6 +36,7 @@ func buildTools(root string, retrieve agent.Tool) ([]agent.Tool, error) {
 //     returned so the caller can surface it rather than mislead the user with a
 //     generic "no RAG index configured" line.
 //   - (tool, nil): enabled.
+//
 // On success the opened store lives for the process: the retriever queries it
 // for the whole session and the OS reclaims the handle at exit.
 func resolveRetriever(ctx context.Context, cfg *config.Config, router *provider.Router, dbPath string) (agent.Tool, error) {
@@ -45,9 +46,9 @@ func resolveRetriever(ctx context.Context, cfg *config.Config, router *provider.
 	if cfg == nil || router == nil {
 		return nil, fmt.Errorf("no provider configured for embeddings")
 	}
-	embModel := embeddingSelector(cfg)
-	if embModel == "" {
-		return nil, fmt.Errorf("no embedding model configured (set defaults.embedding in models.json)")
+	embChain, err := embeddingChain(cfg)
+	if err != nil {
+		return nil, err
 	}
 	info, err := os.Stat(dbPath)
 	if err != nil {
@@ -60,32 +61,10 @@ func resolveRetriever(ctx context.Context, cfg *config.Config, router *provider.
 	if err != nil {
 		return nil, fmt.Errorf("open rag-db %q: %w", dbPath, err)
 	}
-	embedder := rag.EmbedderFunc(func(ctx context.Context, model string, inputs []string) (rag.EmbedResult, error) {
-		resp, err := router.Embed(ctx, provider.EmbedRequest{Model: model, Input: inputs})
-		if err != nil {
-			return rag.EmbedResult{}, err
-		}
-		// Derive VectorSpaceID the same way the indexer did (actual routed
-		// model, else provider/model) so query vectors validate against the
-		// corpus's stored vector space. Mirrors mcp's ragEmbedder; omitting it
-		// makes every query fail with ErrVectorSpaceMismatch on a corpus that
-		// recorded a vector-space ID.
-		result := rag.EmbedResult{
-			Embeddings: resp.Embeddings,
-			Model:      resp.Model,
-			Provider:   resp.Provider,
-		}
-		if resp.RouteOutcome != nil {
-			if am := resp.RouteOutcome.ActualModel; am.Provider != "" && am.Model != "" {
-				result.VectorSpaceID = am.String()
-			}
-		}
-		if result.VectorSpaceID == "" && result.Provider != "" && result.Model != "" {
-			result.VectorSpaceID = result.Provider + "/" + result.Model
-		}
-		return result, nil
-	})
-	retr, err := rag.NewRetrieverWithEmbedder(embedder, store, rag.WithRetrieverModel(embModel))
+	embedder := newChainEmbedder(func(ctx context.Context, rr provider.RoutingRequest) (embedExecutor, error) {
+		return router.Route(ctx, rr)
+	}, embChain)
+	retr, err := rag.NewRetrieverWithEmbedder(embedder, store, rag.WithRetrieverModel(embChain[0]))
 	if err != nil {
 		_ = store.Close()
 		return nil, fmt.Errorf("build retriever for rag-db %q: %w", dbPath, err)
@@ -93,16 +72,91 @@ func resolveRetriever(ctx context.Context, cfg *config.Config, router *provider.
 	return &agenttools.Retrieve{R: retr, K: 5, MaxTokens: 2048}, nil
 }
 
-// embeddingSelector returns the head of the embedding fallback chain, or "".
-func embeddingSelector(cfg *config.Config) string {
+type embedExecutor interface {
+	ExecuteEmbed(ctx context.Context) (*provider.EmbedResponse, error)
+}
+
+type embedRouteFunc func(context.Context, provider.RoutingRequest) (embedExecutor, error)
+
+func newChainEmbedder(route embedRouteFunc, chain []string) rag.Embedder {
+	chain = append([]string(nil), chain...)
+	return rag.EmbedderFunc(func(ctx context.Context, model string, inputs []string) (rag.EmbedResult, error) {
+		if model == "" {
+			return rag.EmbedResult{}, fmt.Errorf("rag: embedder requires explicit model to prevent vector-space drift across embedding-model boundaries")
+		}
+		if len(inputs) == 0 {
+			return rag.EmbedResult{Model: model}, nil
+		}
+		if route == nil {
+			return rag.EmbedResult{}, fmt.Errorf("golem: embedding router unavailable")
+		}
+		rr := provider.RoutingRequest{
+			UseCase:        "embedding",
+			Input:          inputs,
+			RequiredCaps:   provider.CapEmbed,
+			ExpectedOutput: provider.DefaultExpectedOutput("embedding"),
+		}
+		if len(chain) > 0 {
+			rr.PreferredChain = append([]string(nil), chain...)
+			rr.StrictChain = true
+		} else {
+			rr.Model = model
+		}
+		plan, err := route(ctx, rr)
+		if err != nil {
+			return rag.EmbedResult{}, err
+		}
+		if plan == nil {
+			return rag.EmbedResult{}, fmt.Errorf("golem: embedding route returned nil plan")
+		}
+		resp, err := plan.ExecuteEmbed(ctx)
+		if err != nil {
+			return rag.EmbedResult{}, err
+		}
+		if resp == nil {
+			return rag.EmbedResult{}, fmt.Errorf("golem: embedding route returned nil response")
+		}
+		return embedResultFromResponse(resp), nil
+	})
+}
+
+func embedResultFromResponse(resp *provider.EmbedResponse) rag.EmbedResult {
+	// Derive VectorSpaceID the same way the indexer did (actual routed model,
+	// else provider/model) so query vectors validate against the corpus's stored
+	// vector space. Mirrors mcp's ragEmbedder; omitting it makes every query
+	// fail with ErrVectorSpaceMismatch on a corpus that recorded a vector-space ID.
+	result := rag.EmbedResult{
+		Embeddings: resp.Embeddings,
+		Model:      resp.Model,
+		Provider:   resp.Provider,
+	}
+	if resp.RouteOutcome != nil {
+		if am := resp.RouteOutcome.ActualModel; am.Provider != "" && am.Model != "" {
+			result.VectorSpaceID = am.String()
+		}
+	}
+	if result.VectorSpaceID == "" && result.Provider != "" && result.Model != "" {
+		result.VectorSpaceID = result.Provider + "/" + result.Model
+	}
+	return result
+}
+
+// embeddingChain returns the configured embedding fallback chain.
+func embeddingChain(cfg *config.Config) ([]string, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("no provider configured for embeddings")
+	}
 	if _, ok := cfg.Defaults["embedding"]; !ok {
-		return ""
+		return nil, fmt.Errorf("no embedding model configured (set defaults.embedding in models.json)")
 	}
 	chain, err := cfg.RoleFallbackChain("embedding")
 	if err != nil || len(chain) == 0 {
-		return ""
+		if err != nil {
+			return nil, fmt.Errorf("resolve embedding chain: %w", err)
+		}
+		return nil, fmt.Errorf("embedding fallback chain is empty")
 	}
-	return chain[0]
+	return chain, nil
 }
 
 // effectClassName renders an agent.EffectClass bitset for /tools. The agent

--- a/cmd/golem/tools.go
+++ b/cmd/golem/tools.go
@@ -29,25 +29,36 @@ func buildTools(root string, retrieve agent.Tool) ([]agent.Tool, error) {
 	return fileTools, nil
 }
 
-// resolveRetriever builds a retrieve tool when a RAG DB exists at dbPath AND
-// defaults.embedding resolves to a model. Otherwise it returns (nil, false) so
-// the tool is omitted (weak local models waste turns on an unavailable tool).
+// resolveRetriever builds a retrieve tool from an explicitly configured RAG DB.
+// retrieve is opt-in, so it reports three distinct outcomes:
+//   - (nil, nil): not requested (dbPath == ""); the caller omits retrieve quietly.
+//   - (nil, err): requested via -rag-db but could NOT be enabled; the reason is
+//     returned so the caller can surface it rather than mislead the user with a
+//     generic "no RAG index configured" line.
+//   - (tool, nil): enabled.
 // On success the opened store lives for the process: the retriever queries it
 // for the whole session and the OS reclaims the handle at exit.
-func resolveRetriever(ctx context.Context, cfg *config.Config, router *provider.Router, dbPath string) (agent.Tool, bool) {
-	if cfg == nil || dbPath == "" || router == nil {
-		return nil, false
+func resolveRetriever(ctx context.Context, cfg *config.Config, router *provider.Router, dbPath string) (agent.Tool, error) {
+	if dbPath == "" {
+		return nil, nil // retrieve is opt-in and was not requested
+	}
+	if cfg == nil || router == nil {
+		return nil, fmt.Errorf("no provider configured for embeddings")
 	}
 	embModel := embeddingSelector(cfg)
 	if embModel == "" {
-		return nil, false
+		return nil, fmt.Errorf("no embedding model configured (set defaults.embedding in models.json)")
 	}
-	if info, err := os.Stat(dbPath); err != nil || info.IsDir() {
-		return nil, false
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("rag-db %q: %w", dbPath, err)
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("rag-db %q is a directory, not a SQLite file", dbPath)
 	}
 	store, err := rag.NewSQLiteStore(dbPath)
 	if err != nil {
-		return nil, false
+		return nil, fmt.Errorf("open rag-db %q: %w", dbPath, err)
 	}
 	embedder := rag.EmbedderFunc(func(ctx context.Context, model string, inputs []string) (rag.EmbedResult, error) {
 		resp, err := router.Embed(ctx, provider.EmbedRequest{Model: model, Input: inputs})
@@ -77,9 +88,9 @@ func resolveRetriever(ctx context.Context, cfg *config.Config, router *provider.
 	retr, err := rag.NewRetrieverWithEmbedder(embedder, store, rag.WithRetrieverModel(embModel))
 	if err != nil {
 		_ = store.Close()
-		return nil, false
+		return nil, fmt.Errorf("build retriever for rag-db %q: %w", dbPath, err)
 	}
-	return &agenttools.Retrieve{R: retr, K: 5, MaxTokens: 2048}, true
+	return &agenttools.Retrieve{R: retr, K: 5, MaxTokens: 2048}, nil
 }
 
 // embeddingSelector returns the head of the embedding fallback chain, or "".

--- a/cmd/golem/tools.go
+++ b/cmd/golem/tools.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kstruzzieri/go-llm/agent"
+	agenttools "github.com/kstruzzieri/go-llm/agent/tools"
+)
+
+// buildTools returns golem's read-only tool set: the file tools
+// (read_file, search, glob, list) always, plus retrieve appended last when a
+// non-nil retriever tool is supplied. The retrieve argument must be a true nil
+// interface (not a typed-nil pointer) when no retriever is available; a
+// typed-nil would be treated as present.
+func buildTools(root string, retrieve agent.Tool) ([]agent.Tool, error) {
+	fileTools, err := agenttools.NewFileTools(root)
+	if err != nil {
+		return nil, fmt.Errorf("golem: build file tools: %w", err)
+	}
+	if retrieve != nil {
+		return append(fileTools, retrieve), nil
+	}
+	return fileTools, nil
+}
+
+// effectClassName renders an agent.EffectClass bitset for /tools. The agent
+// package has no String() for it, so golem provides one.
+func effectClassName(c agent.EffectClass) string {
+	var parts []string
+	if c&agent.Read != 0 {
+		parts = append(parts, "read")
+	}
+	if c&agent.Write != 0 {
+		parts = append(parts, "write")
+	}
+	if c&agent.Exec != 0 {
+		parts = append(parts, "exec")
+	}
+	if c&agent.Network != 0 {
+		parts = append(parts, "network")
+	}
+	if len(parts) == 0 {
+		return "none"
+	}
+	return strings.Join(parts, "|")
+}

--- a/cmd/golem/tools.go
+++ b/cmd/golem/tools.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/kstruzzieri/go-llm/agent"
 	agenttools "github.com/kstruzzieri/go-llm/agent/tools"
+	"github.com/kstruzzieri/go-llm/config"
+	"github.com/kstruzzieri/go-llm/provider"
+	"github.com/kstruzzieri/go-llm/rag"
 )
 
 // buildTools returns golem's read-only tool set: the file tools
@@ -22,6 +27,71 @@ func buildTools(root string, retrieve agent.Tool) ([]agent.Tool, error) {
 		return append(fileTools, retrieve), nil
 	}
 	return fileTools, nil
+}
+
+// resolveRetriever builds a retrieve tool when a RAG DB exists at dbPath AND
+// defaults.embedding resolves to a model. Otherwise it returns (nil, false) so
+// the tool is omitted (weak local models waste turns on an unavailable tool).
+// On success the opened store lives for the process: the retriever queries it
+// for the whole session and the OS reclaims the handle at exit.
+func resolveRetriever(ctx context.Context, cfg *config.Config, router *provider.Router, dbPath string) (agent.Tool, bool) {
+	if cfg == nil || dbPath == "" || router == nil {
+		return nil, false
+	}
+	embModel := embeddingSelector(cfg)
+	if embModel == "" {
+		return nil, false
+	}
+	if info, err := os.Stat(dbPath); err != nil || info.IsDir() {
+		return nil, false
+	}
+	store, err := rag.NewSQLiteStore(dbPath)
+	if err != nil {
+		return nil, false
+	}
+	embedder := rag.EmbedderFunc(func(ctx context.Context, model string, inputs []string) (rag.EmbedResult, error) {
+		resp, err := router.Embed(ctx, provider.EmbedRequest{Model: model, Input: inputs})
+		if err != nil {
+			return rag.EmbedResult{}, err
+		}
+		// Derive VectorSpaceID the same way the indexer did (actual routed
+		// model, else provider/model) so query vectors validate against the
+		// corpus's stored vector space. Mirrors mcp's ragEmbedder; omitting it
+		// makes every query fail with ErrVectorSpaceMismatch on a corpus that
+		// recorded a vector-space ID.
+		result := rag.EmbedResult{
+			Embeddings: resp.Embeddings,
+			Model:      resp.Model,
+			Provider:   resp.Provider,
+		}
+		if resp.RouteOutcome != nil {
+			if am := resp.RouteOutcome.ActualModel; am.Provider != "" && am.Model != "" {
+				result.VectorSpaceID = am.String()
+			}
+		}
+		if result.VectorSpaceID == "" && result.Provider != "" && result.Model != "" {
+			result.VectorSpaceID = result.Provider + "/" + result.Model
+		}
+		return result, nil
+	})
+	retr, err := rag.NewRetrieverWithEmbedder(embedder, store, rag.WithRetrieverModel(embModel))
+	if err != nil {
+		_ = store.Close()
+		return nil, false
+	}
+	return &agenttools.Retrieve{R: retr, K: 5, MaxTokens: 2048}, true
+}
+
+// embeddingSelector returns the head of the embedding fallback chain, or "".
+func embeddingSelector(cfg *config.Config) string {
+	if _, ok := cfg.Defaults["embedding"]; !ok {
+		return ""
+	}
+	chain, err := cfg.RoleFallbackChain("embedding")
+	if err != nil || len(chain) == 0 {
+		return ""
+	}
+	return chain[0]
 }
 
 // effectClassName renders an agent.EffectClass bitset for /tools. The agent

--- a/cmd/golem/tools_test.go
+++ b/cmd/golem/tools_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/agent"
+)
+
+// stubTool is a minimal agent.Tool to stand in for retrieve.
+type stubTool struct{ name string }
+
+func (s stubTool) Spec() agent.ToolSpec { return agent.ToolSpec{Name: s.name} }
+func (s stubTool) Effect() agent.Effect { return agent.Effect{Class: agent.Read} }
+func (s stubTool) Invoke(ctx context.Context, _ json.RawMessage) (agent.ToolResult, error) {
+	return agent.ToolResult{}, nil
+}
+
+func names(tools []agent.Tool) []string {
+	out := make([]string, len(tools))
+	for i, t := range tools {
+		out[i] = t.Spec().Name
+	}
+	return out
+}
+
+func TestBuildTools_FileOnly(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "x.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tools, err := buildTools(root, nil)
+	if err != nil {
+		t.Fatalf("buildTools: %v", err)
+	}
+	got := names(tools)
+	want := []string{"read_file", "search", "glob", "list"}
+	if len(got) != len(want) {
+		t.Fatalf("tool names = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("tool[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestBuildTools_WithRetrieve(t *testing.T) {
+	root := t.TempDir()
+	tools, err := buildTools(root, stubTool{name: "retrieve"})
+	if err != nil {
+		t.Fatalf("buildTools: %v", err)
+	}
+	got := names(tools)
+	if len(got) != 5 || got[4] != "retrieve" {
+		t.Errorf("tool names = %v, want file tools + retrieve last", got)
+	}
+}
+
+func TestBuildTools_BadRoot(t *testing.T) {
+	if _, err := buildTools(filepath.Join(t.TempDir(), "does-not-exist"), nil); err == nil {
+		t.Fatal("buildTools on missing root err = nil, want error")
+	}
+}
+
+func TestEffectClassName(t *testing.T) {
+	cases := []struct {
+		in   agent.EffectClass
+		want string
+	}{
+		{agent.Read, "read"},
+		{agent.Read | agent.Write, "read|write"},
+		{agent.Exec, "exec"},
+		{agent.Network, "network"},
+		{agent.Read | agent.Write | agent.Exec | agent.Network, "read|write|exec|network"},
+		{agent.EffectClass(0), "none"},
+	}
+	for _, c := range cases {
+		if got := effectClassName(c.in); got != c.want {
+			t.Errorf("effectClassName(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements Golem v1 child B2 (#192): a minimal read-only terminal coding agent under `cmd/golem`. It is the integration child of epic #185 — the first consumer of both `internal/providerbootstrap` (child A, #191) and `agent/tools` (child B1, #194) — wiring them into an `agent.Orchestrator` driven by a stdlib REPL.

- **Strict-chain model routing.** A golem-local `agent.ModelCaller` (a clone of `agent.NewRouterModelCaller`) pins `RoutingRequest.PreferredChain = cfg.RoleFallbackChain("agent")` with `StrictChain:true`, `UseCase:"agent"`, and `RequiredCaps = CapChat|CapStream|CapToolCall`, capturing `RouteOutcome`. When `defaults.agent` is unset it falls back to empty-Model recommend (announced at startup); a misconfigured chain (unknown role / cycle) fails fast.
- **Chain-aware CapToolCall preflight.** At startup, validates the whole configured chain (not just the head) via registry lookup (no live model call); fails fast only when no entry is tool-capable, warns on incapable fallbacks, and checks the recommend result when the chain is unset.
- **Read-only guarantee.** Only `agent/tools` file tools (read_file/search/glob/list) plus an optional `retrieve` are wired; `Request.Approver` is nil (runtime auto-approves Read, denies Write/Exec); no shell/write/network primitive exists. Workspace root defaults to cwd, overridable via `-root`.
- **REPL.** Per-prompt `Run`; slash commands (`/help`, `/exit`|`/quit`, `/clear`, `/model`, `/tools`); Ctrl-C cancels the in-flight run while keeping the REPL alive (with a stale-interrupt drain so an idle Ctrl-C cannot cancel the next prompt); Ctrl-D exits.
- **Append-only renderer.** Streams tokens, prints `> name args`, and dim per-step + final footers. The live `< result` line is intentionally deferred to B3 (it needs the `ToolResultObserver` runtime seam).
- **Optional RAG `retrieve`.** Registered only when `-rag-db` points at an existing SQLite DB and `defaults.embedding` resolves; the query embedder derives the vector-space identity the same way the indexer did so queries validate against the corpus. An explicit `-rag-db` that cannot be enabled surfaces a specific reason rather than the generic "no RAG index configured" notice.

Scope is confined to `cmd/golem/` (a pure consumer — no `agent/` runtime changes). Session persistence, the `ToolResultObserver` seam, the `< result` line, and `--no-session` are deferred to B3 (#193).

## Test Plan

- [x] `go test ./... -race` green (24 packages); golem package covers: chain ModelCaller routing asserts, chain-aware preflight (head-capable / primary-incapable-fallback-capable / none-capable / recommend / bare-model), renderer exact-output (incl. fraction→percent ctx, color, stopped footer), tool assembly, config load + chain gating, an end-to-end read-only REPL session over a temp-dir fixture (real orchestrator + real file tools), slash commands, Ctrl-C mid-run, and retrieve gating.
- [x] `golangci-lint run ./...` — 0 issues; `go vet` + `gofmt` clean.
- [x] `go build ./cmd/golem` produces the binary; `-h` prints usage cleanly.
- [ ] Manual smoke against a live backend: ask a repo question, observe streamed answer + footer; exercise `/tools`, `/model`, Ctrl-C mid-run, Ctrl-D.

Closes #192.

Generated with [Claude Code](https://claude.com/claude-code)