### PR TITLE
feat(golem): approval-gated write/edit tools with diff preview (#201)

### DIFF
--- a/agent/tools/edit.go
+++ b/agent/tools/edit.go
@@ -1,0 +1,142 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/agent"
+)
+
+// EditFile applies a single exact-string replacement to a workspace file.
+// old_string must occur exactly once; new_string may be empty (deletion). Plan
+// computes the after-content and diff; Invoke re-verifies the file is unchanged
+// and the match is still unique before writing atomically.
+type EditFile struct {
+	ws *Workspace
+	j  Journal
+	mutatingBase
+}
+
+// NewEditFile builds the edit_file tool bound to ws, reporting applied edits to
+// journal (may be nil).
+func NewEditFile(ws *Workspace, journal Journal) *EditFile {
+	return &EditFile{ws: ws, j: journal}
+}
+
+type editFileArgs struct {
+	Path      string `json:"path"`
+	OldString string `json:"old_string"`
+	NewString string `json:"new_string"`
+}
+
+func (*EditFile) Spec() agent.ToolSpec {
+	return agent.ToolSpec{
+		Name:        "edit_file",
+		Description: "Replace an exact substring in an existing workspace file. old_string must appear exactly once (otherwise the edit is refused); new_string may be empty to delete it. The change is shown as a diff and requires user approval before it is applied.",
+		Parameters: json.RawMessage(`{
+  "type":"object",
+  "properties":{
+    "path":{"type":"string","description":"file path relative to the workspace root"},
+    "old_string":{"type":"string","description":"exact text to replace; must occur exactly once"},
+    "new_string":{"type":"string","description":"replacement text (empty to delete the match)"}
+  },
+  "required":["path","old_string","new_string"]
+}`),
+	}
+}
+
+func (*EditFile) Effect() agent.Effect {
+	return agent.Effect{Class: agent.Write, Approval: agent.ApprovalOnWrite}
+}
+
+// computeEdit reads the file, validates uniqueness and size, and returns the
+// before/after bytes. It is shared by Plan and the Invoke re-check.
+func (t *EditFile) computeEdit(args editFileArgs) (before, after []byte, err error) {
+	if args.Path == "" {
+		return nil, nil, fmt.Errorf("path is required")
+	}
+	if args.OldString == "" {
+		return nil, nil, fmt.Errorf("old_string is required")
+	}
+	before, err = t.ws.readAll(args.Path)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(before) > mutateMaxBytes {
+		return nil, nil, fmt.Errorf("file exceeds size limit")
+	}
+	sniff := before
+	if len(sniff) > binarySniffBytes {
+		sniff = sniff[:binarySniffBytes]
+	}
+	if bytes.IndexByte(sniff, 0) >= 0 {
+		return nil, nil, fmt.Errorf("binary file (NUL byte detected); refusing to edit")
+	}
+	n := strings.Count(string(before), args.OldString)
+	if n == 0 {
+		return nil, nil, fmt.Errorf("old_string not found")
+	}
+	if n > 1 {
+		return nil, nil, fmt.Errorf("ambiguous: old_string occurs %d times", n)
+	}
+	after = []byte(strings.Replace(string(before), args.OldString, args.NewString, 1))
+	if len(after) > mutateMaxBytes {
+		return nil, nil, fmt.Errorf("result exceeds size limit")
+	}
+	return before, after, nil
+}
+
+func (t *EditFile) Plan(_ context.Context, raw json.RawMessage) (agent.ToolPlan, error) {
+	eff := t.Effect()
+	var args editFileArgs
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return agent.ToolPlan{Effect: eff}, nil
+	}
+	before, after, err := t.computeEdit(args)
+	if err != nil {
+		return agent.ToolPlan{Effect: eff}, nil // gated but un-approvable; Invoke reports why
+	}
+	t.store(contentHash(raw), pendingPlan{
+		path:         args.Path,
+		priorContent: before,
+		priorExists:  true,
+		beforeHash:   contentHash(before),
+		afterContent: after,
+		afterHash:    contentHash(after),
+		summary:      fmt.Sprintf("edit %s", args.Path),
+	})
+	return agent.ToolPlan{Effect: eff, Preview: unifiedDiff(args.Path, before, after, true)}, nil
+}
+
+func (t *EditFile) Invoke(_ context.Context, raw json.RawMessage) (agent.ToolResult, error) {
+	var args editFileArgs
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return errResult("invalid arguments: " + err.Error()), nil
+	}
+	// Recompute from the args to produce an accurate failure reason, then require a
+	// matching pending plan (fails closed if Plan never ran / args changed).
+	before, after, err := t.computeEdit(args)
+	if err != nil {
+		return errResult(err.Error()), nil
+	}
+	pp, ok := t.consume(contentHash(raw))
+	if !ok {
+		return errResult("mutation preview missing; retry"), nil
+	}
+	// The file must be byte-identical to what Plan previewed.
+	if contentHash(before) != pp.beforeHash {
+		return errResult("file changed since preview; retry"), nil
+	}
+	if err := t.ws.WriteFileAtomic(pp.path, after); err != nil {
+		return errResult(err.Error()), nil
+	}
+	record(t.j, MutationRecord{
+		Path: pp.path, PriorContent: pp.priorContent, Existed: true,
+		AfterHash: contentHash(after), Summary: pp.summary, At: time.Now(),
+	})
+	return agent.ToolResult{Content: pp.summary, Preview: pp.summary}, nil
+}

--- a/agent/tools/edit.go
+++ b/agent/tools/edit.go
@@ -87,6 +87,9 @@ func (t *EditFile) computeEdit(args editFileArgs) (before, after []byte, err err
 	if len(after) > mutateMaxBytes {
 		return nil, nil, fmt.Errorf("result exceeds size limit")
 	}
+	if bytes.IndexByte(after, 0) >= 0 {
+		return nil, nil, fmt.Errorf("new_string would introduce a NUL byte; refusing to write binary content")
+	}
 	return before, after, nil
 }
 
@@ -136,7 +139,7 @@ func (t *EditFile) Invoke(_ context.Context, raw json.RawMessage) (agent.ToolRes
 	}
 	record(t.j, MutationRecord{
 		Path: pp.path, PriorContent: pp.priorContent, Existed: true,
-		AfterHash: contentHash(after), Summary: pp.summary, At: time.Now(),
+		AfterHash: pp.afterHash, Summary: pp.summary, At: time.Now(),
 	})
 	return agent.ToolResult{Content: pp.summary, Preview: pp.summary}, nil
 }

