### PR TITLE
feat(golem): approval-gated run_command exec tool (-allow-exec)

### DIFF
--- a/agent/tools/exec.go
+++ b/agent/tools/exec.go
@@ -438,6 +438,3 @@ func formatExecResult(r execResult) string {
 	}
 	return b.String()
 }
-
-// TEMP (removed in Task 10 when exec_unix.go/exec_other.go provide it):
-func newPlatformRunner() commandRunner { return nil }

--- a/agent/tools/exec.go
+++ b/agent/tools/exec.go
@@ -1,0 +1,361 @@
+package tools
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/agent"
+)
+
+const (
+	execStdoutCap      = 32 * 1024
+	execStderrCap      = 32 * 1024
+	execRuntimeCap     = 80 * 1024
+	execDefaultTimeout = 60 * time.Second
+	execMaxTimeout     = 600 * time.Second
+	execWaitDelay      = 2 * time.Second
+	fingerprintLen     = 12
+)
+
+var defaultExecEnvAllowlist = []string{"PATH", "HOME", "LANG", "USER", "TMPDIR"}
+
+type runCommandArgs struct {
+	Argv           []string `json:"argv"`
+	Dir            string   `json:"dir"`
+	TimeoutSeconds *int     `json:"timeout_seconds"`
+}
+
+type execSpec struct {
+	Path string
+	Argv []string
+	Dir  string
+	Env  []string
+}
+
+type execResult struct {
+	ExitCode        int
+	Stdout          []byte
+	Stderr          []byte
+	StdoutTruncated bool
+	StderrTruncated bool
+	Started         bool
+	TimedOut        bool
+}
+
+// commandRunner is the OS-process seam. Run returns a non-nil error ONLY for infra
+// failures (spawn error, timeout-kill, unsupported platform). A normal exit —
+// including non-zero — returns nil error with ExitCode set. Stdout/Stderr are
+// already bounded to the tool's self-caps by the runner.
+type commandRunner interface {
+	Run(ctx context.Context, spec execSpec) (execResult, error)
+}
+
+// execPending is the state Plan computes and Invoke consumes, keyed by raw-args hash.
+type execPending struct {
+	path        string
+	identity    os.FileInfo
+	argv        []string
+	dir         string
+	dirLabel    string
+	env         []string
+	envNames    []string
+	timeout     time.Duration
+	requestedTO int
+	clamped     bool
+	fingerprint string
+}
+
+type execPlanCache struct {
+	mu       sync.Mutex
+	argsHash string
+	plan     execPending
+	hasPlan  bool
+}
+
+func (c *execPlanCache) store(argsHash string, p execPending) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.argsHash, c.plan, c.hasPlan = argsHash, p, true
+}
+
+func (c *execPlanCache) consume(argsHash string) (execPending, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.hasPlan || c.argsHash != argsHash {
+		return execPending{}, false
+	}
+	p := c.plan
+	c.hasPlan, c.plan, c.argsHash = false, execPending{}, ""
+	return p, true
+}
+
+// cappedBuffer stores at most cap bytes but ALWAYS consumes every Write, so a child
+// writing to a full pipe never blocks (no pipe-deadlock); excess is discarded and
+// flagged.
+type cappedBuffer struct {
+	cap       int
+	buf       []byte
+	truncated bool
+}
+
+func (c *cappedBuffer) Write(p []byte) (int, error) {
+	if room := c.cap - len(c.buf); room > 0 {
+		if len(p) <= room {
+			c.buf = append(c.buf, p...)
+		} else {
+			c.buf = append(c.buf, p[:room]...)
+			c.truncated = true
+		}
+	} else if len(p) > 0 {
+		c.truncated = true
+	}
+	return len(p), nil
+}
+
+// RunCommand is the argv-first, approval-gated exec tool. PlanningTool: Plan validates
+// and previews; Invoke re-checks and spawns through the runner seam.
+type RunCommand struct {
+	ws     *Workspace
+	runner commandRunner
+	execPlanCache
+}
+
+func NewRunCommand(ws *Workspace, runner commandRunner) *RunCommand {
+	return &RunCommand{ws: ws, runner: runner}
+}
+
+// NewExecTools builds the exec tool set bound to one Workspace over root, using the
+// platform's real runner. Registered by cmd/golem only under -allow-exec.
+func NewExecTools(root string) ([]agent.Tool, error) {
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		return nil, fmt.Errorf("tools: build exec tools: %w", err)
+	}
+	return []agent.Tool{NewRunCommand(ws, newPlatformRunner())}, nil
+}
+
+func (t *RunCommand) Spec() agent.ToolSpec {
+	return agent.ToolSpec{
+		Name: "run_command",
+		Description: "Run a command directly (argv-first, NO shell: no metacharacters, globbing, or pipes). " +
+			"Returns the exit code plus bounded stdout/stderr. The command is shown to the user and runs only after they approve it. " +
+			"A non-zero exit code is a normal result to read and react to, not an error.",
+		Parameters: json.RawMessage(`{
+  "type":"object",
+  "properties":{
+    "argv":{"type":"array","items":{"type":"string"},"description":"command and arguments; argv[0] is the executable, run without a shell"},
+    "dir":{"type":"string","description":"working directory relative to the workspace root (default: root)"},
+    "timeout_seconds":{"type":"integer","description":"optional time limit; default 60, max 600"}
+  },
+  "required":["argv"]
+}`),
+	}
+}
+
+func (t *RunCommand) baseEffect() agent.Effect {
+	return agent.Effect{
+		Class:     agent.Read | agent.Write | agent.Exec | agent.Network,
+		Approval:  agent.ApprovalAlways,
+		Timeout:   execDefaultTimeout,
+		OutputCap: execRuntimeCap,
+	}
+}
+
+func (t *RunCommand) Effect() agent.Effect { return t.baseEffect() }
+
+// Plan is implemented in Task 8.
+func (t *RunCommand) Plan(_ context.Context, _ json.RawMessage) (agent.ToolPlan, error) {
+	return agent.ToolPlan{Effect: t.baseEffect()}, fmt.Errorf("run_command: Plan not yet implemented")
+}
+
+// Invoke is implemented in Task 9.
+func (t *RunCommand) Invoke(_ context.Context, _ json.RawMessage) (agent.ToolResult, error) {
+	return errResult("run_command: Invoke not yet implemented"), nil
+}
+
+// resolveExecTimeout maps timeout_seconds to an effective duration. nil -> default;
+// <= 0 -> error; > max -> clamp (requested retained for the preview).
+func resolveExecTimeout(sec *int) (eff time.Duration, requested int, clamped bool, err error) {
+	if sec == nil {
+		return execDefaultTimeout, 0, false, nil
+	}
+	if *sec <= 0 {
+		return 0, 0, false, fmt.Errorf("timeout_seconds must be positive")
+	}
+	requested = *sec
+	d := time.Duration(*sec) * time.Second
+	if d > execMaxTimeout {
+		return execMaxTimeout, requested, true, nil
+	}
+	return d, requested, false, nil
+}
+
+// buildExecEnv returns the sanitized child env (only the allowlist names present in
+// the parent) as "K=V" entries plus the sorted list of names actually exposed. The
+// parent's full env (including secrets) is otherwise dropped. lookup is injected for
+// testability (production passes os.LookupEnv).
+func buildExecEnv(lookup func(string) (string, bool)) (env []string, names []string) {
+	for _, k := range defaultExecEnvAllowlist {
+		if v, ok := lookup(k); ok {
+			env = append(env, k+"="+v)
+			names = append(names, k)
+		}
+	}
+	sort.Strings(names)
+	return env, names
+}
+
+// pathFromEnv extracts the PATH value from a built env slice ("" if absent).
+func pathFromEnv(env []string) string {
+	for _, e := range env {
+		if v, ok := strings.CutPrefix(e, "PATH="); ok {
+			return v
+		}
+	}
+	return ""
+}
+
+var errNotExecutable = errors.New("not an executable file")
+
+// isExecutableFile reports whether fi is a regular file with any execute bit set.
+func isExecutableFile(fi os.FileInfo) bool {
+	return fi.Mode().IsRegular() && fi.Mode().Perm()&0o111 != 0
+}
+
+// resolveExecutable resolves argv0 to the executable path that will run, by case:
+//   - bare name (no separator): searched on the sanitized PATH (symlinks followed —
+//     system binaries are commonly symlinked);
+//   - absolute path: stat'd as given (symlinks followed);
+//   - relative with a separator: resolved under the planned cwd through the Workspace
+//     chokepoint (containment + never-follow-symlink), the only case where in-workspace
+//     symlink/containment rules apply.
+//
+// The returned os.FileInfo is used by Invoke for an os.SameFile identity re-check.
+func resolveExecutable(ws *Workspace, dir, argv0, pathValue string) (string, os.FileInfo, error) {
+	if argv0 == "" {
+		return "", nil, fmt.Errorf("empty executable")
+	}
+	if !strings.ContainsRune(argv0, os.PathSeparator) && !strings.ContainsRune(argv0, '/') {
+		return customLookPath(pathValue, argv0)
+	}
+	if filepath.IsAbs(argv0) {
+		clean := filepath.Clean(argv0)
+		fi, err := os.Stat(clean) // follow symlinks: allow Homebrew-style links
+		if err != nil {
+			return "", nil, err
+		}
+		if !isExecutableFile(fi) {
+			return "", nil, errNotExecutable
+		}
+		return clean, fi, nil
+	}
+	// relative with separator: contain under the planned cwd via the Workspace.
+	abs := filepath.Join(dir, argv0)
+	rel, err := filepath.Rel(ws.root, abs)
+	if err != nil {
+		return "", nil, err
+	}
+	resolved, fi, err := ws.resolveFile(rel) // Lstat: rejects symlink + non-regular + escape
+	if err != nil {
+		return "", nil, err
+	}
+	if !isExecutableFile(fi) {
+		return "", nil, errNotExecutable
+	}
+	return resolved, fi, nil
+}
+
+// customLookPath searches pathValue (os.PathListSeparator-delimited) for name,
+// mirroring exec.LookPath semantics over an explicit PATH: the first directory holding
+// an executable regular file wins. Empty PATH entries are skipped (no implicit cwd).
+func customLookPath(pathValue, name string) (string, os.FileInfo, error) {
+	for _, dir := range strings.Split(pathValue, string(os.PathListSeparator)) {
+		if dir == "" {
+			continue
+		}
+		candidate := filepath.Join(dir, name)
+		fi, err := os.Stat(candidate) // follow symlinks
+		if err != nil {
+			continue
+		}
+		if isExecutableFile(fi) {
+			return candidate, fi, nil
+		}
+	}
+	return "", nil, fmt.Errorf("executable %q not found in PATH", name)
+}
+
+// commandFingerprint is a short, stable hash over the approval-relevant inputs
+// (argv, resolved cwd, exposed env-var NAMES, effective timeout). Surfaced in the
+// preview; reused by logs/tests and later 2.1c policy. Uses NUL separators so field
+// boundaries cannot be forged by embedded content.
+func commandFingerprint(argv []string, cwd string, envNames []string, timeout time.Duration) string {
+	h := sha256.New()
+	write := func(s string) { _, _ = h.Write([]byte(s)); _, _ = h.Write([]byte{0}) }
+	write("argv")
+	for _, a := range argv {
+		write(a)
+	}
+	write("cwd")
+	write(cwd)
+	write("env")
+	for _, n := range envNames {
+		write(n)
+	}
+	write("timeout")
+	write(timeout.String())
+	return hex.EncodeToString(h.Sum(nil))[:fingerprintLen]
+}
+
+// renderExecPreview builds the human approval preview (never parsed, never fed to the
+// model). It lists names + source class for env, never values.
+func renderExecPreview(p execPending, originalArgv0 string) string {
+	var b strings.Builder
+	b.WriteString("run command:\n")
+	fmt.Fprintf(&b, "  argv:    %s\n", strings.Join(p.argv, " "))
+	fmt.Fprintf(&b, "  exe:     %s -> %s\n", originalArgv0, p.path)
+	fmt.Fprintf(&b, "  cwd:     %s\n", p.dirLabel)
+	if p.clamped {
+		fmt.Fprintf(&b, "  timeout: %s (requested %ds, clamped)\n", p.timeout, p.requestedTO)
+	} else {
+		fmt.Fprintf(&b, "  timeout: %s\n", p.timeout)
+	}
+	parts := make([]string, len(p.envNames))
+	for i, n := range p.envNames {
+		parts[i] = n + "(parent)"
+	}
+	fmt.Fprintf(&b, "  env:     %s\n", strings.Join(parts, ", "))
+	fmt.Fprintf(&b, "  id:      %s\n", p.fingerprint)
+	return b.String()
+}
+
+// formatExecResult renders the model-facing observation (spec §10.3). Truncation
+// markers are appended in-band when a stream was capped.
+func formatExecResult(r execResult) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "exit code: %d\n", r.ExitCode)
+	b.WriteString("--- stdout ---\n")
+	b.Write(r.Stdout)
+	if r.StdoutTruncated {
+		b.WriteString("\n… [truncated]")
+	}
+	b.WriteString("\n--- stderr ---\n")
+	b.Write(r.Stderr)
+	if r.StderrTruncated {
+		b.WriteString("\n… [truncated]")
+	}
+	return b.String()
+}
+
+// TEMP (removed in Task 10 when exec_unix.go/exec_other.go provide it):
+func newPlatformRunner() commandRunner { return nil }

