### PR TITLE
feat(golem): one-shot -p mode with pure-stdout final answer

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Inside the REPL, use `/help`, `/tools`, `/model`, `/new`, `/clear`, `/undo`, and
 
 ### Scripting / one-shot mode
 
-`-p` runs a single agent turn without the REPL and prints only the final answer to stdout, so the output is safe to capture in scripts. All progress, warnings, and errors go to stderr, and failures exit non-zero. One-shot implies `-no-session` and `-no-compress` (nothing is persisted, and no agent-memory records are written), and approval-gated tools stay unavailable — `-allow-write`/`-allow-exec` are ignored because there is no interactive approver to answer the prompt.
+`-p` runs a single agent turn without the REPL and prints only the final answer to stdout, so the output is safe to capture in scripts. All progress, warnings, and errors go to stderr, and failures exit non-zero. One-shot implies `-no-session`, `-no-compress`, and `-no-memory` (nothing is persisted, and no memory DB is opened), and approval-gated tools stay unavailable — `-allow-write`/`-allow-exec` are ignored because there is no interactive approver to answer the prompt.
 
 Generate a commit message from a staged diff:
 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,17 @@ golem -root /path/to/project -allow-write -allow-exec
 
 Inside the REPL, use `/help`, `/tools`, `/model`, `/new`, `/clear`, `/undo`, and `/exit`. Any other line is sent to the agent as the current goal.
 
+### Scripting / one-shot mode
+
+`-p` runs a single agent turn without the REPL and prints only the final answer to stdout, so the output is safe to capture in scripts. All progress, warnings, and errors go to stderr, and failures exit non-zero. One-shot implies `-no-session` and `-no-compress` (nothing is persisted, and no agent-memory records are written), and approval-gated tools stay unavailable — `-allow-write`/`-allow-exec` are ignored because there is no interactive approver to answer the prompt.
+
+Generate a commit message from a staged diff:
+
+```bash
+msg=$(golem -root /path/to/project -p "Write a conventional commit message for this diff, output only the message: $(git diff --cached)")
+git commit -m "$msg"
+```
+
 ### MCP server
 
 Expose go-llm to Claude Desktop, IDE extensions, or any MCP client:

