### PR TITLE
feat(mcp): audited rag_answer tool with corpus-absence proof (#229, #230)

### DIFF
--- a/mcp/tools_rag.go
+++ b/mcp/tools_rag.go
@@ -50,6 +50,21 @@ func (s *Server) registerRAGTools() {
 	}, s.handleRAGSearch)
 
 	s.mcpServer.AddTool(&gomcp.Tool{
+		Name:        "rag_answer",
+		Description: "Audited RAG answer: retrieves context, asks the model for an answer with supporting quotes, verifies each quote against retrieved context, and returns machine-readable JSON with a server-derived status.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"question":            map[string]any{"type": "string", "description": "The question to answer from indexed context"},
+				"model":               map[string]any{"type": "string", "description": "Model name (uses configured default if omitted)"},
+				"top_k":               map[string]any{"type": "integer", "description": "Number of chunks to retrieve (default: 5)"},
+				"include_diagnostics": map[string]any{"type": "boolean", "description": "Include retrieval/verification diagnostics in the response"},
+			},
+			"required": []string{"question"},
+		},
+	}, s.handleRAGAnswer)
+
+	s.mcpServer.AddTool(&gomcp.Tool{
 		Name:        "rag_stats",
 		Description: "Get vector store statistics (chunk count, source count, dimensions, storage size).",
 		InputSchema: map[string]any{

--- a/mcp/tools_rag_answer.go
+++ b/mcp/tools_rag_answer.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/kstruzzieri/go-llm/rag"
@@ -22,4 +23,46 @@ func quoteInChunk(chunk rag.Chunk, quote string) bool {
 		return false
 	}
 	return strings.Contains(normalizeWS(chunk.Content), q)
+}
+
+// extractJSONObjects returns every top-level {...} object found in s, in order.
+// It tracks string state and backslash escapes so braces inside JSON strings do
+// not affect nesting depth. Text between objects is ignored. Byte iteration is
+// sufficient because the structural characters are all ASCII.
+func extractJSONObjects(s string) []json.RawMessage {
+	var out []json.RawMessage
+	depth, start := 0, -1
+	inStr, esc := false, false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if inStr {
+			switch {
+			case esc:
+				esc = false
+			case c == '\\':
+				esc = true
+			case c == '"':
+				inStr = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inStr = true
+		case '{':
+			if depth == 0 {
+				start = i
+			}
+			depth++
+		case '}':
+			if depth > 0 {
+				depth--
+				if depth == 0 && start >= 0 {
+					out = append(out, json.RawMessage(s[start:i+1]))
+					start = -1
+				}
+			}
+		}
+	}
+	return out
 }

--- a/mcp/tools_rag_answer.go
+++ b/mcp/tools_rag_answer.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
 	"github.com/kstruzzieri/go-llm/ollama"
 	"github.com/kstruzzieri/go-llm/provider"
 	"github.com/kstruzzieri/go-llm/rag"
@@ -310,4 +312,96 @@ func (s *Server) callForAnswer(ctx context.Context, router routeEngine, model, q
 	}
 	ma, ok := parseModelAnswer(text2)
 	return ma, ok, nil
+}
+
+func (s *Server) handleRAGAnswer(ctx context.Context, req *gomcp.CallToolRequest) (*gomcp.CallToolResult, error) {
+	if r := s.requireRAG(); r != nil {
+		return r, nil
+	}
+	var args struct {
+		Question           string `json:"question"`
+		Model              string `json:"model,omitempty"`
+		TopK               int    `json:"top_k,omitempty"`
+		IncludeDiagnostics bool   `json:"include_diagnostics,omitempty"`
+	}
+	if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+		return toolError("validation", "invalid arguments: %v", err), nil
+	}
+	if args.Question == "" {
+		return toolError("validation", "question must not be empty"), nil
+	}
+	topK := args.TopK
+	if topK <= 0 {
+		topK = 5
+	}
+
+	s.mu.RLock()
+	retriever := s.retriever
+	s.mu.RUnlock()
+	if retriever == nil {
+		return toolError("rag", "retriever unavailable; embedding model may not be resolved"), nil
+	}
+
+	results, err := retriever.Retrieve(ctx, args.Question, topK)
+	if err != nil {
+		return toolError("rag", "retrieve: %v", err), nil
+	}
+
+	var (
+		ma     modelAnswer
+		blocks []evidenceBlock
+		result ragAnswerResult
+	)
+
+	if len(results) == 0 {
+		// No retrieved context: skip the model entirely.
+		result = ragAnswerResult{Status: statusNotInRetrievedContext, Sources: []answerSource{}, Quotes: []answerQuote{}, VerificationErrors: []string{}}
+	} else {
+		var evidenceText string
+		evidenceText, blocks = buildEvidenceBlocks(results, ragContextMaxTokens)
+
+		router := s.routerSnapshot()
+		if router == nil {
+			return toolError("config", "router unavailable"), nil
+		}
+		var parsed bool
+		ma, parsed, err = s.callForAnswer(ctx, router, args.Model, args.Question, evidenceText)
+		if err != nil {
+			return toolError("router", "%v", err), nil
+		}
+		if !parsed {
+			result = ragAnswerResult{Status: statusMalformedOutput, Sources: []answerSource{}, Quotes: []answerQuote{}, VerificationErrors: []string{}}
+		} else {
+			result = deriveAnswer(ma, blocks)
+		}
+	}
+
+	if args.IncludeDiagnostics {
+		result.Diagnostics = buildDiagnostics(ma, blocks, result)
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		return toolError("rag", "marshal result: %v", err), nil
+	}
+	return toolResult(string(data)), nil
+}
+
+// buildDiagnostics assembles the opt-in diagnostics block. Corpus fields are
+// added by the #230 wiring (Task 11).
+func buildDiagnostics(ma modelAnswer, blocks []evidenceBlock, res ragAnswerResult) *answerDiagnostics {
+	d := &answerDiagnostics{}
+	for _, b := range blocks {
+		d.RetrievedChunkIDs = append(d.RetrievedChunkIDs, b.ID)
+	}
+	for _, ev := range ma.Evidence {
+		d.EvidenceIDs = append(d.EvidenceIDs, ev.ID)
+	}
+	for _, q := range res.Quotes {
+		d.VerifiedQuoteIDs = append(d.VerifiedQuoteIDs, q.ID)
+	}
+	if res.Answer == "" && strings.TrimSpace(ma.Answer) != "" {
+		d.CandidateAnswer = ma.Answer
+	}
+	return d
 }

--- a/mcp/tools_rag_answer.go
+++ b/mcp/tools_rag_answer.go
@@ -210,3 +210,24 @@ func deriveAnswer(ma modelAnswer, blocks []evidenceBlock) ragAnswerResult {
 	}
 	return res
 }
+
+// buildEvidenceBlocks assigns stable E1..En labels to the retrieved chunks and
+// formats them for the prompt, honoring a character budget (maxTokens*4, the
+// same chars-per-token ratio BuildContext uses). Lower-ranked blocks are dropped
+// when the budget would be exceeded; a dropped block is omitted from the
+// returned slice so the model cannot cite it. The first block is always kept.
+func buildEvidenceBlocks(results []rag.SearchResult, maxTokens int) (string, []evidenceBlock) {
+	maxChars := maxTokens * 4
+	var b strings.Builder
+	var blocks []evidenceBlock
+	for i, r := range results {
+		id := fmt.Sprintf("E%d", i+1)
+		block := fmt.Sprintf("[%s] %s (lines %d-%d)\n%s\n\n", id, r.Chunk.Source, r.Chunk.StartLine, r.Chunk.EndLine, r.Chunk.Content)
+		if b.Len() > 0 && b.Len()+len(block) > maxChars {
+			break
+		}
+		b.WriteString(block)
+		blocks = append(blocks, evidenceBlock{ID: id, Chunk: r.Chunk})
+	}
+	return strings.TrimRight(b.String(), "\n"), blocks
+}

--- a/mcp/tools_rag_answer.go
+++ b/mcp/tools_rag_answer.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/kstruzzieri/go-llm/rag"
@@ -103,4 +104,109 @@ func parseModelAnswer(text string) (modelAnswer, bool) {
 		best, found = ma, true
 	}
 	return best, found
