### PR TITLE
feat: conversation compression with durable summaries (#58)

### DIFF
--- a/agent/context_manager.go
+++ b/agent/context_manager.go
@@ -17,7 +17,10 @@ type ContextManager struct {
 	Estimate  func(string) int // token estimator; len/4 when nil
 }
 
-func durableSummaryPrompt(summary string) string {
+// DurableSummaryPrompt renders the durable summary as the pinned system message
+// injected ahead of raw history. Exported so Golem's trigger accounting counts
+// the exact text agent injects (no drift between estimate and reality).
+func DurableSummaryPrompt(summary string) string {
 	return "Previous conversation summary:\n" + summary
 }
 
@@ -83,7 +86,7 @@ func materializeDurableSummary(st State) State {
 	out.DurableSummary = ""
 	out.Messages = make([]Message, 0, len(st.Messages)+1)
 	out.Messages = append(out.Messages, Message{
-		ChatMessage: provider.ChatMessage{Role: "system", Content: durableSummaryPrompt(summary)},
+		ChatMessage: provider.ChatMessage{Role: "system", Content: DurableSummaryPrompt(summary)},
 		Segment:     Pinned,
 	})
 	out.Messages = append(out.Messages, st.Messages...)

--- a/agent/context_manager.go
+++ b/agent/context_manager.go
@@ -7,8 +7,10 @@ import (
 	"github.com/kstruzzieri/go-llm/provider"
 )
 
-// defaultInputCeiling is a conservative fallback when Budget.InputCeiling is 0.
-const defaultInputCeiling = 8192
+// DefaultInputCeiling is a conservative fallback when Budget.InputCeiling is 0.
+// Exported so consumers (e.g. Golem's compression policy) derive their own
+// token thresholds from the same source rather than duplicating the literal.
+const DefaultInputCeiling = 8192
 
 // ContextManager assembles and bounds the prompt each turn. It is a pure
 // function over State, tool-schema token count, and budget.
@@ -48,7 +50,7 @@ func (m ContextManager) messageCost(msg Message) int {
 func turnBudget(b Budget) TokenBudget {
 	ceiling := b.InputCeiling
 	if ceiling <= 0 {
-		ceiling = defaultInputCeiling
+		ceiling = DefaultInputCeiling
 	}
 	if b.OutputReserve > 0 {
 		ceiling -= b.OutputReserve

--- a/agent/context_manager.go
+++ b/agent/context_manager.go
@@ -1,6 +1,11 @@
 package agent
 
-import "context"
+import (
+	"context"
+	"strings"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
 
 // defaultInputCeiling is a conservative fallback when Budget.InputCeiling is 0.
 const defaultInputCeiling = 8192
@@ -10,6 +15,10 @@ const defaultInputCeiling = 8192
 type ContextManager struct {
 	Compactor Compactor
 	Estimate  func(string) int // token estimator; len/4 when nil
+}
+
+func durableSummaryPrompt(summary string) string {
+	return "Previous conversation summary:\n" + summary
 }
 
 func (m ContextManager) estimate(s string) int {
@@ -65,10 +74,27 @@ func (m ContextManager) totalTokens(st State, toolSchemaTokens int) int {
 	return n
 }
 
+func materializeDurableSummary(st State) State {
+	summary := strings.TrimSpace(st.DurableSummary)
+	if summary == "" {
+		return st
+	}
+	out := st
+	out.DurableSummary = ""
+	out.Messages = make([]Message, 0, len(st.Messages)+1)
+	out.Messages = append(out.Messages, Message{
+		ChatMessage: provider.ChatMessage{Role: "system", Content: durableSummaryPrompt(summary)},
+		Segment:     Pinned,
+	})
+	out.Messages = append(out.Messages, st.Messages...)
+	return out
+}
+
 // Assemble bounds the transcript to fit the budget. toolSchemaTokens is the
 // pinned cost of the active tool schemas (not stored in State).
 func (m ContextManager) Assemble(ctx context.Context, st State, toolSchemaTokens int, budget TokenBudget) (State, Pressure, error) {
 	m = normalizeContextManager(m)
+	st = materializeDurableSummary(st)
 	if m.pinnedTokens(st, toolSchemaTokens) > budget.Input {
 		return st, Pressure{}, ErrContextExhausted
 	}

--- a/agent/context_manager_test.go
+++ b/agent/context_manager_test.go
@@ -62,6 +62,33 @@ func TestAssembleCompactsElastic(t *testing.T) {
 	}
 }
 
+func TestAssembleIncludesDurableSummaryBeforeRawMessages(t *testing.T) {
+	m := ContextManager{Compactor: RecencyCompactor{Estimate: runeEstimator}, Estimate: runeEstimator}
+	st := State{
+		System:         "sys",
+		DurableSummary: "old setup and decisions",
+		Messages: []Message{
+			elastic("user", "recent question"),
+			pinned("user", "goal"),
+		},
+	}
+
+	out, _, err := m.Assemble(context.Background(), st, 0, TokenBudget{Input: 100})
+	if err != nil {
+		t.Fatalf("Assemble: %v", err)
+	}
+	req := buildChatRequest(out, nil, 0)
+	if len(req.Messages) < 4 {
+		t.Fatalf("messages = %+v, want system, durable summary, recent, goal", req.Messages)
+	}
+	if req.Messages[1].Role != "system" || req.Messages[1].Content != durableSummaryPrompt("old setup and decisions") {
+		t.Fatalf("summary message = %+v", req.Messages[1])
+	}
+	if req.Messages[2].Content != "recent question" {
+		t.Fatalf("summary was not before raw messages: %+v", req.Messages)
+	}
+}
+
 func TestAssembleReturnsErrWhenCompactedStateStillOverBudget(t *testing.T) {
 	// An unresolved tail (2 tool_calls, only 1 result present) can never be
 	// dropped. Even after evicting all droppable groups the state won't fit in a

--- a/agent/context_manager_test.go
+++ b/agent/context_manager_test.go
@@ -81,7 +81,7 @@ func TestAssembleIncludesDurableSummaryBeforeRawMessages(t *testing.T) {
 	if len(req.Messages) < 4 {
 		t.Fatalf("messages = %+v, want system, durable summary, recent, goal", req.Messages)
 	}
-	if req.Messages[1].Role != "system" || req.Messages[1].Content != durableSummaryPrompt("old setup and decisions") {
+	if req.Messages[1].Role != "system" || req.Messages[1].Content != DurableSummaryPrompt("old setup and decisions") {
 		t.Fatalf("summary message = %+v", req.Messages[1])
 	}
 	if req.Messages[2].Content != "recent question" {

--- a/agent/model_caller.go
+++ b/agent/model_caller.go
@@ -2,7 +2,10 @@ package agent
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
+	"github.com/kstruzzieri/go-llm/conversation"
 	"github.com/kstruzzieri/go-llm/provider"
 )
 
@@ -72,4 +75,69 @@ func (m *routerModelCaller) Chat(ctx context.Context, req provider.ChatRequest,
 	final := getFinal()
 	final.RouteOutcome = outcome
 	return ModelResult{Response: final, RouteOutcome: outcome}, execErr
+}
+
+type routerSummarizer struct {
+	route func(ctx context.Context, rr provider.RoutingRequest) (planExecutor, error)
+}
+
+// NewRouterSummarizer routes durable-history compression through the optional
+// "summarize" model role.
+func NewRouterSummarizer(r *provider.Router) conversation.Summarizer {
+	return (&routerSummarizer{
+		route: func(ctx context.Context, rr provider.RoutingRequest) (planExecutor, error) {
+			return r.Route(ctx, rr)
+		},
+	}).Summarize
+}
+
+func (s *routerSummarizer) Summarize(ctx context.Context, msgs []conversation.Message) (string, error) {
+	if s.route == nil {
+		return "", fmt.Errorf("agent: summarize route is nil")
+	}
+	const outputReserve = 512
+	rr := provider.RoutingRequest{
+		UseCase: "summarize",
+		Messages: []provider.ChatMessage{
+			{Role: "system", Content: "Summarize older conversation messages for future context. Preserve goals, decisions, tool results, and open tasks. Be concise."},
+			{Role: "user", Content: summarizeTranscript(msgs)},
+		},
+		Options:        provider.ModelOptions{NumPredict: outputReserve},
+		ExpectedOutput: outputReserve,
+		RequiredCaps:   provider.CapChat | provider.CapStream,
+	}
+	plan, err := s.route(ctx, rr)
+	if err != nil {
+		return "", err
+	}
+	wrapped, getFinal := provider.Collect(nil)
+	if err := plan.ExecuteChatStream(ctx, wrapped); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(getFinal().Content), nil
+}
+
+func summarizeTranscript(msgs []conversation.Message) string {
+	var b strings.Builder
+	for _, m := range msgs {
+		if m.Role != "" {
+			b.WriteString(m.Role)
+			b.WriteString(": ")
+		}
+		b.WriteString(m.Content)
+		if len(m.ToolCalls) > 0 {
+			b.WriteString(" tool_calls=")
+			b.Write(m.ToolCalls)
+		}
+		if m.ToolName != "" {
+			b.WriteString(" tool_name=")
+			b.WriteString(m.ToolName)
+		}
+		if m.ToolCallID != "" {
+			b.WriteString(" tool_call_id=")
+			b.WriteString(m.ToolCallID)
+		}
+		b.WriteByte('\n')
+	}
+	return strings.TrimSpace(b.String())
 }

--- a/agent/model_caller.go
+++ b/agent/model_caller.go
@@ -81,6 +81,21 @@ type routerSummarizer struct {
 	route func(ctx context.Context, rr provider.RoutingRequest) (planExecutor, error)
 }
 
+// DefaultSummaryOutputReserve bounds the rolling durable summary. It is the
+// summarizer's NumPredict AND the token headroom Golem reserves for the summary
+// when deciding how much raw history to keep — one constant, no drift.
+const DefaultSummaryOutputReserve = 512
+
+const summarySystemPrompt = `You maintain a single rolling summary of an ongoing coding session. Rewrite the summary so it stays concise and within budget, folding in the new messages.
+Do not invent facts.
+If uncertain, preserve the original wording briefly.
+Output ONLY these sections:
+Goals:
+Decisions:
+Files/commands/tools:
+Open tasks:
+Recent outcome:`
+
 // NewRouterSummarizer routes durable-history compression through the optional
 // "summarize" model role.
 func NewRouterSummarizer(r *provider.Router) conversation.Summarizer {
@@ -91,19 +106,18 @@ func NewRouterSummarizer(r *provider.Router) conversation.Summarizer {
 	}).Summarize
 }
 
-func (s *routerSummarizer) Summarize(ctx context.Context, msgs []conversation.Message) (string, error) {
+func (s *routerSummarizer) Summarize(ctx context.Context, prior string, msgs []conversation.Message) (string, error) {
 	if s.route == nil {
 		return "", fmt.Errorf("agent: summarize route is nil")
 	}
-	const outputReserve = 512
 	rr := provider.RoutingRequest{
 		UseCase: "summarize",
 		Messages: []provider.ChatMessage{
-			{Role: "system", Content: "Summarize older conversation messages for future context. Preserve goals, decisions, tool results, and open tasks. Be concise."},
-			{Role: "user", Content: summarizeTranscript(msgs)},
+			{Role: "system", Content: summarySystemPrompt},
+			{Role: "user", Content: summaryUserContent(prior, msgs)},
 		},
-		Options:        provider.ModelOptions{NumPredict: outputReserve},
-		ExpectedOutput: outputReserve,
+		Options:        provider.ModelOptions{NumPredict: DefaultSummaryOutputReserve},
+		ExpectedOutput: DefaultSummaryOutputReserve,
 		RequiredCaps:   provider.CapChat | provider.CapStream,
 	}
 	plan, err := s.route(ctx, rr)
@@ -115,6 +129,16 @@ func (s *routerSummarizer) Summarize(ctx context.Context, msgs []conversation.Me
 		return "", err
 	}
 	return strings.TrimSpace(getFinal().Content), nil
+}
+
+// summaryUserContent labels the prior summary and the new transcript so the
+// model rewrites one rolling blob rather than appending.
+func summaryUserContent(prior string, msgs []conversation.Message) string {
+	transcript := summarizeTranscript(msgs)
+	if strings.TrimSpace(prior) == "" {
+		return transcript
+	}
+	return "Current summary:\n" + prior + "\n\nNew messages:\n" + transcript
 }
 
 func summarizeTranscript(msgs []conversation.Message) string {

--- a/agent/model_caller.go
+++ b/agent/model_caller.go
@@ -78,6 +78,7 @@ func (m *routerModelCaller) Chat(ctx context.Context, req provider.ChatRequest,
 }
 
 type routerSummarizer struct {
+	chain []string
 	route func(ctx context.Context, rr provider.RoutingRequest) (planExecutor, error)
 }
 
@@ -98,8 +99,9 @@ Recent outcome:`
 
 // NewRouterSummarizer routes durable-history compression through the optional
 // "summarize" model role.
-func NewRouterSummarizer(r *provider.Router) conversation.Summarizer {
+func NewRouterSummarizer(r *provider.Router, chain []string) conversation.Summarizer {
 	return (&routerSummarizer{
+		chain: append([]string(nil), chain...),
 		route: func(ctx context.Context, rr provider.RoutingRequest) (planExecutor, error) {
 			return r.Route(ctx, rr)
 		},
@@ -119,6 +121,10 @@ func (s *routerSummarizer) Summarize(ctx context.Context, prior string, msgs []c
 		Options:        provider.ModelOptions{NumPredict: DefaultSummaryOutputReserve},
 		ExpectedOutput: DefaultSummaryOutputReserve,
 		RequiredCaps:   provider.CapChat | provider.CapStream,
+	}
+	if len(s.chain) > 0 {
+		rr.PreferredChain = append([]string(nil), s.chain...)
+		rr.StrictChain = true
 	}
 	plan, err := s.route(ctx, rr)
 	if err != nil {

--- a/agent/model_caller_test.go
+++ b/agent/model_caller_test.go
@@ -2,8 +2,10 @@ package agent
 
 import (
 	"context"
+	"strings"
 	"testing"
 
+	"github.com/kstruzzieri/go-llm/conversation"
 	"github.com/kstruzzieri/go-llm/provider"
 )
 
@@ -84,5 +86,32 @@ func TestRouterModelCallerUsesNumPredictAsExpectedOutput(t *testing.T) {
 	}
 	if gotReq.ExpectedOutput != 256 {
 		t.Fatalf("ExpectedOutput = %d, want 256", gotReq.ExpectedOutput)
+	}
+}
+
+func TestRouterSummarizerRoutesSummarizeUseCase(t *testing.T) {
+	var gotReq provider.RoutingRequest
+	s := &routerSummarizer{
+		route: func(_ context.Context, rr provider.RoutingRequest) (planExecutor, error) {
+			gotReq = rr
+			return fakePlan{}, nil
+		},
+	}
+
+	got, err := s.Summarize(context.Background(), []conversation.Message{{Role: "user", Content: "old turn"}})
+	if err != nil {
+		t.Fatalf("Summarize: %v", err)
+	}
+	if got != "Hello" {
+		t.Fatalf("summary = %q, want collected model output", got)
+	}
+	if gotReq.UseCase != "summarize" {
+		t.Fatalf("UseCase = %q, want summarize", gotReq.UseCase)
+	}
+	if gotReq.RequiredCaps != provider.CapChat|provider.CapStream {
+		t.Fatalf("RequiredCaps = %s, want chat|stream", gotReq.RequiredCaps)
+	}
+	if len(gotReq.Messages) != 2 || !strings.Contains(gotReq.Messages[1].Content, "user: old turn") {
+		t.Fatalf("Messages = %+v, want old messages in summarize prompt", gotReq.Messages)
 	}
 }

--- a/agent/model_caller_test.go
+++ b/agent/model_caller_test.go
@@ -98,7 +98,8 @@ func TestRouterSummarizerRoutesSummarizeUseCase(t *testing.T) {
 		},
 	}
 
-	got, err := s.Summarize(context.Background(), []conversation.Message{{Role: "user", Content: "old turn"}})
+	got, err := s.Summarize(context.Background(), "PRIOR-SUMMARY",
+		[]conversation.Message{{Role: "user", Content: "old turn"}})
 	if err != nil {
 		t.Fatalf("Summarize: %v", err)
 	}
@@ -111,7 +112,18 @@ func TestRouterSummarizerRoutesSummarizeUseCase(t *testing.T) {
 	if gotReq.RequiredCaps != provider.CapChat|provider.CapStream {
 		t.Fatalf("RequiredCaps = %s, want chat|stream", gotReq.RequiredCaps)
 	}
-	if len(gotReq.Messages) != 2 || !strings.Contains(gotReq.Messages[1].Content, "user: old turn") {
-		t.Fatalf("Messages = %+v, want old messages in summarize prompt", gotReq.Messages)
+	if gotReq.Options.NumPredict != DefaultSummaryOutputReserve {
+		t.Fatalf("NumPredict = %d, want %d", gotReq.Options.NumPredict, DefaultSummaryOutputReserve)
+	}
+	if len(gotReq.Messages) != 2 {
+		t.Fatalf("want system+user, got %d messages", len(gotReq.Messages))
+	}
+	if !strings.Contains(gotReq.Messages[0].Content, "Do not invent facts.") ||
+		!strings.Contains(gotReq.Messages[0].Content, "Open tasks:") {
+		t.Fatalf("system prompt missing constraints/sections: %q", gotReq.Messages[0].Content)
+	}
+	if !strings.Contains(gotReq.Messages[1].Content, "PRIOR-SUMMARY") ||
+		!strings.Contains(gotReq.Messages[1].Content, "user: old turn") {
+		t.Fatalf("user content missing prior/transcript: %q", gotReq.Messages[1].Content)
 	}
 }

--- a/agent/model_caller_test.go
+++ b/agent/model_caller_test.go
@@ -127,3 +127,25 @@ func TestRouterSummarizerRoutesSummarizeUseCase(t *testing.T) {
 		t.Fatalf("user content missing prior/transcript: %q", gotReq.Messages[1].Content)
 	}
 }
+
+func TestRouterSummarizerUsesStrictPreferredChain(t *testing.T) {
+	var gotReq provider.RoutingRequest
+	s := &routerSummarizer{
+		chain: []string{"ollama/light", "hosted/big"},
+		route: func(_ context.Context, rr provider.RoutingRequest) (planExecutor, error) {
+			gotReq = rr
+			return fakePlan{}, nil
+		},
+	}
+
+	if _, err := s.Summarize(context.Background(), "",
+		[]conversation.Message{{Role: "user", Content: "old turn"}}); err != nil {
+		t.Fatalf("Summarize: %v", err)
+	}
+	if !gotReq.StrictChain {
+		t.Fatal("StrictChain = false, want true")
+	}
+	if len(gotReq.PreferredChain) != 2 || gotReq.PreferredChain[0] != "ollama/light" || gotReq.PreferredChain[1] != "hosted/big" {
+		t.Fatalf("PreferredChain = %v, want summarize chain", gotReq.PreferredChain)
+	}
+}

--- a/agent/orchestrator.go
+++ b/agent/orchestrator.go
@@ -29,7 +29,7 @@ func initState(req Request) State {
 		ChatMessage: provider.ChatMessage{Role: "user", Content: req.Goal},
 		Segment:     Pinned,
 	})
-	return State{System: req.System, Messages: msgs}
+	return State{System: req.System, DurableSummary: req.HistorySummary, Messages: msgs}
 }
 
 func buildChatRequest(st State, specs []provider.Tool, outputReserve int) provider.ChatRequest {

--- a/agent/types.go
+++ b/agent/types.go
@@ -63,13 +63,14 @@ type Budget struct {
 
 // Request is the unit of work handed to Run.
 type Request struct {
-	Goal     string
-	System   string
-	History  []provider.ChatMessage // prior non-system turns; runtime marks every entry Elastic
-	Tools    []Tool
-	MaxSteps int // 0 => defaultMaxSteps
-	Budget   Budget
-	Approver Approver // nil => fail-safe (auto Read, deny Write/Exec)
+	Goal           string
+	System         string
+	HistorySummary string
+	History        []provider.ChatMessage // prior non-system turns; runtime marks every entry Elastic
+	Tools          []Tool
+	MaxSteps       int // 0 => defaultMaxSteps
+	Budget         Budget
+	Approver       Approver // nil => fail-safe (auto Read, deny Write/Exec)
 }
 
 // Segment tags a message as always-present (Pinned) or compactable (Elastic).
@@ -89,8 +90,9 @@ type Message struct {
 
 // State is the canonical transcript the Orchestrator owns.
 type State struct {
-	System   string
-	Messages []Message
+	System         string
+	DurableSummary string
+	Messages       []Message
 }
 
 // RetrievalAttribution credits the sources a retrieval-style tool returned.

--- a/cmd/golem/compress.go
+++ b/cmd/golem/compress.go
@@ -47,8 +47,15 @@ func (sess *replSession) maybeCompress(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if len(out.Messages) == len(conv.Messages) {
-		return nil // nothing was evicted (floor covered everything)
+	if len(out.Messages) == len(conv.Messages) && sameDurableSummary(out.DurableSummary, conv.DurableSummary) {
+		return nil // nothing changed (floor covered everything)
 	}
 	return sess.session.applyCompacted(ctx, out)
+}
+
+func sameDurableSummary(a, b *conversation.DurableSummary) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.Content == b.Content && a.MessageCount == b.MessageCount
 }

--- a/cmd/golem/compress.go
+++ b/cmd/golem/compress.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+
+	"github.com/kstruzzieri/go-llm/agent"
+	"github.com/kstruzzieri/go-llm/conversation"
+)
+
+// compressPolicy decides when to compress a session's history into its durable
+// summary. It lives on replSession (which owns runtime wiring); session stays
+// persistence-only.
+type compressPolicy struct {
+	summarize          conversation.Summarizer
+	estimate           conversation.TokenEstimator
+	maxHistoryTokens   int // fire when model-visible history (summary prompt + raw) exceeds this
+	minRecentExchanges int
+	enabled            bool
+}
+
+// maybeCompress runs the post-turn compression policy. Best-effort: on a
+// summarizer/model error the session is left unchanged and the error is returned
+// for the REPL to surface — a turn is never lost to a failed summary.
+func (sess *replSession) maybeCompress(ctx context.Context) error {
+	p := sess.compress
+	if !p.enabled || sess.session == nil || p.summarize == nil {
+		return nil
+	}
+	conv := sess.session.currentConversation()
+
+	// Trigger accounting lives here because Golem (not conversation/) knows the
+	// exact summary prompt agent will inject next turn.
+	summaryPrompt := agent.DurableSummaryPrompt(sess.session.historySummary())
+	historyCost := p.estimate(summaryPrompt) +
+		conversation.EstimateMessagesTokens(conv.Messages, p.estimate)
+	if historyCost <= p.maxHistoryTokens {
+		return nil // model-visible history still fits; no model call
+	}
+
+	// Reserve headroom for the regenerated summary (bounded by NumPredict) when
+	// bounding the retained raw history.
+	maxRawTokens := p.maxHistoryTokens - agent.DefaultSummaryOutputReserve
+	if maxRawTokens < 0 {
+		maxRawTokens = 0
+	}
+	out, err := conversation.CompressMessages(ctx, conv, maxRawTokens, p.minRecentExchanges, p.estimate, p.summarize)
+	if err != nil {
+		return err
+	}
+	if len(out.Messages) == len(conv.Messages) {
+		return nil // nothing was evicted (floor covered everything)
+	}
+	return sess.session.applyCompacted(ctx, out)
+}

--- a/cmd/golem/compress_test.go
+++ b/cmd/golem/compress_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/conversation"
+)
+
+// fillSession appends n user/assistant exchanges of the given content.
+func fillSession(t *testing.T, s *session, n int, body string) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		if err := s.record(context.Background(), body, body); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func newCompressRepl(s *session, sum conversation.Summarizer, maxHistory int, enabled bool) *replSession {
+	return &replSession{
+		session: s,
+		compress: compressPolicy{
+			summarize:          sum,
+			estimate:           conversation.CharRatioEstimator(4.0),
+			maxHistoryTokens:   maxHistory,
+			minRecentExchanges: 1,
+			enabled:            enabled,
+		},
+	}
+}
+
+func TestMaybeCompress_FiresOverThreshold(t *testing.T) {
+	ctx := context.Background()
+	s, _ := openTempSession(t, "workspace:fire")
+	fillSession(t, s, 8, "this is a reasonably long line of conversation text")
+
+	var called bool
+	sum := func(_ context.Context, prior string, msgs []conversation.Message) (string, error) {
+		called = true
+		return "ROLLED-UP", nil
+	}
+	sess := newCompressRepl(s, sum, 20, true) // tiny budget => must fire
+
+	if err := sess.maybeCompress(ctx); err != nil {
+		t.Fatalf("maybeCompress: %v", err)
+	}
+	if !called {
+		t.Fatal("summarizer was not called")
+	}
+	if s.historySummary() != "ROLLED-UP" {
+		t.Fatalf("summary not applied: %q", s.historySummary())
+	}
+	if len(s.msgs) >= 16 {
+		t.Fatalf("history not reduced: %d msgs", len(s.msgs))
+	}
+}
+
+func TestMaybeCompress_NoOpUnderThreshold(t *testing.T) {
+	ctx := context.Background()
+	s, _ := openTempSession(t, "workspace:under")
+	fillSession(t, s, 2, "short")
+
+	called := false
+	sum := func(context.Context, string, []conversation.Message) (string, error) {
+		called = true
+		return "X", nil
+	}
+	sess := newCompressRepl(s, sum, 100000, true) // huge budget => never fire
+
+	if err := sess.maybeCompress(ctx); err != nil {
+		t.Fatalf("maybeCompress: %v", err)
+	}
+	if called {
+		t.Fatal("summarizer called under threshold")
+	}
+}
+
+func TestMaybeCompress_DisabledIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	s, _ := openTempSession(t, "workspace:off")
+	fillSession(t, s, 8, "this is a reasonably long line of conversation text")
+
+	called := false
+	sum := func(context.Context, string, []conversation.Message) (string, error) {
+		called = true
+		return "X", nil
+	}
+	sess := newCompressRepl(s, sum, 20, false) // disabled
+
+	if err := sess.maybeCompress(ctx); err != nil {
+		t.Fatalf("maybeCompress: %v", err)
+	}
+	if called {
+		t.Fatal("summarizer called while disabled")
+	}
+}
+
+func TestMaybeCompress_SummarizerErrorLeavesSessionIntact(t *testing.T) {
+	ctx := context.Background()
+	s, _ := openTempSession(t, "workspace:err")
+	fillSession(t, s, 8, "this is a reasonably long line of conversation text")
+	before := len(s.msgs)
+
+	sum := func(context.Context, string, []conversation.Message) (string, error) {
+		return "", errors.New("model down")
+	}
+	sess := newCompressRepl(s, sum, 20, true)
+
+	err := sess.maybeCompress(ctx)
+	if err == nil || !strings.Contains(err.Error(), "model down") {
+		t.Fatalf("want surfaced summarizer error, got %v", err)
+	}
+	if len(s.msgs) != before || s.summary != nil {
+		t.Fatalf("session mutated on failure: msgs=%d summary=%v", len(s.msgs), s.summary)
+	}
+}

--- a/cmd/golem/compress_test.go
+++ b/cmd/golem/compress_test.go
@@ -78,6 +78,50 @@ func TestMaybeCompress_NoOpUnderThreshold(t *testing.T) {
 	}
 }
 
+func TestMaybeCompress_AppliesRewrittenSummaryWhenRawHistoryUnchanged(t *testing.T) {
+	ctx := context.Background()
+	s, _ := openTempSession(t, "workspace:summary-only")
+	if err := s.record(ctx, "short", "turn"); err != nil {
+		t.Fatal(err)
+	}
+	oversized := strings.Repeat("oversized summary ", 300)
+	s.summary = &conversation.DurableSummary{Content: oversized, MessageCount: 12}
+	beforeMessages := len(s.msgs)
+
+	called := false
+	sum := func(_ context.Context, prior string, msgs []conversation.Message) (string, error) {
+		called = true
+		if prior != oversized {
+			t.Fatalf("prior = %q, want oversized summary", prior)
+		}
+		if len(msgs) != 0 {
+			t.Fatalf("msgs len = %d, want no raw-message eviction", len(msgs))
+		}
+		return "SMALL", nil
+	}
+	sess := newCompressRepl(s, sum, 600, true) // summary pushes over threshold; raw still fits
+
+	if err := sess.maybeCompress(ctx); err != nil {
+		t.Fatalf("maybeCompress: %v", err)
+	}
+	if !called {
+		t.Fatal("summarizer was not called")
+	}
+	if s.historySummary() != "SMALL" {
+		t.Fatalf("summary not applied: %q", s.historySummary())
+	}
+	if len(s.msgs) != beforeMessages {
+		t.Fatalf("messages changed: got %d, want %d", len(s.msgs), beforeMessages)
+	}
+	loaded, err := s.store.Load(ctx, s.id)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.DurableSummary == nil || loaded.DurableSummary.Content != "SMALL" || loaded.DurableSummary.MessageCount != 12 {
+		t.Fatalf("persisted summary = %+v, want rewritten content with same count", loaded.DurableSummary)
+	}
+}
+
 func TestMaybeCompress_DisabledIsNoOp(t *testing.T) {
 	ctx := context.Background()
 	s, _ := openTempSession(t, "workspace:off")

--- a/cmd/golem/compress_test.go
+++ b/cmd/golem/compress_test.go
@@ -117,3 +117,27 @@ func TestMaybeCompress_SummarizerErrorLeavesSessionIntact(t *testing.T) {
 		t.Fatalf("session mutated on failure: msgs=%d summary=%v", len(s.msgs), s.summary)
 	}
 }
+
+func TestRunOnce_TriggersCompressionAfterRecord(t *testing.T) {
+	ctx := context.Background()
+	s, _ := openTempSession(t, "workspace:runonce")
+	fillSession(t, s, 8, "this is a reasonably long line of conversation text")
+
+	called := false
+	sum := func(context.Context, string, []conversation.Message) (string, error) {
+		called = true
+		return "ROLLED", nil
+	}
+	sess := newCompressRepl(s, sum, 20, true)
+
+	// recordResult-equivalent then the post-record compression hook.
+	if err := s.record(ctx, "newq", "newa"); err != nil {
+		t.Fatal(err)
+	}
+	if err := sess.maybeCompress(ctx); err != nil {
+		t.Fatalf("maybeCompress: %v", err)
+	}
+	if !called || s.historySummary() != "ROLLED" {
+		t.Fatalf("post-record compression did not run: called=%v summary=%q", called, s.historySummary())
+	}
+}

--- a/cmd/golem/config.go
+++ b/cmd/golem/config.go
@@ -52,3 +52,21 @@ func resolveAgentChain(cfg *config.Config) (chainPlan, error) {
 	}
 	return chainPlan{chain: chain}, nil
 }
+
+func resolveSummarizeChain(cfg *config.Config) ([]string, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+	if _, ok := cfg.Defaults["summarize"]; !ok {
+		if _, ok := cfg.Defaults["analysis"]; !ok {
+			if _, ok := cfg.Defaults["chat"]; !ok {
+				return nil, nil
+			}
+		}
+	}
+	chain, err := cfg.RoleFallbackChain("summarize")
+	if err != nil {
+		return nil, fmt.Errorf("golem: resolve summarize chain: %w", err)
+	}
+	return chain, nil
+}

--- a/cmd/golem/config_test.go
+++ b/cmd/golem/config_test.go
@@ -71,6 +71,24 @@ func TestResolveAgentChain_EmptyAgentKeyFatal(t *testing.T) {
 	}
 }
 
+func TestResolveSummarizeChain_UsesConfiguredFallbackChain(t *testing.T) {
+	cfg := &config.Config{
+		Models: map[string]config.ModelConfig{
+			"light":  {Name: "small", Provider: "ollama", Fallbacks: []string{"hosted"}},
+			"hosted": {Name: "large", Provider: "openai"},
+		},
+		Defaults: map[string]string{"summarize": "light"},
+	}
+	chain, err := resolveSummarizeChain(cfg)
+	if err != nil {
+		t.Fatalf("resolveSummarizeChain: %v", err)
+	}
+	want := []string{"ollama/small", "openai/large"}
+	if len(chain) != len(want) || chain[0] != want[0] || chain[1] != want[1] {
+		t.Fatalf("chain = %v, want %v", chain, want)
+	}
+}
+
 func TestLoadConfig_ExplicitBadPathFatal(t *testing.T) {
 	if _, err := loadConfig("/nonexistent/path/models.json"); err == nil {
 		t.Fatal("err = nil for nonexistent explicit config path, want fatal")

--- a/cmd/golem/main.go
+++ b/cmd/golem/main.go
@@ -268,7 +268,7 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 
 	maxHistoryTokens := f.inputCeiling
 	if maxHistoryTokens <= 0 {
-		maxHistoryTokens = 8192 // mirror agent defaultInputCeiling
+		maxHistoryTokens = agent.DefaultInputCeiling
 	}
 	maxHistoryTokens /= 2
 

--- a/cmd/golem/main.go
+++ b/cmd/golem/main.go
@@ -271,6 +271,10 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 		maxHistoryTokens = agent.DefaultInputCeiling
 	}
 	maxHistoryTokens /= 2
+	summarizeChain, err := resolveSummarizeChain(bundle.Config)
+	if err != nil {
+		return err
+	}
 
 	caller := newRouterChainCaller(bundle.Router, plan.chain)
 	sess := &replSession{
@@ -283,7 +287,7 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 		retrieveOmitted: retrieveOmitted,
 		session:         sessn,
 		compress: compressPolicy{
-			summarize:          agent.NewRouterSummarizer(bundle.Router),
+			summarize:          agent.NewRouterSummarizer(bundle.Router, summarizeChain),
 			estimate:           conversation.CharRatioEstimator(4.0),
 			maxHistoryTokens:   maxHistoryTokens,
 			minRecentExchanges: 4,

--- a/cmd/golem/main.go
+++ b/cmd/golem/main.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/kstruzzieri/go-llm/agent"
+	"github.com/kstruzzieri/go-llm/conversation"
 	"github.com/kstruzzieri/go-llm/internal/providerbootstrap"
 )
 
@@ -30,6 +31,7 @@ type flags struct {
 	allowExec        bool
 	noRag            bool
 	noProjectContext bool
+	noCompress       bool
 }
 
 func parseFlags(args []string) (flags, error) {
@@ -49,6 +51,7 @@ func parseFlags(args []string) (flags, error) {
 	fs.BoolVar(&f.allowExec, "allow-exec", false, "enable the approval-gated run_command exec tool")
 	fs.BoolVar(&f.noRag, "no-rag", false, "disable the retrieve tool entirely (ignore any auto index)")
 	fs.BoolVar(&f.noProjectContext, "no-project-context", false, "do not load AGENTS.md project-context files into the system prompt")
+	fs.BoolVar(&f.noCompress, "no-compress", false, "disable post-turn conversation compression into a durable summary")
 	fs.StringVar(&f.sessionID, "session", "", "explicit session id to resume or create (default: per-workspace)")
 	if err := fs.Parse(args); err != nil {
 		return flags{}, err
@@ -263,6 +266,12 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 		_, _ = fmt.Fprintln(stderr, line)
 	}
 
+	maxHistoryTokens := f.inputCeiling
+	if maxHistoryTokens <= 0 {
+		maxHistoryTokens = 8192 // mirror agent defaultInputCeiling
+	}
+	maxHistoryTokens /= 2
+
 	caller := newRouterChainCaller(bundle.Router, plan.chain)
 	sess := &replSession{
 		orch:            agent.New(caller, agent.ContextManager{}),
@@ -273,9 +282,16 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 		color:           !f.noColor,
 		retrieveOmitted: retrieveOmitted,
 		session:         sessn,
-		journal:         journal,
-		allowWrite:      f.allowWrite,
-		allowExec:       f.allowExec,
+		compress: compressPolicy{
+			summarize:          agent.NewRouterSummarizer(bundle.Router),
+			estimate:           conversation.CharRatioEstimator(4.0),
+			maxHistoryTokens:   maxHistoryTokens,
+			minRecentExchanges: 4,
+			enabled:            !f.noCompress,
+		},
+		journal:    journal,
+		allowWrite: f.allowWrite,
+		allowExec:  f.allowExec,
 	}
 	if sess.maxSteps == 0 {
 		sess.maxSteps = 16 // mirror agent defaultMaxSteps so the footer's k/max is accurate

--- a/cmd/golem/repl.go
+++ b/cmd/golem/repl.go
@@ -124,6 +124,9 @@ func runOnce(ctx context.Context, out io.Writer, interrupts <-chan struct{}, ses
 		if serr := sess.session.recordResult(ctx, line, res); serr != nil {
 			_, _ = fmt.Fprintf(out, "warning: session not saved: %v\n", serr)
 		}
+		if cerr := sess.maybeCompress(ctx); cerr != nil {
+			_, _ = fmt.Fprintf(out, "warning: compression skipped: %v\n", cerr)
+		}
 	}
 	rend.finalFooter(res)
 }

--- a/cmd/golem/repl.go
+++ b/cmd/golem/repl.go
@@ -24,6 +24,8 @@ type replSession struct {
 
 	session *session // nil => --no-session (no history, no persistence)
 
+	compress compressPolicy // post-turn history compression policy
+
 	lastModel  string           // last routed ActualModel for /model
 	journal    *mutationJournal // nil unless -allow-write enabled writes
 	allowWrite bool

--- a/cmd/golem/repl.go
+++ b/cmd/golem/repl.go
@@ -118,13 +118,17 @@ func runOnce(ctx context.Context, out io.Writer, interrupts <-chan struct{}, ses
 	if m := lastRoutedModel(res); m != "" {
 		sess.lastModel = m
 	}
-	// Persist only a successful, answered run (amendment 6). Use the parent ctx,
-	// not runCtx, so the save is not tied to this turn's cancellation scope.
+	// Persist only a successful, answered run (amendment 6). recordResult uses the
+	// parent ctx so saving the computed answer is not tied to this turn's
+	// cancellation scope. maybeCompress, by contrast, makes a new summarizer model
+	// call — it uses runCtx so a Ctrl-C during post-turn compression interrupts it
+	// (CompressMessages then returns a cancellation error and the session is left
+	// untouched, which the warning below surfaces).
 	if sess.session != nil && res.Answer != "" {
 		if serr := sess.session.recordResult(ctx, line, res); serr != nil {
 			_, _ = fmt.Fprintf(out, "warning: session not saved: %v\n", serr)
 		}
-		if cerr := sess.maybeCompress(ctx); cerr != nil {
+		if cerr := sess.maybeCompress(runCtx); cerr != nil {
 			_, _ = fmt.Fprintf(out, "warning: compression skipped: %v\n", cerr)
 		}
 	}

--- a/cmd/golem/repl.go
+++ b/cmd/golem/repl.go
@@ -95,13 +95,14 @@ func runOnce(ctx context.Context, out io.Writer, interrupts <-chan struct{}, ses
 
 	rend := newRenderer(out, sess.color, sess.maxSteps, sess.clock)
 	req := agent.Request{
-		Goal:     line,
-		System:   sess.baseSystem,
-		History:  sess.session.history(), // nil-safe: nil session => nil
-		Tools:    sess.tools,
-		MaxSteps: sess.maxSteps,
-		Budget:   sess.budget,
-		Approver: approver, // nil when read-only => runtime fail-safe denies Write/Exec
+		Goal:           line,
+		System:         sess.baseSystem,
+		HistorySummary: sess.session.historySummary(), // nil-safe: nil session => empty
+		History:        sess.session.history(),        // nil-safe: nil session => nil
+		Tools:          sess.tools,
+		MaxSteps:       sess.maxSteps,
+		Budget:         sess.budget,
+		Approver:       approver, // nil when read-only => runtime fail-safe denies Write/Exec
 	}
 	res, err := sess.orch.Run(runCtx, req, rend)
 	if err != nil {

--- a/cmd/golem/session.go
+++ b/cmd/golem/session.go
@@ -256,6 +256,35 @@ func (s *session) recordMessages(ctx context.Context, msgs []conversation.Messag
 	return nil
 }
 
+// currentConversation snapshots the session's in-memory state for compression.
+// Messages are copied so the caller cannot mutate the session buffer.
+func (s *session) currentConversation() conversation.Conversation {
+	return conversation.Conversation{
+		ID:             s.id,
+		Messages:       append([]conversation.Message(nil), s.msgs...),
+		DurableSummary: cloneDurableSummary(s.summary),
+	}
+}
+
+// applyCompacted replaces history with a compressed conversation (recent raw
+// messages + durable summary) and persists it. Persistence only — it does not
+// construct the router or summarizer. Mirrors recordMessages' save-then-mutate
+// ordering so a failed save cannot leak partial state.
+func (s *session) applyCompacted(ctx context.Context, conv conversation.Conversation) error {
+	if err := s.store.Save(ctx, conversation.Conversation{
+		ID:             s.id,
+		Title:          sessionTitle(conv.Messages),
+		Messages:       conv.Messages,
+		DurableSummary: cloneDurableSummary(conv.DurableSummary),
+	}); err != nil {
+		return err
+	}
+	s.msgs = conv.Messages
+	s.summary = cloneDurableSummary(conv.DurableSummary)
+	_ = chmodSessionDBFiles(s.dbPath)
+	return nil
+}
+
 func resultConversationMessages(userLine string, res agent.Result) ([]conversation.Message, error) {
 	if len(res.Messages) == 0 {
 		return []conversation.Message{

--- a/cmd/golem/session.go
+++ b/cmd/golem/session.go
@@ -147,11 +147,12 @@ const (
 // re-saved after each successful turn. Single-writer: B3 does not merge
 // concurrent writers — two golem processes on the same id are last-save-wins.
 type session struct {
-	db     *sql.DB
-	dbPath string // retained so record/clear can re-secure sidecars after each write
-	store  conversation.Store
-	id     string
-	msgs   []conversation.Message
+	db      *sql.DB
+	dbPath  string // retained so record/clear can re-secure sidecars after each write
+	store   conversation.Store
+	id      string
+	msgs    []conversation.Message
+	summary *conversation.DurableSummary
 }
 
 // sessionInfo is the startup disclosure for one resolved session.
@@ -207,6 +208,7 @@ func openSession(ctx context.Context, dbPath, id string) (*session, sessionInfo,
 	switch {
 	case lerr == nil:
 		s.msgs = conv.Messages
+		s.summary = cloneDurableSummary(conv.DurableSummary)
 		info.resumed = len(conv.Messages) > 0
 		info.msgCount = len(conv.Messages)
 		info.updatedAt = conv.UpdatedAt
@@ -240,9 +242,10 @@ func (s *session) recordResult(ctx context.Context, userLine string, res agent.R
 func (s *session) recordMessages(ctx context.Context, msgs []conversation.Message) error {
 	next := append(append([]conversation.Message{}, s.msgs...), msgs...)
 	if err := s.store.Save(ctx, conversation.Conversation{
-		ID:       s.id,
-		Title:    sessionTitle(next),
-		Messages: next,
+		ID:             s.id,
+		Title:          sessionTitle(next),
+		Messages:       next,
+		DurableSummary: cloneDurableSummary(s.summary),
 	}); err != nil {
 		return err
 	}
@@ -307,6 +310,13 @@ func (s *session) history() []provider.ChatMessage {
 	return out
 }
 
+func (s *session) historySummary() string {
+	if s == nil || s.summary == nil {
+		return ""
+	}
+	return s.summary.Content
+}
+
 // sessionTitle is the first user line, truncated, for nicer future listings.
 func sessionTitle(msgs []conversation.Message) string {
 	for _, m := range msgs {
@@ -331,6 +341,7 @@ func (s *session) clear(ctx context.Context) error {
 		return err
 	}
 	s.msgs = nil
+	s.summary = nil
 	_ = chmodSessionDBFiles(s.dbPath)
 	return nil
 }
@@ -339,6 +350,7 @@ func (s *session) clear(ctx context.Context) error {
 func (s *session) renew() {
 	s.id = "golem:" + conversation.NewID()
 	s.msgs = nil
+	s.summary = nil
 }
 
 func (s *session) switchTo(ctx context.Context, id string) (sessionInfo, error) {
@@ -348,12 +360,21 @@ func (s *session) switchTo(ctx context.Context, id string) (sessionInfo, error) 
 	}
 	s.id = id
 	s.msgs = conv.Messages
+	s.summary = cloneDurableSummary(conv.DurableSummary)
 	return sessionInfo{
 		id:        id,
 		resumed:   len(conv.Messages) > 0,
 		msgCount:  len(conv.Messages),
 		updatedAt: conv.UpdatedAt,
 	}, nil
+}
+
+func cloneDurableSummary(in *conversation.DurableSummary) *conversation.DurableSummary {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
 }
 
 // Close releases the DB. Nil-safe and idempotent enough for defer.

--- a/cmd/golem/session_test.go
+++ b/cmd/golem/session_test.go
@@ -327,6 +327,39 @@ func TestSession_History(t *testing.T) {
 	}
 }
 
+func TestSession_HistorySummaryLoadedAndPreserved(t *testing.T) {
+	ctx := context.Background()
+	s, _ := openTempSession(t, "workspace:summary")
+	if err := s.store.Save(ctx, conversation.Conversation{
+		ID:       s.id,
+		Title:    "summary",
+		Messages: []conversation.Message{{Role: "user", Content: "recent"}},
+		DurableSummary: &conversation.DurableSummary{
+			Content:      "old compressed turns",
+			MessageCount: 4,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := s.switchTo(ctx, s.id); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.historySummary(); got != "old compressed turns" {
+		t.Fatalf("historySummary() = %q, want durable summary", got)
+	}
+	if err := s.record(ctx, "q", "a"); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := s.store.Load(ctx, s.id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.DurableSummary == nil || loaded.DurableSummary.Content != "old compressed turns" {
+		t.Fatalf("DurableSummary after record = %+v, want preserved", loaded.DurableSummary)
+	}
+}
+
 // Stored content that used to threaten the v1 fence is now inert: history()
 // passes it through verbatim as a real message's Content, with no escaping.
 func TestSession_HistoryInertClosingTag(t *testing.T) {

--- a/cmd/golem/session_test.go
+++ b/cmd/golem/session_test.go
@@ -432,6 +432,25 @@ func TestSession_CurrentConversationSnapshotsState(t *testing.T) {
 	}
 }
 
+func TestSession_ClearAndRenewZeroDurableSummary(t *testing.T) {
+	ctx := context.Background()
+	s, _ := openTempSession(t, "workspace:clearsummary")
+
+	s.summary = &conversation.DurableSummary{Content: "X", MessageCount: 1}
+	if err := s.clear(ctx); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if s.summary != nil || s.historySummary() != "" {
+		t.Fatalf("clear did not zero the durable summary: %+v", s.summary)
+	}
+
+	s.summary = &conversation.DurableSummary{Content: "Y", MessageCount: 1}
+	s.renew()
+	if s.summary != nil {
+		t.Fatalf("renew did not zero the durable summary: %+v", s.summary)
+	}
+}
+
 // TestSession_HistorySkipsRowsTheRuntimeWouldReject proves history() defensively
 // drops any persisted row outside the runtime's user/assistant + non-empty
 // allowlist, so a single foreign/corrupt stored turn cannot brick the session by

--- a/cmd/golem/session_test.go
+++ b/cmd/golem/session_test.go
@@ -382,6 +382,56 @@ func TestSession_HistoryNilSafe(t *testing.T) {
 	}
 }
 
+func TestSession_ApplyCompactedPersistsAndUpdatesState(t *testing.T) {
+	ctx := context.Background()
+	s, _ := openTempSession(t, "workspace:compact")
+	if err := s.record(ctx, "q1", "a1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.record(ctx, "q2", "a2"); err != nil {
+		t.Fatal(err)
+	}
+
+	compacted := conversation.Conversation{
+		ID:             s.id,
+		Messages:       []conversation.Message{{Role: "user", Content: "q2"}, {Role: "assistant", Content: "a2"}},
+		DurableSummary: &conversation.DurableSummary{Content: "summary of q1/a1", MessageCount: 2},
+	}
+	if err := s.applyCompacted(ctx, compacted); err != nil {
+		t.Fatalf("applyCompacted: %v", err)
+	}
+
+	// In-memory state replaced.
+	if len(s.msgs) != 2 || s.historySummary() != "summary of q1/a1" {
+		t.Fatalf("in-memory state not updated: msgs=%d summary=%q", len(s.msgs), s.historySummary())
+	}
+	// Persisted.
+	loaded, err := s.store.Load(ctx, s.id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.DurableSummary == nil || loaded.DurableSummary.Content != "summary of q1/a1" || len(loaded.Messages) != 2 {
+		t.Fatalf("not persisted: %+v", loaded)
+	}
+}
+
+func TestSession_CurrentConversationSnapshotsState(t *testing.T) {
+	ctx := context.Background()
+	s, _ := openTempSession(t, "workspace:snap")
+	if err := s.record(ctx, "q", "a"); err != nil {
+		t.Fatal(err)
+	}
+	conv := s.currentConversation()
+	if conv.ID != s.id || len(conv.Messages) != 2 {
+		t.Fatalf("snapshot mismatch: id=%q msgs=%d", conv.ID, len(conv.Messages))
+	}
+	// Mutating the snapshot must not affect the session buffer.
+	conv.Messages[0].Content = "MUTATED"
+	if s.msgs[0].Content == "MUTATED" {
+		t.Fatal("currentConversation must return a copy of Messages")
+	}
+}
+
 // TestSession_HistorySkipsRowsTheRuntimeWouldReject proves history() defensively
 // drops any persisted row outside the runtime's user/assistant + non-empty
 // allowlist, so a single foreign/corrupt stored turn cannot brick the session by

--- a/conversation/compress.go
+++ b/conversation/compress.go
@@ -67,8 +67,9 @@ func EstimateMessagesTokens(msgs []Message, estimator TokenEstimator) int {
 // estimated cost of non-system raw messages exceeds maxTokens. It retains the
 // most recent exchanges that fit maxTokens, never fewer than minRecentExchanges,
 // and never splits a tool-call/result chain (it reuses trimByExchangesKeep).
-// Returns conv unchanged (no model call) when raw history already fits or there
-// is nothing older than the floor to evict.
+// Returns conv unchanged (no model call) when raw history already fits and
+// there is no durable summary to rewrite, or when the floor keeps all messages
+// and there is no durable summary to rewrite.
 //
 // Safety invariant: raw messages are evicted ONLY after the summary that absorbs
 // them is produced successfully. Any summarizer error (including blank output)
@@ -86,7 +87,13 @@ func CompressMessages(
 	if summarize == nil {
 		return Conversation{}, errNilSummarizer
 	}
-	if EstimateMessagesTokens(conv.Messages, estimator) <= maxTokens {
+	prior, priorCount := "", 0
+	if conv.DurableSummary != nil {
+		prior = conv.DurableSummary.Content
+		priorCount = conv.DurableSummary.MessageCount
+	}
+	hasPrior := strings.TrimSpace(prior) != ""
+	if EstimateMessagesTokens(conv.Messages, estimator) <= maxTokens && !hasPrior {
 		return conv, nil
 	}
 	if minRecentExchanges < 0 {
@@ -118,13 +125,9 @@ func CompressMessages(
 		}
 	}
 	if len(old) == 0 {
-		return conv, nil
-	}
-
-	prior, priorCount := "", 0
-	if conv.DurableSummary != nil {
-		prior = conv.DurableSummary.Content
-		priorCount = conv.DurableSummary.MessageCount
+		if !hasPrior {
+			return conv, nil
+		}
 	}
 	newSummary, err := summarize(ctx, prior, old)
 	if err != nil {

--- a/conversation/compress.go
+++ b/conversation/compress.go
@@ -62,3 +62,105 @@ func EstimateMessagesTokens(msgs []Message, estimator TokenEstimator) int {
 	}
 	return n
 }
+
+// CompressMessages folds the oldest history into the durable summary when the
+// estimated cost of non-system raw messages exceeds maxTokens. It retains the
+// most recent exchanges that fit maxTokens, never fewer than minRecentExchanges,
+// and never splits a tool-call/result chain (it reuses trimByExchangesKeep).
+// Returns conv unchanged (no model call) when raw history already fits or there
+// is nothing older than the floor to evict.
+//
+// Safety invariant: raw messages are evicted ONLY after the summary that absorbs
+// them is produced successfully. Any summarizer error (including blank output)
+// aborts the whole operation and the caller keeps its prior state.
+func CompressMessages(
+	ctx context.Context,
+	conv Conversation,
+	maxTokens, minRecentExchanges int,
+	estimator TokenEstimator,
+	summarize Summarizer,
+) (Conversation, error) {
+	if estimator == nil {
+		panic("conversation: CompressMessages requires non-nil TokenEstimator")
+	}
+	if summarize == nil {
+		return Conversation{}, errNilSummarizer
+	}
+	if EstimateMessagesTokens(conv.Messages, estimator) <= maxTokens {
+		return conv, nil
+	}
+	if minRecentExchanges < 0 {
+		minRecentExchanges = 0
+	}
+
+	// Grow the retained window up from the hard floor while it still fits the
+	// budget and there are older exchanges left to add.
+	// ponytail: O(n^2) over exchanges; fine for chat-history sizes.
+	keep := trimByExchangesKeep(conv.Messages, minRecentExchanges)
+	for next := minRecentExchanges + 1; ; next++ {
+		grown := trimByExchangesKeep(conv.Messages, next)
+		if sameKeepMask(grown, keep) {
+			break // nothing older left to add: floor already keeps everything
+		}
+		if keptRawCost(conv.Messages, grown, estimator) > maxTokens {
+			break // adding the next-oldest exchange overflows the budget
+		}
+		keep = grown
+	}
+
+	recent := make([]Message, 0, len(conv.Messages))
+	old := make([]Message, 0, len(conv.Messages))
+	for i, m := range conv.Messages {
+		if !keep[i] && m.Role != "system" {
+			old = append(old, m)
+		} else {
+			recent = append(recent, m)
+		}
+	}
+	if len(old) == 0 {
+		return conv, nil
+	}
+
+	prior, priorCount := "", 0
+	if conv.DurableSummary != nil {
+		prior = conv.DurableSummary.Content
+		priorCount = conv.DurableSummary.MessageCount
+	}
+	newSummary, err := summarize(ctx, prior, old)
+	if err != nil {
+		return Conversation{}, err
+	}
+	if strings.TrimSpace(newSummary) == "" {
+		return Conversation{}, ErrEmptySummary
+	}
+
+	out := conv
+	out.Messages = recent
+	out.DurableSummary = &DurableSummary{
+		Content:      strings.TrimSpace(newSummary),
+		MessageCount: priorCount + len(old),
+	}
+	return out, nil
+}
+
+func sameKeepMask(a, b []bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func keptRawCost(msgs []Message, keep []bool, estimator TokenEstimator) int {
+	n := 0
+	for i, m := range msgs {
+		if keep[i] && m.Role != "system" {
+			n += messageCost(m, estimator)
+		}
+	}
+	return n
+}

--- a/conversation/compress.go
+++ b/conversation/compress.go
@@ -1,0 +1,64 @@
+package conversation
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+// ErrEmptySummary indicates the summarizer returned successfully but with blank
+// output. CompressMessages treats this as a failed compression so raw messages
+// are never evicted into an empty durable summary.
+var ErrEmptySummary = errors.New("conversation: summarizer returned empty summary")
+
+// errNilSummarizer is returned when CompressMessages is called without a
+// Summarizer. It does NOT fall back to FallbackSummarizer: an unbounded fallback
+// would reintroduce the pinned-blob growth this feature exists to prevent.
+var errNilSummarizer = errors.New("conversation: CompressMessages requires a non-nil Summarizer")
+
+// Summarizer rewrites a rolling durable summary. prior is the existing summary
+// content (may be ""); msgs are the newly-evicted messages to fold in. The
+// returned string REPLACES prior — implementations must consolidate, not append,
+// and are responsible for bounding their own output.
+type Summarizer func(ctx context.Context, prior string, msgs []Message) (string, error)
+
+// FallbackSummarizer is a deterministic, model-free Summarizer for tests and
+// offline use ONLY. It concatenates prior + rendered msgs and is NOT
+// size-bounded; production code must supply a bounded (model-backed) Summarizer.
+func FallbackSummarizer(_ context.Context, prior string, msgs []Message) (string, error) {
+	var b strings.Builder
+	if p := strings.TrimSpace(prior); p != "" {
+		b.WriteString(p)
+		b.WriteString("\n\n")
+	}
+	for _, m := range msgs {
+		if m.Role == "" && m.Content == "" {
+			continue
+		}
+		if m.Role != "" {
+			b.WriteString(m.Role)
+			b.WriteString(": ")
+		}
+		b.WriteString(m.Content)
+		b.WriteByte('\n')
+	}
+	return strings.TrimSpace(b.String()), nil
+}
+
+// EstimateMessagesTokens sums the estimated token cost of every NON-system
+// message, matching CompressMessages' raw-history accounting. Exported so
+// consumers (Golem) can make trigger decisions without re-deriving messageCost.
+// Panics on a nil estimator, consistent with TrimMessages.
+func EstimateMessagesTokens(msgs []Message, estimator TokenEstimator) int {
+	if estimator == nil {
+		panic("conversation: EstimateMessagesTokens requires non-nil TokenEstimator")
+	}
+	n := 0
+	for _, m := range msgs {
+		if m.Role == "system" {
+			continue
+		}
+		n += messageCost(m, estimator)
+	}
+	return n
+}

--- a/conversation/compress_test.go
+++ b/conversation/compress_test.go
@@ -1,0 +1,43 @@
+package conversation
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestFallbackSummarizer_FoldsPriorThenMessages(t *testing.T) {
+	out, err := FallbackSummarizer(context.Background(), "PRIOR",
+		[]Message{{Role: "user", Content: "hello"}, {Role: "assistant", Content: "hi"}})
+	if err != nil {
+		t.Fatalf("FallbackSummarizer: %v", err)
+	}
+	if !strings.HasPrefix(out, "PRIOR") {
+		t.Fatalf("want prior first, got %q", out)
+	}
+	if !strings.Contains(out, "user: hello") || !strings.Contains(out, "assistant: hi") {
+		t.Fatalf("want rendered messages, got %q", out)
+	}
+}
+
+func TestFallbackSummarizer_EmptyPriorOmitsLeadingBlank(t *testing.T) {
+	out, err := FallbackSummarizer(context.Background(), "",
+		[]Message{{Role: "user", Content: "only"}})
+	if err != nil {
+		t.Fatalf("FallbackSummarizer: %v", err)
+	}
+	if strings.HasPrefix(out, "\n") || out != "user: only" {
+		t.Fatalf("want %q, got %q", "user: only", out)
+	}
+}
+
+func TestEstimateMessagesTokens_SkipsSystem(t *testing.T) {
+	est := func(s string) int { return len(s) }
+	msgs := []Message{
+		{Role: "system", Content: "SYSTEM-IGNORED"},
+		{Role: "user", Content: "abc"},
+	}
+	if got := EstimateMessagesTokens(msgs, est); got != len("abc") {
+		t.Fatalf("EstimateMessagesTokens = %d, want %d", got, len("abc"))
+	}
+}

--- a/conversation/compress_test.go
+++ b/conversation/compress_test.go
@@ -2,6 +2,7 @@ package conversation
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -39,5 +40,167 @@ func TestEstimateMessagesTokens_SkipsSystem(t *testing.T) {
 	}
 	if got := EstimateMessagesTokens(msgs, est); got != len("abc") {
 		t.Fatalf("EstimateMessagesTokens = %d, want %d", got, len("abc"))
+	}
+}
+
+func okSummarizer(_ context.Context, prior string, msgs []Message) (string, error) {
+	return FallbackSummarizer(context.Background(), prior, msgs)
+}
+
+func userAsst(u, a string) []Message {
+	return []Message{{Role: "user", Content: u}, {Role: "assistant", Content: a}}
+}
+
+func TestCompressMessages_NoOpWhenUnderBudget(t *testing.T) {
+	conv := Conversation{ID: "c", Messages: userAsst("hi", "yo")}
+	out, err := CompressMessages(context.Background(), conv, 1000, 1, lenEstimator, okSummarizer)
+	if err != nil {
+		t.Fatalf("CompressMessages: %v", err)
+	}
+	if len(out.Messages) != 2 || out.DurableSummary != nil {
+		t.Fatalf("expected unchanged, got msgs=%d summary=%v", len(out.Messages), out.DurableSummary)
+	}
+}
+
+func TestCompressMessages_EvictsOldestBeyondFloor(t *testing.T) {
+	var msgs []Message
+	for i := 0; i < 6; i++ { // 6 exchanges
+		msgs = append(msgs, userAsst("question that is fairly long", "answer that is fairly long")...)
+	}
+	conv := Conversation{ID: "c", Messages: msgs}
+	// Tight budget + floor of 2 exchanges forces eviction of the older 4.
+	out, err := CompressMessages(context.Background(), conv, 40, 2, lenEstimator, okSummarizer)
+	if err != nil {
+		t.Fatalf("CompressMessages: %v", err)
+	}
+	if out.DurableSummary == nil {
+		t.Fatalf("expected a durable summary")
+	}
+	if len(out.Messages) >= len(msgs) {
+		t.Fatalf("expected eviction, kept %d of %d", len(out.Messages), len(msgs))
+	}
+	if out.Messages[0].Role != "user" {
+		t.Fatalf("retained history must start on a user message, got %q", out.Messages[0].Role)
+	}
+	if out.DurableSummary.MessageCount != len(msgs)-len(out.Messages) {
+		t.Fatalf("MessageCount = %d, want %d", out.DurableSummary.MessageCount, len(msgs)-len(out.Messages))
+	}
+}
+
+func TestCompressMessages_HardFloorPreservedEvenWhenOverBudget(t *testing.T) {
+	var msgs []Message
+	for i := 0; i < 5; i++ {
+		msgs = append(msgs, userAsst("xxxxxxxxxx", "yyyyyyyyyy")...)
+	}
+	conv := Conversation{ID: "c", Messages: msgs}
+	// maxTokens far below the cost of even 3 exchanges; floor must still be kept.
+	out, err := CompressMessages(context.Background(), conv, 1, 3, lenEstimator, okSummarizer)
+	if err != nil {
+		t.Fatalf("CompressMessages: %v", err)
+	}
+	// Floor = 3 exchanges = 6 messages retained.
+	if len(out.Messages) != 6 {
+		t.Fatalf("floor not preserved: kept %d, want 6", len(out.Messages))
+	}
+}
+
+func TestCompressMessages_NeverSplitsToolChain(t *testing.T) {
+	// Exchange 1 contains a tool chain; exchange 2 is plain. A boundary that
+	// would land mid-chain must instead drop the whole exchange.
+	msgs := []Message{
+		{Role: "user", Content: "use a tool please now"},
+		{Role: "assistant", ToolCalls: []byte(`[{"id":"t1"}]`)},
+		{Role: "tool", ToolCallID: "t1", Content: "tool result body"},
+		{Role: "assistant", Content: "done with the tool"},
+		{Role: "user", Content: "second question here"},
+		{Role: "assistant", Content: "second answer here"},
+	}
+	conv := Conversation{ID: "c", Messages: msgs}
+	out, err := CompressMessages(context.Background(), conv, 30, 1, lenEstimator, okSummarizer)
+	if err != nil {
+		t.Fatalf("CompressMessages: %v", err)
+	}
+	// The retained span must not begin with an orphan tool/assistant-result.
+	if out.Messages[0].Role != "user" && out.Messages[0].Role != "system" {
+		t.Fatalf("retained span starts mid-chain: %q", out.Messages[0].Role)
+	}
+	// If the tool chain is retained at all, its result must be present with it.
+	hasToolCall, hasToolResult := false, false
+	for _, m := range out.Messages {
+		if m.Role == "assistant" && len(m.ToolCalls) > 0 {
+			hasToolCall = true
+		}
+		if m.Role == "tool" {
+			hasToolResult = true
+		}
+	}
+	if hasToolCall != hasToolResult {
+		t.Fatalf("tool chain split: call=%v result=%v", hasToolCall, hasToolResult)
+	}
+}
+
+func TestCompressMessages_NilSummarizerReturnsError(t *testing.T) {
+	conv := Conversation{ID: "c", Messages: userAsst("a", "b")}
+	if _, err := CompressMessages(context.Background(), conv, 0, 0, lenEstimator, nil); err == nil {
+		t.Fatal("expected error for nil summarizer")
+	}
+}
+
+func TestCompressMessages_NilEstimatorPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic for nil estimator")
+		}
+	}()
+	conv := Conversation{ID: "c", Messages: userAsst("a", "b")}
+	_, _ = CompressMessages(context.Background(), conv, 0, 0, nil, okSummarizer)
+}
+
+func TestCompressMessages_SummarizerErrorLeavesNoLoss(t *testing.T) {
+	conv := Conversation{ID: "c", Messages: append(userAsst("a", "b"), userAsst("c", "d")...)}
+	boom := func(context.Context, string, []Message) (string, error) {
+		return "", errors.New("model down")
+	}
+	out, err := CompressMessages(context.Background(), conv, 1, 1, lenEstimator, boom)
+	if err == nil {
+		t.Fatal("expected summarizer error")
+	}
+	if len(out.Messages) != 0 { // zero-value Conversation on error
+		t.Fatalf("expected zero Conversation on error, got %d msgs", len(out.Messages))
+	}
+}
+
+func TestCompressMessages_BlankSummaryIsError(t *testing.T) {
+	conv := Conversation{ID: "c", Messages: append(userAsst("a", "b"), userAsst("c", "d")...)}
+	blank := func(context.Context, string, []Message) (string, error) { return "   ", nil }
+	_, err := CompressMessages(context.Background(), conv, 1, 1, lenEstimator, blank)
+	if !errors.Is(err, ErrEmptySummary) {
+		t.Fatalf("want ErrEmptySummary, got %v", err)
+	}
+}
+
+func TestCompressMessages_RollingConsolidationPassesPrior(t *testing.T) {
+	conv := Conversation{
+		ID:             "c",
+		Messages:       append(userAsst("old1", "old1a"), userAsst("recent", "recenta")...),
+		DurableSummary: &DurableSummary{Content: "EARLIER", MessageCount: 4},
+	}
+	var seenPrior string
+	cap := func(_ context.Context, prior string, _ []Message) (string, error) {
+		seenPrior = prior
+		return "NEWSUMMARY", nil
+	}
+	out, err := CompressMessages(context.Background(), conv, 1, 1, lenEstimator, cap)
+	if err != nil {
+		t.Fatalf("CompressMessages: %v", err)
+	}
+	if seenPrior != "EARLIER" {
+		t.Fatalf("prior not passed to summarizer: %q", seenPrior)
+	}
+	if out.DurableSummary.Content != "NEWSUMMARY" {
+		t.Fatalf("summary not replaced: %q", out.DurableSummary.Content)
+	}
+	if out.DurableSummary.MessageCount != 4+2 {
+		t.Fatalf("MessageCount = %d, want 6", out.DurableSummary.MessageCount)
 	}
 }

--- a/conversation/compress_test.go
+++ b/conversation/compress_test.go
@@ -62,6 +62,39 @@ func TestCompressMessages_NoOpWhenUnderBudget(t *testing.T) {
 	}
 }
 
+func TestCompressMessages_RewritesPriorSummaryWhenRawHistoryFits(t *testing.T) {
+	conv := Conversation{
+		ID:             "c",
+		Messages:       userAsst("short", "turn"),
+		DurableSummary: &DurableSummary{Content: "OVERSIZED", MessageCount: 12},
+	}
+	called := false
+	sum := func(_ context.Context, prior string, msgs []Message) (string, error) {
+		called = true
+		if prior != "OVERSIZED" {
+			t.Fatalf("prior = %q, want OVERSIZED", prior)
+		}
+		if len(msgs) != 0 {
+			t.Fatalf("msgs len = %d, want no newly evicted messages", len(msgs))
+		}
+		return "SMALL", nil
+	}
+
+	out, err := CompressMessages(context.Background(), conv, 1000, 1, lenEstimator, sum)
+	if err != nil {
+		t.Fatalf("CompressMessages: %v", err)
+	}
+	if !called {
+		t.Fatal("summarizer was not called")
+	}
+	if out.DurableSummary == nil || out.DurableSummary.Content != "SMALL" || out.DurableSummary.MessageCount != 12 {
+		t.Fatalf("summary = %+v, want rewritten content with same count", out.DurableSummary)
+	}
+	if len(out.Messages) != len(conv.Messages) {
+		t.Fatalf("messages len = %d, want %d", len(out.Messages), len(conv.Messages))
+	}
+}
+
 func TestCompressMessages_EvictsOldestBeyondFloor(t *testing.T) {
 	var msgs []Message
 	for i := 0; i < 6; i++ { // 6 exchanges

--- a/conversation/message.go
+++ b/conversation/message.go
@@ -56,11 +56,19 @@ type Message struct {
 
 // Conversation is the unit of persistence.
 type Conversation struct {
-	ID        string
-	Title     string
-	Messages  []Message
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	ID             string
+	Title          string
+	Messages       []Message
+	DurableSummary *DurableSummary
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+// DurableSummary is compressed transcript history kept beside recent raw
+// messages.
+type DurableSummary struct {
+	Content      string
+	MessageCount int
 }
 
 // Summary is the lightweight listing type returned by List (no messages loaded).

--- a/conversation/migration.go
+++ b/conversation/migration.go
@@ -23,6 +23,11 @@ var migrations = []migration{
 		description: "conversation search shadow table and FTS5 index",
 		fn:          migrateV2,
 	},
+	{
+		version:     3,
+		description: "durable conversation summaries",
+		fn:          migrateV3,
+	},
 }
 
 func migrateV1(tx *sql.Tx) error {
@@ -70,6 +75,19 @@ func migrateV2(tx *sql.Tx) error {
 	for _, stmt := range stmts {
 		if _, err := tx.Exec(stmt); err != nil {
 			return fmt.Errorf("conversation: migrate v2: %w", err)
+		}
+	}
+	return nil
+}
+
+func migrateV3(tx *sql.Tx) error {
+	stmts := []string{
+		`ALTER TABLE conversations ADD COLUMN summary_content TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE conversations ADD COLUMN summary_message_count INTEGER NOT NULL DEFAULT 0`,
+	}
+	for _, stmt := range stmts {
+		if _, err := tx.Exec(stmt); err != nil {
+			return fmt.Errorf("conversation: migrate v3: %w", err)
 		}
 	}
 	return nil

--- a/conversation/migration_test.go
+++ b/conversation/migration_test.go
@@ -35,8 +35,8 @@ func TestRunMigrations_FreshDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("version query failed: %v", err)
 	}
-	if version != 2 {
-		t.Fatalf("schema version = %d, want 2", version)
+	if version != 3 {
+		t.Fatalf("schema version = %d, want 3", version)
 	}
 }
 
@@ -54,8 +54,8 @@ func TestRunMigrations_Idempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("version query failed: %v", err)
 	}
-	if version != 2 {
-		t.Fatalf("schema version = %d, want 2", version)
+	if version != 3 {
+		t.Fatalf("schema version = %d, want 3", version)
 	}
 }
 
@@ -88,6 +88,21 @@ func TestRunMigrations_SearchTablesExist(t *testing.T) {
 		).Scan(&count)
 		if err != nil || count != 1 {
 			t.Fatalf("expected %s table, count=%d err=%v", name, count, err)
+		}
+	}
+}
+
+func TestRunMigrations_DurableSummaryColumnsExist(t *testing.T) {
+	db := openTestDB(t)
+	if err := runMigrations(db); err != nil {
+		t.Fatalf("runMigrations() error: %v", err)
+	}
+
+	for _, name := range []string{"summary_content", "summary_message_count"} {
+		var count int
+		err := db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('conversations') WHERE name = ?`, name).Scan(&count)
+		if err != nil || count != 1 {
+			t.Fatalf("expected conversations.%s column, count=%d err=%v", name, count, err)
 		}
 	}
 }

--- a/conversation/migration_test.go
+++ b/conversation/migration_test.go
@@ -1,6 +1,7 @@
 package conversation
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 
@@ -104,5 +105,72 @@ func TestRunMigrations_DurableSummaryColumnsExist(t *testing.T) {
 		if err != nil || count != 1 {
 			t.Fatalf("expected conversations.%s column, count=%d err=%v", name, count, err)
 		}
+	}
+}
+
+// TestRunMigrations_V2ToV3BackwardCompat verifies that a database created at
+// schema v2 (no summary columns) upgrades to v3 in place and that pre-v3 rows
+// load with a nil DurableSummary. This is the spec's backward-compatibility
+// requirement: the v3 migration is additive and never rewrites existing data.
+func TestRunMigrations_V2ToV3BackwardCompat(t *testing.T) {
+	db := openTestDB(t)
+
+	// Build a v2-state database: version table + v1/v2 schema, stamped at v2,
+	// with one pre-v3 conversation row (conversations has no summary columns yet).
+	if _, err := db.Exec(`CREATE TABLE conversation_schema_version (
+		version INTEGER PRIMARY KEY, description TEXT NOT NULL, applied_at INTEGER NOT NULL)`); err != nil {
+		t.Fatalf("create version table: %v", err)
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := migrateV1(tx); err != nil {
+		t.Fatalf("migrateV1: %v", err)
+	}
+	if err := migrateV2(tx); err != nil {
+		t.Fatalf("migrateV2: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO conversation_schema_version (version, description, applied_at)
+		VALUES (1, 'v1', 0), (2, 'v2', 0)`); err != nil {
+		t.Fatalf("stamp versions: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO conversations (id, title, messages, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`,
+		"old1", "old title", `[{"role":"user","content":"hi"}]`, 1, 2,
+	); err != nil {
+		t.Fatalf("insert pre-v3 row: %v", err)
+	}
+
+	// Only v3 should apply now (v1/v2 already stamped).
+	if err := runMigrations(db); err != nil {
+		t.Fatalf("runMigrations() error: %v", err)
+	}
+	var version int
+	if err := db.QueryRow(`SELECT MAX(version) FROM conversation_schema_version`).Scan(&version); err != nil {
+		t.Fatalf("version query failed: %v", err)
+	}
+	if version != 3 {
+		t.Fatalf("schema version = %d, want 3", version)
+	}
+
+	// The pre-v3 row loads with a nil DurableSummary and preserved content.
+	// NewStore re-runs migrations idempotently (already at v3).
+	store, err := NewStore(context.Background(), db)
+	if err != nil {
+		t.Fatalf("NewStore() error: %v", err)
+	}
+	conv, err := store.Load(context.Background(), "old1")
+	if err != nil {
+		t.Fatalf("Load pre-v3 row: %v", err)
+	}
+	if conv.DurableSummary != nil {
+		t.Fatalf("pre-v3 row must load with nil DurableSummary, got %+v", conv.DurableSummary)
+	}
+	if conv.Title != "old title" || len(conv.Messages) != 1 {
+		t.Fatalf("pre-v3 row content not preserved: title=%q msgs=%d", conv.Title, len(conv.Messages))
 	}
 }

--- a/conversation/store.go
+++ b/conversation/store.go
@@ -48,6 +48,7 @@ func (s *SQLiteStore) Save(ctx context.Context, conv Conversation) error {
 	if err != nil {
 		return fmt.Errorf("conversation: save: marshal messages: %w", err)
 	}
+	summaryContent, summaryMessageCount := durableSummaryValues(conv.DurableSummary)
 
 	now := time.Now().UnixMilli()
 
@@ -59,13 +60,15 @@ func (s *SQLiteStore) Save(ctx context.Context, conv Conversation) error {
 	defer func() { _ = tx.Rollback() }()
 
 	_, err = tx.ExecContext(ctx,
-		`INSERT INTO conversations (id, title, messages, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?)
+		`INSERT INTO conversations (id, title, messages, summary_content, summary_message_count, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(id) DO UPDATE SET
-			title      = excluded.title,
-			messages   = excluded.messages,
-			updated_at = excluded.updated_at`,
-		conv.ID, conv.Title, string(messagesJSON), now, now,
+			title                 = excluded.title,
+			messages              = excluded.messages,
+			summary_content       = excluded.summary_content,
+			summary_message_count = excluded.summary_message_count,
+			updated_at            = excluded.updated_at`,
+		conv.ID, conv.Title, string(messagesJSON), summaryContent, summaryMessageCount, now, now,
 	)
 	if err != nil {
 		return fmt.Errorf("conversation: save %q: %w", conv.ID, err)
@@ -83,12 +86,14 @@ func (s *SQLiteStore) Save(ctx context.Context, conv Conversation) error {
 func (s *SQLiteStore) Load(ctx context.Context, id string) (*Conversation, error) {
 	var conv Conversation
 	var messagesJSON string
+	var summaryContent string
+	var summaryMessageCount int
 	var createdMs, updatedMs int64
 
 	err := s.db.QueryRowContext(ctx,
-		`SELECT id, title, messages, created_at, updated_at FROM conversations WHERE id = ?`,
+		`SELECT id, title, messages, summary_content, summary_message_count, created_at, updated_at FROM conversations WHERE id = ?`,
 		id,
-	).Scan(&conv.ID, &conv.Title, &messagesJSON, &createdMs, &updatedMs)
+	).Scan(&conv.ID, &conv.Title, &messagesJSON, &summaryContent, &summaryMessageCount, &createdMs, &updatedMs)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, fmt.Errorf("conversation: load %q: %w", id, ErrNotFound)
@@ -102,6 +107,12 @@ func (s *SQLiteStore) Load(ctx context.Context, id string) (*Conversation, error
 
 	conv.CreatedAt = time.UnixMilli(createdMs)
 	conv.UpdatedAt = time.UnixMilli(updatedMs)
+	if summaryContent != "" || summaryMessageCount > 0 {
+		conv.DurableSummary = &DurableSummary{
+			Content:      summaryContent,
+			MessageCount: summaryMessageCount,
+		}
+	}
 
 	return &conv, nil
 }
@@ -235,6 +246,13 @@ func (s *SQLiteStore) deleteSearchIndex(ctx context.Context, tx *sql.Tx, id stri
 		return fmt.Errorf("conversation: delete %q: delete search metadata: %w", id, err)
 	}
 	return nil
+}
+
+func durableSummaryValues(s *DurableSummary) (string, int) {
+	if s == nil {
+		return "", 0
+	}
+	return s.Content, s.MessageCount
 }
 
 func searchText(msgs []Message) string {

--- a/conversation/store.go
+++ b/conversation/store.go
@@ -53,6 +53,9 @@ func (s *SQLiteStore) Save(ctx context.Context, conv Conversation) error {
 	now := time.Now().UnixMilli()
 
 	searchBody := searchText(msgs)
+	if summaryContent != "" {
+		searchBody += "\n" + summaryContent
+	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("conversation: save %q: begin: %w", conv.ID, err)

--- a/conversation/store_test.go
+++ b/conversation/store_test.go
@@ -67,6 +67,45 @@ func TestSave_And_Load_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestSave_And_Load_RoundTripWithDurableSummary(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	conv := Conversation{
+		ID:    NewID(),
+		Title: "compressed conversation",
+		Messages: []Message{
+			{Role: "user", Content: "recent question"},
+			{Role: "assistant", Content: "recent answer"},
+		},
+		DurableSummary: &DurableSummary{
+			Content:      "Earlier conversation covered repository setup and Golem goals.",
+			MessageCount: 6,
+		},
+	}
+
+	if err := store.Save(ctx, conv); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	loaded, err := store.Load(ctx, conv.ID)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if loaded.DurableSummary == nil {
+		t.Fatal("DurableSummary is nil")
+	}
+	if loaded.DurableSummary.Content != conv.DurableSummary.Content {
+		t.Fatalf("DurableSummary.Content = %q, want %q", loaded.DurableSummary.Content, conv.DurableSummary.Content)
+	}
+	if loaded.DurableSummary.MessageCount != conv.DurableSummary.MessageCount {
+		t.Fatalf("DurableSummary.MessageCount = %d, want %d", loaded.DurableSummary.MessageCount, conv.DurableSummary.MessageCount)
+	}
+	if len(loaded.Messages) != len(conv.Messages) {
+		t.Fatalf("Messages len = %d, want %d", len(loaded.Messages), len(conv.Messages))
+	}
+}
+
 func TestSave_EmptyID_ReturnsError(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()

--- a/conversation/store_test.go
+++ b/conversation/store_test.go
@@ -297,6 +297,32 @@ func TestSearch_FindsMessageTextWithoutLoadingBlobs(t *testing.T) {
 	}
 }
 
+func TestSearch_FindsDurableSummaryText(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	conv := Conversation{
+		ID:       "workspace:compressed",
+		Title:    "Compressed session",
+		Messages: []Message{{Role: "user", Content: "recent turn only"}},
+		DurableSummary: &DurableSummary{
+			Content:      "Earlier turns discussed frobnicator calibration.",
+			MessageCount: 8,
+		},
+	}
+	if err := store.Save(ctx, conv); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	got, err := store.Search(ctx, "frobnicator", SearchOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("Search() error: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != conv.ID {
+		t.Fatalf("Search() = %+v, want compressed session", got)
+	}
+}
+
 func TestSearch_FindsToolCallPayloads(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()

--- a/conversation/trim.go
+++ b/conversation/trim.go
@@ -1,5 +1,10 @@
 package conversation
 
+import (
+	"context"
+	"strings"
+)
+
 // messageCost computes the estimated token cost of a message using all
 // prompt-visible fields.
 func messageCost(m Message, estimator TokenEstimator) int {
@@ -227,23 +232,44 @@ func TrimByExchanges(msgs []Message, maxExchanges int) TrimResult {
 		return TrimResult{Messages: []Message{}}
 	}
 
-	var systemMsgs []Message
-	var nonSystem []Message
-	for _, m := range msgs {
-		if m.Role == "system" {
-			systemMsgs = append(systemMsgs, m)
-		} else {
-			nonSystem = append(nonSystem, m)
+	// Build result preserving original message order.
+	keep := trimByExchangesKeep(msgs, maxExchanges)
+	var result []Message
+	trimmedCount := 0
+	for i, m := range msgs {
+		if keep[i] {
+			result = append(result, m)
+			continue
 		}
+		trimmedCount++
 	}
 
+	return TrimResult{
+		Messages:        result,
+		TrimmedCount:    trimmedCount,
+		EstimatedTokens: 0,
+	}
+}
+
+type exchange struct {
+	start int
+	end   int
+}
+
+func trimByExchangesKeep(msgs []Message, maxExchanges int) []bool {
+	keep := make([]bool, len(msgs))
+	var nonSystem []Message
+	var orig []int
+	for i, m := range msgs {
+		if m.Role == "system" {
+			keep[i] = true
+			continue
+		}
+		nonSystem = append(nonSystem, m)
+		orig = append(orig, i)
+	}
 	if len(nonSystem) == 0 {
-		return TrimResult{Messages: systemMsgs, TrimmedCount: 0}
-	}
-
-	type exchange struct {
-		start int
-		end   int
+		return keep
 	}
 
 	unresolvedStart := -1
@@ -267,24 +293,23 @@ func TrimByExchanges(msgs []Message, maxExchanges int) TrimResult {
 	}
 
 	var exchanges []exchange
-	i := 0
-	for i < resolvedEnd {
-		if nonSystem[i].Role == "user" {
-			ex := exchange{start: i}
-			j := i + 1
-			for j < resolvedEnd {
-				if nonSystem[j].Role == "assistant" && len(nonSystem[j].ToolCalls) == 0 {
-					ex.end = j
-					exchanges = append(exchanges, ex)
-					j++
-					break
-				}
-				j++
-			}
-			i = j
-		} else {
+	for i := 0; i < resolvedEnd; {
+		if nonSystem[i].Role != "user" {
 			i++
+			continue
 		}
+		ex := exchange{start: i}
+		j := i + 1
+		for j < resolvedEnd {
+			if nonSystem[j].Role == "assistant" && len(nonSystem[j].ToolCalls) == 0 {
+				ex.end = j
+				exchanges = append(exchanges, ex)
+				j++
+				break
+			}
+			j++
+		}
+		i = j
 	}
 
 	keepFrom := 0
@@ -292,12 +317,10 @@ func TrimByExchanges(msgs []Message, maxExchanges int) TrimResult {
 		keepFrom = len(exchanges) - maxExchanges
 	}
 
-	keep := make([]bool, len(nonSystem))
-
 	for idx := keepFrom; idx < len(exchanges); idx++ {
 		ex := exchanges[idx]
 		for k := ex.start; k <= ex.end; k++ {
-			keep[k] = true
+			keep[orig[k]] = true
 		}
 	}
 
@@ -310,30 +333,72 @@ func TrimByExchanges(msgs []Message, maxExchanges int) TrimResult {
 			}
 		}
 		for k := tailStart; k < len(nonSystem); k++ {
-			keep[k] = true
+			keep[orig[k]] = true
 		}
 	}
+	return keep
+}
 
-	// Build result preserving original message order.
-	var result []Message
-	trimmedCount := 0
-	nsIdx := 0
+// Summarizer compresses a safe old-message span into durable summary text.
+type Summarizer func(context.Context, []Message) (string, error)
+
+// CompressByExchanges summarizes old safe history and keeps recent raw
+// messages according to TrimByExchanges' safety rules.
+func CompressByExchanges(ctx context.Context, conv Conversation, maxRecentExchanges int, summarize Summarizer) (Conversation, error) {
+	if summarize == nil {
+		summarize = FallbackSummarizer
+	}
+	keep := trimByExchangesKeep(conv.Messages, maxRecentExchanges)
+	old := make([]Message, 0, len(conv.Messages))
+	recent := make([]Message, 0, len(conv.Messages))
+	for i, m := range conv.Messages {
+		if keep[i] {
+			recent = append(recent, m)
+			continue
+		}
+		if m.Role != "system" {
+			old = append(old, m)
+		}
+	}
+	if len(old) == 0 {
+		return conv, nil
+	}
+
+	text, err := summarize(ctx, old)
+	if err != nil {
+		return Conversation{}, err
+	}
+
+	out := conv
+	out.Messages = recent
+	content := strings.TrimSpace(text)
+	count := len(old)
+	if conv.DurableSummary != nil {
+		count += conv.DurableSummary.MessageCount
+		switch {
+		case conv.DurableSummary.Content != "" && content != "":
+			content = conv.DurableSummary.Content + "\n\n" + content
+		case content == "":
+			content = conv.DurableSummary.Content
+		}
+	}
+	out.DurableSummary = &DurableSummary{Content: content, MessageCount: count}
+	return out, nil
+}
+
+// FallbackSummarizer is deterministic and model-free for tests and offline use.
+func FallbackSummarizer(_ context.Context, msgs []Message) (string, error) {
+	var b strings.Builder
 	for _, m := range msgs {
-		if m.Role == "system" {
-			result = append(result, m)
-		} else {
-			if keep[nsIdx] {
-				result = append(result, m)
-			} else {
-				trimmedCount++
-			}
-			nsIdx++
+		if m.Role == "" && m.Content == "" {
+			continue
 		}
+		if m.Role != "" {
+			b.WriteString(m.Role)
+			b.WriteString(": ")
+		}
+		b.WriteString(m.Content)
+		b.WriteByte('\n')
 	}
-
-	return TrimResult{
-		Messages:        result,
-		TrimmedCount:    trimmedCount,
-		EstimatedTokens: 0,
-	}
+	return strings.TrimSpace(b.String()), nil
 }

--- a/conversation/trim.go
+++ b/conversation/trim.go
@@ -1,10 +1,5 @@
 package conversation
 
-import (
-	"context"
-	"strings"
-)
-
 // messageCost computes the estimated token cost of a message using all
 // prompt-visible fields.
 func messageCost(m Message, estimator TokenEstimator) int {
@@ -337,68 +332,4 @@ func trimByExchangesKeep(msgs []Message, maxExchanges int) []bool {
 		}
 	}
 	return keep
-}
-
-// Summarizer compresses a safe old-message span into durable summary text.
-type Summarizer func(context.Context, []Message) (string, error)
-
-// CompressByExchanges summarizes old safe history and keeps recent raw
-// messages according to TrimByExchanges' safety rules.
-func CompressByExchanges(ctx context.Context, conv Conversation, maxRecentExchanges int, summarize Summarizer) (Conversation, error) {
-	if summarize == nil {
-		summarize = FallbackSummarizer
-	}
-	keep := trimByExchangesKeep(conv.Messages, maxRecentExchanges)
-	old := make([]Message, 0, len(conv.Messages))
-	recent := make([]Message, 0, len(conv.Messages))
-	for i, m := range conv.Messages {
-		if keep[i] {
-			recent = append(recent, m)
-			continue
-		}
-		if m.Role != "system" {
-			old = append(old, m)
-		}
-	}
-	if len(old) == 0 {
-		return conv, nil
-	}
-
-	text, err := summarize(ctx, old)
-	if err != nil {
-		return Conversation{}, err
-	}
-
-	out := conv
-	out.Messages = recent
-	content := strings.TrimSpace(text)
-	count := len(old)
-	if conv.DurableSummary != nil {
-		count += conv.DurableSummary.MessageCount
-		switch {
-		case conv.DurableSummary.Content != "" && content != "":
-			content = conv.DurableSummary.Content + "\n\n" + content
-		case content == "":
-			content = conv.DurableSummary.Content
-		}
-	}
-	out.DurableSummary = &DurableSummary{Content: content, MessageCount: count}
-	return out, nil
-}
-
-// FallbackSummarizer is deterministic and model-free for tests and offline use.
-func FallbackSummarizer(_ context.Context, msgs []Message) (string, error) {
-	var b strings.Builder
-	for _, m := range msgs {
-		if m.Role == "" && m.Content == "" {
-			continue
-		}
-		if m.Role != "" {
-			b.WriteString(m.Role)
-			b.WriteString(": ")
-		}
-		b.WriteString(m.Content)
-		b.WriteByte('\n')
-	}
-	return strings.TrimSpace(b.String()), nil
 }

--- a/conversation/trim_test.go
+++ b/conversation/trim_test.go
@@ -1,6 +1,7 @@
 package conversation
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"unicode/utf8"
@@ -323,6 +324,53 @@ func TestTrimByExchanges_ZeroExchanges(t *testing.T) {
 	}
 	if result.Messages[0].Role != "system" {
 		t.Error("expected system message only")
+	}
+}
+
+func TestCompressByExchanges_SummarizesOnlySafeOldMessages(t *testing.T) {
+	conv := Conversation{
+		ID: "c1",
+		Messages: []Message{
+			makeMsg("system", "sys"),
+			makeMsg("user", "q1"),
+			makeMsg("assistant", "a1"),
+			makeMsg("user", "search"),
+			makeToolCallMsg("", `[{"id":"c1","type":"function","function":{"name":"s","arguments":{}}}]`),
+			makeToolResult("data", "s", "c1"),
+			makeMsg("assistant", "found it"),
+			makeMsg("user", "q3"),
+			makeMsg("assistant", "a3"),
+			makeMsg("user", "pending"),
+			makeToolCallMsg("", `[{"id":"c2","type":"function","function":{"name":"act","arguments":{}}}]`),
+			makeToolResult("pending result", "act", "c2"),
+		},
+	}
+
+	var summarized []Message
+	out, err := CompressByExchanges(context.Background(), conv, 1, func(_ context.Context, msgs []Message) (string, error) {
+		summarized = append([]Message(nil), msgs...)
+		return "old q1/search summary", nil
+	})
+	if err != nil {
+		t.Fatalf("CompressByExchanges() error: %v", err)
+	}
+
+	if out.DurableSummary == nil || out.DurableSummary.Content != "old q1/search summary" {
+		t.Fatalf("DurableSummary = %+v, want summary text", out.DurableSummary)
+	}
+	if out.DurableSummary.MessageCount != len(summarized) {
+		t.Fatalf("DurableSummary.MessageCount = %d, want %d", out.DurableSummary.MessageCount, len(summarized))
+	}
+	for _, m := range summarized {
+		if m.Role == "system" || m.Content == "q3" || m.Content == "pending" || m.ToolCallID == "c2" {
+			t.Fatalf("summarized unsafe/recent message: %+v in %+v", m, summarized)
+		}
+	}
+	if len(out.Messages) != 6 {
+		t.Fatalf("Messages len = %d, want system + recent exchange + unresolved tail", len(out.Messages))
+	}
+	if out.Messages[0].Role != "system" || out.Messages[1].Content != "q3" || out.Messages[3].Content != "pending" || out.Messages[4].ToolCalls == nil {
+		t.Fatalf("Messages = %+v, want system, recent exchange, unresolved tail", out.Messages)
 	}
 }
 

--- a/conversation/trim_test.go
+++ b/conversation/trim_test.go
@@ -1,7 +1,6 @@
 package conversation
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 	"unicode/utf8"
@@ -324,53 +323,6 @@ func TestTrimByExchanges_ZeroExchanges(t *testing.T) {
 	}
 	if result.Messages[0].Role != "system" {
 		t.Error("expected system message only")
-	}
-}
-
-func TestCompressByExchanges_SummarizesOnlySafeOldMessages(t *testing.T) {
-	conv := Conversation{
-		ID: "c1",
-		Messages: []Message{
-			makeMsg("system", "sys"),
-			makeMsg("user", "q1"),
-			makeMsg("assistant", "a1"),
-			makeMsg("user", "search"),
-			makeToolCallMsg("", `[{"id":"c1","type":"function","function":{"name":"s","arguments":{}}}]`),
-			makeToolResult("data", "s", "c1"),
-			makeMsg("assistant", "found it"),
-			makeMsg("user", "q3"),
-			makeMsg("assistant", "a3"),
-			makeMsg("user", "pending"),
-			makeToolCallMsg("", `[{"id":"c2","type":"function","function":{"name":"act","arguments":{}}}]`),
-			makeToolResult("pending result", "act", "c2"),
-		},
-	}
-
-	var summarized []Message
-	out, err := CompressByExchanges(context.Background(), conv, 1, func(_ context.Context, msgs []Message) (string, error) {
-		summarized = append([]Message(nil), msgs...)
-		return "old q1/search summary", nil
-	})
-	if err != nil {
-		t.Fatalf("CompressByExchanges() error: %v", err)
-	}
-
-	if out.DurableSummary == nil || out.DurableSummary.Content != "old q1/search summary" {
-		t.Fatalf("DurableSummary = %+v, want summary text", out.DurableSummary)
-	}
-	if out.DurableSummary.MessageCount != len(summarized) {
-		t.Fatalf("DurableSummary.MessageCount = %d, want %d", out.DurableSummary.MessageCount, len(summarized))
-	}
-	for _, m := range summarized {
-		if m.Role == "system" || m.Content == "q3" || m.Content == "pending" || m.ToolCallID == "c2" {
-			t.Fatalf("summarized unsafe/recent message: %+v in %+v", m, summarized)
-		}
-	}
-	if len(out.Messages) != 6 {
-		t.Fatalf("Messages len = %d, want system + recent exchange + unresolved tail", len(out.Messages))
-	}
-	if out.Messages[0].Role != "system" || out.Messages[1].Content != "q3" || out.Messages[3].Content != "pending" || out.Messages[4].ToolCalls == nil {
-		t.Fatalf("Messages = %+v, want system, recent exchange, unresolved tail", out.Messages)
 	}
 }
 


### PR DESCRIPTION
Closes #58. Parent epic #57 (Phase 1: Memory + Config).

## What & why
Long-running Golem sessions previously either replayed full history every turn (unbounded token cost) or lost early context on trim. This adds a **bounded, durable rolling summary** of old turns kept beside recent raw messages — and, critically, a **trigger that actually fires it** (the prior spike was fully plumbed but nothing ever produced a summary).

Design spec drove this (gitignored `docs/superpowers/specs/2026-06-25-conversation-compression-design.md`).

## Layers
- **`conversation/`** (no LLM dep) — `DurableSummary` type + v3 migration (additive, backward-compatible); `Summarizer` seam takes a `prior` summary for **rolling consolidation** (regenerate one bounded blob, never an append log); token-driven `CompressMessages` reuses the tool-safe `trimByExchangesKeep` splitter, enforces a hard `minRecentExchanges` floor, and **never evicts a message unless the absorbing summary was produced successfully** (errors / blank output → `ErrEmptySummary`, no data loss); `EstimateMessagesTokens` accounting helper.
- **`agent/`** — `NewRouterSummarizer` routes the `summarize` use-case (resolves via existing config fallback `summarize → {analysis, chat}`, so **not blocked on #60**); summary bounded by the single-sourced `DefaultSummaryOutputReserve` (`NumPredict`); fixed-section anti-confabulation prompt; exported `DurableSummaryPrompt` + `DefaultInputCeiling` so Golem's trigger accounting/threshold derive from one source (no drift).
- **`cmd/golem/`** — `compressPolicy.maybeCompress` fires post-turn when model-visible history (summary prompt + raw) exceeds ~half the input ceiling, reserving the summary's headroom; `-no-compress` opt-out; `session` stays persistence-only (`currentConversation`/`applyCompacted`). Runs under `runCtx` so Ctrl-C interrupts it.

## Acceptance criteria (#58)
- ✅ Optional + fallback-friendly (`-no-compress`; config fallback, no #60 dep)
- ✅ Never orphans tool-call/result sequences (whole-exchange splitting + adversarial test)
- ✅ Recover both recent raw messages and durable compressed history (round-tripped through store)
- ✅ Backward-compatible round-trip (v3 migration additive; old rows load nil summary — committed v2→v3 test)

## Testing
`scripts/ci-local --mode pre-push` green: golangci-lint 0 issues, `go test -race ./...` all pass. New tests cover the algorithm (9), trigger (5), session persistence (4), agent summarizer (2), and v2→v3 migration backward-compat.

## Reviews
Three adversarial subagent reviews (algorithm, trigger, full-branch holistic incl. the never-reviewed spike) plus `/code-review` (fixed: single-source `DefaultInputCeiling`) and `/criticize-review` (fixed: interruptible compression).

## Known limitations (deferred, degrade safely)
- Resuming a very large pre-existing history → the first compression hands a large transcript to the summarizer (input not bounded; output is). Model error → "compression skipped", no data loss. Iterative/hierarchical summaries are #189.
- Session list title may drift to a later line once the original first message is summarized away (cosmetic).

Generated with [Claude Code](https://claude.com/claude-code)
