### PR TITLE
feat(config): exported side-task use-case API + golem de-dup (#60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,12 @@ in `models.json`.
 The `vision` slot is model selection only; image message payload support is
 tracked separately.
 
+The auxiliary use-case keys are exported as untyped string constants
+(`config.UseCaseSummarize`, `config.UseCaseRerank`, and the rest), enumerated by
+`config.SideTaskUseCases()`, and resolved to a model role by
+`cfg.RoleForUseCase(useCase)` — the same fallback semantics, exposed for callers
+that pick a side-task model without walking the full chain.
+
 ## MCP Server
 
 Expose all go-llm capabilities over the [Model Context Protocol](https://modelcontextprotocol.io/) for use with Claude Desktop, IDE extensions, or any MCP client.

--- a/cmd/golem/config.go
+++ b/cmd/golem/config.go
@@ -57,14 +57,10 @@ func resolveSummarizeChain(cfg *config.Config) ([]string, error) {
 	if cfg == nil {
 		return nil, nil
 	}
-	if _, ok := cfg.Defaults["summarize"]; !ok {
-		if _, ok := cfg.Defaults["analysis"]; !ok {
-			if _, ok := cfg.Defaults["chat"]; !ok {
-				return nil, nil
-			}
-		}
+	if _, ok := cfg.RoleForUseCase(config.UseCaseSummarize); !ok {
+		return nil, nil
 	}
-	chain, err := cfg.RoleFallbackChain("summarize")
+	chain, err := cfg.RoleFallbackChain(config.UseCaseSummarize)
 	if err != nil {
 		return nil, fmt.Errorf("golem: resolve summarize chain: %w", err)
 	}

--- a/cmd/golem/config_test.go
+++ b/cmd/golem/config_test.go
@@ -118,6 +118,21 @@ func TestResolveSummarizeChain_NoDefaultsReturnsNil(t *testing.T) {
 	}
 }
 
+func TestResolveSummarizeChain_FallbackOnlyUsesChat(t *testing.T) {
+	cfg := &config.Config{
+		Models:   map[string]config.ModelConfig{"light": {Name: "small", Provider: "ollama"}},
+		Defaults: map[string]string{"chat": "light"}, // no summarize / analysis
+	}
+	chain, err := resolveSummarizeChain(cfg)
+	if err != nil {
+		t.Fatalf("resolveSummarizeChain: %v", err)
+	}
+	want := []string{"ollama/small"}
+	if len(chain) != len(want) || chain[0] != want[0] {
+		t.Fatalf("chain = %v, want %v (summarize -> chat fallback)", chain, want)
+	}
+}
+
 func TestLoadConfig_ExplicitBadPathFatal(t *testing.T) {
 	if _, err := loadConfig("/nonexistent/path/models.json"); err == nil {
 		t.Fatal("err = nil for nonexistent explicit config path, want fatal")

--- a/cmd/golem/config_test.go
+++ b/cmd/golem/config_test.go
@@ -89,6 +89,35 @@ func TestResolveSummarizeChain_UsesConfiguredFallbackChain(t *testing.T) {
 	}
 }
 
+func TestResolveSummarizeChain_FallbackOnlyUsesAnalysis(t *testing.T) {
+	cfg := &config.Config{
+		Models:   map[string]config.ModelConfig{"light": {Name: "small", Provider: "ollama"}},
+		Defaults: map[string]string{"analysis": "light"}, // no "summarize"
+	}
+	chain, err := resolveSummarizeChain(cfg)
+	if err != nil {
+		t.Fatalf("resolveSummarizeChain: %v", err)
+	}
+	want := []string{"ollama/small"}
+	if len(chain) != len(want) || chain[0] != want[0] {
+		t.Fatalf("chain = %v, want %v (summarize -> analysis fallback)", chain, want)
+	}
+}
+
+func TestResolveSummarizeChain_NoDefaultsReturnsNil(t *testing.T) {
+	cfg := &config.Config{
+		Models:   map[string]config.ModelConfig{"light": {Name: "small", Provider: "ollama"}},
+		Defaults: map[string]string{}, // no summarize / analysis / chat
+	}
+	chain, err := resolveSummarizeChain(cfg)
+	if err != nil {
+		t.Fatalf("resolveSummarizeChain: %v", err)
+	}
+	if chain != nil {
+		t.Fatalf("chain = %v, want nil (no resolvable summarize)", chain)
+	}
+}
+
 func TestLoadConfig_ExplicitBadPathFatal(t *testing.T) {
 	if _, err := loadConfig("/nonexistent/path/models.json"); err == nil {
 		t.Fatal("err = nil for nonexistent explicit config path, want fatal")

--- a/config/candidates.go
+++ b/config/candidates.go
@@ -31,7 +31,7 @@ func (c *Config) ResolveCandidates(ctx context.Context, checker ModelChecker, us
 	if checker == nil {
 		return nil, fmt.Errorf("config: model checker is required")
 	}
-	role, ok := c.roleForUseCase(useCase)
+	role, ok := c.RoleForUseCase(useCase)
 	if !ok {
 		return nil, fmt.Errorf("config: unknown use-case %q", useCase)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -83,20 +83,6 @@ type Config struct {
 	Defaults  map[string]string         `json:"defaults"`
 }
 
-// sideTaskDefaultFallbacks keeps auxiliary model-selection roles optional.
-// "route" here is the side-task model role, not provider.Router itself.
-// Explicit defaults win; these entries only pick an existing use-case when a
-// side-task slot is absent from older models.json files.
-var sideTaskDefaultFallbacks = map[string][]string{
-	"summarize": {"analysis", "chat"},
-	"route":     {"analysis", "chat"},
-	"rerank":    {"analysis", "chat"},
-	"verify":    {"analysis", "chat"},
-	"extract":   {"analysis", "chat"},
-	"approval":  {"agent", "chat"},
-	"vision":    {"chat"},
-}
-
 // ErrConfigNotFound indicates that Default could not find a models.json file
 // in any of its discovery locations.
 var ErrConfigNotFound = errors.New("config: no configuration file found")
@@ -224,7 +210,7 @@ func (c *Config) RoleConfig(role string) *ModelConfig {
 // summarize, route, rerank, verify, extract, approval, and vision fall back to
 // existing defaults when absent. Returns "" if the use-case or its target role is not found.
 func (c *Config) ModelFor(useCase string) string {
-	role, ok := c.roleForUseCase(useCase)
+	role, ok := c.RoleForUseCase(useCase)
 	if !ok {
 		return ""
 	}
@@ -242,18 +228,6 @@ func (c *Config) MustModelFor(useCase string) string {
 		panic(fmt.Sprintf("config: no model for use-case %q", useCase))
 	}
 	return name
-}
-
-func (c *Config) roleForUseCase(useCase string) (string, bool) {
-	if role, ok := c.Defaults[useCase]; ok {
-		return role, true
-	}
-	for _, fallback := range sideTaskDefaultFallbacks[useCase] {
-		if role, ok := c.Defaults[fallback]; ok {
-			return role, true
-		}
-	}
-	return "", false
 }
 
 // ProviderFor returns the provider config for a given role's model.

--- a/config/resolve.go
+++ b/config/resolve.go
@@ -73,7 +73,7 @@ func (c *Config) Resolve(ctx context.Context, checker ModelChecker, useCase stri
 	if checker == nil {
 		return ResolvedModel{}, fmt.Errorf("config: model checker is required")
 	}
-	role, ok := c.roleForUseCase(useCase)
+	role, ok := c.RoleForUseCase(useCase)
 	if !ok {
 		return ResolvedModel{}, fmt.Errorf("config: unknown use-case %q", useCase)
 	}
@@ -213,7 +213,7 @@ func toSet(items []string) map[string]bool {
 // surface as an error. Availability is NOT filtered — that is the Router's
 // job via breakers, warmth, and gates.
 func (c *Config) RoleFallbackChain(useCase string) ([]string, error) {
-	role, ok := c.roleForUseCase(useCase)
+	role, ok := c.RoleForUseCase(useCase)
 	if !ok {
 		return nil, fmt.Errorf("config: unknown use-case %q", useCase)
 	}

--- a/config/sidetasks.go
+++ b/config/sidetasks.go
@@ -1,0 +1,60 @@
+package config
+
+import "sort"
+
+// Auxiliary side-task use-case keys. These are use-case keys (the keys callers
+// set in Config.Defaults), NOT model roles — Defaults maps use-case -> role.
+// Untyped string constants so they drop into the existing string-typed APIs
+// (ModelFor, Resolve, provider.RoutingRequest.UseCase) with no conversion.
+const (
+	UseCaseSummarize = "summarize"
+	UseCaseRoute     = "route"
+	UseCaseRerank    = "rerank"
+	UseCaseVerify    = "verify"
+	UseCaseExtract   = "extract"
+	UseCaseApproval  = "approval"
+	UseCaseVision    = "vision"
+)
+
+// sideTaskUseCaseFallbacks keeps auxiliary side-task use-cases optional.
+// "route" here is the side-task model use-case, not provider.Router itself.
+// Keys AND fallback entries are use-case keys looked up in Config.Defaults;
+// explicit defaults win, these only pick an existing use-case when a side-task
+// slot is absent from older models.json files.
+var sideTaskUseCaseFallbacks = map[string][]string{
+	UseCaseSummarize: {"analysis", "chat"},
+	UseCaseRoute:     {"analysis", "chat"},
+	UseCaseRerank:    {"analysis", "chat"},
+	UseCaseVerify:    {"analysis", "chat"},
+	UseCaseExtract:   {"analysis", "chat"},
+	UseCaseApproval:  {"agent", "chat"},
+	UseCaseVision:    {"chat"},
+}
+
+// SideTaskUseCases returns the auxiliary side-task use-case keys, sorted.
+// Derived from sideTaskUseCaseFallbacks so the enumerator and the fallback
+// table cannot drift.
+func SideTaskUseCases() []string {
+	out := make([]string, 0, len(sideTaskUseCaseFallbacks))
+	for k := range sideTaskUseCaseFallbacks {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// RoleForUseCase resolves a use-case to its configured model role. An explicit
+// Config.Defaults entry wins; otherwise side-task use-cases fall back to
+// existing defaults per sideTaskUseCaseFallbacks. ok is false when neither the
+// use-case nor any of its fallbacks is configured.
+func (c *Config) RoleForUseCase(useCase string) (string, bool) {
+	if role, ok := c.Defaults[useCase]; ok {
+		return role, true
+	}
+	for _, fallback := range sideTaskUseCaseFallbacks[useCase] {
+		if role, ok := c.Defaults[fallback]; ok {
+			return role, true
+		}
+	}
+	return "", false
+}

--- a/config/sidetasks_test.go
+++ b/config/sidetasks_test.go
@@ -91,3 +91,12 @@ func TestRoleForUseCase_ExplicitWins(t *testing.T) {
 		t.Fatalf("RoleForUseCase(summarize) = (%q,%v), want explicit (light,true)", role, ok)
 	}
 }
+
+func TestRoleForUseCase_WalksToSecondFallback(t *testing.T) {
+	// summarize -> {analysis, chat}; with analysis absent it must walk past the
+	// first fallback entry to the second one ("chat").
+	cfg := &Config{Defaults: map[string]string{"chat": "general"}}
+	if role, ok := cfg.RoleForUseCase(UseCaseSummarize); role != "general" || !ok {
+		t.Fatalf("RoleForUseCase(summarize) = (%q,%v), want chat fallback (general,true)", role, ok)
+	}
+}

--- a/config/sidetasks_test.go
+++ b/config/sidetasks_test.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestUseCaseConstants(t *testing.T) {
+	cases := []struct {
+		got  string
+		want string
+	}{
+		{UseCaseSummarize, "summarize"},
+		{UseCaseRoute, "route"},
+		{UseCaseRerank, "rerank"},
+		{UseCaseVerify, "verify"},
+		{UseCaseExtract, "extract"},
+		{UseCaseApproval, "approval"},
+		{UseCaseVision, "vision"},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("constant = %q, want %q", c.got, c.want)
+		}
+	}
+}
+
+func TestSideTaskUseCases_SortedAndMatchesFallbackKeys(t *testing.T) {
+	got := SideTaskUseCases()
+	want := []string{"approval", "extract", "rerank", "route", "summarize", "verify", "vision"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("SideTaskUseCases() = %v, want %v (sorted)", got, want)
+	}
+	if len(got) != len(sideTaskUseCaseFallbacks) {
+		t.Fatalf("SideTaskUseCases() has %d entries, fallback table has %d", len(got), len(sideTaskUseCaseFallbacks))
+	}
+	for _, uc := range got {
+		if _, ok := sideTaskUseCaseFallbacks[uc]; !ok {
+			t.Errorf("SideTaskUseCases() returned %q absent from fallback table", uc)
+		}
+	}
+}
+
+func TestSideTaskUseCaseFallbacks_ValuesAndOrder(t *testing.T) {
+	want := map[string][]string{
+		"summarize": {"analysis", "chat"},
+		"route":     {"analysis", "chat"},
+		"rerank":    {"analysis", "chat"},
+		"verify":    {"analysis", "chat"},
+		"extract":   {"analysis", "chat"},
+		"approval":  {"agent", "chat"},
+		"vision":    {"chat"},
+	}
+	if !reflect.DeepEqual(sideTaskUseCaseFallbacks, want) {
+		t.Fatalf("sideTaskUseCaseFallbacks = %v, want %v", sideTaskUseCaseFallbacks, want)
+	}
+}
+
+func TestRoleForUseCase(t *testing.T) {
+	cfg := &Config{Defaults: map[string]string{
+		"chat":     "general",
+		"analysis": "general",
+		"agent":    "agentRole",
+	}}
+	tests := []struct {
+		useCase  string
+		wantRole string
+		wantOK   bool
+	}{
+		{"chat", "general", true},            // direct hit
+		{UseCaseSummarize, "general", true},  // fallback -> analysis
+		{UseCaseApproval, "agentRole", true}, // fallback -> agent
+		{"nope", "", false},                  // unknown, no fallback
+	}
+	for _, tt := range tests {
+		t.Run(tt.useCase, func(t *testing.T) {
+			role, ok := cfg.RoleForUseCase(tt.useCase)
+			if role != tt.wantRole || ok != tt.wantOK {
+				t.Errorf("RoleForUseCase(%q) = (%q,%v), want (%q,%v)", tt.useCase, role, ok, tt.wantRole, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestRoleForUseCase_ExplicitWins(t *testing.T) {
+	cfg := &Config{Defaults: map[string]string{
+		"analysis":  "general",
+		"summarize": "light",
+	}}
+	if role, ok := cfg.RoleForUseCase(UseCaseSummarize); role != "light" || !ok {
+		t.Fatalf("RoleForUseCase(summarize) = (%q,%v), want explicit (light,true)", role, ok)
+	}
+}


### PR DESCRIPTION
## Summary

Completes #60 on top of bc6c8cc (already on develop), which had shipped the private side-task fallback machinery. This is the API-completeness + de-duplication layer:

- New `config/sidetasks.go` owns the side-task concern (relocated out of the 644-line config.go): exported untyped use-case constants `UseCaseSummarize`/`UseCaseRoute`/`UseCaseRerank`/`UseCaseVerify`/`UseCaseExtract`/`UseCaseApproval`/`UseCaseVision`, a `SideTaskUseCases()` enumerator (derived from the fallback table, drift-proof), and the exported `(*Config).RoleForUseCase` method (renamed from the private `roleForUseCase`). Pure relocate + export + rename; zero resolver behavior change. The private `sideTaskDefaultFallbacks` map is renamed `sideTaskUseCaseFallbacks` (keys and entries are use-case keys, not roles).
- golem `resolveSummarizeChain` drops a hand-rolled summarize -> analysis -> chat presence check (a copy of the fallback table) for the exported `cfg.RoleForUseCase(config.UseCaseSummarize)` predicate, eliminating the duplication and the magic strings.
- README documents the exported surface.

Naming note: these are use-case keys, not model roles (`Defaults` maps use-case -> role); `RoleForUseCase` returns the role for a use-case. Untyped string constants so they drop into the existing string-typed APIs (`ModelFor`, `Resolve`, `provider.RoutingRequest.UseCase`) with no conversion.

Deliberately out of scope: `agent`'s `"summarize"` literal is left as-is (no `config` import into `agent` for one constant); no separate `SideTasks` config block; no `Defaults`-key validation (open vocabulary); no wiring of the not-yet-consumed roles. `models.json` schema is unchanged and backward compatible.

## Test plan

- [x] `env -u GOROOT go test -race ./...` (28 packages ok, 0 failures, no races)
- [x] `golangci-lint run` clean; `gofmt -l` clean; `go vet` clean
- [x] New tests: constant values, `SideTaskUseCases()` sorted + matches map keys, fallback table values+order pinned, `RoleForUseCase` (direct hit, first-fallback, second-fallback walk, approval, unknown, explicit-wins); golem summarize chain for explicit / analysis-fallback / chat-fallback / no-defaults
- [x] Pre-existing config Load/Resolve tests pass unchanged (backward compatibility)

Closes #60