+}
+
+const (
+	statusAnswerFound           = "answer_found"
+	statusUnverifiedAnswer      = "unverified_answer"
+	statusNotInRetrievedContext = "not_in_retrieved_context"
+	statusMalformedOutput       = "malformed_output"
+	statusRetrievalMiss         = "retrieval_miss"  // #230
+	statusCorpusAbsent          = "corpus_absent"   // #230
+	statusNoUsefulTerms         = "no_useful_terms" // #230
+)
+
+// evidenceBlock pairs a prompt-assigned label (E1..En) with the retrieved chunk
+// it represents, so verification can match a cited quote against the exact chunk.
+type evidenceBlock struct {
+	ID    string
+	Chunk rag.Chunk
+}
+
+type answerSource struct {
+	Source    string `json:"source"`
+	StartLine int    `json:"start_line"`
+	EndLine   int    `json:"end_line"`
+}
+
+type answerQuote struct {
+	ID        string `json:"id"`
+	Source    string `json:"source"`
+	StartLine int    `json:"start_line"`
+	EndLine   int    `json:"end_line"`
+	Text      string `json:"text"`
+}
+
+type answerDiagnostics struct {
+	RetrievedChunkIDs       []string `json:"retrieved_chunk_ids,omitempty"`
+	EvidenceIDs             []string `json:"evidence_ids,omitempty"`
+	VerifiedQuoteIDs        []string `json:"verified_quote_ids,omitempty"`
+	CandidateAnswer         string   `json:"candidate_answer,omitempty"`
+	KeywordTerms            []string `json:"keyword_terms,omitempty"`              // #230
+	CorpusMatchCount        *int     `json:"corpus_match_count,omitempty"`         // #230
+	CorpusOutsideMatchCount *int     `json:"corpus_outside_match_count,omitempty"` // #230
+}
+
+type ragAnswerResult struct {
+	Status             string             `json:"status"`
+	AnswerFound        bool               `json:"answer_found"`
+	Answer             string             `json:"answer"`
+	Sources            []answerSource     `json:"sources"`
+	Quotes             []answerQuote      `json:"quotes"`
+	Verified           bool               `json:"verified"`
+	VerificationErrors []string           `json:"verification_errors"`
+	Diagnostics        *answerDiagnostics `json:"diagnostics,omitempty"`
+}
+
+// deriveAnswer verifies the model's cited evidence against the built blocks and
+// produces the audited result for the #229 status set. A returned status of
+// statusNotInRetrievedContext marks the model-declined branch that #230 refines.
+func deriveAnswer(ma modelAnswer, blocks []evidenceBlock) ragAnswerResult {
+	byID := make(map[string]rag.Chunk, len(blocks))
+	for _, bl := range blocks {
+		byID[bl.ID] = bl.Chunk
+	}
+
+	res := ragAnswerResult{
+		Sources:            []answerSource{},
+		Quotes:             []answerQuote{},
+		VerificationErrors: []string{},
+	}
+
+	if strings.TrimSpace(ma.Answer) == "" {
+		// Model declined; no-answer branch (#230 may refine).
+		res.Status = statusNotInRetrievedContext
+		return res
+	}
+
+	seenSource := make(map[string]bool)
+	for _, ev := range ma.Evidence {
+		chunk, ok := byID[ev.ID]
+		if !ok {
+			res.VerificationErrors = append(res.VerificationErrors, fmt.Sprintf("unknown id %q", ev.ID))
+			continue
+		}
+		if !quoteInChunk(chunk, ev.Quote) {
+			res.VerificationErrors = append(res.VerificationErrors, fmt.Sprintf("quote not found in %s", ev.ID))
+			continue
+		}
+		res.Quotes = append(res.Quotes, answerQuote{
+			ID: ev.ID, Source: chunk.Source, StartLine: chunk.StartLine, EndLine: chunk.EndLine, Text: ev.Quote,
+		})
+		key := fmt.Sprintf("%s:%d-%d", chunk.Source, chunk.StartLine, chunk.EndLine)
+		if !seenSource[key] {
+			seenSource[key] = true
+			res.Sources = append(res.Sources, answerSource{Source: chunk.Source, StartLine: chunk.StartLine, EndLine: chunk.EndLine})
+		}
+	}
+
+	if len(res.Quotes) > 0 {
+		res.Status = statusAnswerFound
+		res.AnswerFound = true
+		res.Verified = true
+		res.Answer = strings.TrimSpace(ma.Answer) // public answer only when verified
+	} else {
+		res.Status = statusUnverifiedAnswer // answer given but unsupported (terminal)
+	}
+	return res
 }

--- a/mcp/tools_rag_answer.go
+++ b/mcp/tools_rag_answer.go
@@ -66,3 +66,41 @@ func extractJSONObjects(s string) []json.RawMessage {
 	}
 	return out
 }
+
+// modelAnswer is the ONLY shape the model is asked to produce. status,
+// answer_found, sources, and verified are server-owned and never requested.
+type modelAnswer struct {
+	Answer   string          `json:"answer"`
+	Evidence []modelEvidence `json:"evidence"`
+}
+
+type modelEvidence struct {
+	ID    string `json:"id"`    // short prompt-assigned label E1..En, not the SHA chunk ID
+	Quote string `json:"quote"` // span the model claims to have copied verbatim
+}
+
+// parseModelAnswer returns the LAST extracted JSON object that decodes into a
+// modelAnswer carrying at least an "answer" or "evidence" key. Local models
+// sometimes emit example/scaffolding JSON before the real answer, so the final
+// valid object is the answer attempt.
+func parseModelAnswer(text string) (modelAnswer, bool) {
+	var best modelAnswer
+	found := false
+	for _, raw := range extractJSONObjects(text) {
+		var keys map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &keys); err != nil {
+			continue
+		}
+		_, hasAnswer := keys["answer"]
+		_, hasEvidence := keys["evidence"]
+		if !hasAnswer && !hasEvidence {
+			continue
+		}
+		var ma modelAnswer
+		if err := json.Unmarshal(raw, &ma); err != nil {
+			continue
+		}
+		best, found = ma, true
+	}
+	return best, found
+}

--- a/mcp/tools_rag_answer.go
+++ b/mcp/tools_rag_answer.go
@@ -337,6 +337,7 @@ func (s *Server) handleRAGAnswer(ctx context.Context, req *gomcp.CallToolRequest
 
 	s.mu.RLock()
 	retriever := s.retriever
+	store := s.store
 	s.mu.RUnlock()
 	if retriever == nil {
 		return toolError("rag", "retriever unavailable; embedding model may not be resolved"), nil
@@ -376,8 +377,26 @@ func (s *Server) handleRAGAnswer(ctx context.Context, req *gomcp.CallToolRequest
 		}
 	}
 
+	var (
+		cp        rag.CorpusPresence
+		corpusRan bool
+	)
+	if result.Status == statusNotInRetrievedContext && store != nil {
+		retrievedIDs := make([]string, 0, len(results))
+		for _, r := range results {
+			retrievedIDs = append(retrievedIDs, r.Chunk.ID)
+		}
+		result, cp, corpusRan = s.refineWithCorpus(ctx, store, args.Question, retrievedIDs, result)
+	}
+
 	if args.IncludeDiagnostics {
 		result.Diagnostics = buildDiagnostics(ma, blocks, result)
+		if corpusRan {
+			total, outside := cp.TotalMatches, cp.OutsideMatches
+			result.Diagnostics.KeywordTerms = cp.Terms
+			result.Diagnostics.CorpusMatchCount = &total
+			result.Diagnostics.CorpusOutsideMatchCount = &outside
+		}
 	}
 
 	data, err := json.Marshal(result)
@@ -385,6 +404,39 @@ func (s *Server) handleRAGAnswer(ctx context.Context, req *gomcp.CallToolRequest
 		return toolError("rag", "marshal result: %v", err), nil
 	}
 	return toolResult(string(data)), nil
+}
+
+// corpusKeywordSearcher is the subset of the vector store the corpus-absence
+// check needs. Defined at the consumer (Go idiom); SQLiteStore implements it.
+type corpusKeywordSearcher interface {
+	KeywordPresence(ctx context.Context, query string, retrievedIDs []string) (rag.CorpusPresence, error)
+}
+
+// refineWithCorpus deepens the model-declined branch using a deterministic
+// keyword check. It returns the refined result and the corpus presence (and
+// whether the check ran) for diagnostics. On any error or unsupported store it
+// fails open: the status stays not_in_retrieved_context.
+func (s *Server) refineWithCorpus(ctx context.Context, store rag.VectorStore, question string, retrievedIDs []string, res ragAnswerResult) (ragAnswerResult, rag.CorpusPresence, bool) {
+	searcher, ok := store.(corpusKeywordSearcher)
+	if !ok {
+		return res, rag.CorpusPresence{}, false
+	}
+	cp, err := searcher.KeywordPresence(ctx, question, retrievedIDs)
+	if err != nil {
+		return res, rag.CorpusPresence{}, false // fail open
+	}
+	switch {
+	case len(cp.Terms) == 0:
+		res.Status = statusNoUsefulTerms
+	case cp.OutsideMatches > 0:
+		res.Status = statusRetrievalMiss
+	case cp.TotalMatches == 0:
+		res.Status = statusCorpusAbsent
+	default:
+		// Matches exist only inside the retrieved set, yet the model declined:
+		// not a retrieval miss. Leave status as not_in_retrieved_context.
+	}
+	return res, cp, true
 }
 
 // buildDiagnostics assembles the opt-in diagnostics block. Corpus fields are

