### PR TITLE
fix(golem): distinguish provider-unreachable from not-tool-capable in preflight (#217)

### DIFF
--- a/cmd/golem/main.go
+++ b/cmd/golem/main.go
@@ -172,7 +172,8 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 		return err
 	}
 
-	warns, err := preflightToolCapable(ctx, bundle.Models, plan.chain)
+	resolveEndpoint := newPreflightEndpointResolver(bundle.Config, f.ollamaURL)
+	warns, err := preflightToolCapable(ctx, bundle.Models, plan.chain, resolveEndpoint)
 	if err != nil {
 		return err
 	}

--- a/cmd/golem/modelcaller.go
+++ b/cmd/golem/modelcaller.go
@@ -183,11 +183,13 @@ func resolvePreflightEndpoint(resolve endpointResolver, providerName string) (pr
 // whose registry lookup errored — a connectivity/config failure rather than a
 // capability gap. When the provider's endpoint is known it names the provider +
 // base_url + discovery path (and the HTTP status, when the underlying error
-// carries one); otherwise it surfaces the underlying error verbatim. The
-// returned string is bare: the startup renderer prepends "warning: ".
+// carries one). With no endpoint it surfaces the underlying error verbatim
+// under a neutral "provider lookup failed" framing, since that error may be
+// unreachability OR a not-configured/not-found model and we cannot tell which.
+// The returned string is bare: the startup renderer prepends "warning: ".
 func preflightConnectivityWarn(sel, providerName string, ep preflightEndpoint, epOK bool, lookupErr error) string {
 	if !epOK || ep.BaseURL == "" {
-		return fmt.Sprintf("agent fallback %q: cannot reach provider: %v", sel, lookupErr)
+		return fmt.Sprintf("agent fallback %q: provider lookup failed: %v", sel, lookupErr)
 	}
 	addr := redactBaseURL(ep.BaseURL)
 	var hs httpStatuser

--- a/cmd/golem/modelcaller.go
+++ b/cmd/golem/modelcaller.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/kstruzzieri/go-llm/agent"
@@ -86,6 +87,33 @@ type capChecker interface {
 }
 
 const toolRouteCaps = provider.CapChat | provider.CapStream | provider.CapToolCall
+
+// preflightEndpoint is the discovery endpoint a provider exposes. It is used
+// only to build a human-facing connectivity diagnostic, never to make a call.
+type preflightEndpoint struct {
+	BaseURL    string // provider base_url from config ("" if unknown)
+	ModelsPath string // "/v1/models" (openai-compat) or "/api/tags" (ollama)
+}
+
+// endpointResolver maps a provider name to its discovery endpoint. It returns
+// ok=false when the provider is absent or the config is nil, in which case the
+// diagnostic falls back to a base_url-free message.
+type endpointResolver func(providerName string) (preflightEndpoint, bool)
+
+// httpStatuser is satisfied by *openaicompat.statusError and *ollama.APIError,
+// both preserved through ModelRegistry.Lookup's %w wrapping. The interface
+// exposes only the numeric code; the status text is reconstructed locally.
+type httpStatuser interface{ HTTPStatusCode() int }
+
+// statusLabel renders an HTTP status code as "<code> <text>" (e.g.
+// "404 Not Found"), falling back to "HTTP <code>" for codes without a known
+// textual status.
+func statusLabel(code int) string {
+	if text := http.StatusText(code); text != "" {
+		return fmt.Sprintf("%d %s", code, text)
+	}
+	return fmt.Sprintf("HTTP %d", code)
+}
 
 func profileToolCapable(p *provider.ModelProfile) bool {
 	// Capability.Has tests c&flag == flag across all bits, so reusing the

--- a/cmd/golem/modelcaller.go
+++ b/cmd/golem/modelcaller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/kstruzzieri/go-llm/agent"
@@ -113,6 +114,28 @@ func statusLabel(code int) string {
 		return fmt.Sprintf("%d %s", code, text)
 	}
 	return fmt.Sprintf("HTTP %d", code)
+}
+
+// redactBaseURL strips any userinfo (user:pass@) from a base_url before it is
+// printed in a diagnostic, so credentials never leak into logs. A string that
+// fails to parse and looks userinfo-shaped (contains "@") is replaced wholesale
+// rather than printed raw.
+func redactBaseURL(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		if strings.Contains(raw, "@") {
+			return "<invalid base_url>"
+		}
+		return raw
+	}
+	if strings.Contains(raw, "@") && u.User == nil && u.Host == "" {
+		return "<invalid base_url>"
+	}
+	u.User = nil
+	return u.String()
 }
 
 func profileToolCapable(p *provider.ModelProfile) bool {

--- a/cmd/golem/modelcaller.go
+++ b/cmd/golem/modelcaller.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -179,16 +182,39 @@ func resolvePreflightEndpoint(resolve endpointResolver, providerName string) (pr
 	return resolve(providerName)
 }
 
+func providerDiscoveryFailure(err error) bool {
+	var hs httpStatuser
+	if errors.As(err, &hs) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if errors.Is(err, io.EOF) {
+		return true
+	}
+	var syntaxErr *json.SyntaxError
+	if errors.As(err, &syntaxErr) {
+		return true
+	}
+	var typeErr *json.UnmarshalTypeError
+	return errors.As(err, &typeErr)
+}
+
 // preflightConnectivityWarn builds the bare warning string for a chain entry
 // whose registry lookup errored — a connectivity/config failure rather than a
 // capability gap. When the provider's endpoint is known it names the provider +
 // base_url + discovery path (and the HTTP status, when the underlying error
-// carries one). With no endpoint it surfaces the underlying error verbatim
-// under a neutral "provider lookup failed" framing, since that error may be
-// unreachability OR a not-configured/not-found model and we cannot tell which.
+// carries one). With no endpoint, or when the lookup error is not a discovery
+// failure, it surfaces the underlying error verbatim under a neutral
+// "provider lookup failed" framing.
 // The returned string is bare: the startup renderer prepends "warning: ".
 func preflightConnectivityWarn(sel, providerName string, ep preflightEndpoint, epOK bool, lookupErr error) string {
-	if !epOK || ep.BaseURL == "" {
+	if !epOK || ep.BaseURL == "" || !providerDiscoveryFailure(lookupErr) {
 		return fmt.Sprintf("agent fallback %q: provider lookup failed: %v", sel, lookupErr)
 	}
 	addr := redactBaseURL(ep.BaseURL)

--- a/cmd/golem/modelcaller.go
+++ b/cmd/golem/modelcaller.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -176,6 +177,26 @@ func resolvePreflightEndpoint(resolve endpointResolver, providerName string) (pr
 		return preflightEndpoint{}, false
 	}
 	return resolve(providerName)
+}
+
+// preflightConnectivityWarn builds the bare warning string for a chain entry
+// whose registry lookup errored — a connectivity/config failure rather than a
+// capability gap. When the provider's endpoint is known it names the provider +
+// base_url + discovery path (and the HTTP status, when the underlying error
+// carries one); otherwise it surfaces the underlying error verbatim. The
+// returned string is bare: the startup renderer prepends "warning: ".
+func preflightConnectivityWarn(sel, providerName string, ep preflightEndpoint, epOK bool, lookupErr error) string {
+	if !epOK || ep.BaseURL == "" {
+		return fmt.Sprintf("agent fallback %q: cannot reach provider: %v", sel, lookupErr)
+	}
+	addr := redactBaseURL(ep.BaseURL)
+	var hs httpStatuser
+	if errors.As(lookupErr, &hs) {
+		return fmt.Sprintf("agent fallback %q: cannot reach provider %q at %s (GET %s -> %s); check server/base_url",
+			sel, providerName, addr, ep.ModelsPath, statusLabel(hs.HTTPStatusCode()))
+	}
+	return fmt.Sprintf("agent fallback %q: cannot reach provider %q at %s (GET %s): %v",
+		sel, providerName, addr, ep.ModelsPath, lookupErr)
 }
 
 func profileToolCapable(p *provider.ModelProfile) bool {

--- a/cmd/golem/modelcaller.go
+++ b/cmd/golem/modelcaller.go
@@ -214,11 +214,17 @@ func parseSelector(sel string) (provider.ModelKey, bool) {
 }
 
 // preflightToolCapable verifies the agent chain can route a tool-capable model.
-// It returns warnings for each configured entry that cannot (the Router may
-// still reach them on fallback), and an error only when NO entry — or, for an
-// empty chain, the recommend set — can satisfy chat|stream|tool_call. Pure
-// registry lookup; never makes a live model call.
-func preflightToolCapable(ctx context.Context, reg capChecker, chain []string) (warnings []string, err error) {
+// For each configured entry it classifies the outcome as capable,
+// not-tool-capable (resolved but lacks tool_call), or lookup-errored
+// (provider unreachable / config failure). It returns a bare warning per
+// non-capable entry, and an error only when NO entry — or, for an empty chain,
+// the recommend set — can satisfy chat|stream|tool_call. On that failure the
+// error INLINES every per-entry diagnostic, because the caller returns on the
+// error and would otherwise drop the warnings. Pure registry lookup; never
+// makes a live model call. resolveEndpoint supplies provider base_url +
+// discovery path for connectivity diagnostics; a nil resolver yields
+// base_url-free messages.
+func preflightToolCapable(ctx context.Context, reg capChecker, chain []string, resolveEndpoint endpointResolver) (warnings []string, err error) {
 	if len(chain) == 0 {
 		profs, rerr := reg.Recommend(ctx, provider.RecommendOpts{RequiredCaps: toolRouteCaps})
 		if rerr != nil {
@@ -232,27 +238,47 @@ func preflightToolCapable(ctx context.Context, reg capChecker, chain []string) (
 
 	capable := 0
 	for _, sel := range chain {
-		ok := false
-		if key, parsed := parseSelector(sel); parsed {
-			if p, lerr := reg.Lookup(ctx, key); lerr == nil && profileToolCapable(p) {
-				ok = true
-			}
-		} else if profs, lerr := reg.LookupAny(ctx, sel); lerr == nil {
-			for _, p := range profs {
-				if profileToolCapable(p) {
-					ok = true
-					break
-				}
-			}
-		}
+		ok, warn := evalChainEntry(ctx, reg, sel, resolveEndpoint)
 		if ok {
 			capable++
-		} else {
-			warnings = append(warnings, fmt.Sprintf("agent fallback %q is not tool-capable (chat|stream|tool_call)", sel))
+			continue
 		}
+		warnings = append(warnings, warn)
 	}
 	if capable == 0 {
-		return warnings, fmt.Errorf("golem: no entry in the agent chain is tool-capable (chat|stream|tool_call): %v", chain)
+		return warnings, fmt.Errorf("golem: tool-capability preflight failed:\n%s", strings.Join(warnings, "\n"))
 	}
 	return warnings, nil
+}
+
+// evalChainEntry classifies one agent-chain selector. It returns capable=true
+// when the selector resolves to a tool-capable model; otherwise it returns a
+// bare warning string: a connectivity diagnostic when the registry lookup
+// errored, or the capability message when the model resolved without tool_call.
+func evalChainEntry(ctx context.Context, reg capChecker, sel string, resolveEndpoint endpointResolver) (capable bool, warning string) {
+	notCapable := fmt.Sprintf("agent fallback %q is not tool-capable (chat|stream|tool_call)", sel)
+
+	if key, parsed := parseSelector(sel); parsed {
+		p, lerr := reg.Lookup(ctx, key)
+		if lerr != nil {
+			ep, epOK := resolvePreflightEndpoint(resolveEndpoint, key.Provider)
+			return false, preflightConnectivityWarn(sel, key.Provider, ep, epOK, lerr)
+		}
+		if profileToolCapable(p) {
+			return true, ""
+		}
+		return false, notCapable
+	}
+
+	// Bare model name: resolve across providers.
+	profs, lerr := reg.LookupAny(ctx, sel)
+	if lerr != nil {
+		return false, fmt.Sprintf("agent fallback %q: cannot reach provider: %v", sel, lerr)
+	}
+	for _, p := range profs {
+		if profileToolCapable(p) {
+			return true, ""
+		}
+	}
+	return false, notCapable
 }

--- a/cmd/golem/modelcaller.go
+++ b/cmd/golem/modelcaller.go
@@ -270,10 +270,12 @@ func evalChainEntry(ctx context.Context, reg capChecker, sel string, resolveEndp
 		return false, notCapable
 	}
 
-	// Bare model name: resolve across providers.
+	// Bare model name: resolve across providers. A bare selector names no single
+	// provider, so there is no endpoint to resolve — reuse the connectivity
+	// builder's no-endpoint branch (epOK=false) so the message has one source.
 	profs, lerr := reg.LookupAny(ctx, sel)
 	if lerr != nil {
-		return false, fmt.Sprintf("agent fallback %q: cannot reach provider: %v", sel, lerr)
+		return false, preflightConnectivityWarn(sel, "", preflightEndpoint{}, false, lerr)
 	}
 	for _, p := range profs {
 		if profileToolCapable(p) {

--- a/cmd/golem/modelcaller.go
+++ b/cmd/golem/modelcaller.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/kstruzzieri/go-llm/agent"
+	"github.com/kstruzzieri/go-llm/config"
 	"github.com/kstruzzieri/go-llm/provider"
 )
 
@@ -136,6 +137,45 @@ func redactBaseURL(raw string) string {
 	}
 	u.User = nil
 	return u.String()
+}
+
+// newPreflightEndpointResolver builds an endpointResolver from a config. It
+// mirrors providerbootstrap's ollama base-URL override (providers.go), which is
+// applied to the live client but not written back into the returned Config, so
+// the resolver re-applies it to avoid printing a stale ollama base_url under
+// `golem -ollama-url ...`. The overlay is idempotent for the nil-config
+// synthetic path.
+func newPreflightEndpointResolver(cfg *config.Config, ollamaURLOverride string) endpointResolver {
+	return func(name string) (preflightEndpoint, bool) {
+		if cfg == nil {
+			return preflightEndpoint{}, false
+		}
+		pc, ok := cfg.Providers[name]
+		if !ok {
+			return preflightEndpoint{}, false
+		}
+		apiFormat := pc.APIFormat
+		if apiFormat == "" {
+			apiFormat = "ollama"
+		}
+		if name == "ollama" && apiFormat == "ollama" && ollamaURLOverride != "" {
+			pc.BaseURL = ollamaURLOverride
+		}
+		path := "/api/tags"
+		if apiFormat == "openai-compat" {
+			path = "/v1/models"
+		}
+		return preflightEndpoint{BaseURL: pc.BaseURL, ModelsPath: path}, true
+	}
+}
+
+// resolvePreflightEndpoint guards a nil resolver before invoking it, so callers
+// (and tests) can pass nil to mean "no endpoint metadata available."
+func resolvePreflightEndpoint(resolve endpointResolver, providerName string) (preflightEndpoint, bool) {
+	if resolve == nil {
+		return preflightEndpoint{}, false
+	}
+	return resolve(providerName)
 }
 
 func profileToolCapable(p *provider.ModelProfile) bool {

--- a/cmd/golem/modelcaller_conn_test.go
+++ b/cmd/golem/modelcaller_conn_test.go
@@ -43,12 +43,12 @@ func TestPreflightConnectivityWarn(t *testing.T) {
 		{
 			name: "no endpoint (resolver miss)", sel: "llamacpp/gemma4:31b", provider: "llamacpp",
 			ep: preflightEndpoint{}, epOK: false, err: wrapped,
-			want: `agent fallback "llamacpp/gemma4:31b": cannot reach provider: provider: lookup llamacpp/gemma4:31b: list models: 404`,
+			want: `agent fallback "llamacpp/gemma4:31b": provider lookup failed: provider: lookup llamacpp/gemma4:31b: list models: 404`,
 		},
 		{
 			name: "endpoint ok but empty base_url", sel: "x/y", provider: "x",
 			ep: preflightEndpoint{BaseURL: "", ModelsPath: "/v1/models"}, epOK: true, err: plain,
-			want: `agent fallback "x/y": cannot reach provider: dial tcp 127.0.0.1:8080: connection refused`,
+			want: `agent fallback "x/y": provider lookup failed: dial tcp 127.0.0.1:8080: connection refused`,
 		},
 		{
 			name: "credentials redacted", sel: "llamacpp/gemma4:31b", provider: "llamacpp",

--- a/cmd/golem/modelcaller_conn_test.go
+++ b/cmd/golem/modelcaller_conn_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// statusErr is a fake registry error carrying an HTTP status, mirroring the
+// real *openaicompat.statusError / *ollama.APIError shape.
+type statusErr struct{ code int }
+
+func (e statusErr) Error() string       { return fmt.Sprintf("list models: %d", e.code) }
+func (e statusErr) HTTPStatusCode() int { return e.code }
+
+func TestPreflightConnectivityWarn(t *testing.T) {
+	wrapped := fmt.Errorf("provider: lookup llamacpp/gemma4:31b: %w", statusErr{404})
+	plain := errors.New("dial tcp 127.0.0.1:8080: connection refused")
+
+	ep := preflightEndpoint{BaseURL: "http://127.0.0.1:8080", ModelsPath: "/v1/models"}
+	epCreds := preflightEndpoint{BaseURL: "http://u:p@127.0.0.1:8080", ModelsPath: "/v1/models"}
+	epMalformedCreds := preflightEndpoint{BaseURL: "user:pass@127.0.0.1:8080", ModelsPath: "/v1/models"}
+
+	tests := []struct {
+		name     string
+		sel      string
+		provider string
+		ep       preflightEndpoint
+		epOK     bool
+		err      error
+		want     string
+	}{
+		{
+			name: "status hit + endpoint", sel: "llamacpp/gemma4:31b", provider: "llamacpp",
+			ep: ep, epOK: true, err: wrapped,
+			want: `agent fallback "llamacpp/gemma4:31b": cannot reach provider "llamacpp" at http://127.0.0.1:8080 (GET /v1/models -> 404 Not Found); check server/base_url`,
+		},
+		{
+			name: "no status + endpoint", sel: "llamacpp/gemma4:31b", provider: "llamacpp",
+			ep: ep, epOK: true, err: plain,
+			want: `agent fallback "llamacpp/gemma4:31b": cannot reach provider "llamacpp" at http://127.0.0.1:8080 (GET /v1/models): dial tcp 127.0.0.1:8080: connection refused`,
+		},
+		{
+			name: "no endpoint (resolver miss)", sel: "llamacpp/gemma4:31b", provider: "llamacpp",
+			ep: preflightEndpoint{}, epOK: false, err: wrapped,
+			want: `agent fallback "llamacpp/gemma4:31b": cannot reach provider: provider: lookup llamacpp/gemma4:31b: list models: 404`,
+		},
+		{
+			name: "endpoint ok but empty base_url", sel: "x/y", provider: "x",
+			ep: preflightEndpoint{BaseURL: "", ModelsPath: "/v1/models"}, epOK: true, err: plain,
+			want: `agent fallback "x/y": cannot reach provider: dial tcp 127.0.0.1:8080: connection refused`,
+		},
+		{
+			name: "credentials redacted", sel: "llamacpp/gemma4:31b", provider: "llamacpp",
+			ep: epCreds, epOK: true, err: wrapped,
+			want: `agent fallback "llamacpp/gemma4:31b": cannot reach provider "llamacpp" at http://127.0.0.1:8080 (GET /v1/models -> 404 Not Found); check server/base_url`,
+		},
+		{
+			name: "malformed credentials not leaked", sel: "llamacpp/gemma4:31b", provider: "llamacpp",
+			ep: epMalformedCreds, epOK: true, err: plain,
+			want: `agent fallback "llamacpp/gemma4:31b": cannot reach provider "llamacpp" at <invalid base_url> (GET /v1/models): dial tcp 127.0.0.1:8080: connection refused`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := preflightConnectivityWarn(tt.sel, tt.provider, tt.ep, tt.epOK, tt.err)
+			if got != tt.want {
+				t.Errorf("\n got = %q\nwant = %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/golem/modelcaller_conn_test.go
+++ b/cmd/golem/modelcaller_conn_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"testing"
 )
 
@@ -15,9 +17,12 @@ func (e statusErr) HTTPStatusCode() int { return e.code }
 
 func TestPreflightConnectivityWarn(t *testing.T) {
 	wrapped := fmt.Errorf("provider: lookup llamacpp/gemma4:31b: %w", statusErr{404})
-	plain := errors.New("dial tcp 127.0.0.1:8080: connection refused")
+	netFailure := &net.DNSError{Err: "no such host", Name: "llamacpp.local"}
+	emptyResponse := fmt.Errorf("openaicompat: decode response: %w", io.EOF)
+	notFound := errors.New(`model "missing" not found on "ollama"`)
 
 	ep := preflightEndpoint{BaseURL: "http://127.0.0.1:8080", ModelsPath: "/v1/models"}
+	ollamaEP := preflightEndpoint{BaseURL: "http://localhost:11434", ModelsPath: "/api/tags"}
 	epCreds := preflightEndpoint{BaseURL: "http://u:p@127.0.0.1:8080", ModelsPath: "/v1/models"}
 	epMalformedCreds := preflightEndpoint{BaseURL: "user:pass@127.0.0.1:8080", ModelsPath: "/v1/models"}
 
@@ -37,8 +42,13 @@ func TestPreflightConnectivityWarn(t *testing.T) {
 		},
 		{
 			name: "no status + endpoint", sel: "llamacpp/gemma4:31b", provider: "llamacpp",
-			ep: ep, epOK: true, err: plain,
-			want: `agent fallback "llamacpp/gemma4:31b": cannot reach provider "llamacpp" at http://127.0.0.1:8080 (GET /v1/models): dial tcp 127.0.0.1:8080: connection refused`,
+			ep: ep, epOK: true, err: netFailure,
+			want: `agent fallback "llamacpp/gemma4:31b": cannot reach provider "llamacpp" at http://127.0.0.1:8080 (GET /v1/models): lookup llamacpp.local: no such host`,
+		},
+		{
+			name: "empty discovery response", sel: "llamacpp/gemma4:31b", provider: "llamacpp",
+			ep: ep, epOK: true, err: emptyResponse,
+			want: `agent fallback "llamacpp/gemma4:31b": cannot reach provider "llamacpp" at http://127.0.0.1:8080 (GET /v1/models): openaicompat: decode response: EOF`,
 		},
 		{
 			name: "no endpoint (resolver miss)", sel: "llamacpp/gemma4:31b", provider: "llamacpp",
@@ -47,8 +57,13 @@ func TestPreflightConnectivityWarn(t *testing.T) {
 		},
 		{
 			name: "endpoint ok but empty base_url", sel: "x/y", provider: "x",
-			ep: preflightEndpoint{BaseURL: "", ModelsPath: "/v1/models"}, epOK: true, err: plain,
-			want: `agent fallback "x/y": provider lookup failed: dial tcp 127.0.0.1:8080: connection refused`,
+			ep: preflightEndpoint{BaseURL: "", ModelsPath: "/v1/models"}, epOK: true, err: netFailure,
+			want: `agent fallback "x/y": provider lookup failed: lookup llamacpp.local: no such host`,
+		},
+		{
+			name: "model not found is not reachability", sel: "ollama/missing", provider: "ollama",
+			ep: ollamaEP, epOK: true, err: notFound,
+			want: `agent fallback "ollama/missing": provider lookup failed: model "missing" not found on "ollama"`,
 		},
 		{
 			name: "credentials redacted", sel: "llamacpp/gemma4:31b", provider: "llamacpp",
@@ -57,8 +72,8 @@ func TestPreflightConnectivityWarn(t *testing.T) {
 		},
 		{
 			name: "malformed credentials not leaked", sel: "llamacpp/gemma4:31b", provider: "llamacpp",
-			ep: epMalformedCreds, epOK: true, err: plain,
-			want: `agent fallback "llamacpp/gemma4:31b": cannot reach provider "llamacpp" at <invalid base_url> (GET /v1/models): dial tcp 127.0.0.1:8080: connection refused`,
+			ep: epMalformedCreds, epOK: true, err: netFailure,
+			want: `agent fallback "llamacpp/gemma4:31b": cannot reach provider "llamacpp" at <invalid base_url> (GET /v1/models): lookup llamacpp.local: no such host`,
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/golem/modelcaller_resolver_test.go
+++ b/cmd/golem/modelcaller_resolver_test.go
@@ -14,13 +14,13 @@ func TestNewPreflightEndpointResolver(t *testing.T) {
 	}}
 
 	tests := []struct {
-		name      string
-		cfg       *config.Config
-		override  string
-		provider  string
-		wantOK    bool
-		wantURL   string
-		wantPath  string
+		name     string
+		cfg      *config.Config
+		override string
+		provider string
+		wantOK   bool
+		wantURL  string
+		wantPath string
 	}{
 		{"openai-compat path", cfg, "", "llamacpp", true, "http://127.0.0.1:8080", "/v1/models"},
 		{"ollama path", cfg, "", "ollama", true, "http://localhost:11434", "/api/tags"},

--- a/cmd/golem/modelcaller_resolver_test.go
+++ b/cmd/golem/modelcaller_resolver_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/config"
+)
+
+func TestNewPreflightEndpointResolver(t *testing.T) {
+	cfg := &config.Config{Providers: map[string]config.ProviderConfig{
+		"ollama":   {BaseURL: "http://localhost:11434", APIFormat: "ollama"},
+		"llamacpp": {BaseURL: "http://127.0.0.1:8080", APIFormat: "openai-compat"},
+		"legacy":   {BaseURL: "http://legacy:1", APIFormat: ""}, // empty => ollama
+	}}
+
+	tests := []struct {
+		name      string
+		cfg       *config.Config
+		override  string
+		provider  string
+		wantOK    bool
+		wantURL   string
+		wantPath  string
+	}{
+		{"openai-compat path", cfg, "", "llamacpp", true, "http://127.0.0.1:8080", "/v1/models"},
+		{"ollama path", cfg, "", "ollama", true, "http://localhost:11434", "/api/tags"},
+		{"empty api_format treated as ollama", cfg, "", "legacy", true, "http://legacy:1", "/api/tags"},
+		{"ollama override applied", cfg, "http://override:9", "ollama", true, "http://override:9", "/api/tags"},
+		{"override ignored for non-ollama", cfg, "http://override:9", "llamacpp", true, "http://127.0.0.1:8080", "/v1/models"},
+		{"absent provider", cfg, "", "ghost", false, "", ""},
+		{"nil config", nil, "", "ollama", false, "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newPreflightEndpointResolver(tt.cfg, tt.override)
+			ep, ok := r(tt.provider)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if ep.BaseURL != tt.wantURL || ep.ModelsPath != tt.wantPath {
+				t.Errorf("ep = %+v, want {BaseURL:%q ModelsPath:%q}", ep, tt.wantURL, tt.wantPath)
+			}
+		})
+	}
+}
+
+func TestResolvePreflightEndpoint_NilResolver(t *testing.T) {
+	if _, ok := resolvePreflightEndpoint(nil, "ollama"); ok {
+		t.Error("nil resolver should report ok=false")
+	}
+	r := newPreflightEndpointResolver(&config.Config{Providers: map[string]config.ProviderConfig{
+		"ollama": {BaseURL: "http://x:1", APIFormat: "ollama"},
+	}}, "")
+	if _, ok := resolvePreflightEndpoint(r, "ollama"); !ok {
+		t.Error("present provider should report ok=true")
+	}
+}

--- a/cmd/golem/modelcaller_status_test.go
+++ b/cmd/golem/modelcaller_status_test.go
@@ -21,3 +21,26 @@ func TestStatusLabel(t *testing.T) {
 		})
 	}
 }
+
+func TestRedactBaseURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain unchanged", "http://127.0.0.1:8080", "http://127.0.0.1:8080"},
+		{"trailing path kept", "http://localhost:11434/api", "http://localhost:11434/api"},
+		{"userinfo stripped", "http://user:pass@host:8080", "http://host:8080"},
+		{"user only stripped", "http://user@host:8080", "http://host:8080"},
+		{"malformed with at", "://bad@thing", "<invalid base_url>"},
+		{"scheme-less userinfo shaped", "user:pass@host:8080", "<invalid base_url>"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := redactBaseURL(tt.in); got != tt.want {
+				t.Errorf("redactBaseURL(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/golem/modelcaller_status_test.go
+++ b/cmd/golem/modelcaller_status_test.go
@@ -1,0 +1,23 @@
+package main
+
+import "testing"
+
+func TestStatusLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		code int
+		want string
+	}{
+		{"known 404", 404, "404 Not Found"},
+		{"known 500", 500, "500 Internal Server Error"},
+		{"unknown 599", 599, "HTTP 599"},
+		{"zero", 0, "HTTP 0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := statusLabel(tt.code); got != tt.want {
+				t.Errorf("statusLabel(%d) = %q, want %q", tt.code, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/golem/preflight_test.go
+++ b/cmd/golem/preflight_test.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"testing"
 
@@ -188,7 +188,7 @@ func TestPreflight_LookupErrorResolverMiss(t *testing.T) {
 func TestPreflight_LookupErrorNonStatus(t *testing.T) {
 	key := provider.ModelKey{Provider: "llamacpp", Model: "gemma4:31b"}
 	reg := fakeReg{errByKey: map[provider.ModelKey]error{
-		key: errors.New("dial tcp 127.0.0.1:8080: connection refused"),
+		key: &net.DNSError{Err: "no such host", Name: "llamacpp.local"},
 	}}
 	resolve := fixedEndpoints(map[string]preflightEndpoint{
 		"llamacpp": {BaseURL: "http://127.0.0.1:8080", ModelsPath: "/v1/models"},
@@ -201,11 +201,37 @@ func TestPreflight_LookupErrorNonStatus(t *testing.T) {
 		t.Fatalf("warnings = %v, want 1", warns)
 	}
 	w := warns[0]
-	if !strings.Contains(w, `cannot reach provider "llamacpp" at http://127.0.0.1:8080 (GET /v1/models): dial tcp`) {
+	if !strings.Contains(w, `cannot reach provider "llamacpp" at http://127.0.0.1:8080 (GET /v1/models): lookup llamacpp.local`) {
 		t.Errorf("warning = %q, want non-status connectivity message with endpoint + underlying error", w)
 	}
 	if strings.Contains(w, "->") {
 		t.Errorf("warning = %q, must not include status arrow for non-status errors", w)
+	}
+}
+
+// TestPreflight_QualifiedModelNotFoundIsLookupFailure: a configured provider
+// with a missing model must not be diagnosed as an unreachable provider.
+func TestPreflight_QualifiedModelNotFoundIsLookupFailure(t *testing.T) {
+	key := provider.ModelKey{Provider: "ollama", Model: "missing"}
+	reg := fakeReg{errByKey: map[provider.ModelKey]error{
+		key: fmt.Errorf(`provider: lookup %v: model %q not found on %q`, key, key.Model, key.Provider),
+	}}
+	resolve := fixedEndpoints(map[string]preflightEndpoint{
+		"ollama": {BaseURL: "http://localhost:11434", ModelsPath: "/api/tags"},
+	})
+	warns, err := preflightToolCapable(context.Background(), reg, []string{"ollama/missing"}, resolve)
+	if err == nil {
+		t.Fatal("err = nil, want failure")
+	}
+	if len(warns) != 1 {
+		t.Fatalf("warnings = %v, want 1", warns)
+	}
+	w := warns[0]
+	if !strings.Contains(w, "provider lookup failed:") || !strings.Contains(w, `model "missing" not found on "ollama"`) {
+		t.Errorf("warning = %q, want neutral lookup failure with model-not-found cause", w)
+	}
+	if strings.Contains(w, "cannot reach provider") || strings.Contains(w, "GET /api/tags") {
+		t.Errorf("warning = %q, must not diagnose missing model as provider reachability", w)
 	}
 }
 

--- a/cmd/golem/preflight_test.go
+++ b/cmd/golem/preflight_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -9,19 +11,27 @@ import (
 )
 
 type fakeReg struct {
-	byKey     map[provider.ModelKey]provider.Capability
-	recommend []provider.Capability
+	byKey      map[provider.ModelKey]provider.Capability
+	errByKey   map[provider.ModelKey]error
+	errByModel map[string]error
+	recommend  []provider.Capability
 }
 
 func (f fakeReg) Lookup(ctx context.Context, key provider.ModelKey) (*provider.ModelProfile, error) {
+	if e, ok := f.errByKey[key]; ok {
+		return nil, e
+	}
 	c, ok := f.byKey[key]
 	if !ok {
-		return nil, context.Canceled // any non-nil error; preflight treats lookup error as "not capable"
+		return nil, context.Canceled // not-found: any non-nil error
 	}
 	return &provider.ModelProfile{Caps: c}, nil
 }
 
 func (f fakeReg) LookupAny(ctx context.Context, model string) ([]*provider.ModelProfile, error) {
+	if e, ok := f.errByModel[model]; ok {
+		return nil, e
+	}
 	var out []*provider.ModelProfile
 	for k, c := range f.byKey {
 		if k.Model == model {
@@ -41,11 +51,29 @@ func (f fakeReg) Recommend(ctx context.Context, opts provider.RecommendOpts) ([]
 
 const fullCaps = provider.CapChat | provider.CapStream | provider.CapToolCall
 
+// noEndpoints is a resolver that never resolves an endpoint (base_url-free
+// diagnostics); used where endpoints are not asserted.
+func noEndpoints(string) (preflightEndpoint, bool) { return preflightEndpoint{}, false }
+
+// fixedEndpoints returns a resolver backed by a static map.
+func fixedEndpoints(m map[string]preflightEndpoint) endpointResolver {
+	return func(name string) (preflightEndpoint, bool) {
+		ep, ok := m[name]
+		return ep, ok
+	}
+}
+
+// connStatusErr is a fake lookup error carrying an HTTP status.
+type connStatusErr struct{ code int }
+
+func (e connStatusErr) Error() string       { return fmt.Sprintf("list models: %d", e.code) }
+func (e connStatusErr) HTTPStatusCode() int { return e.code }
+
 func TestPreflight_HeadCapable(t *testing.T) {
 	reg := fakeReg{byKey: map[provider.ModelKey]provider.Capability{
 		{Provider: "ollama", Model: "m1"}: fullCaps,
 	}}
-	warns, err := preflightToolCapable(context.Background(), reg, []string{"ollama/m1"})
+	warns, err := preflightToolCapable(context.Background(), reg, []string{"ollama/m1"}, noEndpoints)
 	if err != nil {
 		t.Fatalf("err = %v, want nil", err)
 	}
@@ -59,12 +87,12 @@ func TestPreflight_PrimaryIncapableFallbackCapable(t *testing.T) {
 		{Provider: "ollama", Model: "m1"}: provider.CapChat | provider.CapStream, // no tool_call
 		{Provider: "ollama", Model: "m2"}: fullCaps,
 	}}
-	warns, err := preflightToolCapable(context.Background(), reg, []string{"ollama/m1", "ollama/m2"})
+	warns, err := preflightToolCapable(context.Background(), reg, []string{"ollama/m1", "ollama/m2"}, noEndpoints)
 	if err != nil {
 		t.Fatalf("err = %v, want nil", err)
 	}
-	if len(warns) != 1 || !strings.Contains(warns[0], "ollama/m1") {
-		t.Errorf("warnings = %v, want one naming ollama/m1", warns)
+	if len(warns) != 1 || !strings.Contains(warns[0], "ollama/m1") || !strings.Contains(warns[0], "not tool-capable") {
+		t.Errorf("warnings = %v, want one capability warning naming ollama/m1", warns)
 	}
 }
 
@@ -72,7 +100,7 @@ func TestPreflight_NoneCapable(t *testing.T) {
 	reg := fakeReg{byKey: map[provider.ModelKey]provider.Capability{
 		{Provider: "ollama", Model: "m1"}: provider.CapChat | provider.CapStream,
 	}}
-	_, err := preflightToolCapable(context.Background(), reg, []string{"ollama/m1"})
+	_, err := preflightToolCapable(context.Background(), reg, []string{"ollama/m1"}, noEndpoints)
 	if err == nil {
 		t.Fatal("err = nil, want failure (no tool-capable entry)")
 	}
@@ -80,11 +108,11 @@ func TestPreflight_NoneCapable(t *testing.T) {
 
 func TestPreflight_EmptyChain_UsesRecommend(t *testing.T) {
 	ok := fakeReg{recommend: []provider.Capability{fullCaps}}
-	if _, err := preflightToolCapable(context.Background(), ok, nil); err != nil {
+	if _, err := preflightToolCapable(context.Background(), ok, nil, noEndpoints); err != nil {
 		t.Fatalf("recommend-capable err = %v, want nil", err)
 	}
 	empty := fakeReg{recommend: nil}
-	if _, err := preflightToolCapable(context.Background(), empty, nil); err == nil {
+	if _, err := preflightToolCapable(context.Background(), empty, nil, noEndpoints); err == nil {
 		t.Fatal("empty recommend err = nil, want failure")
 	}
 }
@@ -96,11 +124,151 @@ func TestPreflight_BareModelNotFound(t *testing.T) {
 	reg := fakeReg{byKey: map[provider.ModelKey]provider.Capability{
 		{Provider: "ollama", Model: "other"}: fullCaps,
 	}}
-	warns, err := preflightToolCapable(context.Background(), reg, []string{"ghost"})
+	warns, err := preflightToolCapable(context.Background(), reg, []string{"ghost"}, noEndpoints)
 	if err == nil {
 		t.Fatal("err = nil for bare model with no capable match, want failure")
 	}
 	if len(warns) != 1 || !strings.Contains(warns[0], "ghost") {
 		t.Errorf("warnings = %v, want one naming ghost", warns)
+	}
+}
+
+// TestPreflight_LookupErrorIsConnectivity: a qualified lookup error with a known
+// endpoint surfaces a connectivity diagnostic naming base_url + status, NOT a
+// capability message.
+func TestPreflight_LookupErrorIsConnectivity(t *testing.T) {
+	key := provider.ModelKey{Provider: "llamacpp", Model: "gemma4:31b"}
+	reg := fakeReg{errByKey: map[provider.ModelKey]error{
+		key: fmt.Errorf("provider: lookup %v: %w", key, connStatusErr{404}),
+	}}
+	resolve := fixedEndpoints(map[string]preflightEndpoint{
+		"llamacpp": {BaseURL: "http://127.0.0.1:8080", ModelsPath: "/v1/models"},
+	})
+	warns, err := preflightToolCapable(context.Background(), reg, []string{"llamacpp/gemma4:31b"}, resolve)
+	if err == nil {
+		t.Fatal("err = nil, want failure")
+	}
+	if len(warns) != 1 {
+		t.Fatalf("warnings = %v, want 1", warns)
+	}
+	w := warns[0]
+	if !strings.Contains(w, "cannot reach provider") || !strings.Contains(w, "http://127.0.0.1:8080") ||
+		!strings.Contains(w, "GET /v1/models -> 404 Not Found") {
+		t.Errorf("warning = %q, want connectivity message with base_url + status", w)
+	}
+	if strings.Contains(w, "not tool-capable") {
+		t.Errorf("warning = %q, must NOT be a capability message", w)
+	}
+	// Terminal error inlines the diagnostic (not dropped).
+	if !strings.Contains(err.Error(), "cannot reach provider") {
+		t.Errorf("err = %q, want inlined connectivity diagnostic", err)
+	}
+}
+
+// TestPreflight_LookupErrorResolverMiss: a qualified lookup error with no
+// endpoint metadata falls back to the verbatim error, no base_url invented.
+func TestPreflight_LookupErrorResolverMiss(t *testing.T) {
+	key := provider.ModelKey{Provider: "llamacpp", Model: "gemma4:31b"}
+	reg := fakeReg{errByKey: map[provider.ModelKey]error{
+		key: fmt.Errorf("boom: %w", connStatusErr{404}),
+	}}
+	warns, err := preflightToolCapable(context.Background(), reg, []string{"llamacpp/gemma4:31b"}, noEndpoints)
+	if err == nil {
+		t.Fatal("err = nil, want failure")
+	}
+	if len(warns) != 1 || !strings.Contains(warns[0], "cannot reach provider:") ||
+		strings.Contains(warns[0], "http://") {
+		t.Errorf("warning = %v, want verbatim fallback without base_url", warns)
+	}
+}
+
+// TestPreflight_LookupErrorNonStatus: a qualified lookup error without a typed
+// HTTP status still surfaces provider + base_url + discovery path and includes
+// the underlying error.
+func TestPreflight_LookupErrorNonStatus(t *testing.T) {
+	key := provider.ModelKey{Provider: "llamacpp", Model: "gemma4:31b"}
+	reg := fakeReg{errByKey: map[provider.ModelKey]error{
+		key: errors.New("dial tcp 127.0.0.1:8080: connection refused"),
+	}}
+	resolve := fixedEndpoints(map[string]preflightEndpoint{
+		"llamacpp": {BaseURL: "http://127.0.0.1:8080", ModelsPath: "/v1/models"},
+	})
+	warns, err := preflightToolCapable(context.Background(), reg, []string{"llamacpp/gemma4:31b"}, resolve)
+	if err == nil {
+		t.Fatal("err = nil, want failure")
+	}
+	if len(warns) != 1 {
+		t.Fatalf("warnings = %v, want 1", warns)
+	}
+	w := warns[0]
+	if !strings.Contains(w, `cannot reach provider "llamacpp" at http://127.0.0.1:8080 (GET /v1/models): dial tcp`) {
+		t.Errorf("warning = %q, want non-status connectivity message with endpoint + underlying error", w)
+	}
+	if strings.Contains(w, "->") {
+		t.Errorf("warning = %q, must not include status arrow for non-status errors", w)
+	}
+}
+
+// TestPreflight_MixedCapableAndErrored: one capable entry + one unreachable
+// entry => nil err (gate passes), one connectivity warning.
+func TestPreflight_MixedCapableAndErrored(t *testing.T) {
+	good := provider.ModelKey{Provider: "ollama", Model: "m1"}
+	bad := provider.ModelKey{Provider: "llamacpp", Model: "down"}
+	reg := fakeReg{
+		byKey:    map[provider.ModelKey]provider.Capability{good: fullCaps},
+		errByKey: map[provider.ModelKey]error{bad: connStatusErr{503}},
+	}
+	resolve := fixedEndpoints(map[string]preflightEndpoint{
+		"llamacpp": {BaseURL: "http://127.0.0.1:8080", ModelsPath: "/v1/models"},
+	})
+	warns, err := preflightToolCapable(context.Background(), reg,
+		[]string{"ollama/m1", "llamacpp/down"}, resolve)
+	if err != nil {
+		t.Fatalf("err = %v, want nil (one entry capable)", err)
+	}
+	if len(warns) != 1 || !strings.Contains(warns[0], "cannot reach provider") {
+		t.Errorf("warnings = %v, want one connectivity warning", warns)
+	}
+}
+
+// TestPreflight_MixedErroredAndNonCapable: zero capable; terminal error must
+// inline BOTH the connectivity and the capability diagnostics, distinctly.
+func TestPreflight_MixedErroredAndNonCapable(t *testing.T) {
+	down := provider.ModelKey{Provider: "llamacpp", Model: "down"}
+	weak := provider.ModelKey{Provider: "ollama", Model: "m1"}
+	reg := fakeReg{
+		byKey:    map[provider.ModelKey]provider.Capability{weak: provider.CapChat | provider.CapStream},
+		errByKey: map[provider.ModelKey]error{down: connStatusErr{404}},
+	}
+	resolve := fixedEndpoints(map[string]preflightEndpoint{
+		"llamacpp": {BaseURL: "http://127.0.0.1:8080", ModelsPath: "/v1/models"},
+	})
+	_, err := preflightToolCapable(context.Background(), reg,
+		[]string{"llamacpp/down", "ollama/m1"}, resolve)
+	if err == nil {
+		t.Fatal("err = nil, want failure")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "cannot reach provider") {
+		t.Errorf("err = %q, missing connectivity diagnostic", msg)
+	}
+	if !strings.Contains(msg, `"ollama/m1" is not tool-capable`) {
+		t.Errorf("err = %q, missing capability diagnostic", msg)
+	}
+}
+
+// TestPreflight_BareLookupAnyError: a bare selector whose LookupAny errors
+// surfaces the verbatim error under the connectivity framing.
+func TestPreflight_BareLookupAnyError(t *testing.T) {
+	reg := fakeReg{errByModel: map[string]error{
+		"gemma4:31b": fmt.Errorf("provider: lookup any %q: all providers failed: %w", "gemma4:31b", connStatusErr{404}),
+	}}
+	warns, err := preflightToolCapable(context.Background(), reg, []string{"gemma4:31b"}, noEndpoints)
+	if err == nil {
+		t.Fatal("err = nil, want failure")
+	}
+	if len(warns) != 1 || !strings.Contains(warns[0], "cannot reach provider:") ||
+		!strings.Contains(warns[0], "all providers failed") {
+		t.Errorf("warning = %v, want verbatim LookupAny error", warns)
 	}
 }

--- a/cmd/golem/preflight_test.go
+++ b/cmd/golem/preflight_test.go
@@ -176,7 +176,7 @@ func TestPreflight_LookupErrorResolverMiss(t *testing.T) {
 	if err == nil {
 		t.Fatal("err = nil, want failure")
 	}
-	if len(warns) != 1 || !strings.Contains(warns[0], "cannot reach provider:") ||
+	if len(warns) != 1 || !strings.Contains(warns[0], "provider lookup failed:") ||
 		strings.Contains(warns[0], "http://") {
 		t.Errorf("warning = %v, want verbatim fallback without base_url", warns)
 	}
@@ -258,7 +258,8 @@ func TestPreflight_MixedErroredAndNonCapable(t *testing.T) {
 }
 
 // TestPreflight_BareLookupAnyError: a bare selector whose LookupAny errors
-// surfaces the verbatim error under the connectivity framing.
+// surfaces the verbatim error under the neutral "provider lookup failed" framing
+// (a bare selector names no single provider/endpoint).
 func TestPreflight_BareLookupAnyError(t *testing.T) {
 	reg := fakeReg{errByModel: map[string]error{
 		"gemma4:31b": fmt.Errorf("provider: lookup any %q: all providers failed: %w", "gemma4:31b", connStatusErr{404}),
@@ -267,7 +268,7 @@ func TestPreflight_BareLookupAnyError(t *testing.T) {
 	if err == nil {
 		t.Fatal("err = nil, want failure")
 	}
-	if len(warns) != 1 || !strings.Contains(warns[0], "cannot reach provider:") ||
+	if len(warns) != 1 || !strings.Contains(warns[0], "provider lookup failed:") ||
 		!strings.Contains(warns[0], "all providers failed") {
 		t.Errorf("warning = %v, want verbatim LookupAny error", warns)
 	}


### PR DESCRIPTION
## Summary
Closes #217. `cmd/golem` preflight (`preflightToolCapable`) collapsed a registry **lookup error** (provider unreachable / `/v1/models` 404 / config failure) into the same "no entry is tool-capable" message as a model that resolved but lacks `tool_call` — sending operators to debug model capabilities when the real fix was "start / point at the backend."

Now each agent-chain entry is classified into one of three outcomes:
- **capable** — counts toward the gate
- **not-tool-capable** — resolved, lacks `tool_call` → existing capability message (unchanged)
- **lookup-errored** — connectivity/config diagnostic naming provider + base_url + discovery path + HTTP status, e.g.
  `agent fallback "llamacpp/gemma4:31b": cannot reach provider "llamacpp" at http://127.0.0.1:8080 (GET /v1/models -> 404 Not Found); check server/base_url`

A mixed chain reports both kinds distinctly. The terminal error now **inlines** every per-entry diagnostic, fixing a latent bug where `warnings` were dropped because the caller returns immediately on the preflight error.

### Notes
- Scope is `cmd/golem` only — no `provider/` or `config/` changes.
- Connectivity diagnostic sources base_url at the CLI call site via an `endpointResolver` built from `bundle.Config`; it mirrors `providerbootstrap`'s ollama `-ollama-url` override (which isn't written back to the returned Config), so it won't print a stale base_url.
- base_url userinfo is redacted before printing (`redactBaseURL`); malformed userinfo-shaped strings collapse to `<invalid base_url>`.
- HTTP status text reconstructed via `http.StatusText` (the shared `httpStatuser` interface exposes only the numeric code).
- No-endpoint / bare-selector lookup errors use a neutral `provider lookup failed: <err>` framing (the error may be unreachability OR a not-configured/not-found model), with the verbatim cause appended.

## Test Plan
- [x] `go test ./cmd/golem/` — table-driven matrix over a fake `capChecker` + fake `endpointResolver`: status-hit, non-status, resolver-miss, credential redaction (incl. malformed), resolver override/nil, mixed capable+errored, mixed errored+non-capable (both diagnostics inlined), bare `LookupAny` error
- [x] `go test -race ./cmd/golem/`
- [x] `go vet ./cmd/golem/` · `golangci-lint run ./cmd/golem/` — 0 issues
- [x] `go build ./...`
- [ ] Pre-existing `mcp/` failures (`TestShowModelToolBasic`, `TestPullModelToolBasic`) need a live backend and fail identically on `develop` — unrelated to this change

Generated with [Claude Code](https://claude.com/claude-code)