### PR TITLE
feat(agent): parallelize independent read-only tool calls

### DIFF
--- a/agent/dispatch.go
+++ b/agent/dispatch.go
@@ -8,7 +8,20 @@ import (
 	"github.com/kstruzzieri/go-llm/provider"
 )
 
+// runToolCalls routes a batch to the parallel path when every call is read-only
+// and independent (canRunParallel); otherwise to the serial path. Single-call
+// batches always go serial (no benefit, zero behavior change).
 func (o *Orchestrator) runToolCalls(ctx context.Context, res *Result, state *State,
+	reg *toolRegistry, calls []provider.ToolCall, approver Approver, obs Observer, step int,
+	gov *restraintGovernor) error {
+
+	if len(calls) >= 2 && canRunParallel(reg, calls) {
+		return o.runToolCallsParallel(ctx, res, state, reg, calls, approver, obs, step, gov)
+	}
+	return o.runToolCallsSerial(ctx, res, state, reg, calls, approver, obs, step, gov)
+}
+
+func (o *Orchestrator) runToolCallsSerial(ctx context.Context, res *Result, state *State,
 	reg *toolRegistry, calls []provider.ToolCall, approver Approver, obs Observer, step int,
 	gov *restraintGovernor) error {
 
@@ -18,40 +31,78 @@ func (o *Orchestrator) runToolCalls(ctx context.Context, res *Result, state *Sta
 		if err != nil {
 			return err // hard abort (ctx cancel / approver error): no ToolResult, no OnToolResult
 		}
-		res.ToolCalls = append(res.ToolCalls, rec)
-		res.Events = append(res.Events, EventRecord{Step: step, Kind: "tool_result"})
-		// out is the exact ToolResult appended to State below (Invoke results are
-		// already capOutput-ed inside dispatch; synthetic failures are short and
-		// uncapped) — so the observer sees what the model sees.
-		if tro, ok := obs.(ToolResultObserver); ok {
-			if err := tro.OnToolResult(ctx, ToolResultEvent{Step: step, Call: call, Result: out}); err != nil {
-				return err
-			}
+		stop, err := recordResult(ctx, res, state, obs, gov, step, call, rec, out)
+		if err != nil {
+			return err
 		}
-		state.Messages = append(state.Messages, toolObservation(call, out))
-		gov.observe(call, out)
-		if sr, tripped := gov.stopReason(); tripped {
-			res.StopReason = sr
+		if stop {
 			return nil
 		}
 	}
 	return nil
 }
 
-func (o *Orchestrator) dispatch(ctx context.Context, reg *toolRegistry, call provider.ToolCall,
-	approver Approver, obs Observer, step int) (ToolResult, ToolCallRecord, error) {
+// recordResult appends one completed tool call's record, result event, optional
+// observer callback, state observation, and governor update — the shared tail used
+// by BOTH the serial and parallel paths so their model-visible semantics cannot
+// drift. `out` is the exact ToolResult appended to State (Invoke results are
+// already capOutput-ed; synthetic failures are short and uncapped) — so the
+// observer sees what the model sees. It returns stop=true (and sets
+// res.StopReason) when the governor trips, or an error to hard-abort the run.
+func recordResult(ctx context.Context, res *Result, state *State, obs Observer,
+	gov *restraintGovernor, step int, call provider.ToolCall, rec ToolCallRecord,
+	out ToolResult) (stop bool, err error) {
+
+	res.ToolCalls = append(res.ToolCalls, rec)
+	res.Events = append(res.Events, EventRecord{Step: step, Kind: "tool_result"})
+	if tro, ok := obs.(ToolResultObserver); ok {
+		if err := tro.OnToolResult(ctx, ToolResultEvent{Step: step, Call: call, Result: out}); err != nil {
+			return false, err
+		}
+	}
+	state.Messages = append(state.Messages, toolObservation(call, out))
+	gov.observe(call, out)
+	if sr, tripped := gov.stopReason(); tripped {
+		res.StopReason = sr
+		return true, nil
+	}
+	return false, nil
+}
+
+// preparedCall is the outcome of the serial, observer/approval phase of one tool
+// call. When prepareCall returns a nil error, exactly one of two states holds:
+//   - result != nil: a synthetic outcome (unknown tool / bad JSON / plan failure /
+//     approval denied). The caller must NOT Invoke; use result directly.
+//   - result == nil: tool and effect are populated; the caller runs invokeCall.
+type preparedCall struct {
+	call   provider.ToolCall
+	tool   Tool
+	effect Effect
+	rec    ToolCallRecord
+	result *ToolResult
+}
+
+// prepareCall runs everything that must stay on the main goroutine and in loop
+// order: lookup, JSON validation, per-call effect/Plan, approval, and OnToolCall.
+// It NEVER appends EventRecords (callers own event ordering) and NEVER Invokes.
+// A non-nil error is a hard abort (ctx cancel / approver failure / observer error);
+// p.rec is still returned so the caller can record it.
+func (o *Orchestrator) prepareCall(ctx context.Context, reg *toolRegistry, call provider.ToolCall,
+	approver Approver, obs Observer, step int) (preparedCall, error) {
 
 	name := call.Function.Name
-	rec := ToolCallRecord{Step: step, Name: name}
+	p := preparedCall{call: call, rec: ToolCallRecord{Step: step, Name: name}}
 
 	tool, ok := reg.lookup(name)
 	if !ok {
-		rec.IsError = true
-		return ToolResult{IsError: true, Content: "unknown tool: " + name}, rec, nil
+		p.rec.IsError = true
+		p.result = &ToolResult{IsError: true, Content: "unknown tool: " + name}
+		return p, nil
 	}
 	if !json.Valid(call.Function.Arguments) {
-		rec.IsError = true
-		return ToolResult{IsError: true, Content: "malformed tool arguments (not valid JSON)"}, rec, nil
+		p.rec.IsError = true
+		p.result = &ToolResult{IsError: true, Content: "malformed tool arguments (not valid JSON)"}
+		return p, nil
 	}
 
 	effect := tool.Effect()
@@ -59,8 +110,9 @@ func (o *Orchestrator) dispatch(ctx context.Context, reg *toolRegistry, call pro
 	if pt, ok := tool.(PlanningTool); ok {
 		plan, err := pt.Plan(ctx, call.Function.Arguments)
 		if err != nil {
-			rec.IsError = true
-			return ToolResult{IsError: true, Content: "plan failed: " + err.Error()}, rec, nil
+			p.rec.IsError = true
+			p.result = &ToolResult{IsError: true, Content: "plan failed: " + err.Error()}
+			return p, nil
 		}
 		effect, preview = plan.Effect, plan.Preview
 	}
@@ -69,28 +121,56 @@ func (o *Orchestrator) dispatch(ctx context.Context, reg *toolRegistry, call pro
 	if needsApproval(effect.Approval, effect.Class) {
 		ok, err := approve(ctx, approver, call, preview)
 		if err != nil {
-			return ToolResult{}, rec, err // ctx cancel / approver failure propagates
+			return p, err // ctx cancel / approver failure propagates
 		}
 		if !ok {
-			rec.IsError, rec.Denied = true, true
-			return ToolResult{IsError: true, Content: "tool call denied by approver"}, rec, nil
+			p.rec.IsError, p.rec.Denied = true, true
+			p.result = &ToolResult{IsError: true, Content: "tool call denied by approver"}
+			return p, nil
 		}
 	}
 
 	if err := obs.OnToolCall(ctx, ToolCallEvent{Step: step, Call: call, Effect: effect, Preview: preview}); err != nil {
-		return ToolResult{}, rec, err
+		return p, err
 	}
 
+	p.tool, p.effect = tool, effect
+	return p, nil
+}
+
+// invokeCall runs the tool body: per-call timeout, Invoke, output cap. Any tool
+// error (including the per-call timeout) becomes a model-visible IsError result.
+// It carries NO parent-cancellation policy — callers decide whether a cancelled
+// parent ctx is a hard abort.
+func (o *Orchestrator) invokeCall(ctx context.Context, tool Tool, effect Effect, args json.RawMessage) ToolResult {
 	cctx, cancel := context.WithTimeout(ctx, effect.Timeout)
 	defer cancel()
-	out, err := tool.Invoke(cctx, call.Function.Arguments)
+	out, err := tool.Invoke(cctx, args)
 	if err != nil {
-		rec.IsError = true
-		return ToolResult{IsError: true, Content: err.Error()}, rec, nil
+		return ToolResult{IsError: true, Content: err.Error()}
 	}
-	out = capOutput(out, effect.OutputCap)
-	rec.IsError = out.IsError
-	return out, rec, nil
+	return capOutput(out, effect.OutputCap)
+}
+
+// dispatch is the serial composition: prepare on the main goroutine, then invoke.
+// A cancelled PARENT context after invoke is a hard abort (distinct from a tool's
+// own per-call timeout, which stays a model-visible IsError observation).
+func (o *Orchestrator) dispatch(ctx context.Context, reg *toolRegistry, call provider.ToolCall,
+	approver Approver, obs Observer, step int) (ToolResult, ToolCallRecord, error) {
+
+	p, err := o.prepareCall(ctx, reg, call, approver, obs, step)
+	if err != nil {
+		return ToolResult{}, p.rec, err
+	}
+	if p.result != nil {
+		return *p.result, p.rec, nil
+	}
+	out := o.invokeCall(ctx, p.tool, p.effect, call.Function.Arguments)
+	if ctx.Err() != nil {
+		return ToolResult{}, p.rec, ctx.Err() // parent cancelled -> hard abort
+	}
+	p.rec.IsError = out.IsError
+	return out, p.rec, nil
 }
 
 // approve applies the fail-safe: a nil approver denies any call that reaches it

--- a/agent/dispatch_parallel.go
+++ b/agent/dispatch_parallel.go
@@ -1,0 +1,106 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// parallelToolCallLimit bounds concurrent read-only tool invocations within a
+// single assistant turn.
+const parallelToolCallLimit = 8 // ponytail: hardcoded MVP cap; make it configurable only if real read fan-out queues.
+
+// parallelSafe reports whether a tool's normalized static effect is exactly
+// read-only and needs no approval — the conservative set safe to run concurrently.
+func parallelSafe(e Effect) bool {
+	e = normalizeEffect(e)
+	return e.Class == Read && !needsApproval(e.Approval, e.Class)
+}
+
+// canRunParallel reports whether EVERY call in the batch may run concurrently. It
+// is a cheap, static, side-effect-free pre-check (no ctx, observer, or Plan). Any
+// miss routes the whole batch to the serial path. PlanningTools are excluded so we
+// never run Plan twice/concurrently; duplicate tool names are excluded to avoid a
+// same-instance Invoke race and to keep governor repeat-detection on the serial path.
+func canRunParallel(reg *toolRegistry, calls []provider.ToolCall) bool {
+	seen := make(map[string]struct{}, len(calls))
+	for _, call := range calls {
+		name := call.Function.Name
+		if _, dup := seen[name]; dup {
+			return false
+		}
+		seen[name] = struct{}{}
+		tool, ok := reg.lookup(name)
+		if !ok {
+			return false
+		}
+		if !json.Valid(call.Function.Arguments) {
+			return false
+		}
+		if _, isPlanning := tool.(PlanningTool); isPlanning {
+			return false
+		}
+		if !parallelSafe(tool.Effect()) {
+			return false
+		}
+	}
+	return true
+}
+
+// runToolCallsParallel dispatches a batch that canRunParallel has vetted as all
+// read-only and independent. Three phases keep all observer/governor work on the
+// main goroutine in model order; only Invoke runs concurrently:
+//
+//	Phase 1 (serial): prepareCall per call -> OnToolCall, in model order.
+//	Phase 2 (parallel): invokeCall per call via a bounded errgroup. Workers never
+//	  fail the group, so the group ctx cancels only when the PARENT ctx cancels.
+//	Phase 3 (serial): record, OnToolResult, append observation, governor, in model
+//	  order, with the same short-circuit-and-discard semantics as the serial path.
+func (o *Orchestrator) runToolCallsParallel(ctx context.Context, res *Result, state *State,
+	reg *toolRegistry, calls []provider.ToolCall, approver Approver, obs Observer, step int,
+	gov *restraintGovernor) error {
+
+	// Phase 1: prepare serially, in model order.
+	prepared := make([]preparedCall, len(calls))
+	for i, call := range calls {
+		res.Events = append(res.Events, EventRecord{Step: step, Kind: "tool_call"})
+		p, err := o.prepareCall(ctx, reg, call, approver, obs, step)
+		if err != nil {
+			return err // hard abort: no invokes launched, nothing to cancel
+		}
+		prepared[i] = p
+	}
+
+	// Phase 2: invoke concurrently, bounded.
+	results := make([]ToolResult, len(prepared))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(parallelToolCallLimit)
+	for i := range prepared {
+		g.Go(func() error {
+			results[i] = o.invokeCall(gctx, prepared[i].tool, prepared[i].effect, prepared[i].call.Function.Arguments)
+			return nil // never fail the group; tool errors are model-visible results
+		})
+	}
+	_ = g.Wait() // joins every worker -> no goroutine leak
+	if err := ctx.Err(); err != nil {
+		return err // parent cancelled -> hard abort
+	}
+
+	// Phase 3: observe serially, in model order, via the shared recordResult tail
+	// so governor/observer semantics are identical to the serial path.
+	for i := range prepared {
+		rec := prepared[i].rec
+		rec.IsError = results[i].IsError
+		stop, err := recordResult(ctx, res, state, obs, gov, step, prepared[i].call, rec, results[i])
+		if err != nil {
+			return err
+		}
+		if stop {
+			return nil // governor tripped: discard later already-computed read-only results
+		}
+	}
+	return nil
+}

--- a/agent/dispatch_parallel_test.go
+++ b/agent/dispatch_parallel_test.go
@@ -1,0 +1,386 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// --- shared test helpers -----------------------------------------------------
+
+// tc builds a function tool call with the given name and raw JSON arguments.
+func tc(name, args string) provider.ToolCall {
+	return provider.ToolCall{
+		ID: name, Type: "function",
+		Function: provider.ToolCallFunction{Name: name, Arguments: json.RawMessage(args)},
+	}
+}
+
+// readTool is a distinct-named, stateless read-only tool.
+type readTool struct{ name string }
+
+func (r readTool) Spec() ToolSpec {
+	return ToolSpec{Name: r.name, Parameters: json.RawMessage(`{"type":"object"}`)}
+}
+func (readTool) Effect() Effect { return Effect{Class: Read, Approval: ApprovalNever} }
+func (r readTool) Invoke(_ context.Context, _ json.RawMessage) (ToolResult, error) {
+	return ToolResult{Content: "r:" + r.name}, nil
+}
+
+// (writeTool is the mutating PlanningTool declared in approval_test.go, name "writer".)
+
+// slowReadTool is a distinct-named read tool with a controllable delay so we can
+// invert completion order vs model order.
+type slowReadTool struct {
+	name string
+	d    time.Duration
+}
+
+func (s slowReadTool) Spec() ToolSpec {
+	return ToolSpec{Name: s.name, Parameters: json.RawMessage(`{"type":"object"}`)}
+}
+func (slowReadTool) Effect() Effect { return Effect{Class: Read, Approval: ApprovalNever} }
+func (s slowReadTool) Invoke(ctx context.Context, _ json.RawMessage) (ToolResult, error) {
+	select {
+	case <-time.After(s.d):
+		return ToolResult{Content: "done:" + s.name}, nil
+	case <-ctx.Done():
+		return ToolResult{}, ctx.Err()
+	}
+}
+
+func toolMessages(msgs []provider.ChatMessage) []provider.ChatMessage {
+	var out []provider.ChatMessage
+	for _, m := range msgs {
+		if m.Role == "tool" {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// --- Task 1: serial parent-cancel hard abort ---------------------------------
+
+// parentBlockTool blocks on its context, then returns ctx.Err(). With a long
+// per-call timeout, only a PARENT cancellation ends it.
+type parentBlockTool struct{ name string }
+
+func (b parentBlockTool) Spec() ToolSpec {
+	return ToolSpec{Name: b.name, Parameters: json.RawMessage(`{"type":"object"}`)}
+}
+func (parentBlockTool) Effect() Effect {
+	return Effect{Class: Read, Approval: ApprovalNever, Timeout: time.Hour}
+}
+func (parentBlockTool) Invoke(ctx context.Context, _ json.RawMessage) (ToolResult, error) {
+	<-ctx.Done()
+	return ToolResult{}, ctx.Err()
+}
+
+// TestSerialDispatchParentCancelHardAborts: a SINGLE-call batch (serial path);
+// cancelling the parent context makes Run return the cancellation error rather
+// than turning it into an IsError observation.
+func TestSerialDispatchParentCancelHardAborts(t *testing.T) {
+	mc := &scriptedCaller{responses: []ModelResult{
+		{Response: provider.ChatResponse{ToolCalls: []provider.ToolCall{{
+			ID: "1", Type: "function",
+			Function: provider.ToolCallFunction{Name: "block", Arguments: json.RawMessage(`{}`)},
+		}}}},
+		{Response: provider.ChatResponse{Content: "unreached", Done: true}},
+	}}
+	o := newTestOrchestrator(mc)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	type runResult struct {
+		res Result
+		err error
+	}
+	done := make(chan runResult, 1)
+	go func() {
+		res, err := o.Run(ctx, Request{Goal: "q", Tools: []Tool{parentBlockTool{name: "block"}}}, nil)
+		done <- runResult{res, err}
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case rr := <-done:
+		if !errors.Is(rr.err, context.Canceled) {
+			t.Fatalf("parent cancel must hard-abort Run with context.Canceled, got err=%v stop=%v", rr.err, rr.res.StopReason)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after parent cancellation (possible goroutine leak)")
+	}
+}
+
+// --- Task 2: eligibility gate ------------------------------------------------
+
+func TestCanRunParallelGate(t *testing.T) {
+	reg, err := newToolRegistry([]Tool{
+		readTool{name: "a"}, readTool{name: "b"}, writeTool{},
+	})
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+	tests := []struct {
+		name  string
+		calls []provider.ToolCall
+		want  bool
+	}{
+		{"two distinct reads", []provider.ToolCall{tc("a", `{}`), tc("b", `{}`)}, true},
+		{"duplicate name", []provider.ToolCall{tc("a", `{}`), tc("a", `{"x":1}`)}, false},
+		{"contains write", []provider.ToolCall{tc("a", `{}`), tc("writer", `{}`)}, false},
+		{"unknown tool", []provider.ToolCall{tc("a", `{}`), tc("zzz", `{}`)}, false},
+		{"bad json", []provider.ToolCall{tc("a", `{}`), tc("b", `{not json`)}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := canRunParallel(reg, tt.calls); got != tt.want {
+				t.Fatalf("canRunParallel = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- Task 3: model-order preservation ----------------------------------------
+
+// TestParallelPreservesModelOrder: completion order (e,d,c,b,a) is inverted from
+// model order (a,b,c,d,e); results and tool observations must follow model order.
+func TestParallelPreservesModelOrder(t *testing.T) {
+	tools := []Tool{
+		slowReadTool{name: "a", d: 60 * time.Millisecond},
+		slowReadTool{name: "b", d: 45 * time.Millisecond},
+		slowReadTool{name: "c", d: 30 * time.Millisecond},
+		slowReadTool{name: "d", d: 15 * time.Millisecond},
+		slowReadTool{name: "e", d: 1 * time.Millisecond},
+	}
+	want := []string{"a", "b", "c", "d", "e"}
+	calls := make([]provider.ToolCall, len(want))
+	for i, n := range want {
+		calls[i] = tc(n, `{}`)
+	}
+	mc := &scriptedCaller{responses: []ModelResult{
+		{Response: provider.ChatResponse{ToolCalls: calls}},
+		{Response: provider.ChatResponse{Content: "done", Done: true}},
+	}}
+	o := newTestOrchestrator(mc)
+	res, err := o.Run(context.Background(), Request{Goal: "q", Tools: tools}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.StopReason != Completed {
+		t.Fatalf("stop = %v, want Completed", res.StopReason)
+	}
+	if len(res.ToolCalls) != len(want) {
+		t.Fatalf("tool call records = %d, want %d", len(res.ToolCalls), len(want))
+	}
+	for i, n := range want {
+		if res.ToolCalls[i].Name != n {
+			t.Fatalf("ToolCalls[%d].Name = %q, want %q", i, res.ToolCalls[i].Name, n)
+		}
+	}
+	tms := toolMessages(res.Messages)
+	if len(tms) != len(want) {
+		t.Fatalf("tool messages = %d, want %d", len(tms), len(want))
+	}
+	for i, n := range want {
+		if tms[i].Content != "done:"+n {
+			t.Fatalf("tool message[%d] = %q, want %q", i, tms[i].Content, "done:"+n)
+		}
+	}
+}
+
+// --- Task 4: faster than serial ----------------------------------------------
+
+// TestParallelFasterThanSerial: N distinct read tools (> the cap, so the bound is
+// exercised) each sleep `unit`. Serial would take ~N*unit; the parallel path runs
+// in a few waves and must finish well under that.
+func TestParallelFasterThanSerial(t *testing.T) {
+	const (
+		n    = 10 // > parallelToolCallLimit (8)
+		unit = 50 * time.Millisecond
+	)
+	tools := make([]Tool, n)
+	calls := make([]provider.ToolCall, n)
+	for i := range n {
+		name := "rt" + string(rune('A'+i))
+		tools[i] = slowReadTool{name: name, d: unit}
+		calls[i] = tc(name, `{}`)
+	}
+	mc := &scriptedCaller{responses: []ModelResult{
+		{Response: provider.ChatResponse{ToolCalls: calls}},
+		{Response: provider.ChatResponse{Content: "done", Done: true}},
+	}}
+	o := newTestOrchestrator(mc)
+
+	start := time.Now()
+	res, err := o.Run(context.Background(), Request{Goal: "q", Tools: tools}, nil)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.ToolCalls) != n {
+		t.Fatalf("tool call records = %d, want %d", len(res.ToolCalls), n)
+	}
+	if elapsed >= 5*unit {
+		t.Fatalf("parallel dispatch took %v; expected < %v (serial would be ~%v)", elapsed, 5*unit, n*unit)
+	}
+}
+
+// --- Task 5: event ordering --------------------------------------------------
+
+// TestParallelEventOrdering: a parallel batch emits all tool_call events, then all
+// tool_result events (no interleave) — the documented ordering for a parallel batch.
+func TestParallelEventOrdering(t *testing.T) {
+	tools := []Tool{readTool{name: "a"}, readTool{name: "b"}, readTool{name: "c"}}
+	calls := []provider.ToolCall{tc("a", `{}`), tc("b", `{}`), tc("c", `{}`)}
+	mc := &scriptedCaller{responses: []ModelResult{
+		{Response: provider.ChatResponse{ToolCalls: calls}},
+		{Response: provider.ChatResponse{Content: "done", Done: true}},
+	}}
+	o := newTestOrchestrator(mc)
+	res, err := o.Run(context.Background(), Request{Goal: "q", Tools: tools}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var seq []string
+	for _, e := range res.Events {
+		if e.Kind == "tool_call" || e.Kind == "tool_result" {
+			seq = append(seq, e.Kind)
+		}
+	}
+	want := []string{"tool_call", "tool_call", "tool_call", "tool_result", "tool_result", "tool_result"}
+	if len(seq) != len(want) {
+		t.Fatalf("tool event sequence = %v, want %v", seq, want)
+	}
+	for i := range want {
+		if seq[i] != want[i] {
+			t.Fatalf("tool event[%d] = %q, want %q (full: %v)", i, seq[i], want[i], seq)
+		}
+	}
+}
+
+// --- Task 6: governor serial tail within a parallel batch --------------------
+
+// erroringReadTool is a distinct-named read tool that always errors.
+type erroringReadTool struct{ name string }
+
+func (e erroringReadTool) Spec() ToolSpec {
+	return ToolSpec{Name: e.name, Parameters: json.RawMessage(`{"type":"object"}`)}
+}
+func (erroringReadTool) Effect() Effect { return Effect{Class: Read, Approval: ApprovalNever} }
+func (erroringReadTool) Invoke(_ context.Context, _ json.RawMessage) (ToolResult, error) {
+	return ToolResult{}, errors.New("boom")
+}
+
+// TestParallelGovernorSerialTail: 5 distinct erroring read tools run concurrently,
+// but Phase 3 applies the governor in model order and short-circuits after
+// defaultToolErrorCap consecutive errors, discarding the trailing (already-run)
+// results. Only the first defaultToolErrorCap results are surfaced.
+func TestParallelGovernorSerialTail(t *testing.T) {
+	const n = 5
+	tools := make([]Tool, n)
+	calls := make([]provider.ToolCall, n)
+	for i := range n {
+		name := "boom" + string(rune('0'+i))
+		tools[i] = erroringReadTool{name: name}
+		calls[i] = tc(name, `{}`)
+	}
+	mc := &scriptedCaller{responses: []ModelResult{
+		{Response: provider.ChatResponse{ToolCalls: calls}},
+	}}
+	o := newTestOrchestrator(mc)
+	res, err := o.Run(context.Background(), Request{Goal: "q", Tools: tools}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.StopReason != ToolErrorCapReached {
+		t.Fatalf("stop = %v, want ToolErrorCapReached", res.StopReason)
+	}
+	if len(res.ToolCalls) != defaultToolErrorCap {
+		t.Fatalf("surfaced tool calls = %d, want %d", len(res.ToolCalls), defaultToolErrorCap)
+	}
+}
+
+// --- Task 7: context cancellation, no leak -----------------------------------
+
+// startSignalTool blocks on its context (long per-call timeout) and signals start
+// and exit through atomic counters, so the test can prove every started worker
+// exited after a parent cancellation (no goroutine leak).
+type startSignalTool struct {
+	name    string
+	started *int32
+	exited  *int32
+}
+
+func (b startSignalTool) Spec() ToolSpec {
+	return ToolSpec{Name: b.name, Parameters: json.RawMessage(`{"type":"object"}`)}
+}
+func (startSignalTool) Effect() Effect {
+	return Effect{Class: Read, Approval: ApprovalNever, Timeout: time.Hour}
+}
+func (b startSignalTool) Invoke(ctx context.Context, _ json.RawMessage) (ToolResult, error) {
+	atomic.AddInt32(b.started, 1)
+	<-ctx.Done()
+	atomic.AddInt32(b.exited, 1)
+	return ToolResult{}, ctx.Err()
+}
+
+// TestParallelContextCancel: a batch of blocking read tools (count <= cap so all
+// start) is interrupted by a parent cancellation. Run must return context.Canceled,
+// and every worker that started must exit (errgroup.Wait joins them).
+func TestParallelContextCancel(t *testing.T) {
+	const n = 4 // <= parallelToolCallLimit so all workers start
+	var started, exited int32
+	tools := make([]Tool, n)
+	calls := make([]provider.ToolCall, n)
+	for i := range n {
+		name := "blk" + string(rune('0'+i))
+		tools[i] = startSignalTool{name: name, started: &started, exited: &exited}
+		calls[i] = tc(name, `{}`)
+	}
+	mc := &scriptedCaller{responses: []ModelResult{
+		{Response: provider.ChatResponse{ToolCalls: calls}},
+		{Response: provider.ChatResponse{Content: "unreached", Done: true}},
+	}}
+	o := newTestOrchestrator(mc)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	type runResult struct {
+		res Result
+		err error
+	}
+	done := make(chan runResult, 1)
+	go func() {
+		res, err := o.Run(ctx, Request{Goal: "q", Tools: tools}, nil)
+		done <- runResult{res, err}
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for atomic.LoadInt32(&started) < int32(n) {
+		select {
+		case <-deadline:
+			t.Fatalf("only %d/%d workers started", atomic.LoadInt32(&started), n)
+		case <-time.After(time.Millisecond):
+		}
+	}
+	cancel()
+
+	select {
+	case rr := <-done:
+		if !errors.Is(rr.err, context.Canceled) {
+			t.Fatalf("Run err = %v, want context.Canceled", rr.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after cancel (goroutine leak)")
+	}
+	if got := atomic.LoadInt32(&exited); got != int32(n) {
+		t.Fatalf("exited workers = %d, want %d (Wait must join every started worker)", got, n)
+	}
+}


### PR DESCRIPTION
Closes #235.

## What

Run a single assistant turn's independent read-only tool calls concurrently, preserving model-visible order, governor semantics, and approval safety. The owned `agent.Orchestrator` loop is unchanged; this is a dispatch-layer performance improvement.

## How

- Split `dispatch` into `prepareCall` (serial: lookup / JSON-valid / effect+Plan / approval / `OnToolCall`) and `invokeCall` (pure tool body: per-call timeout / Invoke / output cap).
- Static gate `canRunParallel` routes a batch to the parallel path only when every call is: tool found, valid JSON args, exactly read-only (`Effect.Class == Read`, no Write/Exec/Network), needs no approval, not a `PlanningTool`, and has no duplicate tool name. Every other batch (and any single-call batch) keeps the serial path unchanged.
- Three-phase parallel runner:
  - Phase 1 (serial): `prepareCall` / `OnToolCall` in model order.
  - Phase 2 (parallel): fan out only `Invoke` via a bounded `errgroup` (`parallelToolCallLimit = 8`). Workers never fail the group, so the group context cancels only on parent-context cancellation.
  - Phase 3 (serial): record / observe / govern through the shared `recordResult` tail, so parallel and serial model-visible semantics cannot drift.
- Parent-context cancellation hard-aborts both paths (no goroutine leak — `errgroup.Wait` joins every worker); a tool's own per-call timeout still surfaces as an `IsError` observation.

## Why these constraints

- Duplicate tool names go serial: avoids a same-instance `Invoke` data race and keeps governor repeat-detection on the serial path.
- `PlanningTool`s go serial: avoids running `Plan` concurrently/twice.
- `Effect.Class == Read` plus no-approval is the conservative concurrency-safe set; mutating/exec/network/approval-required tools are never parallelized.

## Tests (all pass under `-race`)

- `TestCanRunParallelGate` — gate accepts distinct reads, rejects duplicate-name / write / unknown / bad-JSON batches.
- `TestParallelPreservesModelOrder` — inverted completion order still yields model-order results and observations.
- `TestParallelFasterThanSerial` — 10 read tools (> cap) finish well under the serial wall-clock.
- `TestParallelEventOrdering` — all `tool_call` events precede all `tool_result` events.
- `TestParallelGovernorSerialTail` — governor short-circuits a parallel batch in model order, discarding trailing results.
- `TestParallelContextCancel` — parent cancel stops in-flight reads and every worker exits (no leak).
- `TestSerialDispatchParentCancelHardAborts` — serial parent-cancel hard-aborts; existing per-tool-timeout behavior preserved.

Verified locally: `go test ./... -race`, `go vet ./...`, `go build ./...` all green.

## Follow-up (not in scope)

A `ParallelTool` opt-in interface for audited reentrant tools (e.g. allowing multiple concurrent `read_file` calls), and an optional ordered-streaming result flush, are noted as future work.