--- a/mcp/tools_rag_answer.go
+++ b/mcp/tools_rag_answer.go
@@ -1,10 +1,13 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
 
+	"github.com/kstruzzieri/go-llm/ollama"
+	"github.com/kstruzzieri/go-llm/provider"
 	"github.com/kstruzzieri/go-llm/rag"
 )
 
@@ -230,4 +233,81 @@ func buildEvidenceBlocks(results []rag.SearchResult, maxTokens int) (string, []e
 		blocks = append(blocks, evidenceBlock{ID: id, Chunk: r.Chunk})
 	}
 	return strings.TrimRight(b.String(), "\n"), blocks
+}
+
+// buildAnswerPrompt produces the audited-answer chat messages. It describes the
+// required JSON as a FIELD LIST, not a valid JSON example object, so a model
+// that echoes the instructions cannot itself satisfy the parser.
+func buildAnswerPrompt(question, evidence string) []ollama.ChatMessage {
+	system := "You are an audited code question-answering assistant. " +
+		"Answer ONLY from the numbered evidence blocks below. " +
+		"Reply with a single JSON object and nothing else, containing exactly these fields:\n" +
+		"- answer: a string. Use the empty string if the evidence does not answer the question.\n" +
+		"- evidence: a list of items, each with id (the E-label of the block you used) and " +
+		"quote (text copied verbatim from that block).\n" +
+		"Do not invent ids or quotes. Copy each quote exactly from the block you cite."
+	user := fmt.Sprintf("Question: %s\n\nEvidence:\n%s", question, evidence)
+	return []ollama.ChatMessage{
+		{Role: "system", Content: system},
+		{Role: "user", Content: user},
+	}
+}
+
+// routeChat executes one chat round via the router at temperature 0 and returns
+// the response text. Mirrors the routing in handleChat (tools_chat.go).
+func (s *Server) routeChat(ctx context.Context, router routeEngine, model string, msgs []ollama.ChatMessage) (string, error) {
+	zero := 0.0
+	resolved, err := s.routeModelSelector(ctx, model, "chat")
+	if err != nil {
+		return "", err
+	}
+	rr := provider.RoutingRequest{
+		Model:          resolved,
+		UseCase:        "chat",
+		RequiredCaps:   provider.CapChat,
+		Messages:       toProviderChatMessages(msgs),
+		Options:        provider.ModelOptions{Temperature: &zero},
+		ExpectedOutput: provider.DefaultExpectedOutput("chat"),
+		Priority:       provider.PriorityNormal,
+	}
+	if rr.Model == "" {
+		chain, cerr := s.chainFor("chat")
+		if cerr != nil {
+			return "", cerr
+		}
+		rr.PreferredChain = chain
+	}
+	plan, err := router.Route(ctx, rr)
+	if err != nil {
+		return "", err
+	}
+	resp, err := plan.ExecuteChat(ctx)
+	if err != nil {
+		return "", err
+	}
+	return resp.Content, nil
+}
+
+// callForAnswer runs the audited-answer model call with one repair retry when
+// the first reply does not parse. Returns the parsed answer and whether parsing
+// ultimately succeeded.
+func (s *Server) callForAnswer(ctx context.Context, router routeEngine, model, question, evidence string) (modelAnswer, bool, error) {
+	msgs := buildAnswerPrompt(question, evidence)
+	text, err := s.routeChat(ctx, router, model, msgs)
+	if err != nil {
+		return modelAnswer{}, false, err
+	}
+	if ma, ok := parseModelAnswer(text); ok {
+		return ma, true, nil
+	}
+	repair := append(msgs,
+		ollama.ChatMessage{Role: "assistant", Content: text},
+		ollama.ChatMessage{Role: "user", Content: "Your previous reply was not valid JSON. Return ONLY a single valid JSON object with fields answer and evidence, and nothing else."},
+	)
+	text2, err := s.routeChat(ctx, router, model, repair)
+	if err != nil {
+		return modelAnswer{}, false, err
+	}
+	ma, ok := parseModelAnswer(text2)
+	return ma, ok, nil
 }

