### PR TITLE
feat(analysis,mcp): grounding and verification helpers for retrieval-backed answers (#62)

### DIFF
--- a/analysis/support.go
+++ b/analysis/support.go
@@ -5,7 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
+	"github.com/kstruzzieri/go-llm/config"
+	"github.com/kstruzzieri/go-llm/provider"
 	"github.com/kstruzzieri/go-llm/rag"
 )
 
@@ -153,6 +156,69 @@ func lastJSONObjectWith(reply, key string) []byte {
 		}
 	}
 	return nil
+}
+
+const extractSystem = "You decompose an answer into atomic, independently-checkable factual claims. " +
+	"Use only the answer text; do not add facts."
+
+const extractInstruction = "Return ONLY JSON of the form {\"claims\": [\"claim 1\", \"claim 2\"]}. " +
+	"Each claim must be one self-contained factual statement. No commentary, no markdown."
+
+// extractReply is the expected JSON shape from the extract stage.
+type extractReply struct {
+	Claims []string `json:"claims"`
+}
+
+// extractClaims runs the extract stage and returns helper-labeled claims
+// (C1..). Malformed or empty model output falls back to treating the whole
+// answer as a single claim. Claims default to StatusUnsupported until verified.
+func (j *SupportJudge) extractClaims(ctx context.Context, answer string) ([]ClaimSupport, error) {
+	zero := 0.0
+	resp, err := j.chat(ctx, config.UseCaseExtract, provider.ChatRequest{
+		Model:   j.model,
+		Options: provider.ModelOptions{Temperature: &zero},
+		Messages: []provider.ChatMessage{
+			{Role: "system", Content: extractSystem},
+			{Role: "user", Content: "Answer:\n" + answer + "\n\n" + extractInstruction},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("analysis: judge support: extract: %w", err)
+	}
+
+	texts := parseClaimsLenient(resp.Content)
+	if len(texts) == 0 {
+		texts = []string{answer}
+	}
+	claims := make([]ClaimSupport, len(texts))
+	for i, c := range texts {
+		claims[i] = ClaimSupport{
+			ID:     fmt.Sprintf("C%d", i+1),
+			Claim:  c,
+			Status: StatusUnsupported,
+		}
+	}
+	return claims, nil
+}
+
+// parseClaimsLenient extracts non-empty claim strings from a model reply, or
+// nil when nothing usable is present.
+func parseClaimsLenient(reply string) []string {
+	obj := lastJSONObjectWith(reply, "claims")
+	if obj == nil {
+		return nil
+	}
+	var er extractReply
+	if err := json.Unmarshal(obj, &er); err != nil {
+		return nil
+	}
+	var out []string
+	for _, c := range er.Claims {
+		if strings.TrimSpace(c) != "" {
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
 // Judge runs the two-stage pipeline and returns a structured SupportReport.

--- a/analysis/support.go
+++ b/analysis/support.go
@@ -221,6 +221,35 @@ func parseClaimsLenient(reply string) []string {
 	return out
 }
 
+// buildEvidenceBlocks formats evidence as labeled blocks (E1..) for the verify
+// prompt and returns the matching EvidenceRefs. Evidence is assumed ranked
+// best-first; once the running size would exceed maxChars, the lower-ranked
+// tail is dropped. The first block is always kept even if it alone exceeds the
+// budget. maxChars <= 0 uses defaultMaxEvidenceChars.
+func buildEvidenceBlocks(evidence []rag.SearchResult, maxChars int) (string, []EvidenceRef) {
+	if maxChars <= 0 {
+		maxChars = defaultMaxEvidenceChars
+	}
+	var b strings.Builder
+	refs := make([]EvidenceRef, 0, len(evidence))
+	for i, r := range evidence {
+		id := fmt.Sprintf("E%d", i+1)
+		block := fmt.Sprintf("%s: %s (lines %d-%d)\n%s\n\n", id, r.Chunk.Source, r.Chunk.StartLine, r.Chunk.EndLine, r.Chunk.Content)
+		if i > 0 && b.Len()+len(block) > maxChars {
+			break
+		}
+		b.WriteString(block)
+		refs = append(refs, EvidenceRef{
+			ID:        id,
+			ChunkID:   r.Chunk.ID,
+			Source:    r.Chunk.Source,
+			StartLine: r.Chunk.StartLine,
+			EndLine:   r.Chunk.EndLine,
+		})
+	}
+	return b.String(), refs
+}
+
 // Judge runs the two-stage pipeline and returns a structured SupportReport.
 // Stages are added in later tasks; this stub validates input only.
 func (j *SupportJudge) Judge(ctx context.Context, answer string, evidence []rag.SearchResult, opts ...SupportOption) (*SupportReport, error) {

--- a/analysis/support.go
+++ b/analysis/support.go
@@ -221,11 +221,29 @@ func parseClaimsLenient(reply string) []string {
 	return out
 }
 
+// verdictSeverity ranks a verdict by how unsupportive it is, so that duplicate
+// verdicts for the same claim fail closed: a duplicate can never raise a
+// claim's support level. Contradiction is the most severe.
+func verdictSeverity(v verdict) int {
+	if v.Contradicted {
+		return 3
+	}
+	switch parseStatus(v.Status) {
+	case StatusUnsupported:
+		return 2
+	case StatusPartial:
+		return 1
+	default: // StatusSupported
+		return 0
+	}
+}
+
 // buildEvidenceBlocks formats evidence as labeled blocks (E1..) for the verify
 // prompt and returns the matching EvidenceRefs. Evidence is assumed ranked
 // best-first; once the running size would exceed maxChars, the lower-ranked
 // tail is dropped. The first block is always kept even if it alone exceeds the
 // budget. maxChars <= 0 uses defaultMaxEvidenceChars.
+// Evidence content is untrusted, caller-supplied text and is included in the verify prompt verbatim; this judge trusts its own local model, not the evidence.
 func buildEvidenceBlocks(evidence []rag.SearchResult, maxChars int) (string, []EvidenceRef) {
 	if maxChars <= 0 {
 		maxChars = defaultMaxEvidenceChars
@@ -324,7 +342,11 @@ func (j *SupportJudge) verifyClaims(ctx context.Context, claims []ClaimSupport, 
 	}
 	byID := make(map[string]verdict, len(vr.Verdicts))
 	for _, v := range vr.Verdicts {
-		byID[v.ClaimID] = v // last verdict for an id wins
+		// Duplicate claim_id fails closed: keep the least-supportive verdict so a
+		// repeated id can never upgrade a claim's support level.
+		if cur, ok := byID[v.ClaimID]; !ok || verdictSeverity(v) > verdictSeverity(cur) {
+			byID[v.ClaimID] = v
+		}
 	}
 
 	var missing, queries []string

--- a/analysis/support.go
+++ b/analysis/support.go
@@ -1,0 +1,112 @@
+package analysis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/kstruzzieri/go-llm/rag"
+)
+
+// SupportStatus classifies how well an answer (or a single claim) is supported
+// by retrieved evidence.
+type SupportStatus string
+
+const (
+	// StatusSupported means every checked claim is backed by evidence.
+	StatusSupported SupportStatus = "supported"
+	// StatusPartial means some claims are supported and some are not.
+	StatusPartial SupportStatus = "partial"
+	// StatusUnsupported means no claim is backed (or evidence contradicts one).
+	StatusUnsupported SupportStatus = "unsupported"
+)
+
+// EvidenceRef identifies one retrieved chunk by the stable label (E1..) used in
+// claim verdicts, so a SupportReport is self-describing once it leaves the call
+// site.
+type EvidenceRef struct {
+	ID        string `json:"id"`         // E1.. label referenced by ClaimSupport.EvidenceIDs
+	ChunkID   string `json:"chunk_id"`   // rag.Chunk.ID
+	Source    string `json:"source"`     // file path
+	StartLine int    `json:"start_line"`
+	EndLine   int    `json:"end_line"`
+}
+
+// ClaimSupport is the verdict for one atomic claim extracted from the answer.
+type ClaimSupport struct {
+	ID           string        `json:"id"`           // C1.. label assigned by the helper
+	Claim        string        `json:"claim"`        // claim text owned by the helper
+	Status       SupportStatus `json:"status"`
+	EvidenceIDs  []string      `json:"evidence_ids"` // E1.. labels into SupportReport.Evidence
+	Contradicted bool          `json:"contradicted"` // evidence actively refutes the claim
+	Reason       string        `json:"reason"`       // why unsupported / what is missing
+}
+
+// SupportReport is the structured result of judging an answer against evidence.
+type SupportReport struct {
+	Status                 SupportStatus  `json:"status"`
+	Claims                 []ClaimSupport `json:"claims"`
+	Evidence               []EvidenceRef  `json:"evidence"`
+	MissingEvidence        []string       `json:"missing_evidence"`
+	MissingEvidenceQueries []string       `json:"missing_evidence_queries"`
+}
+
+// ErrSupportVerifyMalformed is returned when the verify stage produces output
+// that cannot be parsed into per-claim verdicts. A verifier failure is never
+// silently reported as "unsupported".
+var ErrSupportVerifyMalformed = errors.New("analysis: verify stage produced malformed output")
+
+// defaultMaxEvidenceChars bounds the evidence text included in the verify
+// prompt unless overridden by WithMaxEvidenceChars.
+const defaultMaxEvidenceChars = 6000
+
+// supportConfig holds per-call options for Judge.
+type supportConfig struct {
+	maxEvidenceChars int
+}
+
+// SupportOption configures a Judge call.
+type SupportOption func(*supportConfig)
+
+// WithMaxEvidenceChars bounds the total characters of evidence text included in
+// the verify prompt (default 6000). A value <= 0 leaves the default in place.
+func WithMaxEvidenceChars(n int) SupportOption {
+	return func(cfg *supportConfig) {
+		if n > 0 {
+			cfg.maxEvidenceChars = n
+		}
+	}
+}
+
+// SupportJudge evaluates whether an answer is grounded in retrieved evidence
+// using a two-stage extract -> verify pipeline. It is safe for concurrent use.
+type SupportJudge struct {
+	chat  ChatFunc
+	model string
+}
+
+// NewSupportJudgeWithChat builds a SupportJudge over a router-aware ChatFunc.
+// model is an optional explicit pin: "" routes each stage by its use-case
+// (config.UseCaseExtract / config.UseCaseVerify) via RoleForUseCase; a non-empty
+// value pins both stages to that model. Returns an error for a nil chat.
+func NewSupportJudgeWithChat(chat ChatFunc, model string) (*SupportJudge, error) {
+	if chat == nil {
+		return nil, fmt.Errorf("analysis: new support judge: chat is required")
+	}
+	return &SupportJudge{chat: chat, model: model}, nil
+}
+
+// Judge runs the two-stage pipeline and returns a structured SupportReport.
+// Stages are added in later tasks; this stub validates input only.
+func (j *SupportJudge) Judge(ctx context.Context, answer string, evidence []rag.SearchResult, opts ...SupportOption) (*SupportReport, error) {
+	if answer == "" {
+		return nil, fmt.Errorf("analysis: judge support: answer is required")
+	}
+	cfg := &supportConfig{maxEvidenceChars: defaultMaxEvidenceChars}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	_ = ctx
+	_ = evidence
+	return &SupportReport{Status: StatusUnsupported}, nil
+}

--- a/analysis/support.go
+++ b/analysis/support.go
@@ -384,6 +384,35 @@ func filterEvidenceIDs(ids []string, valid map[string]bool) []string {
 	return out
 }
 
+// aggregateStatus derives the report-level status. Any contradicted claim
+// forces unsupported; otherwise all-supported -> supported, all-unsupported ->
+// unsupported, and any mix -> partial. Empty claims is unsupported.
+func aggregateStatus(claims []ClaimSupport) SupportStatus {
+	if len(claims) == 0 {
+		return StatusUnsupported
+	}
+	allSupported, allUnsupported := true, true
+	for _, c := range claims {
+		if c.Contradicted {
+			return StatusUnsupported
+		}
+		if c.Status != StatusSupported {
+			allSupported = false
+		}
+		if c.Status != StatusUnsupported {
+			allUnsupported = false
+		}
+	}
+	switch {
+	case allSupported:
+		return StatusSupported
+	case allUnsupported:
+		return StatusUnsupported
+	default:
+		return StatusPartial
+	}
+}
+
 // Judge runs the two-stage pipeline and returns a structured SupportReport.
 // Stages are added in later tasks; this stub validates input only.
 func (j *SupportJudge) Judge(ctx context.Context, answer string, evidence []rag.SearchResult, opts ...SupportOption) (*SupportReport, error) {

--- a/analysis/support.go
+++ b/analysis/support.go
@@ -413,8 +413,9 @@ func aggregateStatus(claims []ClaimSupport) SupportStatus {
 	}
 }
 
-// Judge runs the two-stage pipeline and returns a structured SupportReport.
-// Stages are added in later tasks; this stub validates input only.
+// Judge runs the two-stage extract -> verify pipeline and returns a structured
+// SupportReport. It makes no model call when answer is empty (returns an error)
+// or when evidence is empty (returns a deterministic unsupported report).
 func (j *SupportJudge) Judge(ctx context.Context, answer string, evidence []rag.SearchResult, opts ...SupportOption) (*SupportReport, error) {
 	if answer == "" {
 		return nil, fmt.Errorf("analysis: judge support: answer is required")
@@ -423,7 +424,27 @@ func (j *SupportJudge) Judge(ctx context.Context, answer string, evidence []rag.
 	for _, opt := range opts {
 		opt(cfg)
 	}
-	_ = ctx
-	_ = evidence
-	return &SupportReport{Status: StatusUnsupported}, nil
+	if len(evidence) == 0 {
+		return &SupportReport{
+			Status:          StatusUnsupported,
+			MissingEvidence: []string{"no evidence provided"},
+		}, nil
+	}
+
+	claims, err := j.extractClaims(ctx, answer)
+	if err != nil {
+		return nil, err
+	}
+	blocks, refs := buildEvidenceBlocks(evidence, cfg.maxEvidenceChars)
+	claims, missing, queries, err := j.verifyClaims(ctx, claims, blocks, refs)
+	if err != nil {
+		return nil, err
+	}
+	return &SupportReport{
+		Status:                 aggregateStatus(claims),
+		Claims:                 claims,
+		Evidence:               refs,
+		MissingEvidence:        missing,
+		MissingEvidenceQueries: queries,
+	}, nil
 }

--- a/analysis/support.go
+++ b/analysis/support.go
@@ -250,6 +250,140 @@ func buildEvidenceBlocks(evidence []rag.SearchResult, maxChars int) (string, []E
 	return b.String(), refs
 }
 
+const verifySystem = "You judge whether each claim is supported by the evidence. " +
+	"Use ONLY the evidence blocks; do not use outside knowledge."
+
+const verifyInstruction = "For each claim return JSON of the form " +
+	"{\"verdicts\":[{\"claim_id\":\"C1\",\"status\":\"supported|partial|unsupported\"," +
+	"\"evidence_ids\":[\"E1\"],\"contradicted\":false,\"reason\":\"...\",\"missing_query\":\"...\"}]}. " +
+	"status is supported, partial, or unsupported. evidence_ids cite the E labels that back the claim. " +
+	"contradicted is true only when an evidence block refutes the claim. " +
+	"missing_query is a short retrieval query that might find support, set only when unsupported. " +
+	"Return ONLY the JSON, no commentary, no markdown."
+
+// verdict is one entry of the verify stage's JSON reply.
+type verdict struct {
+	ClaimID      string   `json:"claim_id"`
+	Status       string   `json:"status"`
+	EvidenceIDs  []string `json:"evidence_ids"`
+	Contradicted bool     `json:"contradicted"`
+	Reason       string   `json:"reason"`
+	MissingQuery string   `json:"missing_query"`
+}
+
+type verifyReply struct {
+	Verdicts []verdict `json:"verdicts"`
+}
+
+// parseStatus normalizes a model status string, failing closed to
+// StatusUnsupported on anything unrecognized.
+func parseStatus(s string) SupportStatus {
+	switch SupportStatus(strings.ToLower(strings.TrimSpace(s))) {
+	case StatusSupported:
+		return StatusSupported
+	case StatusPartial:
+		return StatusPartial
+	default:
+		return StatusUnsupported
+	}
+}
+
+// verifyClaims runs the verify stage, maps verdicts back to the extracted
+// claims by id, normalizes/fails-closed, and returns the updated claims plus
+// the de-duplicated missing-evidence reasons and retrieval queries.
+func (j *SupportJudge) verifyClaims(ctx context.Context, claims []ClaimSupport, blocks string, refs []EvidenceRef) ([]ClaimSupport, []string, []string, error) {
+	var cb strings.Builder
+	for _, c := range claims {
+		fmt.Fprintf(&cb, "%s: %s\n", c.ID, c.Claim)
+	}
+	zero := 0.0
+	resp, err := j.chat(ctx, config.UseCaseVerify, provider.ChatRequest{
+		Model:   j.model,
+		Options: provider.ModelOptions{Temperature: &zero},
+		Messages: []provider.ChatMessage{
+			{Role: "system", Content: verifySystem},
+			{Role: "user", Content: "Evidence:\n" + blocks + "\nClaims:\n" + cb.String() + "\n" + verifyInstruction},
+		},
+	})
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("analysis: judge support: verify: %w", err)
+	}
+
+	obj := lastJSONObjectWith(resp.Content, "verdicts")
+	if obj == nil {
+		return nil, nil, nil, ErrSupportVerifyMalformed
+	}
+	var vr verifyReply
+	if err := json.Unmarshal(obj, &vr); err != nil {
+		return nil, nil, nil, fmt.Errorf("%w: %v", ErrSupportVerifyMalformed, err)
+	}
+
+	validEvidence := make(map[string]bool, len(refs))
+	for _, r := range refs {
+		validEvidence[r.ID] = true
+	}
+	byID := make(map[string]verdict, len(vr.Verdicts))
+	for _, v := range vr.Verdicts {
+		byID[v.ClaimID] = v // last verdict for an id wins
+	}
+
+	var missing, queries []string
+	seenQuery := make(map[string]bool)
+	for i := range claims {
+		c := &claims[i]
+		v, ok := byID[c.ID]
+		if !ok {
+			c.Status = StatusUnsupported
+			c.Reason = "no verifier verdict returned"
+			missing = append(missing, c.ID+": "+c.Reason)
+			continue
+		}
+		c.Contradicted = v.Contradicted
+		c.Reason = v.Reason
+		c.Status = parseStatus(v.Status)
+		c.EvidenceIDs = filterEvidenceIDs(v.EvidenceIDs, validEvidence)
+		if c.Contradicted {
+			c.Status = StatusUnsupported
+			if c.Reason == "" {
+				c.Reason = "evidence contradicts claim"
+			}
+		}
+		// A support claim with no addressable evidence is not inspectable.
+		if (c.Status == StatusSupported || c.Status == StatusPartial) && len(c.EvidenceIDs) == 0 {
+			c.Status = StatusUnsupported
+			if c.Reason == "" {
+				c.Reason = "claimed support but cited no valid evidence"
+			}
+		}
+		if c.Status == StatusUnsupported {
+			reason := c.Reason
+			if reason == "" {
+				reason = "unsupported"
+			}
+			missing = append(missing, c.ID+": "+reason)
+			if q := strings.TrimSpace(v.MissingQuery); q != "" && !seenQuery[q] {
+				seenQuery[q] = true
+				queries = append(queries, q)
+			}
+		}
+	}
+	return claims, missing, queries, nil
+}
+
+// filterEvidenceIDs keeps only ids present in valid, preserving order and
+// dropping duplicates.
+func filterEvidenceIDs(ids []string, valid map[string]bool) []string {
+	var out []string
+	seen := make(map[string]bool)
+	for _, id := range ids {
+		if valid[id] && !seen[id] {
+			seen[id] = true
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
 // Judge runs the two-stage pipeline and returns a structured SupportReport.
 // Stages are added in later tasks; this stub validates input only.
 func (j *SupportJudge) Judge(ctx context.Context, answer string, evidence []rag.SearchResult, opts ...SupportOption) (*SupportReport, error) {

--- a/analysis/support.go
+++ b/analysis/support.go
@@ -29,17 +29,17 @@ const (
 // claim verdicts, so a SupportReport is self-describing once it leaves the call
 // site.
 type EvidenceRef struct {
-	ID        string `json:"id"`         // E1.. label referenced by ClaimSupport.EvidenceIDs
-	ChunkID   string `json:"chunk_id"`   // rag.Chunk.ID
-	Source    string `json:"source"`     // file path
+	ID        string `json:"id"`       // E1.. label referenced by ClaimSupport.EvidenceIDs
+	ChunkID   string `json:"chunk_id"` // rag.Chunk.ID
+	Source    string `json:"source"`   // file path
 	StartLine int    `json:"start_line"`
 	EndLine   int    `json:"end_line"`
 }
 
 // ClaimSupport is the verdict for one atomic claim extracted from the answer.
 type ClaimSupport struct {
-	ID           string        `json:"id"`           // C1.. label assigned by the helper
-	Claim        string        `json:"claim"`        // claim text owned by the helper
+	ID           string        `json:"id"`    // C1.. label assigned by the helper
+	Claim        string        `json:"claim"` // claim text owned by the helper
 	Status       SupportStatus `json:"status"`
 	EvidenceIDs  []string      `json:"evidence_ids"` // E1.. labels into SupportReport.Evidence
 	Contradicted bool          `json:"contradicted"` // evidence actively refutes the claim

--- a/analysis/support.go
+++ b/analysis/support.go
@@ -2,6 +2,7 @@ package analysis
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -94,6 +95,64 @@ func NewSupportJudgeWithChat(chat ChatFunc, model string) (*SupportJudge, error)
 		return nil, fmt.Errorf("analysis: new support judge: chat is required")
 	}
 	return &SupportJudge{chat: chat, model: model}, nil
+}
+
+// topLevelJSONObjects returns each balanced, top-level {...} substring in s,
+// honoring string literals and escapes so braces inside JSON strings do not
+// break nesting. Order is preserved.
+func topLevelJSONObjects(s string) []string {
+	var out []string
+	depth, start := 0, -1
+	inStr, esc := false, false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if inStr {
+			switch {
+			case esc:
+				esc = false
+			case c == '\\':
+				esc = true
+			case c == '"':
+				inStr = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inStr = true
+		case '{':
+			if depth == 0 {
+				start = i
+			}
+			depth++
+		case '}':
+			if depth > 0 {
+				depth--
+				if depth == 0 && start >= 0 {
+					out = append(out, s[start:i+1])
+					start = -1
+				}
+			}
+		}
+	}
+	return out
+}
+
+// lastJSONObjectWith returns the raw bytes of the last top-level JSON object in
+// reply that parses and contains key, or nil. Choosing the last match skips
+// example/prefatory JSON the model may emit before its real answer.
+func lastJSONObjectWith(reply, key string) []byte {
+	objs := topLevelJSONObjects(reply)
+	for i := len(objs) - 1; i >= 0; i-- {
+		var probe map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(objs[i]), &probe); err != nil {
+			continue
+		}
+		if _, ok := probe[key]; ok {
+			return []byte(objs[i])
+		}
+	}
+	return nil
 }
 
 // Judge runs the two-stage pipeline and returns a structured SupportReport.

--- a/analysis/support.go
+++ b/analysis/support.go
@@ -341,10 +341,16 @@ func (j *SupportJudge) verifyClaims(ctx context.Context, claims []ClaimSupport, 
 		validEvidence[r.ID] = true
 	}
 	byID := make(map[string]verdict, len(vr.Verdicts))
+	duplicateID := make(map[string]bool)
 	for _, v := range vr.Verdicts {
 		// Duplicate claim_id fails closed: keep the least-supportive verdict so a
 		// repeated id can never upgrade a claim's support level.
-		if cur, ok := byID[v.ClaimID]; !ok || verdictSeverity(v) > verdictSeverity(cur) {
+		if cur, ok := byID[v.ClaimID]; ok {
+			duplicateID[v.ClaimID] = true
+			if verdictSeverity(v) > verdictSeverity(cur) {
+				byID[v.ClaimID] = v
+			}
+		} else {
 			byID[v.ClaimID] = v
 		}
 	}
@@ -357,6 +363,12 @@ func (j *SupportJudge) verifyClaims(ctx context.Context, claims []ClaimSupport, 
 		if !ok {
 			c.Status = StatusUnsupported
 			c.Reason = "no verifier verdict returned"
+			missing = append(missing, c.ID+": "+c.Reason)
+			continue
+		}
+		if duplicateID[c.ID] {
+			c.Status = StatusUnsupported
+			c.Reason = "duplicate verifier verdicts returned"
 			missing = append(missing, c.ID+": "+c.Reason)
 			continue
 		}

--- a/analysis/support_fixture_test.go
+++ b/analysis/support_fixture_test.go
@@ -1,0 +1,37 @@
+package analysis
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/rag"
+)
+
+// The same answer+evidence pair is judged two ways elsewhere: the MCP quote
+// verifier (mcp/tools_rag_answer.go) catches an invented literal quote, while
+// this semantic judge catches an unsupported claim. Here we assert the
+// semantic side: an answer whose claim is not entailed is unsupported, and an
+// answer whose claim is entailed is supported, over identical evidence.
+func TestSemanticJudge_FixtureDefectClasses(t *testing.T) {
+	evidence := []rag.SearchResult{ev("h1", "doc.md", "The service retries 3 times on failure.", 1, 1)}
+
+	supported := &recordingChat{replies: []string{
+		`{"claims":["the service retries three times"]}`,
+		`{"verdicts":[{"claim_id":"C1","status":"supported","evidence_ids":["E1"]}]}`,
+	}}
+	j1, _ := NewSupportJudgeWithChat(supported.fn(), "m")
+	r1, err := j1.Judge(context.Background(), "It retries three times.", evidence)
+	if err != nil || r1.Status != StatusSupported {
+		t.Fatalf("entailed claim should be supported: status=%v err=%v", r1.Status, err)
+	}
+
+	unsupported := &recordingChat{replies: []string{
+		`{"claims":["the service sends an email on failure"]}`,
+		`{"verdicts":[{"claim_id":"C1","status":"unsupported","evidence_ids":[],"missing_query":"email on failure"}]}`,
+	}}
+	j2, _ := NewSupportJudgeWithChat(unsupported.fn(), "m")
+	r2, _ := j2.Judge(context.Background(), "It emails you on failure.", evidence)
+	if r2.Status != StatusUnsupported {
+		t.Fatalf("non-entailed claim should be unsupported, got %v", r2.Status)
+	}
+}

--- a/analysis/support_test.go
+++ b/analysis/support_test.go
@@ -436,6 +436,7 @@ func TestVerifyClaims_DuplicateClaimIDFailsClosed(t *testing.T) {
 	for _, reply := range []string{
 		`{"verdicts":[{"claim_id":"C1","status":"unsupported","evidence_ids":[]},{"claim_id":"C1","status":"supported","evidence_ids":["E1"]}]}`,
 		`{"verdicts":[{"claim_id":"C1","status":"supported","evidence_ids":["E1"]},{"claim_id":"C1","status":"unsupported","evidence_ids":[]}]}`,
+		`{"verdicts":[{"claim_id":"C1","status":"supported","evidence_ids":["E1"]},{"claim_id":"C1","status":"supported","evidence_ids":["E1"]}]}`,
 	} {
 		rc := &recordingChat{replies: []string{reply}}
 		j, _ := NewSupportJudgeWithChat(rc.fn(), "m")

--- a/analysis/support_test.go
+++ b/analysis/support_test.go
@@ -328,3 +328,28 @@ func TestVerifyClaims_DedupQueries(t *testing.T) {
 		t.Errorf("duplicate queries should dedup to 1, got %v", queries)
 	}
 }
+
+func TestAggregateStatus(t *testing.T) {
+	c := func(s SupportStatus, contra bool) ClaimSupport {
+		return ClaimSupport{Status: s, Contradicted: contra}
+	}
+	tests := []struct {
+		name   string
+		claims []ClaimSupport
+		want   SupportStatus
+	}{
+		{"empty", nil, StatusUnsupported},
+		{"all supported", []ClaimSupport{c(StatusSupported, false), c(StatusSupported, false)}, StatusSupported},
+		{"all unsupported", []ClaimSupport{c(StatusUnsupported, false), c(StatusUnsupported, false)}, StatusUnsupported},
+		{"mixed", []ClaimSupport{c(StatusSupported, false), c(StatusUnsupported, false)}, StatusPartial},
+		{"partial present", []ClaimSupport{c(StatusPartial, false), c(StatusSupported, false)}, StatusPartial},
+		{"contradicted overrides", []ClaimSupport{c(StatusSupported, false), c(StatusSupported, true)}, StatusUnsupported},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := aggregateStatus(tt.claims); got != tt.want {
+				t.Errorf("aggregateStatus = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/analysis/support_test.go
+++ b/analysis/support_test.go
@@ -329,6 +329,108 @@ func TestVerifyClaims_DedupQueries(t *testing.T) {
 	}
 }
 
+func twoEvidence() []rag.SearchResult {
+	return []rag.SearchResult{ev("h1", "a.go", "alpha facts", 1, 2), ev("h2", "b.go", "beta facts", 3, 4)}
+}
+
+func TestJudge_EmptyAnswer(t *testing.T) {
+	rc := &recordingChat{}
+	j, _ := NewSupportJudgeWithChat(rc.fn(), "m")
+	if _, err := j.Judge(context.Background(), "", twoEvidence()); err == nil {
+		t.Fatal("expected validation error for empty answer")
+	}
+	if len(rc.calls) != 0 {
+		t.Error("no model call expected for empty answer")
+	}
+}
+
+func TestJudge_EmptyEvidenceShortCircuits(t *testing.T) {
+	rc := &recordingChat{}
+	j, _ := NewSupportJudgeWithChat(rc.fn(), "m")
+	report, err := j.Judge(context.Background(), "some answer", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Status != StatusUnsupported {
+		t.Errorf("status = %q, want unsupported", report.Status)
+	}
+	if len(report.MissingEvidence) == 0 {
+		t.Error("expected a missing-evidence note")
+	}
+	if len(rc.calls) != 0 {
+		t.Fatalf("no model calls expected on empty evidence, got %d", len(rc.calls))
+	}
+}
+
+func TestJudge_Supported(t *testing.T) {
+	rc := &recordingChat{replies: []string{
+		`{"claims":["alpha","beta"]}`,
+		`{"verdicts":[{"claim_id":"C1","status":"supported","evidence_ids":["E1"]},{"claim_id":"C2","status":"supported","evidence_ids":["E2"]}]}`,
+	}}
+	j, _ := NewSupportJudgeWithChat(rc.fn(), "m")
+	report, err := j.Judge(context.Background(), "answer", twoEvidence())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Status != StatusSupported {
+		t.Errorf("status = %q, want supported", report.Status)
+	}
+	if len(report.Evidence) != 2 {
+		t.Errorf("expected 2 evidence refs, got %d", len(report.Evidence))
+	}
+	// Proves both #60 roles are consumed, in order.
+	if len(rc.calls) != 2 || rc.calls[0].useCase != config.UseCaseExtract || rc.calls[1].useCase != config.UseCaseVerify {
+		t.Fatalf("call order/use-cases wrong: %+v", rc.calls)
+	}
+}
+
+func TestJudge_Unsupported(t *testing.T) {
+	rc := &recordingChat{replies: []string{
+		`{"claims":["alpha"]}`,
+		`{"verdicts":[{"claim_id":"C1","status":"unsupported","evidence_ids":[],"missing_query":"find alpha"}]}`,
+	}}
+	j, _ := NewSupportJudgeWithChat(rc.fn(), "m")
+	report, _ := j.Judge(context.Background(), "answer", twoEvidence())
+	if report.Status != StatusUnsupported {
+		t.Errorf("status = %q, want unsupported", report.Status)
+	}
+	if len(report.MissingEvidenceQueries) != 1 {
+		t.Errorf("expected one missing-evidence query, got %v", report.MissingEvidenceQueries)
+	}
+}
+
+func TestJudge_Partial(t *testing.T) {
+	rc := &recordingChat{replies: []string{
+		`{"claims":["alpha","beta"]}`,
+		`{"verdicts":[{"claim_id":"C1","status":"supported","evidence_ids":["E1"]},{"claim_id":"C2","status":"unsupported","evidence_ids":[]}]}`,
+	}}
+	j, _ := NewSupportJudgeWithChat(rc.fn(), "m")
+	report, _ := j.Judge(context.Background(), "answer", twoEvidence())
+	if report.Status != StatusPartial {
+		t.Errorf("status = %q, want partial", report.Status)
+	}
+}
+
+func TestJudge_ContradictedForcesUnsupported(t *testing.T) {
+	rc := &recordingChat{replies: []string{
+		`{"claims":["alpha","beta"]}`,
+		`{"verdicts":[{"claim_id":"C1","status":"supported","evidence_ids":["E1"]},{"claim_id":"C2","status":"supported","evidence_ids":["E2"],"contradicted":true}]}`,
+	}}
+	j, _ := NewSupportJudgeWithChat(rc.fn(), "m")
+	report, _ := j.Judge(context.Background(), "answer", twoEvidence())
+	if report.Status != StatusUnsupported {
+		t.Errorf("contradicted claim must force unsupported, got %q", report.Status)
+	}
+}
+
+func TestJudge_MalformedVerifyPropagates(t *testing.T) {
+	rc := &recordingChat{replies: []string{`{"claims":["alpha"]}`, `not json`}}
+	j, _ := NewSupportJudgeWithChat(rc.fn(), "m")
+	if _, err := j.Judge(context.Background(), "answer", twoEvidence()); !errors.Is(err, ErrSupportVerifyMalformed) {
+		t.Fatalf("err = %v, want ErrSupportVerifyMalformed", err)
+	}
+}
+
 func TestAggregateStatus(t *testing.T) {
 	c := func(s SupportStatus, contra bool) ClaimSupport {
 		return ClaimSupport{Status: s, Contradicted: contra}

--- a/analysis/support_test.go
+++ b/analysis/support_test.go
@@ -89,3 +89,35 @@ func TestErrSupportVerifyMalformed_Sentinel(t *testing.T) {
 		t.Fatal("sentinel must match through wrapping via errors.Is")
 	}
 }
+
+func TestLastJSONObjectWith(t *testing.T) {
+	tests := []struct {
+		name  string
+		reply string
+		key   string
+		want  string // "" means nil
+	}{
+		{"plain", `{"claims":["a"]}`, "claims", `{"claims":["a"]}`},
+		{"fenced", "```json\n{\"claims\":[\"a\"]}\n```", "claims", `{"claims":["a"]}`},
+		{"prefatory then real", `here is an example {"foo":1} and the answer {"claims":["a","b"]}`, "claims", `{"claims":["a","b"]}`},
+		{"trailing prose", `{"claims":["a"]} hope that helps`, "claims", `{"claims":["a"]}`},
+		{"brace in string", `{"claims":["uses {x} syntax"]}`, "claims", `{"claims":["uses {x} syntax"]}`},
+		{"missing key", `{"foo":1}`, "claims", ""},
+		{"no json", `sorry, no json here`, "claims", ""},
+		{"last wins", `{"claims":["old"]} {"claims":["new"]}`, "claims", `{"claims":["new"]}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := lastJSONObjectWith(tt.reply, tt.key)
+			if tt.want == "" {
+				if got != nil {
+					t.Fatalf("got %q, want nil", got)
+				}
+				return
+			}
+			if string(got) != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/analysis/support_test.go
+++ b/analysis/support_test.go
@@ -216,3 +216,115 @@ func TestBuildEvidenceBlocks_KeepsFirstEvenIfOversized(t *testing.T) {
 		t.Errorf("expected E1 block present: %q", text)
 	}
 }
+
+func claimsFixture() []ClaimSupport {
+	return []ClaimSupport{
+		{ID: "C1", Claim: "alpha", Status: StatusUnsupported},
+		{ID: "C2", Claim: "beta", Status: StatusUnsupported},
+	}
+}
+
+func refsFixture() []EvidenceRef {
+	return []EvidenceRef{{ID: "E1", ChunkID: "h1", Source: "a.go"}}
+}
+
+func TestVerifyClaims_MapsByClaimID(t *testing.T) {
+	reply := `{"verdicts":[
+		{"claim_id":"C2","status":"supported","evidence_ids":["E1"],"contradicted":false,"reason":"ok","missing_query":""},
+		{"claim_id":"C1","status":"unsupported","evidence_ids":[],"contradicted":false,"reason":"not found","missing_query":"find alpha"}
+	]}`
+	rc := &recordingChat{replies: []string{reply}}
+	j, _ := NewSupportJudgeWithChat(rc.fn(), "m")
+	claims, missing, queries, err := j.verifyClaims(context.Background(), claimsFixture(), "E1: a.go\n...", refsFixture())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// C1 stays text "alpha" even though verdict order differs; mapping is by id.
+	if claims[0].ID != "C1" || claims[0].Claim != "alpha" || claims[0].Status != StatusUnsupported {
+		t.Errorf("C1 = %+v", claims[0])
+	}
+	if claims[1].ID != "C2" || claims[1].Status != StatusSupported || len(claims[1].EvidenceIDs) != 1 {
+		t.Errorf("C2 = %+v", claims[1])
+	}
+	if rc.calls[0].useCase != config.UseCaseVerify {
+		t.Errorf("useCase = %q, want %q", rc.calls[0].useCase, config.UseCaseVerify)
+	}
+	if len(missing) == 0 {
+		t.Error("expected missing evidence reasons for unsupported C1")
+	}
+	if len(queries) != 1 || queries[0] != "find alpha" {
+		t.Errorf("queries = %v, want [find alpha]", queries)
+	}
+}
+
+func TestVerifyClaims_MissingVerdictFailsClosed(t *testing.T) {
+	reply := `{"verdicts":[{"claim_id":"C1","status":"supported","evidence_ids":["E1"]}]}`
+	rc := &recordingChat{replies: []string{reply}}
+	j, _ := NewSupportJudgeWithChat(rc.fn(), "m")
+	claims, _, _, err := j.verifyClaims(context.Background(), claimsFixture(), "blocks", refsFixture())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if claims[1].Status != StatusUnsupported || claims[1].Reason == "" {
+		t.Errorf("C2 with no verdict should be unsupported with a reason: %+v", claims[1])
+	}
+}
+
+func TestVerifyClaims_UnknownStatusFailsClosed(t *testing.T) {
+	reply := `{"verdicts":[{"claim_id":"C1","status":"maybe","evidence_ids":["E1"]},{"claim_id":"C2","status":"supported","evidence_ids":["E1"]}]}`
+	rc := &recordingChat{replies: []string{reply}}
+	j, _ := NewSupportJudgeWithChat(rc.fn(), "m")
+	claims, _, _, _ := j.verifyClaims(context.Background(), claimsFixture(), "blocks", refsFixture())
+	if claims[0].Status != StatusUnsupported {
+		t.Errorf("unknown status should fail closed to unsupported, got %q", claims[0].Status)
+	}
+}
+
+func TestVerifyClaims_DowngradeSupportedWithoutEvidence(t *testing.T) {
+	// supported/partial with no valid evidence id -> downgrade to unsupported.
+	reply := `{"verdicts":[{"claim_id":"C1","status":"supported","evidence_ids":["E9"]},{"claim_id":"C2","status":"partial","evidence_ids":[]}]}`
+	rc := &recordingChat{replies: []string{reply}}
+	j, _ := NewSupportJudgeWithChat(rc.fn(), "m")
+	claims, _, _, _ := j.verifyClaims(context.Background(), claimsFixture(), "blocks", refsFixture())
+	if claims[0].Status != StatusUnsupported || len(claims[0].EvidenceIDs) != 0 {
+		t.Errorf("C1 supported with only invalid E9 should downgrade: %+v", claims[0])
+	}
+	if claims[1].Status != StatusUnsupported {
+		t.Errorf("C2 partial with no evidence should downgrade: %+v", claims[1])
+	}
+}
+
+func TestVerifyClaims_ContradictedFailsClosed(t *testing.T) {
+	reply := `{"verdicts":[{"claim_id":"C1","status":"supported","evidence_ids":["E1"],"contradicted":true},{"claim_id":"C2","status":"supported","evidence_ids":["E1"]}]}`
+	rc := &recordingChat{replies: []string{reply}}
+	j, _ := NewSupportJudgeWithChat(rc.fn(), "m")
+	claims, missing, _, _ := j.verifyClaims(context.Background(), claimsFixture(), "blocks", refsFixture())
+	if claims[0].Status != StatusUnsupported || !claims[0].Contradicted {
+		t.Errorf("contradicted claim should fail closed to unsupported: %+v", claims[0])
+	}
+	if len(missing) == 0 {
+		t.Error("contradicted claim should produce missing-evidence detail")
+	}
+}
+
+func TestVerifyClaims_Malformed(t *testing.T) {
+	rc := &recordingChat{replies: []string{`sorry, I could not produce JSON`}}
+	j, _ := NewSupportJudgeWithChat(rc.fn(), "m")
+	_, _, _, err := j.verifyClaims(context.Background(), claimsFixture(), "blocks", refsFixture())
+	if !errors.Is(err, ErrSupportVerifyMalformed) {
+		t.Fatalf("err = %v, want ErrSupportVerifyMalformed", err)
+	}
+}
+
+func TestVerifyClaims_DedupQueries(t *testing.T) {
+	reply := `{"verdicts":[
+		{"claim_id":"C1","status":"unsupported","evidence_ids":[],"missing_query":"q"},
+		{"claim_id":"C2","status":"unsupported","evidence_ids":[],"missing_query":"q"}
+	]}`
+	rc := &recordingChat{replies: []string{reply}}
+	j, _ := NewSupportJudgeWithChat(rc.fn(), "m")
+	_, _, queries, _ := j.verifyClaims(context.Background(), claimsFixture(), "blocks", refsFixture())
+	if len(queries) != 1 {
+		t.Errorf("duplicate queries should dedup to 1, got %v", queries)
+	}
+}

--- a/analysis/support_test.go
+++ b/analysis/support_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kstruzzieri/go-llm/config"
 	"github.com/kstruzzieri/go-llm/provider"
 )
 
@@ -119,5 +120,51 @@ func TestLastJSONObjectWith(t *testing.T) {
 				t.Fatalf("got %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestExtractClaims_WellFormed(t *testing.T) {
+	rc := &recordingChat{replies: []string{`{"claims":["the sky is blue","water is wet"]}`}}
+	j, _ := NewSupportJudgeWithChat(rc.fn(), "m")
+	claims, err := j.extractClaims(context.Background(), "answer text")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(claims) != 2 {
+		t.Fatalf("got %d claims, want 2", len(claims))
+	}
+	if claims[0].ID != "C1" || claims[1].ID != "C2" {
+		t.Errorf("labels = %q,%q want C1,C2", claims[0].ID, claims[1].ID)
+	}
+	if claims[0].Claim != "the sky is blue" {
+		t.Errorf("claim[0] = %q", claims[0].Claim)
+	}
+	if claims[0].Status != StatusUnsupported {
+		t.Errorf("default status = %q, want unsupported (fail closed)", claims[0].Status)
+	}
+	if len(rc.calls) != 1 || rc.calls[0].useCase != config.UseCaseExtract {
+		t.Fatalf("expected one call with useCase %q, got %+v", config.UseCaseExtract, rc.calls)
+	}
+}
+
+func TestExtractClaims_FallbackWholeAnswer(t *testing.T) {
+	for _, reply := range []string{`not json at all`, `{"claims":[]}`, `{"claims":["   "]}`} {
+		rc := &recordingChat{replies: []string{reply}}
+		j, _ := NewSupportJudgeWithChat(rc.fn(), "m")
+		claims, err := j.extractClaims(context.Background(), "the whole answer")
+		if err != nil {
+			t.Fatalf("reply %q: unexpected error: %v", reply, err)
+		}
+		if len(claims) != 1 || claims[0].Claim != "the whole answer" || claims[0].ID != "C1" {
+			t.Fatalf("reply %q: want single whole-answer claim, got %+v", reply, claims)
+		}
+	}
+}
+
+func TestExtractClaims_ChatError(t *testing.T) {
+	rc := &recordingChat{err: errors.New("boom")}
+	j, _ := NewSupportJudgeWithChat(rc.fn(), "m")
+	if _, err := j.extractClaims(context.Background(), "x"); err == nil {
+		t.Fatal("expected error propagated from chat")
 	}
 }

--- a/analysis/support_test.go
+++ b/analysis/support_test.go
@@ -1,0 +1,91 @@
+package analysis
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// recordingChat is a fake ChatFunc that returns queued replies in call order
+// and records each call's use-case and request. replies[0] answers the first
+// call (extract), replies[1] the second (verify).
+type recordingChat struct {
+	replies []string
+	err     error
+	calls   []recordedCall
+}
+
+type recordedCall struct {
+	useCase string
+	req     provider.ChatRequest
+}
+
+func (rc *recordingChat) fn() ChatFunc {
+	return func(_ context.Context, useCase string, req provider.ChatRequest) (*provider.ChatResponse, error) {
+		rc.calls = append(rc.calls, recordedCall{useCase: useCase, req: req})
+		if rc.err != nil {
+			return nil, rc.err
+		}
+		i := len(rc.calls) - 1
+		content := ""
+		if i < len(rc.replies) {
+			content = rc.replies[i]
+		}
+		return &provider.ChatResponse{Content: content, Done: true}, nil
+	}
+}
+
+func TestNewSupportJudge_NilChat(t *testing.T) {
+	if _, err := NewSupportJudgeWithChat(nil, ""); err == nil {
+		t.Fatal("expected error for nil chat")
+	}
+}
+
+func TestNewSupportJudge_OK(t *testing.T) {
+	rc := &recordingChat{}
+	j, err := NewSupportJudgeWithChat(rc.fn(), "m")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if j == nil {
+		t.Fatal("expected non-nil judge")
+	}
+}
+
+func TestSupportReport_JSONShape(t *testing.T) {
+	r := SupportReport{
+		Status: StatusPartial,
+		Claims: []ClaimSupport{{
+			ID: "C1", Claim: "x", Status: StatusSupported,
+			EvidenceIDs: []string{"E1"}, Contradicted: false, Reason: "ok",
+		}},
+		Evidence:               []EvidenceRef{{ID: "E1", ChunkID: "h", Source: "a.go", StartLine: 1, EndLine: 2}},
+		MissingEvidence:        []string{"gap"},
+		MissingEvidenceQueries: []string{"q"},
+	}
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, want := range []string{
+		`"status"`, `"claims"`, `"evidence"`, `"missing_evidence"`,
+		`"missing_evidence_queries"`, `"evidence_ids"`, `"chunk_id"`,
+		`"start_line"`, `"end_line"`, `"contradicted"`,
+	} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("marshaled report missing %s: %s", want, data)
+		}
+	}
+}
+
+func TestErrSupportVerifyMalformed_Sentinel(t *testing.T) {
+	wrapped := fmt.Errorf("wrapped: %w", ErrSupportVerifyMalformed)
+	if !errors.Is(wrapped, ErrSupportVerifyMalformed) {
+		t.Fatal("sentinel must match through wrapping via errors.Is")
+	}
+}

--- a/analysis/support_test.go
+++ b/analysis/support_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kstruzzieri/go-llm/config"
 	"github.com/kstruzzieri/go-llm/provider"
+	"github.com/kstruzzieri/go-llm/rag"
 )
 
 // recordingChat is a fake ChatFunc that returns queued replies in call order
@@ -166,5 +167,52 @@ func TestExtractClaims_ChatError(t *testing.T) {
 	j, _ := NewSupportJudgeWithChat(rc.fn(), "m")
 	if _, err := j.extractClaims(context.Background(), "x"); err == nil {
 		t.Fatal("expected error propagated from chat")
+	}
+}
+
+func ev(id, source, content string, start, end int) rag.SearchResult {
+	return rag.SearchResult{Chunk: rag.Chunk{ID: id, Source: source, Content: content, StartLine: start, EndLine: end}}
+}
+
+func TestBuildEvidenceBlocks_LabelsAndRefs(t *testing.T) {
+	evidence := []rag.SearchResult{
+		ev("h1", "a.go", "alpha", 1, 2),
+		ev("h2", "b.go", "beta", 3, 4),
+	}
+	text, refs := buildEvidenceBlocks(evidence, 0)
+	if len(refs) != 2 {
+		t.Fatalf("got %d refs, want 2", len(refs))
+	}
+	if refs[0].ID != "E1" || refs[0].ChunkID != "h1" || refs[0].Source != "a.go" || refs[0].StartLine != 1 || refs[0].EndLine != 2 {
+		t.Errorf("ref[0] = %+v", refs[0])
+	}
+	if refs[1].ID != "E2" {
+		t.Errorf("ref[1].ID = %q, want E2", refs[1].ID)
+	}
+	if !strings.Contains(text, "E1: a.go (lines 1-2)") || !strings.Contains(text, "alpha") {
+		t.Errorf("text missing E1 block: %q", text)
+	}
+}
+
+func TestBuildEvidenceBlocks_BudgetDropsTail(t *testing.T) {
+	evidence := []rag.SearchResult{
+		ev("h1", "a.go", strings.Repeat("x", 40), 1, 1),
+		ev("h2", "b.go", strings.Repeat("y", 40), 2, 2),
+		ev("h3", "c.go", strings.Repeat("z", 40), 3, 3),
+	}
+	_, refs := buildEvidenceBlocks(evidence, 60) // only the first block fits under 60
+	if len(refs) != 1 || refs[0].ID != "E1" {
+		t.Fatalf("budget should keep only E1, got %d refs", len(refs))
+	}
+}
+
+func TestBuildEvidenceBlocks_KeepsFirstEvenIfOversized(t *testing.T) {
+	evidence := []rag.SearchResult{ev("h1", "a.go", strings.Repeat("x", 500), 1, 1)}
+	text, refs := buildEvidenceBlocks(evidence, 10) // first block alone exceeds budget
+	if len(refs) != 1 || refs[0].ID != "E1" {
+		t.Fatalf("first block must always be kept, got %d refs", len(refs))
+	}
+	if !strings.Contains(text, "E1:") {
+		t.Errorf("expected E1 block present: %q", text)
 	}
 }

--- a/analysis/support_test.go
+++ b/analysis/support_test.go
@@ -431,6 +431,24 @@ func TestJudge_MalformedVerifyPropagates(t *testing.T) {
 	}
 }
 
+func TestVerifyClaims_DuplicateClaimIDFailsClosed(t *testing.T) {
+	// Both orderings must fail closed: a duplicate verdict can never upgrade.
+	for _, reply := range []string{
+		`{"verdicts":[{"claim_id":"C1","status":"unsupported","evidence_ids":[]},{"claim_id":"C1","status":"supported","evidence_ids":["E1"]}]}`,
+		`{"verdicts":[{"claim_id":"C1","status":"supported","evidence_ids":["E1"]},{"claim_id":"C1","status":"unsupported","evidence_ids":[]}]}`,
+	} {
+		rc := &recordingChat{replies: []string{reply}}
+		j, _ := NewSupportJudgeWithChat(rc.fn(), "m")
+		claims, _, _, err := j.verifyClaims(context.Background(), []ClaimSupport{{ID: "C1", Claim: "alpha", Status: StatusUnsupported}}, "E1: a.go\n...", []EvidenceRef{{ID: "E1", ChunkID: "h1", Source: "a.go"}})
+		if err != nil {
+			t.Fatalf("reply %q: unexpected error: %v", reply, err)
+		}
+		if claims[0].Status != StatusUnsupported {
+			t.Fatalf("reply %q: duplicate claim_id must fail closed to unsupported, got %q", reply, claims[0].Status)
+		}
+	}
+}
+
 func TestAggregateStatus(t *testing.T) {
 	c := func(s SupportStatus, contra bool) ClaimSupport {
 		return ClaimSupport{Status: s, Contradicted: contra}

--- a/mcp/tools_analysis.go
+++ b/mcp/tools_analysis.go
@@ -150,6 +150,21 @@ func (s *Server) registerAnalysisTools() {
 			"required": []string{"strategies"},
 		},
 	}, s.handleCompareStrategies)
+
+	s.mcpServer.AddTool(&gomcp.Tool{
+		Name:        "verify_support",
+		Description: "Judge whether an answer is supported by retrieved evidence. Retrieves context for the question, extracts the answer's claims, verifies each against the evidence, and returns a machine-readable support report.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"answer":   map[string]any{"type": "string", "description": "The answer to verify against retrieved evidence"},
+				"question": map[string]any{"type": "string", "description": "The question used to retrieve supporting evidence"},
+				"top_k":    map[string]any{"type": "integer", "description": "Number of chunks to retrieve (default: 5)"},
+				"model":    map[string]any{"type": "string", "description": "Model name (defers to the configured verify/extract roles if omitted)"},
+			},
+			"required": []string{"answer", "question"},
+		},
+	}, s.handleVerifySupport)
 }
 
 func (s *Server) handleCodeReview(ctx context.Context, req *gomcp.CallToolRequest) (*gomcp.CallToolResult, error) {
@@ -320,6 +335,58 @@ func (s *Server) handleCompareStrategies(ctx context.Context, req *gomcp.CallToo
 	}
 
 	return toolResult(result), nil
+}
+
+func (s *Server) handleVerifySupport(ctx context.Context, req *gomcp.CallToolRequest) (*gomcp.CallToolResult, error) {
+	if r := s.requireRAG(); r != nil {
+		return r, nil
+	}
+
+	var args struct {
+		Answer   string `json:"answer"`
+		Question string `json:"question"`
+		TopK     int    `json:"top_k,omitempty"`
+		Model    string `json:"model,omitempty"`
+	}
+	if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+		return toolError("validation", "invalid arguments: %v", err), nil
+	}
+	if args.Answer == "" {
+		return toolError("validation", "answer must not be empty"), nil
+	}
+	if args.Question == "" {
+		return toolError("validation", "question must not be empty"), nil
+	}
+
+	s.mu.RLock()
+	retriever := s.retriever
+	s.mu.RUnlock()
+	if retriever == nil {
+		return toolError("rag", "retriever unavailable; embedding model may not be resolved"), nil
+	}
+
+	topK := args.TopK
+	if topK <= 0 {
+		topK = 5
+	}
+	evidence, err := retriever.Retrieve(ctx, args.Question, topK)
+	if err != nil {
+		return toolError("rag", "retrieve: %v", err), nil
+	}
+
+	judge, err := analysis.NewSupportJudgeWithChat(s.analysisChatFunc(), args.Model)
+	if err != nil {
+		return toolError("config", "%v", err), nil
+	}
+	report, err := judge.Judge(ctx, args.Answer, evidence)
+	if err != nil {
+		return toolError("analysis", "%v", err), nil
+	}
+	data, err := json.Marshal(report)
+	if err != nil {
+		return toolError("analysis", "marshal report: %v", err), nil
+	}
+	return toolResult(string(data)), nil
 }
 
 func decodeTrainingMetrics(raw json.RawMessage) (analysis.TrainingMetrics, error) {

--- a/mcp/tools_analysis.go
+++ b/mcp/tools_analysis.go
@@ -10,6 +10,7 @@ import (
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/kstruzzieri/go-llm/analysis"
+	"github.com/kstruzzieri/go-llm/config"
 	"github.com/kstruzzieri/go-llm/provider"
 )
 
@@ -21,6 +22,10 @@ func useCaseToConfigRole(useCase string) string {
 		return "analysis"
 	case "embedding":
 		return "embedding"
+	case config.UseCaseVerify, config.UseCaseExtract:
+		// Pass through; chainFor -> RoleFallbackChain -> RoleForUseCase resolves
+		// the side-task fallback (analysis -> chat) configured in #60.
+		return useCase
 	default:
 		return "chat"
 	}

--- a/mcp/tools_analysis_test.go
+++ b/mcp/tools_analysis_test.go
@@ -2,11 +2,14 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"strings"
 	"testing"
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/kstruzzieri/go-llm/analysis"
 )
 
 // analysisOllamaMock returns a handler that responds to /api/chat with a
@@ -335,5 +338,77 @@ func TestUseCaseToConfigRole(t *testing.T) {
 		if got := useCaseToConfigRole(in); got != want {
 			t.Errorf("useCaseToConfigRole(%q) = %q, want %q", in, got, want)
 		}
+	}
+}
+
+func TestVerifySupportToolEmptyAnswer(t *testing.T) {
+	s := newAnswerTestServer(t, nil)
+	result, err := s.handleVerifySupport(context.Background(), rawArgs(t, `{"answer":"","question":"q"}`))
+	if err != nil {
+		t.Fatalf("handleVerifySupport() error = %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected isError = true for empty answer")
+	}
+	if text := extractText(result); !strings.Contains(text, "answer must not be empty") {
+		t.Errorf("error = %q, want to contain %q", text, "answer must not be empty")
+	}
+}
+
+func TestVerifySupportToolEmptyQuestion(t *testing.T) {
+	s := newAnswerTestServer(t, nil)
+	result, err := s.handleVerifySupport(context.Background(), rawArgs(t, `{"answer":"a","question":""}`))
+	if err != nil {
+		t.Fatalf("handleVerifySupport() error = %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected isError = true for empty question")
+	}
+	if text := extractText(result); !strings.Contains(text, "question must not be empty") {
+		t.Errorf("error = %q, want to contain %q", text, "question must not be empty")
+	}
+}
+
+func TestVerifySupportToolRegistered(t *testing.T) {
+	env := newTestEnv(t, analysisOllamaMock()) // RAG disabled by default
+	defer env.cleanup()
+
+	result, err := env.session.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name:      "verify_support",
+		Arguments: map[string]any{"answer": "a", "question": "q"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool() error = %v", err)
+	}
+	if !result.IsError || !strings.Contains(extractText(result), "RAG is disabled") {
+		t.Fatalf("registered tool should return existing RAG-disabled error, got isError=%v text=%q", result.IsError, extractText(result))
+	}
+}
+
+func TestVerifySupportToolHappyPath(t *testing.T) {
+	s := answerEnv(t, &queuedRouteEngine{responses: []string{
+		`{"claims":["computeFoo returns one"]}`,
+		`{"verdicts":[{"claim_id":"C1","status":"supported","evidence_ids":["E1"],"reason":"ok"}]}`,
+	}})
+
+	result, err := s.handleVerifySupport(context.Background(), rawArgs(t, `{"answer":"computeFoo returns one","question":"where is computeFoo","top_k":1}`))
+	if err != nil {
+		t.Fatalf("handleVerifySupport() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected tool error: %s", extractText(result))
+	}
+	var report analysis.SupportReport
+	if err := json.Unmarshal([]byte(extractText(result)), &report); err != nil {
+		t.Fatalf("unmarshal report: %v (%s)", err, extractText(result))
+	}
+	if report.Status != analysis.StatusSupported {
+		t.Fatalf("status = %q, want supported; report=%+v", report.Status, report)
+	}
+	if len(report.Claims) != 1 || len(report.Evidence) != 1 || len(report.Claims[0].EvidenceIDs) != 1 || report.Claims[0].EvidenceIDs[0] != "E1" {
+		t.Fatalf("unexpected report shape: %+v", report)
+	}
+	if !strings.Contains(extractText(result), `"missing_evidence_queries"`) {
+		t.Fatalf("JSON should use lower_snake_case field names: %s", extractText(result))
 	}
 }

--- a/mcp/tools_analysis_test.go
+++ b/mcp/tools_analysis_test.go
@@ -328,6 +328,8 @@ func TestUseCaseToConfigRole(t *testing.T) {
 		"embedding":   "embedding",
 		"chat":        "chat",
 		"unknown":     "chat",
+		"verify":      "verify",
+		"extract":     "extract",
 	}
 	for in, want := range cases {
 		if got := useCaseToConfigRole(in); got != want {


### PR DESCRIPTION
Closes #62.

## Summary

Adds an optional, model-backed support judge that evaluates whether an answer is grounded in retrieved evidence, and wires it into the MCP server. This is the first consumer of the auxiliary `verify`/`extract` side-task roles exported by #60, closing the enabler-to-consumer loop.

- New `analysis/support.go`: pure `SupportJudge` running a two-stage `extract -> verify` pipeline. Stage A decomposes the answer into atomic claims via use-case `config.UseCaseExtract`; stage B judges each claim against labeled evidence via `config.UseCaseVerify`. Returns a structured `SupportReport` (`supported` / `partial` / `unsupported`, per-claim support with evidence refs and reasons, plus `MissingEvidence` and suggested `MissingEvidenceQueries`).
- The helper is pure: it takes already-retrieved `[]rag.SearchResult`, never retrieves, never changes the retriever API, and never imports `memory/`.
- New MCP `verify_support` tool (`mcp/tools_analysis.go`): the thin orchestration wrapper that retrieves evidence for a question, then calls the judge. Retrieval policy lives in the tool; the helper stays pure.
- `useCaseToConfigRole` now passes `verify`/`extract` through to `RoleForUseCase` (fallback `analysis -> chat`); previously they collapsed to `chat`, which would have defeated #60's enabler.

Design choices:
- Fail-closed throughout. Unknown status, missing verdict, a support claim citing no valid evidence, and duplicate `claim_id` verdicts all resolve to `unsupported`; a duplicate verdict can never raise a claim's support level. Malformed verify output returns `ErrSupportVerifyMalformed` and is never coerced to a verdict.
- The existing `rag_answer` deterministic quote verifier is left byte-for-byte unchanged; semantic support judging and literal quote matching are complementary, not interchangeable.

## Test plan

- [x] `env -u GOROOT go test -race ./...` passes (analysis + mcp + full module)
- [x] `gofmt -l` clean on changed files
- [x] `golangci-lint run ./analysis/... ./mcp/...` reports 0 issues
- [x] Tests cover clear supported and unsupported cases, plus partial, contradicted, empty-evidence short-circuit (no model calls), malformed extract fallback, malformed verify error, fail-closed normalization, evidence budgeting, duplicate-claim-id fail-closed, and the `verify_support` tool (validation, registration, deterministic happy path)