--- a/cmd/golem/main.go
+++ b/cmd/golem/main.go
@@ -21,6 +21,8 @@ import (
 type flags struct {
 	configPath       string
 	root             string
+	prompt           string
+	promptSet        bool // -p was passed (distinguishes an explicit empty prompt)
 	ollamaURL        string
 	ragDB            string
 	maxSteps         int
@@ -52,6 +54,7 @@ func parseFlags(args []string) (flags, error) {
 	fs.StringVar(&f.configPath, "config", "", "path to models.json (default: auto-discover)")
 	fs.StringVar(&f.root, "root", ".", "workspace root the tools are scoped to")
 	fs.StringVar(&f.ollamaURL, "ollama-url", "", "override Ollama base URL")
+	fs.StringVar(&f.prompt, "p", "", "one-shot mode: run a single agent turn with this prompt and exit; only the final answer goes to stdout (implies -no-session -no-compress; approval-gated tools are unavailable, so -allow-write/-allow-exec are ignored)")
 	fs.StringVar(&f.ragDB, "rag-db", "", "path to a prebuilt RAG SQLite DB to enable the retrieve tool")
 	fs.IntVar(&f.maxSteps, "max-steps", 0, "max agent steps per prompt (0 => default 16)")
 	fs.IntVar(&f.inputCeiling, "input-ceiling", 0, "token input ceiling (0 => default)")
@@ -79,11 +82,22 @@ func parseFlags(args []string) (flags, error) {
 	if err := fs.Parse(args); err != nil {
 		return flags{}, err
 	}
+	fs.Visit(func(fl *flag.Flag) {
+		if fl.Name == "p" {
+			f.promptSet = true
+		}
+	})
 	return f, nil
 }
 
 // validateFlags rejects flag values flag.Parse cannot police.
 func validateFlags(f flags) error {
+	if f.promptSet && strings.TrimSpace(f.prompt) == "" {
+		return fmt.Errorf("golem: -p requires a non-empty prompt")
+	}
+	if f.promptSet && (f.fresh || f.sessionID != "") {
+		return fmt.Errorf("golem: -p (one-shot) is incompatible with -session and -fresh")
+	}
 	if f.fresh && f.sessionID != "" {
 		return fmt.Errorf("golem: -fresh and -session are mutually exclusive")
 	}
@@ -97,6 +111,25 @@ func validateFlags(f flags) error {
 		return fmt.Errorf("golem: -feedback-db requires -feedback")
 	}
 	return nil
+}
+
+// applyOneShotMode forces the scripting-safe defaults -p implies: no session
+// persistence, no post-turn compression, and no approval-gated tools (there is
+// no interactive approver to answer the prompt, so -allow-write/-allow-exec
+// are dropped with a warning instead of dangling unanswerable approvals).
+func applyOneShotMode(f flags) (flags, []string) {
+	if !f.promptSet {
+		return f, nil
+	}
+	var warns []string
+	f.noSession = true
+	f.noCompress = true
+	if f.allowWrite || f.allowExec {
+		warns = append(warns, "one-shot: -allow-write/-allow-exec ignored (approval prompts need the REPL); write/exec tools unavailable")
+		f.allowWrite = false
+		f.allowExec = false
+	}
+	return f, warns
 }
 
 type startupInfo struct {
@@ -161,8 +194,8 @@ func main() {
 		if errors.Is(err, flag.ErrHelp) {
 			return
 		}
-		// runIndex already rendered its own output; just exit non-zero.
-		if errors.Is(err, errIndexFailed) {
+		// runIndex/runOneShot already rendered their own output; just exit non-zero.
+		if errors.Is(err, errIndexFailed) || errors.Is(err, errOneShotFailed) {
 			os.Exit(1)
 		}
 		_, _ = fmt.Fprintf(os.Stderr, "golem: %v\n", err)
@@ -187,6 +220,7 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 	if err := validateFlags(f); err != nil {
 		return err
 	}
+	f, oneShotWarns := applyOneShotMode(f)
 
 	root, err := filepath.Abs(f.root)
 	if err != nil {
@@ -221,6 +255,7 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 	if err != nil {
 		return err
 	}
+	warns = append(warns, oneShotWarns...)
 
 	autoDBPath, autoWorkspaceID, autoErr := indexDBPathForWorkspace(os.Getenv, root)
 	autoSidecar := ""
@@ -457,6 +492,9 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 		}
 	}()
 
+	if f.promptSet {
+		return runOneShot(ctx, stdout, stderr, interrupts, sess, f.prompt)
+	}
 	return runREPL(ctx, stdin, stdout, interrupts, sess)
 }
 

--- a/cmd/golem/main.go
+++ b/cmd/golem/main.go
@@ -54,7 +54,7 @@ func parseFlags(args []string) (flags, error) {
 	fs.StringVar(&f.configPath, "config", "", "path to models.json (default: auto-discover)")
 	fs.StringVar(&f.root, "root", ".", "workspace root the tools are scoped to")
 	fs.StringVar(&f.ollamaURL, "ollama-url", "", "override Ollama base URL")
-	fs.StringVar(&f.prompt, "p", "", "one-shot mode: run a single agent turn with this prompt and exit; only the final answer goes to stdout (implies -no-session -no-compress; approval-gated tools are unavailable, so -allow-write/-allow-exec are ignored)")
+	fs.StringVar(&f.prompt, "p", "", "one-shot mode: run a single agent turn with this prompt and exit; only the final answer goes to stdout (implies -no-session -no-compress -no-memory; approval-gated tools are unavailable, so -allow-write/-allow-exec are ignored)")
 	fs.StringVar(&f.ragDB, "rag-db", "", "path to a prebuilt RAG SQLite DB to enable the retrieve tool")
 	fs.IntVar(&f.maxSteps, "max-steps", 0, "max agent steps per prompt (0 => default 16)")
 	fs.IntVar(&f.inputCeiling, "input-ceiling", 0, "token input ceiling (0 => default)")
@@ -114,9 +114,10 @@ func validateFlags(f flags) error {
 }
 
 // applyOneShotMode forces the scripting-safe defaults -p implies: no session
-// persistence, no post-turn compression, and no approval-gated tools (there is
-// no interactive approver to answer the prompt, so -allow-write/-allow-exec
-// are dropped with a warning instead of dangling unanswerable approvals).
+// persistence, no post-turn compression, no memory DB, and no approval-gated
+// tools (there is no interactive approver to answer the prompt, so
+// -allow-write/-allow-exec are dropped with a warning instead of dangling
+// unanswerable approvals).
 func applyOneShotMode(f flags) (flags, []string) {
 	if !f.promptSet {
 		return f, nil
@@ -124,6 +125,7 @@ func applyOneShotMode(f flags) (flags, []string) {
 	var warns []string
 	f.noSession = true
 	f.noCompress = true
+	f.noMemory = true
 	if f.allowWrite || f.allowExec {
 		warns = append(warns, "one-shot: -allow-write/-allow-exec ignored (approval prompts need the REPL); write/exec tools unavailable")
 		f.allowWrite = false

--- a/cmd/golem/oneshot_test.go
+++ b/cmd/golem/oneshot_test.go
@@ -60,8 +60,8 @@ func TestRun_OneShotEmptyPromptErrors(t *testing.T) {
 
 func TestApplyOneShotMode(t *testing.T) {
 	got, warns := applyOneShotMode(flags{promptSet: true, prompt: "x", allowWrite: true, allowExec: true})
-	if !got.noSession || !got.noCompress {
-		t.Errorf("one-shot must force -no-session and -no-compress, got %+v", got)
+	if !got.noSession || !got.noCompress || !got.noMemory {
+		t.Errorf("one-shot must force -no-session, -no-compress, and -no-memory, got %+v", got)
 	}
 	if got.allowWrite || got.allowExec {
 		t.Errorf("one-shot must drop -allow-write/-allow-exec (no interactive approver), got %+v", got)
@@ -71,8 +71,8 @@ func TestApplyOneShotMode(t *testing.T) {
 	}
 
 	plain, warns := applyOneShotMode(flags{promptSet: true, prompt: "x"})
-	if !plain.noSession || !plain.noCompress || len(warns) != 0 {
-		t.Errorf("plain one-shot: noSession/noCompress forced without warnings, got %+v %v", plain, warns)
+	if !plain.noSession || !plain.noCompress || !plain.noMemory || len(warns) != 0 {
+		t.Errorf("plain one-shot: noSession/noCompress/noMemory forced without warnings, got %+v %v", plain, warns)
 	}
 
 	repl := flags{allowWrite: true}

--- a/cmd/golem/oneshot_test.go
+++ b/cmd/golem/oneshot_test.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/agent"
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+func TestParseFlags_Prompt(t *testing.T) {
+	f, err := parseFlags([]string{"-p", "summarize this diff"})
+	if err != nil {
+		t.Fatalf("parseFlags: %v", err)
+	}
+	if f.prompt != "summarize this diff" || !f.promptSet {
+		t.Errorf("prompt = %q promptSet = %v, want set", f.prompt, f.promptSet)
+	}
+	def, err := parseFlags(nil)
+	if err != nil {
+		t.Fatalf("parseFlags defaults: %v", err)
+	}
+	if def.prompt != "" || def.promptSet {
+		t.Errorf("prompt must default to unset, got %+v", def)
+	}
+}
+
+func TestValidateFlags_PromptEmpty(t *testing.T) {
+	if err := validateFlags(flags{promptSet: true, prompt: ""}); err == nil {
+		t.Error("-p with an empty prompt must error")
+	}
+	if err := validateFlags(flags{promptSet: true, prompt: "   "}); err == nil {
+		t.Error("-p with a whitespace-only prompt must error")
+	}
+	if err := validateFlags(flags{promptSet: true, prompt: "do it"}); err != nil {
+		t.Errorf("-p with a real prompt must be allowed, got %v", err)
+	}
+}
+
+func TestValidateFlags_PromptSessionExclusive(t *testing.T) {
+	if err := validateFlags(flags{promptSet: true, prompt: "x", sessionID: "s"}); err == nil {
+		t.Error("-p with -session must error (one-shot never persists)")
+	}
+	if err := validateFlags(flags{promptSet: true, prompt: "x", fresh: true}); err == nil {
+		t.Error("-p with -fresh must error (one-shot never persists)")
+	}
+}
+
+func TestRun_OneShotEmptyPromptErrors(t *testing.T) {
+	err := run([]string{"-p", ""}, os.Stdin, os.Stdout, os.Stderr)
+	if err == nil || !strings.Contains(err.Error(), "-p") {
+		t.Fatalf("want empty -p prompt error, got %v", err)
+	}
+}
+
+func TestApplyOneShotMode(t *testing.T) {
+	got, warns := applyOneShotMode(flags{promptSet: true, prompt: "x", allowWrite: true, allowExec: true})
+	if !got.noSession || !got.noCompress {
+		t.Errorf("one-shot must force -no-session and -no-compress, got %+v", got)
+	}
+	if got.allowWrite || got.allowExec {
+		t.Errorf("one-shot must drop -allow-write/-allow-exec (no interactive approver), got %+v", got)
+	}
+	if len(warns) == 0 || !strings.Contains(strings.Join(warns, "\n"), "one-shot") {
+		t.Errorf("dropping approval-gated tools must warn, got %v", warns)
+	}
+
+	plain, warns := applyOneShotMode(flags{promptSet: true, prompt: "x"})
+	if !plain.noSession || !plain.noCompress || len(warns) != 0 {
+		t.Errorf("plain one-shot: noSession/noCompress forced without warnings, got %+v %v", plain, warns)
+	}
+
+	repl := flags{allowWrite: true}
+	if got, warns := applyOneShotMode(repl); !reflect.DeepEqual(got, repl) || len(warns) != 0 {
+		t.Errorf("without -p, flags must pass through untouched, got %+v %v", got, warns)
+	}
+}
+
+// One-shot forcing -no-session must ripple into the #261 agent-memory gate:
+// no session means the create/promote record tools are never registered.
+func TestOneShotDisablesAgentMemoryWrites(t *testing.T) {
+	f, _ := applyOneShotMode(flags{promptSet: true, prompt: "x", agentMemory: true})
+	want, warn := agentMemoryRequest(f.agentMemory, f.noSession)
+	if want || warn == "" {
+		t.Errorf("agent memory must be refused in one-shot mode (want=%v warn=%q)", want, warn)
+	}
+}
+
+func TestOneShot_PrintsOnlyAnswerToStdout(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(root+"/hello.txt", []byte("hi there"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	toolCall := provider.ChatResponse{
+		ToolCalls: []provider.ToolCall{{
+			ID: "c1", Type: "function",
+			Function: provider.ToolCallFunction{Name: "read_file", Arguments: json.RawMessage(`{"path":"hello.txt"}`)},
+		}},
+	}
+	finalAns := provider.ChatResponse{Content: "feat: add greeting file\n"}
+	caller := &scriptCaller{responses: []agent.ModelResult{{Response: toolCall}, {Response: finalAns}}}
+	sess := newTestSession(t, caller, root)
+
+	var stdout, stderr strings.Builder
+	if err := runOneShot(context.Background(), &stdout, &stderr, nil, sess, "commit message please"); err != nil {
+		t.Fatalf("runOneShot: %v", err)
+	}
+	// stdout purity: exactly the final answer plus one trailing newline.
+	if stdout.String() != "feat: add greeting file\n" {
+		t.Errorf("stdout = %q, want the bare answer with one trailing newline", stdout.String())
+	}
+	// All chrome (tool lines, footer) belongs to stderr.
+	if !strings.Contains(stderr.String(), "read_file") {
+		t.Errorf("tool-call progress missing from stderr:\n%s", stderr.String())
+	}
+	for _, banned := range []string{"golem>", "done ·", "\x1b["} {
+		if strings.Contains(stdout.String(), banned) {
+			t.Errorf("stdout must not contain %q:\n%s", banned, stdout.String())
+		}
+	}
+}
+
+// errCaller fails every model call.
+type errCaller struct{ err error }
+
+func (e errCaller) Chat(context.Context, provider.ChatRequest, func(provider.ChatResponse) error) (agent.ModelResult, error) {
+	return agent.ModelResult{}, e.err
+}
+
+func TestOneShot_RunErrorToStderrNonzero(t *testing.T) {
+	sess := newTestSession(t, errCaller{err: errors.New("model unreachable")}, t.TempDir())
+
+	var stdout, stderr strings.Builder
+	err := runOneShot(context.Background(), &stdout, &stderr, nil, sess, "anything")
+	if !errors.Is(err, errOneShotFailed) {
+		t.Fatalf("want errOneShotFailed, got %v", err)
+	}
+	if stdout.String() != "" {
+		t.Errorf("failed run must write nothing to stdout, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "model unreachable") {
+		t.Errorf("stderr must carry the failure reason:\n%s", stderr.String())
+	}
+}
+
+func TestOneShot_EmptyAnswerIsError(t *testing.T) {
+	// No tool calls + empty/whitespace content => Completed without a usable Answer.
+	for _, content := range []string{"", "  \n\t\n"} {
+		caller := &scriptCaller{responses: []agent.ModelResult{{Response: provider.ChatResponse{Content: content}}}}
+		sess := newTestSession(t, caller, t.TempDir())
+
+		var stdout, stderr strings.Builder
+		err := runOneShot(context.Background(), &stdout, &stderr, nil, sess, "anything")
+		if err == nil || !strings.Contains(err.Error(), "no final answer") {
+			t.Fatalf("content %q: empty answer must be a hard error for scripting, got %v", content, err)
+		}
+		if stdout.String() != "" {
+			t.Errorf("content %q: empty answer must write nothing to stdout, got %q", content, stdout.String())
+		}
+	}
+}
+
+// A gated tool call in one-shot mode must be denied by the nil-approver
+// fail-safe (never prompt, never panic on the absent line reader).
+func TestOneShot_GatedExecDeniedWithoutApprover(t *testing.T) {
+	root := t.TempDir()
+	execCall := provider.ChatResponse{
+		ToolCalls: []provider.ToolCall{{
+			ID: "e1", Type: "function",
+			Function: provider.ToolCallFunction{Name: "run_command", Arguments: json.RawMessage(`{"argv":["echo","hello"]}`)},
+		}},
+	}
+	finalAns := provider.ChatResponse{Content: "ok, skipped"}
+	caller := &scriptCaller{responses: []agent.ModelResult{{Response: execCall}, {Response: finalAns}}}
+	sess := newExecOnlyTestSession(t, caller, root)
+
+	var stdout, stderr strings.Builder
+	if err := runOneShot(context.Background(), &stdout, &stderr, nil, sess, "run something"); err != nil {
+		t.Fatalf("runOneShot: %v", err)
+	}
+	if stdout.String() != "ok, skipped\n" {
+		t.Errorf("stdout = %q, want the final answer only", stdout.String())
+	}
+	if strings.Contains(stderr.String(), "Run this command?") || strings.Contains(stdout.String(), "Run this command?") {
+		t.Error("one-shot must never render an approval prompt")
+	}
+}

--- a/cmd/golem/repl.go
+++ b/cmd/golem/repl.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -71,11 +72,35 @@ func runREPL(ctx context.Context, in io.Reader, out io.Writer, interrupts <-chan
 			}
 			continue
 		}
-		runOnce(ctx, out, interrupts, sess, line, lr)
+		_, _ = runOnce(ctx, out, interrupts, sess, line, lr)
 	}
 }
 
-func runOnce(ctx context.Context, out io.Writer, interrupts <-chan struct{}, sess *replSession, line string, lr *lineReader) {
+// errOneShotFailed signals a one-shot turn that already reported its failure
+// on stderr; main exits non-zero without printing a second message.
+var errOneShotFailed = errors.New("one-shot run failed")
+
+// runOneShot executes exactly one agent turn for -p. Only the final answer is
+// written to stdout (with a single trailing newline); every other line the
+// turn produces — tool progress, warnings, errors — goes to stderr via
+// runOnce. A nil lineReader means no interactive approver exists, so the
+// runtime fail-safe denies any approval-gated tool call.
+func runOneShot(ctx context.Context, stdout, stderr io.Writer, interrupts <-chan struct{}, sess *replSession, prompt string) error {
+	res, runErr := runOnce(ctx, stderr, interrupts, sess, prompt, nil)
+	if runErr != nil {
+		return errOneShotFailed // runOnce already reported the failure on stderr
+	}
+	if strings.TrimSpace(res.Answer) == "" {
+		return errors.New("one-shot: model produced no final answer")
+	}
+	_, _ = fmt.Fprintln(stdout, strings.TrimRight(res.Answer, "\n"))
+	return nil
+}
+
+// runOnce runs a single agent turn, rendering all progress and errors to out.
+// It returns the run result so runOneShot can extract the final answer; the
+// REPL ignores it.
+func runOnce(ctx context.Context, out io.Writer, interrupts <-chan struct{}, sess *replSession, line string, lr *lineReader) (agent.Result, error) {
 	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -102,7 +127,7 @@ func runOnce(ctx context.Context, out io.Writer, interrupts <-chan struct{}, ses
 	}
 
 	var approver agent.Approver
-	if needsApprover(sess.allowWrite, sess.allowExec, sess.mcpAttached) {
+	if lr != nil && needsApprover(sess.allowWrite, sess.allowExec, sess.mcpAttached) {
 		approver = newReplApprover(lr, out, sess.color)
 	}
 
@@ -171,10 +196,10 @@ func runOnce(ctx context.Context, out io.Writer, interrupts <-chan struct{}, ses
 	if runErr != nil {
 		if runCtx.Err() != nil {
 			_, _ = fmt.Fprintln(out, "\ncanceled")
-			return
+			return res, runErr
 		}
 		_, _ = fmt.Fprintf(out, "\nerror: %v\n", runErr)
-		return
+		return res, runErr
 	}
 	if m := lastRoutedModel(res); m != "" {
 		sess.lastModel = m
@@ -190,6 +215,7 @@ func runOnce(ctx context.Context, out io.Writer, interrupts <-chan struct{}, ses
 		}
 	}
 	rend.finalFooter(res)
+	return res, nil
 }
 
 // lastRoutedModel returns the ActualModel of the last step that carried a


### PR DESCRIPTION
One-shot non-interactive mode for the Golem terminal agent, motivated by Firn IDE: it shells out to `golem -root <repoRoot> -p "<instruction + diff>"` and uses stdout verbatim as a git commit message, so stdout purity is a hard contract.

## What

- New flag `-p <prompt>`: run exactly one agent turn without the REPL, print only the assistant's final answer to stdout (single trailing newline), exit 0. No banner, no `golem>` prompt, no footers, no ANSI on stdout. All startup notices, tool progress, warnings, and errors go to stderr; failures exit non-zero.
- One-shot implies `-no-session` and `-no-compress`. Nothing is persisted and no post-turn compression runs. Forcing `-no-session` also keeps the #261 agent-memory gate closed: `agentMemoryRequest(agentMemory, noSession=true)` refuses, so the create/promote record tools are never registered and one-shot cannot write or promote memories. Read-only retrieval (memory_search, retrieve, file/search tools) stays available.
- Approval-gated tools are unavailable in one-shot even with `-allow-write`/`-allow-exec`: there is no interactive approver to answer the prompt, so both flags are dropped with a stderr warning and the write/exec tools are never built. If the model still emits a gated call (e.g. via an attached MCP server), runOnce passes a nil approver and the agent runtime fail-safe denies it - no prompt is ever rendered. Documented in the flag help and README.
- Validation: `-p` with an empty/whitespace prompt errors; `-p` is mutually exclusive with `-session` and `-fresh` (one-shot never touches persistence). An empty or whitespace-only final answer is a hard error (nonzero exit, empty stdout) rather than an empty commit message.
- Mechanics: `runOnce` now returns `(agent.Result, error)` and takes a nilable lineReader; `runOneShot` runs the turn with stderr as the render target and writes only `res.Answer` to stdout. The REPL path is behaviorally unchanged. `errOneShotFailed` mirrors the existing `errIndexFailed` pattern so main exits non-zero without printing a duplicate error line.
- README: new "Scripting / one-shot mode" section with a commit-message-from-diff example.

## Tests

cmd/golem/oneshot_test.go, against the existing scriptCaller fake provider and run() harness (no live backend):

- TestParseFlags_Prompt, TestValidateFlags_PromptEmpty, TestValidateFlags_PromptSessionExclusive, TestRun_OneShotEmptyPromptErrors
- TestApplyOneShotMode (forced no-session/no-compress, allow-write/exec dropped with warning, non-one-shot flags pass through untouched)
- TestOneShotDisablesAgentMemoryWrites (one-shot ripples into the #261 sessions-required gate)
- TestOneShot_PrintsOnlyAnswerToStdout (stdout is exactly the answer + newline; tool progress on stderr; `golem>`, footer, and ANSI escapes banned from stdout)
- TestOneShot_RunErrorToStderrNonzero (empty stdout, reason on stderr, errOneShotFailed)
- TestOneShot_EmptyAnswerIsError (empty and whitespace-only answers)
- TestOneShot_GatedExecDeniedWithoutApprover (nil-approver fail-safe, no approval prompt rendered)

Gate: go test ./... (4175 tests, 32 packages), go test -race ./cmd/golem/, go vet ./..., golangci-lint v2.11.4 clean; docker pre-push CI hook ran on push.
