### PR TITLE
feat(memory): working and long-term agent memory records (#114)

### DIFF
--- a/memory/migration.go
+++ b/memory/migration.go
@@ -16,6 +16,7 @@ type migration struct {
 
 var migrations = []migration{
 	{version: 1, description: "baseline memories table + FTS5", fn: migrateV1},
+	{version: 2, description: "agent memory records + FTS5", fn: migrateV2},
 }
 
 func migrateV1(tx *sql.Tx) error {
@@ -38,6 +39,39 @@ func migrateV1(tx *sql.Tx) error {
 	for _, s := range stmts {
 		if _, err := tx.Exec(s); err != nil {
 			return fmt.Errorf("memory: migrate v1: %w", err)
+		}
+	}
+	return nil
+}
+
+func migrateV2(tx *sql.Tx) error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS memory_records (
+			id           TEXT PRIMARY KEY,
+			kind         TEXT NOT NULL,
+			content      TEXT NOT NULL,
+			namespace    TEXT NOT NULL DEFAULT '',
+			workspace_id TEXT NOT NULL DEFAULT '',
+			session_id   TEXT NOT NULL DEFAULT '',
+			source_kind  TEXT NOT NULL DEFAULT '',
+			source_id    TEXT NOT NULL DEFAULT '',
+			source_start INTEGER NOT NULL DEFAULT 0,
+			source_end   INTEGER NOT NULL DEFAULT 0,
+			source_hash  TEXT NOT NULL DEFAULT '',
+			metadata     TEXT NOT NULL DEFAULT '{}',
+			created_at   INTEGER NOT NULL,
+			updated_at   INTEGER NOT NULL,
+			expires_at   INTEGER NOT NULL DEFAULT 0,
+			deleted_at   INTEGER NOT NULL DEFAULT 0
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_memory_records_live
+			ON memory_records(kind, namespace, workspace_id, session_id) WHERE deleted_at = 0`,
+		`CREATE VIRTUAL TABLE IF NOT EXISTS memory_records_fts
+			USING fts5(id UNINDEXED, content, tokenize='porter')`,
+	}
+	for _, s := range stmts {
+		if _, err := tx.Exec(s); err != nil {
+			return fmt.Errorf("memory: migrate v2: %w", err)
 		}
 	}
 	return nil

--- a/memory/record_agent.go
+++ b/memory/record_agent.go
@@ -1,0 +1,100 @@
+package memory
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+// MemoryKind is the record's memory semantics, orthogonal to visibility.
+type MemoryKind string
+
+const (
+	// KindWorking is session-scoped, typically expiring memory; the promotion source.
+	KindWorking MemoryKind = "working"
+	// KindSemantic is a durable fact, preference, or convention.
+	KindSemantic MemoryKind = "semantic"
+	// KindEpisodic is a durable event or experience.
+	KindEpisodic MemoryKind = "episodic"
+)
+
+// Provenance links a record back to what produced it. All fields are opaque to
+// this package. The range is half-open [Start, End); 0 means unset.
+type Provenance struct {
+	SourceKind string // e.g. "conversation" | "tool" | "user"
+	SourceID   string // conversation/session id, tool name, ...
+	Start      int
+	End        int
+	Hash       string // optional content fingerprint
+}
+
+// MemoryRecord is one agent-memory row. Visibility is derived: WorkspaceID=="" is
+// global; WorkspaceID set is workspace-private; SessionID set is session-private
+// (and requires WorkspaceID).
+type MemoryRecord struct {
+	ID          string
+	Kind        MemoryKind
+	Content     string
+	Namespace   string
+	WorkspaceID string
+	SessionID   string
+	Provenance  Provenance
+	Metadata    json.RawMessage // opaque valid JSON value; "{}" when empty
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	ExpiresAt   time.Time // zero = never expires
+	DeletedAt   time.Time // zero = live
+}
+
+// CreateRecordParams are the inputs to Create.
+type CreateRecordParams struct {
+	Kind        MemoryKind
+	Content     string
+	Namespace   string
+	WorkspaceID string
+	SessionID   string
+	Provenance  Provenance
+	Metadata    json.RawMessage // nil/empty normalized to {}
+	ExpiresAt   time.Time       // zero = never
+}
+
+// UpdateRecordParams mutates only safe fields. Kind, WorkspaceID, and SessionID
+// are immutable here (Promote is the only kind-changer; re-scoping is deferred),
+// so Update can never break a create-time invariant. A nil field is left as-is.
+type UpdateRecordParams struct {
+	Content   *string
+	Namespace *string
+	Metadata  json.RawMessage // nil = leave; non-nil empty normalized to {}
+	ExpiresAt *time.Time      // nil = leave; point at zero-time to clear expiry
+}
+
+// RecordAccess is the visibility scope a caller presents to Get/Update/SoftDelete/
+// Promote. A record not visible under this scope is ErrRecordNotFound (existence
+// is never leaked across a workspace/session boundary).
+type RecordAccess struct {
+	WorkspaceID string
+	SessionID   string
+}
+
+// RecordSearchOptions scopes, filters, and bounds Search.
+type RecordSearchOptions struct {
+	WorkspaceID    string
+	SessionID      string
+	Kind           MemoryKind // "" = any
+	Namespace      string     // "" = any
+	Limit          int        // <= 0 => default 8
+	Now            time.Time  // expiry reference; zero => time.Now()
+	IncludeExpired bool
+}
+
+// Sentinel errors for the agent-memory record surface.
+var (
+	ErrRecordNotFound        = errors.New("memory: record not found")
+	ErrEmptyContent          = errors.New("memory: content must not be empty")
+	ErrBadKind               = errors.New("memory: invalid kind")
+	ErrBadMetadata           = errors.New("memory: metadata must be valid JSON")
+	ErrSessionNeedsWorkspace = errors.New("memory: session-scoped record requires workspace_id")
+	ErrWorkingNeedsSession   = errors.New("memory: working memory requires session_id")
+	ErrBadPromotion          = errors.New("memory: promote target must be semantic or episodic")
+	ErrBadProvenanceRange    = errors.New("memory: provenance end must be >= start")
+)

--- a/memory/record_agent.go
+++ b/memory/record_agent.go
@@ -1,3 +1,10 @@
+// This file adds the agent-memory record surface (MemoryRecord /
+// MemoryRecordStore): typed working/semantic/episodic records with provenance,
+// expiration, scoped FTS search, and opt-in promotion. It is a sibling of the
+// user-authored Memory surface in this package and shares the same SQLite
+// migration chain, but owns separate tables (memory_records/_fts). It imports
+// neither conversation/ nor rag/: agent memory, conversation persistence, and
+// document RAG stay separate storage concepts.
 package memory
 
 import (

--- a/memory/record_store.go
+++ b/memory/record_store.go
@@ -253,3 +253,79 @@ func (s *MemoryRecordStore) Search(ctx context.Context, query string, opts Recor
 	}
 	return out, nil
 }
+
+// Update applies the non-nil fields of in to the record visible under acc, bumps
+// updated_at, and re-syncs the FTS row when Content changed. Kind/workspace/session
+// are not mutable here. A miss or out-of-scope record returns ErrRecordNotFound.
+func (s *MemoryRecordStore) Update(ctx context.Context, id string, acc RecordAccess, in UpdateRecordParams) (MemoryRecord, error) {
+	// Validate inputs before opening the tx (matches Create's validate-first pattern).
+	var newContent *string
+	if in.Content != nil {
+		c := strings.TrimSpace(*in.Content)
+		if c == "" {
+			return MemoryRecord{}, ErrEmptyContent
+		}
+		newContent = &c
+	}
+	var metadata *string
+	if in.Metadata != nil {
+		norm, err := normalizeMetadata(in.Metadata)
+		if err != nil {
+			return MemoryRecord{}, err
+		}
+		metadata = &norm
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return MemoryRecord{}, fmt.Errorf("memory: update: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Resolve within scope; also gives us existence.
+	row := tx.QueryRowContext(ctx,
+		`SELECT `+recordColumns+` FROM memory_records
+		  WHERE id = ? AND deleted_at = 0 AND `+visibilityClause,
+		id, acc.WorkspaceID, acc.SessionID)
+	cur, err := scanRecord(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return MemoryRecord{}, ErrRecordNotFound
+		}
+		return MemoryRecord{}, err
+	}
+
+	if newContent != nil {
+		cur.Content = *newContent
+	}
+	if in.Namespace != nil {
+		cur.Namespace = *in.Namespace
+	}
+	if metadata != nil {
+		cur.Metadata = json.RawMessage(*metadata)
+	}
+	if in.ExpiresAt != nil {
+		cur.ExpiresAt = *in.ExpiresAt
+	}
+	now := time.Now().UnixMilli()
+	cur.UpdatedAt = time.UnixMilli(now)
+
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE memory_records SET content = ?, namespace = ?, metadata = ?, expires_at = ?, updated_at = ?
+		  WHERE id = ?`,
+		cur.Content, cur.Namespace, string(cur.Metadata), toMs(cur.ExpiresAt), now, id); err != nil {
+		return MemoryRecord{}, fmt.Errorf("memory: update: %w", err)
+	}
+	if newContent != nil {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM memory_records_fts WHERE id = ?`, id); err != nil {
+			return MemoryRecord{}, fmt.Errorf("memory: update: fts delete: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO memory_records_fts (id, content) VALUES (?, ?)`, id, cur.Content); err != nil {
+			return MemoryRecord{}, fmt.Errorf("memory: update: fts insert: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return MemoryRecord{}, fmt.Errorf("memory: update: commit: %w", err)
+	}
+	return cur, nil
+}

--- a/memory/record_store.go
+++ b/memory/record_store.go
@@ -254,6 +254,39 @@ func (s *MemoryRecordStore) Search(ctx context.Context, query string, opts Recor
 	return out, nil
 }
 
+// SoftDelete marks the record deleted (deleted_at set) within acc's scope and
+// removes its FTS row. An absent, already-deleted, or out-of-scope id returns
+// ErrRecordNotFound (matches SQLiteStore.SoftDelete; not idempotent-silent).
+func (s *MemoryRecordStore) SoftDelete(ctx context.Context, id string, acc RecordAccess) error {
+	now := time.Now().UnixMilli()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("memory: soft delete: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	res, err := tx.ExecContext(ctx,
+		`UPDATE memory_records SET deleted_at = ?, updated_at = ?
+		  WHERE id = ? AND deleted_at = 0 AND `+visibilityClause,
+		now, now, id, acc.WorkspaceID, acc.SessionID)
+	if err != nil {
+		return fmt.Errorf("memory: soft delete: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("memory: soft delete: rows: %w", err)
+	}
+	if n == 0 {
+		return ErrRecordNotFound
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM memory_records_fts WHERE id = ?`, id); err != nil {
+		return fmt.Errorf("memory: soft delete: fts: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("memory: soft delete: commit: %w", err)
+	}
+	return nil
+}
+
 // Update applies the non-nil fields of in to the record visible under acc, bumps
 // updated_at, and re-syncs the FTS row when Content changed. Kind/workspace/session
 // are not mutable here. A miss or out-of-scope record returns ErrRecordNotFound.

--- a/memory/record_store.go
+++ b/memory/record_store.go
@@ -287,6 +287,52 @@ func (s *MemoryRecordStore) SoftDelete(ctx context.Context, id string, acc Recor
 	return nil
 }
 
+// Promote converts a record to a durable kind (semantic or episodic) within acc's
+// scope: it sheds the session binding (session_id cleared), clears expiry, keeps
+// the workspace, and preserves content/provenance. to must be KindSemantic or
+// KindEpisodic. A miss or out-of-scope record returns ErrRecordNotFound. The
+// from-kind is deliberately unrestricted (the intended flow is working ->
+// durable, but re-promoting an already-durable record is a harmless no-op).
+func (s *MemoryRecordStore) Promote(ctx context.Context, id string, acc RecordAccess, to MemoryKind) (MemoryRecord, error) {
+	if to != KindSemantic && to != KindEpisodic {
+		return MemoryRecord{}, ErrBadPromotion
+	}
+	now := time.Now().UnixMilli()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return MemoryRecord{}, fmt.Errorf("memory: promote: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	res, err := tx.ExecContext(ctx,
+		`UPDATE memory_records SET kind = ?, session_id = '', expires_at = 0, updated_at = ?
+		  WHERE id = ? AND deleted_at = 0 AND `+visibilityClause,
+		string(to), now, id, acc.WorkspaceID, acc.SessionID)
+	if err != nil {
+		return MemoryRecord{}, fmt.Errorf("memory: promote: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return MemoryRecord{}, fmt.Errorf("memory: promote: rows: %w", err)
+	}
+	if n == 0 {
+		return MemoryRecord{}, ErrRecordNotFound
+	}
+	// Re-read the mutated row within the tx. FTS is untouched: content is
+	// preserved, only kind/session/expiry changed.
+	row := tx.QueryRowContext(ctx, `SELECT `+recordColumns+` FROM memory_records WHERE id = ?`, id)
+	m, err := scanRecord(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return MemoryRecord{}, ErrRecordNotFound
+		}
+		return MemoryRecord{}, fmt.Errorf("memory: promote: reselect: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return MemoryRecord{}, fmt.Errorf("memory: promote: commit: %w", err)
+	}
+	return m, nil
+}
+
 // Update applies the non-nil fields of in to the record visible under acc, bumps
 // updated_at, and re-syncs the FTS row when Content changed. Kind/workspace/session
 // are not mutable here. A miss or out-of-scope record returns ErrRecordNotFound.

--- a/memory/record_store.go
+++ b/memory/record_store.go
@@ -1,0 +1,178 @@
+package memory
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// MemoryRecordStore is the agent-memory record store. It shares the memory
+// package's DB and migration chain with SQLiteStore but owns the memory_records
+// tables. One implementation; consumers define their own narrow interfaces.
+type MemoryRecordStore struct {
+	db *sql.DB
+}
+
+// NewMemoryRecordStore runs the shared migrations on db and returns a record
+// store. db must already be opened and hardened by the caller.
+func NewMemoryRecordStore(ctx context.Context, db *sql.DB) (*MemoryRecordStore, error) {
+	_ = ctx
+	if err := runMigrations(db); err != nil {
+		return nil, fmt.Errorf("memory: init record store: %w", err)
+	}
+	return &MemoryRecordStore{db: db}, nil
+}
+
+// visibilityClause is the shared WHERE fragment enforcing derived visibility.
+// Bind args in order: workspaceID, sessionID.
+const visibilityClause = `(workspace_id = '' OR workspace_id = ?) AND (session_id = '' OR session_id = ?)`
+
+// recordColumns is the canonical SELECT column list, matching scanRecord.
+const recordColumns = `id, kind, content, namespace, workspace_id, session_id,
+	source_kind, source_id, source_start, source_end, source_hash, metadata,
+	created_at, updated_at, expires_at, deleted_at`
+
+func toMs(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.UnixMilli()
+}
+
+func fromMs(ms int64) time.Time {
+	if ms == 0 {
+		return time.Time{}
+	}
+	return time.UnixMilli(ms)
+}
+
+// normalizeMetadata trims raw, returns "{}" for empty, else validates it parses.
+func normalizeMetadata(raw json.RawMessage) (string, error) {
+	s := strings.TrimSpace(string(raw))
+	if s == "" {
+		return "{}", nil
+	}
+	if !json.Valid([]byte(s)) {
+		return "", ErrBadMetadata
+	}
+	return s, nil
+}
+
+func validKind(k MemoryKind) bool {
+	switch k {
+	case KindWorking, KindSemantic, KindEpisodic:
+		return true
+	default:
+		return false
+	}
+}
+
+func scanRecord(r rowScanner) (MemoryRecord, error) {
+	var (
+		m                    MemoryRecord
+		kind, metadata       string
+		createdMs, updatedMs int64
+		expiresMs, deletedMs int64
+	)
+	if err := r.Scan(
+		&m.ID, &kind, &m.Content, &m.Namespace, &m.WorkspaceID, &m.SessionID,
+		&m.Provenance.SourceKind, &m.Provenance.SourceID, &m.Provenance.Start, &m.Provenance.End, &m.Provenance.Hash,
+		&metadata, &createdMs, &updatedMs, &expiresMs, &deletedMs,
+	); err != nil {
+		return MemoryRecord{}, fmt.Errorf("memory: scan record: %w", err)
+	}
+	m.Kind = MemoryKind(kind)
+	m.Metadata = json.RawMessage(metadata)
+	m.CreatedAt = fromMs(createdMs)
+	m.UpdatedAt = fromMs(updatedMs)
+	m.ExpiresAt = fromMs(expiresMs)
+	m.DeletedAt = fromMs(deletedMs)
+	return m, nil
+}
+
+// Create validates and stores a new record.
+func (s *MemoryRecordStore) Create(ctx context.Context, in CreateRecordParams) (MemoryRecord, error) {
+	content := strings.TrimSpace(in.Content)
+	if content == "" {
+		return MemoryRecord{}, ErrEmptyContent
+	}
+	if !validKind(in.Kind) {
+		return MemoryRecord{}, ErrBadKind
+	}
+	if in.SessionID != "" && in.WorkspaceID == "" {
+		return MemoryRecord{}, ErrSessionNeedsWorkspace
+	}
+	if in.Kind == KindWorking && in.SessionID == "" {
+		return MemoryRecord{}, ErrWorkingNeedsSession
+	}
+	// End == 0 means "unset" (partial provenance, e.g. a known start with no end is
+	// allowed). Only validate ordering when End is actually set.
+	if in.Provenance.End != 0 && in.Provenance.End < in.Provenance.Start {
+		return MemoryRecord{}, ErrBadProvenanceRange
+	}
+	metadata, err := normalizeMetadata(in.Metadata)
+	if err != nil {
+		return MemoryRecord{}, err
+	}
+
+	now := time.Now().UnixMilli()
+	m := MemoryRecord{
+		ID:          newID(),
+		Kind:        in.Kind,
+		Content:     content,
+		Namespace:   in.Namespace,
+		WorkspaceID: in.WorkspaceID,
+		SessionID:   in.SessionID,
+		Provenance:  in.Provenance,
+		Metadata:    json.RawMessage(metadata),
+		CreatedAt:   time.UnixMilli(now),
+		UpdatedAt:   time.UnixMilli(now),
+		ExpiresAt:   in.ExpiresAt,
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return MemoryRecord{}, fmt.Errorf("memory: create: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO memory_records (id, kind, content, namespace, workspace_id, session_id,
+			source_kind, source_id, source_start, source_end, source_hash, metadata,
+			created_at, updated_at, expires_at, deleted_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)`,
+		m.ID, string(m.Kind), m.Content, m.Namespace, m.WorkspaceID, m.SessionID,
+		m.Provenance.SourceKind, m.Provenance.SourceID, m.Provenance.Start, m.Provenance.End, m.Provenance.Hash,
+		metadata, now, now, toMs(m.ExpiresAt)); err != nil {
+		return MemoryRecord{}, fmt.Errorf("memory: create: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO memory_records_fts (id, content) VALUES (?, ?)`, m.ID, m.Content); err != nil {
+		return MemoryRecord{}, fmt.Errorf("memory: create: fts: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return MemoryRecord{}, fmt.Errorf("memory: create: commit: %w", err)
+	}
+	return m, nil
+}
+
+// Get returns the live record with the given id visible under acc. Expired records
+// are still returned (direct fetch; expiry filtering is Search's concern). A miss
+// or a record outside acc's scope returns ErrRecordNotFound.
+func (s *MemoryRecordStore) Get(ctx context.Context, id string, acc RecordAccess) (MemoryRecord, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+recordColumns+`
+		   FROM memory_records
+		  WHERE id = ? AND deleted_at = 0 AND `+visibilityClause,
+		id, acc.WorkspaceID, acc.SessionID)
+	m, err := scanRecord(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return MemoryRecord{}, ErrRecordNotFound
+		}
+		return MemoryRecord{}, err
+	}
+	return m, nil
+}

--- a/memory/record_store.go
+++ b/memory/record_store.go
@@ -389,10 +389,13 @@ func (s *MemoryRecordStore) Update(ctx context.Context, id string, acc RecordAcc
 	now := time.Now().UnixMilli()
 	cur.UpdatedAt = time.UnixMilli(now)
 
+	// Re-assert deleted_at + visibility on the write (defense-in-depth; matches
+	// SoftDelete/Promote so every mutation self-guards rather than trusting the
+	// prior in-tx SELECT).
 	if _, err := tx.ExecContext(ctx,
 		`UPDATE memory_records SET content = ?, namespace = ?, metadata = ?, expires_at = ?, updated_at = ?
-		  WHERE id = ?`,
-		cur.Content, cur.Namespace, string(cur.Metadata), toMs(cur.ExpiresAt), now, id); err != nil {
+		  WHERE id = ? AND deleted_at = 0 AND `+visibilityClause,
+		cur.Content, cur.Namespace, string(cur.Metadata), toMs(cur.ExpiresAt), now, id, acc.WorkspaceID, acc.SessionID); err != nil {
 		return MemoryRecord{}, fmt.Errorf("memory: update: %w", err)
 	}
 	if newContent != nil {

--- a/memory/record_store.go
+++ b/memory/record_store.go
@@ -36,6 +36,16 @@ const recordColumns = `id, kind, content, namespace, workspace_id, session_id,
 	source_kind, source_id, source_start, source_end, source_hash, metadata,
 	created_at, updated_at, expires_at, deleted_at`
 
+// recordColumnsAlias mirrors recordColumns with an `mr.` table alias for joined
+// queries (Search). Keep the two column lists in lockstep with scanRecord.
+const recordColumnsAlias = `mr.id, mr.kind, mr.content, mr.namespace, mr.workspace_id, mr.session_id,
+	mr.source_kind, mr.source_id, mr.source_start, mr.source_end, mr.source_hash, mr.metadata,
+	mr.created_at, mr.updated_at, mr.expires_at, mr.deleted_at`
+
+// visibilityClauseAlias is visibilityClause with the `mr.` alias, for joined
+// queries. Bind args in order: workspaceID, sessionID.
+const visibilityClauseAlias = `(mr.workspace_id = '' OR mr.workspace_id = ?) AND (mr.session_id = '' OR mr.session_id = ?)`
+
 func toMs(t time.Time) int64 {
 	if t.IsZero() {
 		return 0
@@ -175,4 +185,71 @@ func (s *MemoryRecordStore) Get(ctx context.Context, id string, acc RecordAccess
 		return MemoryRecord{}, err
 	}
 	return m, nil
+}
+
+// Search returns live records visible under opts (workspace + session), best match
+// first. An empty/punctuation-only query lists by recency (updated_at DESC); a
+// non-empty query ranks by FTS5 bm25. Expired records are excluded unless
+// opts.IncludeExpired. Returns a non-nil empty slice on no match.
+func (s *MemoryRecordStore) Search(ctx context.Context, query string, opts RecordSearchOptions) ([]MemoryRecord, error) {
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 8
+	}
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	var (
+		where []string
+		args  []any
+	)
+	where = append(where, `mr.deleted_at = 0`)
+	where = append(where, visibilityClauseAlias)
+	args = append(args, opts.WorkspaceID, opts.SessionID)
+	if opts.Kind != "" {
+		where = append(where, `mr.kind = ?`)
+		args = append(args, string(opts.Kind))
+	}
+	if opts.Namespace != "" {
+		where = append(where, `mr.namespace = ?`)
+		args = append(args, opts.Namespace)
+	}
+	if !opts.IncludeExpired {
+		where = append(where, `NOT (mr.expires_at != 0 AND mr.expires_at <= ?)`)
+		args = append(args, now.UnixMilli())
+	}
+
+	var q string
+	match := sanitizeFTS5Query(query)
+	if match == "" {
+		q = `SELECT ` + recordColumnsAlias + ` FROM memory_records mr WHERE ` + strings.Join(where, " AND ") +
+			` ORDER BY mr.updated_at DESC, mr.id ASC LIMIT ?`
+		args = append(args, limit)
+	} else {
+		q = `SELECT ` + recordColumnsAlias + ` FROM memory_records_fts f JOIN memory_records mr ON mr.id = f.id
+			WHERE f.content MATCH ? AND ` + strings.Join(where, " AND ") +
+			` ORDER BY bm25(memory_records_fts) ASC, mr.updated_at DESC, mr.id ASC LIMIT ?`
+		args = append([]any{match}, args...)
+		args = append(args, limit)
+	}
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("memory: search records: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	out := []MemoryRecord{}
+	for rows.Next() {
+		m, err := scanRecord(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("memory: search records: iterate: %w", err)
+	}
+	return out, nil
 }

--- a/memory/record_store_test.go
+++ b/memory/record_store_test.go
@@ -380,3 +380,53 @@ func TestRecordSoftDeleteScope(t *testing.T) {
 		t.Fatalf("session record wrongly deleted: %v", err)
 	}
 }
+
+func TestPromote(t *testing.T) {
+	s := newRecordStore(t)
+	ctx := context.Background()
+	for _, to := range []MemoryKind{KindSemantic, KindEpisodic} {
+		m, _ := s.Create(ctx, CreateRecordParams{
+			Kind: KindWorking, Content: "candidate", WorkspaceID: "w1", SessionID: "s1",
+			Provenance: Provenance{SourceKind: "conversation", SourceID: "c1", Start: 1, End: 4},
+			ExpiresAt:  time.Now().Add(time.Hour),
+		})
+		got, err := s.Promote(ctx, m.ID, RecordAccess{WorkspaceID: "w1", SessionID: "s1"}, to)
+		if err != nil {
+			t.Fatalf("Promote(%s): %v", to, err)
+		}
+		if got.Kind != to {
+			t.Fatalf("kind: got %s want %s", got.Kind, to)
+		}
+		if got.SessionID != "" {
+			t.Fatalf("session not cleared: %q", got.SessionID)
+		}
+		if !got.ExpiresAt.IsZero() {
+			t.Fatalf("expiry not cleared: %v", got.ExpiresAt)
+		}
+		if got.WorkspaceID != "w1" {
+			t.Fatalf("workspace changed: %q", got.WorkspaceID)
+		}
+		if got.Provenance.SourceID != "c1" {
+			t.Fatalf("provenance lost: %+v", got.Provenance)
+		}
+		// now visible to a non-session caller in w1 (session binding shed)
+		if _, err := s.Get(ctx, m.ID, RecordAccess{WorkspaceID: "w1"}); err != nil {
+			t.Fatalf("promoted record not workspace-visible: %v", err)
+		}
+	}
+}
+
+func TestPromoteBadTargetAndMiss(t *testing.T) {
+	s := newRecordStore(t)
+	ctx := context.Background()
+	m, _ := s.Create(ctx, CreateRecordParams{Kind: KindWorking, Content: "x", WorkspaceID: "w1", SessionID: "s1"})
+	if _, err := s.Promote(ctx, m.ID, RecordAccess{WorkspaceID: "w1", SessionID: "s1"}, KindWorking); !errors.Is(err, ErrBadPromotion) {
+		t.Fatalf("promote to working: got %v want ErrBadPromotion", err)
+	}
+	if _, err := s.Promote(ctx, "nope", RecordAccess{}, KindSemantic); !errors.Is(err, ErrRecordNotFound) {
+		t.Fatalf("promote miss: got %v", err)
+	}
+	if _, err := s.Promote(ctx, m.ID, RecordAccess{WorkspaceID: "w1"}, KindSemantic); !errors.Is(err, ErrRecordNotFound) {
+		t.Fatalf("promote of session record without session scope: got %v want ErrRecordNotFound", err)
+	}
+}

--- a/memory/record_store_test.go
+++ b/memory/record_store_test.go
@@ -25,6 +25,15 @@ func newRecordStore(t *testing.T) *MemoryRecordStore {
 	return s
 }
 
+func mustSearch(t *testing.T, s *MemoryRecordStore, query string, opts RecordSearchOptions) []MemoryRecord {
+	t.Helper()
+	got, err := s.Search(context.Background(), query, opts)
+	if err != nil {
+		t.Fatalf("Search(%q): %v", query, err)
+	}
+	return got
+}
+
 func TestCreateValidKinds(t *testing.T) {
 	s := newRecordStore(t)
 	ctx := context.Background()
@@ -147,5 +156,96 @@ func TestGetReturnsExpired(t *testing.T) {
 	}
 	if got.ExpiresAt.IsZero() {
 		t.Fatalf("expected non-zero ExpiresAt round-trip")
+	}
+}
+
+func TestSearchFTSAndEmptyQuery(t *testing.T) {
+	s := newRecordStore(t)
+	ctx := context.Background()
+	_, _ = s.Create(ctx, CreateRecordParams{Kind: KindSemantic, Content: "alpha beta gamma", WorkspaceID: "w1"})
+	_, _ = s.Create(ctx, CreateRecordParams{Kind: KindSemantic, Content: "delta epsilon", WorkspaceID: "w1"})
+
+	hits, err := s.Search(ctx, "beta", RecordSearchOptions{WorkspaceID: "w1"})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) != 1 || hits[0].Content != "alpha beta gamma" {
+		t.Fatalf("FTS search: got %d %v", len(hits), hits)
+	}
+	all, err := s.Search(ctx, "", RecordSearchOptions{WorkspaceID: "w1"})
+	if err != nil {
+		t.Fatalf("Search empty: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("empty-query listing: got %d want 2", len(all))
+	}
+}
+
+func TestSearchFilters(t *testing.T) {
+	s := newRecordStore(t)
+	ctx := context.Background()
+	_, _ = s.Create(ctx, CreateRecordParams{Kind: KindWorking, Content: "task note", WorkspaceID: "w1", SessionID: "s1", Namespace: "ns1"})
+	_, _ = s.Create(ctx, CreateRecordParams{Kind: KindSemantic, Content: "fact note", WorkspaceID: "w1", Namespace: "ns2"})
+
+	byKind := mustSearch(t, s, "", RecordSearchOptions{WorkspaceID: "w1", SessionID: "s1", Kind: KindWorking})
+	if len(byKind) != 1 || byKind[0].Kind != KindWorking {
+		t.Fatalf("kind filter: got %v", byKind)
+	}
+	byNS := mustSearch(t, s, "", RecordSearchOptions{WorkspaceID: "w1", Namespace: "ns2"})
+	if len(byNS) != 1 || byNS[0].Namespace != "ns2" {
+		t.Fatalf("namespace filter: got %v", byNS)
+	}
+}
+
+func TestSearchVisibilityIsolation(t *testing.T) {
+	s := newRecordStore(t)
+	ctx := context.Background()
+	_, _ = s.Create(ctx, CreateRecordParams{Kind: KindEpisodic, Content: "global note"})
+	_, _ = s.Create(ctx, CreateRecordParams{Kind: KindSemantic, Content: "w1 note", WorkspaceID: "w1"})
+	_, _ = s.Create(ctx, CreateRecordParams{Kind: KindWorking, Content: "s1 note", WorkspaceID: "w1", SessionID: "s1"})
+
+	fromS1 := mustSearch(t, s, "", RecordSearchOptions{WorkspaceID: "w1", SessionID: "s1"})
+	if len(fromS1) != 3 {
+		t.Fatalf("session view: got %d want 3", len(fromS1))
+	}
+	fromW1 := mustSearch(t, s, "", RecordSearchOptions{WorkspaceID: "w1"})
+	if len(fromW1) != 2 {
+		t.Fatalf("workspace view: got %d want 2", len(fromW1))
+	}
+	fromW2 := mustSearch(t, s, "", RecordSearchOptions{WorkspaceID: "w2"})
+	if len(fromW2) != 1 {
+		t.Fatalf("other workspace view: got %d want 1", len(fromW2))
+	}
+}
+
+func TestSearchExpiryAndLimit(t *testing.T) {
+	s := newRecordStore(t)
+	ctx := context.Background()
+	now := time.Now()
+	_, _ = s.Create(ctx, CreateRecordParams{Kind: KindSemantic, Content: "live", WorkspaceID: "w1"})
+	_, _ = s.Create(ctx, CreateRecordParams{Kind: KindSemantic, Content: "dead", WorkspaceID: "w1", ExpiresAt: now.Add(-time.Hour)})
+
+	live := mustSearch(t, s, "", RecordSearchOptions{WorkspaceID: "w1", Now: now})
+	if len(live) != 1 || live[0].Content != "live" {
+		t.Fatalf("expiry exclusion: got %v", live)
+	}
+	withExpired := mustSearch(t, s, "", RecordSearchOptions{WorkspaceID: "w1", Now: now, IncludeExpired: true})
+	if len(withExpired) != 2 {
+		t.Fatalf("IncludeExpired: got %d want 2", len(withExpired))
+	}
+	limited := mustSearch(t, s, "", RecordSearchOptions{WorkspaceID: "w1", Now: now, IncludeExpired: true, Limit: 1})
+	if len(limited) != 1 {
+		t.Fatalf("limit: got %d want 1", len(limited))
+	}
+}
+
+func TestSearchNoMatchNonNil(t *testing.T) {
+	s := newRecordStore(t)
+	got, err := s.Search(context.Background(), "zzz", RecordSearchOptions{WorkspaceID: "w1"})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if got == nil || len(got) != 0 {
+		t.Fatalf("want non-nil empty slice, got %v", got)
 	}
 }

--- a/memory/record_store_test.go
+++ b/memory/record_store_test.go
@@ -1,0 +1,151 @@
+package memory
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func newRecordStore(t *testing.T) *MemoryRecordStore {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	s, err := NewMemoryRecordStore(context.Background(), db)
+	if err != nil {
+		t.Fatalf("NewMemoryRecordStore: %v", err)
+	}
+	return s
+}
+
+func TestCreateValidKinds(t *testing.T) {
+	s := newRecordStore(t)
+	ctx := context.Background()
+	cases := []CreateRecordParams{
+		{Kind: KindWorking, Content: "wm", WorkspaceID: "w1", SessionID: "s1"},
+		{Kind: KindSemantic, Content: "sm", WorkspaceID: "w1"},
+		{Kind: KindEpisodic, Content: "em"},
+	}
+	for _, in := range cases {
+		m, err := s.Create(ctx, in)
+		if err != nil {
+			t.Fatalf("Create(%s): %v", in.Kind, err)
+		}
+		if m.ID == "" {
+			t.Fatalf("Create(%s): empty id", in.Kind)
+		}
+		got, err := s.Get(ctx, m.ID, RecordAccess{WorkspaceID: in.WorkspaceID, SessionID: in.SessionID})
+		if err != nil {
+			t.Fatalf("Get(%s): %v", in.Kind, err)
+		}
+		if got.Content != in.Content || got.Kind != in.Kind {
+			t.Fatalf("round-trip mismatch: got %+v want kind=%s content=%s", got, in.Kind, in.Content)
+		}
+		if string(got.Metadata) != "{}" {
+			t.Fatalf("metadata not normalized: %q", got.Metadata)
+		}
+	}
+}
+
+func TestCreateValidation(t *testing.T) {
+	s := newRecordStore(t)
+	ctx := context.Background()
+	cases := []struct {
+		name string
+		in   CreateRecordParams
+		want error
+	}{
+		{"empty content", CreateRecordParams{Kind: KindSemantic, Content: "   "}, ErrEmptyContent},
+		{"bad kind", CreateRecordParams{Kind: "bogus", Content: "x"}, ErrBadKind},
+		{"session needs workspace", CreateRecordParams{Kind: KindSemantic, Content: "x", SessionID: "s1"}, ErrSessionNeedsWorkspace},
+		{"working needs session", CreateRecordParams{Kind: KindWorking, Content: "x", WorkspaceID: "w1"}, ErrWorkingNeedsSession},
+		{"bad provenance range", CreateRecordParams{Kind: KindSemantic, Content: "x", Provenance: Provenance{Start: 5, End: 2}}, ErrBadProvenanceRange},
+		{"bad metadata", CreateRecordParams{Kind: KindSemantic, Content: "x", Metadata: json.RawMessage("{not json")}, ErrBadMetadata},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := s.Create(ctx, c.in); !errors.Is(err, c.want) {
+				t.Fatalf("Create: got %v want %v", err, c.want)
+			}
+		})
+	}
+}
+
+func TestCreateProvenanceRoundTrip(t *testing.T) {
+	s := newRecordStore(t)
+	ctx := context.Background()
+	prov := Provenance{SourceKind: "conversation", SourceID: "c1", Start: 3, End: 9, Hash: "abc"}
+	m, err := s.Create(ctx, CreateRecordParams{Kind: KindSemantic, Content: "x", WorkspaceID: "w1", Provenance: prov, Metadata: json.RawMessage(`{"a":1}`)})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, err := s.Get(ctx, m.ID, RecordAccess{WorkspaceID: "w1"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Provenance != prov {
+		t.Fatalf("provenance mismatch: got %+v want %+v", got.Provenance, prov)
+	}
+	if string(got.Metadata) != `{"a":1}` {
+		t.Fatalf("metadata mismatch: %q", got.Metadata)
+	}
+}
+
+func TestGetMissAndScope(t *testing.T) {
+	s := newRecordStore(t)
+	ctx := context.Background()
+	if _, err := s.Get(ctx, "nope", RecordAccess{}); !errors.Is(err, ErrRecordNotFound) {
+		t.Fatalf("Get miss: got %v want ErrRecordNotFound", err)
+	}
+	m, _ := s.Create(ctx, CreateRecordParams{Kind: KindSemantic, Content: "x", WorkspaceID: "w1"})
+	if _, err := s.Get(ctx, m.ID, RecordAccess{WorkspaceID: "w2"}); !errors.Is(err, ErrRecordNotFound) {
+		t.Fatalf("cross-workspace Get: got %v want ErrRecordNotFound", err)
+	}
+	sm, _ := s.Create(ctx, CreateRecordParams{Kind: KindWorking, Content: "x", WorkspaceID: "w1", SessionID: "s1"})
+	if _, err := s.Get(ctx, sm.ID, RecordAccess{WorkspaceID: "w1"}); !errors.Is(err, ErrRecordNotFound) {
+		t.Fatalf("non-session Get of session record: got %v want ErrRecordNotFound", err)
+	}
+	// positive: a global record (workspace_id="") is visible under any workspace scope.
+	g, _ := s.Create(ctx, CreateRecordParams{Kind: KindSemantic, Content: "global"})
+	if _, err := s.Get(ctx, g.ID, RecordAccess{WorkspaceID: "any"}); err != nil {
+		t.Fatalf("global record not visible under workspace scope: %v", err)
+	}
+}
+
+func TestCreatePartialProvenanceAllowed(t *testing.T) {
+	s := newRecordStore(t)
+	ctx := context.Background()
+	// End == 0 (unset) with a known Start is partial provenance, not an error.
+	m, err := s.Create(ctx, CreateRecordParams{Kind: KindSemantic, Content: "x", WorkspaceID: "w1", Provenance: Provenance{SourceKind: "tool", Start: 5}})
+	if err != nil {
+		t.Fatalf("partial provenance Create: %v", err)
+	}
+	got, err := s.Get(ctx, m.ID, RecordAccess{WorkspaceID: "w1"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Provenance.Start != 5 || got.Provenance.End != 0 {
+		t.Fatalf("partial provenance round-trip: got %+v", got.Provenance)
+	}
+}
+
+func TestGetReturnsExpired(t *testing.T) {
+	s := newRecordStore(t)
+	ctx := context.Background()
+	past := time.Now().Add(-time.Hour)
+	m, _ := s.Create(ctx, CreateRecordParams{Kind: KindSemantic, Content: "x", WorkspaceID: "w1", ExpiresAt: past})
+	got, err := s.Get(ctx, m.ID, RecordAccess{WorkspaceID: "w1"})
+	if err != nil {
+		t.Fatalf("Get expired: %v", err)
+	}
+	if got.ExpiresAt.IsZero() {
+		t.Fatalf("expected non-zero ExpiresAt round-trip")
+	}
+}

--- a/memory/record_store_test.go
+++ b/memory/record_store_test.go
@@ -333,3 +333,50 @@ func TestUpdateMissScopeAndBadMetadata(t *testing.T) {
 		t.Fatalf("whitespace content: got %v want ErrEmptyContent", err)
 	}
 }
+
+func TestRecordSoftDelete(t *testing.T) {
+	s := newRecordStore(t)
+	ctx := context.Background()
+	m, _ := s.Create(ctx, CreateRecordParams{Kind: KindSemantic, Content: "gone soon", WorkspaceID: "w1"})
+	if err := s.SoftDelete(ctx, m.ID, RecordAccess{WorkspaceID: "w1"}); err != nil {
+		t.Fatalf("SoftDelete: %v", err)
+	}
+	if _, err := s.Get(ctx, m.ID, RecordAccess{WorkspaceID: "w1"}); !errors.Is(err, ErrRecordNotFound) {
+		t.Fatalf("Get after delete: got %v", err)
+	}
+	if hits := mustSearch(t, s, "gone", RecordSearchOptions{WorkspaceID: "w1"}); len(hits) != 0 {
+		t.Fatalf("Search after delete: got %v", hits)
+	}
+	// prove the FTS row itself is gone, not merely hidden by the deleted_at join
+	// filter (otherwise orphaned FTS rows would accumulate unbounded).
+	var ftsRows int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM memory_records_fts WHERE id = ?`, m.ID).Scan(&ftsRows); err != nil {
+		t.Fatalf("count fts rows: %v", err)
+	}
+	if ftsRows != 0 {
+		t.Fatalf("orphaned FTS row after delete: count=%d", ftsRows)
+	}
+	if err := s.SoftDelete(ctx, m.ID, RecordAccess{WorkspaceID: "w1"}); !errors.Is(err, ErrRecordNotFound) {
+		t.Fatalf("double delete: got %v want ErrRecordNotFound", err)
+	}
+}
+
+func TestRecordSoftDeleteScope(t *testing.T) {
+	s := newRecordStore(t)
+	ctx := context.Background()
+	m, _ := s.Create(ctx, CreateRecordParams{Kind: KindSemantic, Content: "x", WorkspaceID: "w1"})
+	if err := s.SoftDelete(ctx, m.ID, RecordAccess{WorkspaceID: "w2"}); !errors.Is(err, ErrRecordNotFound) {
+		t.Fatalf("cross-workspace delete: got %v want ErrRecordNotFound", err)
+	}
+	if _, err := s.Get(ctx, m.ID, RecordAccess{WorkspaceID: "w1"}); err != nil {
+		t.Fatalf("record wrongly deleted: %v", err)
+	}
+	// session isolation: a session-scoped record is not deletable without the session.
+	sm, _ := s.Create(ctx, CreateRecordParams{Kind: KindWorking, Content: "y", WorkspaceID: "w1", SessionID: "s1"})
+	if err := s.SoftDelete(ctx, sm.ID, RecordAccess{WorkspaceID: "w1"}); !errors.Is(err, ErrRecordNotFound) {
+		t.Fatalf("cross-session delete: got %v want ErrRecordNotFound", err)
+	}
+	if _, err := s.Get(ctx, sm.ID, RecordAccess{WorkspaceID: "w1", SessionID: "s1"}); err != nil {
+		t.Fatalf("session record wrongly deleted: %v", err)
+	}
+}

--- a/memory/record_store_test.go
+++ b/memory/record_store_test.go
@@ -249,3 +249,87 @@ func TestSearchNoMatchNonNil(t *testing.T) {
 		t.Fatalf("want non-nil empty slice, got %v", got)
 	}
 }
+
+func strptr(s string) *string { return &s }
+
+func TestUpdateFields(t *testing.T) {
+	s := newRecordStore(t)
+	ctx := context.Background()
+	m, _ := s.Create(ctx, CreateRecordParams{Kind: KindSemantic, Content: "old", WorkspaceID: "w1", Namespace: "a"})
+	exp := time.Now().Add(time.Hour)
+	got, err := s.Update(ctx, m.ID, RecordAccess{WorkspaceID: "w1"}, UpdateRecordParams{
+		Content:   strptr("new content"),
+		Namespace: strptr("b"),
+		Metadata:  json.RawMessage(`{"k":1}`),
+		ExpiresAt: &exp,
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got.Content != "new content" || got.Namespace != "b" || string(got.Metadata) != `{"k":1}` || got.ExpiresAt.IsZero() {
+		t.Fatalf("Update result: %+v", got)
+	}
+	hits := mustSearch(t, s, "content", RecordSearchOptions{WorkspaceID: "w1"})
+	if len(hits) != 1 {
+		t.Fatalf("FTS resync: got %d want 1", len(hits))
+	}
+	if old := mustSearch(t, s, "old", RecordSearchOptions{WorkspaceID: "w1"}); len(old) != 0 {
+		t.Fatalf("stale FTS term still matches: %v", old)
+	}
+	// re-fetch from the DB to confirm the write landed (not just the in-memory struct).
+	reread, err := s.Get(ctx, m.ID, RecordAccess{WorkspaceID: "w1"})
+	if err != nil {
+		t.Fatalf("Get after Update: %v", err)
+	}
+	if reread.Content != "new content" || reread.Namespace != "b" || string(reread.Metadata) != `{"k":1}` || reread.ExpiresAt.IsZero() {
+		t.Fatalf("persisted row mismatch: %+v", reread)
+	}
+}
+
+func TestUpdatePartialLeavesOthers(t *testing.T) {
+	s := newRecordStore(t)
+	ctx := context.Background()
+	m, _ := s.Create(ctx, CreateRecordParams{Kind: KindSemantic, Content: "keep", WorkspaceID: "w1", Namespace: "a", Metadata: json.RawMessage(`{"k":1}`)})
+	got, err := s.Update(ctx, m.ID, RecordAccess{WorkspaceID: "w1"}, UpdateRecordParams{Namespace: strptr("b")})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got.Namespace != "b" {
+		t.Fatalf("namespace not updated: %q", got.Namespace)
+	}
+	if got.Content != "keep" || string(got.Metadata) != `{"k":1}` || !got.ExpiresAt.IsZero() {
+		t.Fatalf("untouched fields changed: %+v", got)
+	}
+}
+
+func TestUpdateClearExpiry(t *testing.T) {
+	s := newRecordStore(t)
+	ctx := context.Background()
+	m, _ := s.Create(ctx, CreateRecordParams{Kind: KindSemantic, Content: "x", WorkspaceID: "w1", ExpiresAt: time.Now().Add(time.Hour)})
+	zero := time.Time{}
+	got, err := s.Update(ctx, m.ID, RecordAccess{WorkspaceID: "w1"}, UpdateRecordParams{ExpiresAt: &zero})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if !got.ExpiresAt.IsZero() {
+		t.Fatalf("expected cleared expiry, got %v", got.ExpiresAt)
+	}
+}
+
+func TestUpdateMissScopeAndBadMetadata(t *testing.T) {
+	s := newRecordStore(t)
+	ctx := context.Background()
+	if _, err := s.Update(ctx, "nope", RecordAccess{}, UpdateRecordParams{Namespace: strptr("x")}); !errors.Is(err, ErrRecordNotFound) {
+		t.Fatalf("Update miss: got %v", err)
+	}
+	m, _ := s.Create(ctx, CreateRecordParams{Kind: KindSemantic, Content: "x", WorkspaceID: "w1"})
+	if _, err := s.Update(ctx, m.ID, RecordAccess{WorkspaceID: "w2"}, UpdateRecordParams{Namespace: strptr("x")}); !errors.Is(err, ErrRecordNotFound) {
+		t.Fatalf("cross-workspace Update: got %v", err)
+	}
+	if _, err := s.Update(ctx, m.ID, RecordAccess{WorkspaceID: "w1"}, UpdateRecordParams{Metadata: json.RawMessage("{bad")}); !errors.Is(err, ErrBadMetadata) {
+		t.Fatalf("bad metadata: got %v", err)
+	}
+	if _, err := s.Update(ctx, m.ID, RecordAccess{WorkspaceID: "w1"}, UpdateRecordParams{Content: strptr("   ")}); !errors.Is(err, ErrEmptyContent) {
+		t.Fatalf("whitespace content: got %v want ErrEmptyContent", err)
+	}
+}

--- a/memory/record_store_test.go
+++ b/memory/record_store_test.go
@@ -430,3 +430,36 @@ func TestPromoteBadTargetAndMiss(t *testing.T) {
 		t.Fatalf("promote of session record without session scope: got %v want ErrRecordNotFound", err)
 	}
 }
+
+func TestMemoryRecordsMigrationKeepsMemoriesWorking(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Open BOTH stores on the same DB (shared migration chain, v1 + v2).
+	notes, err := NewStore(ctx, db)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if _, err := NewMemoryRecordStore(ctx, db); err != nil {
+		t.Fatalf("NewMemoryRecordStore: %v", err)
+	}
+
+	// #237 Memory still round-trips: Add, Search, List, ResolveVisible.
+	m, err := notes.Add(ctx, AddParams{Text: "user preference note", Scope: ScopeWorkspace, WorkspaceID: "w1"})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if hits, err := notes.Search(ctx, "preference", SearchOptions{WorkspaceID: "w1"}); err != nil || len(hits) != 1 {
+		t.Fatalf("Search: err=%v n=%d", err, len(hits))
+	}
+	if ms, err := notes.List(ctx, ListOptions{WorkspaceID: "w1"}); err != nil || len(ms) != 1 {
+		t.Fatalf("List: err=%v n=%d", err, len(ms))
+	}
+	if got, err := notes.ResolveVisible(ctx, m.ID, "w1"); err != nil || got.ID != m.ID {
+		t.Fatalf("ResolveVisible: err=%v id=%s", err, got.ID)
+	}
+}


### PR DESCRIPTION
Closes #114.

## Summary

Adds a typed agent-memory record surface to the existing `memory/` package, beside the untouched user-authored `Memory`/`SQLiteStore` from #237. Storage-first foundation only: a pure library with tests. No session-commit extraction, MCP tools, Golem wiring, embeddings, or autonomous policy (those are tracked follow-ups).

New `MemoryRecordStore` with six methods:

- `Create` / `Get` / `Update` / `SoftDelete` / `Search` / `Promote`
- `MemoryRecord`: kind (working/semantic/episodic), content, namespace, workspace/session scoping, structured `Provenance`, opaque JSON metadata, timestamps, expiration, soft-delete.

Design choices:

- Visibility is derived, not an enum: `workspace_id=""` is global, set is workspace-private; `session_id` set is session-private and requires a workspace. Enforced identically on every read and mutation via a shared predicate; out-of-scope rows return `ErrRecordNotFound` (existence never leaks across a workspace/session boundary).
- `Kind` is orthogonal to visibility. Working memory requires a session; `Promote` (working -> semantic/episodic) sheds the session binding and expiry, keeps the workspace, preserves provenance.
- Search is FTS5 bm25 with an empty-query recency-listing path; filters by kind/namespace/workspace/session/recency; query-time expiration exclusion with an `IncludeExpired` escape hatch. No embeddings, no RAG-table mixing.
- Migration v2 (`memory_records` + `memory_records_fts`) is additive on the shared migration chain; the #237 `Memory` surface is untouched. Storage boundary kept crisp: no import of `conversation/` or `rag/`.

## Test plan

- [ ] `env -u GOROOT go test -race ./...` (full suite passes; all agent-memory behavior covered)
- [ ] `env -u GOROOT go test -race ./memory/...` (CRUD, validation, workspace+session visibility isolation, FTS search + recency listing, expiry exclusion, FTS-orphan cleanup on delete, promotion semantics)
- [ ] Compat guard: #237 `Memory` (Add/Search/List/ResolveVisible) still round-trips after migration v2 when both stores share a DB
- [ ] `gofmt -l memory/` clean; `golangci-lint run ./memory/...` clean