--- a/mcp/tools_rag_answer.go
+++ b/mcp/tools_rag_answer.go
@@ -23,6 +23,12 @@ func normalizeWS(s string) string {
 // conservative whitespace normalization. Case-sensitive (code is). Matches
 // against rag.Chunk.Content, never BuildContext output: BuildContext prefixes
 // each line with "<n>| " (PR #227 line anchors), which would corrupt matching.
+//
+// Verification is literal substring presence, with no minimum-meaningfulness
+// floor: a trivially short cited quote (e.g. "1") can satisfy it. A length
+// threshold is intentionally omitted because it would false-negative legitimate
+// short identifiers, and the model is the server's own prompt-controlled local
+// model rather than an adversary.
 func quoteInChunk(chunk rag.Chunk, quote string) bool {
 	q := normalizeWS(quote)
 	if q == "" {

--- a/mcp/tools_rag_answer.go
+++ b/mcp/tools_rag_answer.go
@@ -1,0 +1,25 @@
+package mcp
+
+import (
+	"strings"
+
+	"github.com/kstruzzieri/go-llm/rag"
+)
+
+// normalizeWS collapses internal whitespace runs to single spaces and trims
+// both ends. strings.Fields splits on any Unicode whitespace and drops empties.
+func normalizeWS(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// quoteInChunk reports whether quote appears in the chunk's raw content after
+// conservative whitespace normalization. Case-sensitive (code is). Matches
+// against rag.Chunk.Content, never BuildContext output: BuildContext prefixes
+// each line with "<n>| " (PR #227 line anchors), which would corrupt matching.
+func quoteInChunk(chunk rag.Chunk, quote string) bool {
+	q := normalizeWS(quote)
+	if q == "" {
+		return false
+	}
+	return strings.Contains(normalizeWS(chunk.Content), q)
+}

--- a/mcp/tools_rag_answer.go
+++ b/mcp/tools_rag_answer.go
@@ -450,7 +450,7 @@ func (s *Server) refineWithCorpus(ctx context.Context, store rag.VectorStore, qu
 func buildDiagnostics(ma modelAnswer, blocks []evidenceBlock, res ragAnswerResult) *answerDiagnostics {
 	d := &answerDiagnostics{}
 	for _, b := range blocks {
-		d.RetrievedChunkIDs = append(d.RetrievedChunkIDs, b.ID)
+		d.RetrievedChunkIDs = append(d.RetrievedChunkIDs, b.Chunk.ID)
 	}
 	for _, ev := range ma.Evidence {
 		d.EvidenceIDs = append(d.EvidenceIDs, ev.ID)

--- a/mcp/tools_rag_answer_test.go
+++ b/mcp/tools_rag_answer_test.go
@@ -1,0 +1,31 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/rag"
+)
+
+func TestQuoteInChunk(t *testing.T) {
+	chunk := rag.Chunk{Content: "func BuildContext(results []SearchResult)  {\n\treturn x\n}"}
+	tests := []struct {
+		name  string
+		quote string
+		want  bool
+	}{
+		{"exact", "func BuildContext(results []SearchResult)", true},
+		{"whitespace reflow", "func BuildContext(results []SearchResult) {", true}, // double space collapsed
+		{"newline reflow", "[]SearchResult) { return x }", true},
+		{"case mismatch", "func buildcontext", false},
+		{"absent", "func NeverHere()", false},
+		{"empty quote", "", false},
+		{"line-anchor prefix not present", "42| func BuildContext", false}, // verify vs raw Content, not BuildContext output
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := quoteInChunk(chunk, tc.quote); got != tc.want {
+				t.Errorf("quoteInChunk(%q) = %v, want %v", tc.quote, got, tc.want)
+			}
+		})
+	}
+}

--- a/mcp/tools_rag_answer_test.go
+++ b/mcp/tools_rag_answer_test.go
@@ -85,3 +85,59 @@ func TestParseModelAnswer(t *testing.T) {
 		}
 	})
 }
+
+func TestDeriveAnswer(t *testing.T) {
+	blocks := []evidenceBlock{
+		{ID: "E1", Chunk: rag.Chunk{Content: "func Foo() int { return 1 }", Source: "a.go", StartLine: 10, EndLine: 12}},
+		{ID: "E2", Chunk: rag.Chunk{Content: "var Bar = 2", Source: "b.go", StartLine: 3, EndLine: 3}},
+	}
+
+	t.Run("verified -> answer_found", func(t *testing.T) {
+		ma := modelAnswer{Answer: "Foo returns 1", Evidence: []modelEvidence{{ID: "E1", Quote: "return 1"}}}
+		got := deriveAnswer(ma, blocks)
+		if got.Status != statusAnswerFound || !got.AnswerFound || !got.Verified {
+			t.Fatalf("status=%s found=%v verified=%v", got.Status, got.AnswerFound, got.Verified)
+		}
+		if got.Answer != "Foo returns 1" {
+			t.Errorf("answer = %q, want populated", got.Answer)
+		}
+		if len(got.Sources) != 1 || got.Sources[0].Source != "a.go" || got.Sources[0].StartLine != 10 {
+			t.Errorf("sources = %+v", got.Sources)
+		}
+		if len(got.Quotes) != 1 || got.Quotes[0].ID != "E1" {
+			t.Errorf("quotes = %+v", got.Quotes)
+		}
+	})
+
+	t.Run("invented quote -> unverified, answer suppressed", func(t *testing.T) {
+		ma := modelAnswer{Answer: "Foo returns 99", Evidence: []modelEvidence{{ID: "E1", Quote: "return 99"}}}
+		got := deriveAnswer(ma, blocks)
+		if got.Status != statusUnverifiedAnswer || got.AnswerFound || got.Verified {
+			t.Fatalf("status=%s found=%v", got.Status, got.AnswerFound)
+		}
+		if got.Answer != "" {
+			t.Errorf("answer = %q, want empty (suppressed)", got.Answer)
+		}
+		if len(got.VerificationErrors) != 1 {
+			t.Errorf("verification_errors = %v", got.VerificationErrors)
+		}
+	})
+
+	t.Run("unknown id -> unverified with error", func(t *testing.T) {
+		ma := modelAnswer{Answer: "x", Evidence: []modelEvidence{{ID: "E9", Quote: "return 1"}}}
+		got := deriveAnswer(ma, blocks)
+		if got.Status != statusUnverifiedAnswer {
+			t.Fatalf("status=%s", got.Status)
+		}
+		if len(got.VerificationErrors) != 1 {
+			t.Errorf("verification_errors = %v", got.VerificationErrors)
+		}
+	})
+
+	t.Run("empty answer -> not_in_retrieved_context", func(t *testing.T) {
+		got := deriveAnswer(modelAnswer{Answer: "  "}, blocks)
+		if got.Status != statusNotInRetrievedContext || got.AnswerFound {
+			t.Fatalf("status=%s found=%v", got.Status, got.AnswerFound)
+		}
+	})
+}

--- a/mcp/tools_rag_answer_test.go
+++ b/mcp/tools_rag_answer_test.go
@@ -2,8 +2,11 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
+
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/kstruzzieri/go-llm/config"
 	"github.com/kstruzzieri/go-llm/provider"
@@ -270,4 +273,128 @@ func TestCallForAnswer_RepairRetry(t *testing.T) {
 			t.Errorf("calls = %d, want 2", eng.calls)
 		}
 	})
+}
+
+func TestHandleRAGAnswer(t *testing.T) {
+	good := `{"answer":"computeFoo returns 1","evidence":[{"id":"E1","quote":"return 1"}]}`
+
+	t.Run("answer_found", func(t *testing.T) {
+		s := answerEnv(t, &queuedRouteEngine{responses: []string{good}})
+		res := callAnswer(t, s, `{"question":"what does computeFoo return?"}`)
+		if res.Status != statusAnswerFound || !res.AnswerFound || res.Answer == "" {
+			t.Fatalf("res = %+v", res)
+		}
+	})
+
+	t.Run("unverified answer suppresses public answer", func(t *testing.T) {
+		bad := `{"answer":"Foo returns 7","evidence":[{"id":"E1","quote":"return 7"}]}`
+		s := answerEnv(t, &queuedRouteEngine{responses: []string{bad}})
+		res := callAnswer(t, s, `{"question":"q","include_diagnostics":true}`)
+		if res.Status != statusUnverifiedAnswer || res.Answer != "" {
+			t.Fatalf("res = %+v", res)
+		}
+		if res.Diagnostics == nil || res.Diagnostics.CandidateAnswer == "" {
+			t.Errorf("candidate answer should be in diagnostics: %+v", res.Diagnostics)
+		}
+	})
+
+	t.Run("model declines -> not_in_retrieved_context", func(t *testing.T) {
+		s := answerEnv(t, &queuedRouteEngine{responses: []string{`{"answer":"","evidence":[]}`}})
+		res := callAnswer(t, s, `{"question":"unrelated?"}`)
+		if res.Status != statusNotInRetrievedContext {
+			t.Fatalf("status = %s", res.Status)
+		}
+	})
+
+	t.Run("malformed twice -> malformed_output", func(t *testing.T) {
+		s := answerEnv(t, &queuedRouteEngine{responses: []string{"no", "still no"}})
+		res := callAnswer(t, s, `{"question":"q"}`)
+		if res.Status != statusMalformedOutput {
+			t.Fatalf("status = %s", res.Status)
+		}
+	})
+
+	t.Run("zero retrieved chunks skips model", func(t *testing.T) {
+		eng := &queuedRouteEngine{responses: []string{good}}
+		s := answerEnvWithStore(t, eng, &answerStore{})
+		res := callAnswer(t, s, `{"question":"q"}`)
+		if res.Status != statusNotInRetrievedContext {
+			t.Fatalf("status = %s, want not_in_retrieved_context", res.Status)
+		}
+		if eng.calls != 0 {
+			t.Fatalf("model calls = %d, want 0", eng.calls)
+		}
+	})
+
+	t.Run("missing question -> validation error", func(t *testing.T) {
+		s := answerEnv(t, &queuedRouteEngine{responses: []string{good}})
+		out, err := s.handleRAGAnswer(context.Background(), rawArgs(t, `{}`))
+		if err != nil || out == nil || !out.IsError {
+			t.Fatalf("expected validation error result, got out=%v err=%v", out, err)
+		}
+	})
+}
+
+// callAnswer invokes the handler and unmarshals the JSON tool result.
+func callAnswer(t *testing.T, s *Server, args string) ragAnswerResult {
+	t.Helper()
+	out, err := s.handleRAGAnswer(context.Background(), rawArgs(t, args))
+	if err != nil {
+		t.Fatalf("handler err: %v", err)
+	}
+	if out.IsError {
+		t.Fatalf("unexpected tool error: %s", extractText(out))
+	}
+	var res ragAnswerResult
+	if uerr := json.Unmarshal([]byte(extractText(out)), &res); uerr != nil {
+		t.Fatalf("unmarshal result: %v (%s)", uerr, extractText(out))
+	}
+	return res
+}
+
+// rawArgs wraps a JSON arguments string in a CallToolRequest.
+func rawArgs(t *testing.T, args string) *gomcp.CallToolRequest {
+	t.Helper()
+	return &gomcp.CallToolRequest{Params: &gomcp.CallToolParamsRaw{Arguments: json.RawMessage(args)}}
+}
+
+type answerStore struct {
+	results []rag.SearchResult
+}
+
+func (s *answerStore) Store(context.Context, []rag.Chunk, [][]float64) error { return nil }
+
+func (s *answerStore) Search(_ context.Context, _ []float64, k int) ([]rag.SearchResult, error) {
+	if k > 0 && len(s.results) > k {
+		return s.results[:k], nil
+	}
+	return s.results, nil
+}
+
+func (s *answerStore) DeleteBySource(context.Context, string) error  { return nil }
+func (s *answerStore) Stats(context.Context) (rag.StoreStats, error) { return rag.StoreStats{}, nil }
+func (s *answerStore) Close() error                                  { return nil }
+
+func answerEnv(t *testing.T, eng routeEngine) *Server {
+	t.Helper()
+	chunk := rag.Chunk{
+		ID: "c1", Source: "a.go", StartLine: 10, EndLine: 12,
+		Content: "func computeFoo() int { return 1 }",
+	}
+	store := &answerStore{results: []rag.SearchResult{{Chunk: chunk, Score: 1}}}
+	return answerEnvWithStore(t, eng, store)
+}
+
+func answerEnvWithStore(t *testing.T, eng routeEngine, store rag.VectorStore) *Server {
+	t.Helper()
+	ret, err := rag.NewRetrieverWithEmbedder(rag.EmbedderFunc(func(context.Context, string, []string) (rag.EmbedResult, error) {
+		return rag.EmbedResult{Embeddings: [][]float64{{1}}}, nil
+	}), store)
+	if err != nil {
+		t.Fatalf("NewRetrieverWithEmbedder: %v", err)
+	}
+	s := newAnswerTestServer(t, eng)
+	s.store = store
+	s.retriever = ret
+	return s
 }

