### PR TITLE
feat: behavioral ranking as fail-open third RRF list (#231)

### DIFF
--- a/cmd/golem/feedback.go
+++ b/cmd/golem/feedback.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/kstruzzieri/go-llm/feedback"
+	"github.com/kstruzzieri/go-llm/rag"
+)
+
+type behavioralWeighterHandle struct {
+	weighter rag.BehavioralWeighter
+	db       *sql.DB
+}
+
+// feedbackDBPathForWorkspace resolves the per-workspace writable behavioral
+// feedback DB path (<base>/golem/retrieval-feedback/<key>.db), mirroring
+// indexDBPathForWorkspace. It is validated to live outside the workspace so it
+// is never indexed or edited.
+func feedbackDBPathForWorkspace(getenv func(string) string, root string) (string, error) {
+	base, err := dataDirBase(getenv)
+	if err != nil {
+		return "", err
+	}
+	key := strings.TrimPrefix(workspaceID(root), "workspace:")
+	dbPath := filepath.Join(base, "golem", "retrieval-feedback", key+".db")
+	if err := validatePathOutsideWorkspace(dbPath, root); err != nil {
+		return "", err
+	}
+	return dbPath, nil
+}
+
+// openBehavioralWeighter best-effort opens the feedback DB and returns a
+// consume-only weighter handle. It NEVER returns an error: on any failure it
+// returns a nil handle and a human-readable warning, so retrieval proceeds with
+// neutral ranking. It may run feedback schema migrations, but it never records
+// retrievals or outcomes. Callers own the returned DB handle and must close it
+// during normal shutdown.
+func openBehavioralWeighter(ctx context.Context, dbPath string) (*behavioralWeighterHandle, string) {
+	if err := prepareDBFile(dbPath); err != nil {
+		return nil, "behavioral feedback disabled: " + err.Error()
+	}
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		return nil, fmt.Sprintf("behavioral feedback disabled: open %q: %v", dbPath, err)
+	}
+	db.SetMaxOpenConns(1)
+	for _, pragma := range []string{"PRAGMA journal_mode=WAL", "PRAGMA busy_timeout=5000"} {
+		if _, err := db.ExecContext(ctx, pragma); err != nil {
+			_ = db.Close()
+			return nil, fmt.Sprintf("behavioral feedback disabled: %s: %v", pragma, err)
+		}
+	}
+	store, err := feedback.NewSignalStore(ctx, db)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Sprintf("behavioral feedback disabled: init %q: %v", dbPath, err)
+	}
+	if err := chmodDBFiles(dbPath); err != nil {
+		_ = db.Close()
+		return nil, "behavioral feedback disabled: " + err.Error()
+	}
+	return &behavioralWeighterHandle{
+		weighter: feedback.NewWeightReader(store, feedback.DefaultConfig()),
+		db:       db,
+	}, ""
+}

--- a/cmd/golem/feedback_test.go
+++ b/cmd/golem/feedback_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+func TestFeedbackDBPathForWorkspace(t *testing.T) {
+	base := t.TempDir()
+	getenv := func(k string) string {
+		if k == "XDG_DATA_HOME" {
+			return base
+		}
+		return ""
+	}
+	root := t.TempDir()
+	p, err := feedbackDBPathForWorkspace(getenv, root)
+	if err != nil {
+		t.Fatalf("feedbackDBPathForWorkspace: %v", err)
+	}
+	if !strings.Contains(filepath.ToSlash(p), "golem/retrieval-feedback/") || !strings.HasSuffix(p, ".db") {
+		t.Errorf("unexpected path %q", p)
+	}
+}
+
+func TestFeedbackDBPathForWorkspaceRejectsInsideWorkspace(t *testing.T) {
+	root := t.TempDir()
+	getenv := func(k string) string {
+		if k == "XDG_DATA_HOME" {
+			return root
+		}
+		return ""
+	}
+	if _, err := feedbackDBPathForWorkspace(getenv, root); err == nil {
+		t.Fatalf("expected path inside workspace to be rejected")
+	}
+}
+
+func TestOpenBehavioralWeighterValid(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "sub", "fb.db") // parent dir does not exist yet
+	h, warn := openBehavioralWeighter(context.Background(), dbPath)
+	if h == nil || h.weighter == nil || h.db == nil {
+		t.Fatalf("want non-nil handle, warn=%q", warn)
+	}
+	defer func() { _ = h.db.Close() }()
+	if warn != "" {
+		t.Errorf("unexpected warn: %q", warn)
+	}
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		t.Errorf("feedback DB not created: %v", err)
+	} else if info.Mode().Perm() != 0o600 {
+		t.Errorf("feedback DB mode = %o, want 0600", info.Mode().Perm())
+	}
+	dirInfo, err := os.Stat(filepath.Dir(dbPath))
+	if err != nil {
+		t.Errorf("feedback DB dir not created: %v", err)
+	} else if dirInfo.Mode().Perm() != 0o700 {
+		t.Errorf("feedback DB dir mode = %o, want 0700", dirInfo.Mode().Perm())
+	}
+}
+
+func TestOpenBehavioralWeighterFailsOpen(t *testing.T) {
+	dir := t.TempDir() // a directory path is not a valid SQLite file target
+	h, warn := openBehavioralWeighter(context.Background(), dir)
+	if h != nil {
+		t.Errorf("want nil handle for bad path, got non-nil")
+	}
+	if warn == "" {
+		t.Errorf("want a warning for bad path")
+	}
+}
+
+func TestEnableRetrieveFeedbackValid(t *testing.T) {
+	dataDir := t.TempDir()
+	dbPath := filepath.Join(dataDir, "indexes", "k.db")
+	seedIndex(t, dbPath, "workspace:k", "ollama/nomic")
+	removeSQLiteSidecars(t, dbPath)
+
+	feedbackDB := filepath.Join(dataDir, "feedback", "fb.db")
+	got := enableRetrieve(context.Background(), embedCfg(), &provider.Router{}, retrieveOpts{
+		autoDBPath:      dbPath,
+		autoSidecarPath: sidecarPath(dbPath),
+		workspaceID:     "workspace:k",
+		feedbackDB:      feedbackDB,
+	})
+	if got.tool == nil {
+		t.Fatalf("retrieve should register; warns=%v", got.warns)
+	}
+	if got.feedback == nil || got.feedback.db == nil || got.feedback.weighter == nil {
+		t.Fatalf("feedback handle not returned: %#v", got.feedback)
+	}
+	defer func() { _ = got.feedback.db.Close() }()
+}
+
+func TestEnableRetrieveFeedbackFailsOpen(t *testing.T) {
+	dataDir := t.TempDir()
+	dbPath := filepath.Join(dataDir, "indexes", "k.db")
+	seedIndex(t, dbPath, "workspace:k", "ollama/nomic")
+	removeSQLiteSidecars(t, dbPath)
+
+	got := enableRetrieve(context.Background(), embedCfg(), &provider.Router{}, retrieveOpts{
+		autoDBPath:      dbPath,
+		autoSidecarPath: sidecarPath(dbPath),
+		workspaceID:     "workspace:k",
+		feedbackDB:      t.TempDir(), // directory path: invalid SQLite file target
+	})
+	if got.tool == nil {
+		t.Fatalf("retrieve should remain registered when feedback fails open; warns=%v", got.warns)
+	}
+	if got.feedback != nil {
+		t.Fatalf("bad feedback DB should not return a handle")
+	}
+	joined := strings.Join(got.warns, "\n")
+	if !strings.Contains(joined, "behavioral feedback disabled") {
+		t.Fatalf("missing feedback warning in %v", got.warns)
+	}
+}

