### PR TITLE
feat(rag): default Retriever.Retrieve to hybrid SearchMulti (#225)

### DIFF
--- a/rag/retriever.go
+++ b/rag/retriever.go
@@ -10,9 +10,10 @@ import (
 
 // Retriever queries the vector store and builds augmented prompts.
 type Retriever struct {
-	embedder Embedder
-	model    string
-	store    VectorStore
+	embedder   Embedder
+	model      string
+	store      VectorStore
+	vectorOnly bool
 }
 
 // VectorSpaceProbe summarizes the vector-space-id distribution across a
@@ -42,6 +43,18 @@ type RetrieverOption func(*Retriever)
 func WithRetrieverModel(model string) RetrieverOption {
 	return func(r *Retriever) {
 		r.model = model
+	}
+}
+
+// WithVectorOnly forces vector-only (cosine) retrieval even when the store
+// implements MultiSignalSearcher, disabling the default hybrid path. Use it
+// to bypass hybrid retrieval — for example against an index whose FTS5
+// keyword table is unavailable (a legacy snapshot opened read-only cannot be
+// migrated to add it), or to compare ranking strategies. Hybrid retrieval
+// otherwise depends on the chunks_fts table populated at index time.
+func WithVectorOnly() RetrieverOption {
+	return func(r *Retriever) {
+		r.vectorOnly = true
 	}
 }
 
@@ -98,6 +111,33 @@ func (r *Retriever) Retrieve(ctx context.Context, query string, k int) ([]Search
 
 	if err := r.validateVectorSpace(ctx, res); err != nil {
 		return nil, err
+	}
+
+	// Prefer multi-signal (hybrid) retrieval when the store supports it and the
+	// caller has not opted out: semantic, keyword, and temporal signals
+	// participate in ranking. Retrieve's signature carries no editor context,
+	// so structural/behavioral signals stay inert (empty QueryContext); the
+	// temporal scorer still works, dating chunks against the newest indexed row.
+	if ms, ok := r.store.(MultiSignalSearcher); ok && !r.vectorOnly {
+		scored, err := ms.SearchMulti(ctx, embedding, query, k, QueryContext{})
+		if err != nil {
+			return nil, fmt.Errorf("rag: hybrid search: %w: %w", ErrStoreOperation, err)
+		}
+		if len(scored) == 0 {
+			return nil, nil
+		}
+		// Normalize Score to semantic similarity so the SearchResult contract
+		// (Score == 1 - Distance, in [0,1]) holds identically on both retrieval
+		// paths. Hybrid ranking is preserved in result order, not in Score:
+		// downstream BuildContext renders Score as "similarity", and callers
+		// surface it as a 0..1 value, so it must not carry raw RRF magnitudes.
+		results := make([]SearchResult, len(scored))
+		for i, s := range scored {
+			sr := s.SearchResult
+			sr.Score = 1 - sr.Distance
+			results[i] = sr
+		}
+		return results, nil
 	}
 
 	results, err := r.store.Search(ctx, embedding, k)

--- a/rag/retriever_embedder_test.go
+++ b/rag/retriever_embedder_test.go
@@ -139,8 +139,11 @@ func TestRetrieve_VSIDMatch_proceeds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Retrieve error: %v", err)
 	}
-	if spyStore.searchCalls != 1 {
-		t.Fatalf("Search calls = %d, want 1", spyStore.searchCalls)
+	if spyStore.searchMultiCalls != 1 {
+		t.Fatalf("SearchMulti calls = %d, want 1 (hybrid is default)", spyStore.searchMultiCalls)
+	}
+	if spyStore.searchCalls != 0 {
+		t.Fatalf("Search calls = %d, want 0 when the store supports hybrid", spyStore.searchCalls)
 	}
 	if len(results) != 1 || results[0].Chunk.ID != "c1" {
 		t.Fatalf("results = %+v, want c1", results)
@@ -257,8 +260,11 @@ func TestRetrieve_fullyLegacy_proceeds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Retrieve error: %v", err)
 	}
-	if spyStore.searchCalls != 1 {
-		t.Fatalf("Search calls = %d, want 1", spyStore.searchCalls)
+	if spyStore.searchMultiCalls != 1 {
+		t.Fatalf("SearchMulti calls = %d, want 1 (hybrid is default)", spyStore.searchMultiCalls)
+	}
+	if spyStore.searchCalls != 0 {
+		t.Fatalf("Search calls = %d, want 0 when the store supports hybrid", spyStore.searchCalls)
 	}
 	if len(results) != 2 {
 		t.Fatalf("results = %d, want 2", len(results))
@@ -283,8 +289,11 @@ func TestRetrieve_emptyCorpus_proceeds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Retrieve error: %v", err)
 	}
-	if spyStore.searchCalls != 1 {
-		t.Fatalf("Search calls = %d, want 1", spyStore.searchCalls)
+	if spyStore.searchMultiCalls != 1 {
+		t.Fatalf("SearchMulti calls = %d, want 1 (hybrid is default)", spyStore.searchMultiCalls)
+	}
+	if spyStore.searchCalls != 0 {
+		t.Fatalf("Search calls = %d, want 0 when the store supports hybrid", spyStore.searchCalls)
 	}
 	if len(results) != 0 {
 		t.Fatalf("results = %d, want 0", len(results))
@@ -348,12 +357,19 @@ func TestRetrieve_storeWithoutProber_skipsCheck(t *testing.T) {
 
 type countingSQLiteRetrieverStore struct {
 	*SQLiteStore
-	searchCalls int
+	searchCalls      int
+	searchMultiCalls int
 }
 
 func (s *countingSQLiteRetrieverStore) Search(ctx context.Context, queryEmbedding []float64, k int) ([]SearchResult, error) {
 	s.searchCalls++
 	return s.SQLiteStore.Search(ctx, queryEmbedding, k)
+}
+
+func (s *countingSQLiteRetrieverStore) SearchMulti(ctx context.Context, queryEmbedding []float64, query string,
+	k int, qCtx QueryContext) ([]ScoredResult, error) {
+	s.searchMultiCalls++
+	return s.SQLiteStore.SearchMulti(ctx, queryEmbedding, query, k, qCtx)
 }
 
 type retrieverPlainStore struct {

--- a/rag/retriever_multi_test.go
+++ b/rag/retriever_multi_test.go
@@ -1,0 +1,282 @@
+package rag
+
+import (
+	"context"
+	"errors"
+	"math"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// retrieverMultiStore is a plain store that additionally implements
+// MultiSignalSearcher, so Retrieve should prefer SearchMulti over Search.
+type retrieverMultiStore struct {
+	retrieverPlainStore
+	multiResults     []ScoredResult
+	multiErr         error
+	searchMultiCalls int
+	gotQuery         string
+	gotK             int
+}
+
+func (s *retrieverMultiStore) SearchMulti(_ context.Context, _ []float64, query string,
+	k int, _ QueryContext) ([]ScoredResult, error) {
+	s.searchMultiCalls++
+	s.gotQuery = query
+	s.gotK = k
+	if s.multiErr != nil {
+		return nil, s.multiErr
+	}
+	return s.multiResults, nil
+}
+
+// retrieverMultiProbingStore adds vector-space probing on top of the
+// multi-signal store, to prove vsid validation still gates the hybrid path.
+type retrieverMultiProbingStore struct {
+	retrieverMultiStore
+	probe VectorSpaceProbe
+}
+
+func (s *retrieverMultiProbingStore) ProbeVectorSpaces(context.Context) (VectorSpaceProbe, error) {
+	return s.probe, nil
+}
+
+func TestRetrieve_usesSearchMultiWhenAvailable(t *testing.T) {
+	store := &retrieverMultiStore{
+		multiResults: []ScoredResult{
+			// SearchMulti reports semantic distance; Retrieve must derive the
+			// returned Score from it (Score == 1 - Distance), not pass through.
+			{SearchResult: SearchResult{Chunk: Chunk{ID: "m1"}, Distance: 0.1, Score: 0.0163}},
+		},
+	}
+	emb := &recordingEmbedder{result: EmbedResult{Embeddings: [][]float64{{1, 0}}}}
+	r, err := NewRetrieverWithEmbedder(emb, store)
+	if err != nil {
+		t.Fatalf("NewRetrieverWithEmbedder: %v", err)
+	}
+
+	results, err := r.Retrieve(context.Background(), "myquery", 3)
+	if err != nil {
+		t.Fatalf("Retrieve error: %v", err)
+	}
+	if store.searchMultiCalls != 1 {
+		t.Fatalf("SearchMulti calls = %d, want 1", store.searchMultiCalls)
+	}
+	if store.searchCalls != 0 {
+		t.Fatalf("Search calls = %d, want 0 when SearchMulti is available", store.searchCalls)
+	}
+	if store.gotQuery != "myquery" || store.gotK != 3 {
+		t.Fatalf("SearchMulti got query=%q k=%d, want %q 3", store.gotQuery, store.gotK, "myquery")
+	}
+	if len(results) != 1 || results[0].Chunk.ID != "m1" {
+		t.Fatalf("results = %+v, want one m1", results)
+	}
+	if results[0].Score != 0.9 {
+		t.Fatalf("Score = %v, want 0.9 (1 - Distance), not the raw RRF score", results[0].Score)
+	}
+}
+
+// TestRetrieve_hybridScoreContract drives the real SQLiteStore.SearchMulti and
+// proves the Score field stays a 0..1 similarity consistent with Distance,
+// rather than leaking raw RRF magnitudes (which BuildContext labels as
+// "similarity") into callers.
+func TestRetrieve_hybridScoreContract(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedHybridCorpus(t, store)
+
+	emb := &recordingEmbedder{result: EmbedResult{Embeddings: [][]float64{{1, 0, 0}}}}
+	r, err := NewRetrieverWithEmbedder(emb, store)
+	if err != nil {
+		t.Fatalf("NewRetrieverWithEmbedder: %v", err)
+	}
+
+	results, err := r.Retrieve(ctx, "alpha", 5)
+	if err != nil {
+		t.Fatalf("Retrieve error: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("results empty, want hybrid results")
+	}
+	for _, res := range results {
+		if res.Score < 0 || res.Score > 1 {
+			t.Fatalf("Score = %v for %q, want a 0..1 similarity", res.Score, res.Chunk.ID)
+		}
+		if math.Abs(res.Score-(1-res.Distance)) > 1e-9 {
+			t.Fatalf("Score=%v Distance=%v for %q, want Score == 1 - Distance",
+				res.Score, res.Distance, res.Chunk.ID)
+		}
+	}
+}
+
+// TestRetrieve_readOnlyStore_usesHybrid guards the Golem index path: an
+// immutable read-only store (no migrations) must still serve hybrid retrieval,
+// proving chunks_fts written at index time is queryable read-only.
+func TestRetrieve_readOnlyStore_usesHybrid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "index.db")
+	ctx := context.Background()
+
+	w, err := NewSQLiteStore(path)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	seedHybridCorpus(t, w)
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+
+	ro, err := OpenSQLiteStoreReadOnly(path)
+	if err != nil {
+		t.Fatalf("OpenSQLiteStoreReadOnly: %v", err)
+	}
+	defer func() { _ = ro.Close() }()
+
+	emb := &recordingEmbedder{result: EmbedResult{Embeddings: [][]float64{{1, 0, 0}}}}
+	r, err := NewRetrieverWithEmbedder(emb, ro)
+	if err != nil {
+		t.Fatalf("NewRetrieverWithEmbedder: %v", err)
+	}
+
+	results, err := r.Retrieve(ctx, "alpha", 5)
+	if err != nil {
+		t.Fatalf("read-only hybrid Retrieve error: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("read-only results empty, want hybrid results")
+	}
+}
+
+// TestRetrieve_vectorOnlyOption_usesSearch proves WithVectorOnly bypasses the
+// hybrid path on a store that does support it, falling back to cosine Search.
+func TestRetrieve_vectorOnlyOption_usesSearch(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	seedHybridCorpus(t, store)
+	spy := &countingSQLiteRetrieverStore{SQLiteStore: store}
+
+	emb := &recordingEmbedder{result: EmbedResult{Embeddings: [][]float64{{1, 0, 0}}}}
+	r, err := NewRetrieverWithEmbedder(emb, spy, WithVectorOnly())
+	if err != nil {
+		t.Fatalf("NewRetrieverWithEmbedder: %v", err)
+	}
+
+	results, err := r.Retrieve(ctx, "alpha", 5)
+	if err != nil {
+		t.Fatalf("Retrieve error: %v", err)
+	}
+	if spy.searchCalls != 1 {
+		t.Fatalf("Search calls = %d, want 1 under WithVectorOnly", spy.searchCalls)
+	}
+	if spy.searchMultiCalls != 0 {
+		t.Fatalf("SearchMulti calls = %d, want 0 under WithVectorOnly", spy.searchMultiCalls)
+	}
+	if len(results) == 0 {
+		t.Fatal("results empty, want cosine results")
+	}
+}
+
+// TestRetrieve_searchMultiError_wrapped proves a SearchMulti failure is
+// surfaced (not swallowed) and tagged as the hybrid path.
+func TestRetrieve_searchMultiError_wrapped(t *testing.T) {
+	boom := errors.New("boom")
+	store := &retrieverMultiStore{multiErr: boom}
+	emb := &recordingEmbedder{result: EmbedResult{Embeddings: [][]float64{{1, 0}}}}
+	r, err := NewRetrieverWithEmbedder(emb, store)
+	if err != nil {
+		t.Fatalf("NewRetrieverWithEmbedder: %v", err)
+	}
+
+	_, err = r.Retrieve(context.Background(), "question", 1)
+	if !errors.Is(err, ErrStoreOperation) {
+		t.Fatalf("Retrieve error = %v, want it to wrap ErrStoreOperation", err)
+	}
+	if !errors.Is(err, boom) {
+		t.Fatalf("Retrieve error = %v, want it to wrap the underlying error", err)
+	}
+	if got := err.Error(); !strings.Contains(got, "rag: hybrid search:") {
+		t.Fatalf("Retrieve error = %q, want it to identify the hybrid path", got)
+	}
+}
+
+func TestRetrieve_multiStore_vsidMismatch_skipsSearchMulti(t *testing.T) {
+	store := &retrieverMultiProbingStore{probe: VectorSpaceProbe{KnownIDs: []string{"X"}}}
+	emb := &recordingEmbedder{result: EmbedResult{
+		Embeddings:    [][]float64{{1, 0}},
+		VectorSpaceID: "Y",
+	}}
+	r, err := NewRetrieverWithEmbedder(emb, store)
+	if err != nil {
+		t.Fatalf("NewRetrieverWithEmbedder: %v", err)
+	}
+
+	_, err = r.Retrieve(context.Background(), "question", 1)
+	if !errors.Is(err, ErrVectorSpaceMismatch) {
+		t.Fatalf("Retrieve error = %v, want ErrVectorSpaceMismatch", err)
+	}
+	if store.searchMultiCalls != 0 {
+		t.Fatalf("SearchMulti calls = %d, want 0 on vector-space mismatch", store.searchMultiCalls)
+	}
+}
+
+// seedHybridCorpus stores a small content-bearing corpus (so FTS5 is
+// populated) with orthonormal embeddings for deterministic semantic scores.
+func seedHybridCorpus(t *testing.T, store *SQLiteStore) {
+	t.Helper()
+	chunks := []Chunk{
+		{ID: "c1", Content: "alpha beta gamma", Source: "a.go", StartLine: 1, EndLine: 1, Metadata: map[string]string{}},
+		{ID: "c2", Content: "delta epsilon zeta", Source: "b.go", StartLine: 1, EndLine: 1, Metadata: map[string]string{}},
+		{ID: "c3", Content: "eta theta iota", Source: "c.go", StartLine: 1, EndLine: 1, Metadata: map[string]string{}},
+	}
+	embeddings := [][]float64{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}
+	if err := store.Store(context.Background(), chunks, embeddings); err != nil {
+		t.Fatalf("seed corpus: %v", err)
+	}
+}
+
+// BenchmarkRetrieve measures the default hybrid path against the vector-only
+// fallback on a populated store, documenting the per-query cost of making
+// hybrid the default (#225).
+func BenchmarkRetrieve(b *testing.B) {
+	store, err := NewSQLiteStore(":memory:")
+	if err != nil {
+		b.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const n = 200
+	chunks := make([]Chunk, n)
+	embeddings := make([][]float64, n)
+	for i := range chunks {
+		chunks[i] = Chunk{
+			ID:       "c" + strconv.Itoa(i),
+			Content:  "alpha beta gamma delta token" + strconv.Itoa(i),
+			Source:   "f" + strconv.Itoa(i) + ".go",
+			Metadata: map[string]string{},
+		}
+		embeddings[i] = []float64{float64(i % 7), float64(i % 3), 1}
+	}
+	if err := store.Store(context.Background(), chunks, embeddings); err != nil {
+		b.Fatalf("seed: %v", err)
+	}
+	emb := &recordingEmbedder{result: EmbedResult{Embeddings: [][]float64{{1, 1, 1}}}}
+
+	b.Run("hybrid", func(b *testing.B) {
+		r, _ := NewRetrieverWithEmbedder(emb, store)
+		for i := 0; i < b.N; i++ {
+			if _, err := r.Retrieve(context.Background(), "alpha token", 5); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("vector_only", func(b *testing.B) {
+		r, _ := NewRetrieverWithEmbedder(emb, store, WithVectorOnly())
+		for i := 0; i < b.N; i++ {
+			if _, err := r.Retrieve(context.Background(), "alpha token", 5); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Closes #225.

## What

`rag.Retriever.Retrieve` now uses the store's hybrid `SearchMulti` (semantic + keyword + temporal signals via RRF) when the store implements `MultiSignalSearcher`, instead of the cosine-only `Search`. Stores that don't implement the interface keep the vector-only path. Public signature unchanged; vector-space validation still runs before either search.

All existing callers inherit hybrid retrieval with no schema changes:
- Golem `retrieve` (`agent/tools/retrieve.go`)
- MCP `rag_search` (`mcp/tools_rag.go`)
- MCP chat RAG (`mcp/tools_chat.go`)
- RAG prompts (`mcp/prompts.go`)
- analysis review (`analysis/code_review.go`)

## Score contract

The hybrid path normalizes `SearchResult.Score` to **semantic similarity** (`Score == 1 - Distance`, in `0..1`) so the field means the same thing on both paths — `BuildContext` renders it as "similarity" and callers surface it as a 0..1 value, so it must not carry raw RRF magnitudes. **Hybrid ranking is preserved in result order, not the Score field** (verified no caller re-sorts by Score).

## Opt-out

`WithVectorOnly()` forces the cosine path — escape hatch for an index whose `chunks_fts` is unavailable (e.g. a legacy snapshot opened read-only, which can't be migrated). Confirmed by test that a current `immutable=1` read-only store serves hybrid fine.

## Tests / verification

- `TestRetrieve_hybridScoreContract` — drives the real `SQLiteStore.SearchMulti`, asserts `Score == 1 - Distance ∈ [0,1]`
- `TestRetrieve_readOnlyStore_usesHybrid` — read-only/immutable store serves hybrid (FTS readable)
- `TestRetrieve_vectorOnlyOption_usesSearch` — opt-out routes to `Search`
- `TestRetrieve_searchMultiError_wrapped` — hybrid error surfaced (`ErrStoreOperation`, `rag: hybrid search:`)
- `TestRetrieve_usesSearchMultiWhenAvailable` / `..._multiStore_vsidMismatch_skipsSearchMulti` — path selection + vsid gate
- `BenchmarkRetrieve`: hybrid ~490µs/op vs vector-only ~336µs/op (200-chunk in-memory)

`golangci-lint` clean · `go test -race ./rag` · `go test ./rag ./agent/tools ./mcp ./cmd/golem ./analysis` (1011 pass).

## Out of scope (per issue)

No new scorers, no LLM reranking, no MCP/Golem tool schema changes.

Generated with [Claude Code](https://claude.com/claude-code)