--- a/agent/tools/edit.go
+++ b/agent/tools/edit.go
@@ -101,11 +101,11 @@ func (t *EditFile) Plan(_ context.Context, raw json.RawMessage) (agent.ToolPlan,
 	eff := t.Effect()
 	var args editFileArgs
 	if err := json.Unmarshal(raw, &args); err != nil {
-		return agent.ToolPlan{Effect: eff}, nil
+		return agent.ToolPlan{Effect: eff}, fmt.Errorf("invalid arguments: %w", err)
 	}
 	before, after, err := t.computeEdit(args)
 	if err != nil {
-		return agent.ToolPlan{Effect: eff}, nil // gated but un-approvable; Invoke reports why
+		return agent.ToolPlan{Effect: eff}, err
 	}
 	t.store(ContentHash(raw), pendingPlan{
 		path:         args.Path,

--- a/agent/tools/edit.go
+++ b/agent/tools/edit.go
@@ -103,13 +103,13 @@ func (t *EditFile) Plan(_ context.Context, raw json.RawMessage) (agent.ToolPlan,
 	if err != nil {
 		return agent.ToolPlan{Effect: eff}, nil // gated but un-approvable; Invoke reports why
 	}
-	t.store(contentHash(raw), pendingPlan{
+	t.store(ContentHash(raw), pendingPlan{
 		path:         args.Path,
 		priorContent: before,
 		priorExists:  true,
-		beforeHash:   contentHash(before),
+		beforeHash:   ContentHash(before),
 		afterContent: after,
-		afterHash:    contentHash(after),
+		afterHash:    ContentHash(after),
 		summary:      fmt.Sprintf("edit %s", args.Path),
 	})
 	return agent.ToolPlan{Effect: eff, Preview: unifiedDiff(args.Path, before, after, true)}, nil
@@ -126,12 +126,12 @@ func (t *EditFile) Invoke(_ context.Context, raw json.RawMessage) (agent.ToolRes
 	if err != nil {
 		return errResult(err.Error()), nil
 	}
-	pp, ok := t.consume(contentHash(raw))
+	pp, ok := t.consume(ContentHash(raw))
 	if !ok {
 		return errResult("mutation preview missing; retry"), nil
 	}
 	// The file must be byte-identical to what Plan previewed.
-	if contentHash(before) != pp.beforeHash {
+	if ContentHash(before) != pp.beforeHash {
 		return errResult("file changed since preview; retry"), nil
 	}
 	if err := t.ws.WriteFileAtomic(pp.path, after); err != nil {

--- a/agent/tools/edit.go
+++ b/agent/tools/edit.go
@@ -69,6 +69,10 @@ func (t *EditFile) computeEdit(args editFileArgs) (before, after []byte, err err
 	if len(before) > mutateMaxBytes {
 		return nil, nil, fmt.Errorf("file exceeds size limit")
 	}
+	// Sniff only the first binarySniffBytes of the EXISTING file, mirroring
+	// read_file's policy (a NUL early in the file marks it binary). The bytes we will
+	// actually write (`after`) are NUL-scanned in full below, so an existing NUL past
+	// the sniff window cannot slip through into a written result.
 	sniff := before
 	if len(sniff) > binarySniffBytes {
 		sniff = sniff[:binarySniffBytes]
@@ -120,9 +124,10 @@ func (t *EditFile) Invoke(_ context.Context, raw json.RawMessage) (agent.ToolRes
 	if err := json.Unmarshal(raw, &args); err != nil {
 		return errResult("invalid arguments: " + err.Error()), nil
 	}
-	// Recompute from the args to produce an accurate failure reason, then require a
-	// matching pending plan (fails closed if Plan never ran / args changed).
-	before, after, err := t.computeEdit(args)
+	// Recompute from the args to produce an accurate failure reason (e.g. "old_string
+	// not found" if the file changed) and to re-read current bytes; only `before` is
+	// kept, to re-verify the file is unchanged. The approved bytes come from the plan.
+	before, _, err := t.computeEdit(args)
 	if err != nil {
 		return errResult(err.Error()), nil
 	}
@@ -130,11 +135,13 @@ func (t *EditFile) Invoke(_ context.Context, raw json.RawMessage) (agent.ToolRes
 	if !ok {
 		return errResult("mutation preview missing; retry"), nil
 	}
-	// The file must be byte-identical to what Plan previewed.
+	// The file must be byte-identical to what Plan previewed; then write exactly the
+	// bytes the user approved (pp.afterContent), symmetric with write_file. The
+	// before-hash match guarantees pp.afterContent equals a fresh recomputation.
 	if ContentHash(before) != pp.beforeHash {
 		return errResult("file changed since preview; retry"), nil
 	}
-	if err := t.ws.WriteFileAtomic(pp.path, after); err != nil {
+	if err := t.ws.WriteFileAtomic(pp.path, pp.afterContent); err != nil {
 		return errResult(err.Error()), nil
 	}
 	record(t.j, MutationRecord{

--- a/agent/tools/edit_test.go
+++ b/agent/tools/edit_test.go
@@ -1,0 +1,128 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/agent"
+)
+
+func writeSeed(t *testing.T, root, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(root, name), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEditFileSingleMatch(t *testing.T) {
+	root := t.TempDir()
+	writeSeed(t, root, "a.txt", "alpha\nbravo\ncharlie\n")
+	jr := &recJournal{}
+	ef := NewEditFile(mustWorkspace(t, root), jr)
+
+	_, res := planThenInvoke(t, ef, map[string]any{
+		"path": "a.txt", "old_string": "bravo", "new_string": "BRAVO",
+	})
+	if res.IsError {
+		t.Fatalf("edit errored: %s", res.Content)
+	}
+	got, _ := os.ReadFile(filepath.Join(root, "a.txt"))
+	if string(got) != "alpha\nBRAVO\ncharlie\n" {
+		t.Fatalf("content = %q", got)
+	}
+	if len(jr.recs) != 1 || !jr.recs[0].Existed {
+		t.Fatalf("journal record wrong: %+v", jr.recs)
+	}
+}
+
+func TestEditFileZeroMatch(t *testing.T) {
+	root := t.TempDir()
+	writeSeed(t, root, "a.txt", "alpha\n")
+	ef := NewEditFile(mustWorkspace(t, root), nil)
+	raw, _ := json.Marshal(map[string]any{"path": "a.txt", "old_string": "zzz", "new_string": "q"})
+	plan, _ := ef.Plan(context.Background(), raw)
+	if plan.Preview != "" {
+		t.Fatalf("zero-match must not produce an approvable preview: %q", plan.Preview)
+	}
+	res, _ := ef.Invoke(context.Background(), raw)
+	if !res.IsError {
+		t.Fatal("zero-match invoke must be IsError")
+	}
+}
+
+func TestEditFileAmbiguousMatch(t *testing.T) {
+	root := t.TempDir()
+	writeSeed(t, root, "a.txt", "x\nx\n")
+	ef := NewEditFile(mustWorkspace(t, root), nil)
+	raw, _ := json.Marshal(map[string]any{"path": "a.txt", "old_string": "x", "new_string": "y"})
+	plan, _ := ef.Plan(context.Background(), raw)
+	if plan.Preview != "" {
+		t.Fatalf("ambiguous match must not produce a preview: %q", plan.Preview)
+	}
+	res, _ := ef.Invoke(context.Background(), raw)
+	if !res.IsError || !strings.Contains(res.Content, "ambiguous") {
+		t.Fatalf("ambiguous invoke must fail: %+v", res)
+	}
+}
+
+func TestEditFileEmptyNewStringDeletes(t *testing.T) {
+	root := t.TempDir()
+	writeSeed(t, root, "a.txt", "keep\nDROP\n")
+	ef := NewEditFile(mustWorkspace(t, root), nil)
+	_, res := planThenInvoke(t, ef, map[string]any{
+		"path": "a.txt", "old_string": "DROP\n", "new_string": "",
+	})
+	if res.IsError {
+		t.Fatalf("deletion edit errored: %s", res.Content)
+	}
+	got, _ := os.ReadFile(filepath.Join(root, "a.txt"))
+	if string(got) != "keep\n" {
+		t.Fatalf("content = %q", got)
+	}
+}
+
+func TestEditFileMissingFile(t *testing.T) {
+	root := t.TempDir()
+	ef := NewEditFile(mustWorkspace(t, root), nil)
+	res := invoke(t, ef, map[string]any{"path": "nope.txt", "old_string": "a", "new_string": "b"})
+	if !res.IsError {
+		t.Fatal("editing a missing file must be IsError")
+	}
+}
+
+func TestEditFileBinaryRejected(t *testing.T) {
+	root := t.TempDir()
+	writeSeed(t, root, "bin", "a\x00b")
+	ef := NewEditFile(mustWorkspace(t, root), nil)
+	res := invoke(t, ef, map[string]any{"path": "bin", "old_string": "a", "new_string": "b"})
+	if !res.IsError {
+		t.Fatal("binary file edit must be IsError")
+	}
+}
+
+func TestEditFileChangedSincePreviewFails(t *testing.T) {
+	root := t.TempDir()
+	writeSeed(t, root, "a.txt", "one\ntwo\n")
+	ef := NewEditFile(mustWorkspace(t, root), nil)
+	raw, _ := json.Marshal(map[string]any{"path": "a.txt", "old_string": "two", "new_string": "TWO"})
+	if _, err := ef.Plan(context.Background(), raw); err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	writeSeed(t, root, "a.txt", "one\ntwo\nthree\n") // mutated after Plan
+	res, _ := ef.Invoke(context.Background(), raw)
+	if !res.IsError || !strings.Contains(res.Content, "changed since preview") {
+		t.Fatalf("hash mismatch must fail: %+v", res)
+	}
+}
+
+func TestEditFileEffect(t *testing.T) {
+	ef := NewEditFile(mustWorkspace(t, t.TempDir()), nil)
+	e := ef.Effect()
+	if e.Class != agent.Write || e.Approval != agent.ApprovalOnWrite {
+		t.Fatalf("Effect = %+v, want Write/ApprovalOnWrite", e)
+	}
+}

--- a/agent/tools/edit_test.go
+++ b/agent/tools/edit_test.go
@@ -126,3 +126,63 @@ func TestEditFileEffect(t *testing.T) {
 		t.Fatalf("Effect = %+v, want Write/ApprovalOnWrite", e)
 	}
 }
+
+func TestEditFileNoPendingPlanFails(t *testing.T) {
+	root := t.TempDir()
+	writeSeed(t, root, "a.txt", "hello\n")
+	ef := NewEditFile(mustWorkspace(t, root), nil)
+	res := invoke(t, ef, map[string]any{"path": "a.txt", "old_string": "hello", "new_string": "world"})
+	if !res.IsError || !strings.Contains(res.Content, "preview missing") {
+		t.Fatalf("invoke without plan must fail: %+v", res)
+	}
+}
+
+func TestEditFileMultilineMatch(t *testing.T) {
+	root := t.TempDir()
+	writeSeed(t, root, "a.txt", "head\nB1\nB2\ntail\n")
+	ef := NewEditFile(mustWorkspace(t, root), nil)
+	_, res := planThenInvoke(t, ef, map[string]any{
+		"path": "a.txt", "old_string": "B1\nB2\n", "new_string": "MID\n",
+	})
+	if res.IsError {
+		t.Fatalf("multiline edit errored: %s", res.Content)
+	}
+	got, _ := os.ReadFile(filepath.Join(root, "a.txt"))
+	if string(got) != "head\nMID\ntail\n" {
+		t.Fatalf("multiline content = %q", got)
+	}
+}
+
+func TestEditFileWholeFileEmptied(t *testing.T) {
+	root := t.TempDir()
+	writeSeed(t, root, "a.txt", "only\n")
+	ef := NewEditFile(mustWorkspace(t, root), nil)
+	plan, res := planThenInvoke(t, ef, map[string]any{
+		"path": "a.txt", "old_string": "only\n", "new_string": "",
+	})
+	if res.IsError {
+		t.Fatalf("emptying edit errored: %s", res.Content)
+	}
+	if !strings.Contains(plan.Preview, "empty file: a.txt") {
+		t.Fatalf("emptying preview should use empty-file framing: %q", plan.Preview)
+	}
+	got, _ := os.ReadFile(filepath.Join(root, "a.txt"))
+	if len(got) != 0 {
+		t.Fatalf("file should be emptied, got %q", got)
+	}
+}
+
+func TestEditFileRejectsNulNewString(t *testing.T) {
+	root := t.TempDir()
+	writeSeed(t, root, "a.txt", "hello\n")
+	ef := NewEditFile(mustWorkspace(t, root), nil)
+	raw, _ := json.Marshal(map[string]any{"path": "a.txt", "old_string": "hello", "new_string": "a\x00b"})
+	plan, _ := ef.Plan(context.Background(), raw)
+	if plan.Preview != "" {
+		t.Fatalf("NUL new_string must not produce a preview: %q", plan.Preview)
+	}
+	res, _ := ef.Invoke(context.Background(), raw)
+	if !res.IsError {
+		t.Fatal("NUL new_string must fail")
+	}
+}

--- a/agent/tools/edit_test.go
+++ b/agent/tools/edit_test.go
@@ -44,9 +44,8 @@ func TestEditFileZeroMatch(t *testing.T) {
 	writeSeed(t, root, "a.txt", "alpha\n")
 	ef := NewEditFile(mustWorkspace(t, root), nil)
 	raw, _ := json.Marshal(map[string]any{"path": "a.txt", "old_string": "zzz", "new_string": "q"})
-	plan, _ := ef.Plan(context.Background(), raw)
-	if plan.Preview != "" {
-		t.Fatalf("zero-match must not produce an approvable preview: %q", plan.Preview)
+	if _, err := ef.Plan(context.Background(), raw); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("zero-match Plan error = %v, want not found", err)
 	}
 	res, _ := ef.Invoke(context.Background(), raw)
 	if !res.IsError {
@@ -59,9 +58,8 @@ func TestEditFileAmbiguousMatch(t *testing.T) {
 	writeSeed(t, root, "a.txt", "x\nx\n")
 	ef := NewEditFile(mustWorkspace(t, root), nil)
 	raw, _ := json.Marshal(map[string]any{"path": "a.txt", "old_string": "x", "new_string": "y"})
-	plan, _ := ef.Plan(context.Background(), raw)
-	if plan.Preview != "" {
-		t.Fatalf("ambiguous match must not produce a preview: %q", plan.Preview)
+	if _, err := ef.Plan(context.Background(), raw); err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("ambiguous Plan error = %v, want ambiguous", err)
 	}
 	res, _ := ef.Invoke(context.Background(), raw)
 	if !res.IsError || !strings.Contains(res.Content, "ambiguous") {
@@ -177,9 +175,8 @@ func TestEditFileRejectsNulNewString(t *testing.T) {
 	writeSeed(t, root, "a.txt", "hello\n")
 	ef := NewEditFile(mustWorkspace(t, root), nil)
 	raw, _ := json.Marshal(map[string]any{"path": "a.txt", "old_string": "hello", "new_string": "a\x00b"})
-	plan, _ := ef.Plan(context.Background(), raw)
-	if plan.Preview != "" {
-		t.Fatalf("NUL new_string must not produce a preview: %q", plan.Preview)
+	if _, err := ef.Plan(context.Background(), raw); err == nil || !strings.Contains(err.Error(), "NUL") {
+		t.Fatalf("NUL new_string Plan error = %v, want NUL", err)
 	}
 	res, _ := ef.Invoke(context.Background(), raw)
 	if !res.IsError {

--- a/agent/tools/mutate.go
+++ b/agent/tools/mutate.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/kstruzzieri/go-llm/agent"
 )
 
 const (
@@ -158,5 +160,16 @@ func (b *mutatingBase) consume(argsHash string) (pendingPlan, bool) {
 func record(j Journal, rec MutationRecord) {
 	if j != nil {
 		j.Record(rec)
+	}
+}
+
+// NewMutatingTools builds the workspace-mutating tool set (write_file, edit_file)
+// bound to ws, reporting applied changes to journal (may be nil). The consumer
+// (cmd/golem) appends these to the read-only set only when writes are enabled, and
+// must supply an Approver so the runtime gates each call.
+func NewMutatingTools(ws *Workspace, journal Journal) []agent.Tool {
+	return []agent.Tool{
+		NewWriteFile(ws, journal),
+		NewEditFile(ws, journal),
 	}
 }

--- a/agent/tools/mutate.go
+++ b/agent/tools/mutate.go
@@ -1,0 +1,162 @@
+package tools
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// mutateMaxBytes is the v2 text-file ceiling. Prior content, new content, and
+	// final content must each stay at or below this for write_file / edit_file.
+	mutateMaxBytes = 256 * 1024
+	// absentHash is the sentinel returned for a file that does not exist, distinct
+	// from contentHash of any real (including empty) content.
+	absentHash = "absent"
+	// diffContext is the number of unchanged lines shown around a change.
+	diffContext = 3
+)
+
+// contentHash is the SHA-256 hex of b. Stable, and distinct from absentHash.
+func contentHash(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// splitLines splits s on '\n', dropping the trailing empty element produced by a
+// final newline so a normal text file's line count is intuitive.
+func splitLines(s string) []string {
+	lines := strings.Split(s, "\n")
+	if n := len(lines); n > 0 && lines[n-1] == "" {
+		lines = lines[:n-1]
+	}
+	return lines
+}
+
+// unifiedDiff renders a human-readable line diff for the approval preview ONLY.
+// It is never parsed or fed back to the model. beforeExists distinguishes a
+// brand-new file (all additions) from an overwrite. A non-empty before with an
+// empty after renders as a deletion.
+func unifiedDiff(path string, before, after []byte, beforeExists bool) string {
+	var b strings.Builder
+	if !beforeExists {
+		fmt.Fprintf(&b, "new file: %s\n", path)
+		for _, ln := range splitLines(string(after)) {
+			fmt.Fprintf(&b, "+%s\n", ln)
+		}
+		return b.String()
+	}
+	if len(after) == 0 {
+		fmt.Fprintf(&b, "delete file: %s\n", path)
+		for _, ln := range splitLines(string(before)) {
+			fmt.Fprintf(&b, "-%s\n", ln)
+		}
+		return b.String()
+	}
+	bl := splitLines(string(before))
+	al := splitLines(string(after))
+	p := 0
+	for p < len(bl) && p < len(al) && bl[p] == al[p] {
+		p++
+	}
+	s := 0
+	for s < len(bl)-p && s < len(al)-p && bl[len(bl)-1-s] == al[len(al)-1-s] {
+		s++
+	}
+	fmt.Fprintf(&b, "--- %s\n+++ %s\n", path, path)
+	if p > 0 {
+		start := p - diffContext
+		if start < 0 {
+			start = 0
+		}
+		for i := start; i < p; i++ {
+			fmt.Fprintf(&b, " %s\n", bl[i])
+		}
+	}
+	for i := p; i < len(bl)-s; i++ {
+		fmt.Fprintf(&b, "-%s\n", bl[i])
+	}
+	for i := p; i < len(al)-s; i++ {
+		fmt.Fprintf(&b, "+%s\n", al[i])
+	}
+	end := len(bl) - s + diffContext
+	if end > len(bl) {
+		end = len(bl)
+	}
+	for i := len(bl) - s; i < end; i++ {
+		fmt.Fprintf(&b, " %s\n", bl[i])
+	}
+	return b.String()
+}
+
+// MutationRecord is what an applied write reports to a Journal so the consumer can
+// undo it. PriorContent is the file's bytes before the write (nil if it did not
+// exist); Existed says which. AfterHash is contentHash of the written bytes, used
+// by /undo to confirm the file is unchanged since golem wrote it.
+type MutationRecord struct {
+	Path         string
+	PriorContent []byte
+	Existed      bool
+	AfterHash    string
+	Summary      string
+	At           time.Time
+}
+
+// Journal receives a record after each successful mutation. Defined here at the
+// point of use; cmd/golem supplies the concrete in-memory implementation. A nil
+// Journal is tolerated by the tools (Record is simply skipped).
+type Journal interface {
+	Record(MutationRecord)
+}
+
+// pendingPlan is the state a mutating tool computes in Plan and consumes in Invoke.
+// agent.ToolPlan exposes only Effect+Preview, and Invoke receives only raw args,
+// so the tool carries the previewed result itself, keyed by a hash of the raw args.
+type pendingPlan struct {
+	path         string
+	priorContent []byte
+	priorExists  bool
+	beforeHash   string
+	afterContent []byte
+	afterHash    string
+	summary      string
+}
+
+// mutatingBase holds the single pending plan shared by a tool's Plan/Invoke pair.
+// Only the most recent successful Plan is retained; a denied call simply leaves it
+// to be overwritten by the next Plan.
+type mutatingBase struct {
+	mu       sync.Mutex
+	argsHash string
+	plan     pendingPlan
+	hasPlan  bool
+}
+
+func (b *mutatingBase) store(argsHash string, p pendingPlan) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.argsHash, b.plan, b.hasPlan = argsHash, p, true
+}
+
+// consume returns and clears the pending plan only if argsHash matches the stored
+// one. A mismatch (or no plan) returns ok=false so Invoke fails closed.
+func (b *mutatingBase) consume(argsHash string) (pendingPlan, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !b.hasPlan || b.argsHash != argsHash {
+		return pendingPlan{}, false
+	}
+	p := b.plan
+	b.hasPlan, b.plan, b.argsHash = false, pendingPlan{}, ""
+	return p, true
+}
+
+// record forwards to the journal when one is configured.
+func record(j Journal, rec MutationRecord) {
+	if j != nil {
+		j.Record(rec)
+	}
+}

--- a/agent/tools/mutate.go
+++ b/agent/tools/mutate.go
@@ -39,7 +39,7 @@ func splitLines(s string) []string {
 // unifiedDiff renders a human-readable line diff for the approval preview ONLY.
 // It is never parsed or fed back to the model. beforeExists distinguishes a
 // brand-new file (all additions) from an overwrite. A non-empty before with an
-// empty after renders as a deletion.
+// empty after renders as emptied (truncated to zero bytes).
 func unifiedDiff(path string, before, after []byte, beforeExists bool) string {
 	var b strings.Builder
 	if !beforeExists {
@@ -50,7 +50,7 @@ func unifiedDiff(path string, before, after []byte, beforeExists bool) string {
 		return b.String()
 	}
 	if len(after) == 0 {
-		fmt.Fprintf(&b, "delete file: %s\n", path)
+		fmt.Fprintf(&b, "empty file: %s\n", path)
 		for _, ln := range splitLines(string(before)) {
 			fmt.Fprintf(&b, "-%s\n", ln)
 		}

--- a/agent/tools/mutate.go
+++ b/agent/tools/mutate.go
@@ -16,14 +16,14 @@ const (
 	// final content must each stay at or below this for write_file / edit_file.
 	mutateMaxBytes = 256 * 1024
 	// absentHash is the sentinel returned for a file that does not exist, distinct
-	// from contentHash of any real (including empty) content.
+	// from ContentHash of any real (including empty) content.
 	absentHash = "absent"
 	// diffContext is the number of unchanged lines shown around a change.
 	diffContext = 3
 )
 
-// contentHash is the SHA-256 hex of b. Stable, and distinct from absentHash.
-func contentHash(b []byte) string {
+// ContentHash is the SHA-256 hex of b. Stable, distinct from absentHash, and reused by cmd/golem's undo journal to detect post-write changes.
+func ContentHash(b []byte) string {
 	sum := sha256.Sum256(b)
 	return hex.EncodeToString(sum[:])
 }
@@ -96,7 +96,7 @@ func unifiedDiff(path string, before, after []byte, beforeExists bool) string {
 
 // MutationRecord is what an applied write reports to a Journal so the consumer can
 // undo it. PriorContent is the file's bytes before the write (nil if it did not
-// exist); Existed says which. AfterHash is contentHash of the written bytes, used
+// exist); Existed says which. AfterHash is ContentHash of the written bytes, used
 // by /undo to confirm the file is unchanged since golem wrote it.
 type MutationRecord struct {
 	Path         string

--- a/agent/tools/mutate_test.go
+++ b/agent/tools/mutate_test.go
@@ -3,6 +3,8 @@ package tools
 import (
 	"strings"
 	"testing"
+
+	"github.com/kstruzzieri/go-llm/agent"
 )
 
 func TestContentHashDistinctFromAbsent(t *testing.T) {
@@ -69,6 +71,30 @@ func TestUnifiedDiffIdenticalNoChangeLines(t *testing.T) {
 			if !strings.HasPrefix(ln, "+++") && !strings.HasPrefix(ln, "---") {
 				t.Fatalf("identical inputs produced a change line: %q\nfull:\n%s", ln, d)
 			}
+		}
+	}
+}
+
+func TestNewMutatingTools(t *testing.T) {
+	ws := mustWorkspace(t, t.TempDir())
+	tools := NewMutatingTools(ws, nil)
+	want := map[string]bool{"write_file": false, "edit_file": false}
+	for _, tl := range tools {
+		name := tl.Spec().Name
+		if _, ok := want[name]; !ok {
+			t.Fatalf("unexpected tool %q", name)
+		}
+		want[name] = true
+		if e := tl.Effect(); e.Class != agent.Write || e.Approval != agent.ApprovalOnWrite {
+			t.Fatalf("%q Effect = %+v, want Write/ApprovalOnWrite", name, e)
+		}
+		if _, ok := tl.(agent.PlanningTool); !ok {
+			t.Fatalf("%q must implement PlanningTool", name)
+		}
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Fatalf("missing %q", name)
 		}
 	}
 }

--- a/agent/tools/mutate_test.go
+++ b/agent/tools/mutate_test.go
@@ -8,14 +8,14 @@ import (
 )
 
 func TestContentHashDistinctFromAbsent(t *testing.T) {
-	if contentHash([]byte("")) == absentHash {
+	if ContentHash([]byte("")) == absentHash {
 		t.Fatal("hash of empty content must differ from the absent sentinel")
 	}
-	if contentHash([]byte("a")) == contentHash([]byte("b")) {
+	if ContentHash([]byte("a")) == ContentHash([]byte("b")) {
 		t.Fatal("different content must hash differently")
 	}
-	h1 := contentHash([]byte("a"))
-	h2 := contentHash([]byte("a"))
+	h1 := ContentHash([]byte("a"))
+	h2 := ContentHash([]byte("a"))
 	if h1 != h2 {
 		t.Fatal("hash must be stable")
 	}

--- a/agent/tools/mutate_test.go
+++ b/agent/tools/mutate_test.go
@@ -26,10 +26,10 @@ func TestUnifiedDiffNewFile(t *testing.T) {
 	}
 }
 
-func TestUnifiedDiffDelete(t *testing.T) {
+func TestUnifiedDiffEmpty(t *testing.T) {
 	d := unifiedDiff("a.txt", []byte("one\ntwo\n"), nil, true)
-	if !strings.Contains(d, "delete file: a.txt") || !strings.Contains(d, "-one") {
-		t.Fatalf("delete diff wrong:\n%s", d)
+	if !strings.Contains(d, "empty file: a.txt") || !strings.Contains(d, "-one") {
+		t.Fatalf("empty diff wrong:\n%s", d)
 	}
 }
 

--- a/agent/tools/mutate_test.go
+++ b/agent/tools/mutate_test.go
@@ -1,0 +1,74 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestContentHashDistinctFromAbsent(t *testing.T) {
+	if contentHash([]byte("")) == absentHash {
+		t.Fatal("hash of empty content must differ from the absent sentinel")
+	}
+	if contentHash([]byte("a")) == contentHash([]byte("b")) {
+		t.Fatal("different content must hash differently")
+	}
+	h1 := contentHash([]byte("a"))
+	h2 := contentHash([]byte("a"))
+	if h1 != h2 {
+		t.Fatal("hash must be stable")
+	}
+}
+
+func TestUnifiedDiffNewFile(t *testing.T) {
+	d := unifiedDiff("a.txt", nil, []byte("one\ntwo\n"), false)
+	if !strings.Contains(d, "new file: a.txt") || !strings.Contains(d, "+one") || !strings.Contains(d, "+two") {
+		t.Fatalf("new-file diff wrong:\n%s", d)
+	}
+}
+
+func TestUnifiedDiffDelete(t *testing.T) {
+	d := unifiedDiff("a.txt", []byte("one\ntwo\n"), nil, true)
+	if !strings.Contains(d, "delete file: a.txt") || !strings.Contains(d, "-one") {
+		t.Fatalf("delete diff wrong:\n%s", d)
+	}
+}
+
+func TestUnifiedDiffChangeTrimsCommon(t *testing.T) {
+	before := []byte("ctx1\nold\nctx2\n")
+	after := []byte("ctx1\nnew\nctx2\n")
+	d := unifiedDiff("a.txt", before, after, true)
+	if !strings.Contains(d, "-old") || !strings.Contains(d, "+new") {
+		t.Fatalf("change diff missing -/+ lines:\n%s", d)
+	}
+	if strings.Contains(d, "-ctx1") || strings.Contains(d, "+ctx1") {
+		t.Fatalf("common prefix must not be marked changed:\n%s", d)
+	}
+}
+
+func TestPendingPlanStoreConsumeByArgsHash(t *testing.T) {
+	var base mutatingBase
+	pp := pendingPlan{path: "a.txt", afterContent: []byte("x")}
+	base.store("HASH1", pp)
+	if _, ok := base.consume("WRONG"); ok {
+		t.Fatal("consume with wrong hash must fail")
+	}
+	got, ok := base.consume("HASH1")
+	if !ok || got.path != "a.txt" {
+		t.Fatalf("consume HASH1: ok=%v got=%+v", ok, got)
+	}
+	if _, ok := base.consume("HASH1"); ok {
+		t.Fatal("second consume must fail (plan cleared)")
+	}
+}
+
+func TestUnifiedDiffIdenticalNoChangeLines(t *testing.T) {
+	d := unifiedDiff("a.txt", []byte("x\ny\n"), []byte("x\ny\n"), true)
+	for _, ln := range strings.Split(d, "\n") {
+		if strings.HasPrefix(ln, "+") || strings.HasPrefix(ln, "-") {
+			// the +++/--- header lines are allowed; only single +/- change lines are not
+			if !strings.HasPrefix(ln, "+++") && !strings.HasPrefix(ln, "---") {
+				t.Fatalf("identical inputs produced a change line: %q\nfull:\n%s", ln, d)
+			}
+		}
+	}
+}

--- a/agent/tools/paths.go
+++ b/agent/tools/paths.go
@@ -40,19 +40,21 @@ var ignoreDirs = map[string]bool{
 }
 
 var (
-	errEmptyRoot   = errors.New("empty workspace root")
-	errNUL         = errors.New("path contains NUL byte")
-	errAbsPath     = errors.New("absolute paths are not allowed")
-	errEscape      = errors.New("path escapes the workspace root")
-	errSymlink     = errors.New("symlinks are not followed")
-	errNotRegular  = errors.New("not a regular file")
-	errNotDir      = errors.New("not a directory")
-	errFileChanged = errors.New("file identity changed between stat and open")
+	errEmptyRoot     = errors.New("empty workspace root")
+	errNUL           = errors.New("path contains NUL byte")
+	errAbsPath       = errors.New("absolute paths are not allowed")
+	errEscape        = errors.New("path escapes the workspace root")
+	errSymlink       = errors.New("symlinks are not followed")
+	errNotRegular    = errors.New("not a regular file")
+	errNotDir        = errors.New("not a directory")
+	errFileChanged   = errors.New("file identity changed between stat and open")
+	errParentMissing = errors.New("parent directory does not exist")
 )
 
-// Workspace is the single audited chokepoint for read-only filesystem access.
-// The canonical root is resolved once at construction; no path component is ever
-// resolved through a symlink afterwards (v1 symlink policy: never follow).
+// Workspace is the single audited chokepoint for all filesystem access within the
+// agent workspace. The canonical root is resolved once at construction; no path
+// component is ever resolved through a symlink afterwards (symlink policy: never
+// follow).
 type Workspace struct {
 	root string // canonical absolute root, post-EvalSymlinks, no trailing separator
 }
@@ -284,4 +286,99 @@ func (w *Workspace) openRegularFile(p string) (*os.File, error) {
 		return nil, errFileChanged
 	}
 	return f, nil
+}
+
+// resolveWriteTarget contains a path to a write destination: cleanRel containment,
+// symlink-free ancestry, and an existing parent directory. If the leaf exists it
+// must be a regular file (never overwrite a symlink or directory). priorExists
+// reports whether the leaf already exists. No filesystem mutation occurs here.
+func (w *Workspace) resolveWriteTarget(p string) (abs string, priorExists bool, err error) {
+	abs, err = w.cleanRel(p)
+	if err != nil {
+		return "", false, err
+	}
+	if err := w.rejectSymlinkAncestors(abs); err != nil {
+		return "", false, err
+	}
+	if fi, perr := os.Lstat(filepath.Dir(abs)); perr != nil || !fi.IsDir() {
+		return "", false, errParentMissing
+	}
+	fi, lerr := os.Lstat(abs)
+	if lerr != nil {
+		if os.IsNotExist(lerr) {
+			return abs, false, nil // new file
+		}
+		return "", false, lerr
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return "", false, errSymlink
+	}
+	if !fi.Mode().IsRegular() {
+		return "", false, errNotRegular
+	}
+	return abs, true, nil
+}
+
+// WriteFileAtomic writes content to a workspace-relative path by creating a temp
+// file in the SAME directory, syncing best-effort, and renaming over the target.
+// It re-validates the target through resolveWriteTarget immediately before the
+// rename so a symlink swapped in after planning is rejected. On POSIX, rename
+// replaces a final symlink rather than following it, so containment holds even if
+// the final component changes after the last check. This is NOT a crash-durability
+// contract (undo is in-memory).
+func (w *Workspace) WriteFileAtomic(p string, content []byte) error {
+	abs, _, err := w.resolveWriteTarget(p)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(abs)
+	tmp, err := os.CreateTemp(dir, ".golem-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	cleanup := func() { _ = tmp.Close(); _ = os.Remove(tmpName) }
+	if _, err := tmp.Write(content); err != nil {
+		cleanup()
+		return err
+	}
+	_ = tmp.Sync() // best-effort durability; not a crash guarantee
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	// Re-validate just before rename; reject a symlink/dir swapped in meanwhile.
+	if _, _, err := w.resolveWriteTarget(p); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, abs); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	return nil
+}
+
+// RemoveFile deletes a single regular file inside the workspace. It refuses
+// directories and symlinks and enforces containment. Used by /undo to revert a
+// file that did not exist before a mutation.
+func (w *Workspace) RemoveFile(p string) error {
+	abs, err := w.cleanRel(p)
+	if err != nil {
+		return err
+	}
+	if err := w.rejectSymlinkAncestors(abs); err != nil {
+		return err
+	}
+	fi, err := os.Lstat(abs)
+	if err != nil {
+		return err
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return errSymlink
+	}
+	if !fi.Mode().IsRegular() {
+		return errNotRegular
+	}
+	return os.Remove(abs)
 }

--- a/agent/tools/paths.go
+++ b/agent/tools/paths.go
@@ -395,3 +395,12 @@ func (w *Workspace) readAll(p string) ([]byte, error) {
 	defer func() { _ = f.Close() }()
 	return io.ReadAll(f)
 }
+
+// ReadFileForUndo returns the full bytes of a workspace-relative regular file for
+// undo verification. It applies the same containment + never-follow-symlink checks
+// as every other access but does NOT apply the binary/size guards (undo compares
+// against a recorded hash, not model-facing content). Returns an error if the file
+// is absent.
+func (w *Workspace) ReadFileForUndo(p string) ([]byte, error) {
+	return w.readAll(p)
+}

--- a/agent/tools/paths.go
+++ b/agent/tools/paths.go
@@ -328,9 +328,17 @@ func (w *Workspace) resolveWriteTarget(p string) (abs string, priorExists bool, 
 // the final component changes after the last check. This is NOT a crash-durability
 // contract (undo is in-memory).
 func (w *Workspace) WriteFileAtomic(p string, content []byte) error {
-	abs, _, err := w.resolveWriteTarget(p)
+	abs, priorExists, err := w.resolveWriteTarget(p)
 	if err != nil {
 		return err
+	}
+	mode := os.FileMode(0o600)
+	if priorExists {
+		fi, err := os.Lstat(abs)
+		if err != nil {
+			return err
+		}
+		mode = fi.Mode().Perm()
 	}
 	dir := filepath.Dir(abs)
 	tmp, err := os.CreateTemp(dir, ".golem-*.tmp")
@@ -340,6 +348,10 @@ func (w *Workspace) WriteFileAtomic(p string, content []byte) error {
 	tmpName := tmp.Name()
 	cleanup := func() { _ = tmp.Close(); _ = os.Remove(tmpName) }
 	if _, err := tmp.Write(content); err != nil {
+		cleanup()
+		return err
+	}
+	if err := tmp.Chmod(mode); err != nil {
 		cleanup()
 		return err
 	}

--- a/agent/tools/paths.go
+++ b/agent/tools/paths.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -381,4 +382,16 @@ func (w *Workspace) RemoveFile(p string) error {
 		return errNotRegular
 	}
 	return os.Remove(abs)
+}
+
+// readAll reads a workspace-relative regular file in full, TOCTOU-hardened via
+// openRegularFile. It is the write-side counterpart used by Plan/Invoke to snapshot
+// current content; callers size-check the result against mutateMaxBytes.
+func (w *Workspace) readAll(p string) ([]byte, error) {
+	f, err := w.openRegularFile(p)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	return io.ReadAll(f)
 }

--- a/agent/tools/paths_test.go
+++ b/agent/tools/paths_test.go
@@ -406,6 +406,26 @@ func TestWriteFileAtomicCreateAndOverwrite(t *testing.T) {
 	}
 }
 
+func TestWriteFileAtomicPreservesExistingMode(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "script.sh")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ws := mustWorkspace(t, root)
+
+	if err := ws.WriteFileAtomic("script.sh", []byte("#!/bin/sh\nexit 1\n")); err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fi.Mode().Perm(); got != 0o755 {
+		t.Fatalf("mode after overwrite = %v, want 0755", got)
+	}
+}
+
 func TestWriteFileAtomicRejectsSymlinkLeaf(t *testing.T) {
 	root := t.TempDir()
 	outside := t.TempDir()

--- a/agent/tools/paths_test.go
+++ b/agent/tools/paths_test.go
@@ -341,3 +341,134 @@ func TestNewFileToolsBadRoot(t *testing.T) {
 		t.Fatal("NewFileTools on a non-existent root should error")
 	}
 }
+
+func TestResolveWriteTargetContainment(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "exist.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "dir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "linkdir")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(root, "exist.txt"), filepath.Join(root, "linkleaf")); err != nil {
+		t.Fatal(err)
+	}
+	ws := mustWorkspace(t, root)
+
+	if _, exists, err := ws.resolveWriteTarget("exist.txt"); err != nil || !exists {
+		t.Fatalf("existing regular file: err=%v exists=%v", err, exists)
+	}
+	if _, exists, err := ws.resolveWriteTarget("new.txt"); err != nil || exists {
+		t.Fatalf("new file in existing dir: err=%v exists=%v", err, exists)
+	}
+	if _, _, err := ws.resolveWriteTarget("../escape.txt"); !errors.Is(err, errEscape) {
+		t.Fatalf("escape: got %v want errEscape", err)
+	}
+	if _, _, err := ws.resolveWriteTarget("dir"); !errors.Is(err, errNotRegular) {
+		t.Fatalf("dir leaf: got %v want errNotRegular", err)
+	}
+	if _, _, err := ws.resolveWriteTarget("linkleaf"); !errors.Is(err, errSymlink) {
+		t.Fatalf("symlink leaf: got %v want errSymlink", err)
+	}
+	if _, _, err := ws.resolveWriteTarget("linkdir/x.txt"); !errors.Is(err, errSymlink) {
+		t.Fatalf("symlink ancestor: got %v want errSymlink", err)
+	}
+	if _, _, err := ws.resolveWriteTarget("missingdir/x.txt"); err == nil {
+		t.Fatal("missing parent dir must error")
+	}
+}
+
+func TestWriteFileAtomicCreateAndOverwrite(t *testing.T) {
+	root := t.TempDir()
+	ws := mustWorkspace(t, root)
+
+	if err := ws.WriteFileAtomic("a.txt", []byte("first")); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(root, "a.txt"))
+	if err != nil || string(got) != "first" {
+		t.Fatalf("after create got %q err %v", got, err)
+	}
+	if err := ws.WriteFileAtomic("a.txt", []byte("second")); err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+	got, _ = os.ReadFile(filepath.Join(root, "a.txt"))
+	if string(got) != "second" {
+		t.Fatalf("after overwrite got %q", got)
+	}
+	ents, _ := os.ReadDir(root)
+	if len(ents) != 1 {
+		t.Fatalf("expected 1 entry, got %d: %v", len(ents), ents)
+	}
+}
+
+func TestWriteFileAtomicRejectsSymlinkLeaf(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	target := filepath.Join(outside, "secret.txt")
+	if err := os.WriteFile(target, []byte("SECRET"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(root, "evil")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	ws := mustWorkspace(t, root)
+	if err := ws.WriteFileAtomic("evil", []byte("x")); !errors.Is(err, errSymlink) {
+		t.Fatalf("write through symlink leaf: got %v want errSymlink", err)
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != "SECRET" {
+		t.Fatalf("symlink write escaped root: target now %q", got)
+	}
+}
+
+func TestRemoveFile(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "keep.txt"), []byte("y"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "dir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ws := mustWorkspace(t, root)
+	if err := ws.RemoveFile("a.txt"); err != nil {
+		t.Fatalf("remove regular: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "a.txt")); !os.IsNotExist(err) {
+		t.Fatal("file not removed")
+	}
+	if err := ws.RemoveFile("dir"); !errors.Is(err, errNotRegular) {
+		t.Fatalf("remove dir: got %v want errNotRegular", err)
+	}
+	if err := os.Symlink(filepath.Join(root, "keep.txt"), filepath.Join(root, "lnk")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if err := ws.RemoveFile("lnk"); !errors.Is(err, errSymlink) {
+		t.Fatalf("remove symlink leaf: got %v want errSymlink", err)
+	}
+	if err := ws.RemoveFile("../x"); !errors.Is(err, errEscape) {
+		t.Fatalf("remove escape: got %v want errEscape", err)
+	}
+}
+
+func TestWriteFileAtomicRejectsSymlinkAncestor(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "linkdir")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	ws := mustWorkspace(t, root)
+	if err := ws.WriteFileAtomic("linkdir/new.txt", []byte("x")); !errors.Is(err, errSymlink) {
+		t.Fatalf("write through symlink ancestor: got %v want errSymlink", err)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "new.txt")); !os.IsNotExist(err) {
+		t.Fatal("write escaped root through symlinked ancestor")
+	}
+}

--- a/agent/tools/write.go
+++ b/agent/tools/write.go
@@ -1,0 +1,127 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/agent"
+)
+
+// WriteFile creates or overwrites a workspace file. It is a PlanningTool: Plan
+// computes the diff preview and stashes the resulting content keyed by raw-args
+// hash; Invoke re-checks the previewed state and writes atomically.
+type WriteFile struct {
+	ws *Workspace
+	j  Journal
+	mutatingBase
+}
+
+// NewWriteFile builds the write_file tool bound to ws, reporting applied writes
+// to journal (may be nil).
+func NewWriteFile(ws *Workspace, journal Journal) *WriteFile {
+	return &WriteFile{ws: ws, j: journal}
+}
+
+type writeFileArgs struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
+func (*WriteFile) Spec() agent.ToolSpec {
+	return agent.ToolSpec{
+		Name:        "write_file",
+		Description: "Create a new file or fully overwrite an existing one in the workspace. Paths are relative to the workspace root; escaping the root or following a symlink is refused. The change is shown as a diff and requires user approval before it is applied.",
+		Parameters: json.RawMessage(`{
+  "type":"object",
+  "properties":{
+    "path":{"type":"string","description":"file path relative to the workspace root"},
+    "content":{"type":"string","description":"the full new file content"}
+  },
+  "required":["path","content"]
+}`),
+	}
+}
+
+func (*WriteFile) Effect() agent.Effect {
+	return agent.Effect{Class: agent.Write, Approval: agent.ApprovalOnWrite}
+}
+
+// Plan computes the preview and stashes the pending plan. It never mutates. On any
+// validation failure it returns a ToolPlan with no Preview so the call is still
+// gated (Effect is Write) but the matching Invoke will fail closed (no pending plan).
+func (t *WriteFile) Plan(_ context.Context, raw json.RawMessage) (agent.ToolPlan, error) {
+	eff := t.Effect()
+	var args writeFileArgs
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return agent.ToolPlan{Effect: eff}, nil
+	}
+	if args.Path == "" || len(args.Content) > mutateMaxBytes {
+		return agent.ToolPlan{Effect: eff}, nil
+	}
+	_, priorExists, err := t.ws.resolveWriteTarget(args.Path)
+	if err != nil {
+		return agent.ToolPlan{Effect: eff}, nil
+	}
+	var prior []byte
+	beforeHash := absentHash
+	if priorExists {
+		prior, err = t.ws.readAll(args.Path)
+		if err != nil || len(prior) > mutateMaxBytes {
+			return agent.ToolPlan{Effect: eff}, nil
+		}
+		beforeHash = contentHash(prior)
+	}
+	content := []byte(args.Content)
+	preview := unifiedDiff(args.Path, prior, content, priorExists)
+	t.store(contentHash(raw), pendingPlan{
+		path:         args.Path,
+		priorContent: prior,
+		priorExists:  priorExists,
+		beforeHash:   beforeHash,
+		afterContent: content,
+		afterHash:    contentHash(content),
+		summary:      fmt.Sprintf("write %s", args.Path),
+	})
+	return agent.ToolPlan{Effect: eff, Preview: preview}, nil
+}
+
+func (t *WriteFile) Invoke(_ context.Context, raw json.RawMessage) (agent.ToolResult, error) {
+	pp, ok := t.consume(contentHash(raw))
+	if !ok {
+		return errResult("mutation preview missing; retry"), nil
+	}
+	// Defensive invariant: Plan already rejects oversize content (no plan is stored),
+	// so this never fires in normal flow; it guards against a future carrier change.
+	if len(pp.afterContent) > mutateMaxBytes {
+		return errResult("content exceeds size limit"), nil
+	}
+	_, nowExists, err := t.ws.resolveWriteTarget(pp.path)
+	if err != nil {
+		return errResult(err.Error()), nil
+	}
+	curHash := absentHash
+	if nowExists {
+		cur, rerr := t.ws.readAll(pp.path)
+		if rerr != nil {
+			return errResult(rerr.Error()), nil
+		}
+		curHash = contentHash(cur)
+	}
+	if nowExists != pp.priorExists || curHash != pp.beforeHash {
+		return errResult("file changed since preview; retry"), nil
+	}
+	// Residual TOCTOU window: an external process could change the file's content
+	// between this re-read and the rename below. WriteFileAtomic re-checks path TYPE
+	// (symlink/dir) before renaming but not content; without OS file locks this is an
+	// accepted limitation for a local single-user coding agent.
+	if err := t.ws.WriteFileAtomic(pp.path, pp.afterContent); err != nil {
+		return errResult(err.Error()), nil
+	}
+	record(t.j, MutationRecord{
+		Path: pp.path, PriorContent: pp.priorContent, Existed: pp.priorExists,
+		AfterHash: pp.afterHash, Summary: pp.summary, At: time.Now(),
+	})
+	return agent.ToolResult{Content: pp.summary, Preview: pp.summary}, nil
+}

--- a/agent/tools/write.go
+++ b/agent/tools/write.go
@@ -50,30 +50,39 @@ func (*WriteFile) Effect() agent.Effect {
 }
 
 // Plan computes the preview and stashes the pending plan. It never mutates. On any
-// validation failure it returns a ToolPlan with no Preview so the call is still
-// gated (Effect is Write) but the matching Invoke will fail closed (no pending plan).
+// validation failure it returns an error so dispatch reports the failure without
+// asking the user to approve an empty diff.
 func (t *WriteFile) Plan(_ context.Context, raw json.RawMessage) (agent.ToolPlan, error) {
 	eff := t.Effect()
 	var args writeFileArgs
 	if err := json.Unmarshal(raw, &args); err != nil {
-		return agent.ToolPlan{Effect: eff}, nil
+		return agent.ToolPlan{Effect: eff}, fmt.Errorf("invalid arguments: %w", err)
 	}
-	if args.Path == "" || len(args.Content) > mutateMaxBytes {
-		return agent.ToolPlan{Effect: eff}, nil
+	if args.Path == "" {
+		return agent.ToolPlan{Effect: eff}, fmt.Errorf("path is required")
+	}
+	if len(args.Content) > mutateMaxBytes {
+		return agent.ToolPlan{Effect: eff}, fmt.Errorf("content exceeds size limit")
 	}
 	if bytes.IndexByte([]byte(args.Content), 0) >= 0 {
-		return agent.ToolPlan{Effect: eff}, nil // refuse binary content (no approvable preview)
+		return agent.ToolPlan{Effect: eff}, fmt.Errorf("content contains NUL byte; refusing to write binary content")
 	}
 	_, priorExists, err := t.ws.resolveWriteTarget(args.Path)
 	if err != nil {
-		return agent.ToolPlan{Effect: eff}, nil
+		return agent.ToolPlan{Effect: eff}, err
 	}
 	var prior []byte
 	beforeHash := absentHash
 	if priorExists {
 		prior, err = t.ws.readAll(args.Path)
-		if err != nil || len(prior) > mutateMaxBytes {
-			return agent.ToolPlan{Effect: eff}, nil
+		if err != nil {
+			return agent.ToolPlan{Effect: eff}, err
+		}
+		if len(prior) > mutateMaxBytes {
+			return agent.ToolPlan{Effect: eff}, fmt.Errorf("file exceeds size limit")
+		}
+		if bytes.IndexByte(prior, 0) >= 0 {
+			return agent.ToolPlan{Effect: eff}, fmt.Errorf("binary file (NUL byte detected); refusing to overwrite")
 		}
 		beforeHash = ContentHash(prior)
 	}

--- a/agent/tools/write.go
+++ b/agent/tools/write.go
@@ -75,24 +75,24 @@ func (t *WriteFile) Plan(_ context.Context, raw json.RawMessage) (agent.ToolPlan
 		if err != nil || len(prior) > mutateMaxBytes {
 			return agent.ToolPlan{Effect: eff}, nil
 		}
-		beforeHash = contentHash(prior)
+		beforeHash = ContentHash(prior)
 	}
 	content := []byte(args.Content)
 	preview := unifiedDiff(args.Path, prior, content, priorExists)
-	t.store(contentHash(raw), pendingPlan{
+	t.store(ContentHash(raw), pendingPlan{
 		path:         args.Path,
 		priorContent: prior,
 		priorExists:  priorExists,
 		beforeHash:   beforeHash,
 		afterContent: content,
-		afterHash:    contentHash(content),
+		afterHash:    ContentHash(content),
 		summary:      fmt.Sprintf("write %s", args.Path),
 	})
 	return agent.ToolPlan{Effect: eff, Preview: preview}, nil
 }
 
 func (t *WriteFile) Invoke(_ context.Context, raw json.RawMessage) (agent.ToolResult, error) {
-	pp, ok := t.consume(contentHash(raw))
+	pp, ok := t.consume(ContentHash(raw))
 	if !ok {
 		return errResult("mutation preview missing; retry"), nil
 	}
@@ -111,7 +111,7 @@ func (t *WriteFile) Invoke(_ context.Context, raw json.RawMessage) (agent.ToolRe
 		if rerr != nil {
 			return errResult(rerr.Error()), nil
 		}
-		curHash = contentHash(cur)
+		curHash = ContentHash(cur)
 	}
 	if nowExists != pp.priorExists || curHash != pp.beforeHash {
 		return errResult("file changed since preview; retry"), nil

--- a/agent/tools/write.go
+++ b/agent/tools/write.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -59,6 +60,9 @@ func (t *WriteFile) Plan(_ context.Context, raw json.RawMessage) (agent.ToolPlan
 	}
 	if args.Path == "" || len(args.Content) > mutateMaxBytes {
 		return agent.ToolPlan{Effect: eff}, nil
+	}
+	if bytes.IndexByte([]byte(args.Content), 0) >= 0 {
+		return agent.ToolPlan{Effect: eff}, nil // refuse binary content (no approvable preview)
 	}
 	_, priorExists, err := t.ws.resolveWriteTarget(args.Path)
 	if err != nil {

--- a/agent/tools/write_test.go
+++ b/agent/tools/write_test.go
@@ -126,12 +126,8 @@ func TestWriteFileSizeCap(t *testing.T) {
 	wf := NewWriteFile(mustWorkspace(t, root), nil)
 	big := strings.Repeat("x", mutateMaxBytes+1)
 	raw, _ := json.Marshal(map[string]any{"path": "big.txt", "content": big})
-	plan, err := wf.Plan(context.Background(), raw)
-	if err != nil {
-		t.Fatalf("Plan: %v", err)
-	}
-	if plan.Preview != "" {
-		t.Fatalf("oversize Plan should not produce an approvable preview: %q", plan.Preview)
+	if _, err := wf.Plan(context.Background(), raw); err == nil || !strings.Contains(err.Error(), "size limit") {
+		t.Fatalf("oversize Plan error = %v, want size limit", err)
 	}
 	res, _ := wf.Invoke(context.Background(), raw)
 	if !res.IsError || !strings.Contains(res.Content, "preview missing") {
@@ -150,12 +146,8 @@ func TestWriteFileEffect(t *testing.T) {
 func TestWriteFileParentDirMissing(t *testing.T) {
 	wf := NewWriteFile(mustWorkspace(t, t.TempDir()), nil)
 	raw, _ := json.Marshal(map[string]any{"path": "nosuchdir/file.txt", "content": "x"})
-	plan, err := wf.Plan(context.Background(), raw)
-	if err != nil {
-		t.Fatalf("Plan: %v", err)
-	}
-	if plan.Preview != "" {
-		t.Fatalf("missing parent must not produce an approvable preview: %q", plan.Preview)
+	if _, err := wf.Plan(context.Background(), raw); err == nil {
+		t.Fatal("missing parent must fail during Plan")
 	}
 	res, _ := wf.Invoke(context.Background(), raw)
 	if !res.IsError {
@@ -186,9 +178,8 @@ func TestWriteFileRejectsNulContent(t *testing.T) {
 	root := t.TempDir()
 	wf := NewWriteFile(mustWorkspace(t, root), nil)
 	raw, _ := json.Marshal(map[string]any{"path": "bin.txt", "content": "a\x00b"})
-	plan, _ := wf.Plan(context.Background(), raw)
-	if plan.Preview != "" {
-		t.Fatalf("NUL content must not produce a preview: %q", plan.Preview)
+	if _, err := wf.Plan(context.Background(), raw); err == nil || !strings.Contains(err.Error(), "NUL") {
+		t.Fatalf("NUL content Plan error = %v, want NUL", err)
 	}
 	res, _ := wf.Invoke(context.Background(), raw)
 	if !res.IsError {
@@ -196,5 +187,17 @@ func TestWriteFileRejectsNulContent(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(root, "bin.txt")); !os.IsNotExist(err) {
 		t.Fatal("rejected NUL write must not create the file")
+	}
+}
+
+func TestWriteFileRejectsBinaryPrior(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "bin.txt"), []byte("a\x00b"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	wf := NewWriteFile(mustWorkspace(t, root), nil)
+	raw, _ := json.Marshal(map[string]any{"path": "bin.txt", "content": "text"})
+	if _, err := wf.Plan(context.Background(), raw); err == nil || !strings.Contains(err.Error(), "binary") {
+		t.Fatalf("binary prior Plan error = %v, want binary", err)
 	}
 }

--- a/agent/tools/write_test.go
+++ b/agent/tools/write_test.go
@@ -54,7 +54,7 @@ func TestWriteFileCreate(t *testing.T) {
 	if string(got) != "hello\n" {
 		t.Fatalf("file content = %q", got)
 	}
-	if len(jr.recs) != 1 || jr.recs[0].Existed || jr.recs[0].AfterHash != contentHash([]byte("hello\n")) {
+	if len(jr.recs) != 1 || jr.recs[0].Existed || jr.recs[0].AfterHash != ContentHash([]byte("hello\n")) {
 		t.Fatalf("journal record wrong: %+v", jr.recs)
 	}
 }

--- a/agent/tools/write_test.go
+++ b/agent/tools/write_test.go
@@ -181,3 +181,20 @@ func TestWriteFileDeletedBetweenPlanAndInvoke(t *testing.T) {
 		t.Fatalf("deletion between plan and invoke must fail: %+v", res)
 	}
 }
+
+func TestWriteFileRejectsNulContent(t *testing.T) {
+	root := t.TempDir()
+	wf := NewWriteFile(mustWorkspace(t, root), nil)
+	raw, _ := json.Marshal(map[string]any{"path": "bin.txt", "content": "a\x00b"})
+	plan, _ := wf.Plan(context.Background(), raw)
+	if plan.Preview != "" {
+		t.Fatalf("NUL content must not produce a preview: %q", plan.Preview)
+	}
+	res, _ := wf.Invoke(context.Background(), raw)
+	if !res.IsError {
+		t.Fatal("NUL content write must fail")
+	}
+	if _, err := os.Stat(filepath.Join(root, "bin.txt")); !os.IsNotExist(err) {
+		t.Fatal("rejected NUL write must not create the file")
+	}
+}

--- a/agent/tools/write_test.go
+++ b/agent/tools/write_test.go
@@ -1,0 +1,183 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/agent"
+)
+
+// recJournal is a test Journal capturing records.
+type recJournal struct{ recs []MutationRecord }
+
+func (r *recJournal) Record(m MutationRecord) { r.recs = append(r.recs, m) }
+
+// planThenInvoke runs Plan then Invoke with the SAME raw args, mirroring dispatch.
+func planThenInvoke(t *testing.T, tool agent.Tool, args any) (agent.ToolPlan, agent.ToolResult) {
+	t.Helper()
+	raw, err := json.Marshal(args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pt, ok := tool.(agent.PlanningTool)
+	if !ok {
+		t.Fatal("tool is not a PlanningTool")
+	}
+	plan, perr := pt.Plan(context.Background(), raw)
+	if perr != nil {
+		t.Fatalf("Plan: %v", perr)
+	}
+	res, ierr := tool.Invoke(context.Background(), raw)
+	if ierr != nil {
+		t.Fatalf("Invoke returned a Go error: %v", ierr)
+	}
+	return plan, res
+}
+
+func TestWriteFileCreate(t *testing.T) {
+	root := t.TempDir()
+	jr := &recJournal{}
+	wf := NewWriteFile(mustWorkspace(t, root), jr)
+
+	plan, res := planThenInvoke(t, wf, map[string]any{"path": "new.txt", "content": "hello\n"})
+	if res.IsError {
+		t.Fatalf("create errored: %s", res.Content)
+	}
+	if !strings.Contains(plan.Preview, "new file: new.txt") {
+		t.Fatalf("plan preview wrong: %s", plan.Preview)
+	}
+	got, _ := os.ReadFile(filepath.Join(root, "new.txt"))
+	if string(got) != "hello\n" {
+		t.Fatalf("file content = %q", got)
+	}
+	if len(jr.recs) != 1 || jr.recs[0].Existed || jr.recs[0].AfterHash != contentHash([]byte("hello\n")) {
+		t.Fatalf("journal record wrong: %+v", jr.recs)
+	}
+}
+
+func TestWriteFileOverwriteRecordsPrior(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("OLD\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	jr := &recJournal{}
+	wf := NewWriteFile(mustWorkspace(t, root), jr)
+
+	_, res := planThenInvoke(t, wf, map[string]any{"path": "a.txt", "content": "NEW\n"})
+	if res.IsError {
+		t.Fatalf("overwrite errored: %s", res.Content)
+	}
+	got, _ := os.ReadFile(filepath.Join(root, "a.txt"))
+	if string(got) != "NEW\n" {
+		t.Fatalf("content = %q", got)
+	}
+	if len(jr.recs) != 1 || !jr.recs[0].Existed || string(jr.recs[0].PriorContent) != "OLD\n" {
+		t.Fatalf("journal must capture prior bytes: %+v", jr.recs)
+	}
+}
+
+func TestWriteFilePlanDoesNotMutate(t *testing.T) {
+	root := t.TempDir()
+	wf := NewWriteFile(mustWorkspace(t, root), nil)
+	raw, _ := json.Marshal(map[string]any{"path": "x.txt", "content": "data"})
+	if _, err := wf.Plan(context.Background(), raw); err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "x.txt")); !os.IsNotExist(err) {
+		t.Fatal("Plan must not create the file")
+	}
+}
+
+func TestWriteFileMissingPendingPlanFails(t *testing.T) {
+	root := t.TempDir()
+	wf := NewWriteFile(mustWorkspace(t, root), nil)
+	res := invoke(t, wf, map[string]any{"path": "x.txt", "content": "data"})
+	if !res.IsError || !strings.Contains(res.Content, "preview missing") {
+		t.Fatalf("invoke without plan must fail: %+v", res)
+	}
+}
+
+func TestWriteFilePreviewStateChangedFails(t *testing.T) {
+	root := t.TempDir()
+	wf := NewWriteFile(mustWorkspace(t, root), nil)
+	raw, _ := json.Marshal(map[string]any{"path": "a.txt", "content": "NEW"})
+	if _, err := wf.Plan(context.Background(), raw); err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("SNUCK"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	res, _ := wf.Invoke(context.Background(), raw)
+	if !res.IsError || !strings.Contains(res.Content, "changed since preview") {
+		t.Fatalf("preview-state mismatch must fail: %+v", res)
+	}
+	got, _ := os.ReadFile(filepath.Join(root, "a.txt"))
+	if string(got) != "SNUCK" {
+		t.Fatalf("failed write must not clobber: %q", got)
+	}
+}
+
+func TestWriteFileSizeCap(t *testing.T) {
+	root := t.TempDir()
+	wf := NewWriteFile(mustWorkspace(t, root), nil)
+	big := strings.Repeat("x", mutateMaxBytes+1)
+	raw, _ := json.Marshal(map[string]any{"path": "big.txt", "content": big})
+	plan, err := wf.Plan(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if plan.Preview != "" {
+		t.Fatalf("oversize Plan should not produce an approvable preview: %q", plan.Preview)
+	}
+	res, _ := wf.Invoke(context.Background(), raw)
+	if !res.IsError || !strings.Contains(res.Content, "preview missing") {
+		t.Fatalf("oversize write must fail closed via missing plan: %+v", res)
+	}
+}
+
+func TestWriteFileEffect(t *testing.T) {
+	wf := NewWriteFile(mustWorkspace(t, t.TempDir()), nil)
+	e := wf.Effect()
+	if e.Class != agent.Write || e.Approval != agent.ApprovalOnWrite {
+		t.Fatalf("Effect = %+v, want Write/ApprovalOnWrite", e)
+	}
+}
+
+func TestWriteFileParentDirMissing(t *testing.T) {
+	wf := NewWriteFile(mustWorkspace(t, t.TempDir()), nil)
+	raw, _ := json.Marshal(map[string]any{"path": "nosuchdir/file.txt", "content": "x"})
+	plan, err := wf.Plan(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if plan.Preview != "" {
+		t.Fatalf("missing parent must not produce an approvable preview: %q", plan.Preview)
+	}
+	res, _ := wf.Invoke(context.Background(), raw)
+	if !res.IsError {
+		t.Fatal("Invoke with no plan must error")
+	}
+}
+
+func TestWriteFileDeletedBetweenPlanAndInvoke(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("OLD\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	wf := NewWriteFile(mustWorkspace(t, root), nil)
+	raw, _ := json.Marshal(map[string]any{"path": "a.txt", "content": "NEW\n"})
+	if _, err := wf.Plan(context.Background(), raw); err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if err := os.Remove(filepath.Join(root, "a.txt")); err != nil {
+		t.Fatal(err)
+	}
+	res, _ := wf.Invoke(context.Background(), raw)
+	if !res.IsError || !strings.Contains(res.Content, "changed since preview") {
+		t.Fatalf("deletion between plan and invoke must fail: %+v", res)
+	}
+}

--- a/cmd/golem/approver.go
+++ b/cmd/golem/approver.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/kstruzzieri/go-llm/agent"
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// replApprover renders a mutation's diff preview and prompts the user for a single
+// [y/N] decision over the shared lineReader. It is wired into agent.Request.Approver
+// only when -allow-write is set; otherwise the runtime's nil-approver fail-safe
+// denies every mutating call.
+type replApprover struct {
+	lr    *lineReader
+	out   io.Writer
+	color bool
+}
+
+// Compile-time assertion: replApprover must satisfy agent.Approver.
+var _ agent.Approver = (*replApprover)(nil)
+
+func newReplApprover(lr *lineReader, out io.Writer, color bool) *replApprover {
+	return &replApprover{lr: lr, out: out, color: color}
+}
+
+// Approve prints the diff and reads one line. "y"/"yes" (case-insensitive) approves.
+// "n", empty, and EOF deny with a nil error. A canceled context (Ctrl-C) denies and
+// returns the context error so the run aborts.
+func (a *replApprover) Approve(ctx context.Context, _ provider.ToolCall, preview string) (bool, error) {
+	a.renderDiff(preview)
+	_, _ = fmt.Fprint(a.out, "Apply this change? [y/N] ")
+	line, ok, err := a.lr.ReadLine(ctx)
+	if err != nil {
+		return false, err // ctx canceled: abort the run
+	}
+	if !ok {
+		_, _ = fmt.Fprintln(a.out)
+		return false, nil // EOF: deny
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+func (a *replApprover) renderDiff(preview string) {
+	if !a.color {
+		_, _ = fmt.Fprintln(a.out, preview)
+		return
+	}
+	for _, ln := range strings.Split(strings.TrimRight(preview, "\n"), "\n") {
+		switch {
+		case strings.HasPrefix(ln, "+"):
+			_, _ = fmt.Fprintf(a.out, "\x1b[32m%s\x1b[0m\n", ln) // green add
+		case strings.HasPrefix(ln, "-"):
+			_, _ = fmt.Fprintf(a.out, "\x1b[31m%s\x1b[0m\n", ln) // red remove
+		default:
+			_, _ = fmt.Fprintln(a.out, ln)
+		}
+	}
+}

--- a/cmd/golem/approver_test.go
+++ b/cmd/golem/approver_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+func newCall() provider.ToolCall {
+	return provider.ToolCall{
+		ID: "c1", Type: "function",
+		Function: provider.ToolCallFunction{Name: "write_file"},
+	}
+}
+
+func TestReplApproverApprovesOnYes(t *testing.T) {
+	for _, in := range []string{"y\n", "yes\n", "Y\n"} {
+		var out strings.Builder
+		lr := newLineReader(strings.NewReader(in))
+		ap := newReplApprover(lr, &out, false)
+		ok, err := ap.Approve(context.Background(), newCall(), "--- a\n+old\n")
+		if err != nil || !ok {
+			t.Fatalf("input %q: ok=%v err=%v", in, ok, err)
+		}
+		if !strings.Contains(out.String(), "Apply this change?") {
+			t.Fatalf("prompt missing for %q:\n%s", in, out.String())
+		}
+		if !strings.Contains(out.String(), "+old") {
+			t.Fatalf("diff not rendered for %q:\n%s", in, out.String())
+		}
+	}
+}
+
+func TestReplApproverDeniesOnNoEmptyEOF(t *testing.T) {
+	for _, in := range []string{"n\n", "\n", ""} {
+		var out strings.Builder
+		lr := newLineReader(strings.NewReader(in))
+		ap := newReplApprover(lr, &out, false)
+		ok, err := ap.Approve(context.Background(), newCall(), "preview")
+		if err != nil || ok {
+			t.Fatalf("input %q must deny: ok=%v err=%v", in, ok, err)
+		}
+	}
+}
+
+func TestReplApproverContextCancelAborts(t *testing.T) {
+	pr, pw := io.Pipe()
+	defer func() { _ = pw.Close() }()
+	var out strings.Builder
+	lr := newLineReader(pr)
+	ap := newReplApprover(lr, &out, false)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ok, err := ap.Approve(ctx, newCall(), "preview")
+	if ok || err == nil {
+		t.Fatalf("canceled approval must deny with error: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestReplApproverColorRendersAnsi(t *testing.T) {
+	var out strings.Builder
+	lr := newLineReader(strings.NewReader("n\n"))
+	ap := newReplApprover(lr, &out, true) // color on
+	_, _ = ap.Approve(context.Background(), newCall(), "+added\n-removed\n context\n")
+	s := out.String()
+	if !strings.Contains(s, "\x1b[32m+added") {
+		t.Fatalf("added line not green:\n%q", s)
+	}
+	if !strings.Contains(s, "\x1b[31m-removed") {
+		t.Fatalf("removed line not red:\n%q", s)
+	}
+}

--- a/cmd/golem/journal.go
+++ b/cmd/golem/journal.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	agenttools "github.com/kstruzzieri/go-llm/agent/tools"
+)
+
+// mutationJournal is the in-session undo stack. It implements agenttools.Journal,
+// receiving a record after each applied write, and restores the most recent
+// mutation on /undo via the same containment-checked Workspace primitives the tools
+// use. Records are RAM-only (lost at exit), which is acceptable for an interactive
+// REPL. peek -> verify -> restore -> pop: a refused or failed undo leaves the
+// record on the stack so nothing is lost.
+type mutationJournal struct {
+	ws   *agenttools.Workspace
+	mu   sync.Mutex
+	recs []agenttools.MutationRecord
+}
+
+func newMutationJournal(ws *agenttools.Workspace) *mutationJournal {
+	return &mutationJournal{ws: ws}
+}
+
+// Record pushes a successful mutation. Safe for concurrent use.
+func (j *mutationJournal) Record(rec agenttools.MutationRecord) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.recs = append(j.recs, rec)
+}
+
+// undo reverts the most recent mutation, writing status to out.
+func (j *mutationJournal) undo(out io.Writer) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if len(j.recs) == 0 {
+		_, _ = fmt.Fprintln(out, "nothing to undo")
+		return
+	}
+	rec := j.recs[len(j.recs)-1] // peek
+
+	cur, err := j.ws.ReadFileForUndo(rec.Path)
+	curExists := err == nil
+	curHash := ""
+	if curExists {
+		curHash = agenttools.ContentHash(cur)
+	}
+	if curExists && curHash != rec.AfterHash {
+		_, _ = fmt.Fprintf(out, "cannot undo %s: file changed since golem wrote it\n", rec.Path)
+		return // leave the record on the stack
+	}
+
+	if rec.Existed {
+		if werr := j.ws.WriteFileAtomic(rec.Path, rec.PriorContent); werr != nil {
+			_, _ = fmt.Fprintf(out, "undo failed for %s: %v\n", rec.Path, werr)
+			return
+		}
+	} else {
+		if !curExists {
+			// The created file is already gone — desired state reached. Pop and report.
+			j.recs = j.recs[:len(j.recs)-1]
+			_, _ = fmt.Fprintf(out, "undid %s (already absent)\n", rec.Path)
+			return
+		}
+		if rerr := j.ws.RemoveFile(rec.Path); rerr != nil {
+			_, _ = fmt.Fprintf(out, "undo failed for %s: %v\n", rec.Path, rerr)
+			return
+		}
+	}
+	j.recs = j.recs[:len(j.recs)-1] // pop only on success
+	_, _ = fmt.Fprintf(out, "undid %s\n", rec.Path)
+}

--- a/cmd/golem/journal.go
+++ b/cmd/golem/journal.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"os"
 	"sync"
 
 	agenttools "github.com/kstruzzieri/go-llm/agent/tools"
@@ -44,10 +45,24 @@ func (j *mutationJournal) undo(out io.Writer) {
 	cur, err := j.ws.ReadFileForUndo(rec.Path)
 	curExists := err == nil
 	curHash := ""
+	if err != nil && !os.IsNotExist(err) {
+		_, _ = fmt.Fprintf(out, "cannot undo %s: file changed since golem wrote it\n", rec.Path)
+		return // leave the record on the stack
+	}
 	if curExists {
 		curHash = agenttools.ContentHash(cur)
 	}
-	if curExists && curHash != rec.AfterHash {
+	if !curExists {
+		if !rec.Existed {
+			// The created file is already gone — desired state reached. Pop and report.
+			j.recs = j.recs[:len(j.recs)-1]
+			_, _ = fmt.Fprintf(out, "undid %s (already absent)\n", rec.Path)
+			return
+		}
+		_, _ = fmt.Fprintf(out, "cannot undo %s: file changed since golem wrote it\n", rec.Path)
+		return // leave the record on the stack
+	}
+	if curHash != rec.AfterHash {
 		_, _ = fmt.Fprintf(out, "cannot undo %s: file changed since golem wrote it\n", rec.Path)
 		return // leave the record on the stack
 	}
@@ -58,12 +73,6 @@ func (j *mutationJournal) undo(out io.Writer) {
 			return
 		}
 	} else {
-		if !curExists {
-			// The created file is already gone — desired state reached. Pop and report.
-			j.recs = j.recs[:len(j.recs)-1]
-			_, _ = fmt.Fprintf(out, "undid %s (already absent)\n", rec.Path)
-			return
-		}
 		if rerr := j.ws.RemoveFile(rec.Path); rerr != nil {
 			_, _ = fmt.Fprintf(out, "undo failed for %s: %v\n", rec.Path, rerr)
 			return

--- a/cmd/golem/journal_test.go
+++ b/cmd/golem/journal_test.go
@@ -118,3 +118,35 @@ func TestUndoCreatedFileAlreadyAbsent(t *testing.T) {
 		t.Fatalf("record should have been popped: %q", out2.String())
 	}
 }
+
+func TestUndoCreatedFileRefusesNonRegularReplacement(t *testing.T) {
+	root := t.TempDir()
+	jr, ws := newJournal(t, root)
+	_ = ws.WriteFileAtomic("new.txt", []byte("DATA"))
+	jr.Record(agenttools.MutationRecord{Path: "new.txt", Existed: false, AfterHash: hashFor("DATA")})
+	if err := os.Remove(filepath.Join(root, "new.txt")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "new.txt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var out strings.Builder
+	jr.undo(&out)
+	if !strings.Contains(out.String(), "changed since") {
+		t.Fatalf("undo should refuse non-regular replacement: %q", out.String())
+	}
+	if fi, err := os.Stat(filepath.Join(root, "new.txt")); err != nil || !fi.IsDir() {
+		t.Fatalf("replacement directory should remain: fi=%v err=%v", fi, err)
+	}
+
+	if err := os.Remove(filepath.Join(root, "new.txt")); err != nil {
+		t.Fatal(err)
+	}
+	_ = ws.WriteFileAtomic("new.txt", []byte("DATA"))
+	var out2 strings.Builder
+	jr.undo(&out2)
+	if _, err := os.Stat(filepath.Join(root, "new.txt")); !os.IsNotExist(err) {
+		t.Fatalf("record should remain after refusal and later undo should delete file: %v", err)
+	}
+}

--- a/cmd/golem/journal_test.go
+++ b/cmd/golem/journal_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	agenttools "github.com/kstruzzieri/go-llm/agent/tools"
+)
+
+func hashFor(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+func newJournal(t *testing.T, root string) (*mutationJournal, *agenttools.Workspace) {
+	t.Helper()
+	ws, err := agenttools.NewWorkspace(root)
+	if err != nil {
+		t.Fatalf("NewWorkspace: %v", err)
+	}
+	return newMutationJournal(ws), ws
+}
+
+func TestUndoRestoresOverwrite(t *testing.T) {
+	root := t.TempDir()
+	jr, ws := newJournal(t, root)
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("OLD"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_ = ws.WriteFileAtomic("a.txt", []byte("NEW"))
+	jr.Record(agenttools.MutationRecord{
+		Path: "a.txt", PriorContent: []byte("OLD"), Existed: true,
+		AfterHash: hashFor("NEW"),
+	})
+	var out strings.Builder
+	jr.undo(&out)
+	got, _ := os.ReadFile(filepath.Join(root, "a.txt"))
+	if string(got) != "OLD" {
+		t.Fatalf("undo did not restore prior content: %q", got)
+	}
+	if !strings.Contains(out.String(), "undid a.txt") {
+		t.Fatalf("undo should report success: %q", out.String())
+	}
+}
+
+func TestUndoDeletesCreatedFile(t *testing.T) {
+	root := t.TempDir()
+	jr, ws := newJournal(t, root)
+	_ = ws.WriteFileAtomic("new.txt", []byte("DATA"))
+	jr.Record(agenttools.MutationRecord{
+		Path: "new.txt", Existed: false, AfterHash: hashFor("DATA"),
+	})
+	var out strings.Builder
+	jr.undo(&out)
+	if _, err := os.Stat(filepath.Join(root, "new.txt")); !os.IsNotExist(err) {
+		t.Fatal("undo of a created file must delete it")
+	}
+}
+
+func TestUndoRefusesWhenChangedSince(t *testing.T) {
+	root := t.TempDir()
+	jr, ws := newJournal(t, root)
+	_ = ws.WriteFileAtomic("a.txt", []byte("NEW"))
+	jr.Record(agenttools.MutationRecord{
+		Path: "a.txt", PriorContent: []byte("OLD"), Existed: true, AfterHash: hashFor("NEW"),
+	})
+	_ = os.WriteFile(filepath.Join(root, "a.txt"), []byte("USER-EDIT"), 0o600)
+	var out strings.Builder
+	jr.undo(&out)
+	got, _ := os.ReadFile(filepath.Join(root, "a.txt"))
+	if string(got) != "USER-EDIT" {
+		t.Fatalf("undo must not clobber a changed file: %q", got)
+	}
+	if !strings.Contains(out.String(), "changed since") {
+		t.Fatalf("undo should explain the refusal:\n%s", out.String())
+	}
+	// Record must remain on the stack: after restoring the expected state, a second
+	// undo should now succeed.
+	_ = os.WriteFile(filepath.Join(root, "a.txt"), []byte("NEW"), 0o600)
+	var out2 strings.Builder
+	jr.undo(&out2)
+	got, _ = os.ReadFile(filepath.Join(root, "a.txt"))
+	if string(got) != "OLD" {
+		t.Fatalf("record should have survived the refused undo: %q", got)
+	}
+}
+
+func TestUndoEmptyStack(t *testing.T) {
+	root := t.TempDir()
+	jr, _ := newJournal(t, root)
+	var out strings.Builder
+	jr.undo(&out)
+	if !strings.Contains(out.String(), "nothing to undo") {
+		t.Fatalf("empty stack message missing:\n%s", out.String())
+	}
+}
+
+func TestUndoCreatedFileAlreadyAbsent(t *testing.T) {
+	root := t.TempDir()
+	jr, ws := newJournal(t, root)
+	_ = ws.WriteFileAtomic("new.txt", []byte("DATA"))
+	jr.Record(agenttools.MutationRecord{Path: "new.txt", Existed: false, AfterHash: hashFor("DATA")})
+	// User deletes it before /undo.
+	_ = os.Remove(filepath.Join(root, "new.txt"))
+	var out strings.Builder
+	jr.undo(&out)
+	if !strings.Contains(out.String(), "already absent") {
+		t.Fatalf("undo of an already-absent created file should report success: %q", out.String())
+	}
+	// Record must be popped (a second undo says nothing-to-undo).
+	var out2 strings.Builder
+	jr.undo(&out2)
+	if !strings.Contains(out2.String(), "nothing to undo") {
+		t.Fatalf("record should have been popped: %q", out2.String())
+	}
+}

--- a/cmd/golem/linereader.go
+++ b/cmd/golem/linereader.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"io"
+)
+
+// lineReader serializes line reads from a single underlying reader across the REPL
+// prompt loop and the approval prompt. One goroutine scans lines into an unbuffered
+// channel; ReadLine selects on the channel or ctx, so a read can be canceled
+// (Ctrl-C during an approval) without a second reader stealing buffered input.
+type lineReader struct {
+	lines chan string
+	err   error // final scanner error, set before lines is closed
+}
+
+// newLineReader starts the single scanning goroutine over r. The caller must
+// ensure r eventually reaches EOF or is closed so the goroutine can exit; until
+// then it lives for the process. For the REPL this is os.Stdin (process lifetime).
+func newLineReader(r io.Reader) *lineReader {
+	lr := &lineReader{lines: make(chan string)}
+	go func() {
+		sc := bufio.NewScanner(r)
+		sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for sc.Scan() {
+			lr.lines <- sc.Text()
+		}
+		// Set err BEFORE closing: this write is sequenced before close(lr.lines),
+		// which happens-before any receive that observes the closed channel, so
+		// ReadLine reads lr.err race-free (write → close → receive → read).
+		lr.err = sc.Err()
+		close(lr.lines)
+	}()
+	return lr
+}
+
+// ReadLine returns the next line. ok=false means no line: with a nil error it is a
+// clean EOF; with a non-nil error it is either a scanner failure (channel closed
+// after an error) or ctx cancellation.
+func (lr *lineReader) ReadLine(ctx context.Context) (string, bool, error) {
+	select {
+	case <-ctx.Done():
+		return "", false, ctx.Err()
+	case line, ok := <-lr.lines:
+		if !ok {
+			return "", false, lr.err // nil on clean EOF, non-nil on scanner error
+		}
+		return line, true, nil
+	}
+}

--- a/cmd/golem/linereader_test.go
+++ b/cmd/golem/linereader_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLineReaderSequential(t *testing.T) {
+	lr := newLineReader(strings.NewReader("one\ntwo\n"))
+	ctx := context.Background()
+	if l, ok, err := lr.ReadLine(ctx); !ok || err != nil || l != "one" {
+		t.Fatalf("first: %q ok=%v err=%v", l, ok, err)
+	}
+	if l, ok, err := lr.ReadLine(ctx); !ok || err != nil || l != "two" {
+		t.Fatalf("second: %q ok=%v err=%v", l, ok, err)
+	}
+	if _, ok, _ := lr.ReadLine(ctx); ok {
+		t.Fatal("third read should report EOF (ok=false)")
+	}
+}
+
+func TestLineReaderContextCancel(t *testing.T) {
+	pr, pw := io.Pipe() // never written -> ReadLine blocks until ctx cancels
+	defer func() { _ = pw.Close() }()
+	lr := newLineReader(pr)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { time.Sleep(10 * time.Millisecond); cancel() }()
+	_, ok, err := lr.ReadLine(ctx)
+	if ok || err == nil {
+		t.Fatalf("cancel should return ok=false and ctx err, got ok=%v err=%v", ok, err)
+	}
+}
+
+func TestLineReaderSurfacesScannerError(t *testing.T) {
+	huge := strings.Repeat("x", 2*1024*1024) // exceeds the 1 MiB scanner buffer
+	lr := newLineReader(strings.NewReader(huge))
+	_, ok, err := lr.ReadLine(context.Background())
+	if ok {
+		t.Fatal("oversized line should not yield ok=true")
+	}
+	if err == nil {
+		t.Fatal("scanner error (token too long) must surface, not be swallowed as clean EOF")
+	}
+}

--- a/cmd/golem/main.go
+++ b/cmd/golem/main.go
@@ -25,6 +25,7 @@ type flags struct {
 	noSession     bool
 	fresh         bool
 	sessionID     string
+	allowWrite    bool
 }
 
 func parseFlags(args []string) (flags, error) {
@@ -40,6 +41,7 @@ func parseFlags(args []string) (flags, error) {
 	fs.BoolVar(&f.noColor, "no-color", false, "disable dim ANSI footers")
 	fs.BoolVar(&f.noSession, "no-session", false, "disable persistent session memory")
 	fs.BoolVar(&f.fresh, "fresh", false, "start a new persistent session instead of resuming this workspace")
+	fs.BoolVar(&f.allowWrite, "allow-write", false, "enable approval-gated write_file/edit_file tools")
 	fs.StringVar(&f.sessionID, "session", "", "explicit session id to resume or create (default: per-workspace)")
 	if err := fs.Parse(args); err != nil {
 		return flags{}, err
@@ -158,6 +160,21 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 	}
 	retrieveOmitted := retrieve == nil
 
+	var journal *mutationJournal
+	if f.allowWrite {
+		wt, j, werr := buildWriteTools(root)
+		if werr != nil {
+			return werr
+		}
+		tools = append(tools, wt...)
+		journal = j
+	}
+
+	baseSystem := golemSystemPrompt
+	if f.allowWrite {
+		baseSystem = golemWriteSystemPrompt
+	}
+
 	var sessn *session
 	var sessionLine string
 	if !f.noSession {
@@ -193,12 +210,14 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 	sess := &replSession{
 		orch:            agent.New(caller, agent.ContextManager{}),
 		tools:           tools,
-		baseSystem:      golemSystemPrompt,
+		baseSystem:      baseSystem,
 		maxSteps:        f.maxSteps,
 		budget:          agent.Budget{InputCeiling: f.inputCeiling, OutputReserve: f.outputReserve},
 		color:           !f.noColor,
 		retrieveOmitted: retrieveOmitted,
 		session:         sessn,
+		journal:         journal,
+		allowWrite:      f.allowWrite,
 	}
 	if sess.maxSteps == 0 {
 		sess.maxSteps = 16 // mirror agent defaultMaxSteps so the footer's k/max is accurate

--- a/cmd/golem/main_test.go
+++ b/cmd/golem/main_test.go
@@ -7,6 +7,20 @@ import (
 	"testing"
 )
 
+func TestParseFlagsAllowWrite(t *testing.T) {
+	f, err := parseFlags([]string{"-allow-write"})
+	if err != nil {
+		t.Fatalf("parseFlags: %v", err)
+	}
+	if !f.allowWrite {
+		t.Fatal("-allow-write should set allowWrite")
+	}
+	f2, _ := parseFlags(nil)
+	if f2.allowWrite {
+		t.Fatal("allowWrite must default to false")
+	}
+}
+
 func TestStartupNotices(t *testing.T) {
 	got := startupNotices(startupInfo{
 		workspace:       "/abs/root",

--- a/cmd/golem/repl.go
+++ b/cmd/golem/repl.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -40,15 +39,21 @@ type replSession struct {
 // other line as an agent goal. A value on interrupts cancels the in-flight Run
 // without ending the loop. EOF (Ctrl-D) returns nil.
 func runREPL(ctx context.Context, in io.Reader, out io.Writer, interrupts <-chan struct{}, sess *replSession) error {
-	sc := bufio.NewScanner(in)
-	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	lr := newLineReader(in)
 	for {
 		_, _ = fmt.Fprint(out, "golem> ")
-		if !sc.Scan() {
-			_, _ = fmt.Fprintln(out)
-			return sc.Err()
+		line, ok, err := lr.ReadLine(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil // ctx canceled at the prompt: exit quietly
+			}
+			return err // scanner failure (e.g. line too long): surface it, as before
 		}
-		line := strings.TrimSpace(sc.Text())
+		if !ok {
+			_, _ = fmt.Fprintln(out)
+			return nil // EOF (Ctrl-D)
+		}
+		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
@@ -58,11 +63,11 @@ func runREPL(ctx context.Context, in io.Reader, out io.Writer, interrupts <-chan
 			}
 			continue
 		}
-		runOnce(ctx, out, interrupts, sess, line)
+		runOnce(ctx, out, interrupts, sess, line, lr)
 	}
 }
 
-func runOnce(ctx context.Context, out io.Writer, interrupts <-chan struct{}, sess *replSession, line string) {
+func runOnce(ctx context.Context, out io.Writer, interrupts <-chan struct{}, sess *replSession, line string, lr *lineReader) {
 	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/cmd/golem/repl.go
+++ b/cmd/golem/repl.go
@@ -32,8 +32,9 @@ type replSession struct {
 
 	session *session // nil => --no-session (no history, no persistence)
 
-	lastModel string           // last routed ActualModel for /model
-	journal   *mutationJournal // nil unless -allow-write enabled writes
+	lastModel  string           // last routed ActualModel for /model
+	journal    *mutationJournal // nil unless -allow-write enabled writes
+	allowWrite bool
 }
 
 // runREPL reads lines from in, dispatching slash commands and running every
@@ -94,6 +95,11 @@ func runOnce(ctx context.Context, out io.Writer, interrupts <-chan struct{}, ses
 		}()
 	}
 
+	var approver agent.Approver
+	if sess.allowWrite {
+		approver = newReplApprover(lr, out, sess.color)
+	}
+
 	rend := newRenderer(out, sess.color, sess.maxSteps, sess.clock)
 	req := agent.Request{
 		Goal:     line,
@@ -102,7 +108,7 @@ func runOnce(ctx context.Context, out io.Writer, interrupts <-chan struct{}, ses
 		Tools:    sess.tools,
 		MaxSteps: sess.maxSteps,
 		Budget:   sess.budget,
-		Approver: nil, // read-only => runtime auto-approves Read, denies Write/Exec
+		Approver: approver, // nil when read-only => runtime fail-safe denies Write/Exec
 	}
 	res, err := sess.orch.Run(runCtx, req, rend)
 	if err != nil {

--- a/cmd/golem/repl.go
+++ b/cmd/golem/repl.go
@@ -32,7 +32,8 @@ type replSession struct {
 
 	session *session // nil => --no-session (no history, no persistence)
 
-	lastModel string // last routed ActualModel for /model
+	lastModel string           // last routed ActualModel for /model
+	journal   *mutationJournal // nil unless -allow-write enabled writes
 }
 
 // runREPL reads lines from in, dispatching slash commands and running every
@@ -165,6 +166,12 @@ func dispatchSlash(ctx context.Context, out io.Writer, sess *replSession, line s
 		} else {
 			_, _ = fmt.Fprintln(out, sess.lastModel)
 		}
+	case "/undo":
+		if sess.journal == nil {
+			_, _ = fmt.Fprintln(out, "writes disabled (run with -allow-write)")
+		} else {
+			sess.journal.undo(out)
+		}
 	case "/tools":
 		for _, t := range sess.tools {
 			_, _ = fmt.Fprintf(out, "%s (%s)\n", t.Spec().Name, effectClassName(t.Effect().Class))
@@ -184,6 +191,7 @@ const golemHelp = `commands:
   /model         show the last routed model
   /clear         delete the active session's history
   /new           start a new session (keeps history of the old one)
+  /undo          revert the last applied write (when -allow-write)
   /exit, /quit   leave golem
 any other line is sent to the agent as a goal.
 `

--- a/cmd/golem/repl_test.go
+++ b/cmd/golem/repl_test.go
@@ -240,6 +240,109 @@ func TestREPL_DoesNotPersistCanceledRun(t *testing.T) {
 	}
 }
 
+func TestREPL_ReadOnlyDeniesWriteAttempt(t *testing.T) {
+	root := t.TempDir()
+	// Model attempts a write in a read-only session, then answers.
+	writeCall := provider.ChatResponse{
+		ToolCalls: []provider.ToolCall{{
+			ID: "w1", Type: "function",
+			Function: provider.ToolCallFunction{
+				Name:      "write_file",
+				Arguments: json.RawMessage(`{"path":"out.txt","content":"x\n"}`),
+			},
+		}},
+	}
+	finalAns := provider.ChatResponse{Content: "could not write"}
+	caller := &scriptCaller{responses: []agent.ModelResult{{Response: writeCall}, {Response: finalAns}}}
+	sess := newTestSession(t, caller, root) // read-only: no write tools, nil approver
+	var out strings.Builder
+	in := strings.NewReader("please write out.txt\n")
+	if err := runREPL(context.Background(), in, &out, nil, sess); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+	if strings.Contains(out.String(), "Apply this change?") {
+		t.Fatalf("read-only session must not show an approval prompt:\n%s", out.String())
+	}
+	if _, err := os.Stat(filepath.Join(root, "out.txt")); !os.IsNotExist(err) {
+		t.Fatal("read-only session must not create a file")
+	}
+}
+
+func TestREPL_AllowWriteApprovedWriteApplies(t *testing.T) {
+	root := t.TempDir()
+	writeCall := provider.ChatResponse{
+		ToolCalls: []provider.ToolCall{{
+			ID: "w1", Type: "function",
+			Function: provider.ToolCallFunction{
+				Name:      "write_file",
+				Arguments: json.RawMessage(`{"path":"out.txt","content":"hello\n"}`),
+			},
+		}},
+	}
+	finalAns := provider.ChatResponse{Content: "wrote it"}
+	caller := &scriptCaller{responses: []agent.ModelResult{{Response: writeCall}, {Response: finalAns}}}
+	sess := newWriteEnabledTestSession(t, caller, root)
+
+	var out strings.Builder
+	in := strings.NewReader("write out.txt\ny\n") // goal, then approve the write
+	if err := runREPL(context.Background(), in, &out, nil, sess); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(root, "out.txt"))
+	if err != nil || string(got) != "hello\n" {
+		t.Fatalf("approved write not applied: got %q err %v\nout:\n%s", got, err, out.String())
+	}
+	if !strings.Contains(out.String(), "Apply this change?") {
+		t.Fatalf("approval prompt missing:\n%s", out.String())
+	}
+}
+
+func TestREPL_AllowWriteDeniedWriteSkips(t *testing.T) {
+	root := t.TempDir()
+	writeCall := provider.ChatResponse{
+		ToolCalls: []provider.ToolCall{{
+			ID: "w1", Type: "function",
+			Function: provider.ToolCallFunction{
+				Name:      "write_file",
+				Arguments: json.RawMessage(`{"path":"out.txt","content":"hello\n"}`),
+			},
+		}},
+	}
+	finalAns := provider.ChatResponse{Content: "ok, skipped"}
+	caller := &scriptCaller{responses: []agent.ModelResult{{Response: writeCall}, {Response: finalAns}}}
+	sess := newWriteEnabledTestSession(t, caller, root)
+
+	var out strings.Builder
+	in := strings.NewReader("write out.txt\nn\n") // goal, then deny the write
+	if err := runREPL(context.Background(), in, &out, nil, sess); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "out.txt")); !os.IsNotExist(err) {
+		t.Fatal("denied write must not create the file")
+	}
+}
+
+func newWriteEnabledTestSession(t *testing.T, caller agent.ModelCaller, root string) *replSession {
+	t.Helper()
+	readTools, err := buildTools(root, nil)
+	if err != nil {
+		t.Fatalf("buildTools: %v", err)
+	}
+	writeTools, journal, err := buildWriteTools(root)
+	if err != nil {
+		t.Fatalf("buildWriteTools: %v", err)
+	}
+	return &replSession{
+		orch:       agent.New(caller, agent.ContextManager{}),
+		tools:      append(readTools, writeTools...),
+		baseSystem: golemWriteSystemPrompt,
+		maxSteps:   16,
+		clock:      func() time.Time { return time.Unix(0, 0) },
+		journal:    journal,
+		allowWrite: true,
+	}
+}
+
 func TestREPL_ClearAndNew(t *testing.T) {
 	root := t.TempDir()
 	caller := &scriptCaller{}

--- a/cmd/golem/repl_test.go
+++ b/cmd/golem/repl_test.go
@@ -96,14 +96,14 @@ func TestREPL_SlashCommands(t *testing.T) {
 	root := t.TempDir()
 	caller := &scriptCaller{}
 	var out strings.Builder
-	in := strings.NewReader("/help\n/tools\n/model\n/clear\n/new\n/bogus\n/exit\n")
+	in := strings.NewReader("/help\n/tools\n/model\n/clear\n/new\n/undo\n/bogus\n/exit\n")
 	sess := newTestSession(t, caller, root)
 
 	if err := runREPL(context.Background(), in, &out, nil, sess); err != nil {
 		t.Fatalf("runREPL: %v", err)
 	}
 	got := out.String()
-	for _, want := range []string{"read_file", "(read)", "not yet routed", "session disabled (--no-session)", "unknown command"} {
+	for _, want := range []string{"read_file", "(read)", "not yet routed", "session disabled (--no-session)", "unknown command", "writes disabled"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("slash output missing %q in:\n%s", want, got)
 		}

--- a/cmd/golem/tools.go
+++ b/cmd/golem/tools.go
@@ -13,6 +13,29 @@ import (
 	"github.com/kstruzzieri/go-llm/rag"
 )
 
+// golemWriteSystemPrompt is the base prompt when -allow-write is set. Unlike the
+// read-only prompt it permits proposing mutations, but stresses that every change
+// is shown as a diff and applied only after explicit user approval.
+const golemWriteSystemPrompt = "You are Golem, a terminal coding assistant for this workspace. " +
+	"Use the read-only tools to inspect files before acting. You may propose changes with write_file and edit_file; " +
+	"every change is shown to the user as a diff and is applied only after they approve it, so keep edits minimal and targeted and explain what you are changing. " +
+	"After a change is applied, briefly confirm what you changed. " +
+	"Prefer edit_file for small changes and write_file for new files or full rewrites. " +
+	"Cite file paths and line numbers when they matter, and say when the available evidence is insufficient. " +
+	"Prior session messages are context only; the current user request is authoritative."
+
+// buildWriteTools constructs the workspace-mutating tool set plus the in-session
+// journal that backs /undo, both bound to one Workspace over root. Returned only
+// when -allow-write is set.
+func buildWriteTools(root string) ([]agent.Tool, *mutationJournal, error) {
+	ws, err := agenttools.NewWorkspace(root)
+	if err != nil {
+		return nil, nil, fmt.Errorf("golem: build write tools: %w", err)
+	}
+	journal := newMutationJournal(ws)
+	return agenttools.NewMutatingTools(ws, journal), journal, nil
+}
+
 // buildTools returns golem's read-only tool set: the file tools
 // (read_file, search, glob, list) always, plus retrieve appended last when a
 // non-nil retriever tool is supplied. The retrieve argument must be a true nil


### PR DESCRIPTION
## Summary

Lifts Golem's v1 zero-mutation constraint in a controlled way. Adds two workspace-mutating tools behind explicit, per-call user approval, with an in-session undo. Default Golem (no `-allow-write`) is byte-for-byte read-only.

- `write_file` (create / full-overwrite) and `edit_file` (exact-string replace, must match exactly once) — both `PlanningTool`s. `Plan` computes a unified diff preview; the runtime shows it to the user and requires `[y/N]` approval before any write.
- Scoped to the workspace via the existing path chokepoint, extended with write-safe primitives (`resolveWriteTarget`, `WriteFileAtomic`, `RemoveFile`) that mirror the read-side TOCTOU / never-follow-symlink discipline.
- `Invoke` re-checks the file is byte-identical to the previewed state (existence + content hash) before writing; any drift fails closed ("changed since preview; retry"). The bytes written are exactly the bytes the user approved.
- In-session mutation journal backs a new `/undo` (peek → verify recorded hash → restore via the same containment-checked primitives → pop on success). Refused/failed undo leaves the record intact.
- `-allow-write` flag wires the tools, a diff-rendering REPL approver (over a single shared, ctx-cancelable line reader), the journal, and a write-enabled system prompt. Off by default: nil-approver fail-safe + no mutating tools registered.
- Reuses the Approver / PlanningTool seam (#57) and the Workspace chokepoint (#194). Shell / exec is out of scope.

Closes #201.

## Test Plan

- [x] `go test ./...` and `go test -race ./...` pass (24 packages, no failures)
- [x] `go vet ./...`, `gofmt`, and `staticcheck ./agent/tools/ ./cmd/golem/` clean
- [x] TDD coverage: write-safe path primitives (escape/symlink-leaf/symlink-ancestor/TOCTOU-swap), both tools (match-once, binary/NUL/size guards, preview-state re-check, fail-closed on missing plan), shared line reader (EOF/cancel/scanner-error), approver (y/yes/n/empty/EOF/cancel/color), journal (`/undo` restore/delete-created/hash-guard-keeps-record/already-absent/empty-stack)
- [x] End-to-end REPL integration tests drive the real runtime: approved write applies, denied write makes no change, read-only session denies a write attempt with no prompt and no file
- [x] Read-only parity: with `-allow-write` off, no write tools registered, nil approver, unchanged system prompt