### PR TITLE
feat: runtime context-pressure budgets and stage telemetry (#63)

### DIFF
--- a/agent/agenttest/recorder.go
+++ b/agent/agenttest/recorder.go
@@ -11,12 +11,15 @@ import (
 // RecorderObserver records the ordered sequence of observer callbacks so loop
 // tests can assert the exact event transcript.
 type RecorderObserver struct {
-	mu     sync.Mutex
-	Kinds  []string // "step" | "tool_call" | "token"
-	Steps  []agent.StepEvent
-	Calls  []agent.ToolCallEvent
-	Tokens []agent.TokenEvent
+	mu        sync.Mutex
+	Kinds     []string // "pressure" | "step" | "tool_call" | "token"
+	Steps     []agent.StepEvent
+	Calls     []agent.ToolCallEvent
+	Tokens    []agent.TokenEvent
+	Pressures []agent.PressureEvent
 }
+
+var _ agent.PressureObserver = (*RecorderObserver)(nil)
 
 func (r *RecorderObserver) OnStep(_ context.Context, e agent.StepEvent) error {
 	r.mu.Lock()
@@ -39,5 +42,15 @@ func (r *RecorderObserver) OnToken(_ context.Context, e agent.TokenEvent) error 
 	defer r.mu.Unlock()
 	r.Kinds = append(r.Kinds, "token")
 	r.Tokens = append(r.Tokens, e)
+	return nil
+}
+
+// OnPressure records per-turn pressure events (#63). RecorderObserver thus
+// satisfies agent.PressureObserver.
+func (r *RecorderObserver) OnPressure(_ context.Context, e agent.PressureEvent) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.Kinds = append(r.Kinds, "pressure")
+	r.Pressures = append(r.Pressures, e)
 	return nil
 }

--- a/agent/compactor.go
+++ b/agent/compactor.go
@@ -3,9 +3,12 @@ package agent
 import "context"
 
 // TokenBudget is the input-token budget available to the State messages
-// (system + transcript), already net of tool-schema tokens.
+// (system + transcript), already net of tool-schema tokens. Thresholds carries
+// the per-turn pressure bands (zero value => defaults) so Assemble stays a pure
+// function of its inputs. #63.
 type TokenBudget struct {
-	Input int
+	Input      int
+	Thresholds PressureThresholds
 }
 
 // CompactionReport describes what a Compact call did.

--- a/agent/context_manager.go
+++ b/agent/context_manager.go
@@ -152,6 +152,9 @@ func (m ContextManager) Assemble(ctx context.Context, st State, toolSchemaTokens
 // usedFraction is after/budget, guarding a zero/negative budget.
 func usedFraction(tokens, budget int) float64 {
 	if budget <= 0 {
+		if tokens > 0 {
+			return 1
+		}
 		return 0
 	}
 	return float64(tokens) / float64(budget)

--- a/agent/context_manager.go
+++ b/agent/context_manager.go
@@ -58,7 +58,7 @@ func turnBudget(b Budget) TokenBudget {
 	if ceiling < 0 {
 		ceiling = 0
 	}
-	return TokenBudget{Input: ceiling}
+	return TokenBudget{Input: ceiling, Thresholds: b.Pressure.normalize()}
 }
 
 func (m ContextManager) pinnedTokens(st State, toolSchemaTokens int) int {
@@ -96,31 +96,79 @@ func materializeDurableSummary(st State) State {
 }
 
 // Assemble bounds the transcript to fit the budget. toolSchemaTokens is the
-// pinned cost of the active tool schemas (not stored in State).
+// pinned cost of the active tool schemas (not stored in State). The returned
+// Pressure is fully populated on every path — including the exhaustion error
+// paths — so the orchestrator can emit it before the model call.
 func (m ContextManager) Assemble(ctx context.Context, st State, toolSchemaTokens int, budget TokenBudget) (State, Pressure, error) {
 	m = normalizeContextManager(m)
+	thresholds := budget.Thresholds.normalize()
 	st = materializeDurableSummary(st)
-	if m.pinnedTokens(st, toolSchemaTokens) > budget.Input {
-		return st, Pressure{}, ErrContextExhausted
+
+	pinned := m.pinnedTokens(st, toolSchemaTokens)
+	if pinned > budget.Input {
+		// Pinned segment (system + goal + tool schemas) alone exceeds the ceiling:
+		// a hard runtime exhaustion. Report pinned tokens as the input cost.
+		p := Pressure{
+			UsedPct:     usedFraction(pinned, budget.Input),
+			InputTokens: pinned,
+			InputBudget: budget.Input,
+			Level:       LevelCritical,
+			Cause:       m.pinnedOverflowCause(st, toolSchemaTokens),
+			Mitigation:  MitigationHalt,
+		}
+		return st, p, ErrContextExhausted
 	}
-	// Compactor fits the State messages into the budget left after tool schemas.
+
 	stateBudget := TokenBudget{Input: budget.Input - toolSchemaTokens}
 	out, report, err := m.Compactor.Compact(ctx, st, stateBudget)
 	if err != nil {
 		return st, Pressure{}, err
 	}
 	after := m.totalTokens(out, toolSchemaTokens)
-	used := 0.0
-	if budget.Input > 0 {
-		used = float64(after) / float64(budget.Input)
-	}
+	used := usedFraction(after, budget.Input)
+	evicted := report.DroppedCount > 0
 	compactions := 0
-	if report.DroppedCount > 0 {
+	if evicted {
 		compactions = 1
 	}
-	pressure := Pressure{UsedPct: used, Evicted: report.DroppedCount, Compactions: compactions}
-	if after > budget.Input {
+	exhausted := after > budget.Input
+	level, mitigation := thresholds.Classify(used, exhausted, evicted)
+	pressure := Pressure{
+		UsedPct:     used,
+		Evicted:     report.DroppedCount,
+		Compactions: compactions,
+		InputTokens: after,
+		InputBudget: budget.Input,
+		Level:       level,
+		Cause:       m.dominantCause(out, toolSchemaTokens),
+		Mitigation:  mitigation,
+	}
+	if exhausted {
 		return out, pressure, ErrContextExhausted
 	}
 	return out, pressure, nil
+}
+
+// usedFraction is after/budget, guarding a zero/negative budget.
+func usedFraction(tokens, budget int) float64 {
+	if budget <= 0 {
+		return 0
+	}
+	return float64(tokens) / float64(budget)
+}
+
+// pinnedOverflowCause attributes a pinned-overflow exhaustion to either the tool
+// schemas or the pinned messages (system + goal). It deliberately ignores elastic
+// history, which is irrelevant to a pinned-segment overflow.
+func (m ContextManager) pinnedOverflowCause(st State, toolSchemaTokens int) PressureCause {
+	pinnedMsgs := m.estimate(st.System)
+	for _, msg := range st.Messages {
+		if msg.Segment == Pinned {
+			pinnedMsgs += m.messageCost(msg)
+		}
+	}
+	if toolSchemaTokens > pinnedMsgs {
+		return CauseToolSchema
+	}
+	return CausePinned
 }

--- a/agent/context_manager_test.go
+++ b/agent/context_manager_test.go
@@ -182,6 +182,15 @@ func TestAssemblePinnedOverflowPressure(t *testing.T) {
 	}
 }
 
+func TestUsedFractionSaturatesNonPositiveBudget(t *testing.T) {
+	if got := usedFraction(10, 0); got != 1 {
+		t.Fatalf("usedFraction(positive, zero) = %v, want 1", got)
+	}
+	if got := usedFraction(0, 0); got != 0 {
+		t.Fatalf("usedFraction(zero, zero) = %v, want 0", got)
+	}
+}
+
 func TestTurnBudgetCopiesNormalizedThresholds(t *testing.T) {
 	tb := turnBudget(Budget{InputCeiling: 100, Pressure: PressureThresholds{Warn: 0.80}})
 	if tb.Thresholds != (PressureThresholds{Watch: 0.60, Warn: 0.80, Critical: 0.90}) {

--- a/agent/context_manager_test.go
+++ b/agent/context_manager_test.go
@@ -138,3 +138,53 @@ func TestContextManagerZeroValueUsesDefaultCompactor(t *testing.T) {
 		t.Fatalf("unexpected assembled state: %+v", out.Messages)
 	}
 }
+
+func TestAssembleEnrichedPressureNormalPath(t *testing.T) {
+	m := ContextManager{Compactor: RecencyCompactor{Estimate: runeEstimator}, Estimate: runeEstimator}
+	st := State{System: "sys", Messages: []Message{
+		{ChatMessage: provider.ChatMessage{Role: "user", Content: "hello"}, Segment: Pinned},
+	}}
+	budget := TokenBudget{Input: 1000, Thresholds: PressureThresholds{}.normalize()}
+	_, p, err := m.Assemble(context.Background(), st, 0, budget)
+	if err != nil {
+		t.Fatalf("Assemble: %v", err)
+	}
+	if p.InputBudget != 1000 || p.InputTokens <= 0 {
+		t.Fatalf("tokens/budget not stamped: %+v", p)
+	}
+	if p.Level != LevelOK || p.Mitigation != MitigationNone {
+		t.Fatalf("low usage should be ok/none, got %v/%v", p.Level, p.Mitigation)
+	}
+	if p.Cause == CauseUnknown {
+		t.Fatalf("cause should be attributed, got %v", p.Cause)
+	}
+}
+
+func TestAssemblePinnedOverflowPressure(t *testing.T) {
+	m := ContextManager{Compactor: RecencyCompactor{Estimate: runeEstimator}, Estimate: runeEstimator}
+	st := State{System: "0123456789", Messages: []Message{
+		{ChatMessage: provider.ChatMessage{Role: "user", Content: "q"}, Segment: Pinned},
+	}}
+	budget := TokenBudget{Input: 3, Thresholds: PressureThresholds{}.normalize()}
+	_, p, err := m.Assemble(context.Background(), st, 0, budget)
+	if !errors.Is(err, ErrContextExhausted) {
+		t.Fatalf("want ErrContextExhausted, got %v", err)
+	}
+	if p.Level != LevelCritical || p.Mitigation != MitigationHalt {
+		t.Fatalf("overflow should be critical/halt, got %v/%v", p.Level, p.Mitigation)
+	}
+	wantPinned := m.pinnedTokens(st, 0)
+	if p.InputTokens != wantPinned {
+		t.Fatalf("InputTokens=%d, want pinnedTokens=%d", p.InputTokens, wantPinned)
+	}
+	if p.Cause != CausePinned && p.Cause != CauseToolSchema {
+		t.Fatalf("overflow cause should be pinned/tool_schema, got %v", p.Cause)
+	}
+}
+
+func TestTurnBudgetCopiesNormalizedThresholds(t *testing.T) {
+	tb := turnBudget(Budget{InputCeiling: 100, Pressure: PressureThresholds{Warn: 0.80}})
+	if tb.Thresholds != (PressureThresholds{Watch: 0.60, Warn: 0.80, Critical: 0.90}) {
+		t.Fatalf("thresholds not normalized into TokenBudget: %+v", tb.Thresholds)
+	}
+}

--- a/agent/loop_e2e_test.go
+++ b/agent/loop_e2e_test.go
@@ -58,8 +58,9 @@ func TestEndToEndRetrieveThenAnswer(t *testing.T) {
 	if res.Answer != "final" || res.StopReason != agent.Completed {
 		t.Fatalf("got answer=%q stop=%v", res.Answer, res.StopReason)
 	}
-	// observer saw: step (tool turn), tool_call, token, step (final turn).
-	if len(rec.Kinds) < 4 || rec.Kinds[0] != "step" || rec.Kinds[1] != "tool_call" || rec.Kinds[2] != "token" {
+	// observer saw: pressure (step 0 assembly), step (tool turn), tool_call,
+	// pressure (step 1 assembly), token, step (final turn).
+	if len(rec.Kinds) < 6 || rec.Kinds[0] != "pressure" || rec.Kinds[1] != "step" || rec.Kinds[2] != "tool_call" || rec.Kinds[3] != "pressure" || rec.Kinds[4] != "token" {
 		t.Fatalf("unexpected event order: %v", rec.Kinds)
 	}
 	if len(res.ToolCalls) != 1 || res.ToolCalls[0].Name != "retrieve" {

--- a/agent/observer.go
+++ b/agent/observer.go
@@ -63,6 +63,22 @@ type ToolResultObserver interface {
 	OnToolResult(ctx context.Context, e ToolResultEvent) error
 }
 
+// PressureObserver is an OPTIONAL extension of Observer. When an Observer also
+// implements it, the Orchestrator calls OnPressure once per step immediately
+// after assembling the turn's context and BEFORE the model call — including the
+// path where assembly fails with ErrContextExhausted (so the most important
+// pressure event is never invisible). A returned error aborts Run before the
+// model call, like the other observer callbacks.
+type PressureObserver interface {
+	OnPressure(ctx context.Context, e PressureEvent) error
+}
+
+// PressureEvent reports the per-turn context pressure computed during assembly.
+type PressureEvent struct {
+	Step     int
+	Pressure Pressure
+}
+
 type nopObserver struct{}
 
 func (nopObserver) OnStep(context.Context, StepEvent) error         { return nil }

--- a/agent/orchestrator.go
+++ b/agent/orchestrator.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"strings"
@@ -96,6 +97,15 @@ func (o *Orchestrator) Run(ctx context.Context, req Request, obs Observer) (Resu
 
 	for step := 0; step < maxSteps; step++ {
 		assembled, pressure, err := o.ctxMgr.Assemble(ctx, state, toolSchemaTokens, budget)
+		// Emit pressure before the model call on the success path and on the
+		// exhaustion path; skip only opaque compactor failures (pressure is zero).
+		if err == nil || errors.Is(err, ErrContextExhausted) {
+			if po, ok := obs.(PressureObserver); ok {
+				if perr := po.OnPressure(ctx, PressureEvent{Step: step, Pressure: pressure}); perr != nil {
+					return res, perr
+				}
+			}
+		}
 		if err != nil {
 			return res, err
 		}

--- a/agent/orchestrator_test.go
+++ b/agent/orchestrator_test.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/kstruzzieri/go-llm/provider"
@@ -98,5 +100,79 @@ func TestRunReturnsCurrentTurnTranscriptWithToolObservation(t *testing.T) {
 	}
 	if res.Messages[3].Role != "assistant" || res.Messages[3].Content != "done" {
 		t.Fatalf("message 3 = %+v, want final answer", res.Messages[3])
+	}
+}
+
+// pressureRec is a local observer capturing callback order and pressure events
+// without importing agenttest (avoids any test import cycle).
+type pressureRec struct {
+	kinds      []string
+	pressures  []PressureEvent
+	onPressErr error
+}
+
+func (r *pressureRec) OnStep(_ context.Context, _ StepEvent) error {
+	r.kinds = append(r.kinds, "step")
+	return nil
+}
+func (r *pressureRec) OnToolCall(_ context.Context, _ ToolCallEvent) error {
+	r.kinds = append(r.kinds, "tool_call")
+	return nil
+}
+func (r *pressureRec) OnToken(_ context.Context, _ TokenEvent) error {
+	r.kinds = append(r.kinds, "token")
+	return nil
+}
+func (r *pressureRec) OnPressure(_ context.Context, e PressureEvent) error {
+	r.kinds = append(r.kinds, "pressure")
+	r.pressures = append(r.pressures, e)
+	return r.onPressErr
+}
+
+func TestOnPressureFiresBeforeFirstStep(t *testing.T) {
+	mc := &scriptedCaller{responses: []ModelResult{
+		{Response: provider.ChatResponse{Content: "done", Done: true}},
+	}}
+	o := newTestOrchestrator(mc)
+	rec := &pressureRec{}
+	if _, err := o.Run(context.Background(), Request{Goal: "q"}, rec); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(rec.kinds) == 0 || rec.kinds[0] != "pressure" {
+		t.Fatalf("first callback should be pressure, got %v", rec.kinds)
+	}
+	if len(rec.pressures) == 0 {
+		t.Fatal("expected a pressure event")
+	}
+}
+
+func TestOnPressureFiresOnExhaustionWithoutModelCall(t *testing.T) {
+	mc := &scriptedCaller{responses: nil}
+	o := newTestOrchestrator(mc)
+	rec := &pressureRec{}
+	req := Request{Goal: "0123456789012345678901234567890123456789", Budget: Budget{InputCeiling: 2}}
+	_, err := o.Run(context.Background(), req, rec)
+	if !errors.Is(err, ErrContextExhausted) {
+		t.Fatalf("want ErrContextExhausted, got %v", err)
+	}
+	if mc.calls != 0 {
+		t.Fatalf("model should not be called on exhaustion, calls=%d", mc.calls)
+	}
+	if len(rec.pressures) != 1 || rec.pressures[0].Pressure.Mitigation != MitigationHalt {
+		t.Fatalf("expected one halt pressure event, got %+v", rec.pressures)
+	}
+}
+
+func TestOnPressureErrorAbortsBeforeModelCall(t *testing.T) {
+	mc := &scriptedCaller{responses: nil}
+	o := newTestOrchestrator(mc)
+	sentinel := fmt.Errorf("observer abort")
+	rec := &pressureRec{onPressErr: sentinel}
+	_, err := o.Run(context.Background(), Request{Goal: "q"}, rec)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("want sentinel, got %v", err)
+	}
+	if mc.calls != 0 {
+		t.Fatalf("model should not be called when OnPressure errors, calls=%d", mc.calls)
 	}
 }

--- a/agent/pressure.go
+++ b/agent/pressure.go
@@ -168,6 +168,7 @@ func (t PressureThresholds) Classify(usedPct float64, exhausted, evicted bool) (
 	if exhausted {
 		return LevelCritical, MitigationHalt
 	}
+	t = t.normalize()
 	level := LevelOK
 	switch {
 	case usedPct >= t.Critical:

--- a/agent/pressure.go
+++ b/agent/pressure.go
@@ -1,5 +1,7 @@
 package agent
 
+import "math"
+
 // PressureLevel is the severity of per-turn context-budget usage. It is a label
 // only: LevelCritical does not stop a run (the hard stop is ErrContextExhausted).
 type PressureLevel int
@@ -130,11 +132,17 @@ type PressureThresholds struct {
 	Critical float64
 }
 
+// defaultPressureThresholds is the single source of truth for the conservative
+// warn/watch/critical bands applied when a PressureThresholds is unset or invalid.
+func defaultPressureThresholds() PressureThresholds {
+	return PressureThresholds{Watch: 0.60, Warn: 0.75, Critical: 0.90}
+}
+
 // normalize fills zero fields with their default and, if the result is not a
 // valid monotonic triplet (0 < Watch <= Warn <= Critical <= 1), falls back to the
 // default triplet entirely. This keeps Classify deterministic for any input.
 func (t PressureThresholds) normalize() PressureThresholds {
-	def := PressureThresholds{Watch: 0.60, Warn: 0.75, Critical: 0.90}
+	def := defaultPressureThresholds()
 	if t == (PressureThresholds{}) {
 		return def
 	}
@@ -177,4 +185,17 @@ func (t PressureThresholds) Classify(usedPct float64, exhausted, evicted bool) (
 	default:
 		return level, MitigationNone
 	}
+}
+
+// PressureThresholdsForWarn builds a monotonic triplet around warn (a fraction of
+// the input budget) so a consumer can tune just the warn band without normalize
+// discarding it. It keeps the default watch/critical bands, widening them only
+// when warn falls outside, then normalizes (an out-of-range warn yields defaults).
+func PressureThresholdsForWarn(warn float64) PressureThresholds {
+	def := defaultPressureThresholds()
+	return PressureThresholds{
+		Watch:    math.Min(def.Watch, warn),
+		Warn:     warn,
+		Critical: math.Max(def.Critical, warn),
+	}.normalize()
 }

--- a/agent/pressure.go
+++ b/agent/pressure.go
@@ -80,6 +80,47 @@ func (m PressureMitigation) String() string {
 	}
 }
 
+// dominantCause attributes a turn's input tokens to the single largest bucket.
+// It reuses ContextManager.estimate / messageCost so the attribution can never
+// drift from the token accounting Assemble performs. Per-message precedence:
+// pinned > retrieval (Attrib set) > tool_output (role "tool") > history. Ties
+// resolve to the earliest bucket in {pinned, tool_schema, history, tool_output,
+// retrieval}; an all-zero state yields CauseUnknown.
+func (m ContextManager) dominantCause(st State, toolSchemaTokens int) PressureCause {
+	var pinned, toolOutput, retrieval, history int
+	pinned += m.estimate(st.System)
+	for _, msg := range st.Messages {
+		cost := m.messageCost(msg)
+		switch {
+		case msg.Segment == Pinned:
+			pinned += cost
+		case msg.Attrib != nil:
+			retrieval += cost
+		case msg.Role == "tool":
+			toolOutput += cost
+		default:
+			history += cost
+		}
+	}
+	buckets := []struct {
+		cause  PressureCause
+		tokens int
+	}{
+		{CausePinned, pinned},
+		{CauseToolSchema, toolSchemaTokens},
+		{CauseHistory, history},
+		{CauseToolOutput, toolOutput},
+		{CauseRetrieval, retrieval},
+	}
+	best, bestTokens := CauseUnknown, 0
+	for _, b := range buckets {
+		if b.tokens > bestTokens {
+			best, bestTokens = b.cause, b.tokens
+		}
+	}
+	return best
+}
+
 // PressureThresholds are the fractional bands (of the per-turn input budget) that
 // classify usage. The zero value normalizes to conservative defaults so existing
 // Budget{} callers are unaffected.

--- a/agent/pressure.go
+++ b/agent/pressure.go
@@ -1,0 +1,139 @@
+package agent
+
+// PressureLevel is the severity of per-turn context-budget usage. It is a label
+// only: LevelCritical does not stop a run (the hard stop is ErrContextExhausted).
+type PressureLevel int
+
+const (
+	LevelOK PressureLevel = iota
+	LevelWatch
+	LevelWarn
+	LevelCritical
+)
+
+func (l PressureLevel) String() string {
+	switch l {
+	case LevelOK:
+		return "ok"
+	case LevelWatch:
+		return "watch"
+	case LevelWarn:
+		return "warn"
+	case LevelCritical:
+		return "critical"
+	default:
+		return "unknown"
+	}
+}
+
+// PressureCause names the dominant input bucket driving a turn's token usage.
+type PressureCause int
+
+const (
+	CauseUnknown PressureCause = iota
+	CausePinned
+	CauseToolSchema
+	CauseHistory
+	CauseToolOutput
+	CauseRetrieval
+)
+
+func (c PressureCause) String() string {
+	switch c {
+	case CausePinned:
+		return "pinned"
+	case CauseToolSchema:
+		return "tool_schema"
+	case CauseHistory:
+		return "history"
+	case CauseToolOutput:
+		return "tool_output"
+	case CauseRetrieval:
+		return "retrieval"
+	default:
+		return "unknown"
+	}
+}
+
+// PressureMitigation names what the runtime did (or advises) for a turn.
+// MitigationHalt is emitted only on ErrContextExhausted. A summarizing-compaction
+// mitigation is intentionally absent until #58 ships it.
+type PressureMitigation int
+
+const (
+	MitigationNone PressureMitigation = iota
+	MitigationWarn
+	MitigationEvict
+	MitigationHalt
+)
+
+func (m PressureMitigation) String() string {
+	switch m {
+	case MitigationWarn:
+		return "warn"
+	case MitigationEvict:
+		return "evict"
+	case MitigationHalt:
+		return "halt"
+	default:
+		return "none"
+	}
+}
+
+// PressureThresholds are the fractional bands (of the per-turn input budget) that
+// classify usage. The zero value normalizes to conservative defaults so existing
+// Budget{} callers are unaffected.
+type PressureThresholds struct {
+	Watch    float64
+	Warn     float64
+	Critical float64
+}
+
+// normalize fills zero fields with their default and, if the result is not a
+// valid monotonic triplet (0 < Watch <= Warn <= Critical <= 1), falls back to the
+// default triplet entirely. This keeps Classify deterministic for any input.
+func (t PressureThresholds) normalize() PressureThresholds {
+	def := PressureThresholds{Watch: 0.60, Warn: 0.75, Critical: 0.90}
+	if t == (PressureThresholds{}) {
+		return def
+	}
+	if t.Watch == 0 {
+		t.Watch = def.Watch
+	}
+	if t.Warn == 0 {
+		t.Warn = def.Warn
+	}
+	if t.Critical == 0 {
+		t.Critical = def.Critical
+	}
+	if !(0 < t.Watch && t.Watch <= t.Warn && t.Warn <= t.Critical && t.Critical <= 1) {
+		return def
+	}
+	return t
+}
+
+// Classify maps a used fraction (plus the exhausted/evicted facts known at
+// assembly) to a level and a mitigation. exhausted overrides everything with
+// LevelCritical/MitigationHalt. Mitigation precedence: halt > evict > warn > none.
+func (t PressureThresholds) Classify(usedPct float64, exhausted, evicted bool) (PressureLevel, PressureMitigation) {
+	if exhausted {
+		return LevelCritical, MitigationHalt
+	}
+	level := LevelOK
+	switch {
+	case usedPct >= t.Critical:
+		level = LevelCritical
+	case usedPct >= t.Warn:
+		level = LevelWarn
+	case usedPct >= t.Watch:
+		level = LevelWatch
+	}
+	switch {
+	case evicted:
+		return level, MitigationEvict
+	case level >= LevelWarn:
+		return level, MitigationWarn
+	default:
+		return level, MitigationNone
+	}
+}

--- a/agent/pressure_test.go
+++ b/agent/pressure_test.go
@@ -1,0 +1,64 @@
+package agent
+
+import "testing"
+
+func TestPressureThresholdsClassify(t *testing.T) {
+	def := PressureThresholds{}.normalize() // Watch .60 Warn .75 Critical .90
+	cases := []struct {
+		name      string
+		used      float64
+		exhausted bool
+		evicted   bool
+		wantLevel PressureLevel
+		wantMit   PressureMitigation
+	}{
+		{"ok", 0.10, false, false, LevelOK, MitigationNone},
+		{"watch", 0.65, false, false, LevelWatch, MitigationNone},
+		{"warn", 0.80, false, false, LevelWarn, MitigationWarn},
+		{"critical", 0.95, false, false, LevelCritical, MitigationWarn},
+		{"evict_wins_over_warn", 0.80, false, true, LevelWarn, MitigationEvict},
+		{"exhausted_overrides_all", 0.50, true, true, LevelCritical, MitigationHalt},
+		{"watch_with_evict", 0.65, false, true, LevelWatch, MitigationEvict},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotLevel, gotMit := def.Classify(c.used, c.exhausted, c.evicted)
+			if gotLevel != c.wantLevel || gotMit != c.wantMit {
+				t.Fatalf("Classify(%.2f,%v,%v)=%v/%v want %v/%v",
+					c.used, c.exhausted, c.evicted, gotLevel, gotMit, c.wantLevel, c.wantMit)
+			}
+		})
+	}
+}
+
+func TestPressureThresholdsNormalize(t *testing.T) {
+	def := PressureThresholds{Watch: 0.60, Warn: 0.75, Critical: 0.90}
+	if got := (PressureThresholds{}).normalize(); got != def {
+		t.Fatalf("zero => %+v, want %+v", got, def)
+	}
+	if got := (PressureThresholds{Warn: 0.80}).normalize(); got != (PressureThresholds{Watch: 0.60, Warn: 0.80, Critical: 0.90}) {
+		t.Fatalf("partial fill => %+v", got)
+	}
+	if got := (PressureThresholds{Warn: 0.99}).normalize(); got != def {
+		t.Fatalf("non-monotonic => %+v, want default", got)
+	}
+	if got := (PressureThresholds{Watch: -0.1, Warn: 0.5, Critical: 0.6}).normalize(); got != def {
+		t.Fatalf("out-of-range => %+v, want default", got)
+	}
+}
+
+func TestPressureLabelStrings(t *testing.T) {
+	if LevelOK.String() != "ok" || LevelWatch.String() != "watch" ||
+		LevelWarn.String() != "warn" || LevelCritical.String() != "critical" {
+		t.Fatal("level labels wrong")
+	}
+	if MitigationNone.String() != "none" || MitigationWarn.String() != "warn" ||
+		MitigationEvict.String() != "evict" || MitigationHalt.String() != "halt" {
+		t.Fatal("mitigation labels wrong")
+	}
+	if CauseUnknown.String() != "unknown" || CausePinned.String() != "pinned" ||
+		CauseToolSchema.String() != "tool_schema" || CauseHistory.String() != "history" ||
+		CauseToolOutput.String() != "tool_output" || CauseRetrieval.String() != "retrieval" {
+		t.Fatal("cause labels wrong")
+	}
+}

--- a/agent/pressure_test.go
+++ b/agent/pressure_test.go
@@ -51,6 +51,21 @@ func TestPressureThresholdsNormalize(t *testing.T) {
 	}
 }
 
+func TestPressureThresholdsForWarn(t *testing.T) {
+	// mid-range warn keeps the default watch/critical bands.
+	if got := PressureThresholdsForWarn(0.80); got != (PressureThresholds{Watch: 0.60, Warn: 0.80, Critical: 0.90}) {
+		t.Fatalf("warn 0.80 => %+v", got)
+	}
+	// high warn widens critical so normalize keeps the warn instead of discarding it.
+	if got := PressureThresholdsForWarn(0.95); got != (PressureThresholds{Watch: 0.60, Warn: 0.95, Critical: 0.95}) {
+		t.Fatalf("warn 0.95 => %+v", got)
+	}
+	// low warn lowers watch so normalize keeps the warn.
+	if got := PressureThresholdsForWarn(0.50); got != (PressureThresholds{Watch: 0.50, Warn: 0.50, Critical: 0.90}) {
+		t.Fatalf("warn 0.50 => %+v", got)
+	}
+}
+
 func TestDominantCause(t *testing.T) {
 	m := ContextManager{Estimate: runeEstimator}
 	mkPinned := func(role, content string) Message {

--- a/agent/pressure_test.go
+++ b/agent/pressure_test.go
@@ -35,6 +35,13 @@ func TestPressureThresholdsClassify(t *testing.T) {
 	}
 }
 
+func TestPressureThresholdsClassifyNormalizesZeroValue(t *testing.T) {
+	level, mitigation := (PressureThresholds{}).Classify(0.10, false, false)
+	if level != LevelOK || mitigation != MitigationNone {
+		t.Fatalf("zero-value Classify = %v/%v, want ok/none", level, mitigation)
+	}
+}
+
 func TestPressureThresholdsNormalize(t *testing.T) {
 	def := PressureThresholds{Watch: 0.60, Warn: 0.75, Critical: 0.90}
 	if got := (PressureThresholds{}).normalize(); got != def {

--- a/agent/pressure_test.go
+++ b/agent/pressure_test.go
@@ -1,6 +1,10 @@
 package agent
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
 
 func TestPressureThresholdsClassify(t *testing.T) {
 	def := PressureThresholds{}.normalize() // Watch .60 Warn .75 Critical .90
@@ -44,6 +48,43 @@ func TestPressureThresholdsNormalize(t *testing.T) {
 	}
 	if got := (PressureThresholds{Watch: -0.1, Warn: 0.5, Critical: 0.6}).normalize(); got != def {
 		t.Fatalf("out-of-range => %+v, want default", got)
+	}
+}
+
+func TestDominantCause(t *testing.T) {
+	m := ContextManager{Estimate: runeEstimator}
+	mkPinned := func(role, content string) Message {
+		return Message{ChatMessage: provider.ChatMessage{Role: role, Content: content}, Segment: Pinned}
+	}
+	mkElastic := func(role, content string) Message {
+		return Message{ChatMessage: provider.ChatMessage{Role: role, Content: content}, Segment: Elastic}
+	}
+	mkRetrieval := func(content string) Message {
+		return Message{
+			ChatMessage: provider.ChatMessage{Role: "tool", Content: content},
+			Segment:     Elastic,
+			Attrib:      &RetrievalAttribution{Sources: []RetrievedSource{{StableKey: "k"}}},
+		}
+	}
+	cases := []struct {
+		name             string
+		st               State
+		toolSchemaTokens int
+		want             PressureCause
+	}{
+		{"empty", State{}, 0, CauseUnknown},
+		{"tool_schema_dominates", State{Messages: []Message{mkElastic("user", "hi")}}, 1000, CauseToolSchema},
+		{"pinned_dominates", State{System: "", Messages: []Message{mkPinned("system", "PPPPPPPPPP")}}, 1, CausePinned},
+		{"history_dominates", State{Messages: []Message{mkElastic("assistant", "HHHHHHHHHH")}}, 1, CauseHistory},
+		{"tool_output_dominates", State{Messages: []Message{mkElastic("tool", "TTTTTTTTTT")}}, 1, CauseToolOutput},
+		{"retrieval_beats_tool_output", State{Messages: []Message{mkRetrieval("RRRRRRRRRR")}}, 1, CauseRetrieval},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := m.dominantCause(c.st, c.toolSchemaTokens); got != c.want {
+				t.Fatalf("dominantCause = %v, want %v", got, c.want)
+			}
+		})
 	}
 }
 

--- a/agent/types.go
+++ b/agent/types.go
@@ -59,6 +59,9 @@ type Budget struct {
 	// also subtracted from the per-turn input ceiling during assembly.
 	OutputReserve int
 	TotalTokens   int // 0 = unbounded whole-run cap
+	// Pressure tunes the warn/watch/critical bands classified during assembly.
+	// The zero value normalizes to conservative defaults. #63.
+	Pressure PressureThresholds
 }
 
 // Request is the unit of work handed to Run.
@@ -109,11 +112,17 @@ type RetrievedSource struct {
 	Score     float64
 }
 
-// Pressure is the per-turn context-budget telemetry (#63 seam).
+// Pressure is the per-turn context-budget telemetry (#63 seam). UsedPct,
+// Evicted, Compactions are the original v1 fields; the rest enrich them.
 type Pressure struct {
 	UsedPct     float64
 	Evicted     int
 	Compactions int
+	InputTokens int
+	InputBudget int
+	Level       PressureLevel
+	Cause       PressureCause
+	Mitigation  PressureMitigation
 }
 
 // StepRecord is the durable per-turn truth. RouteOutcome is captured

--- a/cmd/golem/main.go
+++ b/cmd/golem/main.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"math"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -371,14 +370,9 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 
 	budget := agent.Budget{InputCeiling: f.inputCeiling, OutputReserve: f.outputReserve}
 	if f.pressureWarn > 0 {
-		w := float64(f.pressureWarn) / 100
-		// Keep the triplet monotonic for any chosen warn so normalize() does not
-		// fall back to defaults: Watch <= Warn <= Critical.
-		budget.Pressure = agent.PressureThresholds{
-			Watch:    math.Min(0.60, w),
-			Warn:     w,
-			Critical: math.Max(0.90, w),
-		}
+		// The agent package owns the band layout (single source of truth for the
+		// monotonic clamp + defaults); golem only supplies the warn fraction.
+		budget.Pressure = agent.PressureThresholdsForWarn(float64(f.pressureWarn) / 100)
 	}
 	sess := &replSession{
 		orch:            agent.New(caller, agent.ContextManager{}),

--- a/cmd/golem/main.go
+++ b/cmd/golem/main.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"math"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -42,6 +43,7 @@ type flags struct {
 	noMemory         bool
 	trace            bool
 	telemetry        bool
+	pressureWarn     int
 }
 
 func parseFlags(args []string) (flags, error) {
@@ -70,6 +72,7 @@ func parseFlags(args []string) (flags, error) {
 	// -telemetry appends content-light run metrics only (timings, route, usage; no prompt or output).
 	fs.BoolVar(&f.trace, "trace", false, "persist a content-full run trace per turn (outside the workspace; may contain workspace/user content)")
 	fs.BoolVar(&f.telemetry, "telemetry", false, "append content-light run telemetry (timings, route, usage; no prompt/output)")
+	fs.IntVar(&f.pressureWarn, "pressure-warn", 75, "context-pressure warn threshold percent 1-100 (0 disables the warning line)")
 	if err := fs.Parse(args); err != nil {
 		return flags{}, err
 	}
@@ -83,6 +86,9 @@ func validateFlags(f flags) error {
 	}
 	if f.noRag && f.ragDB != "" {
 		return fmt.Errorf("golem: -no-rag and -rag-db are mutually exclusive")
+	}
+	if f.pressureWarn < 0 || f.pressureWarn > 100 {
+		return fmt.Errorf("golem: -pressure-warn must be between 0 and 100")
 	}
 	return nil
 }
@@ -363,12 +369,23 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 		return fmt.Errorf("golem: observability setup: %w", err)
 	}
 
+	budget := agent.Budget{InputCeiling: f.inputCeiling, OutputReserve: f.outputReserve}
+	if f.pressureWarn > 0 {
+		w := float64(f.pressureWarn) / 100
+		// Keep the triplet monotonic for any chosen warn so normalize() does not
+		// fall back to defaults: Watch <= Warn <= Critical.
+		budget.Pressure = agent.PressureThresholds{
+			Watch:    math.Min(0.60, w),
+			Warn:     w,
+			Critical: math.Max(0.90, w),
+		}
+	}
 	sess := &replSession{
 		orch:            agent.New(caller, agent.ContextManager{}),
 		tools:           tools,
 		baseSystem:      baseSystem,
 		maxSteps:        f.maxSteps,
-		budget:          agent.Budget{InputCeiling: f.inputCeiling, OutputReserve: f.outputReserve},
+		budget:          budget,
 		color:           !f.noColor,
 		retrieveOmitted: retrieveOmitted,
 		session:         sessn,
@@ -387,6 +404,7 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 		memoryDBPath: memDBPath,
 		workspaceID:  workspaceID(root),
 		obs:          obsv,
+		pressureWarn: f.pressureWarn > 0,
 	}
 	if sess.maxSteps == 0 {
 		sess.maxSteps = 16 // mirror agent defaultMaxSteps so the footer's k/max is accurate

--- a/cmd/golem/main_test.go
+++ b/cmd/golem/main_test.go
@@ -225,3 +225,29 @@ func TestParseFlagsNoMemory(t *testing.T) {
 		t.Error("noMemory should default false")
 	}
 }
+
+func TestParsePressureWarnFlag(t *testing.T) {
+	f, err := parseFlags(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.pressureWarn != 75 {
+		t.Fatalf("default pressureWarn = %d, want 75", f.pressureWarn)
+	}
+	f, err = parseFlags([]string{"-pressure-warn", "0"})
+	if err != nil || f.pressureWarn != 0 {
+		t.Fatalf("explicit 0: f=%d err=%v", f.pressureWarn, err)
+	}
+}
+
+func TestValidatePressureWarnRange(t *testing.T) {
+	if err := validateFlags(flags{pressureWarn: 75}); err != nil {
+		t.Fatalf("75 should be valid: %v", err)
+	}
+	if err := validateFlags(flags{pressureWarn: -1}); err == nil {
+		t.Fatal("negative pressureWarn should be rejected")
+	}
+	if err := validateFlags(flags{pressureWarn: 101}); err == nil {
+		t.Fatal(">100 pressureWarn should be rejected")
+	}
+}

--- a/cmd/golem/observe.go
+++ b/cmd/golem/observe.go
@@ -163,6 +163,17 @@ func (m *multiObserver) OnToolResult(ctx context.Context, e agent.ToolResultEven
 	return nil
 }
 
+func (m *multiObserver) OnPressure(ctx context.Context, e agent.PressureEvent) error {
+	for _, c := range m.children {
+		if po, ok := c.(agent.PressureObserver); ok {
+			if err := po.OnPressure(ctx, e); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // toolSchemaHash returns a stable fnv64a digest of the active tool specs (name,
 // description, JSON schema) so a trace records which tool surface the run saw
 // without embedding the full schemas (#238: "tool specs or tool schema hash").

--- a/cmd/golem/observe_test.go
+++ b/cmd/golem/observe_test.go
@@ -181,6 +181,35 @@ func TestComposeObserver(t *testing.T) {
 	}
 }
 
+type pressureChild struct{ got []agent.PressureEvent }
+
+func (p *pressureChild) OnStep(context.Context, agent.StepEvent) error         { return nil }
+func (p *pressureChild) OnToolCall(context.Context, agent.ToolCallEvent) error { return nil }
+func (p *pressureChild) OnToken(context.Context, agent.TokenEvent) error       { return nil }
+func (p *pressureChild) OnPressure(_ context.Context, e agent.PressureEvent) error {
+	p.got = append(p.got, e)
+	return nil
+}
+
+type nonPressureObs struct{}
+
+func (nonPressureObs) OnStep(context.Context, agent.StepEvent) error         { return nil }
+func (nonPressureObs) OnToolCall(context.Context, agent.ToolCallEvent) error { return nil }
+func (nonPressureObs) OnToken(context.Context, agent.TokenEvent) error       { return nil }
+
+func TestMultiObserverOnPressureFanout(t *testing.T) {
+	child := &pressureChild{}
+	plain := nonPressureObs{} // does NOT implement PressureObserver
+	m := &multiObserver{children: []agent.Observer{plain, child}}
+	e := agent.PressureEvent{Step: 3, Pressure: agent.Pressure{Level: agent.LevelWarn}}
+	if err := m.OnPressure(context.Background(), e); err != nil {
+		t.Fatal(err)
+	}
+	if len(child.got) != 1 || child.got[0].Step != 3 {
+		t.Fatalf("PressureObserver child not reached: %+v", child.got)
+	}
+}
+
 func TestObserv_TraceAndTelemetryShareRunID(t *testing.T) {
 	base := t.TempDir()
 	root := t.TempDir()

--- a/cmd/golem/render.go
+++ b/cmd/golem/render.go
@@ -14,13 +14,15 @@ import (
 // prints one-line tool-call and tool-result notices, a dim per-step footer, and
 // (via finalFooter) a dim summary after Run.
 type renderer struct {
-	out      io.Writer
-	color    bool
-	maxSteps int
-	now      func() time.Time
-	lastMark time.Time
-	runStart time.Time
-	lastNL   bool
+	out          io.Writer
+	color        bool
+	maxSteps     int
+	now          func() time.Time
+	lastMark     time.Time
+	runStart     time.Time
+	lastNL       bool
+	warnPressure bool // print a one-line context-pressure warning
+	warned       bool // ensures at most one pressure line per run
 }
 
 func newRenderer(out io.Writer, color bool, maxSteps int, now func() time.Time) *renderer {
@@ -112,6 +114,18 @@ func (r *renderer) OnToolResult(_ context.Context, e agent.ToolResultEvent) erro
 		r.lastNL = true
 	}
 	return err
+}
+
+// OnPressure prints a single dim context-pressure warning per run when warnings
+// are enabled and the level reaches warn. Telemetry records every event; the
+// terminal is deduped to avoid spam.
+func (r *renderer) OnPressure(_ context.Context, e agent.PressureEvent) error {
+	if !r.warnPressure || r.warned || e.Pressure.Level < agent.LevelWarn {
+		return nil
+	}
+	r.warned = true
+	return r.writeDim(fmt.Sprintf("context pressure: %s · ctx %.0f%% · cause %s",
+		e.Pressure.Level, e.Pressure.UsedPct*100, e.Pressure.Cause))
 }
 
 // resultSummary derives a terse one-line summary from the result. A tool-set

--- a/cmd/golem/render_test.go
+++ b/cmd/golem/render_test.go
@@ -191,3 +191,43 @@ func TestOnToolResult_NewlineAfterUnterminatedToken(t *testing.T) {
 		t.Errorf("got %q, want %q", buf.String(), want)
 	}
 }
+
+func TestRendererOnPressureGatedOncePerRun(t *testing.T) {
+	var buf bytes.Buffer
+	r := newRenderer(&buf, false, 16, func() time.Time { return time.Unix(0, 0) })
+	r.warnPressure = true
+	warn := agent.PressureEvent{Pressure: agent.Pressure{Level: agent.LevelWarn, UsedPct: 0.80, Cause: agent.CauseHistory}}
+	below := agent.PressureEvent{Pressure: agent.Pressure{Level: agent.LevelWatch, UsedPct: 0.65}}
+	if err := r.OnPressure(context.Background(), below); err != nil {
+		t.Fatal(err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("watch level must not print: %q", buf.String())
+	}
+	if err := r.OnPressure(context.Background(), warn); err != nil {
+		t.Fatal(err)
+	}
+	first := buf.String()
+	if !strings.Contains(first, "pressure") {
+		t.Fatalf("warn level should print a pressure line, got %q", first)
+	}
+	if err := r.OnPressure(context.Background(), warn); err != nil {
+		t.Fatal(err)
+	}
+	if buf.String() != first {
+		t.Fatalf("second warn must not print again (one per run), got %q", buf.String())
+	}
+}
+
+func TestRendererOnPressureDisabled(t *testing.T) {
+	var buf bytes.Buffer
+	r := newRenderer(&buf, false, 16, func() time.Time { return time.Unix(0, 0) })
+	r.warnPressure = false
+	warn := agent.PressureEvent{Pressure: agent.Pressure{Level: agent.LevelCritical, UsedPct: 0.95}}
+	if err := r.OnPressure(context.Background(), warn); err != nil {
+		t.Fatal(err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("disabled renderer must not print: %q", buf.String())
+	}
+}

--- a/cmd/golem/repl.go
+++ b/cmd/golem/repl.go
@@ -32,12 +32,13 @@ type replSession struct {
 	memoryDBPath string              // used to re-secure SQLite sidecars after writes
 	workspaceID  string              // stable id used to scope memory create/list/search
 
-	lastModel   string           // last routed ActualModel for /model
-	journal     *mutationJournal // nil unless -allow-write enabled writes
-	allowWrite  bool
-	allowExec   bool
-	mcpAttached bool    // true when external MCP tools are attached (force approver)
-	obs         *observ // nil unless -trace/-telemetry enabled
+	lastModel    string           // last routed ActualModel for /model
+	journal      *mutationJournal // nil unless -allow-write enabled writes
+	allowWrite   bool
+	allowExec    bool
+	mcpAttached  bool    // true when external MCP tools are attached (force approver)
+	obs          *observ // nil unless -trace/-telemetry enabled
+	pressureWarn bool    // enable the one-per-run context-pressure warning line
 }
 
 // runREPL reads lines from in, dispatching slash commands and running every
@@ -104,6 +105,7 @@ func runOnce(ctx context.Context, out io.Writer, interrupts <-chan struct{}, ses
 	}
 
 	rend := newRenderer(out, sess.color, sess.maxSteps, sess.clock)
+	rend.warnPressure = sess.pressureWarn
 
 	var (
 		runID     string

--- a/internal/agenttrace/record.go
+++ b/internal/agenttrace/record.go
@@ -9,7 +9,8 @@ import (
 )
 
 // SchemaVersion is bumped on any breaking change to the trace/telemetry records.
-const SchemaVersion = 1
+// v2 adds the runtime_stage span and pressure enrichment (#63).
+const SchemaVersion = 2
 
 // TraceMeta is the replay-relevant request context the caller supplies (the
 // agent.Request is not embedded in agent.Result, and history is excluded from
@@ -64,18 +65,25 @@ type pressureLite struct {
 	UsedPct     float64 `json:"used_pct"`
 	Evicted     int     `json:"evicted"`
 	Compactions int     `json:"compactions"`
+	Level       string  `json:"level"`
+	Cause       string  `json:"cause"`
+	Mitigation  string  `json:"mitigation"`
+	InputTokens int     `json:"input_tokens"`
+	InputBudget int     `json:"input_budget"`
 }
 
 type runSpan struct {
-	SchemaVersion int     `json:"schema_version"`
-	RunID         string  `json:"run_id"`
-	SpanID        string  `json:"span_id"`
-	Kind          string  `json:"kind"` // "run"
-	StartedAt     string  `json:"started_at"`
-	DurationMS    float64 `json:"duration_ms"`
-	Steps         int     `json:"steps"`
-	Status        string  `json:"status"`
-	StopReason    string  `json:"stop_reason,omitempty"`
+	SchemaVersion    int     `json:"schema_version"`
+	RunID            string  `json:"run_id"`
+	SpanID           string  `json:"span_id"`
+	Kind             string  `json:"kind"` // "run"
+	StartedAt        string  `json:"started_at"`
+	DurationMS       float64 `json:"duration_ms"`
+	Steps            int     `json:"steps"`
+	Status           string  `json:"status"`
+	StopReason       string  `json:"stop_reason,omitempty"`
+	MaxUsedPct       float64 `json:"max_used_pct"`
+	MaxPressureLevel string  `json:"max_pressure_level"`
 }
 
 type modelStepSpan struct {
@@ -109,6 +117,29 @@ type toolCallSpan struct {
 	Truncated     bool    `json:"truncated"`
 	ContentBytes  int     `json:"content_bytes"`
 	DurationMS    float64 `json:"duration_ms"`
+}
+
+// runtimeStageSpan is one content-light runtime-stage record (#63). Today the
+// only emitted stage is "assemble" (the condense/compact boundary); future
+// stages reuse this shape with a different Stage value.
+type runtimeStageSpan struct {
+	SchemaVersion int     `json:"schema_version"`
+	RunID         string  `json:"run_id"`
+	SpanID        string  `json:"span_id"`
+	ParentID      string  `json:"parent_id"`
+	Kind          string  `json:"kind"`
+	Stage         string  `json:"stage"`
+	Step          int     `json:"step"`
+	Level         string  `json:"level"`
+	Cause         string  `json:"cause"`
+	Mitigation    string  `json:"mitigation"`
+	Outcome       string  `json:"outcome"`
+	UsedPct       float64 `json:"used_pct"`
+	UsedPctDelta  float64 `json:"used_pct_delta"`
+	InputTokens   int     `json:"input_tokens"`
+	InputBudget   int     `json:"input_budget"`
+	Evicted       int     `json:"evicted"`
+	Compactions   int     `json:"compactions"`
 }
 
 // effectString renders an EffectClass bitset as a stable, content-light label.

--- a/internal/agenttrace/sink.go
+++ b/internal/agenttrace/sink.go
@@ -11,6 +11,7 @@ import (
 var (
 	_ agent.Observer           = (*TelemetrySink)(nil)
 	_ agent.ToolResultObserver = (*TelemetrySink)(nil)
+	_ agent.PressureObserver   = (*TelemetrySink)(nil)
 )
 
 // TelemetrySink is a content-light agent.Observer (+ ToolResultObserver). It
@@ -31,6 +32,11 @@ type TelemetrySink struct {
 	lastErr  error
 	lastStep int
 	toolSeq  int
+
+	prevUsedPct float64
+	havePrev    bool
+	maxUsedPct  float64
+	maxLevel    agent.PressureLevel
 }
 
 // NewTelemetrySink opens path for append and returns a sink for one run. started
@@ -66,7 +72,16 @@ func (s *TelemetrySink) OnStep(_ context.Context, e agent.StepEvent) error {
 			Completion: e.Response.Usage.CompletionTokens,
 			Total:      e.Response.Usage.TotalTokens,
 		},
-		Pressure: pressureLite{UsedPct: e.Pressure.UsedPct, Evicted: e.Pressure.Evicted, Compactions: e.Pressure.Compactions},
+		Pressure: pressureLite{
+			UsedPct:     e.Pressure.UsedPct,
+			Evicted:     e.Pressure.Evicted,
+			Compactions: e.Pressure.Compactions,
+			Level:       e.Pressure.Level.String(),
+			Cause:       e.Pressure.Cause.String(),
+			Mitigation:  e.Pressure.Mitigation.String(),
+			InputTokens: e.Pressure.InputTokens,
+			InputBudget: e.Pressure.InputBudget,
+		},
 	}
 	if e.RouteOutcome != nil {
 		span.Model = e.RouteOutcome.ActualModel.String()
@@ -103,6 +118,48 @@ func (s *TelemetrySink) OnToolResult(_ context.Context, e agent.ToolResultEvent)
 	return nil
 }
 
+// OnPressure writes a content-light runtime_stage span for the assembly stage and
+// updates the per-run pressure aggregates. Best-effort: write errors are retained
+// and it returns nil so telemetry never aborts a run.
+func (s *TelemetrySink) OnPressure(_ context.Context, e agent.PressureEvent) error {
+	p := e.Pressure
+	delta := 0.0
+	if s.havePrev {
+		delta = p.UsedPct - s.prevUsedPct
+	}
+	s.prevUsedPct, s.havePrev = p.UsedPct, true
+	if p.UsedPct > s.maxUsedPct {
+		s.maxUsedPct = p.UsedPct
+	}
+	if p.Level > s.maxLevel {
+		s.maxLevel = p.Level
+	}
+	outcome := "ok"
+	if p.Mitigation == agent.MitigationHalt {
+		outcome = "exhausted"
+	}
+	s.record(runtimeStageSpan{
+		SchemaVersion: SchemaVersion,
+		RunID:         s.runID,
+		SpanID:        fmt.Sprintf("%s-stage-assemble-%d", s.runID, e.Step),
+		ParentID:      s.runID + "-run",
+		Kind:          "runtime_stage",
+		Stage:         "assemble",
+		Step:          e.Step,
+		Level:         p.Level.String(),
+		Cause:         p.Cause.String(),
+		Mitigation:    p.Mitigation.String(),
+		Outcome:       outcome,
+		UsedPct:       p.UsedPct,
+		UsedPctDelta:  delta,
+		InputTokens:   p.InputTokens,
+		InputBudget:   p.InputBudget,
+		Evicted:       p.Evicted,
+		Compactions:   p.Compactions,
+	})
+	return nil
+}
+
 // OnToolCall is a no-op: tool spans are emitted from OnToolResult, which carries
 // effect/latency/invoked even for denied calls (where OnToolCall never fires).
 func (s *TelemetrySink) OnToolCall(context.Context, agent.ToolCallEvent) error { return nil }
@@ -118,15 +175,17 @@ func (s *TelemetrySink) Finish(res agent.Result, status string) error {
 		stopReason = res.StopReason.String()
 	}
 	s.record(runSpan{
-		SchemaVersion: SchemaVersion,
-		RunID:         s.runID,
-		SpanID:        s.runID + "-run",
-		Kind:          "run",
-		StartedAt:     s.started.UTC().Format(time.RFC3339Nano),
-		DurationMS:    ms(s.now().Sub(s.started)),
-		Steps:         len(res.Steps),
-		Status:        status,
-		StopReason:    stopReason,
+		SchemaVersion:    SchemaVersion,
+		RunID:            s.runID,
+		SpanID:           s.runID + "-run",
+		Kind:             "run",
+		StartedAt:        s.started.UTC().Format(time.RFC3339Nano),
+		DurationMS:       ms(s.now().Sub(s.started)),
+		Steps:            len(res.Steps),
+		Status:           status,
+		StopReason:       stopReason,
+		MaxUsedPct:       s.maxUsedPct,
+		MaxPressureLevel: s.maxLevel.String(),
 	})
 	return s.lastErr
 }

--- a/internal/agenttrace/sink.go
+++ b/internal/agenttrace/sink.go
@@ -14,11 +14,12 @@ var (
 	_ agent.PressureObserver   = (*TelemetrySink)(nil)
 )
 
-// TelemetrySink is a content-light agent.Observer (+ ToolResultObserver). It
-// emits a model_step span per OnStep and a tool_call span per OnToolResult, then
-// a root run span on Finish (callbacks do not know final status/duration). It is
-// best-effort: write/encode errors are retained on the sink and every callback
-// returns nil so telemetry never aborts a run or changes observer semantics.
+// TelemetrySink is a content-light agent.Observer (+ ToolResultObserver +
+// PressureObserver). It emits a model_step span per OnStep, a tool_call span per
+// OnToolResult, a runtime_stage span per OnPressure, then a root run span on
+// Finish (callbacks do not know final status/duration). It is best-effort:
+// write/encode errors are retained on the sink and every callback returns nil so
+// telemetry never aborts a run or changes observer semantics.
 //
 // It serializes only content-light fields: identity, counts, sizes, durations,
 // and the denied/error/truncated/invoked bools. It never reads or writes prompt,

--- a/internal/agenttrace/sink_test.go
+++ b/internal/agenttrace/sink_test.go
@@ -136,3 +136,84 @@ func TestTelemetrySink_SwallowsWriteErrors(t *testing.T) {
 		t.Fatalf("OnToolResult returned %v, want nil", err)
 	}
 }
+
+func TestTelemetrySinkOnPressureSpan(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "telemetry.jsonl")
+	started := time.Unix(0, 0)
+	sink, err := NewTelemetrySink(path, "run1", started, func() time.Time { return started })
+	if err != nil {
+		t.Fatalf("NewTelemetrySink: %v", err)
+	}
+	p1 := agent.Pressure{UsedPct: 0.50, InputTokens: 50, InputBudget: 100, Level: agent.LevelOK, Cause: agent.CauseHistory, Mitigation: agent.MitigationNone}
+	p2 := agent.Pressure{UsedPct: 0.80, InputTokens: 80, InputBudget: 100, Level: agent.LevelWarn, Cause: agent.CauseHistory, Mitigation: agent.MitigationWarn}
+	if err := sink.OnPressure(context.Background(), agent.PressureEvent{Step: 0, Pressure: p1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.OnPressure(context.Background(), agent.PressureEvent{Step: 1, Pressure: p2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.Finish(agent.Result{}, "completed"); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	_ = sink.Close()
+
+	spans := readSpans(t, path)
+	var stage0, stage1, run map[string]any
+	for _, s := range spans {
+		switch s["kind"] {
+		case "runtime_stage":
+			if s["span_id"] == "run1-stage-assemble-0" {
+				stage0 = s
+			}
+			if s["span_id"] == "run1-stage-assemble-1" {
+				stage1 = s
+			}
+		case "run":
+			run = s
+		}
+	}
+	if stage0 == nil || stage1 == nil || run == nil {
+		t.Fatalf("missing spans: stage0=%v stage1=%v run=%v", stage0 != nil, stage1 != nil, run != nil)
+	}
+	if stage0["stage"] != "assemble" || stage0["parent_id"] != "run1-run" {
+		t.Fatalf("stage0 fields wrong: %+v", stage0)
+	}
+	if stage0["used_pct_delta"].(float64) != 0 {
+		t.Fatalf("first delta should be 0, got %v", stage0["used_pct_delta"])
+	}
+	if d := stage1["used_pct_delta"].(float64); d < 0.29 || d > 0.31 {
+		t.Fatalf("second delta should be ~0.30, got %v", d)
+	}
+	if stage1["level"] != "warn" || stage1["mitigation"] != "warn" || stage1["cause"] != "history" {
+		t.Fatalf("stage1 labels wrong: %+v", stage1)
+	}
+	if mp := run["max_used_pct"].(float64); mp < 0.79 || mp > 0.81 {
+		t.Fatalf("run max_used_pct should be ~0.80, got %v", mp)
+	}
+	if run["max_pressure_level"] != "warn" {
+		t.Fatalf("run max_pressure_level should be warn, got %v", run["max_pressure_level"])
+	}
+	if int(stage0["schema_version"].(float64)) != SchemaVersion || SchemaVersion != 2 {
+		t.Fatalf("schema version: span=%v const=%d want 2", stage0["schema_version"], SchemaVersion)
+	}
+}
+
+func TestTelemetrySinkExhaustedOutcome(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "t.jsonl")
+	started := time.Unix(0, 0)
+	sink, _ := NewTelemetrySink(path, "runX", started, func() time.Time { return started })
+	p := agent.Pressure{UsedPct: 1.2, InputTokens: 120, InputBudget: 100, Level: agent.LevelCritical, Cause: agent.CausePinned, Mitigation: agent.MitigationHalt}
+	_ = sink.OnPressure(context.Background(), agent.PressureEvent{Step: 0, Pressure: p})
+	_ = sink.Close()
+	for _, s := range readSpans(t, path) {
+		if s["kind"] == "runtime_stage" {
+			if s["outcome"] != "exhausted" {
+				t.Fatalf("halt mitigation should yield outcome=exhausted, got %v", s["outcome"])
+			}
+			return
+		}
+	}
+	t.Fatal("no runtime_stage span written")
+}

--- a/internal/agenttrace/sink_test.go
+++ b/internal/agenttrace/sink_test.go
@@ -217,3 +217,35 @@ func TestTelemetrySinkExhaustedOutcome(t *testing.T) {
 	}
 	t.Fatal("no runtime_stage span written")
 }
+
+// TestTelemetrySinkStepSpanEnrichedPressure guards the model_step pressureLite
+// enrichment (level/cause/mitigation/input_budget) added in schema v2, which the
+// other tests exercise only via the runtime_stage span.
+func TestTelemetrySinkStepSpanEnrichedPressure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "t.jsonl")
+	started := time.Unix(0, 0)
+	sink, _ := NewTelemetrySink(path, "runE", started, func() time.Time { return started })
+	_ = sink.OnStep(context.Background(), agent.StepEvent{
+		Index:    0,
+		Pressure: agent.Pressure{UsedPct: 0.8, InputTokens: 80, InputBudget: 100, Level: agent.LevelWarn, Cause: agent.CauseHistory, Mitigation: agent.MitigationWarn},
+	})
+	_ = sink.Close()
+	for _, s := range readSpans(t, path) {
+		if s["kind"] != "model_step" {
+			continue
+		}
+		pr, ok := s["pressure"].(map[string]any)
+		if !ok {
+			t.Fatalf("model_step missing pressure object: %+v", s)
+		}
+		if pr["level"] != "warn" || pr["cause"] != "history" || pr["mitigation"] != "warn" {
+			t.Fatalf("model_step pressure not enriched: %+v", pr)
+		}
+		if int(pr["input_budget"].(float64)) != 100 || int(pr["input_tokens"].(float64)) != 80 {
+			t.Fatalf("model_step pressure tokens missing: %+v", pr)
+		}
+		return
+	}
+	t.Fatal("no model_step span written")
+}


### PR DESCRIPTION
## Summary

Adds runtime-level context-pressure signals that sit above the provider-layer per-request `TokenBudgetValidator` (#48): a per-turn pressure level/cause/mitigation classified against the consumer's `InputCeiling`, surfaced before a turn fails hard, and projected into the just-merged `internal/agenttrace` telemetry seam (#238/#239) as an enriched `pressureLite` plus a new `runtime_stage` span. Implements #63.

## Layer boundary (no duplication of #48)

```
provider.TokenBudgetValidator (#48)   does this request fit MODEL X's context window?   [untouched]
        v
runtime agent.Assemble (#63)          does this turn fit the consumer's InputCeiling?
        v  Pressure{Level,Cause,Mitigation,InputTokens,InputBudget} per turn
internal/agenttrace (#238/#239)       content-light runtime_stage span
```

Runtime pressure is measured against the consumer's `InputCeiling`; provider rejection is measured against the selected model's real context window. Different budgets, different telemetry kinds, never conflated. No provider-layer code is touched.

## What changed

- `agent/pressure.go` (new): pure `PressureLevel` (ok/watch/warn/critical), `PressureCause` (pinned/tool_schema/history/tool_output/retrieval), `PressureMitigation` (none/warn/evict/halt), `PressureThresholds` with `normalize()` (monotonic-guard fallback) and `Classify()`, dominant-bucket cause attribution, and `PressureThresholdsForWarn()` (single source of truth for the band layout).
- `agent.Pressure` enriched (additive); `ContextManager.Assemble` now stamps a fully-populated `Pressure` on every path, including the `ErrContextExhausted` exhaustion path that previously emitted nothing.
- `agent.PressureObserver` (optional, mirrors `ToolResultObserver`): the orchestrator emits `OnPressure` right after assembly and before the model call, so the exhaustion failure is no longer invisible. A returned error aborts the run, like the other observer callbacks.
- `internal/agenttrace` (schema v1 to v2): enriched `pressureLite`, a new `runtime_stage` span (stage `assemble`) with `outcome` and `used_pct_delta`, and per-run `max_used_pct` / `max_pressure_level` aggregates. v1 fields unchanged.
- `cmd/golem`: one flag `-pressure-warn N` (default 75; 0 disables the printed warning) wires the warn band and a gated, once-per-run renderer warning; `multiObserver` fans `OnPressure` to pressure-aware children.

## Scope boundary

The 2026-06-19 issue expansion fields (context depth #189, hierarchical drilldown #190, source freshness #80, policy decisions #115, semantic cache #116) are intentionally out of scope: their producers do not exist yet. The `runtime_stage` span shape is the documented extension seam they attach to later. No `map[string]any` telemetry (content-light / privacy guarantee preserved). Stage telemetry covers only the real boundaries today: `assemble` (this PR) and `generate` (existing `model_step`); retrieve is already a `tool_call` span; rerank/verify are deferred until those boundaries exist.

## Acceptance criteria

- Runtime helpers emit context-pressure warnings before a request fails hard (pre-step `OnPressure` + gated renderer line).
- Compression/warning thresholds and turn budgets are configurable and testable (`Budget.Pressure`, `-pressure-warn`; the turn budget is the existing `InputCeiling`).
- Telemetry distinguishes provider-layer budget rejection from runtime-layer pressure (runtime exhaustion emits a `runtime_stage` span with `outcome=exhausted`; a provider reject emits none).
- No duplicate of #48's token-fit logic (no `provider/` files touched).

## Testing

Table-driven unit tests for classification, normalize, cause attribution, and the warn-band constructor; `Assemble` enrichment + both exhaustion paths; orchestrator pre-step emission (including the exhaustion and observer-error paths); telemetry span schema, ids, delta, and run aggregates; golem flag parse, validation, fan-out, and gated renderer. Full `go test -race ./...` passes; gofmt and golangci-lint clean.

Closes #63
