### PR TITLE
feat(agent/golem): run traces (#238) and content-light telemetry sink (#239)

### DIFF
--- a/agent/dispatch.go
+++ b/agent/dispatch.go
@@ -27,11 +27,11 @@ func (o *Orchestrator) runToolCallsSerial(ctx context.Context, res *Result, stat
 
 	for _, call := range calls {
 		res.Events = append(res.Events, EventRecord{Step: step, Kind: "tool_call"})
-		out, rec, err := o.dispatch(ctx, reg, call, approver, obs, step)
+		out, effect, rec, err := o.dispatch(ctx, reg, call, approver, obs, step)
 		if err != nil {
 			return err // hard abort (ctx cancel / approver error): no ToolResult, no OnToolResult
 		}
-		stop, err := recordResult(ctx, res, state, obs, gov, step, call, rec, out)
+		stop, err := recordResult(ctx, res, state, obs, gov, step, call, effect, rec, out)
 		if err != nil {
 			return err
 		}
@@ -50,13 +50,16 @@ func (o *Orchestrator) runToolCallsSerial(ctx context.Context, res *Result, stat
 // observer sees what the model sees. It returns stop=true (and sets
 // res.StopReason) when the governor trips, or an error to hard-abort the run.
 func recordResult(ctx context.Context, res *Result, state *State, obs Observer,
-	gov *restraintGovernor, step int, call provider.ToolCall, rec ToolCallRecord,
+	gov *restraintGovernor, step int, call provider.ToolCall, effect Effect, rec ToolCallRecord,
 	out ToolResult) (stop bool, err error) {
 
 	res.ToolCalls = append(res.ToolCalls, rec)
 	res.Events = append(res.Events, EventRecord{Step: step, Kind: "tool_result"})
 	if tro, ok := obs.(ToolResultObserver); ok {
-		if err := tro.OnToolResult(ctx, ToolResultEvent{Step: step, Call: call, Result: out}); err != nil {
+		if err := tro.OnToolResult(ctx, ToolResultEvent{
+			Step: step, Call: call, Effect: effect, Result: out,
+			Denied: rec.Denied, Invoked: rec.Invoked, Latency: rec.Latency,
+		}); err != nil {
 			return false, err
 		}
 	}
@@ -117,6 +120,7 @@ func (o *Orchestrator) prepareCall(ctx context.Context, reg *toolRegistry, call 
 		effect, preview = plan.Effect, plan.Preview
 	}
 	effect = normalizeEffect(effect)
+	p.effect = effect // capture now so a denial (which returns before invoke) still carries the effect
 
 	if needsApproval(effect.Approval, effect.Class) {
 		ok, err := approve(ctx, approver, call, preview)
@@ -134,7 +138,7 @@ func (o *Orchestrator) prepareCall(ctx context.Context, reg *toolRegistry, call 
 		return p, err
 	}
 
-	p.tool, p.effect = tool, effect
+	p.tool = tool
 	return p, nil
 }
 
@@ -156,21 +160,24 @@ func (o *Orchestrator) invokeCall(ctx context.Context, tool Tool, effect Effect,
 // A cancelled PARENT context after invoke is a hard abort (distinct from a tool's
 // own per-call timeout, which stays a model-visible IsError observation).
 func (o *Orchestrator) dispatch(ctx context.Context, reg *toolRegistry, call provider.ToolCall,
-	approver Approver, obs Observer, step int) (ToolResult, ToolCallRecord, error) {
+	approver Approver, obs Observer, step int) (ToolResult, Effect, ToolCallRecord, error) {
 
 	p, err := o.prepareCall(ctx, reg, call, approver, obs, step)
 	if err != nil {
-		return ToolResult{}, p.rec, err
+		return ToolResult{}, p.effect, p.rec, err
 	}
 	if p.result != nil {
-		return *p.result, p.rec, nil
+		return *p.result, p.effect, p.rec, nil
 	}
+	start := o.now()
 	out := o.invokeCall(ctx, p.tool, p.effect, call.Function.Arguments)
+	p.rec.Invoked = true
+	p.rec.Latency = o.now().Sub(start)
 	if ctx.Err() != nil {
-		return ToolResult{}, p.rec, ctx.Err() // parent cancelled -> hard abort
+		return ToolResult{}, p.effect, p.rec, ctx.Err() // parent cancelled -> hard abort
 	}
 	p.rec.IsError = out.IsError
-	return out, p.rec, nil
+	return out, p.effect, p.rec, nil
 }
 
 // approve applies the fail-safe: a nil approver denies any call that reaches it

--- a/agent/dispatch_parallel.go
+++ b/agent/dispatch_parallel.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
@@ -74,13 +75,16 @@ func (o *Orchestrator) runToolCallsParallel(ctx context.Context, res *Result, st
 		prepared[i] = p
 	}
 
-	// Phase 2: invoke concurrently, bounded.
+	// Phase 2: invoke concurrently, bounded; time each invoke in isolation.
 	results := make([]ToolResult, len(prepared))
+	latencies := make([]time.Duration, len(prepared))
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(parallelToolCallLimit)
 	for i := range prepared {
 		g.Go(func() error {
+			start := o.now()
 			results[i] = o.invokeCall(gctx, prepared[i].tool, prepared[i].effect, prepared[i].call.Function.Arguments)
+			latencies[i] = o.now().Sub(start)
 			return nil // never fail the group; tool errors are model-visible results
 		})
 	}
@@ -94,7 +98,9 @@ func (o *Orchestrator) runToolCallsParallel(ctx context.Context, res *Result, st
 	for i := range prepared {
 		rec := prepared[i].rec
 		rec.IsError = results[i].IsError
-		stop, err := recordResult(ctx, res, state, obs, gov, step, prepared[i].call, rec, results[i])
+		rec.Invoked = true
+		rec.Latency = latencies[i]
+		stop, err := recordResult(ctx, res, state, obs, gov, step, prepared[i].call, prepared[i].effect, rec, results[i])
 		if err != nil {
 			return err
 		}

--- a/agent/latency_test.go
+++ b/agent/latency_test.go
@@ -1,0 +1,44 @@
+package agent
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeClock is a deterministic, concurrency-safe clock for latency tests.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+func TestWithClock_OverridesNow(t *testing.T) {
+	fixed := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+	o := New(nil, ContextManager{}, WithClock(func() time.Time { return fixed }))
+	if got := o.now(); !got.Equal(fixed) {
+		t.Fatalf("now = %v, want %v", got, fixed)
+	}
+}
+
+func TestNew_DefaultClockIsTimeNow(t *testing.T) {
+	o := New(nil, ContextManager{})
+	if o.now == nil {
+		t.Fatal("default clock is nil")
+	}
+	before := time.Now()
+	if got := o.now(); got.Before(before) {
+		t.Fatalf("default clock returned %v before %v", got, before)
+	}
+}

--- a/agent/latency_test.go
+++ b/agent/latency_test.go
@@ -1,9 +1,12 @@
 package agent
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/kstruzzieri/go-llm/provider"
 )
 
 // fakeClock is a deterministic, concurrency-safe clock for latency tests.
@@ -40,5 +43,47 @@ func TestNew_DefaultClockIsTimeNow(t *testing.T) {
 	before := time.Now()
 	if got := o.now(); got.Before(before) {
 		t.Fatalf("default clock returned %v before %v", got, before)
+	}
+}
+
+// noToolModel returns a single final answer and advances the clock by d on each
+// Chat call so the orchestrator's measured model latency is exactly d.
+type noToolModel struct {
+	clk *fakeClock
+	d   time.Duration
+}
+
+func (m noToolModel) Chat(_ context.Context, _ provider.ChatRequest, _ func(provider.ChatResponse) error) (ModelResult, error) {
+	m.clk.advance(m.d)
+	return ModelResult{Response: provider.ChatResponse{Content: "done"}}, nil
+}
+
+// stepCapture records StepEvents to assert on the live observer projection.
+type stepCapture struct{ steps []StepEvent }
+
+func (c *stepCapture) OnStep(_ context.Context, e StepEvent) error {
+	c.steps = append(c.steps, e)
+	return nil
+}
+func (c *stepCapture) OnToolCall(context.Context, ToolCallEvent) error { return nil }
+func (c *stepCapture) OnToken(context.Context, TokenEvent) error       { return nil }
+
+func TestRun_RecordsModelStepLatency(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(0, 0)}
+	o := New(noToolModel{clk: clk, d: 250 * time.Millisecond}, ContextManager{}, WithClock(clk.now))
+
+	cap := &stepCapture{}
+	res, err := o.Run(context.Background(), Request{Goal: "hi"}, cap)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Steps) != 1 {
+		t.Fatalf("steps = %d, want 1", len(res.Steps))
+	}
+	if res.Steps[0].Latency != 250*time.Millisecond {
+		t.Fatalf("StepRecord.Latency = %v, want 250ms", res.Steps[0].Latency)
+	}
+	if len(cap.steps) != 1 || cap.steps[0].Latency != 250*time.Millisecond {
+		t.Fatalf("StepEvent.Latency = %v, want 250ms", cap.steps)
 	}
 }

--- a/agent/observer.go
+++ b/agent/observer.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"time"
 
 	"github.com/kstruzzieri/go-llm/provider"
 )
@@ -21,6 +22,7 @@ type StepEvent struct {
 	Response     provider.ChatResponse
 	RouteOutcome *provider.RouteOutcome
 	Pressure     Pressure
+	Latency      time.Duration
 }
 
 // ToolCallEvent reports a tool about to be invoked (post-approval).

--- a/agent/observer.go
+++ b/agent/observer.go
@@ -44,9 +44,13 @@ type TokenEvent struct {
 // capping and BEFORE the runtime appends it to State. Result is byte-identical
 // to the observation the model receives.
 type ToolResultEvent struct {
-	Step   int
-	Call   provider.ToolCall
-	Result ToolResult
+	Step    int
+	Call    provider.ToolCall
+	Effect  Effect // normalized effect when known; zero value for unknown-tool / bad-JSON
+	Result  ToolResult
+	Denied  bool
+	Invoked bool
+	Latency time.Duration
 }
 
 // ToolResultObserver is an OPTIONAL extension of Observer. When an Observer also

--- a/agent/orchestrator.go
+++ b/agent/orchestrator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"strings"
+	"time"
 
 	"github.com/kstruzzieri/go-llm/provider"
 )
@@ -13,11 +14,31 @@ import (
 type Orchestrator struct {
 	model  ModelCaller
 	ctxMgr ContextManager
+	now    func() time.Time // wall clock for latency; time.Now unless overridden
+}
+
+// Option configures an Orchestrator at construction. New stays source-compatible
+// for callers that pass none (per feedback_additive_constructors).
+type Option func(*Orchestrator)
+
+// WithClock overrides the wall clock used for step/tool latency measurement. A
+// nil now is ignored so the default time.Now is preserved. Tests inject a fake
+// clock for deterministic latencies.
+func WithClock(now func() time.Time) Option {
+	return func(o *Orchestrator) {
+		if now != nil {
+			o.now = now
+		}
+	}
 }
 
 // New constructs an Orchestrator from a ModelCaller and ContextManager.
-func New(model ModelCaller, ctxMgr ContextManager) *Orchestrator {
-	return &Orchestrator{model: model, ctxMgr: normalizeContextManager(ctxMgr)}
+func New(model ModelCaller, ctxMgr ContextManager, opts ...Option) *Orchestrator {
+	o := &Orchestrator{model: model, ctxMgr: normalizeContextManager(ctxMgr), now: time.Now}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
 }
 
 func initState(req Request) State {

--- a/agent/orchestrator.go
+++ b/agent/orchestrator.go
@@ -104,6 +104,7 @@ func (o *Orchestrator) Run(ctx context.Context, req Request, obs Observer) (Resu
 		}
 
 		tokenLogged := false
+		modelStart := o.now()
 		modelResult, err := o.model.Chat(ctx, buildChatRequest(assembled, specs, req.Budget.OutputReserve), func(c provider.ChatResponse) error {
 			if c.Content == "" {
 				return nil
@@ -114,18 +115,19 @@ func (o *Orchestrator) Run(ctx context.Context, req Request, obs Observer) (Resu
 			}
 			return obs.OnToken(ctx, TokenEvent{Step: step, Content: c.Content})
 		})
+		modelLatency := o.now().Sub(modelStart)
 		if err != nil {
 			return res, err
 		}
 		resp := modelResult.Response
 
 		res.Steps = append(res.Steps, StepRecord{
-			Index: step, Response: resp, RouteOutcome: modelResult.RouteOutcome, Pressure: pressure,
+			Index: step, Response: resp, RouteOutcome: modelResult.RouteOutcome, Pressure: pressure, Latency: modelLatency,
 		})
 		res.Events = append(res.Events, EventRecord{Step: step, Kind: "step"})
 		res.Usage = addUsage(res.Usage, resp.Usage)
 		if err := obs.OnStep(ctx, StepEvent{
-			Index: step, Response: resp, RouteOutcome: modelResult.RouteOutcome, Pressure: pressure,
+			Index: step, Response: resp, RouteOutcome: modelResult.RouteOutcome, Pressure: pressure, Latency: modelLatency,
 		}); err != nil {
 			return res, err
 		}

--- a/agent/tool_latency_parallel_test.go
+++ b/agent/tool_latency_parallel_test.go
@@ -1,0 +1,68 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// sleepTool sleeps d on Invoke; read-only so the batch runs in parallel.
+type sleepTool struct {
+	d    time.Duration
+	name string
+}
+
+func (t sleepTool) Spec() ToolSpec {
+	return ToolSpec{Name: t.name, Parameters: json.RawMessage(`{"type":"object"}`)}
+}
+func (t sleepTool) Effect() Effect { return Effect{Class: Read} }
+func (t sleepTool) Invoke(ctx context.Context, _ json.RawMessage) (ToolResult, error) {
+	select {
+	case <-time.After(t.d):
+	case <-ctx.Done():
+	}
+	return ToolResult{Content: "ok"}, nil
+}
+
+func TestRun_ParallelPerToolLatencyIsolated(t *testing.T) {
+	// Two read-only tools in one assistant turn run concurrently (canRunParallel).
+	model := &scriptedModel{resps: []provider.ChatResponse{
+		{ToolCalls: []provider.ToolCall{
+			toolCall("c1", "slow", "{}"),
+			toolCall("c2", "fast", "{}"),
+		}},
+		{Content: "final"},
+	}}
+	o := New(model, ContextManager{}) // real time.Now
+
+	res, err := o.Run(context.Background(), Request{
+		Goal: "go",
+		Tools: []Tool{
+			sleepTool{d: 60 * time.Millisecond, name: "slow"},
+			sleepTool{d: 5 * time.Millisecond, name: "fast"},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.ToolCalls) != 2 {
+		t.Fatalf("tool calls = %d, want 2", len(res.ToolCalls))
+	}
+	byName := map[string]ToolCallRecord{}
+	for _, r := range res.ToolCalls {
+		byName[r.Name] = r
+	}
+	slow, fast := byName["slow"], byName["fast"]
+	if !slow.Invoked || !fast.Invoked {
+		t.Fatalf("both must be Invoked: slow=%v fast=%v", slow.Invoked, fast.Invoked)
+	}
+	// Per-tool isolation: fast must be far below slow. A sink that timed
+	// OnToolCall->OnToolResult would report ~slow for fast too (recorded in
+	// phase 3 after the slow invoke), so fast >= slow/2 there.
+	if fast.Latency >= slow.Latency/2 {
+		t.Fatalf("fast.Latency=%v not isolated from slow.Latency=%v", fast.Latency, slow.Latency)
+	}
+}

--- a/agent/tool_latency_test.go
+++ b/agent/tool_latency_test.go
@@ -1,0 +1,108 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// scriptedModel returns a pre-set response per step (step 0 first). It never
+// advances the clock, so only tool invokes move time in these tests.
+type scriptedModel struct {
+	resps []provider.ChatResponse
+	step  int
+}
+
+func (m *scriptedModel) Chat(_ context.Context, _ provider.ChatRequest, _ func(provider.ChatResponse) error) (ModelResult, error) {
+	r := m.resps[m.step]
+	m.step++
+	return ModelResult{Response: r}, nil
+}
+
+// clockTool advances the shared fake clock by d on Invoke; effect is read-only.
+type clockTool struct {
+	clk  *fakeClock
+	d    time.Duration
+	name string
+}
+
+func (t clockTool) Spec() ToolSpec {
+	return ToolSpec{Name: t.name, Parameters: json.RawMessage(`{"type":"object"}`)}
+}
+func (t clockTool) Effect() Effect { return Effect{Class: Read} }
+func (t clockTool) Invoke(_ context.Context, _ json.RawMessage) (ToolResult, error) {
+	t.clk.advance(t.d)
+	return ToolResult{Content: "ok"}, nil
+}
+
+// toolResultCapture records ToolResultEvents (implements ToolResultObserver).
+type toolResultCapture struct {
+	stepCapture
+	results []ToolResultEvent
+}
+
+func (c *toolResultCapture) OnToolResult(_ context.Context, e ToolResultEvent) error {
+	c.results = append(c.results, e)
+	return nil
+}
+
+func toolCall(id, name, args string) provider.ToolCall {
+	return provider.ToolCall{ID: id, Type: "function", Function: provider.ToolCallFunction{Name: name, Arguments: json.RawMessage(args)}}
+}
+
+func TestRun_InvokedToolLatencyAndEffect(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(0, 0)}
+	model := &scriptedModel{resps: []provider.ChatResponse{
+		{ToolCalls: []provider.ToolCall{toolCall("c1", "tick", "{}")}},
+		{Content: "final"},
+	}}
+	o := New(model, ContextManager{}, WithClock(clk.now))
+
+	cap := &toolResultCapture{}
+	res, err := o.Run(context.Background(), Request{
+		Goal:  "go",
+		Tools: []Tool{clockTool{clk: clk, d: 40 * time.Millisecond, name: "tick"}},
+	}, cap)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.ToolCalls) != 1 {
+		t.Fatalf("tool calls = %d, want 1", len(res.ToolCalls))
+	}
+	rec := res.ToolCalls[0]
+	if !rec.Invoked || rec.Latency != 40*time.Millisecond {
+		t.Fatalf("rec Invoked=%v Latency=%v, want true/40ms", rec.Invoked, rec.Latency)
+	}
+	if len(cap.results) != 1 {
+		t.Fatalf("ToolResultEvents = %d, want 1", len(cap.results))
+	}
+	ev := cap.results[0]
+	if !ev.Invoked || ev.Latency != 40*time.Millisecond || ev.Effect.Class != Read || ev.Denied {
+		t.Fatalf("event = %+v, want Invoked/40ms/Read/!Denied", ev)
+	}
+}
+
+func TestRun_SyntheticToolNotInvoked(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(0, 0)}
+	model := &scriptedModel{resps: []provider.ChatResponse{
+		{ToolCalls: []provider.ToolCall{toolCall("c1", "ghost", "{}")}}, // unknown tool
+		{Content: "final"},
+	}}
+	o := New(model, ContextManager{}, WithClock(clk.now))
+
+	cap := &toolResultCapture{}
+	res, err := o.Run(context.Background(), Request{Goal: "go", Tools: []Tool{clockTool{clk: clk, d: time.Second, name: "tick"}}}, cap)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	rec := res.ToolCalls[0]
+	if rec.Invoked || rec.Latency != 0 || !rec.IsError {
+		t.Fatalf("synthetic rec = %+v, want !Invoked/0/IsError", rec)
+	}
+	if ev := cap.results[0]; ev.Invoked || ev.Latency != 0 {
+		t.Fatalf("synthetic event = %+v, want !Invoked/0", ev)
+	}
+}

--- a/agent/types.go
+++ b/agent/types.go
@@ -123,6 +123,7 @@ type StepRecord struct {
 	Response     provider.ChatResponse
 	RouteOutcome *provider.RouteOutcome
 	Pressure     Pressure
+	Latency      time.Duration // wall time of the ModelCaller.Chat call for this step
 }
 
 // EventRecord is a lightweight ordered log entry for replay/eval.

--- a/agent/types.go
+++ b/agent/types.go
@@ -138,6 +138,8 @@ type ToolCallRecord struct {
 	Name    string
 	IsError bool
 	Denied  bool
+	Invoked bool          // false for synthetic pre-invoke outcomes (no Invoke ran)
+	Latency time.Duration // wall time of Invoke only; zero when !Invoked
 }
 
 // Result is the canonical final state of a run.

--- a/cmd/golem/main.go
+++ b/cmd/golem/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/kstruzzieri/go-llm/agent"
 	agenttools "github.com/kstruzzieri/go-llm/agent/tools"
@@ -39,6 +40,8 @@ type flags struct {
 	noProjectContext bool
 	noCompress       bool
 	noMemory         bool
+	trace            bool
+	telemetry        bool
 }
 
 func parseFlags(args []string) (flags, error) {
@@ -63,6 +66,10 @@ func parseFlags(args []string) (flags, error) {
 	fs.BoolVar(&f.noCompress, "no-compress", false, "disable post-turn conversation compression into a durable summary")
 	fs.BoolVar(&f.noMemory, "no-memory", false, "disable explicit local memories (/remember, /memories, memory_search)")
 	fs.StringVar(&f.sessionID, "session", "", "explicit session id to resume or create (default: per-workspace)")
+	// -trace persists a full per-run trace (may contain workspace/user content; for replay/eval).
+	// -telemetry appends content-light run metrics only (timings, route, usage; no prompt or output).
+	fs.BoolVar(&f.trace, "trace", false, "persist a content-full run trace per turn (outside the workspace; may contain workspace/user content)")
+	fs.BoolVar(&f.telemetry, "telemetry", false, "append content-light run telemetry (timings, route, usage; no prompt/output)")
 	if err := fs.Parse(args); err != nil {
 		return flags{}, err
 	}
@@ -350,6 +357,12 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 	}
 
 	caller := newRouterChainCaller(bundle.Router, plan.chain)
+
+	obsv, err := newObserv(os.Getenv, root, f.trace, f.telemetry, time.Now)
+	if err != nil {
+		return fmt.Errorf("golem: observability setup: %w", err)
+	}
+
 	sess := &replSession{
 		orch:            agent.New(caller, agent.ContextManager{}),
 		tools:           tools,
@@ -373,6 +386,7 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 		memory:       memStore,
 		memoryDBPath: memDBPath,
 		workspaceID:  workspaceID(root),
+		obs:          obsv,
 	}
 	if sess.maxSteps == 0 {
 		sess.maxSteps = 16 // mirror agent defaultMaxSteps so the footer's k/max is accurate

--- a/cmd/golem/observe.go
+++ b/cmd/golem/observe.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/agent"
+	"github.com/kstruzzieri/go-llm/internal/agenttrace"
+)
+
+// observ holds resolved, validated observability paths and run-id state. It is
+// nil when both -trace and -telemetry are off (the caller checks for nil).
+type observ struct {
+	trace         bool
+	telemetry     bool
+	traceDir      string
+	telemetryPath string
+	clock         func() time.Time
+
+	mu      sync.Mutex
+	counter int
+}
+
+// newObserv resolves trace/telemetry paths from the per-user data dir (reusing
+// dataDirBase + validatePathOutsideWorkspace), validates they fall outside the
+// workspace, and creates the trace dir. Returns nil when both are disabled.
+func newObserv(getenv func(string) string, root string, trace, telemetry bool, clock func() time.Time) (*observ, error) {
+	if !trace && !telemetry {
+		return nil, nil
+	}
+	if clock == nil {
+		clock = time.Now
+	}
+	base, err := dataDirBase(getenv)
+	if err != nil {
+		return nil, err
+	}
+	o := &observ{trace: trace, telemetry: telemetry, clock: clock}
+	if trace {
+		o.traceDir = filepath.Join(base, "golem", "traces")
+		if err := validatePathOutsideWorkspace(o.traceDir, root); err != nil {
+			return nil, err
+		}
+		if err := os.MkdirAll(o.traceDir, sessionDirMode); err != nil {
+			return nil, fmt.Errorf("golem: create trace dir: %w", err)
+		}
+	}
+	if telemetry {
+		o.telemetryPath = filepath.Join(base, "golem", "telemetry.jsonl")
+		if err := validatePathOutsideWorkspace(o.telemetryPath, root); err != nil {
+			return nil, err
+		}
+		if err := os.MkdirAll(filepath.Dir(o.telemetryPath), sessionDirMode); err != nil {
+			return nil, fmt.Errorf("golem: create telemetry dir: %w", err)
+		}
+	}
+	return o, nil
+}
+
+// nextRunID mints a per-turn id: <unix-millis>-<pid>-<counter>. Deterministic
+// given the clock; the counter guarantees uniqueness within a process.
+func (o *observ) nextRunID() string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.counter++
+	return fmt.Sprintf("%d-%d-%d", o.clock().UnixMilli(), os.Getpid(), o.counter)
+}
+
+// startSink opens a TelemetrySink for one run, or returns (nil, nil) when
+// telemetry is off. The caller defers Close on the returned sink.
+func (o *observ) startSink(runID string, started time.Time) (*agenttrace.TelemetrySink, error) {
+	if o == nil || !o.telemetry {
+		return nil, nil
+	}
+	return agenttrace.NewTelemetrySink(o.telemetryPath, runID, started, o.clock)
+}
+
+// writeTrace writes one content-full trace, retrying with a numeric suffix on a
+// run-id path collision (create-exclusive). Best-effort: returns an error the
+// caller logs but does not propagate as a turn failure.
+func (o *observ) writeTrace(runID, startedAt, endedAt string, meta agenttrace.TraceMeta, res agent.Result, status string, partial bool, runErr error) error {
+	rec := agenttrace.BuildTrace(meta, res, status, partial, runErr)
+	rec.RunID = runID
+	rec.StartedAt = startedAt
+	rec.EndedAt = endedAt
+	base := filepath.Join(o.traceDir, startedAt+"-"+runID)
+	for i := 0; i < 5; i++ {
+		path := base + ".json"
+		if i > 0 {
+			path = fmt.Sprintf("%s-%d.json", base, i)
+		}
+		err := agenttrace.WriteTrace(path, rec)
+		if err == nil {
+			return nil
+		}
+		if !os.IsExist(err) {
+			return err
+		}
+	}
+	return fmt.Errorf("golem: trace path collision for run %s", runID)
+}
+
+// composeObserver returns the renderer alone when sink is nil, else a fan-out
+// observer driving both. The sink never errors, so only the renderer can abort.
+func composeObserver(rend agent.Observer, sink *agenttrace.TelemetrySink) agent.Observer {
+	if sink == nil {
+		return rend
+	}
+	return &multiObserver{children: []agent.Observer{rend, sink}}
+}
+
+// multiObserver fans every callback out to its children in order, propagating
+// the first error. It implements ToolResultObserver and forwards OnToolResult
+// only to children that implement it.
+type multiObserver struct{ children []agent.Observer }
+
+func (m *multiObserver) OnStep(ctx context.Context, e agent.StepEvent) error {
+	for _, c := range m.children {
+		if err := c.OnStep(ctx, e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *multiObserver) OnToolCall(ctx context.Context, e agent.ToolCallEvent) error {
+	for _, c := range m.children {
+		if err := c.OnToolCall(ctx, e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *multiObserver) OnToken(ctx context.Context, e agent.TokenEvent) error {
+	for _, c := range m.children {
+		if err := c.OnToken(ctx, e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *multiObserver) OnToolResult(ctx context.Context, e agent.ToolResultEvent) error {
+	for _, c := range m.children {
+		if tro, ok := c.(agent.ToolResultObserver); ok {
+			if err := tro.OnToolResult(ctx, e); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// runStatus derives the trace completeness status from the Run return. agent's
+// StopReason defaults to Completed and is meaningless on an error path, so the
+// policy layer decides status itself.
+func runStatus(runErr error, canceled bool) (status string, partial bool) {
+	switch {
+	case runErr == nil:
+		return "completed", false
+	case canceled:
+		return "canceled", true
+	default:
+		return "error", true
+	}
+}

--- a/cmd/golem/observe.go
+++ b/cmd/golem/observe.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sync"
@@ -97,7 +99,9 @@ func (o *observ) writeTrace(runID, startedAt, endedAt string, meta agenttrace.Tr
 		if err == nil {
 			return nil
 		}
-		if !os.IsExist(err) {
+		// WriteTrace wraps the O_EXCL failure with %w; errors.Is walks that chain
+		// (os.IsExist does not), so a real collision falls through to a suffix.
+		if !errors.Is(err, fs.ErrExist) {
 			return err
 		}
 	}

--- a/cmd/golem/observe.go
+++ b/cmd/golem/observe.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -158,6 +159,27 @@ func (m *multiObserver) OnToolResult(ctx context.Context, e agent.ToolResultEven
 		}
 	}
 	return nil
+}
+
+// toolSchemaHash returns a stable fnv64a digest of the active tool specs (name,
+// description, JSON schema) so a trace records which tool surface the run saw
+// without embedding the full schemas (#238: "tool specs or tool schema hash").
+// Empty when there are no tools. Hashed in slice order, which Golem fixes.
+func toolSchemaHash(tools []agent.Tool) string {
+	if len(tools) == 0 {
+		return ""
+	}
+	h := fnv.New64a()
+	for _, t := range tools {
+		s := t.Spec()
+		_, _ = h.Write([]byte(s.Name))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(s.Description))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write(s.Parameters)
+		_, _ = h.Write([]byte{0})
+	}
+	return fmt.Sprintf("fnv64:%x", h.Sum64())
 }
 
 // runStatus derives the trace completeness status from the Run return. agent's

--- a/cmd/golem/observe.go
+++ b/cmd/golem/observe.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -90,7 +91,8 @@ func (o *observ) writeTrace(runID, startedAt, endedAt string, meta agenttrace.Tr
 	rec.RunID = runID
 	rec.StartedAt = startedAt
 	rec.EndedAt = endedAt
-	base := filepath.Join(o.traceDir, startedAt+"-"+runID)
+	nameStartedAt := strings.NewReplacer(":", "-", "/", "-", "\\", "-").Replace(startedAt)
+	base := filepath.Join(o.traceDir, nameStartedAt+"-"+runID)
 	for i := 0; i < 5; i++ {
 		path := base + ".json"
 		if i > 0 {

--- a/cmd/golem/observe_test.go
+++ b/cmd/golem/observe_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kstruzzieri/go-llm/agent"
+	"github.com/kstruzzieri/go-llm/internal/agenttrace"
 )
 
 func TestNewObserv_DisabledReturnsNil(t *testing.T) {
@@ -70,5 +71,48 @@ func TestComposeObserver(t *testing.T) {
 	rend := newRenderer(io.Discard, false, 4, nil)
 	if got := composeObserver(rend, nil); got != agent.Observer(rend) {
 		t.Fatalf("nil sink should return renderer unchanged")
+	}
+}
+
+func TestObserv_TraceAndTelemetryShareRunID(t *testing.T) {
+	base := t.TempDir()
+	root := t.TempDir()
+	getenv := func(k string) string {
+		if k == "XDG_DATA_HOME" {
+			return base
+		}
+		return ""
+	}
+	o, err := newObserv(getenv, root, true, true, func() time.Time { return time.Unix(1719600000, 0) })
+	if err != nil {
+		t.Fatalf("newObserv: %v", err)
+	}
+	runID := o.nextRunID()
+	started := o.clock()
+
+	sink, err := o.startSink(runID, started)
+	if err != nil {
+		t.Fatalf("startSink: %v", err)
+	}
+	res := agent.Result{Steps: []agent.StepRecord{{Index: 0}}, StopReason: agent.Completed}
+	_ = sink.Finish(res, "completed")
+	_ = sink.Close()
+
+	if err := o.writeTrace(runID,
+		started.UTC().Format(time.RFC3339Nano), started.UTC().Format(time.RFC3339Nano),
+		agenttrace.TraceMeta{Goal: "g"}, res, "completed", false, nil); err != nil {
+		t.Fatalf("writeTrace: %v", err)
+	}
+
+	tel, _ := os.ReadFile(o.telemetryPath)
+	if !strings.Contains(string(tel), runID) {
+		t.Fatalf("telemetry missing run id %q:\n%s", runID, tel)
+	}
+	entries, _ := os.ReadDir(o.traceDir)
+	if len(entries) != 1 {
+		t.Fatalf("trace files = %d, want 1", len(entries))
+	}
+	if !strings.Contains(entries[0].Name(), runID) {
+		t.Fatalf("trace file %q missing run id %q", entries[0].Name(), runID)
 	}
 }

--- a/cmd/golem/observe_test.go
+++ b/cmd/golem/observe_test.go
@@ -47,6 +47,40 @@ func TestNewObserv_ResolvesPathsOutsideWorkspace(t *testing.T) {
 	}
 }
 
+func TestObserv_WriteTraceCollisionRetry(t *testing.T) {
+	base := t.TempDir()
+	root := t.TempDir()
+	getenv := func(k string) string {
+		if k == "XDG_DATA_HOME" {
+			return base
+		}
+		return ""
+	}
+	o, err := newObserv(getenv, root, true, false, func() time.Time { return time.Unix(1719600000, 0) })
+	if err != nil {
+		t.Fatalf("newObserv: %v", err)
+	}
+	runID := "fixed-run"
+	startedAt := "2026-06-28T00-00-00Z"
+	// Pre-create the primary trace path so the first WriteTrace collides; the
+	// retry must fall through to a "-1.json" suffix and leave the seed untouched.
+	primary := filepath.Join(o.traceDir, startedAt+"-"+runID+".json")
+	if werr := os.WriteFile(primary, []byte("preexisting"), 0o600); werr != nil {
+		t.Fatalf("seed: %v", werr)
+	}
+	res := agent.Result{Steps: []agent.StepRecord{{Index: 0}}, StopReason: agent.Completed}
+	if werr := o.writeTrace(runID, startedAt, startedAt, agenttrace.TraceMeta{Goal: "g"}, res, "completed", false, nil); werr != nil {
+		t.Fatalf("writeTrace: %v", werr)
+	}
+	suffixed := filepath.Join(o.traceDir, startedAt+"-"+runID+"-1.json")
+	if _, serr := os.Stat(suffixed); serr != nil {
+		t.Fatalf("expected suffixed trace %q: %v", suffixed, serr)
+	}
+	if b, _ := os.ReadFile(primary); string(b) != "preexisting" {
+		t.Fatalf("primary trace was clobbered: %q", b)
+	}
+}
+
 func TestObserv_NextRunIDUnique(t *testing.T) {
 	o := &observ{clock: func() time.Time { return time.Unix(1719600000, 123_000_000) }}
 	a, b := o.nextRunID(), o.nextRunID()

--- a/cmd/golem/observe_test.go
+++ b/cmd/golem/observe_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -12,6 +13,36 @@ import (
 	"github.com/kstruzzieri/go-llm/agent"
 	"github.com/kstruzzieri/go-llm/internal/agenttrace"
 )
+
+// schemaStubTool is an agent.Tool whose full spec (name/desc/params) varies, for
+// toolSchemaHash tests. (tools_test.go's stubTool exposes only a name.)
+type schemaStubTool struct{ name, desc, params string }
+
+func (s schemaStubTool) Spec() agent.ToolSpec {
+	return agent.ToolSpec{Name: s.name, Description: s.desc, Parameters: json.RawMessage(s.params)}
+}
+func (schemaStubTool) Effect() agent.Effect { return agent.Effect{Class: agent.Read} }
+func (schemaStubTool) Invoke(context.Context, json.RawMessage) (agent.ToolResult, error) {
+	return agent.ToolResult{}, nil
+}
+
+func TestToolSchemaHash(t *testing.T) {
+	if toolSchemaHash(nil) != "" {
+		t.Fatal("nil tools -> want empty hash")
+	}
+	a := []agent.Tool{schemaStubTool{"read", "r", `{"type":"object"}`}}
+	b := []agent.Tool{schemaStubTool{"read", "r", `{"type":"object"}`}}
+	c := []agent.Tool{schemaStubTool{"read", "r", `{"type":"string"}`}}
+	if toolSchemaHash(a) != toolSchemaHash(b) {
+		t.Fatal("identical specs must hash equal")
+	}
+	if toolSchemaHash(a) == toolSchemaHash(c) {
+		t.Fatal("differing schema must change the hash")
+	}
+	if toolSchemaHash(a) == "" {
+		t.Fatal("non-empty tools -> non-empty hash")
+	}
+}
 
 func TestNewObserv_DisabledReturnsNil(t *testing.T) {
 	o, err := newObserv(os.Getenv, t.TempDir(), false, false, time.Now)

--- a/cmd/golem/observe_test.go
+++ b/cmd/golem/observe_test.go
@@ -112,6 +112,48 @@ func TestObserv_WriteTraceCollisionRetry(t *testing.T) {
 	}
 }
 
+func TestObserv_WriteTraceSanitizesStartedAtFilename(t *testing.T) {
+	base := t.TempDir()
+	root := t.TempDir()
+	getenv := func(k string) string {
+		if k == "XDG_DATA_HOME" {
+			return base
+		}
+		return ""
+	}
+	o, err := newObserv(getenv, root, true, false, time.Now)
+	if err != nil {
+		t.Fatalf("newObserv: %v", err)
+	}
+	startedAt := "2026-06-29T10:20:30.123456789Z"
+	res := agent.Result{StopReason: agent.Completed}
+	if err := o.writeTrace("run1", startedAt, startedAt, agenttrace.TraceMeta{Goal: "g"}, res, "completed", false, nil); err != nil {
+		t.Fatalf("writeTrace: %v", err)
+	}
+
+	entries, err := os.ReadDir(o.traceDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("trace files = %d, want 1", len(entries))
+	}
+	if strings.Contains(entries[0].Name(), ":") {
+		t.Fatalf("trace filename contains colon: %q", entries[0].Name())
+	}
+	raw, err := os.ReadFile(filepath.Join(o.traceDir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var rec agenttrace.TraceRecord
+	if err := json.Unmarshal(raw, &rec); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if rec.StartedAt != startedAt {
+		t.Fatalf("started_at = %q, want %q", rec.StartedAt, startedAt)
+	}
+}
+
 func TestObserv_NextRunIDUnique(t *testing.T) {
 	o := &observ{clock: func() time.Time { return time.Unix(1719600000, 123_000_000) }}
 	a, b := o.nextRunID(), o.nextRunID()

--- a/cmd/golem/observe_test.go
+++ b/cmd/golem/observe_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/agent"
+)
+
+func TestNewObserv_DisabledReturnsNil(t *testing.T) {
+	o, err := newObserv(os.Getenv, t.TempDir(), false, false, time.Now)
+	if err != nil {
+		t.Fatalf("newObserv: %v", err)
+	}
+	if o != nil {
+		t.Fatalf("both disabled -> want nil observ, got %+v", o)
+	}
+}
+
+func TestNewObserv_ResolvesPathsOutsideWorkspace(t *testing.T) {
+	base := t.TempDir()
+	root := t.TempDir() // workspace root, distinct from data base
+	getenv := func(k string) string {
+		if k == "XDG_DATA_HOME" {
+			return base
+		}
+		return ""
+	}
+	o, err := newObserv(getenv, root, true, true, time.Now)
+	if err != nil {
+		t.Fatalf("newObserv: %v", err)
+	}
+	if !strings.HasPrefix(o.traceDir, filepath.Join(base, "golem", "traces")) {
+		t.Fatalf("traceDir = %q", o.traceDir)
+	}
+	if o.telemetryPath != filepath.Join(base, "golem", "telemetry.jsonl") {
+		t.Fatalf("telemetryPath = %q", o.telemetryPath)
+	}
+	if _, err := os.Stat(o.traceDir); err != nil {
+		t.Fatalf("traceDir not created: %v", err)
+	}
+}
+
+func TestObserv_NextRunIDUnique(t *testing.T) {
+	o := &observ{clock: func() time.Time { return time.Unix(1719600000, 123_000_000) }}
+	a, b := o.nextRunID(), o.nextRunID()
+	if a == b {
+		t.Fatalf("run ids not unique: %q == %q", a, b)
+	}
+}
+
+func TestRunStatus(t *testing.T) {
+	if s, p := runStatus(nil, false); s != "completed" || p {
+		t.Fatalf("nil err -> %q/%v", s, p)
+	}
+	if s, p := runStatus(context.Canceled, true); s != "canceled" || !p {
+		t.Fatalf("canceled -> %q/%v", s, p)
+	}
+	if s, p := runStatus(context.DeadlineExceeded, false); s != "error" || !p {
+		t.Fatalf("error -> %q/%v", s, p)
+	}
+}
+
+func TestComposeObserver(t *testing.T) {
+	rend := newRenderer(io.Discard, false, 4, nil)
+	if got := composeObserver(rend, nil); got != agent.Observer(rend) {
+		t.Fatalf("nil sink should return renderer unchanged")
+	}
+}

--- a/cmd/golem/repl.go
+++ b/cmd/golem/repl.go
@@ -153,6 +153,7 @@ func runOnce(ctx context.Context, out io.Writer, interrupts <-chan struct{}, ses
 				History:        req.History,
 				MaxSteps:       req.MaxSteps,
 				Budget:         req.Budget,
+				ToolSchemaHash: toolSchemaHash(sess.tools),
 				ModelHint:      lastRoutedModel(res),
 			}
 			startedStr := startedAt.UTC().Format(time.RFC3339Nano)

--- a/cmd/golem/repl.go
+++ b/cmd/golem/repl.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kstruzzieri/go-llm/agent"
 	"github.com/kstruzzieri/go-llm/conversation"
+	"github.com/kstruzzieri/go-llm/internal/agenttrace"
 	"github.com/kstruzzieri/go-llm/memory"
 )
 
@@ -35,7 +36,8 @@ type replSession struct {
 	journal     *mutationJournal // nil unless -allow-write enabled writes
 	allowWrite  bool
 	allowExec   bool
-	mcpAttached bool // true when external MCP tools are attached (force approver)
+	mcpAttached bool    // true when external MCP tools are attached (force approver)
+	obs         *observ // nil unless -trace/-telemetry enabled
 }
 
 // runREPL reads lines from in, dispatching slash commands and running every
@@ -102,6 +104,26 @@ func runOnce(ctx context.Context, out io.Writer, interrupts <-chan struct{}, ses
 	}
 
 	rend := newRenderer(out, sess.color, sess.maxSteps, sess.clock)
+
+	var (
+		runID     string
+		startedAt time.Time
+		sink      *agenttrace.TelemetrySink
+	)
+	observer := agent.Observer(rend)
+	if sess.obs != nil {
+		runID = sess.obs.nextRunID()
+		startedAt = sess.obs.clock()
+		var serr error
+		if sink, serr = sess.obs.startSink(runID, startedAt); serr != nil {
+			_, _ = fmt.Fprintf(out, "warning: telemetry disabled: %v\n", serr)
+		}
+		observer = composeObserver(rend, sink)
+		if sink != nil {
+			defer func() { _ = sink.Close() }()
+		}
+	}
+
 	req := agent.Request{
 		Goal:           line,
 		System:         sess.baseSystem,
@@ -112,24 +134,48 @@ func runOnce(ctx context.Context, out io.Writer, interrupts <-chan struct{}, ses
 		Budget:         sess.budget,
 		Approver:       approver, // nil when read-only => runtime fail-safe denies Write/Exec
 	}
-	res, err := sess.orch.Run(runCtx, req, rend)
-	if err != nil {
+	res, runErr := sess.orch.Run(runCtx, req, observer)
+
+	// Post-run observability on EVERY exit path. Uses the parent ctx (not runCtx)
+	// so a canceled turn still flushes its partial trace.
+	if sess.obs != nil {
+		status, partial := runStatus(runErr, runCtx.Err() != nil)
+		if sink != nil {
+			if ferr := sink.Finish(res, status); ferr != nil {
+				_, _ = fmt.Fprintf(out, "warning: telemetry write incomplete: %v\n", ferr)
+			}
+		}
+		if sess.obs.trace {
+			meta := agenttrace.TraceMeta{
+				Goal:           req.Goal,
+				System:         req.System,
+				HistorySummary: req.HistorySummary,
+				History:        req.History,
+				MaxSteps:       req.MaxSteps,
+				Budget:         req.Budget,
+				ModelHint:      lastRoutedModel(res),
+			}
+			startedStr := startedAt.UTC().Format(time.RFC3339Nano)
+			endedStr := sess.obs.clock().UTC().Format(time.RFC3339Nano)
+			if terr := sess.obs.writeTrace(runID, startedStr, endedStr, meta, res, status, partial, runErr); terr != nil {
+				_, _ = fmt.Fprintf(out, "warning: trace not written: %v\n", terr)
+			}
+		}
+	}
+
+	if runErr != nil {
 		if runCtx.Err() != nil {
 			_, _ = fmt.Fprintln(out, "\ncanceled")
 			return
 		}
-		_, _ = fmt.Fprintf(out, "\nerror: %v\n", err)
+		_, _ = fmt.Fprintf(out, "\nerror: %v\n", runErr)
 		return
 	}
 	if m := lastRoutedModel(res); m != "" {
 		sess.lastModel = m
 	}
-	// Persist only a successful, answered run (amendment 6). recordResult uses the
-	// parent ctx so saving the computed answer is not tied to this turn's
-	// cancellation scope. maybeCompress, by contrast, makes a new summarizer model
-	// call — it uses runCtx so a Ctrl-C during post-turn compression interrupts it
-	// (CompressMessages then returns a cancellation error and the session is left
-	// untouched, which the warning below surfaces).
+	// Persist only a successful, answered run. recordResult uses the parent ctx so
+	// saving the computed answer is not tied to this turn's cancellation scope.
 	if sess.session != nil && res.Answer != "" {
 		if serr := sess.session.recordResult(ctx, line, res); serr != nil {
 			_, _ = fmt.Fprintf(out, "warning: session not saved: %v\n", serr)

--- a/internal/agenttrace/doc.go
+++ b/internal/agenttrace/doc.go
@@ -1,0 +1,6 @@
+// Package agenttrace persists agent-run observability as two projections that
+// share a run id: a post-run, content-full trace (issue #238) and content-light
+// live telemetry spans (issue #239). It owns record schemas, a secured
+// JSON/JSONL writer, the live TelemetrySink observer, and the post-run trace
+// builder. It owns no path policy: callers supply secured, validated paths.
+package agenttrace

--- a/internal/agenttrace/record.go
+++ b/internal/agenttrace/record.go
@@ -1,0 +1,134 @@
+package agenttrace
+
+import (
+	"strings"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/agent"
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// SchemaVersion is bumped on any breaking change to the trace/telemetry records.
+const SchemaVersion = 1
+
+// TraceMeta is the replay-relevant request context the caller supplies (the
+// agent.Request is not embedded in agent.Result, and history is excluded from
+// Result.Messages, so a trace needs it to reconstruct the model input).
+type TraceMeta struct {
+	Goal           string
+	System         string
+	HistorySummary string
+	History        []provider.ChatMessage
+	ToolSchemaHash string
+	ModelHint      string
+	MaxSteps       int
+	Budget         agent.Budget
+}
+
+// TraceRequest is the serialized request side of a trace.
+type TraceRequest struct {
+	Goal           string                 `json:"goal"`
+	System         string                 `json:"system"`
+	HistorySummary string                 `json:"history_summary,omitempty"`
+	History        []provider.ChatMessage `json:"history,omitempty"`
+	ToolSchemaHash string                 `json:"tool_schema_hash"`
+	ModelHint      string                 `json:"model_hint,omitempty"`
+	MaxSteps       int                    `json:"max_steps"`
+	Budget         agent.Budget           `json:"budget"`
+}
+
+// TraceRecord is one content-full run trace (#238). It embeds agent.Result; the
+// embedded record uses Go's default JSON shape (e.g. Latency as integer
+// nanoseconds) - the schema documents that rather than forking a trace-only copy.
+type TraceRecord struct {
+	SchemaVersion int          `json:"schema_version"`
+	RunID         string       `json:"run_id"`
+	StartedAt     string       `json:"started_at"`
+	EndedAt       string       `json:"ended_at"`
+	Status        string       `json:"status"`  // completed | error | canceled
+	Partial       bool         `json:"partial"` // derived: status != completed
+	Request       TraceRequest `json:"request"`
+	Result        agent.Result `json:"result"`
+	Error         string       `json:"error,omitempty"`
+}
+
+// --- telemetry spans (#239, content-light) ---
+
+type usageLite struct {
+	Prompt     int `json:"prompt"`
+	Completion int `json:"completion"`
+	Total      int `json:"total"`
+}
+
+type pressureLite struct {
+	UsedPct     float64 `json:"used_pct"`
+	Evicted     int     `json:"evicted"`
+	Compactions int     `json:"compactions"`
+}
+
+type runSpan struct {
+	SchemaVersion int     `json:"schema_version"`
+	RunID         string  `json:"run_id"`
+	SpanID        string  `json:"span_id"`
+	Kind          string  `json:"kind"` // "run"
+	StartedAt     string  `json:"started_at"`
+	DurationMS    float64 `json:"duration_ms"`
+	Steps         int     `json:"steps"`
+	Status        string  `json:"status"`
+	StopReason    string  `json:"stop_reason"`
+}
+
+type modelStepSpan struct {
+	SchemaVersion int          `json:"schema_version"`
+	RunID         string       `json:"run_id"`
+	SpanID        string       `json:"span_id"`
+	ParentID      string       `json:"parent_id"`
+	Kind          string       `json:"kind"` // "model_step"
+	Step          int          `json:"step"`
+	DurationMS    float64      `json:"duration_ms"`
+	Model         string       `json:"model,omitempty"`
+	PlannedModel  string       `json:"planned_model,omitempty"`
+	FallbacksUsed int          `json:"fallbacks_used"`
+	WasSticky     bool         `json:"was_sticky"`
+	Usage         usageLite    `json:"usage"`
+	Pressure      pressureLite `json:"pressure"`
+}
+
+type toolCallSpan struct {
+	SchemaVersion int     `json:"schema_version"`
+	RunID         string  `json:"run_id"`
+	SpanID        string  `json:"span_id"`
+	ParentID      string  `json:"parent_id"`
+	Kind          string  `json:"kind"` // "tool_call"
+	Step          int     `json:"step"`
+	Name          string  `json:"name"`
+	Effect        string  `json:"effect,omitempty"`
+	Invoked       bool    `json:"invoked"`
+	Denied        bool    `json:"denied"`
+	IsError       bool    `json:"is_error"`
+	Truncated     bool    `json:"truncated"`
+	ContentBytes  int     `json:"content_bytes"`
+	DurationMS    float64 `json:"duration_ms"`
+}
+
+// effectString renders an EffectClass bitset as a stable, content-light label.
+// There is no agent.EffectClass.String(), so agenttrace owns this projection.
+func effectString(c agent.EffectClass) string {
+	var parts []string
+	if c.Has(agent.Read) {
+		parts = append(parts, "read")
+	}
+	if c.Has(agent.Write) {
+		parts = append(parts, "write")
+	}
+	if c.Has(agent.Exec) {
+		parts = append(parts, "exec")
+	}
+	if c.Has(agent.Network) {
+		parts = append(parts, "network")
+	}
+	return strings.Join(parts, "|")
+}
+
+// ms converts a duration to fractional milliseconds for telemetry spans.
+func ms(d time.Duration) float64 { return float64(d) / float64(time.Millisecond) }

--- a/internal/agenttrace/record.go
+++ b/internal/agenttrace/record.go
@@ -75,7 +75,7 @@ type runSpan struct {
 	DurationMS    float64 `json:"duration_ms"`
 	Steps         int     `json:"steps"`
 	Status        string  `json:"status"`
-	StopReason    string  `json:"stop_reason"`
+	StopReason    string  `json:"stop_reason,omitempty"`
 }
 
 type modelStepSpan struct {

--- a/internal/agenttrace/sink.go
+++ b/internal/agenttrace/sink.go
@@ -113,6 +113,10 @@ func (s *TelemetrySink) OnToken(context.Context, agent.TokenEvent) error { retur
 // Finish emits the root run span. Call after Run returns; status is computed by
 // the caller. Returns the first retained write error, if any (advisory only).
 func (s *TelemetrySink) Finish(res agent.Result, status string) error {
+	stopReason := ""
+	if status == "completed" {
+		stopReason = res.StopReason.String()
+	}
 	s.record(runSpan{
 		SchemaVersion: SchemaVersion,
 		RunID:         s.runID,
@@ -122,7 +126,7 @@ func (s *TelemetrySink) Finish(res agent.Result, status string) error {
 		DurationMS:    ms(s.now().Sub(s.started)),
 		Steps:         len(res.Steps),
 		Status:        status,
-		StopReason:    res.StopReason.String(),
+		StopReason:    stopReason,
 	})
 	return s.lastErr
 }

--- a/internal/agenttrace/sink.go
+++ b/internal/agenttrace/sink.go
@@ -1,0 +1,131 @@
+package agenttrace
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/agent"
+)
+
+var (
+	_ agent.Observer           = (*TelemetrySink)(nil)
+	_ agent.ToolResultObserver = (*TelemetrySink)(nil)
+)
+
+// TelemetrySink is a content-light agent.Observer (+ ToolResultObserver). It
+// emits a model_step span per OnStep and a tool_call span per OnToolResult, then
+// a root run span on Finish (callbacks do not know final status/duration). It is
+// best-effort: write/encode errors are retained on the sink and every callback
+// returns nil so telemetry never aborts a run or changes observer semantics.
+//
+// It serializes only content-light fields: identity, counts, sizes, durations,
+// and the denied/error/truncated/invoked bools. It never reads or writes prompt,
+// assistant, tool-argument, tool-output, or raw-error text.
+type TelemetrySink struct {
+	w       *jsonlWriter
+	runID   string
+	started time.Time
+	now     func() time.Time
+
+	lastErr  error
+	lastStep int
+	toolSeq  int
+}
+
+// NewTelemetrySink opens path for append and returns a sink for one run. started
+// is the run's start instant (for the run-span duration); now supplies the end.
+func NewTelemetrySink(path, runID string, started time.Time, now func() time.Time) (*TelemetrySink, error) {
+	w, err := openJSONL(path)
+	if err != nil {
+		return nil, err
+	}
+	if now == nil {
+		now = time.Now
+	}
+	return &TelemetrySink{w: w, runID: runID, started: started, now: now, lastStep: -1}, nil
+}
+
+func (s *TelemetrySink) record(v any) {
+	if err := s.w.write(v); err != nil {
+		s.lastErr = err
+	}
+}
+
+func (s *TelemetrySink) OnStep(_ context.Context, e agent.StepEvent) error {
+	span := modelStepSpan{
+		SchemaVersion: SchemaVersion,
+		RunID:         s.runID,
+		SpanID:        fmt.Sprintf("%s-step-%d", s.runID, e.Index),
+		ParentID:      s.runID + "-run",
+		Kind:          "model_step",
+		Step:          e.Index,
+		DurationMS:    ms(e.Latency),
+		Usage: usageLite{
+			Prompt:     e.Response.Usage.PromptTokens,
+			Completion: e.Response.Usage.CompletionTokens,
+			Total:      e.Response.Usage.TotalTokens,
+		},
+		Pressure: pressureLite{UsedPct: e.Pressure.UsedPct, Evicted: e.Pressure.Evicted, Compactions: e.Pressure.Compactions},
+	}
+	if e.RouteOutcome != nil {
+		span.Model = e.RouteOutcome.ActualModel.String()
+		span.PlannedModel = e.RouteOutcome.PlannedModel.String()
+		span.FallbacksUsed = e.RouteOutcome.FallbacksUsed
+		span.WasSticky = e.RouteOutcome.WasSticky
+	}
+	s.record(span)
+	return nil
+}
+
+func (s *TelemetrySink) OnToolResult(_ context.Context, e agent.ToolResultEvent) error {
+	if e.Step != s.lastStep {
+		s.lastStep, s.toolSeq = e.Step, 0
+	}
+	span := toolCallSpan{
+		SchemaVersion: SchemaVersion,
+		RunID:         s.runID,
+		SpanID:        fmt.Sprintf("%s-tool-%d-%d", s.runID, e.Step, s.toolSeq),
+		ParentID:      fmt.Sprintf("%s-step-%d", s.runID, e.Step),
+		Kind:          "tool_call",
+		Step:          e.Step,
+		Name:          e.Call.Function.Name,
+		Effect:        effectString(e.Effect.Class),
+		Invoked:       e.Invoked,
+		Denied:        e.Denied,
+		IsError:       e.Result.IsError,
+		Truncated:     e.Result.Truncated,
+		ContentBytes:  len(e.Result.Content),
+		DurationMS:    ms(e.Latency),
+	}
+	s.toolSeq++
+	s.record(span)
+	return nil
+}
+
+// OnToolCall is a no-op: tool spans are emitted from OnToolResult, which carries
+// effect/latency/invoked even for denied calls (where OnToolCall never fires).
+func (s *TelemetrySink) OnToolCall(context.Context, agent.ToolCallEvent) error { return nil }
+
+// OnToken is a no-op: token deltas carry assistant content and are not content-light.
+func (s *TelemetrySink) OnToken(context.Context, agent.TokenEvent) error { return nil }
+
+// Finish emits the root run span. Call after Run returns; status is computed by
+// the caller. Returns the first retained write error, if any (advisory only).
+func (s *TelemetrySink) Finish(res agent.Result, status string) error {
+	s.record(runSpan{
+		SchemaVersion: SchemaVersion,
+		RunID:         s.runID,
+		SpanID:        s.runID + "-run",
+		Kind:          "run",
+		StartedAt:     s.started.UTC().Format(time.RFC3339Nano),
+		DurationMS:    ms(s.now().Sub(s.started)),
+		Steps:         len(res.Steps),
+		Status:        status,
+		StopReason:    res.StopReason.String(),
+	})
+	return s.lastErr
+}
+
+// Close releases the underlying file.
+func (s *TelemetrySink) Close() error { return s.w.Close() }

--- a/internal/agenttrace/sink_test.go
+++ b/internal/agenttrace/sink_test.go
@@ -1,0 +1,114 @@
+package agenttrace
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/agent"
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+func readSpans(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	var spans []map[string]any
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		if strings.TrimSpace(sc.Text()) == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal(sc.Bytes(), &m); err != nil {
+			t.Fatalf("bad span line %q: %v", sc.Text(), err)
+		}
+		spans = append(spans, m)
+	}
+	return spans
+}
+
+func TestTelemetrySink_SpansAndContentLight(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "telemetry.jsonl")
+	clk := time.Unix(0, 0)
+	sink, err := NewTelemetrySink(path, "run7", clk, func() time.Time { return clk.Add(3 * time.Second) })
+	if err != nil {
+		t.Fatalf("NewTelemetrySink: %v", err)
+	}
+
+	ctx := context.Background()
+	// A model step that carries a SECRET in assistant content + usage/route.
+	_ = sink.OnStep(ctx, agent.StepEvent{
+		Index:    0,
+		Response: provider.ChatResponse{Content: "SECRET-assistant", Usage: provider.Usage{PromptTokens: 9, CompletionTokens: 1, TotalTokens: 10}},
+		RouteOutcome: &provider.RouteOutcome{
+			ActualModel: provider.ModelKey{Provider: "llamacpp", Model: "qwen3:8b"},
+			WasSticky:   true,
+		},
+		Pressure: agent.Pressure{UsedPct: 0.5},
+		Latency:  2 * time.Second,
+	})
+	// A tool result that carries SECRET args + output.
+	_ = sink.OnToolResult(ctx, agent.ToolResultEvent{
+		Step:    0,
+		Call:    provider.ToolCall{Function: provider.ToolCallFunction{Name: "read_file", Arguments: json.RawMessage(`{"path":"SECRET-arg"}`)}},
+		Effect:  agent.Effect{Class: agent.Read},
+		Result:  agent.ToolResult{Content: "SECRET-output", Truncated: true},
+		Invoked: true,
+		Latency: 4 * time.Millisecond,
+	})
+	res := agent.Result{Steps: []agent.StepRecord{{Index: 0}}, StopReason: agent.Completed}
+	if err := sink.Finish(res, "completed"); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	spans := readSpans(t, path)
+	kinds := map[string]int{}
+	for _, s := range spans {
+		kinds[s["kind"].(string)]++
+	}
+	if kinds["model_step"] != 1 || kinds["tool_call"] != 1 || kinds["run"] != 1 {
+		t.Fatalf("span kinds = %v, want one each", kinds)
+	}
+
+	raw, _ := os.ReadFile(path)
+	for _, secret := range []string{"SECRET-assistant", "SECRET-arg", "SECRET-output"} {
+		if strings.Contains(string(raw), secret) {
+			t.Fatalf("telemetry leaked %q:\n%s", secret, raw)
+		}
+	}
+	// Sanity: content-light fields ARE present.
+	if !strings.Contains(string(raw), "qwen3:8b") || !strings.Contains(string(raw), `"content_bytes":13`) {
+		t.Fatalf("missing content-light fields:\n%s", raw)
+	}
+}
+
+// TestTelemetrySink_SwallowsWriteErrors proves the sink never aborts a run.
+func TestTelemetrySink_SwallowsWriteErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "telemetry.jsonl")
+	sink, err := NewTelemetrySink(path, "run1", time.Unix(0, 0), time.Now)
+	if err != nil {
+		t.Fatalf("NewTelemetrySink: %v", err)
+	}
+	// Close the underlying file early so subsequent writes fail.
+	_ = sink.Close()
+	if err := sink.OnStep(context.Background(), agent.StepEvent{Index: 0}); err != nil {
+		t.Fatalf("OnStep returned %v, want nil (best-effort)", err)
+	}
+	if err := sink.OnToolResult(context.Background(), agent.ToolResultEvent{Step: 0}); err != nil {
+		t.Fatalf("OnToolResult returned %v, want nil", err)
+	}
+}

--- a/internal/agenttrace/sink_test.go
+++ b/internal/agenttrace/sink_test.go
@@ -20,7 +20,7 @@ func readSpans(t *testing.T, path string) []map[string]any {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	var spans []map[string]any
 	sc := bufio.NewScanner(f)
 	for sc.Scan() {

--- a/internal/agenttrace/sink_test.go
+++ b/internal/agenttrace/sink_test.go
@@ -95,6 +95,30 @@ func TestTelemetrySink_SpansAndContentLight(t *testing.T) {
 	}
 }
 
+func TestTelemetrySink_OmitsStopReasonForNonCompletedStatus(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "telemetry.jsonl")
+	sink, err := NewTelemetrySink(path, "run-error", time.Unix(0, 0), time.Now)
+	if err != nil {
+		t.Fatalf("NewTelemetrySink: %v", err)
+	}
+
+	if err := sink.Finish(agent.Result{}, "error"); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	spans := readSpans(t, path)
+	if len(spans) != 1 || spans[0]["kind"] != "run" {
+		t.Fatalf("spans = %+v, want one run span", spans)
+	}
+	if _, ok := spans[0]["stop_reason"]; ok {
+		t.Fatalf("error span has stop_reason = %v", spans[0]["stop_reason"])
+	}
+}
+
 // TestTelemetrySink_SwallowsWriteErrors proves the sink never aborts a run.
 func TestTelemetrySink_SwallowsWriteErrors(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/agenttrace/trace.go
+++ b/internal/agenttrace/trace.go
@@ -11,21 +11,15 @@ func BuildTrace(meta TraceMeta, res agent.Result, status string, partial bool, r
 	if runErr != nil {
 		errStr = runErr.Error()
 	}
+	// TraceMeta and TraceRequest are identical in shape (TraceRequest only adds
+	// JSON tags), so a direct conversion keeps the two in lockstep — a field
+	// drift becomes a compile error here rather than a silent omission.
 	return TraceRecord{
 		SchemaVersion: SchemaVersion,
 		Status:        status,
 		Partial:       partial,
-		Request: TraceRequest{
-			Goal:           meta.Goal,
-			System:         meta.System,
-			HistorySummary: meta.HistorySummary,
-			History:        meta.History,
-			ToolSchemaHash: meta.ToolSchemaHash,
-			ModelHint:      meta.ModelHint,
-			MaxSteps:       meta.MaxSteps,
-			Budget:         meta.Budget,
-		},
-		Result: res,
-		Error:  errStr,
+		Request:       TraceRequest(meta),
+		Result:        res,
+		Error:         errStr,
 	}
 }

--- a/internal/agenttrace/trace.go
+++ b/internal/agenttrace/trace.go
@@ -1,0 +1,31 @@
+package agenttrace
+
+import "github.com/kstruzzieri/go-llm/agent"
+
+// BuildTrace assembles a content-full trace from request metadata and the final
+// (or partial) agent.Result. status/partial are computed by the caller because
+// agent.StopReason defaults to Completed and is meaningless on an error return.
+// RunID, StartedAt, and EndedAt are stamped by the caller after BuildTrace.
+func BuildTrace(meta TraceMeta, res agent.Result, status string, partial bool, runErr error) TraceRecord {
+	errStr := ""
+	if runErr != nil {
+		errStr = runErr.Error()
+	}
+	return TraceRecord{
+		SchemaVersion: SchemaVersion,
+		Status:        status,
+		Partial:       partial,
+		Request: TraceRequest{
+			Goal:           meta.Goal,
+			System:         meta.System,
+			HistorySummary: meta.HistorySummary,
+			History:        meta.History,
+			ToolSchemaHash: meta.ToolSchemaHash,
+			ModelHint:      meta.ModelHint,
+			MaxSteps:       meta.MaxSteps,
+			Budget:         meta.Budget,
+		},
+		Result: res,
+		Error:  errStr,
+	}
+}

--- a/internal/agenttrace/trace_test.go
+++ b/internal/agenttrace/trace_test.go
@@ -1,0 +1,75 @@
+package agenttrace
+
+import (
+	"context"
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/agent"
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+func sampleResult() agent.Result {
+	return agent.Result{
+		Answer:     "the answer",
+		Steps:      []agent.StepRecord{{Index: 0, Latency: 10 * time.Millisecond}},
+		Usage:      provider.Usage{PromptTokens: 5, CompletionTokens: 7, TotalTokens: 12},
+		StopReason: agent.Completed,
+	}
+}
+
+func TestBuildTrace_StatusAndPartial(t *testing.T) {
+	meta := TraceMeta{Goal: "do a thing", System: "sys", MaxSteps: 16}
+	res := sampleResult()
+
+	ok := BuildTrace(meta, res, "completed", false, nil)
+	if ok.Status != "completed" || ok.Partial {
+		t.Fatalf("completed: status=%q partial=%v", ok.Status, ok.Partial)
+	}
+	if ok.Request.Goal != "do a thing" || ok.Result.Answer != "the answer" {
+		t.Fatalf("request/result not embedded: %+v", ok)
+	}
+	if ok.SchemaVersion != SchemaVersion {
+		t.Fatalf("schema_version = %d, want %d", ok.SchemaVersion, SchemaVersion)
+	}
+
+	bad := BuildTrace(meta, res, "canceled", true, context.Canceled)
+	if bad.Status != "canceled" || !bad.Partial || bad.Error == "" {
+		t.Fatalf("canceled: status=%q partial=%v error=%q", bad.Status, bad.Partial, bad.Error)
+	}
+}
+
+func TestWriteTrace_ExclusiveAndSecured(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "20260628-run7.json")
+	rec := BuildTrace(TraceMeta{Goal: "g"}, sampleResult(), "completed", false, nil)
+
+	if err := WriteTrace(path, rec); err != nil {
+		t.Fatalf("WriteTrace: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != fs.FileMode(0o600) {
+		t.Fatalf("perm = %v, want 0600", info.Mode().Perm())
+	}
+	var got TraceRecord
+	b, _ := os.ReadFile(path)
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Result.Answer != "the answer" {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+
+	// Exclusive: a second write to the same path must fail, not clobber/append.
+	if err := WriteTrace(path, rec); err == nil || !strings.Contains(err.Error(), "exist") {
+		t.Fatalf("second WriteTrace err = %v, want exists error", err)
+	}
+}

--- a/internal/agenttrace/writer.go
+++ b/internal/agenttrace/writer.go
@@ -41,16 +41,22 @@ func (w *jsonlWriter) Close() error { return w.f.Close() }
 // WriteTrace writes one content-full trace to path, create-exclusive so a
 // run-id collision returns an error (the caller retries with a suffixed path)
 // instead of appending to or clobbering an existing trace.
-func WriteTrace(path string, rec TraceRecord) error {
+func WriteTrace(path string, rec TraceRecord) (err error) {
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, fileMode)
 	if err != nil {
 		return fmt.Errorf("agenttrace: create trace %q: %w", path, err)
 	}
-	defer f.Close()
+	defer func() {
+		// A failed Close on a written file can mean unflushed/lost data, so
+		// surface it — but never mask an earlier encode error.
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("agenttrace: close trace %q: %w", path, cerr)
+		}
+	}()
 	enc := json.NewEncoder(f)
 	enc.SetIndent("", "  ")
-	if err := enc.Encode(rec); err != nil {
-		return fmt.Errorf("agenttrace: encode trace %q: %w", path, err)
+	if encErr := enc.Encode(rec); encErr != nil {
+		return fmt.Errorf("agenttrace: encode trace %q: %w", path, encErr)
 	}
 	return nil
 }

--- a/internal/agenttrace/writer.go
+++ b/internal/agenttrace/writer.go
@@ -1,0 +1,56 @@
+package agenttrace
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+const fileMode os.FileMode = 0o600
+
+// jsonlWriter appends content-light telemetry spans to a caller-supplied path,
+// one JSON object per line, each written in a single Write so concurrent
+// processes sharing the file do not interleave partial lines. It owns no path
+// policy. Used by one run's TelemetrySink, whose callbacks are serial.
+type jsonlWriter struct {
+	f *os.File
+}
+
+func openJSONL(path string) (*jsonlWriter, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, fileMode)
+	if err != nil {
+		return nil, fmt.Errorf("agenttrace: open telemetry %q: %w", path, err)
+	}
+	return &jsonlWriter{f: f}, nil
+}
+
+func (w *jsonlWriter) write(v any) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("agenttrace: marshal span: %w", err)
+	}
+	b = append(b, '\n')
+	if _, err := w.f.Write(b); err != nil {
+		return fmt.Errorf("agenttrace: write span: %w", err)
+	}
+	return nil
+}
+
+func (w *jsonlWriter) Close() error { return w.f.Close() }
+
+// WriteTrace writes one content-full trace to path, create-exclusive so a
+// run-id collision returns an error (the caller retries with a suffixed path)
+// instead of appending to or clobbering an existing trace.
+func WriteTrace(path string, rec TraceRecord) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, fileMode)
+	if err != nil {
+		return fmt.Errorf("agenttrace: create trace %q: %w", path, err)
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(rec); err != nil {
+		return fmt.Errorf("agenttrace: encode trace %q: %w", path, err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds agent-run observability as one seam with two projections, both opt-in and default off:

- **Run traces (#238)** — a post-run, content-full dump of `agent.Result` plus request metadata, one `.json` file per run, for replay / eval / debugging.
- **Telemetry sink (#239)** — a live, content-light `agent.Observer` that streams operational spans (timings, route identity, usage, pressure, tool metadata) to a shared append-only `.jsonl`, with no prompt / assistant / tool content.

Both share a single `run_id` so a telemetry stream joins its trace.

Closes #238. Closes #239.

## Design

Three layers, clean ownership cut:

- **`agent` (producer)** — additive timing only, no behavior change. `Orchestrator` gains an injected clock (`WithClock` option, defaults to `time.Now`). Model-step latency is measured around `o.model.Chat` in `Run`; per-tool invoke latency is measured inside the invoke path, with each parallel worker timing its own invoke so a slow tool's latency is not blurred across the concurrent batch. `StepRecord`/`StepEvent` gain `Latency`; `ToolCallRecord` gains `Invoked`/`Latency`; `ToolResultEvent` gains `Effect`/`Denied`/`Invoked`/`Latency`.
- **`internal/agenttrace` (shared, importable by `cmd/golem`, `cmd/llm-bench`, a future replay command; not external)** — record schemas, a secured JSON/JSONL writer (files `0600`; trace JSON is create-exclusive so it never clobbers/appends; the written trace file's `Close` error is surfaced), `BuildTrace`/`WriteTrace`, and the live `TelemetrySink`. The sink is best-effort: it serializes only identity / counts / sizes / durations / bools, never content, and returns `nil` from every callback even on write failure so telemetry never aborts a run.
- **`cmd/golem` (policy)** — `-trace` / `-telemetry` flags (default off), path resolution reusing the existing out-of-workspace data-dir machinery (`$XDG_DATA_HOME/golem/...`, validated outside the workspace, dir `0700`), per-turn `run_id`, a fan-out `multiObserver` (preserves the renderer's error/abort behavior; the sink cannot abort), independent status computation, and a post-run write on every exit path using the parent context so a canceled turn still flushes its partial trace.

## Acceptance criteria

- #238 disabled -> behavior unchanged (the full existing golem suite runs with observability off and passes); enabled -> one trace artifact per run, final/partial status plus stop reason, tool-schema hash for replay; tests cover success, tool-call, and canceled/partial runs; format importable by `cmd/llm-bench`/replay via `internal/agenttrace`.
- #239 content-light timings/usage/pressure/stop; disabled by default; observer callback and abort semantics unchanged (regression test on a closed writer); sensitive content omitted by default (leak regression test feeds secret markers into goal/system/assistant/args/output and asserts absence).

## Testing

`env -u GOROOT go test -race ./...` (whole module) passes; `go vet ./...` clean; `gofmt` clean; `golangci-lint run` reports no issues on `agent` / `internal/agenttrace` / `cmd/golem`. New tests cover: deterministic model-step and per-tool latency (fake clock), parallel per-tool isolation (the falsifier for sink-side timing), content-light leak regression, sink swallow-on-write-error, trace status/partial mapping, secured-file modes and create-exclusive collision retry, run-id join between trace and telemetry, and the tool-schema hash.

## Documented residuals (not bugs)

- `ToolResultEvent` carries `Denied` beyond the originally-scoped `Effect`/`Invoked`/`Latency`: the sink observes events, not records, and `OnToolCall` is deliberately not fired for denied calls, so the `tool_call` span needs the denied signal on the event.
- `telemetry.jsonl` is append-only with no rotation (out of scope for this slice).
- The embedded `agent.Result` in a trace uses Go's default JSON shape, so `StopReason` serializes as an integer and `Latency` as nanoseconds; the top-level `status` string carries success/failure independently.
- `model_hint` records the resolved model (`lastRoutedModel`), the more useful replay signal, rather than a request-side hint.

## Review

Cleared an independent code review (one fix: trace collision-retry was misclassifying the wrapped `O_EXCL` error via `os.IsExist`; switched to `errors.Is(err, fs.ErrExist)` with a regression test) and an adversarial criticize pass (one fix: populated the previously-empty `tool_schema_hash` to meet the #238 replay criterion).
