### PR TITLE
[codex] Swap lightweight local model to Qwen3.5 MTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
+<p align="center">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/brand/golem-lockup-on-dark.svg">
   <img alt="Golem agent logo" src="assets/brand/golem-lockup-on-light.svg" width="260">
 </picture>
+</p>
 
 # go-llm
 

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ models:
     cmd: llama-server -m /models/qwen3.6-35b-a3b.gguf --port ${PORT} -c 8192 -ngl 99 --jinja
   "qwen3-coder-next:latest":
     cmd: llama-server -m /models/qwen3-coder-next.gguf --port ${PORT} -c 8192 -ngl 99 --jinja
-  "qwen3:8b":
-    cmd: llama-server -m /models/qwen3-8b.gguf --port ${PORT} -c 8192 -ngl 99 --jinja
+  "qwen3.5:9b-mtp":
+    cmd: llama-server -m /models/qwen3.5-9b-mtp.gguf --port ${PORT} -c 8192 -ngl 99 --jinja
   "qwen3-embedding:8b":
     cmd: llama-server -m /models/qwen3-embedding-8b.gguf --port ${PORT} -c 8192 -ngl 99 --embeddings
 ```

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -36,7 +36,7 @@ models:
   "gemma4:31b":              { cmd: llama-server -m /models/gemma4-31b.gguf --port ${PORT} -c 8192 -ngl 99 --jinja }
   "qwen3.6:35b-a3b":         { cmd: llama-server -m /models/qwen3.6-35b-a3b.gguf --port ${PORT} -c 8192 -ngl 99 --jinja }
   "qwen3-coder-next:latest": { cmd: llama-server -m /models/qwen3-coder-next.gguf --port ${PORT} -c 8192 -ngl 99 --jinja }
-  "qwen3:8b":                { cmd: llama-server -m /models/qwen3-8b.gguf --port ${PORT} -c 8192 -ngl 99 --jinja }
+  "qwen3.5:9b-mtp":          { cmd: llama-server -m /models/qwen3.5-9b-mtp.gguf --port ${PORT} -c 8192 -ngl 99 --jinja }
   "qwen3-embedding:8b":      { cmd: llama-server -m /models/qwen3-embedding-8b.gguf --port ${PORT} -c 8192 -ngl 99 --embeddings }
 ```
 
