### PR TITLE
[codex] Add cross-session conversation search

### DIFF
--- a/agent/orchestrator.go
+++ b/agent/orchestrator.go
@@ -69,6 +69,7 @@ func (o *Orchestrator) Run(ctx context.Context, req Request, obs Observer) (Resu
 	budget := turnBudget(req.Budget)
 
 	state := initState(req)
+	historyLen := len(req.History)
 	gov := &restraintGovernor{} // per-Run loop state; never shared across Run calls
 	var res Result
 
@@ -109,7 +110,9 @@ func (o *Orchestrator) Run(ctx context.Context, req Request, obs Observer) (Resu
 		}
 
 		if len(resp.ToolCalls) == 0 {
+			state.Messages = append(state.Messages, assistantMessage(resp))
 			res.Answer = resp.Content
+			res.Messages = resultMessages(state, historyLen)
 			if budgetExceeded(res.Usage, req.Budget) {
 				res.StopReason = BudgetReached
 			} else {
@@ -124,16 +127,19 @@ func (o *Orchestrator) Run(ctx context.Context, req Request, obs Observer) (Resu
 			return res, err
 		}
 		if res.StopReason != Completed {
+			res.Messages = resultMessages(state, historyLen)
 			res.Events = append(res.Events, EventRecord{Step: step, Kind: "stop"})
 			return res, nil
 		}
 		if budgetExceeded(res.Usage, req.Budget) {
 			res.StopReason = BudgetReached
+			res.Messages = resultMessages(state, historyLen)
 			res.Events = append(res.Events, EventRecord{Step: step, Kind: "stop"})
 			return res, nil
 		}
 	}
 	res.StopReason = StepCapReached
+	res.Messages = resultMessages(state, historyLen)
 	res.Events = append(res.Events, EventRecord{Step: maxSteps - 1, Kind: "stop"})
 	return res, nil
 }
@@ -149,6 +155,17 @@ func addUsage(a, b provider.Usage) provider.Usage {
 	a.CompletionTokens += b.CompletionTokens
 	a.TotalTokens += b.TotalTokens
 	return a
+}
+
+func resultMessages(st State, historyLen int) []provider.ChatMessage {
+	if historyLen >= len(st.Messages) {
+		return nil
+	}
+	out := make([]provider.ChatMessage, 0, len(st.Messages)-historyLen)
+	for _, m := range st.Messages[historyLen:] {
+		out = append(out, cloneChatMessage(m.ChatMessage))
+	}
+	return out
 }
 
 func budgetExceeded(u provider.Usage, b Budget) bool {

--- a/agent/orchestrator_test.go
+++ b/agent/orchestrator_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/kstruzzieri/go-llm/provider"
@@ -60,5 +61,42 @@ func TestRunWithZeroValueContextManagerUsesDefaults(t *testing.T) {
 	}
 	if res.Answer != "ok" {
 		t.Fatalf("answer = %q, want ok", res.Answer)
+	}
+}
+
+func TestRunReturnsCurrentTurnTranscriptWithToolObservation(t *testing.T) {
+	mc := &scriptedCaller{responses: []ModelResult{
+		{Response: provider.ChatResponse{ToolCalls: []provider.ToolCall{{
+			ID: "c1", Type: "function",
+			Function: provider.ToolCallFunction{
+				Name:      "echo",
+				Arguments: json.RawMessage(`{"x":1}`),
+			},
+		}}}},
+		{Response: provider.ChatResponse{Content: "done", Done: true}},
+	}}
+	o := newTestOrchestrator(mc)
+	res, err := o.Run(context.Background(), Request{
+		Goal:  "use echo",
+		Tools: []Tool{echoTool{name: "echo"}},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Messages) != 4 {
+		t.Fatalf("Messages = %+v, want user/tool-call/tool/final transcript", res.Messages)
+	}
+	if res.Messages[0].Role != "user" || res.Messages[0].Content != "use echo" {
+		t.Fatalf("message 0 = %+v, want current user goal", res.Messages[0])
+	}
+	if res.Messages[1].Role != "assistant" || len(res.Messages[1].ToolCalls) != 1 {
+		t.Fatalf("message 1 = %+v, want assistant tool call", res.Messages[1])
+	}
+	if res.Messages[2].Role != "tool" || res.Messages[2].ToolName != "echo" ||
+		res.Messages[2].ToolCallID != "c1" || res.Messages[2].Content != `tool-said:{"x":1}` {
+		t.Fatalf("message 2 = %+v, want echo tool observation", res.Messages[2])
+	}
+	if res.Messages[3].Role != "assistant" || res.Messages[3].Content != "done" {
+		t.Fatalf("message 3 = %+v, want final answer", res.Messages[3])
 	}
 }

--- a/agent/types.go
+++ b/agent/types.go
@@ -140,6 +140,7 @@ type ToolCallRecord struct {
 // Result is the canonical final state of a run.
 type Result struct {
 	Answer     string
+	Messages   []provider.ChatMessage
 	Steps      []StepRecord
 	Events     []EventRecord
 	Usage      provider.Usage

--- a/cmd/golem/render.go
+++ b/cmd/golem/render.go
@@ -71,8 +71,8 @@ func (r *renderer) OnStep(_ context.Context, e agent.StepEvent) error {
 
 func (r *renderer) finalFooter(res agent.Result) {
 	total := r.now().Sub(r.runStart).Seconds()
-	line := fmt.Sprintf("done · %d steps · %.1fs · %d tok",
-		len(res.Steps), total, res.Usage.TotalTokens)
+	line := fmt.Sprintf("done · %s · %.1fs · %d tok",
+		plural(len(res.Steps), "step", "steps"), total, res.Usage.TotalTokens)
 	if res.StopReason != agent.Completed {
 		// Double space (not " · ") deliberately sets the stop reason apart from
 		// the metric fields above it — it is a status suffix, not another metric.

--- a/cmd/golem/render_test.go
+++ b/cmd/golem/render_test.go
@@ -86,7 +86,7 @@ func TestRenderer_FinalFooter_Completed_NoStoppedSuffix(t *testing.T) {
 		Usage:      provider.Usage{TotalTokens: 42},
 		StopReason: agent.Completed,
 	})
-	want := "done · 1 steps · 2.0s · 42 tok\n"
+	want := "done · 1 step · 2.0s · 42 tok\n"
 	if buf.String() != want {
 		t.Errorf("completed footer = %q, want %q (no stopped suffix)", buf.String(), want)
 	}

--- a/cmd/golem/repl.go
+++ b/cmd/golem/repl.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/kstruzzieri/go-llm/agent"
+	"github.com/kstruzzieri/go-llm/conversation"
 )
 
 // replSession holds the per-process state the REPL needs.
@@ -117,7 +118,7 @@ func runOnce(ctx context.Context, out io.Writer, interrupts <-chan struct{}, ses
 	// Persist only a successful, answered run (amendment 6). Use the parent ctx,
 	// not runCtx, so the save is not tied to this turn's cancellation scope.
 	if sess.session != nil && res.Answer != "" {
-		if serr := sess.session.record(ctx, line, res.Answer); serr != nil {
+		if serr := sess.session.recordResult(ctx, line, res); serr != nil {
 			_, _ = fmt.Fprintf(out, "warning: session not saved: %v\n", serr)
 		}
 	}
@@ -137,7 +138,8 @@ func lastRoutedModel(res agent.Result) string {
 
 // dispatchSlash handles a slash command; returns true to exit the REPL.
 func dispatchSlash(ctx context.Context, out io.Writer, sess *replSession, line string) bool {
-	cmd := strings.Fields(line)[0]
+	fields := strings.Fields(line)
+	cmd := fields[0]
 	switch cmd {
 	case "/exit", "/quit":
 		return true
@@ -157,6 +159,32 @@ func dispatchSlash(ctx context.Context, out io.Writer, sess *replSession, line s
 		} else {
 			sess.session.renew()
 			_, _ = fmt.Fprintf(out, "session: %s (new)\n", sess.session.id)
+		}
+	case "/sessions":
+		if sess.session == nil {
+			_, _ = fmt.Fprintln(out, "session disabled (--no-session)")
+		} else if err := printSessions(ctx, out, sess.session); err != nil {
+			_, _ = fmt.Fprintf(out, "sessions failed: %v\n", err)
+		}
+	case "/search-sessions":
+		if sess.session == nil {
+			_, _ = fmt.Fprintln(out, "session disabled (--no-session)")
+		} else if q := strings.TrimSpace(strings.TrimPrefix(line, cmd)); q == "" {
+			_, _ = fmt.Fprintln(out, "usage: /search-sessions <query>")
+		} else if err := printSessionSearch(ctx, out, sess.session, q); err != nil {
+			_, _ = fmt.Fprintf(out, "session search failed: %v\n", err)
+		}
+	case "/resume":
+		if sess.session == nil {
+			_, _ = fmt.Fprintln(out, "session disabled (--no-session)")
+		} else if len(fields) != 2 {
+			_, _ = fmt.Fprintln(out, "usage: /resume <session-id>")
+		} else if id, err := resolveSessionID(sessionIDOpts{explicit: fields[1]}); err != nil {
+			_, _ = fmt.Fprintln(out, err)
+		} else if info, err := sess.session.switchTo(ctx, id); err != nil {
+			_, _ = fmt.Fprintf(out, "resume failed: %v\n", err)
+		} else {
+			_, _ = fmt.Fprintln(out, info.line())
 		}
 	case "/model":
 		if sess.lastModel == "" {
@@ -189,7 +217,65 @@ const golemHelp = `commands:
   /model         show the last routed model
   /clear         delete the active session's history
   /new           start a new session (keeps history of the old one)
+  /sessions      list saved sessions
+  /search-sessions <query>
+                 search saved sessions
+  /resume <id>   switch to a saved session
   /undo          revert the last applied write (when -allow-write)
   /exit, /quit   leave golem
 any other line is sent to the agent as a goal.
 `
+
+func printSessions(ctx context.Context, out io.Writer, s *session) error {
+	summaries, err := s.store.List(ctx)
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintln(out, "sessions:")
+	if len(summaries) == 0 {
+		_, _ = fmt.Fprintln(out, "  (none)")
+		return nil
+	}
+	for _, sum := range summaries {
+		title := strings.TrimSpace(sum.Title)
+		if title == "" {
+			title = "(untitled)"
+		}
+		_, _ = fmt.Fprintf(out, "  %s  %s  updated %s  %s\n",
+			sum.ID,
+			plural(sum.MessageCount, "message", "messages"),
+			sum.UpdatedAt.Format("2006-01-02 15:04"),
+			title,
+		)
+	}
+	return nil
+}
+
+func printSessionSearch(ctx context.Context, out io.Writer, s *session, query string) error {
+	results, err := s.store.Search(ctx, query, conversation.SearchOptions{Limit: 10})
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintln(out, "session search:")
+	if len(results) == 0 {
+		_, _ = fmt.Fprintln(out, "  (no matches)")
+		return nil
+	}
+	for _, res := range results {
+		title := strings.TrimSpace(res.Title)
+		if title == "" {
+			title = "(untitled)"
+		}
+		snippet := strings.TrimSpace(strings.ReplaceAll(res.Snippet, "\n", " "))
+		if snippet == "" {
+			snippet = title
+		}
+		_, _ = fmt.Fprintf(out, "  %s  updated %s  %s\n    %s\n",
+			res.ID,
+			res.UpdatedAt.Format("2006-01-02 15:04"),
+			title,
+			snippet,
+		)
+	}
+	return nil
+}

--- a/cmd/golem/repl_test.go
+++ b/cmd/golem/repl_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kstruzzieri/go-llm/agent"
+	"github.com/kstruzzieri/go-llm/conversation"
 	"github.com/kstruzzieri/go-llm/provider"
 )
 
@@ -220,6 +221,57 @@ func TestREPL_HistoryReachesModelAsRealRoles(t *testing.T) {
 	}
 }
 
+func TestREPL_PersistsToolTranscriptButResumesPlainHistory(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "hello.txt"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	toolCall := provider.ChatResponse{ToolCalls: []provider.ToolCall{{
+		ID: "c1", Type: "function",
+		Function: provider.ToolCallFunction{
+			Name:      "read_file",
+			Arguments: json.RawMessage(`{"path":"hello.txt"}`),
+		},
+	}}}
+	caller := &scriptCaller{responses: []agent.ModelResult{
+		{Response: toolCall},
+		{Response: provider.ChatResponse{Content: "it says hi"}},
+	}}
+	sess := newSessionedTestSession(t, caller, root, "workspace:toolhist")
+
+	var out strings.Builder
+	if err := runREPL(context.Background(), strings.NewReader("read it\n"), &out, nil, sess); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+	if len(sess.session.msgs) != 4 {
+		t.Fatalf("persisted messages = %+v, want user/tool-call/tool/final transcript", sess.session.msgs)
+	}
+	if sess.session.msgs[1].Role != "assistant" || len(sess.session.msgs[1].ToolCalls) == 0 {
+		t.Fatalf("assistant tool call not persisted: %+v", sess.session.msgs[1])
+	}
+	if sess.session.msgs[2].Role != "tool" || sess.session.msgs[2].ToolName != "read_file" ||
+		sess.session.msgs[2].ToolCallID != "c1" || sess.session.msgs[2].Content != "hi" {
+		t.Fatalf("tool result not persisted: %+v", sess.session.msgs[2])
+	}
+
+	resume := &captureCaller{answer: "second"}
+	sess.orch = agent.New(resume, agent.ContextManager{})
+	if err := runREPL(context.Background(), strings.NewReader("again\n"), &out, nil, sess); err != nil {
+		t.Fatalf("second runREPL: %v", err)
+	}
+	roles := make([]string, len(resume.messages))
+	for i, m := range resume.messages {
+		roles[i] = m.Role
+		if len(m.ToolCalls) != 0 || m.ToolName != "" || m.ToolCallID != "" {
+			t.Fatalf("history message %d leaked tool metadata: %+v", i, m)
+		}
+	}
+	wantRoles := []string{"system", "user", "assistant", "user"}
+	if strings.Join(roles, ",") != strings.Join(wantRoles, ",") {
+		t.Fatalf("resume roles = %v, want %v", roles, wantRoles)
+	}
+}
+
 func TestREPL_DoesNotPersistCanceledRun(t *testing.T) {
 	root := t.TempDir()
 	caller := &scriptCaller{block: make(chan struct{})} // never unblocked
@@ -415,5 +467,102 @@ func TestREPL_ClearAndNew(t *testing.T) {
 	}
 	if sess.session.id == oldID || !strings.HasPrefix(sess.session.id, "golem:") {
 		t.Errorf("/new did not switch session id: %q", sess.session.id)
+	}
+}
+
+func TestREPL_SessionsListsStoredSessions(t *testing.T) {
+	root := t.TempDir()
+	caller := &scriptCaller{}
+	sess := newSessionedTestSession(t, caller, root, "workspace:list")
+	if err := sess.session.record(context.Background(), "current question", "current answer"); err != nil {
+		t.Fatal(err)
+	}
+	if err := sess.session.store.Save(context.Background(), conversation.Conversation{
+		ID:       "user:other",
+		Title:    "other title",
+		Messages: []conversation.Message{{Role: "user", Content: "other"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var out strings.Builder
+	in := strings.NewReader("/sessions\n/exit\n")
+	if err := runREPL(context.Background(), in, &out, nil, sess); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{"sessions:", "workspace:list", "2 messages", "current question", "user:other", "1 message", "other title"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("/sessions output missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestREPL_ResumeSwitchesActiveSession(t *testing.T) {
+	root := t.TempDir()
+	caller := &captureCaller{answer: "new answer"}
+	sess := newSessionedTestSession(t, caller, root, "workspace:current")
+	if err := sess.session.record(context.Background(), "current question", "current answer"); err != nil {
+		t.Fatal(err)
+	}
+	if err := sess.session.store.Save(context.Background(), conversation.Conversation{
+		ID:    "user:other",
+		Title: "other question",
+		Messages: []conversation.Message{
+			{Role: "user", Content: "other question"},
+			{Role: "assistant", Content: "other answer"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var out strings.Builder
+	in := strings.NewReader("/resume user:other\nfollow up\n")
+	if err := runREPL(context.Background(), in, &out, nil, sess); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+	if sess.session.id != "user:other" {
+		t.Fatalf("active session = %q, want user:other", sess.session.id)
+	}
+	if !strings.Contains(out.String(), "session: user:other resumed, 2 messages") {
+		t.Fatalf("resume output missing in:\n%s", out.String())
+	}
+	wantRoles := []string{"system", "user", "assistant", "user"}
+	wantContent := []string{buildSystemPrompt(false, false), "other question", "other answer", "follow up"}
+	if len(caller.messages) != len(wantRoles) {
+		t.Fatalf("messages = %+v, want %d entries", caller.messages, len(wantRoles))
+	}
+	for i := range wantRoles {
+		if caller.messages[i].Role != wantRoles[i] || caller.messages[i].Content != wantContent[i] {
+			t.Errorf("message %d = {%q,%q}, want {%q,%q}",
+				i, caller.messages[i].Role, caller.messages[i].Content, wantRoles[i], wantContent[i])
+		}
+	}
+}
+
+func TestREPL_SearchSessions(t *testing.T) {
+	root := t.TempDir()
+	caller := &scriptCaller{}
+	sess := newSessionedTestSession(t, caller, root, "workspace:search")
+	if err := sess.session.record(context.Background(), "approval prompts", "writes require approval"); err != nil {
+		t.Fatal(err)
+	}
+	if err := sess.session.store.Save(context.Background(), conversation.Conversation{
+		ID:       "user:other",
+		Title:    "other",
+		Messages: []conversation.Message{{Role: "user", Content: "quantum notes"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var out strings.Builder
+	in := strings.NewReader("/search-sessions approval\n/exit\n")
+	if err := runREPL(context.Background(), in, &out, nil, sess); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "session search:") || !strings.Contains(got, "workspace:search") ||
+		!strings.Contains(got, "approval prompts") || strings.Contains(got, "user:other") {
+		t.Fatalf("search output wrong:\n%s", got)
 	}
 }

--- a/cmd/golem/session.go
+++ b/cmd/golem/session.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kstruzzieri/go-llm/agent"
 	"github.com/kstruzzieri/go-llm/conversation"
 	"github.com/kstruzzieri/go-llm/provider"
 	_ "modernc.org/sqlite"
@@ -221,10 +223,22 @@ func openSession(ctx context.Context, dbPath, id string) (*session, sessionInfo,
 // It only mutates the in-memory buffer after Save succeeds, so a failed save
 // cannot leak an unsaved turn into future history() output or a later successful save.
 func (s *session) record(ctx context.Context, userLine, answer string) error {
-	next := append(append([]conversation.Message{}, s.msgs...),
+	return s.recordMessages(ctx, []conversation.Message{
 		conversation.Message{Role: "user", Content: userLine},
 		conversation.Message{Role: "assistant", Content: answer},
-	)
+	})
+}
+
+func (s *session) recordResult(ctx context.Context, userLine string, res agent.Result) error {
+	msgs, err := resultConversationMessages(userLine, res)
+	if err != nil {
+		return err
+	}
+	return s.recordMessages(ctx, msgs)
+}
+
+func (s *session) recordMessages(ctx context.Context, msgs []conversation.Message) error {
+	next := append(append([]conversation.Message{}, s.msgs...), msgs...)
 	if err := s.store.Save(ctx, conversation.Conversation{
 		ID:       s.id,
 		Title:    sessionTitle(next),
@@ -237,6 +251,33 @@ func (s *session) record(ctx context.Context, userLine, answer string) error {
 	// this write; re-secure them (the WAL can hold un-checkpointed message text).
 	_ = chmodSessionDBFiles(s.dbPath)
 	return nil
+}
+
+func resultConversationMessages(userLine string, res agent.Result) ([]conversation.Message, error) {
+	if len(res.Messages) == 0 {
+		return []conversation.Message{
+			{Role: "user", Content: userLine},
+			{Role: "assistant", Content: res.Answer},
+		}, nil
+	}
+	out := make([]conversation.Message, len(res.Messages))
+	for i, m := range res.Messages {
+		cm := conversation.Message{
+			Role:       m.Role,
+			Content:    m.Content,
+			ToolName:   m.ToolName,
+			ToolCallID: m.ToolCallID,
+		}
+		if len(m.ToolCalls) > 0 {
+			raw, err := json.Marshal(m.ToolCalls)
+			if err != nil {
+				return nil, fmt.Errorf("golem: marshal tool calls at message %d: %w", i, err)
+			}
+			cm.ToolCalls = raw
+		}
+		out[i] = cm
+	}
+	return out, nil
 }
 
 // history maps the persisted conversation to real-role chat messages for the
@@ -298,6 +339,21 @@ func (s *session) clear(ctx context.Context) error {
 func (s *session) renew() {
 	s.id = "golem:" + conversation.NewID()
 	s.msgs = nil
+}
+
+func (s *session) switchTo(ctx context.Context, id string) (sessionInfo, error) {
+	conv, err := s.store.Load(ctx, id)
+	if err != nil {
+		return sessionInfo{}, err
+	}
+	s.id = id
+	s.msgs = conv.Messages
+	return sessionInfo{
+		id:        id,
+		resumed:   len(conv.Messages) > 0,
+		msgCount:  len(conv.Messages),
+		updatedAt: conv.UpdatedAt,
+	}, nil
 }
 
 // Close releases the DB. Nil-safe and idempotent enough for defer.

--- a/conversation/message.go
+++ b/conversation/message.go
@@ -72,6 +72,23 @@ type Summary struct {
 	UpdatedAt    time.Time
 }
 
+// SearchOptions scopes and bounds conversation search.
+type SearchOptions struct {
+	Limit    int
+	IDPrefix string
+}
+
+// SearchResult is one matching prior conversation.
+type SearchResult struct {
+	ID           string
+	Title        string
+	Snippet      string
+	MessageCount int
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+	Score        float64
+}
+
 // TrimResult holds the trimmed message slice and metadata about the trim.
 type TrimResult struct {
 	Messages        []Message

--- a/conversation/migration.go
+++ b/conversation/migration.go
@@ -18,6 +18,11 @@ var migrations = []migration{
 		description: "baseline conversations table",
 		fn:          migrateV1,
 	},
+	{
+		version:     2,
+		description: "conversation search shadow table and FTS5 index",
+		fn:          migrateV2,
+	},
 }
 
 func migrateV1(tx *sql.Tx) error {
@@ -35,6 +40,36 @@ func migrateV1(tx *sql.Tx) error {
 	for _, stmt := range stmts {
 		if _, err := tx.Exec(stmt); err != nil {
 			return fmt.Errorf("conversation: migrate v1: %w", err)
+		}
+	}
+	return nil
+}
+
+func migrateV2(tx *sql.Tx) error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS conversation_search (
+			id            TEXT PRIMARY KEY,
+			title         TEXT NOT NULL DEFAULT '',
+			body          TEXT NOT NULL,
+			message_count INTEGER NOT NULL,
+			created_at    INTEGER NOT NULL,
+			updated_at    INTEGER NOT NULL
+		)`,
+		`CREATE VIRTUAL TABLE IF NOT EXISTS conversation_fts USING fts5(
+			id UNINDEXED,
+			title,
+			body
+		)`,
+		`INSERT OR REPLACE INTO conversation_search (id, title, body, message_count, created_at, updated_at)
+		 SELECT id, title, messages, json_array_length(messages), created_at, updated_at
+		   FROM conversations`,
+		`DELETE FROM conversation_fts`,
+		`INSERT INTO conversation_fts (id, title, body)
+		 SELECT id, title, body FROM conversation_search`,
+	}
+	for _, stmt := range stmts {
+		if _, err := tx.Exec(stmt); err != nil {
+			return fmt.Errorf("conversation: migrate v2: %w", err)
 		}
 	}
 	return nil

--- a/conversation/migration_test.go
+++ b/conversation/migration_test.go
@@ -35,8 +35,8 @@ func TestRunMigrations_FreshDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("version query failed: %v", err)
 	}
-	if version != 1 {
-		t.Fatalf("schema version = %d, want 1", version)
+	if version != 2 {
+		t.Fatalf("schema version = %d, want 2", version)
 	}
 }
 
@@ -54,8 +54,8 @@ func TestRunMigrations_Idempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("version query failed: %v", err)
 	}
-	if version != 1 {
-		t.Fatalf("schema version = %d, want 1", version)
+	if version != 2 {
+		t.Fatalf("schema version = %d, want 2", version)
 	}
 }
 
@@ -71,5 +71,23 @@ func TestRunMigrations_IndexExists(t *testing.T) {
 	).Scan(&count)
 	if err != nil || count != 1 {
 		t.Fatalf("expected idx_conversations_updated_id index, count=%d err=%v", count, err)
+	}
+}
+
+func TestRunMigrations_SearchTablesExist(t *testing.T) {
+	db := openTestDB(t)
+	if err := runMigrations(db); err != nil {
+		t.Fatalf("runMigrations() error: %v", err)
+	}
+
+	for _, name := range []string{"conversation_search", "conversation_fts"} {
+		var count int
+		err := db.QueryRow(
+			`SELECT COUNT(*) FROM sqlite_master WHERE name = ?`,
+			name,
+		).Scan(&count)
+		if err != nil || count != 1 {
+			t.Fatalf("expected %s table, count=%d err=%v", name, count, err)
+		}
 	}
 }

--- a/conversation/store.go
+++ b/conversation/store.go
@@ -253,6 +253,10 @@ func searchText(msgs []Message) string {
 			b.WriteByte(' ')
 			b.WriteString(m.ToolCallID)
 		}
+		if len(m.ToolCalls) > 0 {
+			b.WriteByte(' ')
+			b.Write(m.ToolCalls)
+		}
 		b.WriteByte('\n')
 	}
 	return b.String()

--- a/conversation/store.go
+++ b/conversation/store.go
@@ -5,7 +5,9 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
+	"unicode"
 )
 
 // Store defines conversation persistence operations.
@@ -13,6 +15,7 @@ type Store interface {
 	Save(ctx context.Context, conv Conversation) error
 	Load(ctx context.Context, id string) (*Conversation, error)
 	List(ctx context.Context) ([]Summary, error)
+	Search(ctx context.Context, query string, opts SearchOptions) ([]SearchResult, error)
 	Delete(ctx context.Context, id string) error
 }
 
@@ -48,7 +51,14 @@ func (s *SQLiteStore) Save(ctx context.Context, conv Conversation) error {
 
 	now := time.Now().UnixMilli()
 
-	_, err = s.db.ExecContext(ctx,
+	searchBody := searchText(msgs)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("conversation: save %q: begin: %w", conv.ID, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = tx.ExecContext(ctx,
 		`INSERT INTO conversations (id, title, messages, created_at, updated_at)
 		 VALUES (?, ?, ?, ?, ?)
 		 ON CONFLICT(id) DO UPDATE SET
@@ -59,6 +69,12 @@ func (s *SQLiteStore) Save(ctx context.Context, conv Conversation) error {
 	)
 	if err != nil {
 		return fmt.Errorf("conversation: save %q: %w", conv.ID, err)
+	}
+	if err := s.saveSearchIndex(ctx, tx, conv.ID, conv.Title, searchBody, len(msgs), now, now); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("conversation: save %q: commit: %w", conv.ID, err)
 	}
 	return nil
 }
@@ -123,11 +139,145 @@ func (s *SQLiteStore) List(ctx context.Context) ([]Summary, error) {
 	return summaries, nil
 }
 
+func (s *SQLiteStore) Search(ctx context.Context, query string, opts SearchOptions) ([]SearchResult, error) {
+	match := sanitizeFTS5Query(query)
+	if match == "" {
+		return []SearchResult{}, nil
+	}
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT s.id, s.title,
+		        snippet(conversation_fts, 2, '', '', '...', 12) AS snippet,
+		        s.message_count, s.created_at, s.updated_at,
+		        bm25(conversation_fts) AS score
+		   FROM conversation_fts
+		   JOIN conversation_search s ON s.id = conversation_fts.id
+		  WHERE conversation_fts MATCH ?
+		    AND (? = '' OR s.id LIKE ? || '%')
+		  ORDER BY score ASC, s.updated_at DESC, s.id ASC
+		  LIMIT ?`,
+		match, opts.IDPrefix, opts.IDPrefix, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("conversation: search: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	results := []SearchResult{}
+	for rows.Next() {
+		var r SearchResult
+		var createdMs, updatedMs int64
+		if err := rows.Scan(&r.ID, &r.Title, &r.Snippet, &r.MessageCount, &createdMs, &updatedMs, &r.Score); err != nil {
+			return nil, fmt.Errorf("conversation: search: scan: %w", err)
+		}
+		r.CreatedAt = time.UnixMilli(createdMs)
+		r.UpdatedAt = time.UnixMilli(updatedMs)
+		results = append(results, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("conversation: search: iterate: %w", err)
+	}
+	return results, nil
+}
+
 // Delete removes a conversation by ID. Returns nil if not found (idempotent).
 func (s *SQLiteStore) Delete(ctx context.Context, id string) error {
-	_, err := s.db.ExecContext(ctx, `DELETE FROM conversations WHERE id = ?`, id)
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
+		return fmt.Errorf("conversation: delete %q: begin: %w", id, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `DELETE FROM conversations WHERE id = ?`, id); err != nil {
 		return fmt.Errorf("conversation: delete %q: %w", id, err)
 	}
+	if err := s.deleteSearchIndex(ctx, tx, id); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("conversation: delete %q: commit: %w", id, err)
+	}
 	return nil
+}
+
+func (s *SQLiteStore) saveSearchIndex(ctx context.Context, tx *sql.Tx, id, title, body string, msgCount int, createdMs, updatedMs int64) error {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM conversation_fts WHERE id = ?`, id); err != nil {
+		return fmt.Errorf("conversation: save %q: delete search fts: %w", id, err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO conversation_search (id, title, body, message_count, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(id) DO UPDATE SET
+			title         = excluded.title,
+			body          = excluded.body,
+			message_count = excluded.message_count,
+			updated_at    = excluded.updated_at`,
+		id, title, body, msgCount, createdMs, updatedMs,
+	); err != nil {
+		return fmt.Errorf("conversation: save %q: upsert search metadata: %w", id, err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO conversation_fts (id, title, body) VALUES (?, ?, ?)`,
+		id, title, body,
+	); err != nil {
+		return fmt.Errorf("conversation: save %q: insert search fts: %w", id, err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) deleteSearchIndex(ctx context.Context, tx *sql.Tx, id string) error {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM conversation_fts WHERE id = ?`, id); err != nil {
+		return fmt.Errorf("conversation: delete %q: delete search fts: %w", id, err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM conversation_search WHERE id = ?`, id); err != nil {
+		return fmt.Errorf("conversation: delete %q: delete search metadata: %w", id, err)
+	}
+	return nil
+}
+
+func searchText(msgs []Message) string {
+	var b strings.Builder
+	for _, m := range msgs {
+		if m.Role != "" {
+			b.WriteString(m.Role)
+			b.WriteString(": ")
+		}
+		b.WriteString(m.Content)
+		if m.ToolName != "" {
+			b.WriteByte(' ')
+			b.WriteString(m.ToolName)
+		}
+		if m.ToolCallID != "" {
+			b.WriteByte(' ')
+			b.WriteString(m.ToolCallID)
+		}
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func sanitizeFTS5Query(query string) string {
+	var tokens []string
+	var current strings.Builder
+	for _, r := range query {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' {
+			current.WriteRune(r)
+		} else if current.Len() > 0 {
+			tokens = append(tokens, current.String())
+			current.Reset()
+		}
+	}
+	if current.Len() > 0 {
+		tokens = append(tokens, current.String())
+	}
+	if len(tokens) == 0 {
+		return ""
+	}
+	quoted := make([]string, len(tokens))
+	for i, t := range tokens {
+		quoted[i] = `"` + strings.ReplaceAll(t, `"`, `""`) + `"`
+	}
+	return strings.Join(quoted, " ")
 }

--- a/conversation/store_test.go
+++ b/conversation/store_test.go
@@ -2,6 +2,7 @@ package conversation
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -254,6 +255,32 @@ func TestSearch_FindsMessageTextWithoutLoadingBlobs(t *testing.T) {
 	}
 	if got[0].CreatedAt.IsZero() || got[0].UpdatedAt.IsZero() {
 		t.Fatalf("Search() timestamps missing: %+v", got[0])
+	}
+}
+
+func TestSearch_FindsToolCallPayloads(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	if err := store.Save(ctx, Conversation{
+		ID:    "workspace:toolcall",
+		Title: "Tool call session",
+		Messages: []Message{
+			{Role: "user", Content: "read it"},
+			{Role: "assistant", ToolCalls: json.RawMessage(`[{"id":"c1","type":"function","function":{"name":"read_file","arguments":{"path":"secret.go"}}}]`)},
+			{Role: "tool", Content: "package secret", ToolName: "read_file", ToolCallID: "c1"},
+			{Role: "assistant", Content: "found it"},
+		},
+	}); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	got, err := store.Search(ctx, "secret.go", SearchOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("Search() error: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "workspace:toolcall" {
+		t.Fatalf("Search() = %+v, want tool-call session", got)
 	}
 }
 

--- a/conversation/store_test.go
+++ b/conversation/store_test.go
@@ -3,6 +3,7 @@ package conversation
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -212,6 +213,120 @@ func TestDelete_Idempotent(t *testing.T) {
 	_, err := store.Load(ctx, id)
 	if !errors.Is(err, ErrNotFound) {
 		t.Errorf("Load after Delete: error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSearch_FindsMessageTextWithoutLoadingBlobs(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	conv := Conversation{
+		ID:    "workspace:alpha",
+		Title: "Golem session",
+		Messages: []Message{
+			{Role: "user", Content: "How do approval prompts work?"},
+			{Role: "assistant", Content: "The approval prompt gates writes and exec."},
+		},
+	}
+	if err := store.Save(ctx, conv); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+	if err := store.Save(ctx, Conversation{
+		ID:       "workspace:beta",
+		Title:    "Unrelated",
+		Messages: []Message{{Role: "user", Content: "quantum trading notes"}},
+	}); err != nil {
+		t.Fatalf("Save() unrelated error: %v", err)
+	}
+
+	got, err := store.Search(ctx, "approval prompt", SearchOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("Search() error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Search() len = %d, want 1: %+v", len(got), got)
+	}
+	if got[0].ID != conv.ID || got[0].Title != conv.Title || got[0].MessageCount != 2 {
+		t.Fatalf("Search() result = %+v, want alpha metadata", got[0])
+	}
+	if got[0].Snippet == "" {
+		t.Fatal("Search() result missing snippet")
+	}
+	if got[0].CreatedAt.IsZero() || got[0].UpdatedAt.IsZero() {
+		t.Fatalf("Search() timestamps missing: %+v", got[0])
+	}
+}
+
+func TestSearch_UpdateAndDeleteStayInSync(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	id := "workspace:sync"
+	if err := store.Save(ctx, Conversation{
+		ID:       id,
+		Title:    "Sync",
+		Messages: []Message{{Role: "user", Content: "alpha needle"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Save(ctx, Conversation{
+		ID:       id,
+		Title:    "Sync",
+		Messages: []Message{{Role: "user", Content: "bravo needle"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	oldResults, err := store.Search(ctx, "alpha", SearchOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("Search(old) error: %v", err)
+	}
+	if len(oldResults) != 0 {
+		t.Fatalf("old term still indexed after update: %+v", oldResults)
+	}
+	newResults, err := store.Search(ctx, "bravo", SearchOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("Search(new) error: %v", err)
+	}
+	if len(newResults) != 1 || newResults[0].ID != id {
+		t.Fatalf("new term results = %+v, want %q", newResults, id)
+	}
+
+	if err := store.Delete(ctx, id); err != nil {
+		t.Fatal(err)
+	}
+	deleted, err := store.Search(ctx, "bravo", SearchOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("Search(after delete) error: %v", err)
+	}
+	if len(deleted) != 0 {
+		t.Fatalf("deleted conversation still indexed: %+v", deleted)
+	}
+}
+
+func TestSearch_IDPrefixScopeAndLimit(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	for _, conv := range []Conversation{
+		{ID: "workspace:a", Title: "A", Messages: []Message{{Role: "user", Content: "shared term"}}},
+		{ID: "user:b", Title: "B", Messages: []Message{{Role: "user", Content: "shared term"}}},
+		{ID: "user:c", Title: "C", Messages: []Message{{Role: "user", Content: "shared term"}}},
+	} {
+		if err := store.Save(ctx, conv); err != nil {
+			t.Fatalf("Save(%s): %v", conv.ID, err)
+		}
+	}
+
+	got, err := store.Search(ctx, "shared", SearchOptions{IDPrefix: "user:", Limit: 1})
+	if err != nil {
+		t.Fatalf("Search() error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Search() len = %d, want 1: %+v", len(got), got)
+	}
+	if !strings.HasPrefix(got[0].ID, "user:") {
+		t.Fatalf("Search() = %+v, want user: scoped result", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add FTS5-backed cross-session search to `conversation.Store`
- keep the JSON conversation blob format intact while syncing a shadow search table on save/update/delete
- expose Golem session search/list/resume commands and persist full runtime tool transcripts

## Impact

Golem can now search prior saved sessions without loading every conversation blob, and resumed sessions retain durable tool-call/result history while still feeding plain user/assistant history back into future prompts.

Closes #59
Refs #57
Refs #185

## Validation

- `rtk env GOCACHE=/private/tmp/go-llm-gocache go test ./...`
- pre-push hook: lint, race tests, compile smoke
