### PR TITLE
feat(config): ${ENV} expansion for provider api_key + hosted-API README (BYO key)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-llm
 
-A batteries-included Go module for building local-first AI features against local model backends. Run models through **[llama.cpp](https://github.com/ggml-org/llama.cpp)** — the recommended, primary backend for best local performance, via its OpenAI-compatible server — or through [Ollama](https://ollama.com). Provides a complete pipeline from model management and configuration through RAG-powered retrieval to domain-specific analysis — all running locally with no cloud dependencies or API keys.
+A batteries-included Go module for building local-first AI features against local model backends. Run models through **[llama.cpp](https://github.com/ggml-org/llama.cpp)** — the recommended, primary backend for best local performance, via its OpenAI-compatible server — or through [Ollama](https://ollama.com). Provides a complete pipeline from model management and configuration through RAG-powered retrieval to domain-specific analysis — local-first by default — no cloud account required — with optional bring-your-own-key access to hosted OpenAI-compatible APIs (see [Use a hosted API](#use-a-hosted-api-bring-your-own-key)).
 
 Designed for embedding into Go applications that need LLM capabilities: chat, tool calling, code completion, retrieval-augmented generation, and more. Also runs as a standalone [MCP server](#mcp-server) for use as a local AI service without embedding. Pure Go with minimal dependencies (no CGo).
 
@@ -108,6 +108,76 @@ Then declare one `openai-compat` provider per port and point each model at its p
 ```
 
 `api_format` defaults to `ollama` when omitted, so pre-existing configs load unchanged. The low-level `ollama.NewClient()` API (used in the examples below) talks to Ollama directly; to target a llama.cpp backend, configure an `openai-compat` provider as above and route through `provider.Router`.
+
+## Use a hosted API (bring your own key)
+
+No local GPU? Point go-llm at any hosted **OpenAI-compatible** endpoint with the
+`openai-compat` provider and your own API key. `base_url` is the server **root** —
+do **not** include `/v1`; go-llm appends it.
+
+Keep the secret out of the file: set `api_key` to a `${ENV_VAR}` reference and
+export the variable. go-llm expands it when the config loads and fails fast if the
+variable is unset or empty, so a missing key surfaces as a clear config error
+rather than a remote 401. Literal keys still work, but `${ENV_VAR}` is recommended.
+
+```bash
+export OPENAI_API_KEY=sk-...
+golem -config models.json
+```
+
+```json
+{
+  "providers": {
+    "openai": {
+      "base_url": "https://api.openai.com",
+      "api_format": "openai-compat",
+      "api_key": "${OPENAI_API_KEY}"
+    }
+  },
+  "models": {
+    "agent":     { "name": "gpt-4o",                 "provider": "openai", "type": "dense", "capabilities": ["chat", "stream", "tool_call"] },
+    "embedding": { "name": "text-embedding-3-small", "provider": "openai", "type": "embedding" }
+  },
+  "defaults": { "chat": "agent", "agent": "agent", "embedding": "embedding" }
+}
+```
+
+Golem's agent loop routes the **`agent`** role, so set `defaults.agent` to a
+chat/stream/**tool-call**-capable model. `golem index` and RAG need an
+**embedding**-capable model — set `defaults.embedding` to one (hosted providers
+without embeddings can omit it and skip indexing).
+
+### More compatibility examples
+
+Only `base_url` and the model `name` change; go-llm appends `/v1` to each.
+
+| Provider | `base_url` | Notes |
+|----------|-----------|-------|
+| OpenAI | `https://api.openai.com` | |
+| OpenRouter | `https://openrouter.ai/api` | One key → many models (incl. Claude, Llama). The OpenAI SDK base is `…/api/v1`; go-llm adds the `/v1`. |
+| Anthropic (OpenAI-compat layer) | `https://api.anthropic.com` | Anthropic's **OpenAI SDK compatibility** endpoint (`…/v1/`), handy for testing/comparison — **not** native Claude support. The native `/v1/messages` API is not supported. |
+
+### Mixing providers and fallbacks
+
+Providers and keys coexist — declare several and let a model fall back across them:
+
+```json
+{
+  "providers": {
+    "openai":     { "base_url": "https://api.openai.com",    "api_format": "openai-compat", "api_key": "${OPENAI_API_KEY}" },
+    "openrouter": { "base_url": "https://openrouter.ai/api", "api_format": "openai-compat", "api_key": "${OPENROUTER_API_KEY}" }
+  },
+  "models": {
+    "agent":        { "name": "gpt-4o",                       "provider": "openai",     "type": "dense", "capabilities": ["chat", "stream", "tool_call"], "fallbacks": ["agent-backup"] },
+    "agent-backup": { "name": "anthropic/claude-3.5-sonnet",  "provider": "openrouter", "type": "dense", "capabilities": ["chat", "stream", "tool_call"] }
+  },
+  "defaults": { "agent": "agent" }
+}
+```
+
+If a hosted backend lacks an endpoint (`/v1/completions`, embeddings, FIM, or
+tool calls), set that model's `capabilities` to the endpoints that actually work
+so the Router won't send unsupported requests.
 
 ## Quick Start
 

--- a/config/config.go
+++ b/config/config.go
@@ -329,6 +329,61 @@ func Load(path string) (*Config, error) {
 	return &cfg, nil
 }
 
+// expandAPIKeyRefs replaces every ${NAME} reference in value with the value of
+// environment variable NAME. A value containing no "${" is returned verbatim, so
+// existing literal keys keep working. A referenced variable that is unset or
+// empty, or a malformed reference, returns an error naming providerName. Errors
+// never contain an expanded secret value. Only the provider api_key field uses
+// this helper.
+func expandAPIKeyRefs(providerName, value string) (string, error) {
+	if !strings.Contains(value, "${") {
+		return value, nil
+	}
+	var b strings.Builder
+	for i := 0; i < len(value); {
+		if value[i] == '$' && i+1 < len(value) && value[i+1] == '{' {
+			rel := strings.IndexByte(value[i+2:], '}')
+			if rel < 0 {
+				return "", fmt.Errorf("config: provider %q api_key: malformed environment reference %q", providerName, value[i:])
+			}
+			name := value[i+2 : i+2+rel]
+			if !validEnvName(name) {
+				return "", fmt.Errorf("config: provider %q api_key: malformed environment reference %q", providerName, "${"+name+"}")
+			}
+			v, ok := os.LookupEnv(name)
+			if !ok || v == "" {
+				return "", fmt.Errorf("config: provider %q api_key references unset or empty environment variable %q", providerName, name)
+			}
+			b.WriteString(v)
+			i += 2 + rel + 1
+			continue
+		}
+		b.WriteByte(value[i])
+		i++
+	}
+	return b.String(), nil
+}
+
+// validEnvName reports whether s is a POSIX-style environment identifier
+// matching [A-Za-z_][A-Za-z0-9_]*.
+func validEnvName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		letter := c == '_' || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+		digit := c >= '0' && c <= '9'
+		if i == 0 && !letter {
+			return false
+		}
+		if i > 0 && !letter && !digit {
+			return false
+		}
+	}
+	return true
+}
+
 // MustLoad is like Load but panics on error.
 func MustLoad(path string) *Config {
 	cfg, err := Load(path)

--- a/config/config.go
+++ b/config/config.go
@@ -307,6 +307,10 @@ func Default() (*Config, error) {
 }
 
 // Load reads a models.json file from path, parses it, applies defaults, and validates.
+// As part of loading, ${ENV} references in each provider's api_key are expanded
+// from the environment (see expandProviderAPIKeys); this happens only on the
+// file-backed Load path, so programmatically constructed Config values keep
+// api_key literal.
 func Load(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -323,6 +323,11 @@ func Load(path string) (*Config, error) {
 		return nil, err
 	}
 
+	// Expand ${ENV} references in provider api_key fields (file-backed loads only).
+	if err := cfg.expandProviderAPIKeys(); err != nil {
+		return nil, err
+	}
+
 	// Apply defaults after validation passes.
 	cfg.applyDefaults()
 
@@ -391,6 +396,27 @@ func MustLoad(path string) *Config {
 		panic(err)
 	}
 	return cfg
+}
+
+// expandProviderAPIKeys rewrites each provider's api_key, expanding ${ENV}
+// references. Providers are visited in sorted order so the first error is
+// deterministic when several reference bad variables.
+func (cfg *Config) expandProviderAPIKeys() error {
+	keys := make([]string, 0, len(cfg.Providers))
+	for k := range cfg.Providers {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		p := cfg.Providers[k]
+		expanded, err := expandAPIKeyRefs(k, p.APIKey)
+		if err != nil {
+			return err
+		}
+		p.APIKey = expanded
+		cfg.Providers[k] = p
+	}
+	return nil
 }
 
 // applyDefaults materializes implicit provider assignments and timeout defaults.

--- a/config/config.go
+++ b/config/config.go
@@ -353,11 +353,11 @@ func expandAPIKeyRefs(providerName, value string) (string, error) {
 		if value[i] == '$' && i+1 < len(value) && value[i+1] == '{' {
 			rel := strings.IndexByte(value[i+2:], '}')
 			if rel < 0 {
-				return "", fmt.Errorf("config: provider %q api_key: malformed environment reference %q", providerName, value[i:])
+				return "", fmt.Errorf("config: provider %q api_key: malformed environment reference", providerName)
 			}
 			name := value[i+2 : i+2+rel]
 			if !validEnvName(name) {
-				return "", fmt.Errorf("config: provider %q api_key: malformed environment reference %q", providerName, "${"+name+"}")
+				return "", fmt.Errorf("config: provider %q api_key: malformed environment reference", providerName)
 			}
 			v, ok := os.LookupEnv(name)
 			if !ok || v == "" {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -868,3 +868,62 @@ func TestLoad_RootModelsJSON(t *testing.T) {
 		t.Errorf("expected 7 models, got %d", len(cfg.Models))
 	}
 }
+
+func TestExpandAPIKeyRefs(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		value    string
+		env      map[string]string
+		want     string
+		wantErr  string // substring; "" means no error
+	}{
+		{name: "literal unchanged", provider: "p", value: "sk-literal", want: "sk-literal"},
+		{name: "empty unchanged", provider: "p", value: "", want: ""},
+		{name: "dollar without brace literal", provider: "p", value: "a$b", want: "a$b"},
+		{name: "whole value expands", provider: "p", value: "${K}", env: map[string]string{"K": "sk-1"}, want: "sk-1"},
+		{name: "embedded expands", provider: "p", value: "Bearer-${K}", env: map[string]string{"K": "tok"}, want: "Bearer-tok"},
+		{name: "multiple refs", provider: "p", value: "${A}-${B}", env: map[string]string{"A": "x", "B": "y"}, want: "x-y"},
+		{name: "unset var errors", provider: "openai", value: "${GO_LLM_TEST_MISSING_API_KEY}", wantErr: `provider "openai" api_key references unset or empty environment variable "GO_LLM_TEST_MISSING_API_KEY"`},
+		{name: "empty var errors", provider: "openai", value: "${E}", env: map[string]string{"E": ""}, wantErr: `references unset or empty environment variable "E"`},
+		{name: "malformed empty name", provider: "p", value: "${}", wantErr: "malformed environment reference"},
+		{name: "unterminated", provider: "p", value: "${K", wantErr: "malformed environment reference"},
+		{name: "illegal char", provider: "p", value: "${A B}", wantErr: "malformed environment reference"},
+		{name: "leading digit invalid", provider: "p", value: "${1A}", wantErr: "malformed environment reference"},
+		{name: "adjacent refs no separator", provider: "p", value: "${A}${B}", env: map[string]string{"A": "x", "B": "y"}, want: "xy"},
+		{name: "non-ascii name invalid", provider: "p", value: "${KÉY}", wantErr: "malformed environment reference"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+			if tc.name == "unset var errors" {
+				old, hadOld := os.LookupEnv("GO_LLM_TEST_MISSING_API_KEY")
+				if err := os.Unsetenv("GO_LLM_TEST_MISSING_API_KEY"); err != nil {
+					t.Fatalf("unset test env: %v", err)
+				}
+				t.Cleanup(func() {
+					if hadOld {
+						_ = os.Setenv("GO_LLM_TEST_MISSING_API_KEY", old)
+					} else {
+						_ = os.Unsetenv("GO_LLM_TEST_MISSING_API_KEY")
+					}
+				})
+			}
+			got, err := expandAPIKeyRefs(tc.provider, tc.value)
+			if tc.wantErr != "" {
+				if err == nil || !contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -877,6 +877,7 @@ func TestExpandAPIKeyRefs(t *testing.T) {
 		env      map[string]string
 		want     string
 		wantErr  string // substring; "" means no error
+		notErr   []string
 	}{
 		{name: "literal unchanged", provider: "p", value: "sk-literal", want: "sk-literal"},
 		{name: "empty unchanged", provider: "p", value: "", want: ""},
@@ -892,6 +893,20 @@ func TestExpandAPIKeyRefs(t *testing.T) {
 		{name: "leading digit invalid", provider: "p", value: "${1A}", wantErr: "malformed environment reference"},
 		{name: "adjacent refs no separator", provider: "p", value: "${A}${B}", env: map[string]string{"A": "x", "B": "y"}, want: "xy"},
 		{name: "non-ascii name invalid", provider: "p", value: "${KÉY}", wantErr: "malformed environment reference"},
+		{
+			name:     "unterminated does not echo raw api key",
+			provider: "openai",
+			value:    "sk-secret-${BROKEN",
+			wantErr:  `provider "openai" api_key: malformed environment reference`,
+			notErr:   []string{"sk-secret", "${BROKEN"},
+		},
+		{
+			name:     "invalid name does not echo raw api key",
+			provider: "openai",
+			value:    "sk-secret-${BAD NAME}",
+			wantErr:  `provider "openai" api_key: malformed environment reference`,
+			notErr:   []string{"sk-secret", "${BAD NAME}", "BAD NAME"},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -916,6 +931,11 @@ func TestExpandAPIKeyRefs(t *testing.T) {
 				if err == nil || !contains(err.Error(), tc.wantErr) {
 					t.Fatalf("err = %v, want substring %q", err, tc.wantErr)
 				}
+				for _, forbidden := range tc.notErr {
+					if contains(err.Error(), forbidden) {
+						t.Fatalf("err = %q, must not contain %q", err.Error(), forbidden)
+					}
+				}
 				return
 			}
 			if err != nil {
@@ -925,6 +945,29 @@ func TestExpandAPIKeyRefs(t *testing.T) {
 				t.Errorf("got %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestLoad_MalformedAPIKeyEnvExpansionDoesNotLeakSecret(t *testing.T) {
+	cfg := `{
+  "providers": {
+    "hosted": {"base_url": "https://api.openai.com", "api_format": "openai-compat", "api_key": "sk-secret-${BROKEN"}
+  },
+  "models": {"agent": {"name": "gpt-4o", "provider": "hosted", "type": "dense"}},
+  "defaults": {"agent": "agent"}
+}`
+	path := writeTempJSON(t, cfg)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for malformed env reference, got nil")
+	}
+	if !contains(err.Error(), `provider "hosted"`) || !contains(err.Error(), "malformed environment reference") {
+		t.Errorf("error = %q, want provider name and malformed reference message", err.Error())
+	}
+	for _, forbidden := range []string{"sk-secret", "${BROKEN"} {
+		if contains(err.Error(), forbidden) {
+			t.Errorf("error = %q, must not contain %q", err.Error(), forbidden)
+		}
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -927,3 +927,58 @@ func TestExpandAPIKeyRefs(t *testing.T) {
 		})
 	}
 }
+
+func TestLoad_APIKeyEnvExpansion(t *testing.T) {
+	t.Setenv("GOLEM_TEST_KEY", "sk-secret-123")
+	cfg := `{
+  "providers": {
+    "hosted": {"base_url": "https://api.openai.com", "api_format": "openai-compat", "api_key": "${GOLEM_TEST_KEY}"}
+  },
+  "models": {"agent": {"name": "gpt-4o", "provider": "hosted", "type": "dense"}},
+  "defaults": {"agent": "agent"}
+}`
+	path := writeTempJSON(t, cfg)
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := loaded.Providers["hosted"].APIKey; got != "sk-secret-123" {
+		t.Errorf("api_key = %q, want expanded %q", got, "sk-secret-123")
+	}
+}
+
+func TestLoad_APIKeyEnvExpansion_UnsetErrors(t *testing.T) {
+	cfg := `{
+  "providers": {
+    "hosted": {"base_url": "https://api.openai.com", "api_format": "openai-compat", "api_key": "${GOLEM_TEST_MISSING}"}
+  },
+  "models": {"agent": {"name": "gpt-4o", "provider": "hosted", "type": "dense"}},
+  "defaults": {"agent": "agent"}
+}`
+	path := writeTempJSON(t, cfg)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for unset env var, got nil")
+	}
+	if !contains(err.Error(), `provider "hosted"`) || !contains(err.Error(), "GOLEM_TEST_MISSING") {
+		t.Errorf("error = %q, want provider name and var name", err.Error())
+	}
+}
+
+func TestLoad_LiteralAPIKeyUnchanged(t *testing.T) {
+	cfg := `{
+  "providers": {
+    "hosted": {"base_url": "https://api.openai.com", "api_format": "openai-compat", "api_key": "sk-plain"}
+  },
+  "models": {"agent": {"name": "gpt-4o", "provider": "hosted", "type": "dense"}},
+  "defaults": {"agent": "agent"}
+}`
+	path := writeTempJSON(t, cfg)
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := loaded.Providers["hosted"].APIKey; got != "sk-plain" {
+		t.Errorf("api_key = %q, want unchanged literal", got)
+	}
+}

--- a/internal/providerbootstrap/apikey_integration_test.go
+++ b/internal/providerbootstrap/apikey_integration_test.go
@@ -1,0 +1,78 @@
+package providerbootstrap
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/config"
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+func TestAPIKeyEnvExpansionReachesTransport(t *testing.T) {
+	var gotAuth atomic.Value
+	gotAuth.Store("")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth.Store(r.Header.Get("Authorization"))
+		switch r.URL.Path {
+		case "/v1/models":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]any{{"id": "test-model"}}})
+		case "/v1/chat/completions":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"choices": []map[string]any{{"message": map[string]any{"role": "assistant", "content": "ok"}}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("GOLEM_IT_KEY", "sk-expanded-secret")
+
+	cfgJSON := `{
+  "providers": {
+    "hosted": {"base_url": "` + srv.URL + `", "api_format": "openai-compat", "api_key": "${GOLEM_IT_KEY}"}
+  },
+  "models": {"agent": {"name": "test-model", "provider": "hosted", "type": "dense"}},
+  "defaults": {"agent": "agent"}
+}`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "models.json")
+	if err := os.WriteFile(path, []byte(cfgJSON), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+
+	ctx := context.Background()
+	bundle, err := New(ctx, Options{Config: cfg})
+	if err != nil {
+		t.Fatalf("providerbootstrap.New: %v", err)
+	}
+	defer func() { _ = bundle.Close() }()
+
+	p, ok := bundle.Providers.Get("hosted")
+	if !ok {
+		t.Fatal("provider \"hosted\" not registered")
+	}
+
+	_, err = p.Chat(ctx, provider.ChatRequest{
+		Model:    "test-model",
+		Messages: []provider.ChatMessage{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	if got := gotAuth.Load().(string); got != "Bearer sk-expanded-secret" {
+		t.Errorf("Authorization = %q, want %q", got, "Bearer sk-expanded-secret")
+	}
+}


### PR DESCRIPTION
## Summary

Lets users run Golem/go-llm against a hosted **OpenAI-compatible** API with their own key, without pasting a plaintext secret into `models.json`.

- **`${ENV}` expansion for provider `api_key`** — `config.Load` now expands `${NAME}` references from the environment (e.g. `"api_key": "${OPENAI_API_KEY}"`). The file holds only the reference; the secret stays in the environment.
- **Fail-closed** — an unset *or* empty referenced variable is a hard load error (no silent auth-disable → no confusing remote 401). Malformed refs (`${}`, unterminated, illegal name) error too.
- **Backward compatible** — values with no `${` pass through verbatim; empty `api_key` stays empty (local no-auth servers unchanged). Shipped `models.json` loads identically.
- **Boundary** — expansion runs only on the file-backed `Load` path (covers `Default`/`MustLoad`, Golem `-config`, MCP `--config`). Programmatically built `*config.Config` values stay literal — intentional; documented on `Load`'s godoc.
- **README** — new "Use a hosted API (bring your own key)" section (OpenAI, OpenRouter, Anthropic OpenAI-compat layer with native-API caveat; multi-provider/fallback; capability-variance guidance). Intro line corrected from "no cloud dependencies or API keys" to local-first-with-optional-BYO.

Secret hygiene: the expanded value is never logged or placed in any error — errors name only the provider and the variable name.

Deferred to a follow-up PR: a Claude-Code-style first-run bootstrap / zero-config onboarding (run on an env var alone, no `models.json`).

## Implementation

5 commits, TDD throughout:
- `feat(config)` add `${ENV}` expansion helper (`expandAPIKeyRefs` / `validEnvName`) — 14-case table
- `feat(config)` wire into `Load` (sorted iteration, fail-closed) + 3 Load-level tests
- `test(providerbootstrap)` end-to-end test: expanded key reaches `Authorization: Bearer` via `httptest.Server`
- `docs(readme)` BYO hosted-API section
- `docs(config)` note expansion on `Load` godoc

## Test Plan

- [x] `go test -race ./...` — all packages `ok`
- [x] `gofmt -l` clean; `go vet` 0; `golangci-lint run` 0 issues
- [x] Unit (expander), `Load`-level (expand / unset-error / literal-unchanged), and config→transport integration tests pass
- [x] README JSON examples verified to load via `config.Load` (capability strings `chat`/`stream`/`tool_call` and types validated against code)

Generated with [Claude Code](https://claude.com/claude-code)