### PR TITLE
docs: opt-in MCP agent_memory_* tools + --agent-memory-db

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ go-llm/
 ├── mcp/             # MCP server: tools, prompts, resources over stdio/HTTP/2 — wired through provider.Router
 ├── mcpclient/       # MCP client: adapts external MCP servers' tools into agent.Tool (stdio/streamable-HTTP); consumed by cmd/golem
 ├── conversation/    # Persistent conversation storage with SQLite
-├── memory/          # Explicit user-controlled local memories (SQLite, scope-filtered FTS5/bm25 search); separate from conversation + RAG; backs Golem /remember + memory_search
+├── memory/          # Explicit user-controlled local memories + agent-memory records (SQLite, scope-filtered FTS5/bm25 search); shared hardened-open primitives (open.go); separate from conversation + RAG; backs Golem /remember + memory_search AND MCP agent_memory_* tools
 ├── projectcontext/  # AGENTS.md-style project-context loader (discovery, safe read, ordering; consumed by cmd/golem)
 ├── feedback/        # Implicit user behavioral signal collection
 ├── fingerprint/     # Model profiling (latency benchmarks, capability detection)

--- a/README.md
+++ b/README.md
@@ -540,6 +540,9 @@ go build -o go-llm-mcp ./cmd/go-llm-mcp/
 
 # Custom Ollama URL
 ./go-llm-mcp --ollama-url http://gpu-server:11434
+
+# Opt-in agent-memory tools (agent_memory_search/create/promote)
+./go-llm-mcp --agent-memory-db ~/.local/share/go-llm/memories.db
 ```
 
 Claude Desktop configuration (`claude_desktop_config.json`):
@@ -555,7 +558,7 @@ Claude Desktop configuration (`claude_desktop_config.json`):
 }
 ```
 
-The server exposes 19 tools (chat, generate, code completion, embeddings, RAG, model management, analysis), 4 prompt templates, 7 concrete resources, and 1 resource template. Chat, generate, completion, embedding, and analysis tools accept an optional `model` parameter; when omitted, the request is routed by `provider.Router` using a use-case-appropriate weight profile (chat / fim / embedding / reasoning / analysis / code-review / agent), with circuit-breaker-aware fallback. Routing state for diagnostics is exposed via the `route://breakers`, `route://warmth`, and `route://sticky` resources. (The actual model that served a given call is computed internally as `RouteOutcome.ActualModel` but is not currently included in tool responses; see Roadmap.)
+The server exposes 19 tools by default (chat, generate, code completion, embeddings, RAG, model management, analysis) plus 3 opt-in agent-memory tools (`agent_memory_search`, `agent_memory_create`, `agent_memory_promote`) registered only when `--agent-memory-db <path>` is set, 4 prompt templates, 7 concrete resources, and 1 resource template. Chat, generate, completion, embedding, and analysis tools accept an optional `model` parameter; when omitted, the request is routed by `provider.Router` using a use-case-appropriate weight profile (chat / fim / embedding / reasoning / analysis / code-review / agent), with circuit-breaker-aware fallback. Routing state for diagnostics is exposed via the `route://breakers`, `route://warmth`, and `route://sticky` resources. (The actual model that served a given call is computed internally as `RouteOutcome.ActualModel` but is not currently included in tool responses; see Roadmap.)
 
 ## Parquet Export
 


### PR DESCRIPTION
Follow-up to #258 (merged). Documents the opt-in agent-memory MCP tools that #258 added:

- README "MCP Server" section: the tool surface is 19 by default plus 3 opt-in agent-memory tools (`agent_memory_search`/`create`/`promote`) registered only when `--agent-memory-db <path>` is set. Added a usage example for the flag.
- CLAUDE.md architecture: the `memory/` package now also holds agent-memory records + the shared hardened-open primitives (`open.go`) and backs the MCP agent_memory_* tools, not just Golem.

Docs-only; no code change.