--- a/agent/tools/exec.go
+++ b/agent/tools/exec.go
@@ -48,7 +48,6 @@ type execResult struct {
 	Stderr          []byte
 	StdoutTruncated bool
 	StderrTruncated bool
-	Started         bool
 	TimedOut        bool
 }
 
@@ -256,6 +255,9 @@ func (t *RunCommand) Invoke(ctx context.Context, raw json.RawMessage) (agent.Too
 		if res.TimedOut {
 			return errResult(fmt.Sprintf("command timed out after %s", pp.timeout)), nil
 		}
+		if errors.Is(runErr, context.Canceled) {
+			return errResult("command canceled"), nil
+		}
 		return errResult("command failed to run: " + runErr.Error()), nil
 	}
 	return agent.ToolResult{Content: formatExecResult(res)}, nil
@@ -402,6 +404,31 @@ func fmtTimeout(d time.Duration) string {
 	return fmt.Sprintf("%ds", int(d.Seconds()))
 }
 
+// quoteArgForPreview returns a quoted form of arg when it is empty or contains any
+// whitespace character (space, tab, newline), so an approval reviewer can see exact
+// argument boundaries. Simple arguments are returned bare.
+func quoteArgForPreview(arg string) string {
+	for _, r := range arg {
+		if r == ' ' || r == '\t' || r == '\n' || r == '\r' {
+			return fmt.Sprintf("%q", arg)
+		}
+	}
+	if arg == "" {
+		return `""`
+	}
+	return arg
+}
+
+// renderArgvForPreview renders an argv slice so that each argument containing
+// whitespace or that is empty is shown quoted, and simple arguments are bare.
+func renderArgvForPreview(argv []string) string {
+	parts := make([]string, len(argv))
+	for i, a := range argv {
+		parts[i] = quoteArgForPreview(a)
+	}
+	return strings.Join(parts, " ")
+}
+
 // renderExecPreview builds the human approval preview (never parsed, never fed to the
 // model). It lists names + source class for env, never values.
 func renderExecPreview(p execPending, originalArgv0 string) string {
@@ -411,7 +438,7 @@ func renderExecPreview(p execPending, originalArgv0 string) string {
 		dirDisplay = "(workspace root)"
 	}
 	b.WriteString("run command:\n")
-	fmt.Fprintf(&b, "  argv:    %s\n", strings.Join(p.argv, " "))
+	fmt.Fprintf(&b, "  argv:    %s\n", renderArgvForPreview(p.argv))
 	fmt.Fprintf(&b, "  exe:     %s -> %s\n", originalArgv0, p.path)
 	fmt.Fprintf(&b, "  cwd:     %s\n", dirDisplay)
 	if p.clamped {

--- a/agent/tools/exec.go
+++ b/agent/tools/exec.go
@@ -188,6 +188,11 @@ func (t *RunCommand) Plan(_ context.Context, raw json.RawMessage) (agent.ToolPla
 	if strings.TrimSpace(args.Argv[0]) == "" {
 		return agent.ToolPlan{Effect: eff}, fmt.Errorf("argv[0] must not be blank")
 	}
+	for _, a := range args.Argv {
+		if strings.IndexByte(a, 0) >= 0 {
+			return agent.ToolPlan{Effect: eff}, fmt.Errorf("argv must not contain NUL bytes")
+		}
+	}
 	timeout, requested, clamped, err := resolveExecTimeout(args.TimeoutSeconds)
 	if err != nil {
 		return agent.ToolPlan{Effect: eff}, err
@@ -217,7 +222,7 @@ func (t *RunCommand) Plan(_ context.Context, raw json.RawMessage) (agent.ToolPla
 // The label is the workspace-relative path passed in, or "" for root; callers that need
 // a display string should substitute "(workspace root)" when the label is empty.
 func (t *RunCommand) resolveDirArg(dir string) (abs, label string, err error) {
-	if strings.TrimSpace(dir) == "" {
+	if strings.TrimSpace(dir) == "" || filepath.Clean(dir) == "." {
 		return t.ws.root, "", nil
 	}
 	abs, _, err = t.ws.resolveDir(dir)
@@ -277,6 +282,8 @@ func resolveExecTimeout(sec *int) (eff time.Duration, requested int, clamped boo
 // the parent) as "K=V" entries plus the sorted list of names actually exposed. The
 // parent's full env (including secrets) is otherwise dropped. lookup is injected for
 // testability (production passes os.LookupEnv).
+// NOTE: HOME is passed through by design, so approved commands may read files under
+// the user's home directory. This is an approval gate, not a filesystem sandbox.
 func buildExecEnv(lookup func(string) (string, bool)) (env []string, names []string) {
 	for _, k := range defaultExecEnvAllowlist {
 		if v, ok := lookup(k); ok {

--- a/agent/tools/exec.go
+++ b/agent/tools/exec.go
@@ -317,6 +317,11 @@ func commandFingerprint(argv []string, cwd string, envNames []string, timeout ti
 	return hex.EncodeToString(h.Sum(nil))[:fingerprintLen]
 }
 
+// fmtTimeout formats a duration as seconds (e.g. "60s") for the approval preview.
+func fmtTimeout(d time.Duration) string {
+	return fmt.Sprintf("%ds", int(d.Seconds()))
+}
+
 // renderExecPreview builds the human approval preview (never parsed, never fed to the
 // model). It lists names + source class for env, never values.
 func renderExecPreview(p execPending, originalArgv0 string) string {
@@ -326,9 +331,9 @@ func renderExecPreview(p execPending, originalArgv0 string) string {
 	fmt.Fprintf(&b, "  exe:     %s -> %s\n", originalArgv0, p.path)
 	fmt.Fprintf(&b, "  cwd:     %s\n", p.dirLabel)
 	if p.clamped {
-		fmt.Fprintf(&b, "  timeout: %s (requested %ds, clamped)\n", p.timeout, p.requestedTO)
+		fmt.Fprintf(&b, "  timeout: %s (requested %ds, clamped)\n", fmtTimeout(p.timeout), p.requestedTO)
 	} else {
-		fmt.Fprintf(&b, "  timeout: %s\n", p.timeout)
+		fmt.Fprintf(&b, "  timeout: %s\n", fmtTimeout(p.timeout))
 	}
 	parts := make([]string, len(p.envNames))
 	for i, n := range p.envNames {

--- a/agent/tools/exec.go
+++ b/agent/tools/exec.go
@@ -173,9 +173,58 @@ func (t *RunCommand) baseEffect() agent.Effect {
 
 func (t *RunCommand) Effect() agent.Effect { return t.baseEffect() }
 
-// Plan is implemented in Task 8.
-func (t *RunCommand) Plan(_ context.Context, _ json.RawMessage) (agent.ToolPlan, error) {
-	return agent.ToolPlan{Effect: t.baseEffect()}, fmt.Errorf("run_command: Plan not yet implemented")
+// Plan validates args, resolves cwd + executable + env + timeout, renders the preview,
+// and stashes a pending plan keyed by the raw-args hash. It never spawns. Any failure
+// returns an error so dispatch reports it without prompting for approval.
+func (t *RunCommand) Plan(_ context.Context, raw json.RawMessage) (agent.ToolPlan, error) {
+	eff := t.baseEffect()
+	var args runCommandArgs
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return agent.ToolPlan{Effect: eff}, fmt.Errorf("invalid arguments: %w", err)
+	}
+	if len(args.Argv) == 0 {
+		return agent.ToolPlan{Effect: eff}, fmt.Errorf("argv is required and must be non-empty")
+	}
+	if strings.TrimSpace(args.Argv[0]) == "" {
+		return agent.ToolPlan{Effect: eff}, fmt.Errorf("argv[0] must not be blank")
+	}
+	timeout, requested, clamped, err := resolveExecTimeout(args.TimeoutSeconds)
+	if err != nil {
+		return agent.ToolPlan{Effect: eff}, err
+	}
+	dir, dirLabel, err := t.resolveDirArg(args.Dir)
+	if err != nil {
+		return agent.ToolPlan{Effect: eff}, err
+	}
+	env, envNames := buildExecEnv(os.LookupEnv)
+	path, fi, err := resolveExecutable(t.ws, dir, args.Argv[0], pathFromEnv(env))
+	if err != nil {
+		return agent.ToolPlan{Effect: eff}, fmt.Errorf("resolve %q: %w", args.Argv[0], err)
+	}
+	fp := commandFingerprint(args.Argv, dir, envNames, timeout)
+	p := execPending{
+		path: path, identity: fi, argv: args.Argv, dir: dir, dirLabel: dirLabel,
+		env: env, envNames: envNames, timeout: timeout, requestedTO: requested,
+		clamped: clamped, fingerprint: fp,
+	}
+	t.store(ContentHash(raw), p)
+	eff.Timeout = timeout
+	return agent.ToolPlan{Effect: eff, Preview: renderExecPreview(p, args.Argv[0])}, nil
+}
+
+// resolveDirArg resolves the optional dir argument through the Workspace chokepoint,
+// returning the absolute cwd and a human label. Empty -> workspace root (label "").
+// The label is the workspace-relative path passed in, or "" for root; callers that need
+// a display string should substitute "(workspace root)" when the label is empty.
+func (t *RunCommand) resolveDirArg(dir string) (abs, label string, err error) {
+	if strings.TrimSpace(dir) == "" {
+		return t.ws.root, "", nil
+	}
+	abs, _, err = t.ws.resolveDir(dir)
+	if err != nil {
+		return "", "", fmt.Errorf("dir %q: %w", dir, err)
+	}
+	return abs, dir, nil
 }
 
 // Invoke is implemented in Task 9.
@@ -326,10 +375,14 @@ func fmtTimeout(d time.Duration) string {
 // model). It lists names + source class for env, never values.
 func renderExecPreview(p execPending, originalArgv0 string) string {
 	var b strings.Builder
+	dirDisplay := p.dirLabel
+	if dirDisplay == "" {
+		dirDisplay = "(workspace root)"
+	}
 	b.WriteString("run command:\n")
 	fmt.Fprintf(&b, "  argv:    %s\n", strings.Join(p.argv, " "))
 	fmt.Fprintf(&b, "  exe:     %s -> %s\n", originalArgv0, p.path)
-	fmt.Fprintf(&b, "  cwd:     %s\n", p.dirLabel)
+	fmt.Fprintf(&b, "  cwd:     %s\n", dirDisplay)
 	if p.clamped {
 		fmt.Fprintf(&b, "  timeout: %s (requested %ds, clamped)\n", fmtTimeout(p.timeout), p.requestedTO)
 	} else {

--- a/agent/tools/exec.go
+++ b/agent/tools/exec.go
@@ -66,6 +66,7 @@ type execPending struct {
 	argv        []string
 	dir         string
 	dirLabel    string
+	dirIdentity os.FileInfo
 	env         []string
 	envNames    []string
 	timeout     time.Duration
@@ -196,7 +197,7 @@ func (t *RunCommand) Plan(_ context.Context, raw json.RawMessage) (agent.ToolPla
 	if err != nil {
 		return agent.ToolPlan{Effect: eff}, err
 	}
-	dir, dirLabel, err := t.resolveDirArg(args.Dir)
+	dir, dirLabel, dirIdentity, err := t.resolveDirArg(args.Dir)
 	if err != nil {
 		return agent.ToolPlan{Effect: eff}, err
 	}
@@ -208,8 +209,8 @@ func (t *RunCommand) Plan(_ context.Context, raw json.RawMessage) (agent.ToolPla
 	fp := commandFingerprint(args.Argv, dir, envNames, timeout)
 	p := execPending{
 		path: path, identity: fi, argv: args.Argv, dir: dir, dirLabel: dirLabel,
-		env: env, envNames: envNames, timeout: timeout, requestedTO: requested,
-		clamped: clamped, fingerprint: fp,
+		dirIdentity: dirIdentity, env: env, envNames: envNames, timeout: timeout,
+		requestedTO: requested, clamped: clamped, fingerprint: fp,
 	}
 	t.store(ContentHash(raw), p)
 	eff.Timeout = timeout
@@ -220,15 +221,22 @@ func (t *RunCommand) Plan(_ context.Context, raw json.RawMessage) (agent.ToolPla
 // returning the absolute cwd and a human label. Empty -> workspace root (label "").
 // The label is the workspace-relative path passed in, or "" for root; callers that need
 // a display string should substitute "(workspace root)" when the label is empty.
-func (t *RunCommand) resolveDirArg(dir string) (abs, label string, err error) {
+func (t *RunCommand) resolveDirArg(dir string) (abs, label string, identity os.FileInfo, err error) {
 	if strings.TrimSpace(dir) == "" || filepath.Clean(dir) == "." {
-		return t.ws.root, "", nil
+		fi, err := os.Lstat(t.ws.root)
+		if err != nil {
+			return "", "", nil, err
+		}
+		if !fi.IsDir() {
+			return "", "", nil, errNotDir
+		}
+		return t.ws.root, "", fi, nil
 	}
-	abs, _, err = t.ws.resolveDir(dir)
+	abs, identity, err = t.ws.resolveDir(dir)
 	if err != nil {
-		return "", "", fmt.Errorf("dir %q: %w", dir, err)
+		return "", "", nil, fmt.Errorf("dir %q: %w", dir, err)
 	}
-	return abs, dir, nil
+	return abs, dir, identity, nil
 }
 
 // Invoke consumes the pending plan (fail-closed on hash mismatch), re-resolves and
@@ -240,8 +248,8 @@ func (t *RunCommand) Invoke(ctx context.Context, raw json.RawMessage) (agent.Too
 		return errResult("exec preview missing; retry"), nil
 	}
 	// Re-resolve cwd: an escape/symlink introduced after Plan fails closed.
-	dir, _, err := t.resolveDirArg(pp.dirLabel)
-	if err != nil || dir != pp.dir {
+	dir, _, dirIdentity, err := t.resolveDirArg(pp.dirLabel)
+	if err != nil || dir != pp.dir || pp.dirIdentity == nil || !os.SameFile(dirIdentity, pp.dirIdentity) {
 		return errResult("working directory changed since approval; retry"), nil
 	}
 	// Re-resolve executable against the APPROVED env (stored PATH), compare path +
@@ -273,10 +281,11 @@ func resolveExecTimeout(sec *int) (eff time.Duration, requested int, clamped boo
 		return 0, 0, false, fmt.Errorf("timeout_seconds must be positive")
 	}
 	requested = *sec
-	d := time.Duration(*sec) * time.Second
-	if d > execMaxTimeout {
+	maxSeconds := int(execMaxTimeout / time.Second)
+	if *sec > maxSeconds {
 		return execMaxTimeout, requested, true, nil
 	}
+	d := time.Duration(*sec) * time.Second
 	return d, requested, false, nil
 }
 
@@ -360,12 +369,17 @@ func resolveExecutable(ws *Workspace, dir, argv0, pathValue string) (string, os.
 // customLookPath searches pathValue (os.PathListSeparator-delimited) for name,
 // mirroring exec.LookPath semantics over an explicit PATH: the first directory holding
 // an executable regular file wins. Empty PATH entries are skipped (no implicit cwd).
+// Returned paths are absolute so cmd.Dir cannot change what the approved path means.
 func customLookPath(pathValue, name string) (string, os.FileInfo, error) {
 	for _, dir := range strings.Split(pathValue, string(os.PathListSeparator)) {
 		if dir == "" {
 			continue
 		}
 		candidate := filepath.Join(dir, name)
+		candidate, err := filepath.Abs(candidate)
+		if err != nil {
+			continue
+		}
 		fi, err := os.Stat(candidate) // follow symlinks
 		if err != nil {
 			continue

--- a/agent/tools/exec.go
+++ b/agent/tools/exec.go
@@ -227,9 +227,33 @@ func (t *RunCommand) resolveDirArg(dir string) (abs, label string, err error) {
 	return abs, dir, nil
 }
 
-// Invoke is implemented in Task 9.
-func (t *RunCommand) Invoke(_ context.Context, _ json.RawMessage) (agent.ToolResult, error) {
-	return errResult("run_command: Invoke not yet implemented"), nil
+// Invoke consumes the pending plan (fail-closed on hash mismatch), re-resolves and
+// re-checks the cwd and executable against what was approved, then spawns through the
+// runner. Non-zero exit is a normal observation; only infra failures are tool errors.
+func (t *RunCommand) Invoke(ctx context.Context, raw json.RawMessage) (agent.ToolResult, error) {
+	pp, ok := t.consume(ContentHash(raw))
+	if !ok {
+		return errResult("exec preview missing; retry"), nil
+	}
+	// Re-resolve cwd: an escape/symlink introduced after Plan fails closed.
+	dir, _, err := t.resolveDirArg(pp.dirLabel)
+	if err != nil || dir != pp.dir {
+		return errResult("working directory changed since approval; retry"), nil
+	}
+	// Re-resolve executable against the APPROVED env (stored PATH), compare path +
+	// identity (os.SameFile) so a symlink swap or same-path binary replacement fails closed.
+	path, fi, rerr := resolveExecutable(t.ws, pp.dir, pp.argv[0], pathFromEnv(pp.env))
+	if rerr != nil || path != pp.path || !os.SameFile(fi, pp.identity) {
+		return errResult("executable changed since approval; retry"), nil
+	}
+	res, runErr := t.runner.Run(ctx, execSpec{Path: pp.path, Argv: pp.argv, Dir: pp.dir, Env: pp.env})
+	if runErr != nil {
+		if res.TimedOut {
+			return errResult(fmt.Sprintf("command timed out after %s", pp.timeout)), nil
+		}
+		return errResult("command failed to run: " + runErr.Error()), nil
+	}
+	return agent.ToolResult{Content: formatExecResult(res)}, nil
 }
 
 // resolveExecTimeout maps timeout_seconds to an effective duration. nil -> default;

--- a/agent/tools/exec_other.go
+++ b/agent/tools/exec_other.go
@@ -1,0 +1,18 @@
+//go:build !unix
+
+package tools
+
+import (
+	"context"
+	"errors"
+)
+
+var errExecUnsupported = errors.New("exec unsupported on this platform")
+
+type unsupportedRunner struct{}
+
+func newPlatformRunner() commandRunner { return unsupportedRunner{} }
+
+func (unsupportedRunner) Run(_ context.Context, _ execSpec) (execResult, error) {
+	return execResult{}, errExecUnsupported
+}

--- a/agent/tools/exec_test.go
+++ b/agent/tools/exec_test.go
@@ -400,7 +400,7 @@ func (f *fakeRunner) Run(ctx context.Context, spec execSpec) (execResult, error)
 	f.called, f.gotSpec = true, spec
 	if f.blockCtx {
 		<-ctx.Done()
-		return execResult{Started: true, TimedOut: true}, fmt.Errorf("timed out")
+		return execResult{TimedOut: true}, context.DeadlineExceeded
 	}
 	return f.result, f.err
 }
@@ -423,7 +423,7 @@ func TestInvokeNonZeroExitNotError(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip()
 	}
-	fr := &fakeRunner{result: execResult{ExitCode: 1, Stdout: []byte("FAIL\n"), Started: true}}
+	fr := &fakeRunner{result: execResult{ExitCode: 1, Stdout: []byte("FAIL\n")}}
 	rc, _ := invokeRC(t, fr)
 	raw := json.RawMessage(`{"argv":["mycmd"]}`)
 	if _, err := rc.Plan(context.Background(), raw); err != nil {
@@ -448,7 +448,7 @@ func TestInvokePlanMismatchFailsClosed(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip()
 	}
-	fr := &fakeRunner{result: execResult{Started: true}}
+	fr := &fakeRunner{}
 	rc, _ := invokeRC(t, fr)
 	if _, err := rc.Plan(context.Background(), json.RawMessage(`{"argv":["mycmd"]}`)); err != nil {
 		t.Fatal(err)
@@ -523,7 +523,7 @@ func TestInvokeDirChangedFailsClosed(t *testing.T) {
 	t.Setenv("PATH", pathDir)
 	t.Setenv("HOME", "/home/x")
 
-	fr := &fakeRunner{result: execResult{Started: true}}
+	fr := &fakeRunner{}
 	rc := NewRunCommand(ws, fr)
 
 	raw := json.RawMessage(`{"argv":["mycmd"],"dir":"sub"}`)
@@ -566,7 +566,7 @@ func TestInvokeExecutableChangedFailsClosed(t *testing.T) {
 	t.Setenv("PATH", pathDir)
 	t.Setenv("HOME", "/home/x")
 
-	fr := &fakeRunner{result: execResult{Started: true}}
+	fr := &fakeRunner{}
 	rc := NewRunCommand(ws, fr)
 
 	raw := json.RawMessage(`{"argv":["mycmd"]}`)
@@ -590,5 +590,82 @@ func TestInvokeExecutableChangedFailsClosed(t *testing.T) {
 	}
 	if fr.called {
 		t.Error("runner must not be called when executable identity check fails")
+	}
+}
+
+// Fix 1: runner returning DeadlineExceeded + TimedOut=true must produce "timed out" message.
+func TestInvokeRunnerTimeoutMessage(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+	fr := &fakeRunner{result: execResult{TimedOut: true}, err: context.DeadlineExceeded}
+	rc, _ := invokeRC(t, fr)
+	raw := json.RawMessage(`{"argv":["mycmd"]}`)
+	if _, err := rc.Plan(context.Background(), raw); err != nil {
+		t.Fatal(err)
+	}
+	res, err := rc.Invoke(context.Background(), raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Error("timeout runner error must surface as IsError")
+	}
+	if !strings.Contains(res.Content, "timed out") {
+		t.Errorf("want 'timed out' in content, got: %q", res.Content)
+	}
+}
+
+// Fix 1: runner returning context.Canceled (no TimedOut) must produce "canceled" message.
+func TestInvokeRunnerCanceledMessage(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+	fr := &fakeRunner{err: context.Canceled}
+	rc, _ := invokeRC(t, fr)
+	raw := json.RawMessage(`{"argv":["mycmd"]}`)
+	if _, err := rc.Plan(context.Background(), raw); err != nil {
+		t.Fatal(err)
+	}
+	res, err := rc.Invoke(context.Background(), raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Error("canceled runner error must surface as IsError")
+	}
+	if !strings.Contains(res.Content, "canceled") {
+		t.Errorf("want 'canceled' in content, got: %q", res.Content)
+	}
+}
+
+// Fix 3: renderExecPreview must quote args that contain spaces.
+func TestRenderExecPreviewQuotesSpacedArgs(t *testing.T) {
+	p := execPending{
+		path:        "/usr/bin/git",
+		argv:        []string{"git", "commit", "-m", "hello world"},
+		dirLabel:    "",
+		envNames:    []string{"PATH"},
+		timeout:     60 * time.Second,
+		fingerprint: "abc123",
+	}
+	out := renderExecPreview(p, "git")
+	// The spaced arg must appear quoted.
+	if !strings.Contains(out, `"hello world"`) {
+		t.Errorf("spaced arg not quoted in preview:\n%s", out)
+	}
+	// Simple args must appear bare (no quotes).
+	if strings.Contains(out, `"git"`) || strings.Contains(out, `"commit"`) || strings.Contains(out, `"-m"`) {
+		t.Errorf("simple args should not be quoted in preview:\n%s", out)
+	}
+}
+
+// Fix 3: renderArgvForPreview must leave simple argv like "go test ./..." unquoted.
+func TestRenderArgvForPreviewNoExtraQuotes(t *testing.T) {
+	argv := []string{"go", "test", "./..."}
+	got := renderArgvForPreview(argv)
+	want := "go test ./..."
+	if got != want {
+		t.Errorf("renderArgvForPreview = %q, want %q", got, want)
 	}
 }

--- a/agent/tools/exec_test.go
+++ b/agent/tools/exec_test.go
@@ -1,0 +1,57 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/agent"
+)
+
+func TestRunCommandSpec(t *testing.T) {
+	rc := NewRunCommand(nil, nil)
+	s := rc.Spec()
+	if s.Name != "run_command" {
+		t.Fatalf("name = %q, want run_command", s.Name)
+	}
+	for _, want := range []string{"argv", "dir", "timeout_seconds"} {
+		if !strings.Contains(string(s.Parameters), want) {
+			t.Errorf("schema missing %q: %s", want, s.Parameters)
+		}
+	}
+	if strings.Contains(string(s.Parameters), "oneOf") {
+		t.Error("schema must not use oneOf")
+	}
+}
+
+func TestRunCommandEffect(t *testing.T) {
+	e := NewRunCommand(nil, nil).Effect()
+	for _, c := range []agent.EffectClass{agent.Read, agent.Write, agent.Exec, agent.Network} {
+		if !e.Class.Has(c) {
+			t.Errorf("effect class missing bit %v", c)
+		}
+	}
+	if e.Approval != agent.ApprovalAlways {
+		t.Errorf("approval = %v, want ApprovalAlways", e.Approval)
+	}
+	if e.OutputCap != execRuntimeCap {
+		t.Errorf("OutputCap = %d, want %d", e.OutputCap, execRuntimeCap)
+	}
+}
+
+func TestCappedBuffer(t *testing.T) {
+	b := &cappedBuffer{cap: 4}
+	n, err := b.Write([]byte("abcdef"))
+	if err != nil || n != 6 {
+		t.Fatalf("Write = %d,%v; want 6,nil (must consume all to avoid pipe deadlock)", n, err)
+	}
+	if string(b.buf) != "abcd" {
+		t.Errorf("buf = %q, want abcd", b.buf)
+	}
+	if !b.truncated {
+		t.Error("truncated should be true")
+	}
+	n, _ = b.Write([]byte("g"))
+	if n != 1 || string(b.buf) != "abcd" {
+		t.Errorf("post-cap write: n=%d buf=%q", n, b.buf)
+	}
+}

--- a/agent/tools/exec_test.go
+++ b/agent/tools/exec_test.go
@@ -39,6 +39,43 @@ func TestRunCommandEffect(t *testing.T) {
 	}
 }
 
+func TestBuildExecEnv(t *testing.T) {
+	parent := map[string]string{
+		"PATH":           "/usr/bin:/bin",
+		"HOME":           "/home/x",
+		"LANG":           "en_US.UTF-8",
+		"USER":           "x",
+		"SECRET_TOKEN":   "shhh",
+		"OPENAI_API_KEY": "sk-xyz",
+		// TMPDIR intentionally absent -> skipped, not errored
+	}
+	lookup := func(k string) (string, bool) { v, ok := parent[k]; return v, ok }
+
+	env, names := buildExecEnv(lookup)
+
+	joined := strings.Join(env, "\n")
+	if strings.Contains(joined, "SECRET_TOKEN") || strings.Contains(joined, "OPENAI_API_KEY") {
+		t.Fatalf("secret leaked into child env: %q", env)
+	}
+	for _, want := range []string{"PATH=/usr/bin:/bin", "HOME=/home/x", "LANG=en_US.UTF-8", "USER=x"} {
+		found := false
+		for _, e := range env {
+			if e == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("env missing %q (got %v)", want, env)
+		}
+	}
+	if got := strings.Join(names, ","); got != "HOME,LANG,PATH,USER" {
+		t.Errorf("names = %q, want sorted present names HOME,LANG,PATH,USER", got)
+	}
+	if pathFromEnv(env) != "/usr/bin:/bin" {
+		t.Errorf("pathFromEnv = %q", pathFromEnv(env))
+	}
+}
+
 func TestResolveExecTimeout(t *testing.T) {
 	p := func(n int) *int { return &n }
 	cases := []struct {

--- a/agent/tools/exec_test.go
+++ b/agent/tools/exec_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kstruzzieri/go-llm/agent"
 )
@@ -35,6 +36,39 @@ func TestRunCommandEffect(t *testing.T) {
 	}
 	if e.OutputCap != execRuntimeCap {
 		t.Errorf("OutputCap = %d, want %d", e.OutputCap, execRuntimeCap)
+	}
+}
+
+func TestResolveExecTimeout(t *testing.T) {
+	p := func(n int) *int { return &n }
+	cases := []struct {
+		name      string
+		in        *int
+		wantEff   time.Duration
+		wantReq   int
+		wantClamp bool
+		wantErr   bool
+	}{
+		{"default", nil, 60 * time.Second, 0, false, false},
+		{"explicit", p(120), 120 * time.Second, 120, false, false},
+		{"zero", p(0), 0, 0, false, true},
+		{"negative", p(-5), 0, 0, false, true},
+		{"max", p(600), 600 * time.Second, 600, false, false},
+		{"clamp", p(900), 600 * time.Second, 900, true, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			eff, req, clamp, err := resolveExecTimeout(c.in)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, c.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if eff != c.wantEff || req != c.wantReq || clamp != c.wantClamp {
+				t.Errorf("got (%v,%d,%v) want (%v,%d,%v)", eff, req, clamp, c.wantEff, c.wantReq, c.wantClamp)
+			}
+		})
 	}
 }
 

--- a/agent/tools/exec_test.go
+++ b/agent/tools/exec_test.go
@@ -1,6 +1,8 @@
 package tools
 
 import (
+	"context"
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -295,3 +297,66 @@ func TestCappedBuffer(t *testing.T) {
 		t.Errorf("post-cap write: n=%d buf=%q", n, b.buf)
 	}
 }
+
+// Task 8: Plan tests
+
+func planWS(t *testing.T) (*RunCommand, string) {
+	t.Helper()
+	root := t.TempDir()
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return NewRunCommand(ws, nil), root
+}
+
+func TestPlanValid(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix exec semantics")
+	}
+	rc, root := planWS(t)
+	pathDir := t.TempDir()
+	writeExecutable(t, filepath.Join(pathDir, "mycmd"), "#!/bin/sh\n")
+	t.Setenv("PATH", pathDir)
+	t.Setenv("HOME", "/home/x")
+
+	raw := json.RawMessage(`{"argv":["mycmd","arg"]}`)
+	plan, err := rc.Plan(context.Background(), raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Effect.Timeout != execDefaultTimeout {
+		t.Errorf("timeout = %v, want %v", plan.Effect.Timeout, execDefaultTimeout)
+	}
+	if plan.Effect.OutputCap != execRuntimeCap {
+		t.Errorf("OutputCap = %d", plan.Effect.OutputCap)
+	}
+	if !strings.Contains(plan.Preview, "mycmd arg") {
+		t.Errorf("preview missing argv:\n%s", plan.Preview)
+	}
+	// pending plan is stashed under the raw-args hash
+	if _, ok := rc.consume(ContentHash(raw)); !ok {
+		t.Error("expected stashed pending plan")
+	}
+	_ = root
+}
+
+func TestPlanRejects(t *testing.T) {
+	rc, _ := planWS(t)
+	cases := map[string]string{
+		"empty argv":   `{"argv":[]}`,
+		"blank argv0":  `{"argv":["   "]}`,
+		"bad json":     `{"argv":`,
+		"zero timeout": `{"argv":["echo"],"timeout_seconds":0}`,
+		"dir escape":   `{"argv":["echo"],"dir":"../../etc"}`,
+		"absolute dir": `{"argv":["echo"],"dir":"/etc"}`,
+	}
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := rc.Plan(context.Background(), json.RawMessage(raw)); err == nil {
+				t.Errorf("Plan(%s) = nil err, want error", raw)
+			}
+		})
+	}
+}
+

--- a/agent/tools/exec_test.go
+++ b/agent/tools/exec_test.go
@@ -574,12 +574,17 @@ func TestInvokeExecutableChangedFailsClosed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Between Plan and Invoke: replace mycmd with a new file at a different inode.
-	// os.Remove + writeExecutable allocates a new inode, so os.SameFile returns false.
-	if err := os.Remove(filepath.Join(pathDir, "mycmd")); err != nil {
+	// Between Plan and Invoke: replace mycmd with a different file at a NEW inode.
+	// Writing a sibling and renaming it over the path guarantees a distinct inode on
+	// any filesystem: the sibling is allocated a fresh inode while the original still
+	// exists, then rename relinks the path to it. A plain remove+recreate can reuse the
+	// original inode on ext4/overlayfs, which would make os.SameFile pass and silently
+	// defeat the identity check this test exists to verify.
+	swapped := filepath.Join(pathDir, "mycmd.new")
+	writeExecutable(t, swapped, "#!/bin/sh\n# inode B\n")
+	if err := os.Rename(swapped, filepath.Join(pathDir, "mycmd")); err != nil {
 		t.Fatal(err)
 	}
-	writeExecutable(t, filepath.Join(pathDir, "mycmd"), "#!/bin/sh\n# inode B\n")
 
 	res, err := rc.Invoke(context.Background(), raw)
 	if err != nil {

--- a/agent/tools/exec_test.go
+++ b/agent/tools/exec_test.go
@@ -129,6 +129,45 @@ func TestResolveExecutable(t *testing.T) {
 	_ = exec.ErrNotFound
 }
 
+func TestRenderExecPreview(t *testing.T) {
+	p := execPending{
+		path:        "/usr/local/go/bin/go",
+		argv:        []string{"go", "test", "./..."},
+		dirLabel:    "(workspace root)",
+		envNames:    []string{"HOME", "PATH"},
+		timeout:     60 * time.Second,
+		fingerprint: "abc123def456",
+	}
+	out := renderExecPreview(p, "go")
+	for _, want := range []string{
+		"go test ./...",
+		"go -> /usr/local/go/bin/go",
+		"(workspace root)",
+		"60s",
+		"HOME(parent)", "PATH(parent)",
+		"abc123def456",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("preview missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "clamped") {
+		t.Error("unclamped preview should not mention clamping")
+	}
+}
+
+func TestRenderExecPreviewClamped(t *testing.T) {
+	p := execPending{
+		path: "/bin/sleep", argv: []string{"sleep", "999"},
+		dirLabel: "sub", envNames: []string{"PATH"},
+		timeout: 600 * time.Second, requestedTO: 900, clamped: true, fingerprint: "f1",
+	}
+	out := renderExecPreview(p, "sleep")
+	if !strings.Contains(out, "600s (requested 900s, clamped)") {
+		t.Errorf("missing clamp note:\n%s", out)
+	}
+}
+
 func TestCommandFingerprint(t *testing.T) {
 	base := commandFingerprint([]string{"go", "test"}, "/w", []string{"PATH"}, 60*time.Second)
 	if len(base) != fingerprintLen {

--- a/agent/tools/exec_test.go
+++ b/agent/tools/exec_test.go
@@ -129,6 +129,30 @@ func TestResolveExecutable(t *testing.T) {
 	_ = exec.ErrNotFound
 }
 
+func TestCommandFingerprint(t *testing.T) {
+	base := commandFingerprint([]string{"go", "test"}, "/w", []string{"PATH"}, 60*time.Second)
+	if len(base) != fingerprintLen {
+		t.Fatalf("len = %d, want %d", len(base), fingerprintLen)
+	}
+	if base != commandFingerprint([]string{"go", "test"}, "/w", []string{"PATH"}, 60*time.Second) {
+		t.Error("must be stable for identical inputs")
+	}
+	diff := []struct {
+		name string
+		f    string
+	}{
+		{"argv", commandFingerprint([]string{"go", "vet"}, "/w", []string{"PATH"}, 60*time.Second)},
+		{"cwd", commandFingerprint([]string{"go", "test"}, "/x", []string{"PATH"}, 60*time.Second)},
+		{"env", commandFingerprint([]string{"go", "test"}, "/w", []string{"PATH", "HOME"}, 60*time.Second)},
+		{"timeout", commandFingerprint([]string{"go", "test"}, "/w", []string{"PATH"}, 30*time.Second)},
+	}
+	for _, d := range diff {
+		if d.f == base {
+			t.Errorf("%s change did not alter fingerprint", d.name)
+		}
+	}
+}
+
 func TestBuildExecEnv(t *testing.T) {
 	parent := map[string]string{
 		"PATH":           "/usr/bin:/bin",

--- a/agent/tools/exec_test.go
+++ b/agent/tools/exec_test.go
@@ -351,6 +351,7 @@ func TestPlanRejects(t *testing.T) {
 		"zero timeout": `{"argv":["echo"],"timeout_seconds":0}`,
 		"dir escape":   `{"argv":["echo"],"dir":"../../etc"}`,
 		"absolute dir": `{"argv":["echo"],"dir":"/etc"}`,
+		"nul in argv":  "{\"argv\":[\"echo\x00evil\"]}",
 	}
 	for name, raw := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -358,6 +359,30 @@ func TestPlanRejects(t *testing.T) {
 				t.Errorf("Plan(%s) = nil err, want error", raw)
 			}
 		})
+	}
+}
+
+func TestPlanDirDotIsRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix exec semantics")
+	}
+	rc, _ := planWS(t)
+	pathDir := t.TempDir()
+	writeExecutable(t, filepath.Join(pathDir, "mycmd"), "#!/bin/sh\n")
+	t.Setenv("PATH", pathDir)
+	t.Setenv("HOME", "/home/x")
+
+	raw := json.RawMessage(`{"argv":["mycmd"],"dir":"."}`)
+	plan, err := rc.Plan(context.Background(), raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(plan.Preview, "(workspace root)") {
+		t.Errorf("dir=. should resolve to (workspace root) in preview:\n%s", plan.Preview)
+	}
+	// Must NOT show a bare "cwd: ." in the preview.
+	if strings.Contains(plan.Preview, "cwd:     .") {
+		t.Errorf("dir=. must not show as bare dot in cwd line:\n%s", plan.Preview)
 	}
 }
 

--- a/agent/tools/exec_test.go
+++ b/agent/tools/exec_test.go
@@ -129,6 +129,22 @@ func TestResolveExecutable(t *testing.T) {
 	_ = exec.ErrNotFound
 }
 
+func TestFormatExecResult(t *testing.T) {
+	out := formatExecResult(execResult{ExitCode: 1, Stdout: []byte("hello\n"), Stderr: []byte("oops\n")})
+	for _, want := range []string{"exit code: 1", "--- stdout ---", "hello", "--- stderr ---", "oops"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestFormatExecResultTruncationMarkers(t *testing.T) {
+	out := formatExecResult(execResult{ExitCode: 0, Stdout: []byte("a"), StdoutTruncated: true, Stderr: []byte("b"), StderrTruncated: true})
+	if c := strings.Count(out, "[truncated]"); c != 2 {
+		t.Errorf("want 2 truncation markers, got %d:\n%s", c, out)
+	}
+}
+
 func TestRenderExecPreview(t *testing.T) {
 	p := execPending{
 		path:        "/usr/local/go/bin/go",

--- a/agent/tools/exec_test.go
+++ b/agent/tools/exec_test.go
@@ -1,6 +1,10 @@
 package tools
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -37,6 +41,92 @@ func TestRunCommandEffect(t *testing.T) {
 	if e.OutputCap != execRuntimeCap {
 		t.Errorf("OutputCap = %d, want %d", e.OutputCap, execRuntimeCap)
 	}
+}
+
+func writeExecutable(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResolveExecutable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix exec-bit semantics")
+	}
+	root := t.TempDir()
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Use ws.root (canonical, post-EvalSymlinks) so path arithmetic is consistent.
+	dir := ws.root
+	// bin/ holds a workspace-relative script
+	if err := os.Mkdir(filepath.Join(dir, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutable(t, filepath.Join(dir, "bin", "tool.sh"), "#!/bin/sh\necho hi\n")
+
+	// a PATH dir outside the workspace with a bare command
+	pathDir := t.TempDir()
+	writeExecutable(t, filepath.Join(pathDir, "mycmd"), "#!/bin/sh\n")
+	pathVal := pathDir + string(os.PathListSeparator) + "/usr/bin:/bin"
+
+	t.Run("bare via PATH", func(t *testing.T) {
+		got, fi, err := resolveExecutable(ws, dir, "mycmd", pathVal)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != filepath.Join(pathDir, "mycmd") || fi == nil {
+			t.Errorf("resolved %q", got)
+		}
+	})
+	t.Run("bare not found", func(t *testing.T) {
+		if _, _, err := resolveExecutable(ws, dir, "no_such_cmd_xyz", pathVal); err == nil {
+			t.Error("want error")
+		}
+	})
+	t.Run("absolute", func(t *testing.T) {
+		abs := filepath.Join(pathDir, "mycmd")
+		got, _, err := resolveExecutable(ws, dir, abs, pathVal)
+		if err != nil || got != abs {
+			t.Errorf("got %q err %v", got, err)
+		}
+	})
+	t.Run("separator under workspace", func(t *testing.T) {
+		got, _, err := resolveExecutable(ws, dir, "bin/tool.sh", pathVal)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != filepath.Join(dir, "bin", "tool.sh") {
+			t.Errorf("resolved %q", got)
+		}
+	})
+	t.Run("separator escaping workspace rejected", func(t *testing.T) {
+		if _, _, err := resolveExecutable(ws, dir, "../escape.sh", pathVal); err == nil {
+			t.Error("want escape error")
+		}
+	})
+	t.Run("separator symlink rejected", func(t *testing.T) {
+		target := filepath.Join(pathDir, "mycmd")
+		link := filepath.Join(dir, "bin", "linked.sh")
+		if err := os.Symlink(target, link); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := resolveExecutable(ws, dir, "bin/linked.sh", pathVal); err == nil {
+			t.Error("want symlink rejection for in-workspace separator path")
+		}
+	})
+	t.Run("non-executable rejected", func(t *testing.T) {
+		p := filepath.Join(dir, "bin", "data.txt")
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := resolveExecutable(ws, dir, "bin/data.txt", pathVal); err == nil {
+			t.Error("want non-executable rejection")
+		}
+	})
+	_ = exec.ErrNotFound
 }
 
 func TestBuildExecEnv(t *testing.T) {

--- a/agent/tools/exec_test.go
+++ b/agent/tools/exec_test.go
@@ -477,3 +477,93 @@ func TestInvokeTimeoutIsError(t *testing.T) {
 		t.Error("timeout must surface as IsError")
 	}
 }
+
+func TestInvokeDirChangedFailsClosed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix symlink semantics")
+	}
+	root := t.TempDir()
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Create root/sub as a real directory so Plan accepts it.
+	subDir := filepath.Join(ws.root, "sub")
+	if err := os.Mkdir(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Set up a PATH dir with mycmd so Plan can resolve the executable.
+	pathDir := t.TempDir()
+	writeExecutable(t, filepath.Join(pathDir, "mycmd"), "#!/bin/sh\n")
+	t.Setenv("PATH", pathDir)
+	t.Setenv("HOME", "/home/x")
+
+	fr := &fakeRunner{result: execResult{Started: true}}
+	rc := NewRunCommand(ws, fr)
+
+	raw := json.RawMessage(`{"argv":["mycmd"],"dir":"sub"}`)
+	if _, err := rc.Plan(context.Background(), raw); err != nil {
+		t.Fatal(err)
+	}
+
+	// Between Plan and Invoke: replace root/sub with a symlink pointing outside the workspace.
+	outside := t.TempDir()
+	if err := os.RemoveAll(subDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, subDir); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := rc.Invoke(context.Background(), raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Error("dir changed to symlink: want IsError=true")
+	}
+	if fr.called {
+		t.Error("runner must not be called when dir check fails")
+	}
+}
+
+func TestInvokeExecutableChangedFailsClosed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix inode/SameFile semantics")
+	}
+	root := t.TempDir()
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pathDir := t.TempDir()
+	writeExecutable(t, filepath.Join(pathDir, "mycmd"), "#!/bin/sh\n# inode A\n")
+	t.Setenv("PATH", pathDir)
+	t.Setenv("HOME", "/home/x")
+
+	fr := &fakeRunner{result: execResult{Started: true}}
+	rc := NewRunCommand(ws, fr)
+
+	raw := json.RawMessage(`{"argv":["mycmd"]}`)
+	if _, err := rc.Plan(context.Background(), raw); err != nil {
+		t.Fatal(err)
+	}
+
+	// Between Plan and Invoke: replace mycmd with a new file at a different inode.
+	// os.Remove + writeExecutable allocates a new inode, so os.SameFile returns false.
+	if err := os.Remove(filepath.Join(pathDir, "mycmd")); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutable(t, filepath.Join(pathDir, "mycmd"), "#!/bin/sh\n# inode B\n")
+
+	res, err := rc.Invoke(context.Background(), raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Error("executable swapped: want IsError=true")
+	}
+	if fr.called {
+		t.Error("runner must not be called when executable identity check fails")
+	}
+}

--- a/agent/tools/exec_test.go
+++ b/agent/tools/exec_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -360,3 +361,119 @@ func TestPlanRejects(t *testing.T) {
 	}
 }
 
+// Task 9: Invoke tests
+
+type fakeRunner struct {
+	result   execResult
+	err      error
+	blockCtx bool // when true, block until ctx is done then report TimedOut
+	gotSpec  execSpec
+	called   bool
+}
+
+func (f *fakeRunner) Run(ctx context.Context, spec execSpec) (execResult, error) {
+	f.called, f.gotSpec = true, spec
+	if f.blockCtx {
+		<-ctx.Done()
+		return execResult{Started: true, TimedOut: true}, fmt.Errorf("timed out")
+	}
+	return f.result, f.err
+}
+
+func invokeRC(t *testing.T, fr *fakeRunner) (*RunCommand, string) {
+	t.Helper()
+	root := t.TempDir()
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pathDir := t.TempDir()
+	writeExecutable(t, filepath.Join(pathDir, "mycmd"), "#!/bin/sh\n")
+	t.Setenv("PATH", pathDir)
+	t.Setenv("HOME", "/home/x")
+	return NewRunCommand(ws, fr), root
+}
+
+func TestInvokeNonZeroExitNotError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+	fr := &fakeRunner{result: execResult{ExitCode: 1, Stdout: []byte("FAIL\n"), Started: true}}
+	rc, _ := invokeRC(t, fr)
+	raw := json.RawMessage(`{"argv":["mycmd"]}`)
+	if _, err := rc.Plan(context.Background(), raw); err != nil {
+		t.Fatal(err)
+	}
+	res, err := rc.Invoke(context.Background(), raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Error("non-zero exit must NOT be a tool error")
+	}
+	if !strings.Contains(res.Content, "exit code: 1") || !strings.Contains(res.Content, "FAIL") {
+		t.Errorf("content = %q", res.Content)
+	}
+	if !fr.called || fr.gotSpec.Dir == "" {
+		t.Error("runner not invoked with a resolved spec")
+	}
+}
+
+func TestInvokePlanMismatchFailsClosed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+	fr := &fakeRunner{result: execResult{Started: true}}
+	rc, _ := invokeRC(t, fr)
+	if _, err := rc.Plan(context.Background(), json.RawMessage(`{"argv":["mycmd"]}`)); err != nil {
+		t.Fatal(err)
+	}
+	// different args -> hash mismatch -> fail closed, runner never called
+	res, err := rc.Invoke(context.Background(), json.RawMessage(`{"argv":["mycmd","x"]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError || fr.called {
+		t.Errorf("want fail-closed without spawning; IsError=%v called=%v", res.IsError, fr.called)
+	}
+}
+
+func TestInvokeInfraError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+	fr := &fakeRunner{err: fmt.Errorf("spawn boom")}
+	rc, _ := invokeRC(t, fr)
+	raw := json.RawMessage(`{"argv":["mycmd"]}`)
+	if _, err := rc.Plan(context.Background(), raw); err != nil {
+		t.Fatal(err)
+	}
+	res, err := rc.Invoke(context.Background(), raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Error("runner infra error must surface as IsError")
+	}
+}
+
+func TestInvokeTimeoutIsError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+	fr := &fakeRunner{blockCtx: true}
+	rc, _ := invokeRC(t, fr)
+	raw := json.RawMessage(`{"argv":["mycmd"]}`)
+	if _, err := rc.Plan(context.Background(), raw); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	res, err := rc.Invoke(ctx, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Error("timeout must surface as IsError")
+	}
+}

--- a/agent/tools/exec_test.go
+++ b/agent/tools/exec_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -82,6 +83,24 @@ func TestResolveExecutable(t *testing.T) {
 		}
 		if got != filepath.Join(pathDir, "mycmd") || fi == nil {
 			t.Errorf("resolved %q", got)
+		}
+	})
+	t.Run("bare via relative PATH returns absolute path", func(t *testing.T) {
+		processRoot := t.TempDir()
+		relBin := filepath.Join(processRoot, "relbin")
+		if err := os.Mkdir(relBin, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeExecutable(t, filepath.Join(relBin, "relcmd"), "#!/bin/sh\n")
+		t.Chdir(processRoot)
+
+		got, fi, err := resolveExecutable(ws, dir, "relcmd", "relbin")
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := filepath.Join(relBin, "relcmd")
+		if got != want || !filepath.IsAbs(got) || fi == nil {
+			t.Errorf("resolved %q, want absolute %q", got, want)
 		}
 	})
 	t.Run("bare not found", func(t *testing.T) {
@@ -264,6 +283,17 @@ func TestResolveExecTimeout(t *testing.T) {
 		{"negative", p(-5), 0, 0, false, true},
 		{"max", p(600), 600 * time.Second, 600, false, false},
 		{"clamp", p(900), 600 * time.Second, 900, true, false},
+	}
+	if strconv.IntSize == 64 {
+		huge := int(int64(10_000_000_000))
+		cases = append(cases, struct {
+			name      string
+			in        *int
+			wantEff   time.Duration
+			wantReq   int
+			wantClamp bool
+			wantErr   bool
+		}{"clamp before duration overflow", p(huge), execMaxTimeout, huge, true, false})
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -549,6 +579,55 @@ func TestInvokeDirChangedFailsClosed(t *testing.T) {
 	}
 	if fr.called {
 		t.Error("runner must not be called when dir check fails")
+	}
+}
+
+func TestInvokeDirIdentityChangedFailsClosed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix inode/SameFile semantics")
+	}
+	root := t.TempDir()
+	ws, err := NewWorkspace(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	subDir := filepath.Join(ws.root, "sub")
+	if err := os.Mkdir(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pathDir := t.TempDir()
+	writeExecutable(t, filepath.Join(pathDir, "mycmd"), "#!/bin/sh\n")
+	t.Setenv("PATH", pathDir)
+	t.Setenv("HOME", "/home/x")
+
+	fr := &fakeRunner{}
+	rc := NewRunCommand(ws, fr)
+	raw := json.RawMessage(`{"argv":["mycmd"],"dir":"sub"}`)
+	if _, err := rc.Plan(context.Background(), raw); err != nil {
+		t.Fatal(err)
+	}
+
+	oldSub := filepath.Join(ws.root, "sub.old")
+	newSub := filepath.Join(ws.root, "sub.new")
+	if err := os.Rename(subDir, oldSub); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(newSub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(newSub, subDir); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := rc.Invoke(context.Background(), raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Error("dir identity changed: want IsError=true")
+	}
+	if fr.called {
+		t.Error("runner must not be called when dir identity check fails")
 	}
 }
 

--- a/agent/tools/exec_unix.go
+++ b/agent/tools/exec_unix.go
@@ -46,7 +46,6 @@ func (unixRunner) Run(ctx context.Context, spec execSpec) (execResult, error) {
 	waitErr := cmd.Wait()
 
 	res := execResult{
-		Started:         true,
 		Stdout:          stdout.buf,
 		Stderr:          stderr.buf,
 		StdoutTruncated: stdout.truncated,
@@ -54,7 +53,9 @@ func (unixRunner) Run(ctx context.Context, spec execSpec) (execResult, error) {
 		ExitCode:        cmd.ProcessState.ExitCode(),
 	}
 	if ctx.Err() != nil {
-		res.TimedOut = true
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			res.TimedOut = true
+		}
 		return res, ctx.Err()
 	}
 	if waitErr != nil {

--- a/agent/tools/exec_unix.go
+++ b/agent/tools/exec_unix.go
@@ -1,0 +1,69 @@
+//go:build unix
+
+package tools
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"syscall"
+)
+
+// unixRunner executes commands in their own process group so a timeout/cancel can kill
+// the whole group (reaping ordinary children), and bounds stdout/stderr to the tool's
+// self-caps while always consuming pipe writes (no deadlock).
+type unixRunner struct{}
+
+func newPlatformRunner() commandRunner { return unixRunner{} }
+
+func (unixRunner) Run(ctx context.Context, spec execSpec) (execResult, error) {
+	// CommandContext (NOT exec.Command) is REQUIRED: cmd.Cancel and cmd.WaitDelay are
+	// only consulted when the command was created with a context. With exec.Command the
+	// custom group-kill Cancel would never fire on timeout.
+	cmd := exec.CommandContext(ctx, spec.Path, spec.Argv[1:]...)
+	cmd.Dir = spec.Dir
+	cmd.Env = spec.Env
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	stdout := &cappedBuffer{cap: execStdoutCap}
+	stderr := &cappedBuffer{cap: execStderrCap}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	// Context-driven cancel: kill the whole process GROUP (negative pid). WaitDelay
+	// bounds how long a child that ignores the kill can keep pipes open.
+	cmd.Cancel = func() error {
+		if cmd.Process != nil {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		}
+		return nil
+	}
+	cmd.WaitDelay = execWaitDelay
+
+	if err := cmd.Start(); err != nil {
+		return execResult{}, err
+	}
+	waitErr := cmd.Wait()
+
+	res := execResult{
+		Started:         true,
+		Stdout:          stdout.buf,
+		Stderr:          stderr.buf,
+		StdoutTruncated: stdout.truncated,
+		StderrTruncated: stderr.truncated,
+		ExitCode:        cmd.ProcessState.ExitCode(),
+	}
+	if ctx.Err() != nil {
+		res.TimedOut = true
+		return res, ctx.Err()
+	}
+	if waitErr != nil {
+		var ee *exec.ExitError
+		if errors.As(waitErr, &ee) {
+			// normal non-zero exit: ExitCode already set, NOT an infra error
+			return res, nil
+		}
+		return res, waitErr
+	}
+	return res, nil
+}

--- a/agent/tools/exec_unix_test.go
+++ b/agent/tools/exec_unix_test.go
@@ -6,7 +6,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -20,28 +23,70 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-// helperMain: ["echo", args...] -> print args to stdout; ["fail", code] -> exit code;
-// ["sleep", seconds] -> sleep (spawns its own child to verify group kill);
-// ["dumpenv"] -> print env one per line.
+// helperMain handles hermetic helper sub-commands:
+//
+//	["echo", args...]              -> print args to stdout
+//	["errto", args...]             -> print args to stderr
+//	["fail"]                       -> exit with code 3
+//	["dumpenv"]                    -> print env, one key=value per line
+//	["sleep"]                      -> sleep 30s (plain sleeper, e.g. for timeout tests)
+//	["groupkill", <pidfile>]       -> spawn a grandchild justsleep, write its PID to
+//	                                  <pidfile>, then sleep 30s; used to verify that
+//	                                  a group-kill reaps the grandchild too
+//	["justsleep"]                  -> sleep 30s (grandchild target for groupkill test)
 func helperMain(args []string) int {
 	if len(args) == 0 {
 		return 0
 	}
 	switch args[0] {
 	case "echo":
-		fmt.Fprintln(os.Stdout, strings.Join(args[1:], " "))
+		_, _ = fmt.Fprintln(os.Stdout, strings.Join(args[1:], " "))
 		return 0
 	case "errto":
-		fmt.Fprintln(os.Stderr, strings.Join(args[1:], " "))
+		_, _ = fmt.Fprintln(os.Stderr, strings.Join(args[1:], " "))
 		return 0
 	case "fail":
 		return 3
 	case "dumpenv":
 		for _, e := range os.Environ() {
-			fmt.Fprintln(os.Stdout, e)
+			_, _ = fmt.Fprintln(os.Stdout, e)
 		}
 		return 0
 	case "sleep":
+		time.Sleep(30 * time.Second)
+		return 0
+	case "groupkill":
+		if len(args) < 2 {
+			_, _ = fmt.Fprintln(os.Stderr, "groupkill: missing pidfile argument")
+			return 1
+		}
+		pidfile := args[1]
+		// Spawn a grandchild that will sleep in the same process group; a
+		// group-kill of this process's group must also terminate it.
+		self, err := os.Executable()
+		if err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, "groupkill: os.Executable:", err)
+			return 1
+		}
+		child := exec.Command(self, "__golem_exec_helper__", "justsleep")
+		// Explicitly do NOT set Setpgid on the grandchild so it stays in the
+		// same process group as this helper and the group-kill from the runner
+		// will reach it.
+		if err := child.Start(); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, "groupkill: child.Start:", err)
+			return 1
+		}
+		// Write grandchild PID to the pidfile so the test can read it.
+		if err := os.WriteFile(pidfile, []byte(strconv.Itoa(child.Process.Pid)), 0o600); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, "groupkill: WriteFile:", err)
+			_ = child.Process.Kill()
+			return 1
+		}
+		// Block until killed (along with the grandchild) by a group-kill.
+		time.Sleep(30 * time.Second)
+		return 0
+	case "justsleep":
+		// Grandchild target: just sleep; meant to be killed by a group SIGKILL.
 		time.Sleep(30 * time.Second)
 		return 0
 	}
@@ -123,5 +168,68 @@ func TestUnixRunnerOutputCap(t *testing.T) {
 	}
 	if len(res.Stdout) > execStdoutCap || !res.StdoutTruncated {
 		t.Errorf("len=%d truncated=%v want <=%d and truncated", len(res.Stdout), res.StdoutTruncated, execStdoutCap)
+	}
+}
+
+// TestUnixRunnerGroupKillReapsChild verifies that the Setpgid + group-kill machinery
+// in unixRunner actually reaps grandchildren that share the leader's process group,
+// not just the leader itself.
+func TestUnixRunnerGroupKillReapsChild(t *testing.T) {
+	pidfile := t.TempDir() + "/grandchild.pid"
+
+	r := unixRunner{}
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	// Run the "groupkill" helper in the background so we can poll the pidfile
+	// while it runs.
+	type result struct {
+		res execResult
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		res, err := r.Run(ctx, helperSpec(t, "groupkill", pidfile))
+		done <- result{res, err}
+	}()
+
+	// Poll for the pidfile (written by the helper after the grandchild starts).
+	var grandchildPID int
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(pidfile)
+		if err == nil && len(data) > 0 {
+			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+			if parseErr == nil && pid > 0 {
+				grandchildPID = pid
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if grandchildPID == 0 {
+		t.Fatal("timed out waiting for grandchild pidfile to appear")
+	}
+
+	// Wait for the runner to finish (context timeout fires, group-kill issued).
+	r2 := <-done
+	if !r2.res.TimedOut {
+		t.Errorf("want TimedOut=true, got TimedOut=%v err=%v", r2.res.TimedOut, r2.err)
+	}
+
+	// Poll up to 2s confirming the grandchild is gone (SIGKILL to group must have
+	// reached it).  syscall.Kill(pid, 0) returns ESRCH when the process no longer
+	// exists (or has been fully reaped by its own parent).
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		err := syscall.Kill(grandchildPID, 0)
+		if err == syscall.ESRCH {
+			return // grandchild is gone — test passes
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	// One last check to produce a clear failure message.
+	if err := syscall.Kill(grandchildPID, 0); err != syscall.ESRCH {
+		t.Errorf("grandchild pid %d still alive after group-kill (Kill(pid,0) err=%v)", grandchildPID, err)
 	}
 }

--- a/agent/tools/exec_unix_test.go
+++ b/agent/tools/exec_unix_test.go
@@ -1,0 +1,127 @@
+//go:build unix
+
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestMain doubles as a hermetic helper binary: when invoked with the sentinel first
+// arg, it behaves as the child process the runner spawns, then exits.
+func TestMain(m *testing.M) {
+	if len(os.Args) > 1 && os.Args[1] == "__golem_exec_helper__" {
+		os.Exit(helperMain(os.Args[2:]))
+	}
+	os.Exit(m.Run())
+}
+
+// helperMain: ["echo", args...] -> print args to stdout; ["fail", code] -> exit code;
+// ["sleep", seconds] -> sleep (spawns its own child to verify group kill);
+// ["dumpenv"] -> print env one per line.
+func helperMain(args []string) int {
+	if len(args) == 0 {
+		return 0
+	}
+	switch args[0] {
+	case "echo":
+		fmt.Fprintln(os.Stdout, strings.Join(args[1:], " "))
+		return 0
+	case "errto":
+		fmt.Fprintln(os.Stderr, strings.Join(args[1:], " "))
+		return 0
+	case "fail":
+		return 3
+	case "dumpenv":
+		for _, e := range os.Environ() {
+			fmt.Fprintln(os.Stdout, e)
+		}
+		return 0
+	case "sleep":
+		time.Sleep(30 * time.Second)
+		return 0
+	}
+	return 0
+}
+
+func helperSpec(t *testing.T, args ...string) execSpec {
+	t.Helper()
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	argv := append([]string{self, "__golem_exec_helper__"}, args...)
+	return execSpec{Path: self, Argv: argv, Dir: t.TempDir(), Env: []string{"PATH=/usr/bin:/bin"}}
+}
+
+func TestUnixRunnerEchoAndExit(t *testing.T) {
+	r := unixRunner{}
+	res, err := r.Run(context.Background(), helperSpec(t, "echo", "hello", "world"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.ExitCode != 0 || !strings.Contains(string(res.Stdout), "hello world") {
+		t.Errorf("exit=%d stdout=%q", res.ExitCode, res.Stdout)
+	}
+}
+
+func TestUnixRunnerNonZeroExit(t *testing.T) {
+	r := unixRunner{}
+	res, err := r.Run(context.Background(), helperSpec(t, "fail"))
+	if err != nil {
+		t.Fatalf("non-zero exit must not be a runner error: %v", err)
+	}
+	if res.ExitCode != 3 {
+		t.Errorf("exit = %d, want 3", res.ExitCode)
+	}
+}
+
+func TestUnixRunnerTimeoutKills(t *testing.T) {
+	r := unixRunner{}
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	res, err := r.Run(ctx, helperSpec(t, "sleep", "30"))
+	if err == nil {
+		t.Fatal("want timeout error")
+	}
+	if !res.TimedOut {
+		t.Error("want TimedOut=true")
+	}
+	if time.Since(start) > 10*time.Second {
+		t.Error("kill did not take effect promptly")
+	}
+}
+
+func TestUnixRunnerEnvIsolation(t *testing.T) {
+	r := unixRunner{}
+	spec := helperSpec(t, "dumpenv")
+	spec.Env = []string{"PATH=/usr/bin:/bin", "HOME=/home/x"}
+	res, err := r.Run(context.Background(), spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dump := string(res.Stdout)
+	if !strings.Contains(dump, "HOME=/home/x") || !strings.Contains(dump, "PATH=") {
+		t.Errorf("allowlisted vars missing:\n%s", dump)
+	}
+	if strings.Contains(dump, "__golem_exec_helper__") {
+		t.Error("sentinel leaked into env (should be argv only)")
+	}
+}
+
+func TestUnixRunnerOutputCap(t *testing.T) {
+	r := unixRunner{}
+	big := strings.Repeat("x", execStdoutCap+5000)
+	res, err := r.Run(context.Background(), helperSpec(t, "echo", big))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Stdout) > execStdoutCap || !res.StdoutTruncated {
+		t.Errorf("len=%d truncated=%v want <=%d and truncated", len(res.Stdout), res.StdoutTruncated, execStdoutCap)
+	}
+}

--- a/agent/tools/exec_unix_test.go
+++ b/agent/tools/exec_unix_test.go
@@ -178,7 +178,7 @@ func TestUnixRunnerGroupKillReapsChild(t *testing.T) {
 	pidfile := t.TempDir() + "/grandchild.pid"
 
 	r := unixRunner{}
-	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 
 	// Run the "groupkill" helper in the background so we can poll the pidfile
@@ -195,7 +195,7 @@ func TestUnixRunnerGroupKillReapsChild(t *testing.T) {
 
 	// Poll for the pidfile (written by the helper after the grandchild starts).
 	var grandchildPID int
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		data, err := os.ReadFile(pidfile)
 		if err == nil && len(data) > 0 {
@@ -217,10 +217,10 @@ func TestUnixRunnerGroupKillReapsChild(t *testing.T) {
 		t.Errorf("want TimedOut=true, got TimedOut=%v err=%v", r2.res.TimedOut, r2.err)
 	}
 
-	// Poll up to 2s confirming the grandchild is gone (SIGKILL to group must have
+	// Poll up to 5s confirming the grandchild is gone (SIGKILL to group must have
 	// reached it).  syscall.Kill(pid, 0) returns ESRCH when the process no longer
 	// exists (or has been fully reaped by its own parent).
-	deadline = time.Now().Add(2 * time.Second)
+	deadline = time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		err := syscall.Kill(grandchildPID, 0)
 		if err == syscall.ESRCH {

--- a/cmd/golem/approver.go
+++ b/cmd/golem/approver.go
@@ -27,12 +27,21 @@ func newReplApprover(lr *lineReader, out io.Writer, color bool) *replApprover {
 	return &replApprover{lr: lr, out: out, color: color}
 }
 
-// Approve prints the diff and reads one line. "y"/"yes" (case-insensitive) approves.
+// Approve shows the preview and reads one line. "y"/"yes" (case-insensitive) approves.
 // "n", empty, and EOF deny with a nil error. A canceled context (Ctrl-C) denies and
 // returns the context error so the run aborts.
-func (a *replApprover) Approve(ctx context.Context, _ provider.ToolCall, preview string) (bool, error) {
-	a.renderDiff(preview)
-	_, _ = fmt.Fprint(a.out, "Apply this change? [y/N] ")
+// The prompt and rendering are action-neutral: run_command calls get a plain preview
+// and "Run this command?" prompt; all other calls get the diff rendering and "Apply
+// this change?" prompt.
+func (a *replApprover) Approve(ctx context.Context, call provider.ToolCall, preview string) (bool, error) {
+	isExec := call.Function.Name == "run_command"
+	if isExec {
+		a.renderPlain(preview)
+		_, _ = fmt.Fprint(a.out, "Run this command? [y/N] ")
+	} else {
+		a.renderDiff(preview)
+		_, _ = fmt.Fprint(a.out, "Apply this change? [y/N] ")
+	}
 	line, ok, err := a.lr.ReadLine(ctx)
 	if err != nil {
 		return false, err // ctx canceled: abort the run
@@ -47,6 +56,11 @@ func (a *replApprover) Approve(ctx context.Context, _ provider.ToolCall, preview
 	default:
 		return false, nil
 	}
+}
+
+// renderPlain prints a non-diff preview verbatim (no +/- coloring).
+func (a *replApprover) renderPlain(preview string) {
+	_, _ = fmt.Fprintln(a.out, strings.TrimRight(preview, "\n"))
 }
 
 func (a *replApprover) renderDiff(preview string) {

--- a/cmd/golem/approver_test.go
+++ b/cmd/golem/approver_test.go
@@ -60,6 +60,24 @@ func TestReplApproverContextCancelAborts(t *testing.T) {
 	}
 }
 
+func TestApproverExecPromptNeutral(t *testing.T) {
+	in := strings.NewReader("y\n")
+	var out strings.Builder
+	a := newReplApprover(newLineReader(in), &out, false)
+	call := provider.ToolCall{Function: provider.ToolCallFunction{Name: "run_command"}}
+	ok, err := a.Approve(context.Background(), call, "run command:\n  argv: go test\n")
+	if err != nil || !ok {
+		t.Fatalf("ok=%v err=%v", ok, err)
+	}
+	s := out.String()
+	if !strings.Contains(s, "Run this command?") {
+		t.Errorf("exec prompt should say 'Run this command?':\n%s", s)
+	}
+	if strings.Contains(s, "Apply this change?") {
+		t.Error("exec call must not use the diff prompt")
+	}
+}
+
 func TestReplApproverColorRendersAnsi(t *testing.T) {
 	var out strings.Builder
 	lr := newLineReader(strings.NewReader("n\n"))

--- a/cmd/golem/main.go
+++ b/cmd/golem/main.go
@@ -27,6 +27,7 @@ type flags struct {
 	fresh            bool
 	sessionID        string
 	allowWrite       bool
+	allowExec        bool
 	noRag            bool
 	noProjectContext bool
 }
@@ -45,6 +46,7 @@ func parseFlags(args []string) (flags, error) {
 	fs.BoolVar(&f.noSession, "no-session", false, "disable persistent session memory")
 	fs.BoolVar(&f.fresh, "fresh", false, "start a new persistent session instead of resuming this workspace")
 	fs.BoolVar(&f.allowWrite, "allow-write", false, "enable approval-gated write_file/edit_file tools")
+	fs.BoolVar(&f.allowExec, "allow-exec", false, "enable the approval-gated run_command exec tool")
 	fs.BoolVar(&f.noRag, "no-rag", false, "disable the retrieve tool entirely (ignore any auto index)")
 	fs.BoolVar(&f.noProjectContext, "no-project-context", false, "do not load AGENTS.md project-context files into the system prompt")
 	fs.StringVar(&f.sessionID, "session", "", "explicit session id to resume or create (default: per-workspace)")
@@ -208,10 +210,15 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 		journal = j
 	}
 
-	baseSystem := golemSystemPrompt
-	if f.allowWrite {
-		baseSystem = golemWriteSystemPrompt
+	if f.allowExec {
+		et, eerr := buildExecTools(root)
+		if eerr != nil {
+			return eerr
+		}
+		tools = append(tools, et...)
 	}
+
+	baseSystem := buildSystemPrompt(f.allowWrite, f.allowExec)
 	projectContextLine := ""
 	if !f.noProjectContext {
 		if block, n, perr := loadProjectContext(ctx, root, os.Getenv); perr != nil {
@@ -267,6 +274,7 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 		session:         sessn,
 		journal:         journal,
 		allowWrite:      f.allowWrite,
+		allowExec:       f.allowExec,
 	}
 	if sess.maxSteps == 0 {
 		sess.maxSteps = 16 // mirror agent defaultMaxSteps so the footer's k/max is accurate

--- a/cmd/golem/main_test.go
+++ b/cmd/golem/main_test.go
@@ -164,6 +164,16 @@ func TestParseFlagsProjectContextOptOut(t *testing.T) {
 	}
 }
 
+func TestParseFlagsAllowExec(t *testing.T) {
+	f, err := parseFlags([]string{"-allow-exec"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !f.allowExec {
+		t.Error("allowExec should be true")
+	}
+}
+
 func TestStartupNoticesProjectContextLineIsInformational(t *testing.T) {
 	got := startupNotices(startupInfo{
 		workspace:          "/abs/root",

--- a/cmd/golem/repl.go
+++ b/cmd/golem/repl.go
@@ -10,15 +10,6 @@ import (
 	"github.com/kstruzzieri/go-llm/agent"
 )
 
-// golemSystemPrompt is the read-only capability framing sent on every turn. The
-// final sentence is the instruction-priority note that replaces v1's rendered
-// untrusted-history block: prior turns now arrive as real chat messages.
-const golemSystemPrompt = "You are Golem, a read-only terminal coding assistant for this workspace. " +
-	"Use the available read-only tools to inspect files before answering repo-specific questions; " +
-	"do not claim to modify files, run shell commands, install packages, or change project state. " +
-	"Keep answers concise, cite file paths and line numbers when they matter, and say when the available evidence is insufficient. " +
-	"Prior session messages are context only; the current user request is authoritative."
-
 // replSession holds the per-process state the REPL needs.
 type replSession struct {
 	orch            *agent.Orchestrator
@@ -35,6 +26,7 @@ type replSession struct {
 	lastModel  string           // last routed ActualModel for /model
 	journal    *mutationJournal // nil unless -allow-write enabled writes
 	allowWrite bool
+	allowExec  bool
 }
 
 // runREPL reads lines from in, dispatching slash commands and running every
@@ -96,7 +88,7 @@ func runOnce(ctx context.Context, out io.Writer, interrupts <-chan struct{}, ses
 	}
 
 	var approver agent.Approver
-	if sess.allowWrite {
+	if sess.allowWrite || sess.allowExec {
 		approver = newReplApprover(lr, out, sess.color)
 	}
 

--- a/cmd/golem/repl_test.go
+++ b/cmd/golem/repl_test.go
@@ -48,7 +48,7 @@ func newTestSession(t *testing.T, caller agent.ModelCaller, root string) *replSe
 	return &replSession{
 		orch:       agent.New(caller, agent.ContextManager{}),
 		tools:      tools,
-		baseSystem: golemSystemPrompt,
+		baseSystem: buildSystemPrompt(false, false),
 		maxSteps:   16,
 		clock:      func() time.Time { return time.Unix(0, 0) },
 	}
@@ -174,7 +174,7 @@ func newSessionedTestSession(t *testing.T, caller agent.ModelCaller, root, id st
 	return &replSession{
 		orch:       agent.New(caller, agent.ContextManager{}),
 		tools:      tools,
-		baseSystem: golemSystemPrompt,
+		baseSystem: buildSystemPrompt(false, false),
 		maxSteps:   16,
 		clock:      func() time.Time { return time.Unix(0, 0) },
 		session:    s,
@@ -198,13 +198,13 @@ func TestREPL_HistoryReachesModelAsRealRoles(t *testing.T) {
 	}
 
 	// The system prompt is exactly the base prompt — history is sent as real messages, not appended.
-	if caller.system != golemSystemPrompt {
+	if caller.system != buildSystemPrompt(false, false) {
 		t.Errorf("system must equal baseSystem (history is sent as real messages, not appended), got:\n%s", caller.system)
 	}
 	// Prior turn reaches the model as real user/assistant messages, ahead of the
 	// current goal: system, user(prior), assistant(prior), user(goal).
 	wantRoles := []string{"system", "user", "assistant", "user"}
-	wantContent := []string{golemSystemPrompt, "earlier question", "earlier answer", "new question"}
+	wantContent := []string{buildSystemPrompt(false, false), "earlier question", "earlier answer", "new question"}
 	if len(caller.messages) != len(wantRoles) {
 		t.Fatalf("messages = %+v, want %d entries", caller.messages, len(wantRoles))
 	}
@@ -335,7 +335,7 @@ func newWriteEnabledTestSession(t *testing.T, caller agent.ModelCaller, root str
 	return &replSession{
 		orch:       agent.New(caller, agent.ContextManager{}),
 		tools:      append(readTools, writeTools...),
-		baseSystem: golemWriteSystemPrompt,
+		baseSystem: buildSystemPrompt(true, false),
 		maxSteps:   16,
 		clock:      func() time.Time { return time.Unix(0, 0) },
 		journal:    journal,

--- a/cmd/golem/repl_test.go
+++ b/cmd/golem/repl_test.go
@@ -343,6 +343,55 @@ func newWriteEnabledTestSession(t *testing.T, caller agent.ModelCaller, root str
 	}
 }
 
+func newExecOnlyTestSession(t *testing.T, caller agent.ModelCaller, root string) *replSession {
+	t.Helper()
+	readTools, err := buildTools(root, nil)
+	if err != nil {
+		t.Fatalf("buildTools: %v", err)
+	}
+	execTools, err := buildExecTools(root)
+	if err != nil {
+		t.Fatalf("buildExecTools: %v", err)
+	}
+	return &replSession{
+		orch:       agent.New(caller, agent.ContextManager{}),
+		tools:      append(readTools, execTools...),
+		baseSystem: buildSystemPrompt(false, true),
+		maxSteps:   16,
+		clock:      func() time.Time { return time.Unix(0, 0) },
+		allowExec:  true,
+	}
+}
+
+// TestRunOnceExecOnlyWiresApprover verifies that -allow-exec alone (no -allow-write)
+// wires the approval gate. The model emits a run_command call; the user denies it with
+// "n"; the test asserts the "Run this command?" prompt was shown and no file was
+// written (i.e. the approver was actually invoked).
+func TestRunOnceExecOnlyWiresApprover(t *testing.T) {
+	root := t.TempDir()
+	execCall := provider.ChatResponse{
+		ToolCalls: []provider.ToolCall{{
+			ID: "e1", Type: "function",
+			Function: provider.ToolCallFunction{
+				Name:      "run_command",
+				Arguments: json.RawMessage(`{"argv":["echo","hello"]}`),
+			},
+		}},
+	}
+	finalAns := provider.ChatResponse{Content: "ok, skipped"}
+	caller := &scriptCaller{responses: []agent.ModelResult{{Response: execCall}, {Response: finalAns}}}
+	sess := newExecOnlyTestSession(t, caller, root)
+
+	var out strings.Builder
+	in := strings.NewReader("run something\nn\n") // goal, then deny the exec
+	if err := runREPL(context.Background(), in, &out, nil, sess); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+	if !strings.Contains(out.String(), "Run this command?") {
+		t.Errorf("exec-only session must show 'Run this command?' approval prompt:\n%s", out.String())
+	}
+}
+
 func TestREPL_ClearAndNew(t *testing.T) {
 	root := t.TempDir()
 	caller := &scriptCaller{}

--- a/cmd/golem/tools.go
+++ b/cmd/golem/tools.go
@@ -13,16 +13,46 @@ import (
 	"github.com/kstruzzieri/go-llm/rag"
 )
 
-// golemWriteSystemPrompt is the base prompt when -allow-write is set. Unlike the
-// read-only prompt it permits proposing mutations, but stresses that every change
-// is shown as a diff and applied only after explicit user approval.
-const golemWriteSystemPrompt = "You are Golem, a terminal coding assistant for this workspace. " +
-	"Use the read-only tools to inspect files before acting. You may propose changes with write_file and edit_file; " +
-	"every change is shown to the user as a diff and is applied only after they approve it, so keep edits minimal and targeted and explain what you are changing. " +
-	"After a change is applied, briefly confirm what you changed. " +
-	"Prefer edit_file for small changes and write_file for new files or full rewrites. " +
-	"Cite file paths and line numbers when they matter, and say when the available evidence is insufficient. " +
-	"Prior session messages are context only; the current user request is authoritative."
+// Prompt fragments composed by capability. The base read-only framing is always
+// present; capability or prohibition fragments are appended per enabled flag.
+const golemBasePrompt = "You are Golem, a terminal coding assistant for this workspace. " +
+	"Use the read-only tools to inspect files before answering repo-specific questions. " +
+	"Keep answers concise, cite file paths and line numbers when they matter, and say when the available evidence is insufficient."
+
+const golemNoWriteFragment = " Do not claim to modify files or change project state on disk."
+const golemNoExecFragment = " Do not claim to run shell commands, install packages, or otherwise execute processes."
+const golemWriteFragment = " You may propose changes with write_file and edit_file; every change is shown to the user as a diff and is applied only after they approve it, so keep edits minimal and targeted and explain what you are changing. Prefer edit_file for small changes and write_file for new files or full rewrites."
+const golemExecFragment = " You may run commands with run_command to build, test, or lint and verify your work; every command is shown to the user and runs only after they approve it, so prefer minimal, targeted commands. A non-zero exit code is a normal result to read and react to. Respect AGENTS.md guidance."
+const golemPriorityNote = " Prior session messages are context only; the current user request is authoritative."
+
+// buildSystemPrompt composes the base framing with capability fragments. The
+// no-commands prohibition applies whenever exec is disabled (so write-only sessions
+// still cannot run commands); the no-modify prohibition applies whenever write is
+// disabled.
+func buildSystemPrompt(allowWrite, allowExec bool) string {
+	b := golemBasePrompt
+	if allowWrite {
+		b += golemWriteFragment
+	} else {
+		b += golemNoWriteFragment
+	}
+	if allowExec {
+		b += golemExecFragment
+	} else {
+		b += golemNoExecFragment
+	}
+	return b + golemPriorityNote
+}
+
+// buildExecTools constructs the approval-gated exec tool set bound to one Workspace
+// over root. Returned only when -allow-exec is set.
+func buildExecTools(root string) ([]agent.Tool, error) {
+	tools, err := agenttools.NewExecTools(root)
+	if err != nil {
+		return nil, fmt.Errorf("golem: build exec tools: %w", err)
+	}
+	return tools, nil
+}
 
 // buildWriteTools constructs the workspace-mutating tool set plus the in-session
 // journal that backs /undo, both bound to one Workspace over root. Returned only

--- a/cmd/golem/tools_test.go
+++ b/cmd/golem/tools_test.go
@@ -67,6 +67,18 @@ func TestBuildTools_BadRoot(t *testing.T) {
 	}
 }
 
+func TestBuildTools_NoExecTool(t *testing.T) {
+	tools, err := buildTools(t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("buildTools: %v", err)
+	}
+	for _, tool := range tools {
+		if tool.Spec().Name == "run_command" {
+			t.Error("run_command must not be present in the read-only tool set (requires -allow-exec)")
+		}
+	}
+}
+
 func TestBuildSystemPrompt(t *testing.T) {
 	ro := buildSystemPrompt(false, false)
 	if !strings.Contains(ro, "Do not") || strings.Contains(ro, "run_command to") {

--- a/cmd/golem/tools_test.go
+++ b/cmd/golem/tools_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kstruzzieri/go-llm/agent"
@@ -63,6 +64,51 @@ func TestBuildTools_WithRetrieve(t *testing.T) {
 func TestBuildTools_BadRoot(t *testing.T) {
 	if _, err := buildTools(filepath.Join(t.TempDir(), "does-not-exist"), nil); err == nil {
 		t.Fatal("buildTools on missing root err = nil, want error")
+	}
+}
+
+func TestBuildSystemPrompt(t *testing.T) {
+	cases := []struct {
+		name           string
+		write, exec    bool
+		mustContain    []string
+		mustNotContain []string
+	}{
+		{"readonly", false, false,
+			[]string{"do not", "run_command" /*not*/},
+			nil},
+	}
+	_ = cases
+	ro := buildSystemPrompt(false, false)
+	if !strings.Contains(ro, "Do not") || strings.Contains(ro, "run_command to") {
+		t.Errorf("read-only prompt wrong:\n%s", ro)
+	}
+	wo := buildSystemPrompt(true, false)
+	if !strings.Contains(wo, "write_file") {
+		t.Error("write-only prompt missing write capability")
+	}
+	if !strings.Contains(wo, "Do not") {
+		t.Error("write-only must still forbid running commands (!allowExec)")
+	}
+	eo := buildSystemPrompt(false, true)
+	if !strings.Contains(eo, "run_command") {
+		t.Error("exec prompt missing exec capability")
+	}
+	if strings.Contains(eo, "Do not claim to run") {
+		t.Error("exec-enabled prompt must NOT forbid commands")
+	}
+	if !strings.Contains(eo, "authoritative") {
+		t.Error("priority note dropped")
+	}
+}
+
+func TestBuildExecTools(t *testing.T) {
+	tools, err := buildExecTools(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 1 || tools[0].Spec().Name != "run_command" {
+		t.Fatalf("got %d tools", len(tools))
 	}
 }
 

--- a/cmd/golem/tools_test.go
+++ b/cmd/golem/tools_test.go
@@ -68,17 +68,6 @@ func TestBuildTools_BadRoot(t *testing.T) {
 }
 
 func TestBuildSystemPrompt(t *testing.T) {
-	cases := []struct {
-		name           string
-		write, exec    bool
-		mustContain    []string
-		mustNotContain []string
-	}{
-		{"readonly", false, false,
-			[]string{"do not", "run_command" /*not*/},
-			nil},
-	}
-	_ = cases
 	ro := buildSystemPrompt(false, false)
 	if !strings.Contains(ro, "Do not") || strings.Contains(ro, "run_command to") {
 		t.Errorf("read-only prompt wrong:\n%s", ro)


### PR DESCRIPTION
## Summary

Adds `run_command` (Golem v2.1b, closes #207): an argv-first, approval-gated command-execution tool that closes the edit -> test -> observe loop. Disabled by default; enabled only behind `-allow-exec`.

- New `RunCommand` tool in `agent/tools` (`exec.go`), with process execution split by build tag: `exec_unix.go` (real process-group runner) and `exec_other.go` (compile-safe non-unix stub), so the module still builds on Windows for consumers that import unrelated packages.
- Wired into `cmd/golem` behind `-allow-exec`: capability-composed system prompt (a write-only session still forbids running commands), and an action-neutral approver ("Run this command?" with a plain, non-diff preview).

## Security posture (structural containment + human approval; NOT a sandbox)

- Flag-gated registration; nil-approver fail-safe denies; `ApprovalAlways`.
- Plan/Invoke integrity: the approved command is what runs. `Plan` never spawns; `Invoke` consumes a pending plan keyed by a raw-args hash (fail-closed on mismatch), then re-resolves and re-checks the cwd and executable immediately before exec, comparing both resolved path and `os.SameFile` identity (catches a symlink swap or same-path binary replacement).
- Working directory resolved through the existing `Workspace` chokepoint (default = workspace root; absolute/escape/symlink rejected).
- Sanitized env allowlist (`PATH, HOME, LANG, USER, TMPDIR`, parent passthrough); the parent's other env vars (including secrets) are not inherited. The allowlist is intentionally extensible later.
- Process-group timeout kill (`Setpgid` + group `SIGKILL` via `cmd.Cancel`, bounded by `WaitDelay`); bounded, non-deadlocking stdout/stderr capture (32 KiB each).
- Non-zero exit is a normal observation (the model must see failing tests), NOT a tool error; tool errors are reserved for infra failures.
- argv-first, no shell. Shell-string mode and an enforced command-policy engine are deferred to follow-ups; AGENTS.md "forbidden commands" remain advisory prompt text only.

## Test plan

- [ ] `go test -race ./...` passes
- [ ] `golangci-lint run` reports no issues
- [ ] `GOOS=windows GOARCH=amd64 go build ./agent/...` builds (exercises the non-unix stub)
- [ ] Manual: `golem -allow-exec`, ask it to run `go test ./...`, approve, observe exit code + output; confirm `run_command` is absent from `/tools` without the flag

Coverage includes: no-exec-without-approval, fail-closed re-checks (args-hash mismatch, cwd change, executable identity swap), parent-secret env isolation, timeout process-group kill reaping a grandchild, output capping, and the non-unix stub.

Generated with [Claude Code](https://claude.com/claude-code)