--- a/mcp/tools_rag_answer_test.go
+++ b/mcp/tools_rag_answer_test.go
@@ -29,3 +29,32 @@ func TestQuoteInChunk(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractJSONObjects(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"plain", `{"a":1}`, []string{`{"a":1}`}},
+		{"prose around", "sure:\n{\"a\":1}\nthanks", []string{`{"a":1}`}},
+		{"two objects", `{"a":1} then {"b":2}`, []string{`{"a":1}`, `{"b":2}`}},
+		{"nested", `{"a":{"b":2}}`, []string{`{"a":{"b":2}}`}},
+		{"brace in string", `{"a":"}{"}`, []string{`{"a":"}{"}`}},
+		{"escaped quote in string", `{"a":"x\"}"}`, []string{`{"a":"x\"}"}`}},
+		{"none", `no json here`, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractJSONObjects(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d objects %v, want %d %v", len(got), got, len(tc.want), tc.want)
+			}
+			for i := range got {
+				if string(got[i]) != tc.want[i] {
+					t.Errorf("obj[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/mcp/tools_rag_answer_test.go
+++ b/mcp/tools_rag_answer_test.go
@@ -1,9 +1,12 @@
 package mcp
 
 import (
+	"context"
 	"strings"
 	"testing"
 
+	"github.com/kstruzzieri/go-llm/config"
+	"github.com/kstruzzieri/go-llm/provider"
 	"github.com/kstruzzieri/go-llm/rag"
 )
 
@@ -168,6 +171,103 @@ func TestBuildEvidenceBlocks(t *testing.T) {
 		}
 		if strings.Contains(text, "E2") {
 			t.Errorf("E2 should have been dropped:\n%s", text)
+		}
+	})
+}
+
+// queuedRouteEngine returns successive chat contents on each Route call, so a
+// test can drive the repair retry (call 1 malformed, call 2 valid). Each
+// rag_answer model turn performs exactly one Route+ExecuteChat. Modeled on
+// recordingRouteEngine / fakeRouteProvider in mcp/router_seam_test.go.
+type queuedRouteEngine struct {
+	responses []string
+	calls     int
+}
+
+func (e *queuedRouteEngine) Route(ctx context.Context, req provider.RoutingRequest) (*provider.RoutePlan, error) {
+	content := ""
+	if e.calls < len(e.responses) {
+		content = e.responses[e.calls]
+	}
+	e.calls++
+	model := req.Model
+	if model == "" && len(req.PreferredChain) > 0 {
+		model = req.PreferredChain[0]
+	}
+	prov := &fakeRouteProvider{name: "fake", chatContent: content}
+	return &provider.RoutePlan{
+		Provider: prov,
+		Model:    model,
+		Profile: &provider.ModelProfile{
+			Key:           provider.ModelKey{Provider: "fake", Model: model},
+			Caps:          provider.CapChat | provider.CapGenerate | provider.CapEmbed | provider.CapStream,
+			ContextWindow: 8192,
+		},
+		Request: req,
+		Budget:  provider.BudgetResult{Decision: provider.BudgetOK},
+	}, nil
+}
+
+func (e *queuedRouteEngine) Close() error { return nil }
+func (e *queuedRouteEngine) BreakerInfo(string) (provider.BreakerInfo, bool) {
+	return provider.BreakerInfo{}, false
+}
+func (e *queuedRouteEngine) WarmthSnapshot() []provider.WarmModel              { return nil }
+func (e *queuedRouteEngine) StickyRoutes() map[string]provider.StickyRouteInfo { return nil }
+
+func newAnswerTestServer(t *testing.T, router routeEngine) *Server {
+	t.Helper()
+	if router == nil {
+		router = &queuedRouteEngine{}
+	}
+	return &Server{
+		cfg: &config.Config{
+			Defaults: map[string]string{"chat": "primary"},
+			Models: map[string]config.ModelConfig{
+				"primary": {Name: "qwen3:8b", Provider: "ollama"},
+			},
+		},
+		router: router,
+	}
+}
+
+func TestCallForAnswer_RepairRetry(t *testing.T) {
+	s := newAnswerTestServer(t, nil)
+	good := `{"answer":"ok","evidence":[]}`
+
+	t.Run("first valid, no retry", func(t *testing.T) {
+		eng := &queuedRouteEngine{responses: []string{good}}
+		ma, ok, err := s.callForAnswer(context.Background(), eng, "", "q", "E1...")
+		if err != nil || !ok || ma.Answer != "ok" {
+			t.Fatalf("ma=%+v ok=%v err=%v", ma, ok, err)
+		}
+		if eng.calls != 1 {
+			t.Errorf("calls = %d, want 1", eng.calls)
+		}
+	})
+
+	t.Run("malformed then valid", func(t *testing.T) {
+		eng := &queuedRouteEngine{responses: []string{"not json", good}}
+		ma, ok, err := s.callForAnswer(context.Background(), eng, "", "q", "E1...")
+		if err != nil || !ok || ma.Answer != "ok" {
+			t.Fatalf("ma=%+v ok=%v err=%v", ma, ok, err)
+		}
+		if eng.calls != 2 {
+			t.Errorf("calls = %d, want 2 (one repair)", eng.calls)
+		}
+	})
+
+	t.Run("malformed twice -> not ok", func(t *testing.T) {
+		eng := &queuedRouteEngine{responses: []string{"nope", "still nope"}}
+		_, ok, err := s.callForAnswer(context.Background(), eng, "", "q", "E1...")
+		if err != nil {
+			t.Fatalf("err = %v", err)
+		}
+		if ok {
+			t.Fatal("expected ok=false after failed repair")
+		}
+		if eng.calls != 2 {
+			t.Errorf("calls = %d, want 2", eng.calls)
 		}
 	})
 }

--- a/mcp/tools_rag_answer_test.go
+++ b/mcp/tools_rag_answer_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/kstruzzieri/go-llm/rag"
@@ -138,6 +139,35 @@ func TestDeriveAnswer(t *testing.T) {
 		got := deriveAnswer(modelAnswer{Answer: "  "}, blocks)
 		if got.Status != statusNotInRetrievedContext || got.AnswerFound {
 			t.Fatalf("status=%s found=%v", got.Status, got.AnswerFound)
+		}
+	})
+}
+
+func TestBuildEvidenceBlocks(t *testing.T) {
+	results := []rag.SearchResult{
+		{Chunk: rag.Chunk{Source: "a.go", StartLine: 1, EndLine: 1, Content: "alpha"}},
+		{Chunk: rag.Chunk{Source: "b.go", StartLine: 2, EndLine: 2, Content: "beta"}},
+	}
+	t.Run("labels and format", func(t *testing.T) {
+		text, blocks := buildEvidenceBlocks(results, 4096)
+		if len(blocks) != 2 || blocks[0].ID != "E1" || blocks[1].ID != "E2" {
+			t.Fatalf("blocks = %+v", blocks)
+		}
+		if !strings.Contains(text, "[E1] a.go (lines 1-1)") || !strings.Contains(text, "alpha") {
+			t.Errorf("text missing E1 block:\n%s", text)
+		}
+		if !strings.Contains(text, "[E2] b.go (lines 2-2)") {
+			t.Errorf("text missing E2 block:\n%s", text)
+		}
+	})
+	t.Run("budget drops tail but keeps first", func(t *testing.T) {
+		// maxTokens=1 -> maxChars=4, far smaller than one block; first still included.
+		text, blocks := buildEvidenceBlocks(results, 1)
+		if len(blocks) != 1 || blocks[0].ID != "E1" {
+			t.Fatalf("blocks = %+v", blocks)
+		}
+		if strings.Contains(text, "E2") {
+			t.Errorf("E2 should have been dropped:\n%s", text)
 		}
 	})
 }

