### PR TITLE
feat(golem): adapt MCP client tools into agent.Tool (#236)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ go-llm/
 ├── completion/      # IDE inline completion (Fill-in-the-Middle)
 ├── analysis/        # Domain-specific analysis helpers (code review, ML metrics, trading)
 ├── mcp/             # MCP server: tools, prompts, resources over stdio/HTTP/2 — wired through provider.Router
+├── mcpclient/       # MCP client: adapts external MCP servers' tools into agent.Tool (stdio/streamable-HTTP); consumed by cmd/golem
 ├── conversation/    # Persistent conversation storage with SQLite
 ├── memory/          # Explicit user-controlled local memories (SQLite, scope-filtered FTS5/bm25 search); separate from conversation + RAG; backs Golem /remember + memory_search
 ├── projectcontext/  # AGENTS.md-style project-context loader (discovery, safe read, ordering; consumed by cmd/golem)
@@ -48,7 +49,7 @@ Keep minimal. Allowed external dependencies:
 - `modernc.org/sqlite` — pure Go SQLite driver (no CGo)
 - `golang.org/x/sync` — concurrency primitives (errgroup for bounded worker pools)
 - `golang.org/x/net` — h2c HTTP/2 cleartext transport (only imported by `mcp/`)
-- `github.com/modelcontextprotocol/go-sdk` — official MCP Go SDK (only imported by `mcp/`)
+- `github.com/modelcontextprotocol/go-sdk` — official MCP Go SDK (imported by `mcp/` server side, `mcpclient/` client side, and `cmd/llm-bench/`)
 - `github.com/parquet-go/parquet-go` — Parquet file writer (only imported by `rag/parquet/`)
 - `github.com/santhosh-tekuri/jsonschema/v6` — JSON Schema validator (only imported by `cmd/llm-bench/`)
 

--- a/cmd/golem/approver.go
+++ b/cmd/golem/approver.go
@@ -12,8 +12,8 @@ import (
 
 // replApprover renders a mutation's diff preview and prompts the user for a single
 // [y/N] decision over the shared lineReader. It is wired into agent.Request.Approver
-// only when -allow-write is set; otherwise the runtime's nil-approver fail-safe
-// denies every mutating call.
+// only when a configured tool needs approval; otherwise the runtime's nil-approver
+// fail-safe denies every mutating call.
 type replApprover struct {
 	lr    *lineReader
 	out   io.Writer
@@ -30,14 +30,18 @@ func newReplApprover(lr *lineReader, out io.Writer, color bool) *replApprover {
 // Approve shows the preview and reads one line. "y"/"yes" (case-insensitive) approves.
 // "n", empty, and EOF deny with a nil error. A canceled context (Ctrl-C) denies and
 // returns the context error so the run aborts.
-// The prompt and rendering are action-neutral: run_command calls get a plain preview
-// and "Run this command?" prompt; all other calls get the diff rendering and "Apply
+// The prompt and rendering are action-neutral: run_command and MCP calls get a
+// plain preview and run prompt; all other calls get the diff rendering and "Apply
 // this change?" prompt.
 func (a *replApprover) Approve(ctx context.Context, call provider.ToolCall, preview string) (bool, error) {
 	isExec := call.Function.Name == "run_command"
+	isMCP := strings.HasPrefix(call.Function.Name, "mcp__")
 	if isExec {
 		a.renderPlain(preview)
 		_, _ = fmt.Fprint(a.out, "Run this command? [y/N] ")
+	} else if isMCP {
+		a.renderPlain(preview)
+		_, _ = fmt.Fprint(a.out, "Run this MCP tool? [y/N] ")
 	} else {
 		a.renderDiff(preview)
 		_, _ = fmt.Fprint(a.out, "Apply this change? [y/N] ")

--- a/cmd/golem/approver_test.go
+++ b/cmd/golem/approver_test.go
@@ -78,6 +78,24 @@ func TestApproverExecPromptNeutral(t *testing.T) {
 	}
 }
 
+func TestApproverMCPPromptShowsRunTool(t *testing.T) {
+	in := strings.NewReader("y\n")
+	var out strings.Builder
+	a := newReplApprover(newLineReader(in), &out, false)
+	call := provider.ToolCall{Function: provider.ToolCallFunction{Name: "mcp__fs__read"}}
+	ok, err := a.Approve(context.Background(), call, "mcp tool call:\n  args: {}\n")
+	if err != nil || !ok {
+		t.Fatalf("ok=%v err=%v", ok, err)
+	}
+	s := out.String()
+	if !strings.Contains(s, "Run this MCP tool?") {
+		t.Errorf("mcp prompt should say 'Run this MCP tool?':\n%s", s)
+	}
+	if strings.Contains(s, "Apply this change?") {
+		t.Error("mcp call must not use the diff prompt")
+	}
+}
+
 func TestReplApproverColorRendersAnsi(t *testing.T) {
 	var out strings.Builder
 	lr := newLineReader(strings.NewReader("n\n"))

--- a/cmd/golem/main.go
+++ b/cmd/golem/main.go
@@ -15,6 +15,7 @@ import (
 	agenttools "github.com/kstruzzieri/go-llm/agent/tools"
 	"github.com/kstruzzieri/go-llm/conversation"
 	"github.com/kstruzzieri/go-llm/internal/providerbootstrap"
+	"github.com/kstruzzieri/go-llm/mcpclient"
 	"github.com/kstruzzieri/go-llm/memory"
 )
 
@@ -32,6 +33,8 @@ type flags struct {
 	sessionID        string
 	allowWrite       bool
 	allowExec        bool
+	mcpStdio         stringSliceFlag
+	mcpHTTP          stringSliceFlag
 	noRag            bool
 	noProjectContext bool
 	noCompress       bool
@@ -53,6 +56,8 @@ func parseFlags(args []string) (flags, error) {
 	fs.BoolVar(&f.fresh, "fresh", false, "start a new persistent session instead of resuming this workspace")
 	fs.BoolVar(&f.allowWrite, "allow-write", false, "enable approval-gated write_file/edit_file tools")
 	fs.BoolVar(&f.allowExec, "allow-exec", false, "enable the approval-gated run_command exec tool")
+	fs.Var(&f.mcpStdio, "mcp-stdio", "attach an MCP server over stdio: \"[alias=]command args...\" (repeatable; use `env KEY=val cmd` for env vars)")
+	fs.Var(&f.mcpHTTP, "mcp-http", "attach an MCP server over streamable HTTP: \"[alias=]https://endpoint\" (repeatable)")
 	fs.BoolVar(&f.noRag, "no-rag", false, "disable the retrieve tool entirely (ignore any auto index)")
 	fs.BoolVar(&f.noProjectContext, "no-project-context", false, "do not load AGENTS.md project-context files into the system prompt")
 	fs.BoolVar(&f.noCompress, "no-compress", false, "disable post-turn conversation compression into a durable summary")
@@ -251,6 +256,29 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 		tools = append(tools, et...)
 	}
 
+	var mcpManager *mcpclient.Manager
+	mcpAttached := false
+	if servers, perr := parseMCPServers(f.mcpStdio, f.mcpHTTP); perr != nil {
+		return perr // fatal: bad flag config / explicit duplicate alias
+	} else if len(servers) > 0 {
+		mgr, mcpWarns, cerr := mcpclient.Connect(ctx, mcpClientImpl(), servers)
+		if cerr != nil {
+			return cerr // fatal: invalid / duplicate alias
+		}
+		for _, w := range mcpWarns {
+			warns = append(warns, "mcp: "+w.Error())
+		}
+		mcpTools := mgr.Tools()
+		tools = append(tools, mcpTools...)
+		mcpManager = mgr
+		mcpAttached = len(mcpTools) > 0
+	}
+	defer func() {
+		if mcpManager != nil {
+			_ = mcpManager.Close()
+		}
+	}()
+
 	baseSystem := buildSystemPrompt(f.allowWrite, f.allowExec)
 	baseSystem += memorySystemFragment(memoryEnabled)
 	projectContextLine := ""
@@ -331,6 +359,7 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 		journal:      journal,
 		allowWrite:   f.allowWrite,
 		allowExec:    f.allowExec,
+		mcpAttached:  mcpAttached,
 		memory:       memStore,
 		memoryDBPath: memDBPath,
 		workspaceID:  workspaceID(root),

--- a/cmd/golem/main.go
+++ b/cmd/golem/main.go
@@ -91,6 +91,7 @@ type startupInfo struct {
 	sessionLine        string
 	projectContextLine string
 	memoryLine         string
+	mcpLine            string
 }
 
 // startupNotices renders the human-facing startup lines (written to stderr).
@@ -102,6 +103,9 @@ func startupNotices(info startupInfo) []string {
 	}
 	if info.memoryLine != "" {
 		out = append(out, info.memoryLine)
+	}
+	if info.mcpLine != "" {
+		out = append(out, info.mcpLine)
 	}
 	if info.projectContextLine != "" {
 		out = append(out, info.projectContextLine)
@@ -258,6 +262,7 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 
 	var mcpManager *mcpclient.Manager
 	mcpAttached := false
+	mcpLine := ""
 	if servers, perr := parseMCPServers(f.mcpStdio, f.mcpHTTP); perr != nil {
 		return perr // fatal: bad flag config / explicit duplicate alias
 	} else if len(servers) > 0 {
@@ -272,6 +277,10 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 		tools = append(tools, mcpTools...)
 		mcpManager = mgr
 		mcpAttached = len(mcpTools) > 0
+		// Positive confirmation so a silently-failed server attach is visible:
+		// attached-tool count against the configured-server count (failures and
+		// skipped tools appear as the "mcp: ..." warnings above).
+		mcpLine = fmt.Sprintf("mcp: attached %d tool(s) from %d configured server(s)", len(mcpTools), len(servers))
 	}
 	defer func() {
 		if mcpManager != nil {
@@ -325,6 +334,7 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 		sessionLine:        sessionLine,
 		projectContextLine: projectContextLine,
 		memoryLine:         memoryLine,
+		mcpLine:            mcpLine,
 	}) {
 		_, _ = fmt.Fprintln(stderr, line)
 	}

--- a/cmd/golem/main_test.go
+++ b/cmd/golem/main_test.go
@@ -130,6 +130,30 @@ func TestStartupNotices_SessionLine(t *testing.T) {
 	}
 }
 
+func TestStartupNotices_MCPLine(t *testing.T) {
+	got := startupNotices(startupInfo{
+		workspace: "/r",
+		mcpLine:   "mcp: attached 3 tool(s) from 2 configured server(s)",
+	})
+	joined := strings.Join(got, "\n")
+	if !strings.Contains(joined, "mcp: attached 3 tool(s) from 2 configured server(s)") {
+		t.Errorf("mcp line missing in:\n%s", joined)
+	}
+}
+
+func TestParseFlags_MCPServersRepeatable(t *testing.T) {
+	f, err := parseFlags([]string{"-mcp-stdio", "npx a", "-mcp-stdio", "npx b", "-mcp-http", "https://h/mcp"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.mcpStdio) != 2 {
+		t.Errorf("mcpStdio = %v, want 2 entries", f.mcpStdio)
+	}
+	if len(f.mcpHTTP) != 1 {
+		t.Errorf("mcpHTTP = %v, want 1 entry", f.mcpHTTP)
+	}
+}
+
 func TestValidateFlags_NoRagWithRagDBExclusive(t *testing.T) {
 	err := validateFlags(flags{noRag: true, ragDB: "/x.db"})
 	if err == nil {

--- a/cmd/golem/mcp.go
+++ b/cmd/golem/mcp.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/kstruzzieri/go-llm/mcpclient"
+)
+
+const mcpClientName = "golem"
+
+var golemAliasRE = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
+
+// stringSliceFlag is a repeatable string flag (-mcp-stdio a -mcp-stdio b).
+type stringSliceFlag []string
+
+func (s *stringSliceFlag) String() string     { return strings.Join(*s, ",") }
+func (s *stringSliceFlag) Set(v string) error { *s = append(*s, v); return nil }
+
+// splitAlias splits "[alias=]spec". The left of the first '=' is the alias only
+// if it fully matches the alias regex; otherwise the whole value is the spec.
+// This keeps URLs with query strings and `env KEY=val cmd` stdio forms intact.
+// Caveat (documented in flag help): a bare leading `KEY=val cmd` is read as
+// alias=KEY; use `env KEY=val cmd` to pass environment variables.
+func splitAlias(value string) (alias, spec string) {
+	if i := strings.IndexByte(value, '='); i >= 0 {
+		if cand := value[:i]; golemAliasRE.MatchString(cand) {
+			return cand, value[i+1:]
+		}
+	}
+	return "", value
+}
+
+func sanitizeAlias(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-':
+			b.WriteRune(r)
+		}
+	}
+	out := b.String()
+	if len(out) > 64 {
+		out = out[:64]
+	}
+	return out
+}
+
+// parseMCPServers turns the repeatable flag values into mcpclient.Server configs,
+// deriving aliases when omitted and rejecting explicit-alias collisions. (Connect
+// also rejects duplicates, fatally; this gives a clearer per-flag message.)
+func parseMCPServers(stdioFlags, httpFlags []string) ([]mcpclient.Server, error) {
+	used := make(map[string]bool)
+	var servers []mcpclient.Server
+
+	derive := func(base string) string {
+		a := sanitizeAlias(base)
+		if a == "" {
+			a = "mcp"
+		}
+		cand := a
+		for n := 2; used[cand]; n++ {
+			cand = fmt.Sprintf("%s%d", a, n)
+		}
+		used[cand] = true
+		return cand
+	}
+	claimExplicit := func(flagName, raw, alias string) error {
+		if used[alias] {
+			return fmt.Errorf("-%s %q: duplicate alias %q", flagName, raw, alias)
+		}
+		used[alias] = true
+		return nil
+	}
+
+	for _, f := range stdioFlags {
+		alias, spec := splitAlias(strings.TrimSpace(f))
+		fields := strings.Fields(spec)
+		if len(fields) == 0 {
+			return nil, fmt.Errorf("-mcp-stdio %q: empty command", f)
+		}
+		if alias == "" {
+			alias = derive(filepath.Base(fields[0]))
+		} else if err := claimExplicit("mcp-stdio", f, alias); err != nil {
+			return nil, err
+		}
+		servers = append(servers, mcpclient.StdioServer(alias, fields))
+	}
+
+	for _, f := range httpFlags {
+		alias, spec := splitAlias(strings.TrimSpace(f))
+		spec = strings.TrimSpace(spec)
+		if spec == "" {
+			return nil, fmt.Errorf("-mcp-http %q: empty endpoint", f)
+		}
+		if alias == "" {
+			host := spec
+			if u, err := url.Parse(spec); err == nil && u.Host != "" {
+				host = u.Host
+			}
+			alias = derive(host)
+		} else if err := claimExplicit("mcp-http", f, alias); err != nil {
+			return nil, err
+		}
+		servers = append(servers, mcpclient.HTTPServer(alias, spec))
+	}
+	return servers, nil
+}
+
+// needsApprover reports whether the REPL must install the interactive approver.
+// MCP tools are ApprovalAlways, so they require it even with no write/exec.
+func needsApprover(allowWrite, allowExec, mcpAttached bool) bool {
+	return allowWrite || allowExec || mcpAttached
+}
+
+func mcpClientImpl() mcpclient.Implementation {
+	return mcpclient.Implementation{Name: mcpClientName, Version: "dev"}
+}

--- a/cmd/golem/mcp.go
+++ b/cmd/golem/mcp.go
@@ -5,8 +5,10 @@ import (
 	"net/url"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
+	"github.com/kstruzzieri/go-llm/internal/mcpstdio"
 	"github.com/kstruzzieri/go-llm/mcpclient"
 )
 
@@ -61,12 +63,20 @@ func parseMCPServers(stdioFlags, httpFlags []string) ([]mcpclient.Server, error)
 		if a == "" {
 			a = "mcp"
 		}
-		cand := a
-		for n := 2; used[cand]; n++ {
-			cand = fmt.Sprintf("%s%d", a, n)
+		for n := 1; ; n++ {
+			cand := a
+			if n > 1 {
+				suffix := strconv.Itoa(n)
+				if maxBase := 64 - len(suffix); len(cand) > maxBase {
+					cand = cand[:maxBase]
+				}
+				cand += suffix
+			}
+			if !used[cand] {
+				used[cand] = true
+				return cand
+			}
 		}
-		used[cand] = true
-		return cand
 	}
 	claimExplicit := func(flagName, raw, alias string) error {
 		if used[alias] {
@@ -78,7 +88,10 @@ func parseMCPServers(stdioFlags, httpFlags []string) ([]mcpclient.Server, error)
 
 	for _, f := range stdioFlags {
 		alias, spec := splitAlias(strings.TrimSpace(f))
-		fields := strings.Fields(spec)
+		fields, err := mcpstdio.ParseCommand(spec)
+		if err != nil {
+			return nil, fmt.Errorf("-mcp-stdio %q: %w", f, err)
+		}
 		if len(fields) == 0 {
 			return nil, fmt.Errorf("-mcp-stdio %q: empty command", f)
 		}

--- a/cmd/golem/mcp_test.go
+++ b/cmd/golem/mcp_test.go
@@ -1,0 +1,63 @@
+package main
+
+import "testing"
+
+func TestSplitAlias(t *testing.T) {
+	tests := []struct{ in, alias, spec string }{
+		{"fs=npx server", "fs", "npx server"},
+		{"npx server", "", "npx server"},
+		{"https://h/p?token=x", "", "https://h/p?token=x"},
+		{"env FOO=bar mycmd", "", "env FOO=bar mycmd"},
+		{"FOO=bar mycmd", "FOO", "bar mycmd"},
+	}
+	for _, tt := range tests {
+		a, s := splitAlias(tt.in)
+		if a != tt.alias || s != tt.spec {
+			t.Errorf("splitAlias(%q) = (%q,%q), want (%q,%q)", tt.in, a, s, tt.alias, tt.spec)
+		}
+	}
+}
+
+func TestParseMCPServersDerivesAndDedupes(t *testing.T) {
+	servers, err := parseMCPServers(
+		[]string{"npx mcp-fs /tmp", "fs2=npx mcp-fs /var"},
+		[]string{"https://api.example.com/mcp"},
+	)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(servers) != 3 {
+		t.Fatalf("got %d servers", len(servers))
+	}
+	seen := map[string]bool{}
+	for _, s := range servers {
+		if s.Alias == "" || seen[s.Alias] {
+			t.Fatalf("alias %q empty or duplicate", s.Alias)
+		}
+		seen[s.Alias] = true
+	}
+}
+
+func TestParseMCPServersExplicitAliasCollision(t *testing.T) {
+	if _, err := parseMCPServers([]string{"a=x", "a=y"}, nil); err == nil {
+		t.Fatal("explicit duplicate alias must error")
+	}
+}
+
+func TestParseMCPServersEmptyCommand(t *testing.T) {
+	if _, err := parseMCPServers([]string{"   "}, nil); err == nil {
+		t.Fatal("empty stdio command must error")
+	}
+}
+
+func TestApproverInstalledWhenMCPAttached(t *testing.T) {
+	if !needsApprover(false, false, true) {
+		t.Fatal("MCP-attached read-only session must install the approver")
+	}
+	if needsApprover(false, false, false) {
+		t.Fatal("plain read-only session must NOT install an approver")
+	}
+	if !needsApprover(true, false, false) {
+		t.Fatal("write session must install the approver")
+	}
+}

--- a/cmd/golem/mcp_test.go
+++ b/cmd/golem/mcp_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestSplitAlias(t *testing.T) {
 	tests := []struct{ in, alias, spec string }{
@@ -36,6 +39,46 @@ func TestParseMCPServersDerivesAndDedupes(t *testing.T) {
 		}
 		seen[s.Alias] = true
 	}
+}
+
+func TestParseMCPServersStdioQuotedArgs(t *testing.T) {
+	servers, err := parseMCPServers([]string{`fs="/tmp/my server" --config "Project A.json" 'single quoted arg' bare`}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := serverCommand(servers[0])
+	want := []string{"/tmp/my server", "--config", "Project A.json", "single quoted arg", "bare"}
+	if len(got) != len(want) {
+		t.Fatalf("command = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("command = %#v, want %#v", got, want)
+		}
+	}
+}
+
+func TestParseMCPServersDerivedAliasSuffixStaysValid(t *testing.T) {
+	long := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	servers, err := parseMCPServers([]string{long, long}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers[1].Alias) > 64 {
+		t.Fatalf("alias %q length = %d, want <= 64", servers[1].Alias, len(servers[1].Alias))
+	}
+	if servers[0].Alias == servers[1].Alias {
+		t.Fatalf("aliases must be unique: %q", servers[0].Alias)
+	}
+}
+
+func serverCommand(server any) []string {
+	v := reflect.ValueOf(server).FieldByName("command")
+	out := make([]string, v.Len())
+	for i := range out {
+		out[i] = v.Index(i).String()
+	}
+	return out
 }
 
 func TestParseMCPServersExplicitAliasCollision(t *testing.T) {

--- a/cmd/golem/repl.go
+++ b/cmd/golem/repl.go
@@ -31,10 +31,11 @@ type replSession struct {
 	memoryDBPath string              // used to re-secure SQLite sidecars after writes
 	workspaceID  string              // stable id used to scope memory create/list/search
 
-	lastModel  string           // last routed ActualModel for /model
-	journal    *mutationJournal // nil unless -allow-write enabled writes
-	allowWrite bool
-	allowExec  bool
+	lastModel   string           // last routed ActualModel for /model
+	journal     *mutationJournal // nil unless -allow-write enabled writes
+	allowWrite  bool
+	allowExec   bool
+	mcpAttached bool // true when external MCP tools are attached (force approver)
 }
 
 // runREPL reads lines from in, dispatching slash commands and running every
@@ -96,7 +97,7 @@ func runOnce(ctx context.Context, out io.Writer, interrupts <-chan struct{}, ses
 	}
 
 	var approver agent.Approver
-	if sess.allowWrite || sess.allowExec {
+	if needsApprover(sess.allowWrite, sess.allowExec, sess.mcpAttached) {
 		approver = newReplApprover(lr, out, sess.color)
 	}
 

--- a/cmd/llm-bench/tool_schema_mcp.go
+++ b/cmd/llm-bench/tool_schema_mcp.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
-	"unicode"
 
+	"github.com/kstruzzieri/go-llm/internal/mcpstdio"
 	mcp "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -52,72 +52,7 @@ func newMCPToolSchemaSourceStdio(command string) (*mcpToolSchemaSource, error) {
 }
 
 func parseStdioCommand(command string) ([]string, error) {
-	var parts []string
-	var b strings.Builder
-	var quote rune
-	inToken := false
-
-	flush := func() {
-		parts = append(parts, b.String())
-		b.Reset()
-		inToken = false
-	}
-
-	runes := []rune(strings.TrimSpace(command))
-	for i := 0; i < len(runes); i++ {
-		r := runes[i]
-		if quote != '\'' && r == '\\' {
-			if i+1 < len(runes) && isStdioEscapedRune(quote, runes[i+1]) {
-				b.WriteRune(runes[i+1])
-				i++
-			} else {
-				b.WriteRune(r)
-			}
-			inToken = true
-			continue
-		}
-		if quote != 0 {
-			if r == quote {
-				quote = 0
-				continue
-			}
-			b.WriteRune(r)
-			inToken = true
-			continue
-		}
-
-		switch {
-		case r == '\'' || r == '"':
-			quote = r
-			inToken = true
-		case unicode.IsSpace(r):
-			if inToken {
-				flush()
-			}
-		default:
-			b.WriteRune(r)
-			inToken = true
-		}
-	}
-	if quote != 0 {
-		return nil, fmt.Errorf("unterminated %q quote", quote)
-	}
-	if inToken {
-		flush()
-	}
-	return parts, nil
-}
-
-func isStdioEscapedRune(quote rune, next rune) bool {
-	// Only consume escapes for parser delimiters; other backslashes are
-	// preserved as Windows path separators.
-	if quote == '"' {
-		return next == '"'
-	}
-	if quote == 0 {
-		return unicode.IsSpace(next) || next == '\'' || next == '"'
-	}
-	return false
+	return mcpstdio.ParseCommand(command)
 }
 
 func newMCPToolSchemaSourceHTTP(endpoint string) (*mcpToolSchemaSource, error) {

--- a/internal/mcpstdio/command.go
+++ b/internal/mcpstdio/command.go
@@ -1,0 +1,78 @@
+// Package mcpstdio parses command strings for MCP stdio transports.
+package mcpstdio
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// ParseCommand splits an MCP stdio command string into argv. It supports the
+// small shell-like subset users expect in flags: whitespace separation, single
+// and double quotes, and backslash escapes for delimiters.
+func ParseCommand(command string) ([]string, error) {
+	var parts []string
+	var b strings.Builder
+	var quote rune
+	inToken := false
+
+	flush := func() {
+		parts = append(parts, b.String())
+		b.Reset()
+		inToken = false
+	}
+
+	runes := []rune(strings.TrimSpace(command))
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+		if quote != '\'' && r == '\\' {
+			if i+1 < len(runes) && isEscapedRune(quote, runes[i+1]) {
+				b.WriteRune(runes[i+1])
+				i++
+			} else {
+				b.WriteRune(r)
+			}
+			inToken = true
+			continue
+		}
+		if quote != 0 {
+			if r == quote {
+				quote = 0
+				continue
+			}
+			b.WriteRune(r)
+			inToken = true
+			continue
+		}
+
+		switch {
+		case r == '\'' || r == '"':
+			quote = r
+			inToken = true
+		case unicode.IsSpace(r):
+			if inToken {
+				flush()
+			}
+		default:
+			b.WriteRune(r)
+			inToken = true
+		}
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("unterminated %q quote", quote)
+	}
+	if inToken {
+		flush()
+	}
+	return parts, nil
+}
+
+func isEscapedRune(quote rune, next rune) bool {
+	if quote == '"' {
+		return next == '"'
+	}
+	if quote == 0 {
+		return unicode.IsSpace(next) || next == '\'' || next == '"'
+	}
+	return false
+}

--- a/mcpclient/adapter.go
+++ b/mcpclient/adapter.go
@@ -1,0 +1,81 @@
+package mcpclient
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/kstruzzieri/go-llm/agent"
+)
+
+const (
+	defaultToolTimeout   = 60 * time.Second
+	defaultToolOutputCap = 32 * 1024
+)
+
+// toolCaller is the minimal slice of *gomcp.ClientSession the adapter needs, so
+// tests can inject a fake without a live session.
+type toolCaller interface {
+	CallTool(ctx context.Context, params *gomcp.CallToolParams) (*gomcp.CallToolResult, error)
+}
+
+// toolAdapter exposes one remote MCP tool as an agent.Tool.
+type toolAdapter struct {
+	caller       toolCaller
+	remoteName   string // unprefixed name sent to the server
+	prefixedName string // namespaced model-facing name
+	description  string
+	schema       json.RawMessage
+	timeout      time.Duration
+	outputCap    int
+}
+
+var _ agent.Tool = (*toolAdapter)(nil)
+
+func (a *toolAdapter) Spec() agent.ToolSpec {
+	return agent.ToolSpec{Name: a.prefixedName, Description: a.description, Parameters: a.schema}
+}
+
+// Effect is the conservative upper bound for an untrusted remote tool. Class is
+// the full bitset: the only consumer of Class is needsApproval, which
+// ApprovalAlways already forces to true, so the full set changes no control flow
+// and only makes /tools honest. ApprovalAlways is mandatory -- Network alone is
+// NOT "mutating" (IsMutating checks Write|Exec), so an ApprovalDefault network
+// tool would skip approval entirely.
+func (a *toolAdapter) Effect() agent.Effect {
+	to, oc := a.timeout, a.outputCap
+	if to <= 0 {
+		to = defaultToolTimeout
+	}
+	if oc <= 0 {
+		oc = defaultToolOutputCap
+	}
+	return agent.Effect{
+		Class:     agent.Read | agent.Write | agent.Exec | agent.Network,
+		Approval:  agent.ApprovalAlways,
+		Timeout:   to,
+		OutputCap: oc,
+	}
+}
+
+// Invoke calls the remote tool. Every failure mode (bad args, transport/session
+// error) returns a ToolResult{IsError:true} with a nil Go error: a non-nil error
+// would hard-abort the agent loop. The runtime applies Effect.Timeout and
+// Effect.OutputCap around this call.
+func (a *toolAdapter) Invoke(ctx context.Context, raw json.RawMessage) (agent.ToolResult, error) {
+	var args any
+	if len(raw) > 0 && string(raw) != "null" {
+		var m map[string]any
+		if err := json.Unmarshal(raw, &m); err != nil {
+			return agent.ToolResult{IsError: true, Content: "invalid arguments: " + err.Error()}, nil
+		}
+		args = m
+	}
+	res, err := a.caller.CallTool(ctx, &gomcp.CallToolParams{Name: a.remoteName, Arguments: args})
+	if err != nil {
+		return agent.ToolResult{IsError: true, Content: "mcp call failed: " + err.Error()}, nil
+	}
+	return agent.ToolResult{Content: flattenContent(res), IsError: res.IsError}, nil
+}

--- a/mcpclient/adapter.go
+++ b/mcpclient/adapter.go
@@ -3,6 +3,8 @@ package mcpclient
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -33,6 +35,7 @@ type toolAdapter struct {
 }
 
 var _ agent.Tool = (*toolAdapter)(nil)
+var _ agent.PlanningTool = (*toolAdapter)(nil)
 
 func (a *toolAdapter) Spec() agent.ToolSpec {
 	return agent.ToolSpec{Name: a.prefixedName, Description: a.description, Parameters: a.schema}
@@ -58,6 +61,20 @@ func (a *toolAdapter) Effect() agent.Effect {
 		Timeout:   to,
 		OutputCap: oc,
 	}
+}
+
+func (a *toolAdapter) Plan(_ context.Context, raw json.RawMessage) (agent.ToolPlan, error) {
+	args := strings.TrimSpace(string(raw))
+	if args == "" {
+		args = "{}"
+	}
+	return agent.ToolPlan{
+		Effect: a.Effect(),
+		Preview: fmt.Sprintf(
+			"mcp tool call:\n  tool: %s\n  remote: %s\n  args: %s\n",
+			a.prefixedName, a.remoteName, args,
+		),
+	}, nil
 }
 
 // Invoke calls the remote tool. Every failure mode (bad args, transport/session

--- a/mcpclient/adapter_test.go
+++ b/mcpclient/adapter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -41,6 +42,26 @@ func TestAdapterSpecAndEffect(t *testing.T) {
 	}
 	if e.Timeout <= 0 || e.OutputCap <= 0 {
 		t.Fatal("effect must declare a positive timeout and output cap")
+	}
+}
+
+func TestAdapterPlanShowsMCPCall(t *testing.T) {
+	a := newAdapter(&fakeCaller{})
+	pt, ok := any(a).(agent.PlanningTool)
+	if !ok {
+		t.Fatal("mcp adapter must provide an approval preview")
+	}
+	plan, err := pt.Plan(context.Background(), json.RawMessage(`{"path":"x y"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Effect.Approval != agent.ApprovalAlways {
+		t.Fatalf("approval = %v, want ApprovalAlways", plan.Effect.Approval)
+	}
+	for _, want := range []string{`tool: mcp__fs__read`, `remote: read`, `args: {"path":"x y"}`} {
+		if !strings.Contains(plan.Preview, want) {
+			t.Fatalf("preview missing %q:\n%s", want, plan.Preview)
+		}
 	}
 }
 

--- a/mcpclient/adapter_test.go
+++ b/mcpclient/adapter_test.go
@@ -1,0 +1,85 @@
+package mcpclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/kstruzzieri/go-llm/agent"
+)
+
+type fakeCaller struct {
+	gotName string
+	gotArgs any
+	res     *gomcp.CallToolResult
+	err     error
+}
+
+func (f *fakeCaller) CallTool(_ context.Context, p *gomcp.CallToolParams) (*gomcp.CallToolResult, error) {
+	f.gotName, f.gotArgs = p.Name, p.Arguments
+	return f.res, f.err
+}
+
+func newAdapter(c toolCaller) *toolAdapter {
+	return &toolAdapter{caller: c, remoteName: "read", prefixedName: "mcp__fs__read", description: "d", schema: json.RawMessage(`{"type":"object"}`)}
+}
+
+func TestAdapterSpecAndEffect(t *testing.T) {
+	a := newAdapter(&fakeCaller{})
+	if a.Spec().Name != "mcp__fs__read" {
+		t.Fatalf("name %q", a.Spec().Name)
+	}
+	e := a.Effect()
+	if e.Approval != agent.ApprovalAlways {
+		t.Fatal("imported tools must require approval (ApprovalAlways)")
+	}
+	if !e.Class.Has(agent.Network) || !e.Class.IsMutating() {
+		t.Fatal("effect must be a conservative upper bound (network + mutating)")
+	}
+	if e.Timeout <= 0 || e.OutputCap <= 0 {
+		t.Fatal("effect must declare a positive timeout and output cap")
+	}
+}
+
+func TestAdapterInvokeMapsResult(t *testing.T) {
+	fc := &fakeCaller{res: &gomcp.CallToolResult{Content: []gomcp.Content{&gomcp.TextContent{Text: "ok"}}}}
+	out, err := newAdapter(fc).Invoke(context.Background(), json.RawMessage(`{"path":"x"}`))
+	if err != nil {
+		t.Fatalf("Invoke returned a hard error: %v", err)
+	}
+	if out.IsError || out.Content != "ok" {
+		t.Fatalf("got %+v", out)
+	}
+	if fc.gotName != "read" {
+		t.Fatalf("called remote name %q, want unprefixed 'read'", fc.gotName)
+	}
+}
+
+func TestAdapterInvokeServerError(t *testing.T) {
+	fc := &fakeCaller{res: &gomcp.CallToolResult{IsError: true, Content: []gomcp.Content{&gomcp.TextContent{Text: "boom"}}}}
+	out, _ := newAdapter(fc).Invoke(context.Background(), nil)
+	if !out.IsError {
+		t.Fatal("CallToolResult.IsError must map to ToolResult.IsError")
+	}
+}
+
+func TestAdapterInvokeTransportError(t *testing.T) {
+	fc := &fakeCaller{err: errors.New("session dropped")}
+	out, err := newAdapter(fc).Invoke(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("transport error must NOT be a hard error (would abort the loop): %v", err)
+	}
+	if !out.IsError {
+		t.Fatal("transport error must become ToolResult{IsError:true}")
+	}
+}
+
+func TestAdapterInvokeBadArgs(t *testing.T) {
+	out, err := newAdapter(&fakeCaller{}).Invoke(context.Background(), json.RawMessage(`{not json`))
+	if err != nil || !out.IsError {
+		t.Fatalf("malformed args -> IsError, no hard error; got (%+v,%v)", out, err)
+	}
+}

--- a/mcpclient/connect.go
+++ b/mcpclient/connect.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"time"
+	"unicode/utf8"
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -185,8 +186,14 @@ func adaptTools(caller toolCaller, alias string, remote []*gomcp.Tool) ([]agent.
 		}
 		desc := rt.Description
 		if len(desc) > maxDescBytes {
-			desc = desc[:maxDescBytes] + "...[truncated]"
-			warns = append(warns, fmt.Errorf("server %q: tool %q description truncated to %d bytes", alias, rt.Name, maxDescBytes))
+			// Back up to a UTF-8 rune boundary so truncation never splits a rune
+			// (mirrors the runtime's capOutput).
+			cut := maxDescBytes
+			for cut > 0 && !utf8.RuneStart(desc[cut]) {
+				cut--
+			}
+			desc = desc[:cut] + "...[truncated]"
+			warns = append(warns, fmt.Errorf("server %q: tool %q description truncated to %d bytes", alias, rt.Name, cut))
 		}
 		out = append(out, &toolAdapter{
 			caller:       caller,

--- a/mcpclient/connect.go
+++ b/mcpclient/connect.go
@@ -164,8 +164,13 @@ func adaptTools(caller toolCaller, alias string, remote []*gomcp.Tool) ([]agent.
 	var (
 		out   []agent.Tool
 		warns []error
+		seen  = make(map[string]bool)
 	)
 	for _, rt := range remote {
+		if rt == nil {
+			warns = append(warns, fmt.Errorf("server %q: skipping nil tool", alias))
+			continue
+		}
 		if len(out) >= maxToolsPerServer {
 			warns = append(warns, fmt.Errorf("server %q: more than %d tools, truncating", alias, maxToolsPerServer))
 			break
@@ -173,6 +178,10 @@ func adaptTools(caller toolCaller, alias string, remote []*gomcp.Tool) ([]agent.
 		name, ok := composeName(alias, rt.Name)
 		if !ok {
 			warns = append(warns, fmt.Errorf("server %q: skipping tool %q (invalid or over-long composed name)", alias, rt.Name))
+			continue
+		}
+		if seen[name] {
+			warns = append(warns, fmt.Errorf("server %q: skipping duplicate tool %q", alias, rt.Name))
 			continue
 		}
 		schema, err := normalizeSchema(rt.InputSchema)
@@ -204,6 +213,7 @@ func adaptTools(caller toolCaller, alias string, remote []*gomcp.Tool) ([]agent.
 			timeout:      defaultToolTimeout,
 			outputCap:    defaultToolOutputCap,
 		})
+		seen[name] = true
 	}
 	return out, warns
 }

--- a/mcpclient/connect.go
+++ b/mcpclient/connect.go
@@ -58,8 +58,9 @@ type Manager struct {
 	tools    []agent.Tool
 }
 
-// Tools returns the namespaced adapter tools in deterministic (server, list)
-// order. The slice is a copy; callers may append freely.
+// Tools returns the namespaced adapter tools in server-then-list order (the
+// order each server returned its tools). The slice is a copy; callers may
+// append freely.
 func (m *Manager) Tools() []agent.Tool {
 	out := make([]agent.Tool, len(m.tools))
 	copy(out, m.tools)

--- a/mcpclient/connect.go
+++ b/mcpclient/connect.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -13,6 +14,12 @@ import (
 const (
 	maxToolsPerServer = 128
 	maxListPages      = 100
+	// connectTimeout bounds the handshake + tools/list for one server so a stdio
+	// command that spawns but never speaks MCP (or a hung HTTP endpoint) cannot
+	// block startup forever. It scopes only setup: the SDK keeps the session's
+	// background loop on its own context, so cancelling here does not close the
+	// live session, which is later driven by per-call dispatch contexts.
+	connectTimeout = 30 * time.Second
 )
 
 // lister is the minimal slice of *gomcp.ClientSession for paginated tools/list.
@@ -114,6 +121,16 @@ func connectOne(ctx context.Context, impl Implementation, s Server) (*gomcp.Clie
 	if err != nil {
 		return nil, nil, []error{fmt.Errorf("server %q: %w", s.Alias, err)}
 	}
+	return connectVia(ctx, impl, s.Alias, tr)
+}
+
+// connectVia performs the dial + handshake + tools/list + adapt for one server
+// over an already-built transport. Split from connectOne so tests can drive it
+// with an in-memory transport. Setup is time-bounded (see connectTimeout); the
+// returned session outlives the bounded context.
+func connectVia(ctx context.Context, impl Implementation, alias string, tr gomcp.Transport) (*gomcp.ClientSession, []agent.Tool, []error) {
+	ctx, cancel := context.WithTimeout(ctx, connectTimeout)
+	defer cancel()
 	client := gomcp.NewClient(
 		&gomcp.Implementation{Name: impl.Name, Version: impl.Version},
 		// Empty Capabilities disables the roots capability (SDK #607 behavior) and
@@ -122,10 +139,10 @@ func connectOne(ctx context.Context, impl Implementation, s Server) (*gomcp.Clie
 	)
 	session, err := client.Connect(ctx, tr, nil)
 	if err != nil {
-		return nil, nil, []error{fmt.Errorf("server %q: connect: %w", s.Alias, err)}
+		return nil, nil, []error{fmt.Errorf("server %q: connect: %w", alias, err)}
 	}
-	remote, listWarns := listAllTools(ctx, session, s.Alias)
-	tools, adaptWarns := adaptTools(session, s.Alias, remote)
+	remote, listWarns := listAllTools(ctx, session, alias)
+	tools, adaptWarns := adaptTools(session, alias, remote)
 	return session, tools, append(listWarns, adaptWarns...)
 }
 

--- a/mcpclient/connect.go
+++ b/mcpclient/connect.go
@@ -14,6 +14,16 @@ import (
 const (
 	maxToolsPerServer = 128
 	maxListPages      = 100
+	// maxSchemaBytes bounds a remote tool's input schema. The schema comes from
+	// an untrusted server and is sent to the model in the tool list on EVERY turn
+	// (unlike tool results, which the runtime output-caps post-hoc), so an
+	// oversized schema is a persistent prompt-bloat / cost vector. A tool whose
+	// normalized schema exceeds this is skipped (a clipped JSON schema would be
+	// invalid), so the cap is generous: any real tool schema is far smaller.
+	maxSchemaBytes = 32 * 1024
+	// maxDescBytes bounds a remote tool's description (also untrusted, also sent
+	// every turn). Free text, so it is truncated rather than skipped.
+	maxDescBytes = 8 * 1024
 	// connectTimeout bounds the handshake + tools/list for one server so a stdio
 	// command that spawns but never speaks MCP (or a hung HTTP endpoint) cannot
 	// block startup forever. It scopes only setup: the SDK keeps the session's
@@ -169,11 +179,20 @@ func adaptTools(caller toolCaller, alias string, remote []*gomcp.Tool) ([]agent.
 			warns = append(warns, fmt.Errorf("server %q: skipping tool %q (%v)", alias, rt.Name, err))
 			continue
 		}
+		if len(schema) > maxSchemaBytes {
+			warns = append(warns, fmt.Errorf("server %q: skipping tool %q (schema %d bytes exceeds %d cap)", alias, rt.Name, len(schema), maxSchemaBytes))
+			continue
+		}
+		desc := rt.Description
+		if len(desc) > maxDescBytes {
+			desc = desc[:maxDescBytes] + "...[truncated]"
+			warns = append(warns, fmt.Errorf("server %q: tool %q description truncated to %d bytes", alias, rt.Name, maxDescBytes))
+		}
 		out = append(out, &toolAdapter{
 			caller:       caller,
 			remoteName:   rt.Name,
 			prefixedName: name,
-			description:  rt.Description,
+			description:  desc,
 			schema:       schema,
 			timeout:      defaultToolTimeout,
 			outputCap:    defaultToolOutputCap,

--- a/mcpclient/connect.go
+++ b/mcpclient/connect.go
@@ -1,0 +1,165 @@
+package mcpclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/kstruzzieri/go-llm/agent"
+)
+
+const (
+	maxToolsPerServer = 128
+	maxListPages      = 100
+)
+
+// lister is the minimal slice of *gomcp.ClientSession for paginated tools/list.
+type lister interface {
+	ListTools(ctx context.Context, params *gomcp.ListToolsParams) (*gomcp.ListToolsResult, error)
+}
+
+// listAllTools walks tools/list pagination, guarding against a runaway page
+// count and a cursor that makes no progress. Errors and truncation are returned
+// as warnings, never fatal.
+func listAllTools(ctx context.Context, l lister, alias string) ([]*gomcp.Tool, []error) {
+	var (
+		out    []*gomcp.Tool
+		warns  []error
+		cursor string
+	)
+	for page := 0; ; page++ {
+		if page >= maxListPages {
+			warns = append(warns, fmt.Errorf("server %q: tools/list exceeded %d pages, truncating", alias, maxListPages))
+			break
+		}
+		res, err := l.ListTools(ctx, &gomcp.ListToolsParams{Cursor: cursor})
+		if err != nil {
+			warns = append(warns, fmt.Errorf("server %q: tools/list: %w", alias, err))
+			break
+		}
+		out = append(out, res.Tools...)
+		if res.NextCursor == "" {
+			break
+		}
+		if res.NextCursor == cursor {
+			warns = append(warns, fmt.Errorf("server %q: tools/list cursor made no progress, stopping", alias))
+			break
+		}
+		cursor = res.NextCursor
+	}
+	return out, warns
+}
+
+// Manager holds live client sessions and the tools adapted from them.
+type Manager struct {
+	sessions []*gomcp.ClientSession
+	tools    []agent.Tool
+}
+
+// Tools returns the namespaced adapter tools in deterministic (server, list)
+// order. The slice is a copy; callers may append freely.
+func (m *Manager) Tools() []agent.Tool {
+	out := make([]agent.Tool, len(m.tools))
+	copy(out, m.tools)
+	return out
+}
+
+// Close closes every client session (which terminates stdio subprocesses).
+func (m *Manager) Close() error {
+	var errs []error
+	for _, s := range m.sessions {
+		if err := s.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// Connect dials each server, lists its tools (paginated), and adapts them.
+// Fatal error: invalid or duplicate alias (config error). Everything else -- a
+// server that fails to connect/list, a tool skipped for an invalid name/schema,
+// a per-server cap truncation -- is a non-fatal warning, so one bad server never
+// aborts startup.
+func Connect(ctx context.Context, impl Implementation, servers []Server) (*Manager, []error, error) {
+	seen := make(map[string]bool, len(servers))
+	for _, s := range servers {
+		if !validAlias(s.Alias) {
+			return nil, nil, fmt.Errorf("mcpclient: invalid server alias %q", s.Alias)
+		}
+		if seen[s.Alias] {
+			return nil, nil, fmt.Errorf("mcpclient: duplicate server alias %q", s.Alias)
+		}
+		seen[s.Alias] = true
+	}
+
+	m := &Manager{}
+	var warnings []error
+	for _, s := range servers {
+		session, tools, warns := connectOne(ctx, impl, s)
+		warnings = append(warnings, warns...)
+		if session == nil {
+			continue
+		}
+		m.sessions = append(m.sessions, session)
+		m.tools = append(m.tools, tools...)
+	}
+	return m, warnings, nil
+}
+
+func connectOne(ctx context.Context, impl Implementation, s Server) (*gomcp.ClientSession, []agent.Tool, []error) {
+	tr, err := s.transport()
+	if err != nil {
+		return nil, nil, []error{fmt.Errorf("server %q: %w", s.Alias, err)}
+	}
+	client := gomcp.NewClient(
+		&gomcp.Implementation{Name: impl.Name, Version: impl.Version},
+		// Empty Capabilities disables the roots capability (SDK #607 behavior) and
+		// advertises no sampling/elicitation -- none are honored here.
+		&gomcp.ClientOptions{Capabilities: &gomcp.ClientCapabilities{}},
+	)
+	session, err := client.Connect(ctx, tr, nil)
+	if err != nil {
+		return nil, nil, []error{fmt.Errorf("server %q: connect: %w", s.Alias, err)}
+	}
+	remote, listWarns := listAllTools(ctx, session, s.Alias)
+	tools, adaptWarns := adaptTools(session, s.Alias, remote)
+	return session, tools, append(listWarns, adaptWarns...)
+}
+
+// adaptTools builds adapters for a server's tools, skipping (with a warning) any
+// tool whose composed name is invalid or whose schema is not an object, and
+// capping per-server tool count to guard the provider tool-count limit.
+func adaptTools(caller toolCaller, alias string, remote []*gomcp.Tool) ([]agent.Tool, []error) {
+	var (
+		out   []agent.Tool
+		warns []error
+	)
+	for _, rt := range remote {
+		if len(out) >= maxToolsPerServer {
+			warns = append(warns, fmt.Errorf("server %q: more than %d tools, truncating", alias, maxToolsPerServer))
+			break
+		}
+		name, ok := composeName(alias, rt.Name)
+		if !ok {
+			warns = append(warns, fmt.Errorf("server %q: skipping tool %q (invalid or over-long composed name)", alias, rt.Name))
+			continue
+		}
+		schema, err := normalizeSchema(rt.InputSchema)
+		if err != nil {
+			warns = append(warns, fmt.Errorf("server %q: skipping tool %q (%v)", alias, rt.Name, err))
+			continue
+		}
+		out = append(out, &toolAdapter{
+			caller:       caller,
+			remoteName:   rt.Name,
+			prefixedName: name,
+			description:  rt.Description,
+			schema:       schema,
+			timeout:      defaultToolTimeout,
+			outputCap:    defaultToolOutputCap,
+		})
+	}
+	return out, warns
+}

--- a/mcpclient/connect_test.go
+++ b/mcpclient/connect_test.go
@@ -1,0 +1,66 @@
+package mcpclient
+
+import (
+	"context"
+	"testing"
+
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestAdaptToolsSkipsAndCaps(t *testing.T) {
+	remote := []*gomcp.Tool{
+		{Name: "good", InputSchema: map[string]any{"type": "object"}},
+		{Name: "bad name", InputSchema: map[string]any{"type": "object"}},
+		{Name: "arr", InputSchema: []any{1}},
+		{Name: "nilschema"},
+	}
+	tools, warns := adaptTools(&fakeCaller{}, "fs", remote)
+	if len(tools) != 2 {
+		t.Fatalf("got %d tools, want 2", len(tools))
+	}
+	if len(warns) != 2 {
+		t.Fatalf("got %d warns, want 2", len(warns))
+	}
+}
+
+func TestAdaptToolsPerServerCap(t *testing.T) {
+	var remote []*gomcp.Tool
+	for i := 0; i < maxToolsPerServer+5; i++ {
+		remote = append(remote, &gomcp.Tool{Name: "t" + itoa(i), InputSchema: map[string]any{"type": "object"}})
+	}
+	tools, warns := adaptTools(&fakeCaller{}, "fs", remote)
+	if len(tools) != maxToolsPerServer {
+		t.Fatalf("got %d tools, want cap %d", len(tools), maxToolsPerServer)
+	}
+	if len(warns) != 1 {
+		t.Fatalf("cap truncation must warn; got %d warns", len(warns))
+	}
+}
+
+func TestConnectDuplicateAliasFatal(t *testing.T) {
+	_, _, err := Connect(context.Background(), Implementation{Name: "golem"},
+		[]Server{StdioServer("fs", []string{"x"}), StdioServer("fs", []string{"y"})})
+	if err == nil {
+		t.Fatal("duplicate alias must be a fatal error")
+	}
+}
+
+func TestConnectInvalidAliasFatal(t *testing.T) {
+	_, _, err := Connect(context.Background(), Implementation{Name: "golem"},
+		[]Server{StdioServer("bad alias", []string{"x"})})
+	if err == nil {
+		t.Fatal("invalid alias must be a fatal error")
+	}
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}

--- a/mcpclient/connect_test.go
+++ b/mcpclient/connect_test.go
@@ -2,6 +2,7 @@ package mcpclient
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -34,6 +35,40 @@ func TestAdaptToolsPerServerCap(t *testing.T) {
 	}
 	if len(warns) != 1 {
 		t.Fatalf("cap truncation must warn; got %d warns", len(warns))
+	}
+}
+
+func TestAdaptToolsSchemaSizeCapSkips(t *testing.T) {
+	// A schema that marshals beyond maxSchemaBytes must be skipped+warned, not
+	// registered (it would bloat the prompt every turn).
+	big := map[string]any{"type": "object", "x": strings.Repeat("a", maxSchemaBytes+1)}
+	tools, warns := adaptTools(&fakeCaller{}, "fs", []*gomcp.Tool{
+		{Name: "ok", InputSchema: map[string]any{"type": "object"}},
+		{Name: "huge", InputSchema: big},
+	})
+	if len(tools) != 1 {
+		t.Fatalf("got %d tools, want 1 (huge skipped)", len(tools))
+	}
+	if tools[0].Spec().Name != "mcp__fs__ok" {
+		t.Fatalf("kept the wrong tool: %s", tools[0].Spec().Name)
+	}
+	if len(warns) != 1 {
+		t.Fatalf("oversized schema must warn; got %d warns", len(warns))
+	}
+}
+
+func TestAdaptToolsDescriptionTruncated(t *testing.T) {
+	tools, warns := adaptTools(&fakeCaller{}, "fs", []*gomcp.Tool{
+		{Name: "d", Description: strings.Repeat("x", maxDescBytes+50), InputSchema: map[string]any{"type": "object"}},
+	})
+	if len(tools) != 1 {
+		t.Fatalf("got %d tools, want 1 (description truncated, not skipped)", len(tools))
+	}
+	if got := len(tools[0].Spec().Description); got > maxDescBytes+len("...[truncated]") {
+		t.Fatalf("description not truncated: %d bytes", got)
+	}
+	if len(warns) != 1 {
+		t.Fatalf("truncation must warn; got %d warns", len(warns))
 	}
 }
 

--- a/mcpclient/connect_test.go
+++ b/mcpclient/connect_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -69,6 +70,19 @@ func TestAdaptToolsDescriptionTruncated(t *testing.T) {
 	}
 	if len(warns) != 1 {
 		t.Fatalf("truncation must warn; got %d warns", len(warns))
+	}
+}
+
+func TestAdaptToolsDescriptionTruncationKeepsValidUTF8(t *testing.T) {
+	// Multi-byte runes so a naive byte cut at maxDescBytes would split a rune.
+	tools, _ := adaptTools(&fakeCaller{}, "fs", []*gomcp.Tool{
+		{Name: "u", Description: strings.Repeat("世", maxDescBytes), InputSchema: map[string]any{"type": "object"}},
+	})
+	if len(tools) != 1 {
+		t.Fatalf("got %d tools, want 1", len(tools))
+	}
+	if !utf8.ValidString(tools[0].Spec().Description) {
+		t.Fatal("truncated description is not valid UTF-8 (cut split a rune)")
 	}
 }
 

--- a/mcpclient/connect_test.go
+++ b/mcpclient/connect_test.go
@@ -25,6 +25,38 @@ func TestAdaptToolsSkipsAndCaps(t *testing.T) {
 	}
 }
 
+func TestAdaptToolsSkipsNilTool(t *testing.T) {
+	tools, warns := adaptTools(&fakeCaller{}, "fs", []*gomcp.Tool{
+		nil,
+		{Name: "good", InputSchema: map[string]any{"type": "object"}},
+	})
+	if len(tools) != 1 {
+		t.Fatalf("got %d tools, want 1", len(tools))
+	}
+	if tools[0].Spec().Name != "mcp__fs__good" {
+		t.Fatalf("kept the wrong tool: %s", tools[0].Spec().Name)
+	}
+	if len(warns) != 1 {
+		t.Fatalf("nil tool must warn; got %d warns", len(warns))
+	}
+}
+
+func TestAdaptToolsSkipsDuplicateNames(t *testing.T) {
+	tools, warns := adaptTools(&fakeCaller{}, "fs", []*gomcp.Tool{
+		{Name: "read", InputSchema: map[string]any{"type": "object"}},
+		{Name: "read", InputSchema: map[string]any{"type": "object"}},
+	})
+	if len(tools) != 1 {
+		t.Fatalf("got %d tools, want duplicate skipped", len(tools))
+	}
+	if tools[0].Spec().Name != "mcp__fs__read" {
+		t.Fatalf("kept the wrong tool: %s", tools[0].Spec().Name)
+	}
+	if len(warns) != 1 {
+		t.Fatalf("duplicate tool must warn; got %d warns", len(warns))
+	}
+}
+
 func TestAdaptToolsPerServerCap(t *testing.T) {
 	var remote []*gomcp.Tool
 	for i := 0; i < maxToolsPerServer+5; i++ {

--- a/mcpclient/content.go
+++ b/mcpclient/content.go
@@ -27,12 +27,16 @@ func flattenContent(res *gomcp.CallToolResult) string {
 		fmt.Fprintf(&b, "[non-text content: %T]", c)
 	}
 	if res.StructuredContent != nil {
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
 		if raw, err := json.Marshal(res.StructuredContent); err == nil {
-			if b.Len() > 0 {
-				b.WriteByte('\n')
-			}
 			b.WriteString("[structured] ")
 			b.Write(raw)
+		} else {
+			// Honor the no-silent-loss invariant: a marshal failure still leaves a
+			// marker rather than dropping the structured payload without a trace.
+			b.WriteString("[structured: unmarshalable]")
 		}
 	}
 	return b.String()

--- a/mcpclient/content.go
+++ b/mcpclient/content.go
@@ -1,0 +1,39 @@
+package mcpclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// flattenContent renders an MCP tool result into a single string for
+// agent.ToolResult.Content. Nothing is silently dropped: text blocks are
+// concatenated, any non-text block becomes a typed marker, and StructuredContent
+// (if present) is appended under a [structured] marker. We type-switch only on
+// TextContent and let every other content variant fall to the marker branch, so
+// the function does not depend on the field layout of image/audio/resource types.
+func flattenContent(res *gomcp.CallToolResult) string {
+	var b strings.Builder
+	for i, c := range res.Content {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		if tc, ok := c.(*gomcp.TextContent); ok {
+			b.WriteString(tc.Text)
+			continue
+		}
+		fmt.Fprintf(&b, "[non-text content: %T]", c)
+	}
+	if res.StructuredContent != nil {
+		if raw, err := json.Marshal(res.StructuredContent); err == nil {
+			if b.Len() > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString("[structured] ")
+			b.Write(raw)
+		}
+	}
+	return b.String()
+}

--- a/mcpclient/content_test.go
+++ b/mcpclient/content_test.go
@@ -1,0 +1,40 @@
+package mcpclient
+
+import (
+	"strings"
+	"testing"
+
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestFlattenContent(t *testing.T) {
+	t.Run("text blocks joined", func(t *testing.T) {
+		res := &gomcp.CallToolResult{Content: []gomcp.Content{
+			&gomcp.TextContent{Text: "hello"},
+			&gomcp.TextContent{Text: "world"},
+		}}
+		if got := flattenContent(res); got != "hello\nworld" {
+			t.Fatalf("got %q", got)
+		}
+	})
+	t.Run("non-text becomes a marker, never dropped", func(t *testing.T) {
+		res := &gomcp.CallToolResult{Content: []gomcp.Content{
+			&gomcp.TextContent{Text: "caption"},
+			&gomcp.ImageContent{},
+		}}
+		got := flattenContent(res)
+		if !strings.Contains(got, "caption") || !strings.Contains(got, "[non-text content") {
+			t.Fatalf("expected text + marker, got %q", got)
+		}
+	})
+	t.Run("structured content appended under marker", func(t *testing.T) {
+		res := &gomcp.CallToolResult{
+			Content:           []gomcp.Content{&gomcp.TextContent{Text: "t"}},
+			StructuredContent: map[string]any{"k": "v"},
+		}
+		got := flattenContent(res)
+		if !strings.Contains(got, "t") || !strings.Contains(got, "[structured]") || !strings.Contains(got, `"k":"v"`) {
+			t.Fatalf("got %q", got)
+		}
+	})
+}

--- a/mcpclient/content_test.go
+++ b/mcpclient/content_test.go
@@ -37,4 +37,11 @@ func TestFlattenContent(t *testing.T) {
 			t.Fatalf("got %q", got)
 		}
 	})
+	t.Run("unmarshalable structured content still leaves a marker", func(t *testing.T) {
+		// A channel cannot be JSON-marshaled; the invariant says never drop silently.
+		res := &gomcp.CallToolResult{StructuredContent: make(chan int)}
+		if got := flattenContent(res); !strings.Contains(got, "[structured: unmarshalable]") {
+			t.Fatalf("got %q, want unmarshalable marker", got)
+		}
+	})
 }

--- a/mcpclient/doc.go
+++ b/mcpclient/doc.go
@@ -1,0 +1,4 @@
+// Package mcpclient adapts the tools of external MCP servers into agent.Tool
+// values so an agent loop can call them. It is the client counterpart to the
+// server-side mcp package; it does not reuse server handler logic.
+package mcpclient

--- a/mcpclient/e2e_test.go
+++ b/mcpclient/e2e_test.go
@@ -1,0 +1,59 @@
+package mcpclient
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type echoIn struct {
+	Text string `json:"text" jsonschema:"the text to echo"`
+}
+
+func TestEndToEndInMemory(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Real SDK server exposing one tool.
+	srv := gomcp.NewServer(&gomcp.Implementation{Name: "test-srv", Version: "0.0.1"}, nil)
+	gomcp.AddTool(srv, &gomcp.Tool{Name: "echo", Description: "echo the input"},
+		func(_ context.Context, _ *gomcp.CallToolRequest, in echoIn) (*gomcp.CallToolResult, any, error) {
+			return &gomcp.CallToolResult{Content: []gomcp.Content{&gomcp.TextContent{Text: "echo: " + in.Text}}}, nil, nil
+		})
+
+	serverTr, clientTr := gomcp.NewInMemoryTransports()
+	go func() { _ = srv.Run(ctx, serverTr) }()
+
+	// Real adapter client over the in-memory transport.
+	client := gomcp.NewClient(&gomcp.Implementation{Name: "golem", Version: "test"},
+		&gomcp.ClientOptions{Capabilities: &gomcp.ClientCapabilities{}})
+	session, err := client.Connect(ctx, clientTr, nil)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = session.Close() }()
+
+	remote, warns := listAllTools(ctx, session, "fs")
+	if len(remote) != 1 || len(warns) != 0 {
+		t.Fatalf("listed %d tools, %d warns", len(remote), len(warns))
+	}
+	tools, warns := adaptTools(session, "fs", remote)
+	if len(tools) != 1 || len(warns) != 0 {
+		t.Fatalf("adapted %d tools, %d warns", len(tools), len(warns))
+	}
+
+	tl := tools[0]
+	if tl.Spec().Name != "mcp__fs__echo" {
+		t.Fatalf("name %q", tl.Spec().Name)
+	}
+	out, err := tl.Invoke(ctx, json.RawMessage(`{"text":"hi"}`))
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	if out.IsError || out.Content != "echo: hi" {
+		t.Fatalf("got %+v", out)
+	}
+}

--- a/mcpclient/e2e_test.go
+++ b/mcpclient/e2e_test.go
@@ -27,28 +27,23 @@ func TestEndToEndInMemory(t *testing.T) {
 	serverTr, clientTr := gomcp.NewInMemoryTransports()
 	go func() { _ = srv.Run(ctx, serverTr) }()
 
-	// Real adapter client over the in-memory transport.
-	client := gomcp.NewClient(&gomcp.Implementation{Name: "golem", Version: "test"},
-		&gomcp.ClientOptions{Capabilities: &gomcp.ClientCapabilities{}})
-	session, err := client.Connect(ctx, clientTr, nil)
-	if err != nil {
-		t.Fatalf("connect: %v", err)
+	// Drive the real mcpclient connect path: handshake + time-bounded setup +
+	// paginated list + adapt, over the in-memory transport.
+	session, tools, warns := connectVia(ctx, Implementation{Name: "golem", Version: "test"}, "fs", clientTr)
+	if session == nil {
+		t.Fatalf("connectVia returned nil session; warns=%v", warns)
 	}
 	defer func() { _ = session.Close() }()
-
-	remote, warns := listAllTools(ctx, session, "fs")
-	if len(remote) != 1 || len(warns) != 0 {
-		t.Fatalf("listed %d tools, %d warns", len(remote), len(warns))
-	}
-	tools, warns := adaptTools(session, "fs", remote)
 	if len(tools) != 1 || len(warns) != 0 {
-		t.Fatalf("adapted %d tools, %d warns", len(tools), len(warns))
+		t.Fatalf("adapted %d tools, %d warns: %v", len(tools), len(warns), warns)
 	}
 
 	tl := tools[0]
 	if tl.Spec().Name != "mcp__fs__echo" {
 		t.Fatalf("name %q", tl.Spec().Name)
 	}
+	// Invoke AFTER connectVia returned: its bounded setup context is now cancelled,
+	// so a successful call proves the session outlives the connect timeout.
 	out, err := tl.Invoke(ctx, json.RawMessage(`{"text":"hi"}`))
 	if err != nil {
 		t.Fatalf("invoke: %v", err)

--- a/mcpclient/list_test.go
+++ b/mcpclient/list_test.go
@@ -53,3 +53,23 @@ func TestListAllToolsErrorWarns(t *testing.T) {
 		t.Fatalf("got %d tools, %d warns", len(got), len(warns))
 	}
 }
+
+// advancingLister never returns an empty cursor and always advances it, so only
+// the maxListPages cap can stop the walk (exercises the runaway-page guard).
+type advancingLister struct{ n int }
+
+func (a *advancingLister) ListTools(_ context.Context, _ *gomcp.ListToolsParams) (*gomcp.ListToolsResult, error) {
+	a.n++
+	return &gomcp.ListToolsResult{Tools: []*gomcp.Tool{tool("t" + itoa(a.n))}, NextCursor: "c" + itoa(a.n)}, nil
+}
+
+func TestListAllToolsPageCap(t *testing.T) {
+	l := &advancingLister{}
+	got, warns := listAllTools(context.Background(), l, "fs")
+	if len(got) != maxListPages {
+		t.Fatalf("got %d tools, want page cap %d", len(got), maxListPages)
+	}
+	if len(warns) != 1 {
+		t.Fatalf("page-cap truncation must warn; got %d warns", len(warns))
+	}
+}

--- a/mcpclient/list_test.go
+++ b/mcpclient/list_test.go
@@ -1,0 +1,55 @@
+package mcpclient
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type fakeLister struct {
+	pages []*gomcp.ListToolsResult
+	errs  []error
+	i     int
+}
+
+func (f *fakeLister) ListTools(_ context.Context, _ *gomcp.ListToolsParams) (*gomcp.ListToolsResult, error) {
+	defer func() { f.i++ }()
+	if f.i < len(f.errs) && f.errs[f.i] != nil {
+		return nil, f.errs[f.i]
+	}
+	return f.pages[f.i], nil
+}
+
+func tool(n string) *gomcp.Tool { return &gomcp.Tool{Name: n} }
+
+func TestListAllToolsPaginates(t *testing.T) {
+	l := &fakeLister{pages: []*gomcp.ListToolsResult{
+		{Tools: []*gomcp.Tool{tool("a")}, NextCursor: "c1"},
+		{Tools: []*gomcp.Tool{tool("b")}, NextCursor: ""},
+	}}
+	got, warns := listAllTools(context.Background(), l, "fs")
+	if len(got) != 2 || len(warns) != 0 {
+		t.Fatalf("got %d tools, %d warns", len(got), len(warns))
+	}
+}
+
+func TestListAllToolsCursorNoProgress(t *testing.T) {
+	l := &fakeLister{pages: []*gomcp.ListToolsResult{
+		{Tools: []*gomcp.Tool{tool("a")}, NextCursor: "stuck"},
+		{Tools: []*gomcp.Tool{tool("b")}, NextCursor: "stuck"},
+	}}
+	got, warns := listAllTools(context.Background(), l, "fs")
+	if len(got) != 2 || len(warns) != 1 {
+		t.Fatalf("got %d tools, %d warns (want stop+warn)", len(got), len(warns))
+	}
+}
+
+func TestListAllToolsErrorWarns(t *testing.T) {
+	l := &fakeLister{pages: []*gomcp.ListToolsResult{nil}, errs: []error{errors.New("nope")}}
+	got, warns := listAllTools(context.Background(), l, "fs")
+	if len(got) != 0 || len(warns) != 1 {
+		t.Fatalf("got %d tools, %d warns", len(got), len(warns))
+	}
+}

--- a/mcpclient/name.go
+++ b/mcpclient/name.go
@@ -1,0 +1,27 @@
+package mcpclient
+
+import "regexp"
+
+// maxComposedNameLen caps the model-facing tool name. The SDK permits 128 chars
+// and '.', but provider function-name schemas are narrower (OpenAI: 64,
+// [A-Za-z0-9_-]); we validate to the strict provider ceiling on our side.
+const maxComposedNameLen = 64
+
+var (
+	nameRE  = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+	aliasRE = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
+)
+
+func validAlias(a string) bool { return aliasRE.MatchString(a) }
+
+// composeName builds the namespaced "mcp__<alias>__<remote>" name and reports
+// whether it is usable as a provider tool name. A remote name with characters
+// outside the provider set, or an over-long composed name, is rejected so the
+// caller can skip+warn rather than register an invalid tool.
+func composeName(alias, remote string) (string, bool) {
+	name := "mcp__" + alias + "__" + remote
+	if len(name) > maxComposedNameLen || !nameRE.MatchString(name) {
+		return "", false
+	}
+	return name, true
+}

--- a/mcpclient/name_test.go
+++ b/mcpclient/name_test.go
@@ -1,0 +1,37 @@
+package mcpclient
+
+import "testing"
+
+func TestComposeName(t *testing.T) {
+	tests := []struct {
+		name, alias, remote, want string
+		ok                        bool
+	}{
+		{"simple", "fs", "read_file", "mcp__fs__read_file", true},
+		{"hyphens-digits", "srv-1", "do-x2", "mcp__srv-1__do-x2", true},
+		{"bad char in remote", "fs", "read file", "", false},
+		{"dot rejected (narrower than SDK)", "fs", "a.b", "", false},
+		{"too long", "fs", "veryveryveryveryveryveryveryveryveryveryveryverylongtoolname", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := composeName(tt.alias, tt.remote)
+			if ok != tt.ok || got != tt.want {
+				t.Fatalf("composeName(%q,%q) = (%q,%v), want (%q,%v)", tt.alias, tt.remote, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestValidAlias(t *testing.T) {
+	for _, a := range []string{"fs", "srv-1", "a_b"} {
+		if !validAlias(a) {
+			t.Errorf("validAlias(%q) = false, want true", a)
+		}
+	}
+	for _, a := range []string{"", "a b", "a.b", "a/b"} {
+		if validAlias(a) {
+			t.Errorf("validAlias(%q) = true, want false", a)
+		}
+	}
+}

--- a/mcpclient/schema.go
+++ b/mcpclient/schema.go
@@ -1,0 +1,31 @@
+package mcpclient
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const emptyObjectSchema = `{"type":"object"}`
+
+// normalizeSchema converts the SDK's Tool.InputSchema (typed `any`, usually a
+// map[string]any from the client) into a JSON Schema object suitable for
+// agent.ToolSpec.Parameters. A nil/null schema becomes {"type":"object"}; a
+// schema whose top level is not a JSON object, or that fails to marshal, is an
+// error so the caller can skip the tool and warn.
+func normalizeSchema(in any) (json.RawMessage, error) {
+	if in == nil {
+		return json.RawMessage(emptyObjectSchema), nil
+	}
+	raw, err := json.Marshal(in)
+	if err != nil {
+		return nil, fmt.Errorf("marshal input schema: %w", err)
+	}
+	if string(raw) == "null" {
+		return json.RawMessage(emptyObjectSchema), nil
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil, fmt.Errorf("input schema is not a JSON object: %w", err)
+	}
+	return raw, nil
+}

--- a/mcpclient/schema_test.go
+++ b/mcpclient/schema_test.go
@@ -1,0 +1,34 @@
+package mcpclient
+
+import "testing"
+
+func TestNormalizeSchema(t *testing.T) {
+	t.Run("nil -> empty object", func(t *testing.T) {
+		got, err := normalizeSchema(nil)
+		if err != nil || string(got) != `{"type":"object"}` {
+			t.Fatalf("got (%s,%v)", got, err)
+		}
+	})
+	t.Run("typed-null -> empty object", func(t *testing.T) {
+		var p *int // marshals to "null"
+		got, err := normalizeSchema(p)
+		if err != nil || string(got) != `{"type":"object"}` {
+			t.Fatalf("got (%s,%v)", got, err)
+		}
+	})
+	t.Run("object passes through", func(t *testing.T) {
+		in := map[string]any{"type": "object", "properties": map[string]any{"q": map[string]any{"type": "string"}}}
+		got, err := normalizeSchema(in)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if len(got) == 0 || got[0] != '{' {
+			t.Fatalf("expected JSON object, got %s", got)
+		}
+	})
+	t.Run("non-object rejected", func(t *testing.T) {
+		if _, err := normalizeSchema([]any{1, 2}); err == nil {
+			t.Fatal("expected error for array schema")
+		}
+	})
+}

--- a/mcpclient/server.go
+++ b/mcpclient/server.go
@@ -1,0 +1,63 @@
+package mcpclient
+
+import (
+	"fmt"
+	"os/exec"
+
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// Implementation identifies this client to the server. Local mirror of the SDK
+// type so cmd/golem never imports go-sdk.
+type Implementation struct {
+	Name    string
+	Version string
+}
+
+type transportKind int
+
+const (
+	transportStdio transportKind = iota
+	transportHTTP
+)
+
+// Server is one configured MCP server to attach. Build it via StdioServer or
+// HTTPServer; the underlying SDK transport is constructed internally by Connect.
+type Server struct {
+	Alias    string
+	kind     transportKind
+	command  []string // stdio
+	endpoint string   // http
+}
+
+// StdioServer attaches an MCP server run as a subprocess over stdin/stdout.
+func StdioServer(alias string, command []string) Server {
+	return Server{Alias: alias, kind: transportStdio, command: command}
+}
+
+// HTTPServer attaches an MCP server reachable over streamable HTTP.
+func HTTPServer(alias, endpoint string) Server {
+	return Server{Alias: alias, kind: transportHTTP, endpoint: endpoint}
+}
+
+// transport builds the SDK transport. The stdio subprocess is created with
+// exec.Command (NOT CommandContext): its lifetime is bound to the session and
+// ended by Manager.Close, not by the short-lived Connect context.
+func (s Server) transport() (gomcp.Transport, error) {
+	switch s.kind {
+	case transportStdio:
+		if len(s.command) == 0 {
+			return nil, fmt.Errorf("mcpclient: stdio server %q has empty command", s.Alias)
+		}
+		return &gomcp.CommandTransport{Command: exec.Command(s.command[0], s.command[1:]...)}, nil
+	case transportHTTP:
+		if s.endpoint == "" {
+			return nil, fmt.Errorf("mcpclient: http server %q has empty endpoint", s.Alias)
+		}
+		// DisableStandaloneSSE: MVP only needs request/response; no server-initiated
+		// notifications, no standalone SSE stream, no auto-reconnect on that stream.
+		return &gomcp.StreamableClientTransport{Endpoint: s.endpoint, DisableStandaloneSSE: true}, nil
+	default:
+		return nil, fmt.Errorf("mcpclient: server %q has unknown transport", s.Alias)
+	}
+}

--- a/mcpclient/server_test.go
+++ b/mcpclient/server_test.go
@@ -1,0 +1,46 @@
+package mcpclient
+
+import (
+	"testing"
+
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestStdioTransport(t *testing.T) {
+	tr, err := StdioServer("fs", []string{"echo", "hi"}).transport()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if _, ok := tr.(*gomcp.CommandTransport); !ok {
+		t.Fatalf("want *CommandTransport, got %T", tr)
+	}
+}
+
+func TestStdioEmptyCommand(t *testing.T) {
+	if _, err := StdioServer("fs", nil).transport(); err == nil {
+		t.Fatal("empty command must error")
+	}
+}
+
+func TestHTTPTransport(t *testing.T) {
+	tr, err := HTTPServer("api", "https://h/mcp").transport()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	sc, ok := tr.(*gomcp.StreamableClientTransport)
+	if !ok {
+		t.Fatalf("want *StreamableClientTransport, got %T", tr)
+	}
+	if !sc.DisableStandaloneSSE {
+		t.Fatal("MVP must disable the standalone SSE stream (request/response only)")
+	}
+	if sc.Endpoint != "https://h/mcp" {
+		t.Fatalf("endpoint %q", sc.Endpoint)
+	}
+}
+
+func TestHTTPEmptyEndpoint(t *testing.T) {
+	if _, err := HTTPServer("api", "").transport(); err == nil {
+		t.Fatal("empty endpoint must error")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a self-contained `mcpclient/` package that adapts an external MCP server's tools into `agent.Tool` values, and wires it into the Golem CLI so it can consume third-party MCP tools through the existing agent loop. It does not replace the owned agent loop and does not reuse the server-side `mcp/` handler logic.

Stacked on #248 (#240): this PR is based on `feat/mcp-sdk-bump-240` because it needs the v1.6.1 client API. GitHub will retarget it to `develop` automatically when #248 merges.

## What's included

`mcpclient/` (new package; only `mcp/`, `mcpclient/`, and `cmd/llm-bench/` import the go-sdk):

- One `toolAdapter` per remote tool. Transports: stdio (`CommandTransport`) and streamable-HTTP (`StreamableClientTransport` with `DisableStandaloneSSE` for request/response-only MVP).
- Paginated `tools/list` with page-count and cursor-no-progress guards.
- `Connect` returns `(*Manager, []error warnings, error fatal)`: a server that fails to connect or list degrades to a warning and contributes no tools, never aborting startup. Fatal only for invalid/duplicate alias.
- Setup (handshake + list) is bounded by a 30s timeout so a stdio command that spawns but never speaks MCP cannot hang startup. The SDK keeps the session loop on its own context, so the bounded setup context does not close the live session (covered by the end-to-end test, which invokes after the setup context is cancelled).
- `Manager.Close()` closes every session (terminating stdio subprocesses); wired into Golem shutdown.

Conservative effects and safety:

- Every imported tool is `Read|Write|Exec|Network` + `ApprovalAlways`. Remote tool annotations (e.g. `ReadOnlyHint`) are not trusted to relax approval.
- Namespaced names `mcp__<alias>__<tool>`, validated to the provider charset and a 64-char ceiling; invalid/over-long names are skipped with a warning; duplicate alias is fatal; built-in collisions are caught by the existing tool registry.
- Untrusted input bounded: input schema is size-capped (oversized tools skipped, since a clipped JSON schema would be invalid), description is size-capped (truncated on a UTF-8 rune boundary). Result content flattening drops nothing (non-text and structured content become markers).
- Transport/session errors and bad arguments become `ToolResult{IsError:true}` with a nil Go error, so they never hard-abort the agent loop.

Golem wiring:

- Repeatable `-mcp-stdio` / `-mcp-http` flags (`[alias=]spec`, with documented alias-parse rules).
- The interactive approver is force-installed whenever MCP tools attach. MCP tools are `ApprovalAlways`, so without this the nil-approver fail-safe would deny every call.
- A startup line confirms attached tool/server counts so a silently-failed attach is visible.

## Acceptance criteria

- A test MCP server with one tool can be listed, adapted, invoked, and returns a model-visible observation: covered by an end-to-end test against a real in-memory SDK server, exercised through the real connect path.
- Name collisions rejected or namespaced deterministically: covered.
- Tool-call errors become `ToolResult{IsError:true}`, not loop crashes: covered.
- Timeout and output caps covered by tests (declared in `Effect`, enforced by the runtime).
- Does not duplicate the server handler logic: this is a new client package.

## Non-goals (deferred)

Resource subscriptions, OAuth/client-registration, trust profiles / annotation trust, config-file server registry, reconnect-on-drop, roots advertisement, and migrating `cmd/llm-bench`'s client plumbing onto `mcpclient/`.

## Testing

- `env -u GOROOT go test -race ./...` — pass
- `golangci-lint run ./...` — 0 issues
- `gofmt` — clean

Closes #236
