### PR TITLE
[codex] isolate MCP tests from ambient config

### DIFF
--- a/mcp/main_test.go
+++ b/mcp/main_test.go
@@ -1,0 +1,28 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	home, err := os.MkdirTemp("", "go-llm-mcp-test-home-*")
+	if err != nil {
+		panic(err)
+	}
+
+	if err := os.Unsetenv("GO_LLM_CONFIG"); err != nil {
+		panic(err)
+	}
+	if err := os.Setenv("HOME", home); err != nil {
+		panic(err)
+	}
+	if err := os.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config")); err != nil {
+		panic(err)
+	}
+
+	code := m.Run()
+	_ = os.RemoveAll(home)
+	os.Exit(code)
+}


### PR DESCRIPTION
## Summary
- add an MCP package TestMain that unsets GO_LLM_CONFIG and points HOME/XDG_CONFIG_HOME at a temp directory
- keep MCP unit tests from inheriting live/default provider config from the developer machine
- restore deterministic mcp behavior for issue #9 test-baseline hardening

Refs #9.

## Root cause
MCP tests that expected no configured models could inherit auto-discovered provider config from the host environment, causing providerbootstrap refreshes for live/default providers such as llamacpp or ollama to displace the intended test assertions.

## Validation
- rtk env -u GOROOT GOCACHE=/private/tmp/go-llm-gocache go test ./...
- push hook: lint
- push hook: race tests
- push hook: compile smoke