--- a/mcp/tools_rag_answer_test.go
+++ b/mcp/tools_rag_answer_test.go
@@ -58,3 +58,30 @@ func TestExtractJSONObjects(t *testing.T) {
 		})
 	}
 }
+
+func TestParseModelAnswer(t *testing.T) {
+	t.Run("single valid", func(t *testing.T) {
+		ma, ok := parseModelAnswer(`{"answer":"yes","evidence":[{"id":"E1","quote":"q"}]}`)
+		if !ok || ma.Answer != "yes" || len(ma.Evidence) != 1 || ma.Evidence[0].ID != "E1" {
+			t.Fatalf("got %+v ok=%v", ma, ok)
+		}
+	})
+	t.Run("echo then real picks last", func(t *testing.T) {
+		in := `Here is the format {"answer":"","evidence":[]} and my answer: {"answer":"real","evidence":[]}`
+		ma, ok := parseModelAnswer(in)
+		if !ok || ma.Answer != "real" {
+			t.Fatalf("got %+v ok=%v, want answer=real", ma, ok)
+		}
+	})
+	t.Run("object without answer or evidence skipped", func(t *testing.T) {
+		ma, ok := parseModelAnswer(`{"foo":1} {"answer":"x"}`)
+		if !ok || ma.Answer != "x" {
+			t.Fatalf("got %+v ok=%v", ma, ok)
+		}
+	})
+	t.Run("no valid object", func(t *testing.T) {
+		if _, ok := parseModelAnswer(`no json {nope}`); ok {
+			t.Fatal("expected ok=false")
+		}
+	})
+}