--- a/cmd/golem/main.go
+++ b/cmd/golem/main.go
@@ -43,6 +43,8 @@ type flags struct {
 	trace            bool
 	telemetry        bool
 	pressureWarn     int
+	feedback         bool
+	feedbackDB       string
 }
 
 func parseFlags(args []string) (flags, error) {
@@ -72,6 +74,8 @@ func parseFlags(args []string) (flags, error) {
 	fs.BoolVar(&f.trace, "trace", false, "persist a content-full run trace per turn (outside the workspace; may contain workspace/user content)")
 	fs.BoolVar(&f.telemetry, "telemetry", false, "append content-light run telemetry (timings, route, usage; no prompt/output)")
 	fs.IntVar(&f.pressureWarn, "pressure-warn", 75, "context-pressure warn threshold percent 1-100 (0 disables the warning line)")
+	fs.BoolVar(&f.feedback, "feedback", false, "enable optional behavioral feedback ranking (consume-only; reads a per-workspace feedback DB)")
+	fs.StringVar(&f.feedbackDB, "feedback-db", "", "override the behavioral feedback DB path (default: per-workspace under the data dir)")
 	if err := fs.Parse(args); err != nil {
 		return flags{}, err
 	}
@@ -88,6 +92,9 @@ func validateFlags(f flags) error {
 	}
 	if f.pressureWarn < 0 || f.pressureWarn > 100 {
 		return fmt.Errorf("golem: -pressure-warn must be between 0 and 100")
+	}
+	if f.feedbackDB != "" && !f.feedback {
+		return fmt.Errorf("golem: -feedback-db requires -feedback")
 	}
 	return nil
 }
@@ -218,13 +225,31 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 	} else if !f.noRag && f.ragDB == "" {
 		warns = append(warns, "retrieve auto-index disabled: "+autoErr.Error())
 	}
+	feedbackDB := ""
+	if f.feedback && !f.noRag {
+		if f.feedbackDB != "" {
+			if err := validatePathOutsideWorkspace(f.feedbackDB, root); err != nil {
+				warns = append(warns, "behavioral feedback disabled: "+err.Error())
+			} else {
+				feedbackDB = f.feedbackDB
+			}
+		} else if p, ferr := feedbackDBPathForWorkspace(os.Getenv, root); ferr != nil {
+			warns = append(warns, "behavioral feedback disabled: "+ferr.Error())
+		} else {
+			feedbackDB = p
+		}
+	}
 	rr := enableRetrieve(ctx, bundle.Config, bundle.Router, retrieveOpts{
 		noRag:           f.noRag,
 		ragDB:           f.ragDB,
 		autoDBPath:      autoDBPath,
 		autoSidecarPath: autoSidecar,
 		workspaceID:     autoWorkspaceID,
+		feedbackDB:      feedbackDB,
 	})
+	if rr.feedback != nil && rr.feedback.db != nil {
+		defer func() { _ = rr.feedback.db.Close() }()
+	}
 	retrieve := rr.tool
 	warns = append(warns, rr.warns...)
 	retrieveLine := rr.line

--- a/cmd/golem/main_test.go
+++ b/cmd/golem/main_test.go
@@ -161,6 +161,15 @@ func TestValidateFlags_NoRagWithRagDBExclusive(t *testing.T) {
 	}
 }
 