@@ -57,7 +57,7 @@ not run the whole fleet at once (and on a 128GB box you can't co-resident it).
 ollama pull gemma4:31b            # general / agent / judge / analysis
 ollama pull qwen3.6:35b-a3b       # fast fallback / lower-latency chat
 ollama pull qwen3-coder-next:latest  # coding / review / FIM
-ollama pull qwen3:8b              # lightweight
+ollama pull qwen3:8b              # lightweight fallback for Ollama-only installs
 ollama pull qwen3-embedding:8b    # embeddings (RAG)
 ```
 
@@ -125,7 +125,7 @@ Consumer applications (Firn IDE, Flux ML) can also use `config.Default()` to dis
 | `judge` | `gemma4:31b` (~20GB) | Local LLM-as-judge scoring for captured trace replays |
 | `fast` | `qwen3.6:35b-a3b` (~28GB) | Lower-latency chat and strong fallback path |
 | `coding` | `qwen3-coder-next:latest` (~46GB) | Code generation, review, FIM completions |
-| `lightweight` | `qwen3:8b` (~6GB) | Quick answers, classification, low-stakes tasks |
+| `lightweight` | `qwen3.5:9b-mtp` (~6GB) | Quick answers, classification, low-stakes tasks |
 | `embedding` | `qwen3-embedding:8b` (~5GB) | Vector embeddings for RAG search |
 
 The `analysis` use-case currently maps to the `general` role, so it also
@@ -337,8 +337,8 @@ go-llm/
 
 | Setup | RAM | Recommended Models |
 |-------|-----|-------------------|
-| Minimal (8GB) | 8GB | `qwen3:8b` only |
-| Standard (16-32GB) | 16-32GB | `qwen3:8b` + `qwen3-embedding:8b` |
+| Minimal (8GB) | 8GB | `qwen3.5:9b-mtp` only |
+| Standard (16-32GB) | 16-32GB | `qwen3.5:9b-mtp` + `qwen3-embedding:8b` |
 | Large (32-64GB) | 32-64GB | One primary model at a time (`gemma4:31b` or `qwen3.6:35b-a3b`), adding smaller models only if memory allows |
 | Power (128GB+) | 128GB+ | Full reference lineup from `models.json` |
 

--- a/docs/llm/README.md
+++ b/docs/llm/README.md
@@ -42,7 +42,7 @@ not "what `go-llm` requires."
 - **`gemma4:31b`** (dense) — agent / judge / reasoning (86.4% τ2-bench,
   80.0% LiveCodeBench, native function calling)
 - **`qwen3.6:35b-a3b`** — fast MoE (73.4% SWE-bench, 3B active)
-- **`qwen3:8b`** — lightweight / FIM
+- **`qwen3.5:9b-mtp`** — lightweight / FIM
 
 The fleet co-resides in ~77GB with comfortable headroom. **llama.cpp is now
 the primary local backend** (run one `llama-server` per model on its own

--- a/docs/llm/setups.md
+++ b/docs/llm/setups.md
@@ -22,7 +22,7 @@ to `go-llm`. This is what `models.json` ships with.
 | `agent` | `gemma4:31b` (dense) | ~20GB | 86.4% τ2-bench, 80.0% LiveCodeBench, native function calling |
 | `general` / `analysis` | `gemma4:31b` (thinking mode on) | shared | Gemma 4 doubles as reasoner |
 | `fast` | `qwen3.6:35b-a3b` | ~28GB (Q6) | Superseded the legacy qwen3.5:35b-a3b |
-| `lightweight` | `qwen3:8b` | ~6GB | FIM completion |
+| `lightweight` | `qwen3.5:9b-mtp` | ~6GB | MTP FIM completion |
 | `embedding` | `qwen3-embedding:8b` | ~5GB | |
 
 **Resident memory:** ~77GB with the optional `qwen3.6:35b-a3b`, or ~57GB

--- a/models.json
+++ b/models.json
@@ -57,12 +57,12 @@
       "fallbacks": ["fast", "lightweight"]
     },
     "lightweight": {
-      "name": "qwen3:8b",
+      "name": "qwen3.5:9b-mtp",
       "provider": "llamacpp",
-      "description": "Small and fast — FIM / inline completion, simple tasks.",
+      "description": "Qwen3.5 9B MTP — lightweight FIM / inline completion, simple tasks.",
       "type": "dense",
-      "parameters": "8B",
-      "context_window": 40960
+      "parameters": "9B",
+      "context_window": 262144
     },
     "embedding": {
       "name": "qwen3-embedding:8b",

--- a/provider/catalog.json
+++ b/provider/catalog.json
@@ -49,6 +49,7 @@
       "context_window": 131072,
       "variants": {
         "7b":  { "ram_required": 5.0, "ram_recommended": 8.0, "vram_recommended": 5.0, "quality": "good", "speed": "fast" },
+        "9b":  { "ram_required": 6.0, "ram_recommended": 9.0, "vram_recommended": 6.0, "quality": "good", "speed": "fast" },
         "14b": { "ram_required": 9.0, "ram_recommended": 12.0, "vram_recommended": 9.0, "quality": "great", "speed": "medium" },
         "27b": { "ram_required": 17.0, "ram_recommended": 22.0, "vram_recommended": 17.0, "quality": "great", "speed": "medium" },
         "35b": { "ram_required": 22.0, "ram_recommended": 28.0, "vram_recommended": 22.0, "quality": "great", "speed": "medium" }

--- a/provider/model_registry_test.go
+++ b/provider/model_registry_test.go
@@ -425,6 +425,48 @@ func TestModelRegistry_Lookup_Qwen3CoderNextLatestCatalogMatch(t *testing.T) {
 	}
 }
 
+func TestModelRegistry_Lookup_Qwen35NineBMTPUsesCatalog(t *testing.T) {
+	ctx := context.Background()
+
+	prov := &mrMockProvider{
+		name: "llamacpp",
+		caps: CapChat | CapGenerate | CapStream,
+		models: []ModelInfo{
+			{Name: "qwen3.5:9b-mtp"},
+		},
+	}
+
+	reg := &mrMockProviderRegistry{
+		providers: map[string]Provider{"llamacpp": prov},
+	}
+
+	mr, err := NewModelRegistry(reg, newMrMockFingerprintStore())
+	if err != nil {
+		t.Fatalf("NewModelRegistry() error: %v", err)
+	}
+
+	profile, err := mr.Lookup(ctx, ModelKey{Provider: "llamacpp", Model: "qwen3.5:9b-mtp"})
+	if err != nil {
+		t.Fatalf("Lookup() error: %v", err)
+	}
+
+	if profile.Resources.RAMRequired != 6.0 {
+		t.Errorf("RAMRequired = %f, want 6.0", profile.Resources.RAMRequired)
+	}
+	if profile.Resources.RAMRecommended != 9.0 {
+		t.Errorf("RAMRecommended = %f, want 9.0", profile.Resources.RAMRecommended)
+	}
+	if profile.Quality != TierGood {
+		t.Errorf("Quality = %v, want %v", profile.Quality, TierGood)
+	}
+	if profile.Speed != TierGreat {
+		t.Errorf("Speed = %v, want %v", profile.Speed, TierGreat)
+	}
+	if profile.FIM == nil {
+		t.Fatal("expected FIM config from catalog, got nil")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // TestModelRegistry_Lookup_UnknownModel
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- update `models.json` lightweight role from `qwen3:8b` to `qwen3.5:9b-mtp`
- update llama.cpp setup docs to use `qwen3.5-9b-mtp.gguf`
- leave historical benchmark references unchanged

## Local model changes
- downloaded `/Users/keith.struzzieri/models/gguf/qwen3.6-27b-mtp.gguf`
- downloaded `/Users/keith.struzzieri/models/gguf/qwen3.5-9b-mtp.gguf`
- removed old local `qwen3.6-27b` and `qwen3-8b` GGUFs plus matching Ollama blob leftovers

## Validation
- `llama-server` load check for both new GGUFs on temporary local ports
- `jq . models.json`
- `GOCACHE=/tmp/go-llm-go-build go test ./config`
- pre-push lint, race tests, and compile smoke passed during `git push`
