### PR TITLE
[codex] add auxiliary model default fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ provider.CompleteStream(ctx, req, func(token string) error {
 
 ## Model Configuration
 
-Load model settings from `models.json` with provider configs, role-based defaults, and fallback chains that resolve against available Ollama models.
+Load model settings from `models.json` with provider configs, role-based defaults, and fallback chains that resolve against available provider models.
 
 `go-llm` does not hard-code a model roster — `models.json` is the sole source of truth. Substitute any model your configured provider can load by editing `models.json`; capabilities (chat / embedding / tool-call) are detected at runtime by `fingerprint/`. See [`docs/llm/`](docs/llm/) for the reference lineup shipped by default and the full BYO guide.
 
@@ -468,6 +468,42 @@ model := cfg.ModelFor("chat") // e.g., "gemma4:31b"
 resolved, _ := cfg.Resolve(ctx, client, "chat")
 fmt.Printf("Using %s (fallback: %v)\n", resolved.Name, resolved.IsFallback)
 ```
+
+### Auxiliary model defaults
+
+`models.json` can optionally define side-task defaults for runtime helpers:
+`summarize`, `route`, `rerank`, `verify`, `extract`, `approval`, and `vision`.
+If one is omitted, go-llm falls back to existing defaults:
+
+| Side task | Fallback defaults |
+| --- | --- |
+| `summarize` | `analysis`, then `chat` |
+| `route` | `analysis`, then `chat` |
+| `rerank` | `analysis`, then `chat` |
+| `verify` | `analysis`, then `chat` |
+| `extract` | `analysis`, then `chat` |
+| `approval` | `agent`, then `chat` |
+| `vision` | `chat` |
+
+Explicit side-task defaults always win:
+
+```json
+{
+  "defaults": {
+    "chat": "general",
+    "analysis": "general",
+    "agent": "agent",
+    "summarize": "lightweight"
+  }
+}
+```
+
+`ModelFor`, `Resolve`, `ResolveCandidates`, and `RoleFallbackChain` all apply
+this fallback behavior. `ResolveAll` only enumerates defaults explicitly present
+in `models.json`.
+
+The `vision` slot is model selection only; image message payload support is
+tracked separately.
 
 ## MCP Server
 

--- a/config/candidates.go
+++ b/config/candidates.go
@@ -18,6 +18,8 @@ type CandidateModel struct {
 
 // ResolveCandidates returns all available models for a use-case, ordered by
 // config preference (primary first, then fallback chain traversal order).
+// Optional auxiliary use-cases first fall back to existing configured defaults
+// when their own Defaults slot is absent.
 // Unlike Resolve (which returns the first available model), this enumerates
 // every reachable model that is currently available, giving orchestration
 // layers the full candidate set for enrichment and scoring.
@@ -29,7 +31,7 @@ func (c *Config) ResolveCandidates(ctx context.Context, checker ModelChecker, us
 	if checker == nil {
 		return nil, fmt.Errorf("config: model checker is required")
 	}
-	role, ok := c.Defaults[useCase]
+	role, ok := c.roleForUseCase(useCase)
 	if !ok {
 		return nil, fmt.Errorf("config: unknown use-case %q", useCase)
 	}

--- a/config/candidates_test.go
+++ b/config/candidates_test.go
@@ -157,6 +157,25 @@ func TestResolveCandidates_UnknownUseCase(t *testing.T) {
 	}
 }
 
+func TestResolveCandidates_SideTaskFallbackUseCase(t *testing.T) {
+	cfg := loadTestConfig(t)
+	checker := &mockChecker{models: []string{"qwen3.5:27b", "qwen3:8b"}}
+
+	got, err := cfg.ResolveCandidates(context.Background(), checker, "summarize")
+	if err != nil {
+		t.Fatalf("ResolveCandidates() error: %v", err)
+	}
+	wantRoles := []string{"general", "lightweight"}
+	if len(got) != len(wantRoles) {
+		t.Fatalf("len(candidates) = %d, want %d: %+v", len(got), len(wantRoles), got)
+	}
+	for i, want := range wantRoles {
+		if got[i].Role != want {
+			t.Fatalf("candidate roles = %+v, want %v", got, wantRoles)
+		}
+	}
+}
+
 func TestResolveCandidates_UnknownDefaultRole(t *testing.T) {
 	cfg := &Config{
 		Models: map[string]ModelConfig{

--- a/config/candidates_test.go
+++ b/config/candidates_test.go
@@ -176,6 +176,25 @@ func TestResolveCandidates_SideTaskFallbackUseCase(t *testing.T) {
 	}
 }
 
+func TestResolveCandidates_ApprovalFallbackUsesAgentDefault(t *testing.T) {
+	cfg := loadTestConfig(t)
+	checker := &mockChecker{models: []string{"qwen3.5:35b-a3b", "qwen3.5:27b", "qwen3:8b"}}
+
+	got, err := cfg.ResolveCandidates(context.Background(), checker, "approval")
+	if err != nil {
+		t.Fatalf("ResolveCandidates() error: %v", err)
+	}
+	wantRoles := []string{"fast", "lightweight"}
+	if len(got) != len(wantRoles) {
+		t.Fatalf("len(candidates) = %d, want %d: %+v", len(got), len(wantRoles), got)
+	}
+	for i, want := range wantRoles {
+		if got[i].Role != want {
+			t.Fatalf("candidate roles = %+v, want %v", got, wantRoles)
+		}
+	}
+}
+
 func TestResolveCandidates_UnknownDefaultRole(t *testing.T) {
 	cfg := &Config{
 		Models: map[string]ModelConfig{

--- a/config/config.go
+++ b/config/config.go
@@ -83,7 +83,8 @@ type Config struct {
 	Defaults  map[string]string         `json:"defaults"`
 }
 
-// sideTaskDefaultFallbacks keeps auxiliary orchestration roles optional.
+// sideTaskDefaultFallbacks keeps auxiliary model-selection roles optional.
+// "route" here is the side-task model role, not provider.Router itself.
 // Explicit defaults win; these entries only pick an existing use-case when a
 // side-task slot is absent from older models.json files.
 var sideTaskDefaultFallbacks = map[string][]string{
@@ -220,8 +221,8 @@ func (c *Config) RoleConfig(role string) *ModelConfig {
 // ModelFor resolves a use-case to a model name through the defaults chain.
 // It looks up useCase in Defaults to find the role, then looks up that role in
 // Models to return the model Name. Optional auxiliary use-cases such as
-// summarize, rerank, verify, extract, approval, and vision fall back to existing
-// defaults when absent. Returns "" if the use-case or its target role is not found.
+// summarize, route, rerank, verify, extract, approval, and vision fall back to
+// existing defaults when absent. Returns "" if the use-case or its target role is not found.
 func (c *Config) ModelFor(useCase string) string {
 	role, ok := c.roleForUseCase(useCase)
 	if !ok {

--- a/config/config.go
+++ b/config/config.go
@@ -83,6 +83,19 @@ type Config struct {
 	Defaults  map[string]string         `json:"defaults"`
 }
 
+// sideTaskDefaultFallbacks keeps auxiliary orchestration roles optional.
+// Explicit defaults win; these entries only pick an existing use-case when a
+// side-task slot is absent from older models.json files.
+var sideTaskDefaultFallbacks = map[string][]string{
+	"summarize": {"analysis", "chat"},
+	"route":     {"analysis", "chat"},
+	"rerank":    {"analysis", "chat"},
+	"verify":    {"analysis", "chat"},
+	"extract":   {"analysis", "chat"},
+	"approval":  {"agent", "chat"},
+	"vision":    {"chat"},
+}
+
 // ErrConfigNotFound indicates that Default could not find a models.json file
 // in any of its discovery locations.
 var ErrConfigNotFound = errors.New("config: no configuration file found")
@@ -205,10 +218,12 @@ func (c *Config) RoleConfig(role string) *ModelConfig {
 }
 
 // ModelFor resolves a use-case to a model name through the defaults chain.
-// It looks up useCase in Defaults to find the role, then looks up that role in Models
-// to return the model Name. Returns "" if the use-case or its target role is not found.
+// It looks up useCase in Defaults to find the role, then looks up that role in
+// Models to return the model Name. Optional auxiliary use-cases such as
+// summarize, rerank, verify, extract, approval, and vision fall back to existing
+// defaults when absent. Returns "" if the use-case or its target role is not found.
 func (c *Config) ModelFor(useCase string) string {
-	role, ok := c.Defaults[useCase]
+	role, ok := c.roleForUseCase(useCase)
 	if !ok {
 		return ""
 	}
@@ -226,6 +241,18 @@ func (c *Config) MustModelFor(useCase string) string {
 		panic(fmt.Sprintf("config: no model for use-case %q", useCase))
 	}
 	return name
+}
+
+func (c *Config) roleForUseCase(useCase string) (string, bool) {
+	if role, ok := c.Defaults[useCase]; ok {
+		return role, true
+	}
+	for _, fallback := range sideTaskDefaultFallbacks[useCase] {
+		if role, ok := c.Defaults[fallback]; ok {
+			return role, true
+		}
+	}
+	return "", false
 }
 
 // ProviderFor returns the provider config for a given role's model.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -624,6 +624,13 @@ func TestModelFor(t *testing.T) {
 		{"embedding", "qwen3-embedding:8b"},
 		{"agent", "qwen3.5:35b-a3b"},
 		{"analysis", "qwen3.5:27b"},
+		{"summarize", "qwen3.5:27b"},
+		{"route", "qwen3.5:27b"},
+		{"rerank", "qwen3.5:27b"},
+		{"verify", "qwen3.5:27b"},
+		{"extract", "qwen3.5:27b"},
+		{"approval", "qwen3.5:35b-a3b"},
+		{"vision", "qwen3.5:27b"},
 		{"unknown", ""},
 	}
 
@@ -634,6 +641,18 @@ func TestModelFor(t *testing.T) {
 				t.Errorf("ModelFor(%q) = %q, want %q", tt.useCase, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestModelFor_ExplicitSideTaskDefaultWins(t *testing.T) {
+	cfg, err := Load("testdata/valid.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cfg.Defaults["summarize"] = "lightweight"
+
+	if got := cfg.ModelFor("summarize"); got != "qwen3:8b" {
+		t.Fatalf("ModelFor(\"summarize\") = %q, want explicit lightweight model", got)
 	}
 }
 

--- a/config/resolve.go
+++ b/config/resolve.go
@@ -66,12 +66,14 @@ type ResolvedModel struct {
 
 // Resolve checks availability and walks the fallback chain for a single use-case.
 // It calls checker.AvailableModels once, builds a lookup set, then tries the
-// primary model followed by each fallback until one is found in the set.
+// primary model followed by each fallback until one is found in the set. Optional
+// auxiliary use-cases first fall back to existing configured defaults when their
+// own Defaults slot is absent.
 func (c *Config) Resolve(ctx context.Context, checker ModelChecker, useCase string) (ResolvedModel, error) {
 	if checker == nil {
 		return ResolvedModel{}, fmt.Errorf("config: model checker is required")
 	}
-	role, ok := c.Defaults[useCase]
+	role, ok := c.roleForUseCase(useCase)
 	if !ok {
 		return ResolvedModel{}, fmt.Errorf("config: unknown use-case %q", useCase)
 	}
@@ -201,7 +203,8 @@ func toSet(items []string) map[string]bool {
 
 // RoleFallbackChain returns the ordered chain of model selectors for a use-case
 // role: the primary model first, then each fallback in declared order, then
-// transitively each fallback's fallbacks. Selectors are always provider-
+// transitively each fallback's fallbacks. Optional auxiliary use-cases first
+// fall back to existing configured defaults when absent. Selectors are always provider-
 // qualified ("provider/model") because Load defaults Model.Provider to
 // "ollama" when unset.
 //
@@ -210,7 +213,7 @@ func toSet(items []string) map[string]bool {
 // surface as an error. Availability is NOT filtered — that is the Router's
 // job via breakers, warmth, and gates.
 func (c *Config) RoleFallbackChain(useCase string) ([]string, error) {
-	role, ok := c.Defaults[useCase]
+	role, ok := c.roleForUseCase(useCase)
 	if !ok {
 		return nil, fmt.Errorf("config: unknown use-case %q", useCase)
 	}

--- a/config/resolve_test.go
+++ b/config/resolve_test.go
@@ -227,6 +227,33 @@ func TestResolve_SideTaskFallbackUseCase(t *testing.T) {
 	}
 }
 
+func TestResolve_ApprovalFallbackUsesAgentDefault(t *testing.T) {
+	cfg := loadTestConfig(t)
+	checker := &mockChecker{models: []string{"qwen3.5:35b-a3b", "qwen3.5:27b"}}
+
+	got, err := cfg.Resolve(context.Background(), checker, "approval")
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+	if got.Role != "fast" || got.Name != "qwen3.5:35b-a3b" {
+		t.Fatalf("Resolve(\"approval\") = %+v, want agent/fast fallback", got)
+	}
+}
+
+func TestResolve_ExplicitSideTaskDefaultWins(t *testing.T) {
+	cfg := loadTestConfig(t)
+	cfg.Defaults["summarize"] = "lightweight"
+	checker := &mockChecker{models: []string{"qwen3.5:27b", "qwen3:8b"}}
+
+	got, err := cfg.Resolve(context.Background(), checker, "summarize")
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+	if got.Role != "lightweight" || got.Name != "qwen3:8b" {
+		t.Fatalf("Resolve(\"summarize\") = %+v, want explicit lightweight role", got)
+	}
+}
+
 func TestResolve_CheckerError(t *testing.T) {
 	cfg := loadTestConfig(t)
 	checker := &mockChecker{err: fmt.Errorf("connection refused")}
@@ -334,6 +361,27 @@ func TestResolveAll_NoneAvailable(t *testing.T) {
 	_, err := cfg.ResolveAll(context.Background(), checker)
 	if err == nil {
 		t.Fatal("expected error when no models are available")
+	}
+}
+
+func TestResolveAll_OnlyExplicitDefaults(t *testing.T) {
+	cfg := loadTestConfig(t)
+	checker := &mockChecker{models: []string{
+		"qwen3.5:27b",
+		"qwen3.5:35b-a3b",
+		"qwen3-coder-next:latest",
+		"qwen3:8b",
+		"qwen3-embedding:8b",
+	}}
+
+	results, err := cfg.ResolveAll(context.Background(), checker)
+	if err != nil {
+		t.Fatalf("ResolveAll() error: %v", err)
+	}
+	for _, useCase := range []string{"summarize", "route", "rerank", "verify", "extract", "approval", "vision"} {
+		if _, ok := results[useCase]; ok {
+			t.Fatalf("ResolveAll() included virtual side-task %q in %+v", useCase, results)
+		}
 	}
 }
 
@@ -488,6 +536,24 @@ func TestConfig_RoleFallbackChain_SideTaskFallbackUseCase(t *testing.T) {
 		t.Fatalf("RoleFallbackChain(\"summarize\"): %v", err)
 	}
 	want := []string{"ollama/qwen3.5:27b", "ollama/qwen3:8b"}
+	if len(chain) != len(want) {
+		t.Fatalf("chain = %v, want %v", chain, want)
+	}
+	for i := range want {
+		if chain[i] != want[i] {
+			t.Fatalf("chain = %v, want %v", chain, want)
+		}
+	}
+}
+
+func TestConfig_RoleFallbackChain_ApprovalFallbackUseCase(t *testing.T) {
+	cfg := loadTestConfig(t)
+
+	chain, err := cfg.RoleFallbackChain("approval")
+	if err != nil {
+		t.Fatalf("RoleFallbackChain(\"approval\"): %v", err)
+	}
+	want := []string{"ollama/qwen3.5:35b-a3b", "ollama/qwen3:8b"}
 	if len(chain) != len(want) {
 		t.Fatalf("chain = %v, want %v", chain, want)
 	}

--- a/config/resolve_test.go
+++ b/config/resolve_test.go
@@ -214,6 +214,19 @@ func TestResolve_UnknownUseCase(t *testing.T) {
 	}
 }
 
+func TestResolve_SideTaskFallbackUseCase(t *testing.T) {
+	cfg := loadTestConfig(t)
+	checker := &mockChecker{models: []string{"qwen3.5:27b"}}
+
+	got, err := cfg.Resolve(context.Background(), checker, "summarize")
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+	if got.Role != "general" || got.Name != "qwen3.5:27b" {
+		t.Fatalf("Resolve(\"summarize\") = %+v, want analysis/general fallback", got)
+	}
+}
+
 func TestResolve_CheckerError(t *testing.T) {
 	cfg := loadTestConfig(t)
 	checker := &mockChecker{err: fmt.Errorf("connection refused")}
@@ -464,6 +477,24 @@ func TestConfig_RoleFallbackChain_UnknownUseCase(t *testing.T) {
 	_, err := cfg.RoleFallbackChain("unknown")
 	if err == nil {
 		t.Fatal("expected unknown-use-case error, got nil")
+	}
+}
+
+func TestConfig_RoleFallbackChain_SideTaskFallbackUseCase(t *testing.T) {
+	cfg := loadTestConfig(t)
+
+	chain, err := cfg.RoleFallbackChain("summarize")
+	if err != nil {
+		t.Fatalf("RoleFallbackChain(\"summarize\"): %v", err)
+	}
+	want := []string{"ollama/qwen3.5:27b", "ollama/qwen3:8b"}
+	if len(chain) != len(want) {
+		t.Fatalf("chain = %v, want %v", chain, want)
+	}
+	for i := range want {
+		if chain[i] != want[i] {
+			t.Fatalf("chain = %v, want %v", chain, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add optional auxiliary model default fallback behavior for runtime side-task roles: `summarize`, `route`, `rerank`, `verify`, `extract`, `approval`, and `vision`.
- Route `ModelFor`, `Resolve`, `ResolveCandidates`, and `RoleFallbackChain` through the same use-case fallback helper.
- Document side-task defaults and resolver behavior in the README.

Refs #60.

## Tests

- `rtk env GOCACHE=/private/tmp/go-llm-gocache go test ./...`
- `rtk git diff --check`
- pre-push hook: lint, race tests, compile smoke