+func TestValidateFlags_FeedbackDBRequiresFeedback(t *testing.T) {
+	if err := validateFlags(flags{feedbackDB: "/x.db"}); err == nil {
+		t.Fatal("want error when -feedback-db is set without -feedback")
+	}
+	if err := validateFlags(flags{feedback: true, feedbackDB: "/x.db"}); err != nil {
+		t.Fatalf("want no error when -feedback and -feedback-db both set: %v", err)
+	}
+}
+
 func TestParseFlags_NoRag(t *testing.T) {
 	f, err := parseFlags([]string{"-no-rag"})
 	if err != nil {

--- a/cmd/golem/retrieve_enable.go
+++ b/cmd/golem/retrieve_enable.go
@@ -19,6 +19,7 @@ type retrieveOpts struct {
 	autoDBPath      string // per-workspace index DB path
 	autoSidecarPath string // per-workspace sidecar path
 	workspaceID     string // workspace:<sha16> for sidecar validation
+	feedbackDB      string // resolved feedback DB path; "" => behavioral ranking off
 }
 
 // retrieveResult is the startup outcome. line is the positive disclosure to show
@@ -28,6 +29,7 @@ type retrieveOpts struct {
 // auto index). It stays false only when there genuinely is no usable index.
 type retrieveResult struct {
 	tool           agent.Tool
+	feedback       *behavioralWeighterHandle
 	line           string
 	warns          []string
 	suppressNotice bool
@@ -42,15 +44,19 @@ func enableRetrieve(ctx context.Context, cfg *config.Config, router *provider.Ro
 	}
 
 	if opts.ragDB != "" {
-		tool, dec, _, err := buildGatedRetriever(ctx, cfg, router, opts.ragDB, expected)
+		tool, feedback, feedbackWarn, dec, _, err := buildGatedRetriever(ctx, cfg, router, opts.ragDB, expected, opts.feedbackDB)
 		if err != nil {
 			return retrieveResult{warns: []string{"retrieve disabled: " + err.Error()}, suppressNotice: true}
 		}
 		if tool == nil {
 			return retrieveResult{warns: []string{explicitMismatchWarning(opts.ragDB, dec, expected)}, suppressNotice: true}
 		}
-		return retrieveResult{tool: tool, line: "retrieve: rag-db " + opts.ragDB, suppressNotice: true,
-			warns: legacyWarnIfAny(dec)}
+		warns := legacyWarnIfAny(dec)
+		if feedbackWarn != "" {
+			warns = append(warns, feedbackWarn)
+		}
+		return retrieveResult{tool: tool, feedback: feedback, line: "retrieve: rag-db " + opts.ragDB, suppressNotice: true,
+			warns: warns}
 	}
 
 	// Auto-discovery: require both the DB and a valid sidecar.
@@ -64,7 +70,7 @@ func enableRetrieve(ctx context.Context, cfg *config.Config, router *provider.Ro
 	if verr := validateSidecar(sc, opts.workspaceID); verr != nil {
 		return retrieveResult{}
 	}
-	tool, dec, stats, err := buildGatedRetriever(ctx, cfg, router, opts.autoDBPath, expected)
+	tool, feedback, feedbackWarn, dec, stats, err := buildGatedRetriever(ctx, cfg, router, opts.autoDBPath, expected, opts.feedbackDB)
 	if err != nil {
 		// An index exists but could not be opened/probed: a specific warning
 		// already explains why, so suppress the contradictory generic "no index"
@@ -76,7 +82,11 @@ func enableRetrieve(ctx context.Context, cfg *config.Config, router *provider.Ro
 		// stands alone; suppress the generic "no index" notice.
 		return retrieveResult{warns: []string{autoMismatchWarning(dec, expected)}, suppressNotice: true}
 	}
-	return retrieveResult{tool: tool, line: autoLine(sc, stats), warns: legacyWarnIfAny(dec)}
+	warns := legacyWarnIfAny(dec)
+	if feedbackWarn != "" {
+		warns = append(warns, feedbackWarn)
+	}
+	return retrieveResult{tool: tool, feedback: feedback, line: autoLine(sc, stats), warns: warns}
 }
 
 // expectedVectorSpaces returns the provider-qualified vsid set the current

--- a/cmd/golem/tools.go
+++ b/cmd/golem/tools.go
@@ -171,11 +171,18 @@ func embeddingChain(cfg *config.Config) ([]string, error) {
 
 // buildGatedRetriever stats dbPath, opens it, probes its stored vector space,
 // reads store stats for startup display, and applies the §6.1 gate against
-// expected. It returns:
-//   - (tool, decision, stats, nil) when the corpus is registerable (decision.kind may
-//     be vsLegacy, surfaced as a soft warning by the caller);
-//   - (nil, decision, stats, nil) when the gate disables retrieve (vsMismatch/vsInconsistent);
-//   - (nil, _, zero stats, err) when the DB cannot be opened/probed or the embedder is unavailable.
+// expected. It returns (tool, feedback, feedbackWarn, decision, stats, err):
+//   - tool/decision/stats set, err nil when the corpus is registerable
+//     (decision.kind may be vsLegacy, surfaced as a soft warning by the caller);
+//   - nil tool, err nil when the gate disables retrieve (vsMismatch/vsInconsistent);
+//   - nil tool, zero stats, err set when the DB cannot be opened/probed or the
+//     embedder is unavailable.
+//
+// When feedbackDB != "" it best-effort opens a consume-only behavioral weighter
+// and injects it into the store. feedback is non-nil only on success (the caller
+// owns it and must close feedback.db); it stays nil when feedback is disabled or
+// fails to open. feedbackWarn is non-empty when feedback failed to open, in which
+// case retrieval still registers and ranks neutrally.
 //
 // The opened store lives for the process on success (closed by the OS at exit).
 func buildGatedRetriever(ctx context.Context, cfg *config.Config, router *provider.Router, dbPath string, expected []string, feedbackDB string) (agent.Tool, *behavioralWeighterHandle, string, vsDecision, rag.StoreStats, error) {

--- a/cmd/golem/tools.go
+++ b/cmd/golem/tools.go
@@ -178,39 +178,39 @@ func embeddingChain(cfg *config.Config) ([]string, error) {
 //   - (nil, _, zero stats, err) when the DB cannot be opened/probed or the embedder is unavailable.
 //
 // The opened store lives for the process on success (closed by the OS at exit).
-func buildGatedRetriever(ctx context.Context, cfg *config.Config, router *provider.Router, dbPath string, expected []string) (agent.Tool, vsDecision, rag.StoreStats, error) {
+func buildGatedRetriever(ctx context.Context, cfg *config.Config, router *provider.Router, dbPath string, expected []string, feedbackDB string) (agent.Tool, *behavioralWeighterHandle, string, vsDecision, rag.StoreStats, error) {
 	if cfg == nil || router == nil {
-		return nil, vsDecision{}, rag.StoreStats{}, fmt.Errorf("no provider configured for embeddings")
+		return nil, nil, "", vsDecision{}, rag.StoreStats{}, fmt.Errorf("no provider configured for embeddings")
 	}
 	embChain, err := embeddingChain(cfg)
 	if err != nil {
-		return nil, vsDecision{}, rag.StoreStats{}, err
+		return nil, nil, "", vsDecision{}, rag.StoreStats{}, err
 	}
 	info, err := os.Stat(dbPath)
 	if err != nil {
-		return nil, vsDecision{}, rag.StoreStats{}, fmt.Errorf("rag-db %q: %w", dbPath, err)
+		return nil, nil, "", vsDecision{}, rag.StoreStats{}, fmt.Errorf("rag-db %q: %w", dbPath, err)
 	}
 	if info.IsDir() {
-		return nil, vsDecision{}, rag.StoreStats{}, fmt.Errorf("rag-db %q is a directory, not a SQLite file", dbPath)
+		return nil, nil, "", vsDecision{}, rag.StoreStats{}, fmt.Errorf("rag-db %q is a directory, not a SQLite file", dbPath)
 	}
 	store, err := rag.OpenSQLiteStoreReadOnly(dbPath)
 	if err != nil {
-		return nil, vsDecision{}, rag.StoreStats{}, fmt.Errorf("open index db %q: %w", dbPath, err)
+		return nil, nil, "", vsDecision{}, rag.StoreStats{}, fmt.Errorf("open index db %q: %w", dbPath, err)
 	}
 	probe, err := store.ProbeVectorSpaces(ctx)
 	if err != nil {
 		_ = store.Close()
-		return nil, vsDecision{}, rag.StoreStats{}, fmt.Errorf("probe index db %q: %w", dbPath, err)
+		return nil, nil, "", vsDecision{}, rag.StoreStats{}, fmt.Errorf("probe index db %q: %w", dbPath, err)
 	}
 	stats, err := store.Stats(ctx)
 	if err != nil {
 		_ = store.Close()
-		return nil, vsDecision{}, rag.StoreStats{}, fmt.Errorf("read index stats %q: %w", dbPath, err)
+		return nil, nil, "", vsDecision{}, rag.StoreStats{}, fmt.Errorf("read index stats %q: %w", dbPath, err)
 	}
 	dec := vsGateDecision(probe.KnownIDs, probe.HasUnknown, expected)
 	if !dec.register {
 		_ = store.Close()
-		return nil, dec, stats, nil
+		return nil, nil, "", dec, stats, nil
 	}
 	embedder := newChainEmbedder(func(rc context.Context, rr provider.RoutingRequest) (embedExecutor, error) {
 		return router.Route(rc, rr)
@@ -218,9 +218,19 @@ func buildGatedRetriever(ctx context.Context, cfg *config.Config, router *provid
 	retr, err := rag.NewRetrieverWithEmbedder(embedder, store, rag.WithRetrieverModel(embChain[0]))
 	if err != nil {
 		_ = store.Close()
-		return nil, vsDecision{}, rag.StoreStats{}, fmt.Errorf("build retriever for %q: %w", dbPath, err)
+		return nil, nil, "", vsDecision{}, rag.StoreStats{}, fmt.Errorf("build retriever for %q: %w", dbPath, err)
 	}
-	return &agenttools.Retrieve{R: retr, K: 5, MaxTokens: 2048}, dec, stats, nil
+	var feedbackHandle *behavioralWeighterHandle
+	feedbackWarn := ""
+	if feedbackDB != "" {
+		if h, warn := openBehavioralWeighter(ctx, feedbackDB); h != nil {
+			store.SetBehavioralWeighter(h.weighter)
+			feedbackHandle = h
+		} else if warn != "" {
+			feedbackWarn = warn
+		}
+	}
+	return &agenttools.Retrieve{R: retr, K: 5, MaxTokens: 2048}, feedbackHandle, feedbackWarn, dec, stats, nil
 }
 
 // effectClassName renders an agent.EffectClass bitset for /tools. The agent

--- a/feedback/collector.go
+++ b/feedback/collector.go
@@ -188,31 +188,7 @@ func (c *Collector) Weights(ctx context.Context, chunkKey string) (float64, erro
 // query. Keys that are below MinRetrievals or that have no aggregate return
 // 0.0.
 func (c *Collector) WeightsBatch(ctx context.Context, chunkKeys []string) (map[string]float64, error) {
-	result := make(map[string]float64, len(chunkKeys))
-	for _, k := range chunkKeys {
-		result[k] = 0
-	}
-
-	totalSignals, err := c.store.SignalCount(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if totalSignals < c.config.WarmupSignals {
-		return result, nil
-	}
-
-	aggs, err := c.store.GetAggregatesBatch(ctx, chunkKeys)
-	if err != nil {
-		return nil, err
-	}
-
-	for k, agg := range aggs {
-		if agg.RetrievalCount >= c.config.MinRetrievals {
-			result[k] = agg.WeightedScore
-		}
-	}
-
-	return result, nil
+	return weightsBatch(ctx, c.store, c.config, chunkKeys)
 }
 
 // sweepLoop runs in a goroutine, expiring attribution windows and applying

--- a/feedback/weights.go
+++ b/feedback/weights.go
@@ -1,0 +1,54 @@
+package feedback
+
+import "context"
+
+// weightsBatch applies cold-start (warmup) and MinRetrievals gating over a
+// store's aggregates. It is the single source of truth shared by Collector and
+// WeightReader so the two cannot diverge. Keys below MinRetrievals, unknown
+// keys, and every key during warmup return 0.
+func weightsBatch(ctx context.Context, store SignalStore, cfg CollectorConfig, chunkKeys []string) (map[string]float64, error) {
+	result := make(map[string]float64, len(chunkKeys))
+	for _, k := range chunkKeys {
+		result[k] = 0
+	}
+
+	totalSignals, err := store.SignalCount(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if totalSignals < cfg.WarmupSignals {
+		return result, nil
+	}
+
+	aggs, err := store.GetAggregatesBatch(ctx, chunkKeys)
+	if err != nil {
+		return nil, err
+	}
+	for k, agg := range aggs {
+		if agg.RetrievalCount >= cfg.MinRetrievals {
+			result[k] = agg.WeightedScore
+		}
+	}
+	return result, nil
+}
+
+// WeightReader exposes read-only behavioral weights without the Collector's
+// attribution windows or background sweep goroutine. Use it where ranking only
+// consumes weights and must never open attribution windows or emit signals.
+type WeightReader struct {
+	store  SignalStore
+	config CollectorConfig
+}
+
+// NewWeightReader builds a read-only reader over store. Negative config fields
+// resolve to their defaults (matching Collector); zero values keep their
+// meaning (no warmup / no minimum / no decay).
+func NewWeightReader(store SignalStore, config CollectorConfig) *WeightReader {
+	return &WeightReader{store: store, config: config.withDefaults()}
+}
+
+// WeightsBatch returns gated behavioral weights for chunkKeys. Unknown or
+// below-threshold keys return 0. During warmup all keys return 0.
+func (r *WeightReader) WeightsBatch(ctx context.Context, chunkKeys []string) (map[string]float64, error) {
+	return weightsBatch(ctx, r.store, r.config, chunkKeys)
+}

--- a/feedback/weights.go
+++ b/feedback/weights.go
@@ -2,6 +2,8 @@ package feedback
 
 import "context"
 
+const weightLookupBatchSize = 900
+
 // weightsBatch applies cold-start (warmup) and MinRetrievals gating over a
 // store's aggregates. It is the single source of truth shared by Collector and
 // WeightReader so the two cannot diverge. Keys below MinRetrievals, unknown
@@ -20,13 +22,19 @@ func weightsBatch(ctx context.Context, store SignalStore, cfg CollectorConfig, c
 		return result, nil
 	}
 
-	aggs, err := store.GetAggregatesBatch(ctx, chunkKeys)
-	if err != nil {
-		return nil, err
-	}
-	for k, agg := range aggs {
-		if agg.RetrievalCount >= cfg.MinRetrievals {
-			result[k] = agg.WeightedScore
+	for start := 0; start < len(chunkKeys); start += weightLookupBatchSize {
+		end := start + weightLookupBatchSize
+		if end > len(chunkKeys) {
+			end = len(chunkKeys)
+		}
+		aggs, err := store.GetAggregatesBatch(ctx, chunkKeys[start:end])
+		if err != nil {
+			return nil, err
+		}
+		for k, agg := range aggs {
+			if agg.RetrievalCount >= cfg.MinRetrievals {
+				result[k] = agg.WeightedScore
+			}
 		}
 	}
 	return result, nil

--- a/feedback/weights_test.go
+++ b/feedback/weights_test.go
@@ -1,0 +1,97 @@
+package feedback
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// warmedStore returns a store where chunk-1 has 2 positive signals (clears a
+// WarmupSignals=2 gate) and retrieval_count=1, with aggregates recomputed.
+func warmedStore(t *testing.T) *SQLiteSignalStore {
+	t.Helper()
+	ctx := context.Background()
+	store := newTestStore(t)
+	if err := store.IncrementRetrievalCount(ctx, []string{"chunk-1"}); err != nil {
+		t.Fatalf("IncrementRetrievalCount: %v", err)
+	}
+	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCompletionAccepted, 0.8, time.Time{}); err != nil {
+		t.Fatalf("InsertSignal 1: %v", err)
+	}
+	if err := store.InsertSignal(ctx, "r1", "chunk-1", SignalCodeKept, 0.6, time.Time{}); err != nil {
+		t.Fatalf("InsertSignal 2: %v", err)
+	}
+	if err := store.RecomputeAggregates(ctx, 0); err != nil { // lambda 0 => no decay
+		t.Fatalf("RecomputeAggregates: %v", err)
+	}
+	return store
+}
+
+func TestWeightReaderWarmed(t *testing.T) {
+	ctx := context.Background()
+	store := warmedStore(t)
+	r := NewWeightReader(store, CollectorConfig{WarmupSignals: 2, MinRetrievals: 1})
+
+	w, err := r.WeightsBatch(ctx, []string{"chunk-1", "chunk-2"})
+	if err != nil {
+		t.Fatalf("WeightsBatch: %v", err)
+	}
+	if got := w["chunk-1"]; got < 1.39 || got > 1.41 {
+		t.Errorf("chunk-1 weight = %v, want ~1.4", got)
+	}
+	if w["chunk-2"] != 0 {
+		t.Errorf("chunk-2 weight = %v, want 0 (unknown key)", w["chunk-2"])
+	}
+}
+
+func TestWeightReaderColdStart(t *testing.T) {
+	ctx := context.Background()
+	store := warmedStore(t) // 2 signals total
+	// WarmupSignals=5 not met by 2 signals => all zero.
+	r := NewWeightReader(store, CollectorConfig{WarmupSignals: 5, MinRetrievals: 1})
+	w, err := r.WeightsBatch(ctx, []string{"chunk-1"})
+	if err != nil {
+		t.Fatalf("WeightsBatch: %v", err)
+	}
+	if w["chunk-1"] != 0 {
+		t.Errorf("cold-start weight = %v, want 0", w["chunk-1"])
+	}
+}
+
+func TestWeightReaderMinRetrievalsGate(t *testing.T) {
+	ctx := context.Background()
+	store := warmedStore(t) // retrieval_count for chunk-1 == 1
+	r := NewWeightReader(store, CollectorConfig{WarmupSignals: 2, MinRetrievals: 5})
+	w, err := r.WeightsBatch(ctx, []string{"chunk-1"})
+	if err != nil {
+		t.Fatalf("WeightsBatch: %v", err)
+	}
+	if w["chunk-1"] != 0 {
+		t.Errorf("below-MinRetrievals weight = %v, want 0", w["chunk-1"])
+	}
+}
+
+func TestWeightReaderParityWithCollector(t *testing.T) {
+	ctx := context.Background()
+	store := warmedStore(t)
+	cfg := CollectorConfig{WarmupSignals: 2, MinRetrievals: 1}
+
+	reader := NewWeightReader(store, cfg)
+	collector := NewCollector(store, cfg)
+	defer collector.Close()
+
+	keys := []string{"chunk-1", "chunk-2"}
+	rw, err := reader.WeightsBatch(ctx, keys)
+	if err != nil {
+		t.Fatalf("reader: %v", err)
+	}
+	cw, err := collector.WeightsBatch(ctx, keys)
+	if err != nil {
+		t.Fatalf("collector: %v", err)
+	}
+	for _, k := range keys {
+		if rw[k] != cw[k] {
+			t.Errorf("parity mismatch for %q: reader=%v collector=%v", k, rw[k], cw[k])
+		}
+	}
+}

--- a/feedback/weights_test.go
+++ b/feedback/weights_test.go
@@ -2,9 +2,39 @@ package feedback
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 )
+
+var errTestBatchTooLarge = errors.New("test batch too large")
+
+type batchingStore struct {
+	SignalStore
+	signalCount int
+	maxBatch    int
+	calls       [][]string
+	aggs        map[string]Aggregate
+}
+
+func (s *batchingStore) SignalCount(ctx context.Context) (int, error) {
+	return s.signalCount, nil
+}
+
+func (s *batchingStore) GetAggregatesBatch(ctx context.Context, chunkKeys []string) (map[string]Aggregate, error) {
+	if len(chunkKeys) > s.maxBatch {
+		return nil, errTestBatchTooLarge
+	}
+	s.calls = append(s.calls, append([]string(nil), chunkKeys...))
+	out := make(map[string]Aggregate, len(chunkKeys))
+	for _, k := range chunkKeys {
+		if agg, ok := s.aggs[k]; ok {
+			out[k] = agg
+		}
+	}
+	return out, nil
+}
 
 // warmedStore returns a store where chunk-1 has 2 positive signals (clears a
 // WarmupSignals=2 gate) and retrieval_count=1, with aggregates recomputed.
@@ -68,6 +98,34 @@ func TestWeightReaderMinRetrievalsGate(t *testing.T) {
 	}
 	if w["chunk-1"] != 0 {
 		t.Errorf("below-MinRetrievals weight = %v, want 0", w["chunk-1"])
+	}
+}
+
+func TestWeightReaderBatchesAggregateLookups(t *testing.T) {
+	const keyCount = 1001
+	keys := make([]string, keyCount)
+	aggs := make(map[string]Aggregate, keyCount)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("chunk-%04d", i)
+		aggs[keys[i]] = Aggregate{WeightedScore: float64(i), RetrievalCount: 1}
+	}
+	store := &batchingStore{signalCount: 1, maxBatch: 900, aggs: aggs}
+	reader := NewWeightReader(store, CollectorConfig{WarmupSignals: 1, MinRetrievals: 1})
+
+	got, err := reader.WeightsBatch(context.Background(), keys)
+	if err != nil {
+		t.Fatalf("WeightsBatch: %v", err)
+	}
+	if len(store.calls) != 2 {
+		t.Fatalf("GetAggregatesBatch calls = %d, want 2", len(store.calls))
+	}
+	for i, call := range store.calls {
+		if len(call) > store.maxBatch {
+			t.Fatalf("call %d len = %d, want <= %d", i, len(call), store.maxBatch)
+		}
+	}
+	if got["chunk-1000"] != 1000 {
+		t.Fatalf("chunk-1000 weight = %v, want 1000", got["chunk-1000"])
 	}
 }
 

--- a/mcp/feedback_test.go
+++ b/mcp/feedback_test.go
@@ -1,0 +1,80 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWithRetrievalFeedbackSetsPath(t *testing.T) {
+	s := &Server{}
+	WithRetrievalFeedback("/tmp/fb.db")(s)
+	if s.feedbackDBPath != "/tmp/fb.db" {
+		t.Errorf("feedbackDBPath = %q, want /tmp/fb.db", s.feedbackDBPath)
+	}
+}
+
+func TestWithRetrievalFeedbackOpensAndCloses(t *testing.T) {
+	mock := httptest.NewServer(routingFallbackHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})))
+	defer mock.Close()
+
+	ragPath := filepath.Join(t.TempDir(), "rag.db")
+	feedbackPath := filepath.Join(t.TempDir(), "feedback", "feedback.db")
+	s, err := NewServer(context.Background(),
+		WithOllamaURL(mock.URL),
+		WithRAGPath(ragPath),
+		WithRetrievalFeedback(feedbackPath),
+	)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	if s.feedbackDB == nil {
+		_ = s.Close()
+		t.Fatal("feedbackDB = nil, want opened feedback DB")
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if s.feedbackDB != nil {
+		t.Fatal("feedbackDB not cleared after Close")
+	}
+	if info, err := os.Stat(feedbackPath); err != nil {
+		t.Fatalf("feedback DB not created: %v", err)
+	} else if info.Mode().Perm() != 0o600 {
+		t.Fatalf("feedback DB mode = %o, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestWithRetrievalFeedbackBadPathIsNonFatal(t *testing.T) {
+	mock := httptest.NewServer(routingFallbackHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})))
+	defer mock.Close()
+
+	ragPath := filepath.Join(t.TempDir(), "rag.db")
+	blockingParent := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blockingParent, []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	s, err := NewServer(context.Background(),
+		WithOllamaURL(mock.URL),
+		WithRAGPath(ragPath),
+		WithRetrievalFeedback(filepath.Join(blockingParent, "feedback.db")),
+	)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v, want feedback-open failure to be non-fatal", err)
+	}
+	defer func() { _ = s.Close() }()
+	if s.store == nil {
+		t.Fatal("RAG store = nil, want server to continue with RAG store")
+	}
+	if s.feedbackDB != nil {
+		t.Fatal("feedbackDB = non-nil, want bad feedback path to stay disabled")
+	}
+}

--- a/mcp/feedback_test.go
+++ b/mcp/feedback_test.go
@@ -37,6 +37,19 @@ func TestWithRetrievalFeedbackOpensAndCloses(t *testing.T) {
 		_ = s.Close()
 		t.Fatal("feedbackDB = nil, want opened feedback DB")
 	}
+	// WAL/SHM sidecars (if present while the DB is open) must be 0600: telemetry
+	// must never leak through a sidecar. They may legitimately not exist yet.
+	for _, sidecar := range []string{feedbackPath + "-wal", feedbackPath + "-shm"} {
+		if info, err := os.Stat(sidecar); err == nil {
+			if info.Mode().Perm() != 0o600 {
+				_ = s.Close()
+				t.Fatalf("sidecar %s mode = %o, want 0600", sidecar, info.Mode().Perm())
+			}
+		} else if !os.IsNotExist(err) {
+			_ = s.Close()
+			t.Fatalf("stat sidecar %s: %v", sidecar, err)
+		}
+	}
 	if err := s.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -5,6 +5,7 @@ package mcp
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"log"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/kstruzzieri/go-llm/completion"
 	"github.com/kstruzzieri/go-llm/config"
+	"github.com/kstruzzieri/go-llm/feedback"
 	"github.com/kstruzzieri/go-llm/fingerprint"
 	"github.com/kstruzzieri/go-llm/internal/providerbootstrap"
 	"github.com/kstruzzieri/go-llm/ollama"
@@ -53,6 +55,8 @@ type Server struct {
 	ragDisabled       bool
 	transcriptDBPath  string
 	transcriptStore   *transcript.Store
+	feedbackDBPath    string
+	feedbackDB        *sql.DB
 	fingerprintStore  fingerprint.Store
 	tlsCert           string
 	tlsKey            string
@@ -129,6 +133,17 @@ func WithTranscriptStore(path string) Option {
 	}
 }
 
+// WithRetrievalFeedback enables optional behavioral feedback ranking by opening the
+// given SQLite DB at startup and injecting a consume-only weighter into the RAG
+// store. Schema migrations may run, but the server never records retrievals or
+// outcomes. Open failure is non-fatal (logged; ranking stays neutral). MCP
+// requires an explicit path because it has no canonical workspace root.
+func WithRetrievalFeedback(path string) Option {
+	return func(s *Server) {
+		s.feedbackDBPath = path
+	}
+}
+
 // WithFingerprintStore enables model fingerprint persistence and profiling
 // through the provider-aware ModelRegistry.
 func WithFingerprintStore(store fingerprint.Store) Option {
@@ -170,6 +185,81 @@ func defaultRAGPath() string {
 		return "rag.db"
 	}
 	return filepath.Join(home, ".local", "share", "go-llm", "rag.db")
+}
+
+// prepareRetrievalFeedbackDB creates the feedback DB's parent dir (0700) and the
+// DB file (0600) before sql.Open. Feedback data is behavioral telemetry; it must
+// stay private (mirrors the session/feedback DB handling elsewhere).
+func prepareRetrievalFeedbackDB(path string) error {
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return fmt.Errorf("create retrieval feedback dir %q: %w", dir, err)
+		}
+	}
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return fmt.Errorf("create retrieval feedback db %q: %w", path, err)
+	}
+	if err := f.Chmod(0o600); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("chmod retrieval feedback db %q: %w", path, err)
+	}
+	return f.Close()
+}
+
+// chmodRetrievalFeedbackDBFiles re-applies 0600 to the feedback DB and its WAL/SHM
+// sidecars, which journal_mode=WAL creates with default (group/world-readable on
+// some umasks) permissions. Telemetry must never leak through a sidecar.
+func chmodRetrievalFeedbackDBFiles(path string) error {
+	for _, p := range []string{path, path + "-wal", path + "-shm"} {
+		info, err := os.Stat(p)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("stat retrieval feedback db %q: %w", p, err)
+		}
+		if info.IsDir() {
+			return fmt.Errorf("retrieval feedback db %q is a directory", p)
+		}
+		if err := os.Chmod(p, 0o600); err != nil {
+			return fmt.Errorf("chmod retrieval feedback db %q: %w", p, err)
+		}
+	}
+	return nil
+}
+
+// openRetrievalFeedbackWeighter best-effort opens the feedback DB and returns a
+// consume-only weighter plus the owning *sql.DB. It is hardened the same way as
+// the Golem path: single connection, WAL + busy_timeout, private 0600 files
+// (including WAL/SHM sidecars). Migrations may run, but it never records
+// retrievals or outcomes. On any failure it closes the db and returns an error;
+// the caller logs and continues with neutral ranking (non-fatal).
+func openRetrievalFeedbackWeighter(ctx context.Context, path string) (*sql.DB, rag.BehavioralWeighter, error) {
+	if err := prepareRetrievalFeedbackDB(path); err != nil {
+		return nil, nil, err
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open retrieval feedback db %q: %w", path, err)
+	}
+	db.SetMaxOpenConns(1)
+	for _, pragma := range []string{"PRAGMA journal_mode=WAL", "PRAGMA busy_timeout=5000"} {
+		if _, err := db.ExecContext(ctx, pragma); err != nil {
+			_ = db.Close()
+			return nil, nil, fmt.Errorf("retrieval feedback %s: %w", pragma, err)
+		}
+	}
+	store, err := feedback.NewSignalStore(ctx, db)
+	if err != nil {
+		_ = db.Close()
+		return nil, nil, fmt.Errorf("init retrieval feedback db %q: %w", path, err)
+	}
+	if err := chmodRetrievalFeedbackDBFiles(path); err != nil {
+		_ = db.Close()
+		return nil, nil, err
+	}
+	return db, feedback.NewWeightReader(store, feedback.DefaultConfig()), nil
 }
 
 // NewServer creates and initializes an MCP server with the given options.
@@ -251,6 +341,14 @@ func NewServer(ctx context.Context, opts ...Option) (*Server, error) {
 			return nil, fmt.Errorf("mcp: open RAG store: %w", err)
 		}
 		s.store = store
+		if s.feedbackDBPath != "" {
+			if fdb, weighter, err := openRetrievalFeedbackWeighter(ctx, s.feedbackDBPath); err != nil {
+				log.Printf("mcp: behavioral feedback disabled: %v", err)
+			} else {
+				s.feedbackDB = fdb
+				store.SetBehavioralWeighter(weighter)
+			}
+		}
 	}
 
 	// Step 4b: open the optional transcript store (off unless WithTranscriptStore
@@ -691,6 +789,8 @@ func (s *Server) Close() error {
 	store := s.store
 	router := s.router
 	tstore := s.transcriptStore
+	fdb := s.feedbackDB
+	s.feedbackDB = nil
 	s.store = nil
 	s.indexer = nil
 	s.retriever = nil
@@ -711,5 +811,9 @@ func (s *Server) Close() error {
 	if tstore != nil {
 		transcriptErr = tstore.Close()
 	}
-	return errors.Join(routerErr, storeErr, transcriptErr)
+	var feedbackErr error
+	if fdb != nil {
+		feedbackErr = fdb.Close()
+	}
+	return errors.Join(routerErr, storeErr, transcriptErr, feedbackErr)
 }

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -138,6 +138,8 @@ func WithTranscriptStore(path string) Option {
 // store. Schema migrations may run, but the server never records retrievals or
 // outcomes. Open failure is non-fatal (logged; ranking stays neutral). MCP
 // requires an explicit path because it has no canonical workspace root.
+// It has no effect when RAG is disabled (WithRAGDisabled or empty RAG path),
+// since the weighter is injected into the RAG store.
 func WithRetrievalFeedback(path string) Option {
 	return func(s *Server) {
 		s.feedbackDBPath = path

--- a/rag/retriever.go
+++ b/rag/retriever.go
@@ -115,9 +115,11 @@ func (r *Retriever) Retrieve(ctx context.Context, query string, k int) ([]Search
 
 	// Prefer multi-signal (hybrid) retrieval when the store supports it and the
 	// caller has not opted out: semantic, keyword, and temporal signals
-	// participate in ranking. Retrieve's signature carries no editor context,
-	// so structural/behavioral signals stay inert (empty QueryContext); the
-	// temporal scorer still works, dating chunks against the newest indexed row.
+	// participate in ranking. Retrieve's signature carries no editor context, so
+	// the structural scorer stays inert (empty QueryContext); the temporal scorer
+	// still works, dating chunks against the newest indexed row. Behavioral does
+	// NOT depend on QueryContext: when a weighter is installed (SetBehavioralWeighter)
+	// it is active here too, keyed by each chunk's StableKey.
 	if ms, ok := r.store.(MultiSignalSearcher); ok && !r.vectorOnly {
 		scored, err := ms.SearchMulti(ctx, embedding, query, k, QueryContext{})
 		if err != nil {

--- a/rag/scorer.go
+++ b/rag/scorer.go
@@ -14,6 +14,14 @@ type SignalScorer interface {
 		queryEmbedding []float64, qCtx QueryContext) ([]float64, error)
 }
 
+// BehavioralWeighter supplies optional per-chunk behavioral weights keyed by
+// stable chunk key. It is the only behavioral surface the ranking path holds,
+// so ranking physically cannot open attribution windows or record signals.
+// *feedback.WeightReader satisfies it structurally; rag does not import feedback.
+type BehavioralWeighter interface {
+	WeightsBatch(ctx context.Context, keys []string) (map[string]float64, error)
+}
+
 // QueryContext carries metadata about the retrieval request.
 // It provides contextual signals (current file, workspace root, open files)
 // that individual scorers can use to improve relevance.

--- a/rag/scorer_behavioral.go
+++ b/rag/scorer_behavioral.go
@@ -1,0 +1,65 @@
+package rag
+
+import "context"
+
+// BehavioralScorer scores chunks by accumulated behavioral feedback weight,
+// keyed by stable chunk key. It is fail-open: any weighter error yields neutral
+// (all-zero) scores and a nil error, so retrieval never aborts on feedback
+// failure.
+type BehavioralScorer struct {
+	w BehavioralWeighter
+}
+
+// NewBehavioralScorer wraps a BehavioralWeighter. A nil weighter scores neutral.
+func NewBehavioralScorer(w BehavioralWeighter) *BehavioralScorer {
+	return &BehavioralScorer{w: w}
+}
+
+// Name returns "behavioral".
+func (s *BehavioralScorer) Name() string { return "behavioral" }
+
+// behavioralKey returns the stable attribution key for a chunk and whether it is
+// usable. An empty StableKey is not usable and is never passed to the weighter;
+// behavioral identity must survive re-index, and chunk.ID does not.
+func behavioralKey(c Chunk) (string, bool) {
+	if c.StableKey == "" {
+		return "", false
+	}
+	return c.StableKey, true
+}
+
+// ScoreBatch returns per-chunk behavioral weights aligned to the input order.
+// Chunks with no usable key, or any key the weighter reports nothing for, score
+// 0. On weighter error all chunks score 0 and the error is swallowed.
+func (s *BehavioralScorer) ScoreBatch(ctx context.Context, chunks []Chunk, query string,
+	queryEmbedding []float64, qCtx QueryContext) ([]float64, error) {
+	scores := make([]float64, len(chunks))
+	if s.w == nil || len(chunks) == 0 {
+		return scores, nil
+	}
+
+	keys := make([]string, 0, len(chunks))
+	seen := make(map[string]struct{}, len(chunks))
+	for _, c := range chunks {
+		if k, ok := behavioralKey(c); ok {
+			if _, dup := seen[k]; !dup {
+				seen[k] = struct{}{}
+				keys = append(keys, k)
+			}
+		}
+	}
+	if len(keys) == 0 {
+		return scores, nil
+	}
+
+	weights, err := s.w.WeightsBatch(ctx, keys)
+	if err != nil {
+		return scores, nil // fail open: neutral (scores still all-zero), no error
+	}
+	for i, c := range chunks {
+		if k, ok := behavioralKey(c); ok {
+			scores[i] = weights[k]
+		}
+	}
+	return scores, nil
+}

--- a/rag/scorer_behavioral.go
+++ b/rag/scorer_behavioral.go
@@ -1,6 +1,9 @@
 package rag
 
-import "context"
+import (
+	"context"
+	"errors"
+)
 
 // BehavioralScorer scores chunks by accumulated behavioral feedback weight,
 // keyed by stable chunk key. It is fail-open: any weighter error yields neutral
@@ -54,6 +57,9 @@ func (s *BehavioralScorer) ScoreBatch(ctx context.Context, chunks []Chunk, query
 
 	weights, err := s.w.WeightsBatch(ctx, keys)
 	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return scores, err
+		}
 		return scores, nil // fail open: neutral (scores still all-zero), no error
 	}
 	for i, c := range chunks {

--- a/rag/scorer_behavioral_test.go
+++ b/rag/scorer_behavioral_test.go
@@ -1,0 +1,87 @@
+package rag
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type fakeWeighter struct {
+	weights map[string]float64
+	err     error
+	gotKeys []string
+}
+
+func (f *fakeWeighter) WeightsBatch(ctx context.Context, keys []string) (map[string]float64, error) {
+	f.gotKeys = keys
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := make(map[string]float64, len(keys))
+	for _, k := range keys {
+		out[k] = f.weights[k]
+	}
+	return out, nil
+}
+
+func TestBehavioralScorerUsesStableKey(t *testing.T) {
+	fw := &fakeWeighter{weights: map[string]float64{"sk1": 0.7}}
+	s := NewBehavioralScorer(fw)
+	chunks := []Chunk{
+		{ID: "c1", StableKey: "sk1"},
+		{ID: "c2", StableKey: ""}, // empty => neutral, never queried
+	}
+	scores, err := s.ScoreBatch(context.Background(), chunks, "q", nil, QueryContext{})
+	if err != nil {
+		t.Fatalf("ScoreBatch: %v", err)
+	}
+	if scores[0] != 0.7 {
+		t.Errorf("scores[0] = %v, want 0.7", scores[0])
+	}
+	if scores[1] != 0 {
+		t.Errorf("scores[1] = %v, want 0 (empty StableKey)", scores[1])
+	}
+	for _, k := range fw.gotKeys {
+		if k == "" {
+			t.Fatal("empty string was passed as a weighter key")
+		}
+	}
+}
+
+func TestBehavioralScorerFailsOpen(t *testing.T) {
+	fw := &fakeWeighter{err: errors.New("store unavailable")}
+	s := NewBehavioralScorer(fw)
+	chunks := []Chunk{{ID: "c1", StableKey: "sk1"}}
+	scores, err := s.ScoreBatch(context.Background(), chunks, "q", nil, QueryContext{})
+	if err != nil {
+		t.Fatalf("ScoreBatch returned error, want nil (fail-open): %v", err)
+	}
+	if len(scores) != 1 || scores[0] != 0 {
+		t.Errorf("scores = %v, want [0] on fail-open", scores)
+	}
+}
+
+func TestBehavioralScorerDeduplicatesKeys(t *testing.T) {
+	fw := &fakeWeighter{weights: map[string]float64{"sk1": 0.5}}
+	s := NewBehavioralScorer(fw)
+	chunks := []Chunk{
+		{ID: "c1", StableKey: "sk1"},
+		{ID: "c2", StableKey: "sk1"},
+	}
+	scores, err := s.ScoreBatch(context.Background(), chunks, "q", nil, QueryContext{})
+	if err != nil {
+		t.Fatalf("ScoreBatch: %v", err)
+	}
+	if len(fw.gotKeys) != 1 {
+		t.Errorf("weighter got %d keys, want 1 (deduped): %v", len(fw.gotKeys), fw.gotKeys)
+	}
+	if scores[0] != 0.5 || scores[1] != 0.5 {
+		t.Errorf("scores = %v, want both 0.5", scores)
+	}
+}
+
+func TestBehavioralScorerName(t *testing.T) {
+	if NewBehavioralScorer(nil).Name() != "behavioral" {
+		t.Errorf("Name() = %q, want \"behavioral\"", NewBehavioralScorer(nil).Name())
+	}
+}

--- a/rag/scorer_behavioral_test.go
+++ b/rag/scorer_behavioral_test.go
@@ -61,6 +61,16 @@ func TestBehavioralScorerFailsOpen(t *testing.T) {
 	}
 }
 
+func TestBehavioralScorerPreservesCancellation(t *testing.T) {
+	fw := &fakeWeighter{err: context.Canceled}
+	s := NewBehavioralScorer(fw)
+	chunks := []Chunk{{ID: "c1", StableKey: "sk1"}}
+	_, err := s.ScoreBatch(context.Background(), chunks, "q", nil, QueryContext{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ScoreBatch error = %v, want context.Canceled", err)
+	}
+}
+
 func TestBehavioralScorerDeduplicatesKeys(t *testing.T) {
 	fw := &fakeWeighter{weights: map[string]float64{"sk1": 0.5}}
 	s := NewBehavioralScorer(fw)

--- a/rag/search_multi.go
+++ b/rag/search_multi.go
@@ -81,10 +81,28 @@ func (s *SQLiteStore) SearchMulti(ctx context.Context, queryEmbedding []float64,
 	semanticRanks := computeRanks(semanticScores)
 	keywordRanks := computeRanks(keywordScores)
 
+	// Optional behavioral signal as a third RRF list. It is folded only when a
+	// weighter is configured AND at least one chunk has a non-zero weight, so
+	// cold-start (all-zero) leaves the raw fused score byte-for-byte unchanged.
+	var behavioralScores []float64
+	var behavioralRanks []int
+	foldBehavioral := false
+	if s.behavioral != nil {
+		behavioralScores, _ = NewBehavioralScorer(s.behavioral).
+			ScoreBatch(ctx, chunks, query, queryEmbedding, qCtx) // fail-open: never errors
+		if anyNonZero(behavioralScores) {
+			behavioralRanks = computeRanks(behavioralScores)
+			foldBehavioral = true
+		}
+	}
+
 	// Build final scored results.
 	results := make([]ScoredResult, len(chunks))
 	for i, chunk := range chunks {
 		rrfScore := rrfContribution(semanticRanks[i]) + rrfContribution(keywordRanks[i])
+		if foldBehavioral {
+			rrfScore += rrfContribution(behavioralRanks[i])
+		}
 
 		// Add weighted bonuses from non-ranked signals.
 		var temporalBonus, structuralBonus float64
@@ -97,18 +115,25 @@ func (s *SQLiteStore) SearchMulti(ctx context.Context, queryEmbedding []float64,
 
 		finalScore := rrfScore + temporalBonus + structuralBonus
 
+		signals := map[string]float64{
+			"semantic":   semanticScores[i],
+			"keyword":    keywordScores[i],
+			"temporal":   safeIndex(temporalScores, i),
+			"structural": structuralScores[i],
+		}
+		// Expose behavioral only when a weighter is configured (0 during
+		// cold-start, raw weighted score otherwise). Absent when nil.
+		if s.behavioral != nil {
+			signals["behavioral"] = safeIndex(behavioralScores, i)
+		}
+
 		results[i] = ScoredResult{
 			SearchResult: SearchResult{
 				Chunk:    chunk,
 				Score:    finalScore,
 				Distance: 1 - semanticScores[i], // cosine distance from semantic signal
 			},
-			Signals: map[string]float64{
-				"semantic":   semanticScores[i],
-				"keyword":    keywordScores[i],
-				"temporal":   safeIndex(temporalScores, i),
-				"structural": structuralScores[i],
-			},
+			Signals: signals,
 		}
 	}
 
@@ -199,6 +224,17 @@ func computeRanks(scores []float64) []int {
 // rrfContribution computes the RRF score contribution for a given rank.
 func rrfContribution(rank int) float64 {
 	return 1.0 / float64(rrfK+rank)
+}
+
+// anyNonZero reports whether xs contains any non-zero value. Used to skip the
+// behavioral RRF list during cold-start so raw fused scores stay identical.
+func anyNonZero(xs []float64) bool {
+	for _, x := range xs {
+		if x != 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // safeIndex returns scores[i] if in bounds, or 0.

--- a/rag/search_multi.go
+++ b/rag/search_multi.go
@@ -88,8 +88,11 @@ func (s *SQLiteStore) SearchMulti(ctx context.Context, queryEmbedding []float64,
 	var behavioralRanks []int
 	foldBehavioral := false
 	if s.behavioral != nil {
-		behavioralScores, _ = NewBehavioralScorer(s.behavioral).
-			ScoreBatch(ctx, chunks, query, queryEmbedding, qCtx) // fail-open: never errors
+		behavioralScores, err = NewBehavioralScorer(s.behavioral).
+			ScoreBatch(ctx, chunks, query, queryEmbedding, qCtx)
+		if err != nil {
+			return nil, fmt.Errorf("rag: behavioral scoring: %w", err)
+		}
 		if anyNonZero(behavioralScores) {
 			behavioralRanks = computeRanks(behavioralScores)
 			foldBehavioral = true

--- a/rag/search_multi_test.go
+++ b/rag/search_multi_test.go
@@ -2,10 +2,13 @@ package rag
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
 )
+
+var errTestWeighter = errors.New("test weighter failure")
 
 func TestSearchMultiBasic(t *testing.T) {
 	store := newTestStore(t)
@@ -252,5 +255,144 @@ func TestComputeRanks(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// behavioralFixture stores three chunks with StableKeys and returns the store.
+// T is the relevant chunk (top semantic+keyword), M is middling, B is
+// irrelevant. qCtx is empty so temporal is uniform (all indexed together) and
+// structural is zero for all — isolating behavioral per the spec.
+func behavioralFixture(t *testing.T) *SQLiteStore {
+	t.Helper()
+	store := newTestStore(t)
+	ctx := context.Background()
+	chunks := []Chunk{
+		{ID: "T", StableKey: "skT", Content: "golang concurrency channels", Source: "a.go", StartLine: 1, EndLine: 5, Metadata: map[string]string{}},
+		{ID: "M", StableKey: "skM", Content: "golang slices", Source: "b.go", StartLine: 1, EndLine: 5, Metadata: map[string]string{}},
+		{ID: "B", StableKey: "skB", Content: "python pandas dataframe", Source: "c.go", StartLine: 1, EndLine: 5, Metadata: map[string]string{}},
+	}
+	embeddings := [][]float64{
+		{1.0, 0.0, 0.0}, // T closest to query
+		{0.6, 0.0, 0.8}, // M partial
+		{0.0, 1.0, 0.0}, // B orthogonal
+	}
+	if err := store.Store(ctx, chunks, embeddings); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	return store
+}
+
+func ids(rs []ScoredResult) []string {
+	out := make([]string, len(rs))
+	for i, r := range rs {
+		out[i] = r.Chunk.ID
+	}
+	return out
+}
+
+// query "golang concurrency", embedding aligned with T.
+var (
+	behQuery = "golang concurrency"
+	behEmb   = []float64{0.95, 0.0, 0.1}
+)
+
+func TestSearchMultiNilWeighterNoBehavioralSignal(t *testing.T) {
+	store := behavioralFixture(t)
+	res, err := store.SearchMulti(context.Background(), behEmb, behQuery, 3, QueryContext{})
+	if err != nil {
+		t.Fatalf("SearchMulti: %v", err)
+	}
+	for _, r := range res {
+		if _, ok := r.Signals["behavioral"]; ok {
+			t.Errorf("nil weighter must not add a 'behavioral' signal key, got %v", r.Signals)
+		}
+	}
+}
+
+func TestSearchMultiColdStartInert(t *testing.T) {
+	store := behavioralFixture(t)
+	ctx := context.Background()
+	base, err := store.SearchMulti(ctx, behEmb, behQuery, 3, QueryContext{})
+	if err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+	// All-zero weighter == cold-start: contribution skipped, raw scores unchanged.
+	store.SetBehavioralWeighter(&fakeWeighter{weights: map[string]float64{}})
+	got, err := store.SearchMulti(ctx, behEmb, behQuery, 3, QueryContext{})
+	if err != nil {
+		t.Fatalf("with weighter: %v", err)
+	}
+	for i := range base {
+		if got[i].Chunk.ID != base[i].Chunk.ID || got[i].Score != base[i].Score {
+			t.Errorf("cold-start not inert at %d: base=(%s,%v) got=(%s,%v)",
+				i, base[i].Chunk.ID, base[i].Score, got[i].Chunk.ID, got[i].Score)
+		}
+	}
+}
+
+func TestSearchMultiFailOpenPreservesBaseline(t *testing.T) {
+	store := behavioralFixture(t)
+	ctx := context.Background()
+	base, err := store.SearchMulti(ctx, behEmb, behQuery, 3, QueryContext{})
+	if err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+	store.SetBehavioralWeighter(&fakeWeighter{err: errTestWeighter})
+	got, err := store.SearchMulti(ctx, behEmb, behQuery, 3, QueryContext{})
+	if err != nil {
+		t.Fatalf("SearchMulti must not surface weighter error: %v", err)
+	}
+	for i := range base {
+		if got[i].Chunk.ID != base[i].Chunk.ID || got[i].Score != base[i].Score {
+			t.Errorf("fail-open not inert at %d: base=(%s,%v) got=(%s,%v)",
+				i, base[i].Chunk.ID, base[i].Score, got[i].Chunk.ID, got[i].Score)
+		}
+	}
+}
+
+// Dominance: a behavior-only favorite (B, irrelevant) with a huge weight cannot
+// outrank T, which is rank-1 in both semantic and keyword. Temporal/structural
+// are uniform (empty qCtx, co-indexed), isolating behavioral per the spec.
+func TestSearchMultiBehavioralCannotDominate(t *testing.T) {
+	store := behavioralFixture(t)
+	store.SetBehavioralWeighter(&fakeWeighter{weights: map[string]float64{"skB": 100.0}})
+	res, err := store.SearchMulti(context.Background(), behEmb, behQuery, 3, QueryContext{})
+	if err != nil {
+		t.Fatalf("SearchMulti: %v", err)
+	}
+	if res[0].Chunk.ID != "T" {
+		t.Errorf("behavior-only favorite dominated: top=%s, want T; order=%v", res[0].Chunk.ID, ids(res))
+	}
+}
+
+// Warmed feedback reorders genuinely near-tied candidates: with M and B close on
+// relevance, a strong positive weight on B lifts it above M.
+func TestSearchMultiWarmedReordersNearTies(t *testing.T) {
+	store := behavioralFixture(t)
+	ctx := context.Background()
+	base, err := store.SearchMulti(ctx, behEmb, behQuery, 3, QueryContext{})
+	if err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+	basePos := map[string]int{}
+	for i, id := range ids(base) {
+		basePos[id] = i
+	}
+	// Favor B heavily; it should climb at least one position vs baseline.
+	store.SetBehavioralWeighter(&fakeWeighter{weights: map[string]float64{"skB": 50.0}})
+	got, err := store.SearchMulti(ctx, behEmb, behQuery, 3, QueryContext{})
+	if err != nil {
+		t.Fatalf("warmed: %v", err)
+	}
+	gotPos := map[string]int{}
+	for i, id := range ids(got) {
+		gotPos[id] = i
+	}
+	if gotPos["B"] >= basePos["B"] {
+		t.Errorf("expected B to climb with positive feedback: base pos=%d got pos=%d (order %v)",
+			basePos["B"], gotPos["B"], ids(got))
+	}
+	if got[0].Chunk.ID != "T" {
+		t.Errorf("T must remain top (relevance winner), got %v", ids(got))
 	}
 }

--- a/rag/search_multi_test.go
+++ b/rag/search_multi_test.go
@@ -350,6 +350,15 @@ func TestSearchMultiFailOpenPreservesBaseline(t *testing.T) {
 	}
 }
 
+func TestSearchMultiPropagatesBehavioralCancellation(t *testing.T) {
+	store := behavioralFixture(t)
+	store.SetBehavioralWeighter(&fakeWeighter{err: context.Canceled})
+	_, err := store.SearchMulti(context.Background(), behEmb, behQuery, 3, QueryContext{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("SearchMulti error = %v, want context.Canceled", err)
+	}
+}
+
 // Dominance: a behavior-only favorite (B, irrelevant) with a huge weight cannot
 // outrank T, which is rank-1 in both semantic and keyword. Temporal/structural
 // are uniform (empty qCtx, co-indexed), isolating behavioral per the spec.

--- a/rag/sqlite_store.go
+++ b/rag/sqlite_store.go
@@ -25,7 +25,8 @@ var (
 
 // SQLiteStore is a VectorStore backed by SQLite with brute-force cosine similarity.
 type SQLiteStore struct {
-	db *sql.DB
+	db         *sql.DB
+	behavioral BehavioralWeighter // optional; nil => behavioral signal inert
 }
 
 type replaceSourceOptions struct {
@@ -92,6 +93,14 @@ func OpenSQLiteStoreReadOnly(dbPath string) (*SQLiteStore, error) {
 		return nil, fmt.Errorf("rag: open sqlite read-only %q: %w", dbPath, err)
 	}
 	return &SQLiteStore{db: db}, nil
+}
+
+// SetBehavioralWeighter installs an optional behavioral weighter consumed by
+// SearchMulti as a third RRF list. Startup-only: call once during wiring, before
+// any concurrent retrieval. It takes no lock and is not safe to call against
+// in-flight SearchMulti calls.
+func (s *SQLiteStore) SetBehavioralWeighter(w BehavioralWeighter) {
+	s.behavioral = w
 }
 
 // DB returns the underlying *sql.DB for packages that need shared access


### PR DESCRIPTION
## Summary

Wires the existing `feedback` package's behavioral weights into `rag` multi-signal retrieval as an optional, cold-start-neutral, fail-open third reciprocal-rank-fusion (RRF) list that cannot dominate semantic/keyword relevance. Closes #231.

- `feedback.WeightReader`: goroutine-free, read-only weight reader sharing one `weightsBatch` gating helper with `Collector` (parity-tested so they cannot diverge).
- `rag.BehavioralWeighter` interface + fail-open `BehavioralScorer`, keyed by stable chunk key. `rag` does not import `feedback`; the seam is a one-method interface.
- `SearchMulti` folds behavioral as a third RRF list only when a weighter is installed AND at least one weight is non-zero. Cold-start and fail-open leave the fused score byte-for-byte identical to no-feedback. Rank-only fusion bounds each list to `1/(rrfK+rank)`, so a behavior-only favorite cannot outrank a semantic+keyword winner.
- Golem: `-feedback` / `-feedback-db` flags open a per-workspace feedback DB (private 0600 files / 0700 dir, single connection, WAL + busy_timeout, validated outside the workspace) and inject a read-only weighter. Open failure warns and falls back to neutral ranking; never disables retrieval. DB closed on shutdown.
- MCP: `WithRetrievalFeedback` opens an explicit feedback DB with the same hardening and injects the weighter. Open failure is logged and non-fatal. DB closed on shutdown.
- Consume-only: no `RegisterRetrieval`, no signal/outcome recording anywhere. The only behavioral surface ranking holds is read-only `WeightsBatch`.

## Test Plan

- [x] `env -u GOROOT go test -race ./...` (full suite passes)
- [x] `env -u GOROOT golangci-lint run` on changed packages (0 issues)
- [x] `gofmt -l` clean on all changed files
- [x] Cold-start inertness and fail-open assert raw `Score` equality (not just ordering)
- [x] Dominance: behavior-only favorite with weight 100 cannot outrank the relevance winner
- [x] Warmed feedback reorders genuine near-ties without displacing the relevance winner
- [x] Golem + MCP wiring: valid open injects, bad path is non-fatal, feedback DB files are 0600 (incl. WAL/SHM sidecars), DB closed on shutdown
- [x] Per-task spec + quality review, final whole-branch review, and adversarial criticize-review pass

## Notes

- Rebased on `develop@4af55ca` (resolved the `cmd/golem/main.go` flag-block adjacency with #63 `-pressure-warn`).
