### PR TITLE
feat(rag): markdown heading-aware chunking (#228)

### DIFF
--- a/rag/chunker_code.go
+++ b/rag/chunker_code.go
@@ -33,7 +33,8 @@ func NewCodeChunker(opts ...ChunkerOption) Chunker {
 	return c
 }
 
-// Chunk splits content respecting code structure when possible.
+// Chunk splits content respecting code structure when possible. Markdown files
+// are split on heading sections; unknown file types fall back to sliding window.
 func (c *codeChunker) Chunk(source string, content string) ([]Chunk, error) {
 	if content == "" {
 		return nil, nil
@@ -45,36 +46,45 @@ func (c *codeChunker) Chunk(source string, content string) ([]Chunk, error) {
 	}
 
 	if lang == "" {
-		// Fall back to sliding window for unknown file types
-		sw, err := NewSlidingWindowChunker(c.maxSize, c.overlap)
-		if err != nil {
-			return nil, fmt.Errorf("rag: create fallback chunker for %q: %w", source, err)
+		// Not a recognized code language. Try markdown heading-aware splitting
+		// before the generic sliding-window fallback.
+		if isMarkdown(source) {
+			chunks, err := splitByHeadings(source, content, c.maxSize, c.overlap)
+			if err != nil {
+				return nil, err
+			}
+			if len(chunks) > 0 {
+				return chunks, nil
+			}
+			// Headingless markdown falls through to sliding window below.
 		}
-		swChunks, err := sw.Chunk(source, content)
-		if err != nil {
-			return nil, err
-		}
-		populateSlidingWindowMetadata(swChunks)
-		return swChunks, nil
+		return c.slidingFallback(source, content)
 	}
 
 	chunks := c.splitByBoundaries(source, content, lang)
 	if len(chunks) == 0 {
-		// No boundaries found, fall back to sliding window
-		sw, err := NewSlidingWindowChunker(c.maxSize, c.overlap)
-		if err != nil {
-			return nil, fmt.Errorf("rag: create fallback chunker for %q: %w", source, err)
-		}
-		swChunks, err := sw.Chunk(source, content)
-		if err != nil {
-			return nil, err
-		}
-		populateSlidingWindowMetadata(swChunks)
-		return swChunks, nil
+		// No boundaries found, fall back to sliding window.
+		return c.slidingFallback(source, content)
 	}
 
 	populateCodeChunkMetadata(chunks, lang)
 	return chunks, nil
+}
+
+// slidingFallback chunks content with a sliding window using this chunker's
+// max/overlap config. Used for unknown file types, headingless markdown, and
+// code files with no detectable boundaries.
+func (c *codeChunker) slidingFallback(source, content string) ([]Chunk, error) {
+	sw, err := NewSlidingWindowChunker(c.maxSize, c.overlap)
+	if err != nil {
+		return nil, fmt.Errorf("rag: create fallback chunker for %q: %w", source, err)
+	}
+	swChunks, err := sw.Chunk(source, content)
+	if err != nil {
+		return nil, err
+	}
+	populateSlidingWindowMetadata(swChunks)
+	return swChunks, nil
 }
 
 // detectLanguage infers the programming language from a file path.

--- a/rag/chunker_code.go
+++ b/rag/chunker_code.go
@@ -15,8 +15,15 @@ type codeChunker struct {
 	language string
 }
 
+// codeChunkerBehaviorVersion identifies the chunk-output behavior of
+// codeChunker. Bump it whenever the chunks produced for some input change, so
+// cached embeddings with the old signature are treated as incompatible and
+// re-embedded. 1 = pre-markdown; 2 = markdown heading-aware sectioning.
+const codeChunkerBehaviorVersion = 2
+
 func (c *codeChunker) sourceSignature() string {
-	return fmt.Sprintf("%T:max=%d:overlap=%d:language=%s", c, c.maxSize, c.overlap, c.language)
+	return fmt.Sprintf("%T:v=%d:max=%d:overlap=%d:language=%s",
+		c, codeChunkerBehaviorVersion, c.maxSize, c.overlap, c.language)
 }
 
 // NewCodeChunker returns a chunker that respects code boundaries.

--- a/rag/chunker_markdown.go
+++ b/rag/chunker_markdown.go
@@ -1,6 +1,7 @@
 package rag
 
 import (
+	"fmt"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -77,4 +78,104 @@ func parseHeading(line string) (level int, title string, ok bool) {
 		title = strings.Repeat("#", level)
 	}
 	return level, title, true
+}
+
+// splitByHeadings splits Markdown into section-aware chunks on ATX heading
+// boundaries. It returns (nil, nil) when no heading is found, so the caller can
+// fall back to whole-file sliding-window chunking (unchanged behavior). Content
+// before the first heading is preserved as preamble chunks (anchor_hash, no
+// section_path). Every section is run through the sliding-window chunker so an
+// oversized section is bounded by the same max/overlap behavior as the rest of
+// the corpus; a section that fits yields a single sub-chunk.
+func splitByHeadings(source, content string, maxSize, overlap int) ([]Chunk, error) {
+	lines := strings.Split(content, "\n")
+
+	type section struct {
+		startLine int      // 1-based file line of the heading
+		path      string   // e.g. "Parent > Child"
+		body      []string // lines including the heading line
+	}
+	type frame struct {
+		level int
+		title string
+	}
+
+	var (
+		preamble []string
+		sections []section
+		stack    []frame
+		inFence  bool
+		curIdx   = -1 // index into sections of the open section; -1 = preamble
+	)
+
+	appendLine := func(s string) {
+		// Index-based, NOT a pointer into sections: appending a new section may
+		// reallocate the backing array and dangle a held pointer.
+		if curIdx < 0 {
+			preamble = append(preamble, s)
+		} else {
+			sections[curIdx].body = append(sections[curIdx].body, s)
+		}
+	}
+
+	for i, line := range lines {
+		if fenceRe.MatchString(line) {
+			inFence = !inFence
+			appendLine(line)
+			continue
+		}
+		if !inFence {
+			if level, title, ok := parseHeading(line); ok {
+				for len(stack) > 0 && stack[len(stack)-1].level >= level {
+					stack = stack[:len(stack)-1]
+				}
+				stack = append(stack, frame{level: level, title: title})
+				titles := make([]string, len(stack))
+				for k := range stack {
+					titles[k] = stack[k].title
+				}
+				sections = append(sections, section{
+					startLine: i + 1,
+					path:      strings.Join(titles, " > "),
+					body:      []string{line},
+				})
+				curIdx = len(sections) - 1
+				continue
+			}
+		}
+		appendLine(line)
+	}
+
+	if len(sections) == 0 {
+		return nil, nil
+	}
+
+	sw, err := NewSlidingWindowChunker(maxSize, overlap)
+	if err != nil {
+		return nil, fmt.Errorf("rag: markdown chunker for %q: %w", source, err)
+	}
+
+	var chunks []Chunk
+	if text := strings.Join(preamble, "\n"); strings.TrimSpace(text) != "" {
+		pre, err := sw.Chunk(source, text)
+		if err != nil {
+			return nil, err
+		}
+		chunks = append(chunks, pre...) // keep anchor_hash, no section_path
+	}
+	for _, sec := range sections {
+		sub, err := sw.Chunk(source, strings.Join(sec.body, "\n"))
+		if err != nil {
+			return nil, err
+		}
+		rebaseChunkLines(sub, sec.startLine-1)
+		for j := range sub {
+			sub[j].Language = "markdown"
+			sub[j].Metadata["section_path"] = sec.path
+			delete(sub[j].Metadata, "anchor_hash")
+		}
+		chunks = append(chunks, sub...)
+	}
+	populateMarkdownChunkMetadata(chunks)
+	return chunks, nil
 }

--- a/rag/chunker_markdown.go
+++ b/rag/chunker_markdown.go
@@ -3,6 +3,7 @@ package rag
 import (
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -28,6 +29,35 @@ func isMarkdown(path string) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+// rebaseChunkLines shifts each chunk's line numbers by lineOffset and recomputes
+// its ID. The ID recompute is mandatory: chunkID embeds StartLine, so a chunk
+// produced against a within-section span (1-based) would otherwise carry an ID
+// reflecting the wrong file line.
+func rebaseChunkLines(chunks []Chunk, lineOffset int) {
+	for i := range chunks {
+		chunks[i].StartLine += lineOffset
+		chunks[i].EndLine += lineOffset
+		chunks[i].ID = chunkID(chunks[i].Source, chunks[i].Content, chunks[i].StartLine)
+	}
+}
+
+// populateMarkdownChunkMetadata assigns chunk_ordinal per identical full
+// section_path in document order (mirrors populateCodeChunkMetadata). Chunks
+// with no section_path (preamble/fallback) are left untouched — they keep the
+// anchor_hash + ordinal the sliding-window chunker already gave them.
+func populateMarkdownChunkMetadata(chunks []Chunk) {
+	ordinals := make(map[string]int)
+	for i := range chunks {
+		path := chunks[i].Metadata["section_path"]
+		if path == "" {
+			continue
+		}
+		ord := ordinals[path]
+		ordinals[path] = ord + 1
+		chunks[i].Metadata["chunk_ordinal"] = strconv.Itoa(ord)
 	}
 }
 

--- a/rag/chunker_markdown.go
+++ b/rag/chunker_markdown.go
@@ -134,6 +134,10 @@ func splitByHeadings(source, content string, maxSize, overlap int) ([]Chunk, err
 				for k := range stack {
 					titles[k] = stack[k].title
 				}
+				// section_path uses an unescaped " > " join for readability. A
+				// heading whose title literally contains " > " can alias a nested
+				// path, but ordinals still keep keys unique within a document and
+				// the assignment is deterministic across re-indexes.
 				sections = append(sections, section{
 					startLine: i + 1,
 					path:      strings.Join(titles, " > "),

--- a/rag/chunker_markdown.go
+++ b/rag/chunker_markdown.go
@@ -20,8 +20,8 @@ var headingRe = regexp.MustCompile(`^ {0,3}(#{1,6})([ \t].*)?$`)
 var closingHashRe = regexp.MustCompile(`[ \t]+#+[ \t]*$`)
 
 // fenceRe matches a fenced-code delimiter line: after up to 3 leading spaces, a
-// run of 3 or more backticks OR 3 or more tildes.
-var fenceRe = regexp.MustCompile("^ {0,3}(`{3,}|~{3,})")
+// run of 3 or more backticks OR 3 or more tildes, plus any trailing text.
+var fenceRe = regexp.MustCompile("^ {0,3}(`{3,}|~{3,})(.*)$")
 
 // isMarkdown reports whether path has a Markdown extension.
 func isMarkdown(path string) bool {
@@ -80,6 +80,14 @@ func parseHeading(line string) (level int, title string, ok bool) {
 	return level, title, true
 }
 
+func parseFence(line string) (marker byte, length int, rest string, ok bool) {
+	m := fenceRe.FindStringSubmatch(line)
+	if m == nil {
+		return 0, 0, "", false
+	}
+	return m[1][0], len(m[1]), m[2], true
+}
+
 // splitByHeadings splits Markdown into section-aware chunks on ATX heading
 // boundaries. It returns (nil, nil) when no heading is found, so the caller can
 // fall back to whole-file sliding-window chunking (unchanged behavior). Content
@@ -105,6 +113,8 @@ func splitByHeadings(source, content string, maxSize, overlap int) ([]Chunk, err
 		sections []section
 		stack    []frame
 		inFence  bool
+		fenceCh  byte
+		fenceLen int
 		curIdx   = -1 // index into sections of the open section; -1 = preamble
 	)
 
@@ -119,8 +129,16 @@ func splitByHeadings(source, content string, maxSize, overlap int) ([]Chunk, err
 	}
 
 	for i, line := range lines {
-		if fenceRe.MatchString(line) {
-			inFence = !inFence
+		if marker, length, rest, ok := parseFence(line); ok {
+			if !inFence {
+				inFence = true
+				fenceCh = marker
+				fenceLen = length
+			} else if marker == fenceCh && length >= fenceLen && strings.TrimSpace(rest) == "" {
+				inFence = false
+				fenceCh = 0
+				fenceLen = 0
+			}
 			appendLine(line)
 			continue
 		}

--- a/rag/chunker_markdown.go
+++ b/rag/chunker_markdown.go
@@ -1,0 +1,50 @@
+package rag
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// ATX heading: up to 3 leading spaces, 1-6 '#', then either end-of-line or a
+// space/tab followed by the title. Group 2 (the remainder) must start with a
+// space/tab or be absent, so "###Title" is not a heading. 4+ leading spaces
+// fall outside the {0,3} cap and are treated as indented code, not a heading.
+var headingRe = regexp.MustCompile(`^ {0,3}(#{1,6})([ \t].*)?$`)
+
+// closingHashRe strips a CommonMark closing hash sequence: a run of '#' at end
+// of line preceded by whitespace. It will NOT strip a '#' that is part of the
+// title (e.g. "C#"), because that '#' is not preceded by whitespace.
+var closingHashRe = regexp.MustCompile(`[ \t]+#+[ \t]*$`)
+
+// fenceRe matches a fenced-code delimiter line: after up to 3 leading spaces, a
+// run of 3 or more backticks OR 3 or more tildes.
+var fenceRe = regexp.MustCompile("^ {0,3}(`{3,}|~{3,})")
+
+// isMarkdown reports whether path has a Markdown extension.
+func isMarkdown(path string) bool {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".md", ".markdown":
+		return true
+	default:
+		return false
+	}
+}
+
+// parseHeading reports whether line is an ATX heading. On match it returns the
+// level (1-6) and the derived title. An empty title (bare "#") is normalized to
+// level-many '#' characters so the section-path segment is deterministic and
+// non-empty — otherwise a chunk built from it would carry no stable-key field.
+func parseHeading(line string) (level int, title string, ok bool) {
+	m := headingRe.FindStringSubmatch(line)
+	if m == nil {
+		return 0, "", false
+	}
+	level = len(m[1])
+	rest := closingHashRe.ReplaceAllString(m[2], "")
+	title = strings.TrimSpace(rest)
+	if title == "" {
+		title = strings.Repeat("#", level)
+	}
+	return level, title, true
+}

--- a/rag/chunker_markdown_test.go
+++ b/rag/chunker_markdown_test.go
@@ -1,0 +1,58 @@
+package rag
+
+import "testing"
+
+func TestIsMarkdown(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"README.md", true},
+		{"docs/guide.MD", true},
+		{"notes.markdown", true},
+		{"main.go", false},
+		{"data.json", false},
+		{"noext", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := isMarkdown(tt.path); got != tt.want {
+				t.Errorf("isMarkdown(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseHeading(t *testing.T) {
+	tests := []struct {
+		name      string
+		line      string
+		wantLevel int
+		wantTitle string
+		wantOK    bool
+	}{
+		{"h1", "# Title", 1, "Title", true},
+		{"h3", "### Deep", 3, "Deep", true},
+		{"h6", "###### Six", 6, "Six", true},
+		{"three leading spaces", "   ## Indented", 2, "Indented", true},
+		{"no space after hashes", "###Title", 0, "", false},
+		{"seven hashes not a heading", "####### Seven", 0, "", false},
+		{"bare hash normalizes", "#", 1, "#", true},
+		{"bare double hash normalizes", "##", 2, "##", true},
+		{"trailing closing hashes stripped", "## Heading ##", 2, "Heading", true},
+		{"hash in title kept (no preceding space)", "# C#", 1, "C#", true},
+		{"spaced trailing hash stripped", "# C #", 1, "C", true},
+		{"four leading spaces not a heading", "    # Code", 0, "", false},
+		{"empty line", "", 0, "", false},
+		{"plain text", "just text", 0, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			level, title, ok := parseHeading(tt.line)
+			if ok != tt.wantOK || level != tt.wantLevel || title != tt.wantTitle {
+				t.Errorf("parseHeading(%q) = (%d, %q, %v), want (%d, %q, %v)",
+					tt.line, level, title, ok, tt.wantLevel, tt.wantTitle, tt.wantOK)
+			}
+		})
+	}
+}

--- a/rag/chunker_markdown_test.go
+++ b/rag/chunker_markdown_test.go
@@ -195,6 +195,27 @@ func TestSplitByHeadingsFenceGuard(t *testing.T) {
 	}
 }
 
+func TestSplitByHeadingsFenceRequiresMatchingDelimiter(t *testing.T) {
+	content := "# Real\n````markdown\n```go\n# not a heading\n```\n````\nafter\n"
+	chunks, err := splitByHeadings("doc.md", content, 1500, 200)
+	if err != nil {
+		t.Fatalf("splitByHeadings() error: %v", err)
+	}
+	count := 0
+	for _, c := range chunks {
+		if c.Metadata["section_path"] != "" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("got %d section chunks, want 1 (shorter nested fence must not close outer fence)", count)
+	}
+	realChunk := findChunk(t, chunks, "Real")
+	if !strings.Contains(realChunk.Content, "# not a heading") {
+		t.Errorf("nested fenced '#' should stay inside the Real section: %q", realChunk.Content)
+	}
+}
+
 func TestSplitByHeadingsOversized(t *testing.T) {
 	body := strings.Repeat("padding line of text\n", 20)
 	content := "preamble\n# Big\n" + body

--- a/rag/chunker_markdown_test.go
+++ b/rag/chunker_markdown_test.go
@@ -189,9 +189,9 @@ func TestSplitByHeadingsFenceGuard(t *testing.T) {
 	if count != 1 {
 		t.Fatalf("got %d section chunks, want 1 (fence '#' must not split)", count)
 	}
-	real := findChunk(t, chunks, "Real")
-	if !strings.Contains(real.Content, "# not a heading") {
-		t.Errorf("fenced '#' should stay inside the Real section: %q", real.Content)
+	realChunk := findChunk(t, chunks, "Real")
+	if !strings.Contains(realChunk.Content, "# not a heading") {
+		t.Errorf("fenced '#' should stay inside the Real section: %q", realChunk.Content)
 	}
 }
 

--- a/rag/chunker_markdown_test.go
+++ b/rag/chunker_markdown_test.go
@@ -1,6 +1,8 @@
 package rag
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestIsMarkdown(t *testing.T) {
 	tests := []struct {
@@ -54,5 +56,49 @@ func TestParseHeading(t *testing.T) {
 					tt.line, level, title, ok, tt.wantLevel, tt.wantTitle, tt.wantOK)
 			}
 		})
+	}
+}
+
+func TestRebaseChunkLines(t *testing.T) {
+	content := "alpha\nbeta"
+	chunks := []Chunk{{
+		ID:        chunkID("doc.md", content, 1),
+		Content:   content,
+		Source:    "doc.md",
+		StartLine: 1,
+		EndLine:   2,
+		Metadata:  map[string]string{},
+	}}
+	rebaseChunkLines(chunks, 9) // section started at file line 10
+
+	if chunks[0].StartLine != 10 || chunks[0].EndLine != 11 {
+		t.Fatalf("lines = (%d, %d), want (10, 11)", chunks[0].StartLine, chunks[0].EndLine)
+	}
+	// ID must be recomputed against the rebased StartLine, not the within-span one.
+	want := chunkID("doc.md", content, 10)
+	if chunks[0].ID != want {
+		t.Errorf("ID = %q, want %q (recomputed at rebased line)", chunks[0].ID, want)
+	}
+}
+
+func TestPopulateMarkdownChunkMetadata(t *testing.T) {
+	chunks := []Chunk{
+		{Metadata: map[string]string{"anchor_hash": "p0", "chunk_ordinal": "0"}}, // preamble, no section_path
+		{Metadata: map[string]string{"section_path": "A"}},
+		{Metadata: map[string]string{"section_path": "A > B"}},
+		{Metadata: map[string]string{"section_path": "A > B"}}, // duplicate path
+		{Metadata: map[string]string{"section_path": "A"}},     // duplicate path
+	}
+	populateMarkdownChunkMetadata(chunks)
+
+	// Preamble chunk untouched.
+	if chunks[0].Metadata["chunk_ordinal"] != "0" || chunks[0].Metadata["section_path"] != "" {
+		t.Errorf("preamble chunk altered: %v", chunks[0].Metadata)
+	}
+	wantOrd := []string{"", "0", "0", "1", "1"}
+	for i := 1; i < len(chunks); i++ {
+		if got := chunks[i].Metadata["chunk_ordinal"]; got != wantOrd[i] {
+			t.Errorf("chunk %d ordinal = %q, want %q", i, got, wantOrd[i])
+		}
 	}
 }

--- a/rag/chunker_markdown_test.go
+++ b/rag/chunker_markdown_test.go
@@ -1,6 +1,9 @@
 package rag
 
 import (
+	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -100,5 +103,165 @@ func TestPopulateMarkdownChunkMetadata(t *testing.T) {
 		if got := chunks[i].Metadata["chunk_ordinal"]; got != wantOrd[i] {
 			t.Errorf("chunk %d ordinal = %q, want %q", i, got, wantOrd[i])
 		}
+	}
+}
+
+// findChunk returns the first chunk whose section_path equals path.
+func findChunk(t *testing.T, chunks []Chunk, path string) Chunk {
+	t.Helper()
+	for _, c := range chunks {
+		if c.Metadata["section_path"] == path {
+			return c
+		}
+	}
+	t.Fatalf("no chunk with section_path %q (have %d chunks)", path, len(chunks))
+	return Chunk{}
+}
+
+func TestSplitByHeadingsNested(t *testing.T) {
+	content := "# A\nintro\n## B\nbody text\n"
+	chunks, err := splitByHeadings("doc.md", content, 1500, 200)
+	if err != nil {
+		t.Fatalf("splitByHeadings() error: %v", err)
+	}
+	a := findChunk(t, chunks, "A")
+	if a.Language != "markdown" {
+		t.Errorf("A language = %q, want markdown", a.Language)
+	}
+	if !strings.Contains(a.Content, "# A") || !strings.Contains(a.Content, "intro") {
+		t.Errorf("A content missing heading/intro: %q", a.Content)
+	}
+	b := findChunk(t, chunks, "A > B")
+	if !strings.Contains(b.Content, "## B") || !strings.Contains(b.Content, "body text") {
+		t.Errorf("A>B content wrong: %q", b.Content)
+	}
+	if a.Metadata["anchor_hash"] != "" {
+		t.Errorf("section chunk should not carry anchor_hash: %v", a.Metadata)
+	}
+}
+
+func TestSplitByHeadingsDuplicatePaths(t *testing.T) {
+	content := "# Top\n## Setup\nfirst\n## Other\nx\n## Setup\nsecond\n"
+	chunks, err := splitByHeadings("doc.md", content, 1500, 200)
+	if err != nil {
+		t.Fatalf("splitByHeadings() error: %v", err)
+	}
+	var setupOrdinals []string
+	for _, c := range chunks {
+		if c.Metadata["section_path"] == "Top > Setup" {
+			setupOrdinals = append(setupOrdinals, c.Metadata["chunk_ordinal"])
+		}
+	}
+	if len(setupOrdinals) != 2 || setupOrdinals[0] != "0" || setupOrdinals[1] != "1" {
+		t.Errorf("Top > Setup ordinals = %v, want [0 1]", setupOrdinals)
+	}
+}
+
+func TestSplitByHeadingsPreamble(t *testing.T) {
+	content := "intro paragraph before any heading\n\n# Real\nbody\n"
+	chunks, err := splitByHeadings("doc.md", content, 1500, 200)
+	if err != nil {
+		t.Fatalf("splitByHeadings() error: %v", err)
+	}
+	if chunks[0].Metadata["section_path"] != "" {
+		t.Errorf("preamble chunk has section_path: %v", chunks[0].Metadata)
+	}
+	if chunks[0].Metadata["anchor_hash"] == "" {
+		t.Errorf("preamble chunk missing anchor_hash: %v", chunks[0].Metadata)
+	}
+	if !strings.Contains(chunks[0].Content, "intro paragraph") {
+		t.Errorf("preamble content lost: %q", chunks[0].Content)
+	}
+}
+
+func TestSplitByHeadingsFenceGuard(t *testing.T) {
+	content := "# Real\nbefore\n```sh\n# not a heading\necho hi\n```\nafter\n"
+	chunks, err := splitByHeadings("doc.md", content, 1500, 200)
+	if err != nil {
+		t.Fatalf("splitByHeadings() error: %v", err)
+	}
+	count := 0
+	for _, c := range chunks {
+		if c.Metadata["section_path"] != "" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("got %d section chunks, want 1 (fence '#' must not split)", count)
+	}
+	real := findChunk(t, chunks, "Real")
+	if !strings.Contains(real.Content, "# not a heading") {
+		t.Errorf("fenced '#' should stay inside the Real section: %q", real.Content)
+	}
+}
+
+func TestSplitByHeadingsOversized(t *testing.T) {
+	body := strings.Repeat("padding line of text\n", 20)
+	content := "preamble\n# Big\n" + body
+	chunks, err := splitByHeadings("doc.md", content, 50, 10)
+	if err != nil {
+		t.Fatalf("splitByHeadings() error: %v", err)
+	}
+	var big []Chunk
+	for _, c := range chunks {
+		if c.Metadata["section_path"] == "Big" {
+			big = append(big, c)
+		}
+	}
+	if len(big) < 2 {
+		t.Fatalf("oversized section produced %d chunks, want >= 2", len(big))
+	}
+	for i, c := range big {
+		if c.Metadata["chunk_ordinal"] != strconv.Itoa(i) {
+			t.Errorf("sub-chunk %d ordinal = %q, want %q", i, c.Metadata["chunk_ordinal"], strconv.Itoa(i))
+		}
+		if c.StartLine < 2 {
+			t.Errorf("sub-chunk %d StartLine = %d, want >= 2 (rebased)", i, c.StartLine)
+		}
+		if c.ID != chunkID(c.Source, c.Content, c.StartLine) {
+			t.Errorf("sub-chunk %d ID not consistent with rebased StartLine", i)
+		}
+	}
+}
+
+func TestSplitByHeadingsEmptyHeadingHasStableKey(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "doc.md")
+	content := "#\nbody under a bare heading\n"
+	chunks, err := splitByHeadings(source, content, 1500, 200)
+	if err != nil {
+		t.Fatalf("splitByHeadings() error: %v", err)
+	}
+	if len(chunks) == 0 {
+		t.Fatal("expected at least one chunk")
+	}
+	if got := chunks[0].Metadata["section_path"]; got != "#" {
+		t.Fatalf("empty heading section_path = %q, want %q", got, "#")
+	}
+	key, err := ComputeStableKey(chunks[0], root)
+	if err != nil {
+		t.Fatalf("ComputeStableKey() error: %v", err)
+	}
+	if key != "doc.md::##0" {
+		t.Errorf("stable key = %q, want %q", key, "doc.md::##0")
+	}
+}
+
+func TestSplitByHeadingsHeadingless(t *testing.T) {
+	content := "just text\nno headings here\n"
+	chunks, err := splitByHeadings("doc.md", content, 1500, 200)
+	if err != nil {
+		t.Fatalf("splitByHeadings() error: %v", err)
+	}
+	if chunks != nil {
+		t.Errorf("headingless content should return nil (caller falls back), got %d chunks", len(chunks))
+	}
+}
+
+func TestSplitByHeadingsConfigError(t *testing.T) {
+	content := "# H\nbody\n"
+	_, err := splitByHeadings("doc.md", content, 0, 0)
+	if err == nil {
+		t.Fatal("expected error for invalid maxSize/overlap, got nil")
 	}
 }

--- a/rag/chunker_markdown_test.go
+++ b/rag/chunker_markdown_test.go
@@ -265,3 +265,69 @@ func TestSplitByHeadingsConfigError(t *testing.T) {
 		t.Fatal("expected error for invalid maxSize/overlap, got nil")
 	}
 }
+
+func TestCodeChunkerMarkdownEndToEnd(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "doc.md")
+	content := "# A\nintro\n## B\nbody text\n"
+
+	chunks, err := NewCodeChunker().Chunk(source, content)
+	if err != nil {
+		t.Fatalf("Chunk() error: %v", err)
+	}
+	var b Chunk
+	for _, c := range chunks {
+		if c.Metadata["section_path"] == "A > B" {
+			b = c
+		}
+	}
+	if b.Language != "markdown" {
+		t.Fatalf("A > B chunk not found or wrong language: %+v", b)
+	}
+	key, err := ComputeStableKey(b, root)
+	if err != nil {
+		t.Fatalf("ComputeStableKey() error: %v", err)
+	}
+	if key != "doc.md::A > B#0" {
+		t.Errorf("stable key = %q, want %q", key, "doc.md::A > B#0")
+	}
+}
+
+func TestCodeChunkerMarkdownHeadingless(t *testing.T) {
+	content := "plain prose with no headings at all, just text.\n"
+	chunks, err := NewCodeChunker().Chunk("notes.md", content)
+	if err != nil {
+		t.Fatalf("Chunk() error: %v", err)
+	}
+	if len(chunks) == 0 {
+		t.Fatal("expected fallback chunks")
+	}
+	for _, c := range chunks {
+		if c.Metadata["section_path"] != "" {
+			t.Errorf("headingless md should have no section_path: %v", c.Metadata)
+		}
+		if c.Metadata["anchor_hash"] == "" {
+			t.Errorf("headingless md should fall back to anchor_hash: %v", c.Metadata)
+		}
+	}
+}
+
+func TestCodeChunkerWithLanguageOverridesMarkdown(t *testing.T) {
+	content := "def hello():\n    return 1\n"
+	chunks, err := NewCodeChunker(WithLanguage("python")).Chunk("weird.md", content)
+	if err != nil {
+		t.Fatalf("Chunk() error: %v", err)
+	}
+	for _, c := range chunks {
+		if c.Language != "python" {
+			t.Errorf("chunk language = %q, want python (override must win)", c.Language)
+		}
+	}
+}
+
+func TestCodeChunkerMarkdownConfigErrorPropagates(t *testing.T) {
+	_, err := NewCodeChunker(WithMaxChunkSize(0)).Chunk("doc.md", "# H\nbody\n")
+	if err == nil {
+		t.Fatal("expected error to propagate from markdown path, got nil")
+	}
+}

--- a/rag/incremental_test.go
+++ b/rag/incremental_test.go
@@ -2,6 +2,7 @@ package rag
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -214,6 +215,34 @@ func TestSourceSignatureV1V2Incompatible(t *testing.T) {
 	}
 	if v1.String() == v2.String() {
 		t.Fatal("v1 and v2 source signatures should serialize differently")
+	}
+}
+
+func TestCodeChunkerBehaviorVersionInvalidatesCache(t *testing.T) {
+	// The markdown change alters .md chunk output, so the chunker signature must
+	// differ from the pre-markdown one, forcing a re-embed.
+	if codeChunkerBehaviorVersion < 2 {
+		t.Fatalf("codeChunkerBehaviorVersion = %d, want >= 2", codeChunkerBehaviorVersion)
+	}
+
+	cur := chunkerSignature(NewCodeChunker())
+	if !strings.Contains(cur, "v=2") {
+		t.Errorf("code chunker signature %q should encode behavior version v=2", cur)
+	}
+
+	// A stored signature carrying the pre-markdown chunker string must be
+	// treated as incompatible -> requires full re-embed.
+	current := sourceSignature{
+		Version:          sourceSignatureVersion,
+		ContentHash:      contentHash("# Heading\nbody"),
+		EmbeddingModel:   "qwen3-embedding:8b",
+		Chunker:          cur,
+		StableKeyVersion: stableKeyVersion,
+	}
+	stored := current
+	stored.Chunker = "*rag.codeChunker:v=1:max=1500:overlap=200:language=" // pre-markdown form
+	if stored.compatibleWith(current) {
+		t.Error("pre-markdown chunker signature should be incompatible with the markdown-aware one")
 	}
 }
 


### PR DESCRIPTION
## Summary

Markdown files were part of the default indexable set but fell through to sliding-window chunking: sections split arbitrarily and chunks carried fallback `anchor_hash` keys instead of section-aware stable keys. This change makes `.md` files split on ATX heading boundaries and carry `section_path` + `chunk_ordinal` metadata, so `ComputeStableKey` produces stable `{rel_path}::{section_path}#{ordinal}` keys that survive re-indexing.

Indexing-side only. No retrieval, agent, or `ComputeStableKey` logic changes — the key path for `section_path` already existed; this populates it.

Closes #228.

## Approach

- New `rag/chunker_markdown.go`, mirroring `rag/chunker_code.go`. `codeChunker.Chunk` gains a markdown branch nested inside its `lang == ""` path (before the sliding-window fallback), so an explicit `WithLanguage` override on a `.md` file still routes to the code path.
- `splitByHeadings` does a single line pass with a heading stack and a fenced-code flag:
  - ATX headings only (`#` .. `######`), up to 3 leading spaces; a space/tab is required after the hashes (`###Title` is not a heading); a closing hash run is stripped only when whitespace-preceded (`# C#` keeps `C#`); an empty title (bare `#`) is normalized to level-many `#` so the section path is deterministic and non-empty.
  - Headings inside ``` / ~~~ fences are ignored. Indented code blocks are excluded by the 3-space cap.
  - `section_path` is the readable `Parent > Child` join over the heading stack.
- Every section runs through the existing sliding-window chunker, then sub-chunk line numbers are rebased to true file lines (with chunk ID recomputed, since the ID embeds `StartLine`) and re-tagged with `section_path`. A section that fits yields one sub-chunk; an oversized section yields several bounded by the existing max/overlap behavior.
- Content before the first heading is preserved as preamble chunks (`anchor_hash`, no `section_path`). Heading-less markdown returns nil so the caller falls back to whole-file sliding-window behavior, unchanged.
- `chunk_ordinal` is assigned per identical full `section_path` in document order, mirroring the code chunker's per-symbol counter; duplicate headings and oversized sub-chunks stay unique.
- Extracted the three duplicated sliding-window fallback blocks in `codeChunker.Chunk` into a single `slidingFallback` helper.

## Re-index invalidation

`.md` chunk output changes, so cached embeddings must invalidate. `codeChunkerBehaviorVersion = 2` is added to `codeChunker.sourceSignature()` (`%T:v=2:max=...`), so any stored signature from before this change is treated as incompatible and re-embedded once. `stableKeyVersion` and the global `sourceSignatureVersion` are intentionally not bumped (key semantics unchanged; bumping the chunker behavior version leaves custom-injected-chunker caches alone).

## Known limitation

`section_path` uses an unescaped `" > "` join for readability. A heading whose title literally contains `" > "` can alias a nested path, but ordinals still keep keys unique within a document and assignment is deterministic across re-indexes. Documented at the join site.

## Testing

New tests cover nested headings, duplicate section paths (ordinals), heading-less fallback, oversized sections (multi sub-chunk, rebased lines, recomputed IDs), `#` inside a fence, preamble, no-space and empty/closing-hash heading parsing, config-error propagation, the signature/invalidation bump, and an end-to-end `NewCodeChunker().Chunk` -> `ComputeStableKey` path.

Gate: `go test -race ./...` passes, `golangci-lint run` clean, `gofmt` clean.

## Out of scope (per issue)

Markdown parser dependency, Setext underline headings, table extraction, PDF/docx parsing, code chunking changes, retrieval enrichment.