--- a/mcp/tools_rag_answer_test.go
+++ b/mcp/tools_rag_answer_test.go
@@ -375,6 +375,128 @@ func (s *answerStore) DeleteBySource(context.Context, string) error  { return ni
 func (s *answerStore) Stats(context.Context) (rag.StoreStats, error) { return rag.StoreStats{}, nil }
 func (s *answerStore) Close() error                                  { return nil }
 
+type corpusOnlyStore struct {
+	*answerStore
+	presence     rag.CorpusPresence
+	err          error
+	gotQuestion  string
+	gotRetrieved []string
+}
+
+func (s *corpusOnlyStore) KeywordPresence(_ context.Context, question string, retrievedIDs []string) (rag.CorpusPresence, error) {
+	s.gotQuestion = question
+	s.gotRetrieved = append([]string(nil), retrievedIDs...)
+	return s.presence, s.err
+}
+
+func TestRefineWithCorpus(t *testing.T) {
+	base := ragAnswerResult{Status: statusNotInRetrievedContext}
+	tests := []struct {
+		name       string
+		store      rag.VectorStore
+		wantStatus string
+		wantRan    bool
+	}{
+		{
+			name:       "unsupported store leaves status",
+			store:      &answerStore{},
+			wantStatus: statusNotInRetrievedContext,
+			wantRan:    false,
+		},
+		{
+			name: "keyword error leaves status",
+			store: &corpusOnlyStore{
+				answerStore: &answerStore{},
+				err:         context.Canceled,
+			},
+			wantStatus: statusNotInRetrievedContext,
+			wantRan:    false,
+		},
+		{
+			name: "no useful terms",
+			store: &corpusOnlyStore{
+				answerStore: &answerStore{},
+				presence:    rag.CorpusPresence{},
+			},
+			wantStatus: statusNoUsefulTerms,
+			wantRan:    true,
+		},
+		{
+			name: "outside matches -> retrieval_miss",
+			store: &corpusOnlyStore{
+				answerStore: &answerStore{},
+				presence: rag.CorpusPresence{
+					Terms: []string{"RareSymbolZ"}, TotalMatches: 2, OutsideMatches: 1,
+				},
+			},
+			wantStatus: statusRetrievalMiss,
+			wantRan:    true,
+		},
+		{
+			name: "absent -> corpus_absent",
+			store: &corpusOnlyStore{
+				answerStore: &answerStore{},
+				presence: rag.CorpusPresence{
+					Terms: []string{"MissingSymbol"}, TotalMatches: 0, OutsideMatches: 0,
+				},
+			},
+			wantStatus: statusCorpusAbsent,
+			wantRan:    true,
+		},
+		{
+			name: "inside-only stays not_in_retrieved_context",
+			store: &corpusOnlyStore{
+				answerStore: &answerStore{},
+				presence: rag.CorpusPresence{
+					Terms: []string{"computeFoo"}, TotalMatches: 1, OutsideMatches: 0,
+				},
+			},
+			wantStatus: statusNotInRetrievedContext,
+			wantRan:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Server{}
+			got, _, ran := s.refineWithCorpus(context.Background(), tt.store, "where is RareSymbolZ", []string{"c1"}, base)
+			if got.Status != tt.wantStatus || ran != tt.wantRan {
+				t.Fatalf("status=%s ran=%v, want status=%s ran=%v", got.Status, ran, tt.wantStatus, tt.wantRan)
+			}
+		})
+	}
+}
+
+func TestHandleRAGAnswer_CorpusDiagnostics(t *testing.T) {
+	decline := `{"answer":"","evidence":[]}`
+	chunk := rag.Chunk{
+		ID: "c1", Source: "a.go", StartLine: 10, EndLine: 12,
+		Content: "func computeFoo() int { return 1 }",
+	}
+	store := &corpusOnlyStore{
+		answerStore: &answerStore{results: []rag.SearchResult{{Chunk: chunk, Score: 1}}},
+		presence: rag.CorpusPresence{
+			Terms: []string{"computeFoo"}, TotalMatches: 1, OutsideMatches: 0,
+		},
+	}
+	s := answerEnvWithStore(t, &queuedRouteEngine{responses: []string{decline}}, store)
+	res := callAnswer(t, s, `{"question":"where is computeFoo","include_diagnostics":true}`)
+	if res.Status != statusNotInRetrievedContext {
+		t.Fatalf("status = %s, want not_in_retrieved_context", res.Status)
+	}
+	if res.Diagnostics == nil || res.Diagnostics.CorpusMatchCount == nil || *res.Diagnostics.CorpusMatchCount != 1 {
+		t.Fatalf("diagnostics = %+v, want corpus match count 1", res.Diagnostics)
+	}
+	if res.Diagnostics.CorpusOutsideMatchCount == nil || *res.Diagnostics.CorpusOutsideMatchCount != 0 {
+		t.Fatalf("diagnostics = %+v, want outside match count 0", res.Diagnostics)
+	}
+	if store.gotQuestion != "where is computeFoo" {
+		t.Fatalf("question = %q", store.gotQuestion)
+	}
+	if len(store.gotRetrieved) != 1 || store.gotRetrieved[0] != "c1" {
+		t.Fatalf("retrieved IDs = %v, want [c1]", store.gotRetrieved)
+	}
+}
+
 func answerEnv(t *testing.T, eng routeEngine) *Server {
 	t.Helper()
 	chunk := rag.Chunk{

--- a/mcp/tools_rag_answer_test.go
+++ b/mcp/tools_rag_answer_test.go
@@ -296,6 +296,9 @@ func TestHandleRAGAnswer(t *testing.T) {
 		if res.Diagnostics == nil || res.Diagnostics.CandidateAnswer == "" {
 			t.Errorf("candidate answer should be in diagnostics: %+v", res.Diagnostics)
 		}
+		if len(res.Diagnostics.RetrievedChunkIDs) != 1 || res.Diagnostics.RetrievedChunkIDs[0] != "c1" {
+			t.Errorf("retrieved_chunk_ids = %v, want [c1]", res.Diagnostics.RetrievedChunkIDs)
+		}
 	})
 
 	t.Run("model declines -> not_in_retrieved_context", func(t *testing.T) {

--- a/rag/corpus_presence.go
+++ b/rag/corpus_presence.go
@@ -1,0 +1,54 @@
+package rag
+
+import (
+	"strings"
+	"unicode"
+)
+
+// corpusKeywordTerms reduces a query to quoted-literal phrases plus code-shaped
+// tokens from the remaining text, then returns the deduped term list plus a
+// disjunctive FTS5 MATCH expression ("t1" OR "t2" ...).
+//
+// Disjunction is deliberate: corpus-absence must not false-negative. OR over
+// useful terms over-detects presence (the safe direction for an absence proof)
+// rather than risking a false "absent" when terms are split across chunks.
+// Returns nil, "" when no useful terms exist.
+func corpusKeywordTerms(query string) ([]string, string) {
+	remainder, spans := extractQuotedSpans(query)
+	var terms []string
+	seen := make(map[string]bool)
+	add := func(tok string) {
+		tok = strings.TrimSpace(tok)
+		if tok == "" || seen[tok] {
+			return
+		}
+		seen[tok] = true
+		terms = append(terms, tok)
+	}
+	for _, span := range spans {
+		add(span)
+	}
+
+	extracted := extractCodeQuery(remainder)
+	var cur strings.Builder
+	flush := func() {
+		add(cur.String())
+		cur.Reset()
+	}
+	for _, r := range extracted {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' {
+			cur.WriteRune(r)
+		} else {
+			flush()
+		}
+	}
+	flush()
+	if len(terms) == 0 {
+		return nil, ""
+	}
+	quoted := make([]string, len(terms))
+	for i, t := range terms {
+		quoted[i] = `"` + strings.ReplaceAll(t, `"`, `""`) + `"`
+	}
+	return terms, strings.Join(quoted, " OR ")
+}

--- a/rag/corpus_presence.go
+++ b/rag/corpus_presence.go
@@ -24,6 +24,12 @@ func corpusKeywordTerms(query string) ([]string, string) {
 		if tok == "" || seen[tok] {
 			return
 		}
+		// A term with no letter or digit (e.g. a punctuation-only quoted literal
+		// like "===") tokenizes to an empty FTS5 phrase: it would mislabel absence
+		// or trip an FTS5 parse edge. Such a term carries no searchable content.
+		if strings.IndexFunc(tok, func(r rune) bool { return unicode.IsLetter(r) || unicode.IsDigit(r) }) < 0 {
+			return
+		}
 		seen[tok] = true
 		terms = append(terms, tok)
 	}

--- a/rag/corpus_presence.go
+++ b/rag/corpus_presence.go
@@ -1,6 +1,8 @@
 package rag
 
 import (
+	"context"
+	"fmt"
 	"strings"
 	"unicode"
 )
@@ -51,4 +53,50 @@ func corpusKeywordTerms(query string) ([]string, string) {
 		quoted[i] = `"` + strings.ReplaceAll(t, `"`, `""`) + `"`
 	}
 	return terms, strings.Join(quoted, " OR ")
+}
+
+// CorpusPresence reports deterministic keyword/literal presence across the whole
+// indexed corpus. It is a keyword absence signal, not a semantic absence proof.
+type CorpusPresence struct {
+	Terms          []string // code-shaped or quoted-literal terms extracted from the query
+	TotalMatches   int      // distinct chunks matching any useful term across the corpus
+	OutsideMatches int      // matching chunks whose ID is not in retrievedIDs
+}
+
+// KeywordPresence runs a deterministic disjunctive FTS5 search for the query's
+// useful terms across all chunks. retrievedIDs are excluded when computing
+// OutsideMatches; pass nil to treat every match as outside. No LLM call.
+func (s *SQLiteStore) KeywordPresence(ctx context.Context, query string, retrievedIDs []string) (CorpusPresence, error) {
+	terms, expr := corpusKeywordTerms(query)
+	if expr == "" {
+		return CorpusPresence{}, nil
+	}
+	cp := CorpusPresence{Terms: terms}
+
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(DISTINCT c.id)
+		 FROM chunks_fts JOIN chunks c ON c.rowid = chunks_fts.rowid
+		 WHERE chunks_fts MATCH ?`, expr).Scan(&cp.TotalMatches); err != nil {
+		return CorpusPresence{}, fmt.Errorf("rag: corpus keyword count: %w", err)
+	}
+
+	if len(retrievedIDs) == 0 {
+		cp.OutsideMatches = cp.TotalMatches
+		return cp, nil
+	}
+
+	// COUNT matches whose chunk id is not in the retrieved set.
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(retrievedIDs)), ",")
+	q := fmt.Sprintf(
+		`SELECT COUNT(DISTINCT c.id) FROM chunks_fts JOIN chunks c ON c.rowid = chunks_fts.rowid
+		 WHERE chunks_fts MATCH ? AND c.id NOT IN (%s)`, placeholders)
+	sqlArgs := make([]any, 0, len(retrievedIDs)+1)
+	sqlArgs = append(sqlArgs, expr)
+	for _, id := range retrievedIDs {
+		sqlArgs = append(sqlArgs, id)
+	}
+	if err := s.db.QueryRowContext(ctx, q, sqlArgs...).Scan(&cp.OutsideMatches); err != nil {
+		return CorpusPresence{}, fmt.Errorf("rag: corpus keyword outside count: %w", err)
+	}
+	return cp, nil
 }

--- a/rag/corpus_presence_test.go
+++ b/rag/corpus_presence_test.go
@@ -39,6 +39,13 @@ func TestCorpusKeywordTerms(t *testing.T) {
 			t.Errorf("terms = %v, want exactly [getUserID]", terms)
 		}
 	})
+	t.Run("punctuation-only quoted literal dropped", func(t *testing.T) {
+		// A quoted literal with no letter/digit has no searchable FTS5 content.
+		terms, expr := corpusKeywordTerms(`find "==="`)
+		if len(terms) != 0 || expr != "" {
+			t.Errorf("terms = %v expr = %q, want empty", terms, expr)
+		}
+	})
 }
 
 // contains is shared by the corpus_presence tests in this file.

--- a/rag/corpus_presence_test.go
+++ b/rag/corpus_presence_test.go
@@ -1,0 +1,51 @@
+package rag
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCorpusKeywordTerms(t *testing.T) {
+	t.Run("code query -> tokens and OR expr", func(t *testing.T) {
+		terms, expr := corpusKeywordTerms("where is BuildContext defined")
+		if len(terms) == 0 || !contains(terms, "BuildContext") {
+			t.Fatalf("terms = %v, want BuildContext", terms)
+		}
+		if !strings.Contains(expr, `"BuildContext"`) || (len(terms) > 1 && !strings.Contains(expr, " OR ")) {
+			t.Errorf("expr = %q", expr)
+		}
+	})
+	t.Run("quoted literal phrase preserved", func(t *testing.T) {
+		terms, expr := corpusKeywordTerms(`find "hello world"`)
+		if len(terms) != 1 || terms[0] != "hello world" {
+			t.Fatalf("terms = %v, want [hello world]", terms)
+		}
+		if !strings.Contains(expr, `"hello world"`) {
+			t.Errorf("expr = %q, want quoted phrase", expr)
+		}
+	})
+	t.Run("prose only -> no terms", func(t *testing.T) {
+		terms, expr := corpusKeywordTerms("what is the meaning of all this")
+		if len(terms) != 0 || expr != "" {
+			t.Errorf("terms = %v expr = %q, want empty", terms, expr)
+		}
+	})
+	t.Run("dedupe", func(t *testing.T) {
+		// getUserID is unambiguously code-shaped (internal case boundary), so it
+		// survives extractCodeQuery; repeated, it must collapse to one term.
+		terms, _ := corpusKeywordTerms("getUserID getUserID")
+		if len(terms) != 1 || terms[0] != "getUserID" {
+			t.Errorf("terms = %v, want exactly [getUserID]", terms)
+		}
+	})
+}
+
+// contains is shared by the corpus_presence tests in this file.
+func contains(xs []string, v string) bool {
+	for _, x := range xs {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}

--- a/rag/corpus_presence_test.go
+++ b/rag/corpus_presence_test.go
@@ -1,6 +1,7 @@
 package rag
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
@@ -48,4 +49,90 @@ func contains(xs []string, v string) bool {
 		}
 	}
 	return false
+}
+
+func TestKeywordPresence(t *testing.T) {
+	ctx := context.Background()
+	store, err := NewSQLiteStore(t.TempDir() + "/p.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+
+	chunks := []Chunk{
+		{ID: "c1", Source: "a.go", StartLine: 1, EndLine: 1, Content: "func BuildContext() {}"},
+		{ID: "c2", Source: "b.go", StartLine: 1, EndLine: 1, Content: "func numberLines() {}"},
+		{ID: "c3", Source: "c.go", StartLine: 1, EndLine: 1, Content: "package main // unrelated prose"},
+		{ID: "c4", Source: "d.go", StartLine: 1, EndLine: 1, Content: `const greeting = "hello world"`},
+	}
+	embs := [][]float64{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}, {1, 1, 0}}
+	if err := store.Store(ctx, chunks, embs); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("present across corpus", func(t *testing.T) {
+		cp, err := store.KeywordPresence(ctx, "where is BuildContext", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cp.TotalMatches != 1 || cp.OutsideMatches != 1 {
+			t.Fatalf("cp = %+v, want total=1 outside=1", cp)
+		}
+		if !contains(cp.Terms, "BuildContext") {
+			t.Errorf("terms = %v", cp.Terms)
+		}
+	})
+
+	t.Run("outside excludes retrieved id", func(t *testing.T) {
+		cp, err := store.KeywordPresence(ctx, "BuildContext", []string{"c1"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cp.TotalMatches != 1 || cp.OutsideMatches != 0 {
+			t.Fatalf("cp = %+v, want total=1 outside=0", cp)
+		}
+	})
+
+	t.Run("absent term", func(t *testing.T) {
+		cp, err := store.KeywordPresence(ctx, "NonexistentSymbolXYZ", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cp.TotalMatches != 0 {
+			t.Fatalf("cp = %+v, want total=0", cp)
+		}
+	})
+
+	t.Run("no useful terms", func(t *testing.T) {
+		cp, err := store.KeywordPresence(ctx, "what is the meaning of it all", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(cp.Terms) != 0 || cp.TotalMatches != 0 {
+			t.Fatalf("cp = %+v, want no terms", cp)
+		}
+	})
+
+	t.Run("quoted literal phrase", func(t *testing.T) {
+		cp, err := store.KeywordPresence(ctx, `find "hello world"`, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cp.TotalMatches != 1 || cp.OutsideMatches != 1 {
+			t.Fatalf("cp = %+v, want total=1 outside=1", cp)
+		}
+		if !contains(cp.Terms, "hello world") {
+			t.Errorf("terms = %v, want hello world", cp.Terms)
+		}
+	})
+
+	t.Run("disjunction: terms split across chunks both count", func(t *testing.T) {
+		cp, err := store.KeywordPresence(ctx, "BuildContext and numberLines", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cp.TotalMatches != 2 {
+			t.Fatalf("cp = %+v, want total=2 (OR semantics)", cp)
+		}
+	})
 }


### PR DESCRIPTION
Adds one new MCP tool, rag_answer, that returns a machine-readable, audited answer instead of prose. The server retrieves context, asks the model for an answer plus supporting quotes, then deterministically verifies each quote against the retrieved chunk it was cited from. The server (not the model) decides whether an answer was found, what the sources are, and which status to report.

Closes #229 and #230. Existing chat, rag_search, and all other tools/prompts are unchanged.

## What it does

Input: { question (required), model?, top_k?=5, include_diagnostics?=false }

Flow:
- retrieve context (existing hybrid path); if zero chunks, skip the model
- build numbered evidence blocks E1..En (capped at ragContextMaxTokens), prompt the model for JSON-only { answer, evidence:[{id, quote}] } at temperature 0
- parse tolerantly (scan balanced JSON objects, take the last that validates) with one repair retry
- verify each cited quote against that specific chunk's raw content
- derive status, answer, and sources server-side

Model contract is intentionally minimal: the model is asked only for answer and evidence. status, answer_found, sources, and verified are server-owned. Cited ids are short prompt-assigned labels (E1..En), not chunk hashes.

## Statuses (server-derived)

#229:
- answer_found: non-empty answer with at least one verified quote
- unverified_answer: answer given but no quote verified (public answer suppressed; candidate moved to diagnostics)
- not_in_retrieved_context: model declined, corpus check not run/inconclusive
- malformed_output: unparseable after the repair retry

#230 (deepens the model-declined branch only, via a deterministic FTS5 keyword check over the whole corpus, no LLM call):
- retrieval_miss: matching chunks exist outside the retrieved set
- corpus_absent: zero corpus matches for the extracted terms
- no_useful_terms: no code-shaped or quoted-literal terms could be extracted

The corpus check is disjunctive (OR over terms) so absence is never falsely reported when terms are split across chunks, excludes retrieved ids in SQL to compute outside-set matches precisely, and fails open to not_in_retrieved_context if the store does not support it or the query errors. It reuses the existing extractCodeQuery/extractQuotedSpans helpers (so PR #226's prose-abbreviation handling carries through). Only KeywordPresence and CorpusPresence are newly exported from rag.

## Verification details

- Quotes are matched against rag.Chunk.Content, never BuildContext output (its line-anchor prefixes would corrupt matching), case-sensitive after whitespace normalization.
- sources are built only from verified quotes; model-claimed provenance is never authoritative.
- include_diagnostics=true adds retrieved/evidence/verified ids, the suppressed candidate answer, keyword terms, and corpus match counts. Default response stays clean.

## Known design decisions (flagged for review)

- quote verification is literal substring presence with no minimum-length floor: a trivially short cited quote can satisfy it. A threshold was omitted deliberately because it would false-negative legitimate short identifiers, and the model is the server's own prompt-controlled local model, not an adversary. Documented in quoteInChunk.
- parse uses last-valid-object-wins, on the assumption that local models emit scaffolding/example JSON before the real answer.

## Tests and gate

- Unit: quoteInChunk, extractJSONObjects, parseModelAnswer (last-valid), deriveAnswer (all #229 statuses), buildEvidenceBlocks (budget), callForAnswer (repair retry).
- Real SQLiteStore drives KeywordPresence (present/absent/outside-excluded/no-terms/quoted-phrase/disjunction/punctuation-only).
- Handler: answer_found, unverified suppression, decline, malformed, zero-retrieved skips the model, validation; refineWithCorpus status ladder and corpus diagnostics.
- go test -race ./... passes (3842 tests, 28 packages); golangci-lint clean; gofmt clean.