### PR TITLE
feat(provider/golem): auto-detect tool_call via active probe + capability discoverability

### DIFF
--- a/cmd/golem/capprobe.go
+++ b/cmd/golem/capprobe.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+
+	"github.com/kstruzzieri/go-llm/fingerprint"
+	"github.com/kstruzzieri/go-llm/memory"
+	_ "modernc.org/sqlite"
+)
+
+// capProbeHandle owns the capability-probe store and its DB handle so run()
+// can close it at shutdown (mirrors behavioralWeighterHandle).
+type capProbeHandle struct {
+	store fingerprint.CapProbeStore
+	db    *sql.DB
+}
+
+// sidecarSecuringCapStore re-chmods the DB file and its -wal/-shm sidecars
+// after every mutation. SaveCapProbe runs mid-session (route-time probes), and
+// a WAL checkpoint can recreate a sidecar honoring the umask rather than the DB
+// file's 0600 mode (#237 lesson: every writable golem DB re-secures per write).
+// The store is the only write seam golem controls, so the invariant lives here.
+// Reads pass straight through; only mutations trigger the re-chmod.
+type sidecarSecuringCapStore struct {
+	inner fingerprint.CapProbeStore
+	path  string
+}
+
+func (s sidecarSecuringCapStore) GetCapProbe(ctx context.Context, backendID, modelName, capability string) (*fingerprint.CapProbe, error) {
+	return s.inner.GetCapProbe(ctx, backendID, modelName, capability)
+}
+
+func (s sidecarSecuringCapStore) SaveCapProbe(ctx context.Context, probe fingerprint.CapProbe) error {
+	err := s.inner.SaveCapProbe(ctx, probe)
+	_ = chmodDBFiles(s.path) // best-effort: a loosened sidecar is worse than a surfaced save error
+	return err
+}
+
+func (s sidecarSecuringCapStore) DeleteCapProbes(ctx context.Context, backendID, modelName string) error {
+	err := s.inner.DeleteCapProbes(ctx, backendID, modelName)
+	_ = chmodDBFiles(s.path) // checkpoint can recreate sidecars here too
+	return err
+}
+
+// capProbeStorePath resolves the shared capability-probe DB path:
+// $XDG_DATA_HOME/golem/fingerprints.db (else ~/.local/share/golem/...).
+// Mirrors memoryDBPath's use of dataDirBase.
+func capProbeStorePath(getenv func(string) string) (string, error) {
+	base, err := dataDirBase(getenv)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "golem", "fingerprints.db"), nil
+}
+
+// openCapProbeStore opens (creating if needed) the capability-probe store
+// with the same hardening as golem's sibling DBs: outside-workspace path
+// validation, 0700 dir / 0600 file, WAL single-conn open, and post-migration
+// sidecar re-chmod (shared memory.OpenHardenedDB primitives). On any failure
+// it degrades to an in-memory store for this run and returns a warning —
+// probe verdicts still apply, persistence is lost. Never fatal.
+func openCapProbeStore(ctx context.Context, getenv func(string) string, root string) (*capProbeHandle, string) {
+	h, err := openCapProbeStoreFile(ctx, getenv, root)
+	if err == nil {
+		return h, ""
+	}
+	db, merr := sql.Open("sqlite", ":memory:")
+	if merr == nil {
+		// database/sql pools connections and each :memory: connection is a
+		// separate database; clamp to one so migrations and queries agree.
+		db.SetMaxOpenConns(1)
+		var s *fingerprint.SQLiteStore
+		if s, merr = fingerprint.NewStore(ctx, db); merr == nil {
+			return &capProbeHandle{store: s, db: db}, fmt.Sprintf("capability probe cache degraded to in-memory: %v", err)
+		}
+		_ = db.Close()
+	}
+	return nil, fmt.Sprintf("capability probe cache disabled: %v (memory fallback failed: %v)", err, merr)
+}
+
+// openCapProbeStoreFile is the file-backed happy path behind openCapProbeStore.
+func openCapProbeStoreFile(ctx context.Context, getenv func(string) string, root string) (*capProbeHandle, error) {
+	path, err := capProbeStorePath(getenv)
+	if err != nil {
+		return nil, err
+	}
+	if err := validatePathOutsideWorkspace(path, root); err != nil {
+		return nil, err
+	}
+	db, err := memory.OpenHardenedDB(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	store, err := fingerprint.NewStore(ctx, db)
+	if err != nil {
+		_ = db.Close()
+		_ = chmodDBFiles(path) // best-effort: failed migrations may leave loose sidecars
+		return nil, err
+	}
+	if err := chmodDBFiles(path); err != nil { // migrations may create -wal/-shm
+		_ = db.Close()
+		return nil, err
+	}
+	// Wrap so every mid-session SaveCapProbe/DeleteCapProbes re-secures sidecars.
+	// The in-memory fallback stays unwrapped: it has no file path to chmod.
+	return &capProbeHandle{store: sidecarSecuringCapStore{inner: store, path: path}, db: db}, nil
+}

--- a/cmd/golem/capprobe_integration_test.go
+++ b/cmd/golem/capprobe_integration_test.go
@@ -1,0 +1,213 @@
+//go:build integration
+
+// Integration coverage for the tool-capability probe against a real
+// OpenAI-compatible server (llama.cpp llama-server, vLLM, LM Studio).
+//
+// Requires a running server. Configure via environment:
+//
+//	GO_LLM_TEST_OPENAI_BASE    server root, no /v1 (e.g. http://127.0.0.1:8091)
+//	GO_LLM_TEST_TOOL_MODEL     a model the server lists that supports tool calls
+//	GO_LLM_TEST_NOTOOL_MODEL   (optional) a listed model that does NOT
+//
+// When GO_LLM_TEST_OPENAI_BASE / GO_LLM_TEST_TOOL_MODEL are unset the whole
+// file is skipped, so a plain `go test ./...` without a server is unaffected.
+// Run with: go test -tags integration ./cmd/golem/
+package main
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/fingerprint"
+	"github.com/kstruzzieri/go-llm/fingerprint/probers"
+	"github.com/kstruzzieri/go-llm/provider"
+	"github.com/kstruzzieri/go-llm/provider/openaicompat"
+	_ "modernc.org/sqlite"
+)
+
+// newInMemoryCapProbeStore opens a fresh in-memory SQLite fingerprint store,
+// which satisfies fingerprint.CapProbeStore. Clamped to one connection because
+// each :memory: connection is a separate database.
+func newInMemoryCapProbeStore(t *testing.T, ctx context.Context) *fingerprint.SQLiteStore {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open in-memory sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := fingerprint.NewStore(ctx, db)
+	if err != nil {
+		t.Fatalf("fingerprint.NewStore: %v", err)
+	}
+	return store
+}
+
+// capIntegrationEnv reads and validates the server env, skipping the test when
+// the required vars are absent.
+type capIntegrationEnv struct {
+	base        string
+	toolModel   string
+	notoolModel string
+}
+
+func capIntegrationEnvOrSkip(t *testing.T) capIntegrationEnv {
+	t.Helper()
+	base := os.Getenv("GO_LLM_TEST_OPENAI_BASE")
+	toolModel := os.Getenv("GO_LLM_TEST_TOOL_MODEL")
+	if base == "" || toolModel == "" {
+		t.Skip("set GO_LLM_TEST_OPENAI_BASE and GO_LLM_TEST_TOOL_MODEL to run the capability-probe integration test")
+	}
+	return capIntegrationEnv{
+		base:        strings.TrimRight(base, "/"),
+		toolModel:   toolModel,
+		notoolModel: os.Getenv("GO_LLM_TEST_NOTOOL_MODEL"),
+	}
+}
+
+// TestProbeToolCall_LiveOpenAICompat drives the raw prober against the live
+// server: the tool-capable model must probe "yes"; an optional non-tool model
+// must probe "no" or "inconclusive" (never a false "yes").
+func TestProbeToolCall_LiveOpenAICompat(t *testing.T) {
+	env := capIntegrationEnvOrSkip(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	prober := probers.NewOpenAICompatProber(openaicompat.NewProvider(openaicompat.NewClient(env.base)))
+
+	outcome, err := prober.ProbeToolCall(ctx, env.toolModel)
+	if err != nil {
+		t.Fatalf("ProbeToolCall(%q) error: %v", env.toolModel, err)
+	}
+	if outcome.State != fingerprint.CapProbeYes {
+		t.Fatalf("tool model %q probe state = %q, want yes (detail: %q)", env.toolModel, outcome.State, outcome.Detail)
+	}
+
+	if env.notoolModel == "" {
+		t.Logf("GO_LLM_TEST_NOTOOL_MODEL unset; skipping negative assertion")
+		return
+	}
+	outcome, err = prober.ProbeToolCall(ctx, env.notoolModel)
+	if err != nil {
+		t.Fatalf("ProbeToolCall(%q) error: %v", env.notoolModel, err)
+	}
+	switch outcome.State {
+	case fingerprint.CapProbeNo, fingerprint.CapProbeInconclusive:
+		// Expected: the model must not falsely claim tool support.
+	default:
+		t.Fatalf("non-tool model %q probe state = %q, want no or inconclusive (detail: %q)", env.notoolModel, outcome.State, outcome.Detail)
+	}
+}
+
+// countingProxy fronts the real server with a reverse proxy that counts the
+// upstream chat-completions requests, so a cache hit (zero additional chat
+// requests) is observable.
+type countingProxy struct {
+	srv      *httptest.Server
+	chatReqs atomic.Int64
+}
+
+func newCountingProxy(t *testing.T, base string) *countingProxy {
+	t.Helper()
+	target, err := url.Parse(base)
+	if err != nil {
+		t.Fatalf("parse base url %q: %v", base, err)
+	}
+	cp := &countingProxy{}
+	rp := httputil.NewSingleHostReverseProxy(target)
+	cp.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/chat/completions") {
+			cp.chatReqs.Add(1)
+		}
+		rp.ServeHTTP(w, r)
+	}))
+	t.Cleanup(cp.srv.Close)
+	return cp
+}
+
+func (cp *countingProxy) chatCount() int64 { return cp.chatReqs.Load() }
+
+// TestResolveToolCall_LiveCacheHit exercises the full registry resolve path
+// through a recording proxy: the first ResolveToolCall probes (>=1 upstream
+// chat request), the verdict persists to a temp fingerprint store, and the
+// second ResolveToolCall is a cache hit (0 additional upstream chat requests).
+func TestResolveToolCall_LiveCacheHit(t *testing.T) {
+	env := capIntegrationEnvOrSkip(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	proxy := newCountingProxy(t, env.base)
+
+	const providerName = "openai-local"
+	prov := openaicompat.NewProvider(
+		openaicompat.NewClient(proxy.srv.URL),
+		openaicompat.WithProviderName(providerName),
+	)
+
+	pReg := provider.NewRegistry()
+	if err := pReg.Register(prov); err != nil {
+		t.Fatalf("Register(%q): %v", providerName, err)
+	}
+	if err := pReg.RefreshModels(ctx, providerName); err != nil {
+		t.Fatalf("RefreshModels(%q): %v", providerName, err)
+	}
+
+	// A temp in-memory fingerprint store doubles as the cap-probe store, as in
+	// providerbootstrap (the SQLite store satisfies both interfaces).
+	store := newInMemoryCapProbeStore(t, ctx)
+
+	// The prober factory returns a real OpenAICompatProber wired to the same
+	// proxied provider. ModelDigest is left empty so the registry falls back to
+	// key.String() on both the write and read side (mirrors the openai-compat
+	// path, whose runtime info has no digest).
+	factory := func(_ context.Context, key provider.ModelKey, _ *provider.ModelInfo, p provider.Provider) (*provider.FingerprintProberSpec, error) {
+		oc, ok := p.(*openaicompat.Provider)
+		if !ok {
+			t.Fatalf("prober factory: provider is %T, want *openaicompat.Provider", p)
+		}
+		return &provider.FingerprintProberSpec{Prober: probers.NewOpenAICompatProber(oc)}, nil
+	}
+
+	mr, err := provider.NewModelRegistry(pReg, store,
+		provider.WithCapabilityProbeStore(store),
+		provider.WithCapabilityProber(factory),
+	)
+	if err != nil {
+		t.Fatalf("NewModelRegistry: %v", err)
+	}
+
+	key := provider.ModelKey{Provider: providerName, Model: env.toolModel}
+
+	before := proxy.chatCount()
+	state, err := mr.ResolveToolCall(ctx, key)
+	if err != nil {
+		t.Fatalf("first ResolveToolCall(%v): %v", key, err)
+	}
+	if state != fingerprint.CapProbeYes {
+		t.Fatalf("first resolve state = %q, want yes", state)
+	}
+	afterFirst := proxy.chatCount()
+	if afterFirst-before < 1 {
+		t.Fatalf("first resolve made %d upstream chat requests, want >=1 (probe must hit the server)", afterFirst-before)
+	}
+
+	state, err = mr.ResolveToolCall(ctx, key)
+	if err != nil {
+		t.Fatalf("second ResolveToolCall(%v): %v", key, err)
+	}
+	if state != fingerprint.CapProbeYes {
+		t.Fatalf("second resolve state = %q, want yes", state)
+	}
+	if got := proxy.chatCount() - afterFirst; got != 0 {
+		t.Fatalf("second resolve made %d additional upstream chat requests, want 0 (cache hit)", got)
+	}
+}

--- a/cmd/golem/capprobe_test.go
+++ b/cmd/golem/capprobe_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/fingerprint"
+)
+
+func TestCapProbeStorePath_UsesDataDir(t *testing.T) {
+	base := t.TempDir()
+	getenv := func(k string) string {
+		if k == "XDG_DATA_HOME" {
+			return base
+		}
+		return ""
+	}
+	p, err := capProbeStorePath(getenv)
+	if err != nil {
+		t.Fatalf("capProbeStorePath: %v", err)
+	}
+	if want := filepath.Join(base, "golem", "fingerprints.db"); p != want {
+		t.Errorf("path = %q, want %q", p, want)
+	}
+}
+
+func TestOpenCapProbeStore_CreatesHardenedFile(t *testing.T) {
+	base := t.TempDir()
+	root := t.TempDir()
+	getenv := func(k string) string {
+		if k == "XDG_DATA_HOME" {
+			return base
+		}
+		return ""
+	}
+	h, warn := openCapProbeStore(context.Background(), getenv, root)
+	if h == nil || h.store == nil || h.db == nil {
+		t.Fatalf("want non-nil handle, got %#v (warn=%q)", h, warn)
+	}
+	defer func() { _ = h.db.Close() }()
+	if warn != "" {
+		t.Errorf("unexpected warn: %q", warn)
+	}
+	dbPath := filepath.Join(base, "golem", "fingerprints.db")
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("cap-probe DB not created: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("cap-probe DB mode = %o, want 0600", info.Mode().Perm())
+	}
+	dirInfo, err := os.Stat(filepath.Dir(dbPath))
+	if err != nil {
+		t.Fatalf("cap-probe DB dir not created: %v", err)
+	}
+	if dirInfo.Mode().Perm() != 0o700 {
+		t.Errorf("cap-probe DB dir mode = %o, want 0700", dirInfo.Mode().Perm())
+	}
+	assertDBFilesSecured(t, dbPath)
+}
+
+// assertDBFilesSecured checks the DB file and any present -wal/-shm sidecars
+// are 0600. Missing sidecars are fine (WAL may not have spilled yet).
+func assertDBFilesSecured(t *testing.T, dbPath string) {
+	t.Helper()
+	for _, p := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+		info, err := os.Stat(p)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			t.Fatalf("stat %q: %v", p, err)
+		}
+		if info.Mode().Perm() != 0o600 {
+			t.Errorf("%q mode = %o, want 0600", p, info.Mode().Perm())
+		}
+	}
+}
+
+func TestOpenCapProbeStore_SaveCapProbeSecuresSidecars(t *testing.T) {
+	// SaveCapProbe runs mid-session (route-time probes). A WAL checkpoint can
+	// recreate a -wal/-shm sidecar at the umask, not 0600. The store decorator
+	// must re-chmod after every write.
+	base := t.TempDir()
+	root := t.TempDir()
+	getenv := func(k string) string {
+		if k == "XDG_DATA_HOME" {
+			return base
+		}
+		return ""
+	}
+	ctx := context.Background()
+	h, warn := openCapProbeStore(ctx, getenv, root)
+	if h == nil || h.store == nil {
+		t.Fatalf("want non-nil handle, got %#v (warn=%q)", h, warn)
+	}
+	defer func() { _ = h.db.Close() }()
+
+	dbPath := filepath.Join(base, "golem", "fingerprints.db")
+	// Loosen the sidecars before the write to prove the decorator re-secures
+	// them: if it did not run, they would stay 0666 after SaveCapProbe.
+	for _, suffix := range []string{"-wal", "-shm"} {
+		if err := os.Chmod(dbPath+suffix, 0o666); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("loosen %s: %v", suffix, err)
+		}
+	}
+	row := fingerprint.CapProbe{
+		BackendID:    "lc",
+		ModelName:    "m",
+		Capability:   "tool_call",
+		State:        fingerprint.CapProbeYes,
+		ModelDigest:  "d",
+		ProbeVersion: fingerprint.CurrentToolProbeVersion,
+		TestedAt:     time.Now(),
+	}
+	if err := h.store.SaveCapProbe(ctx, row); err != nil {
+		t.Fatalf("SaveCapProbe: %v", err)
+	}
+	assertDBFilesSecured(t, dbPath)
+}
+
+func TestOpenCapProbeStore_FallsBackToMemoryOnFailure(t *testing.T) {
+	// XDG_DATA_HOME points at a regular file, so creating <base>/golem fails.
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	getenv := func(k string) string {
+		if k == "XDG_DATA_HOME" {
+			return blocker
+		}
+		return ""
+	}
+	ctx := context.Background()
+	h, warn := openCapProbeStore(ctx, getenv, t.TempDir())
+	if h == nil || h.store == nil {
+		t.Fatalf("want in-memory fallback store, got nil (warn=%q)", warn)
+	}
+	defer func() { _ = h.db.Close() }()
+	if warn == "" {
+		t.Errorf("want a degradation warning")
+	}
+	// The fallback store must actually work for this run: save + read back.
+	row := fingerprint.CapProbe{
+		BackendID:    "lc",
+		ModelName:    "m",
+		Capability:   "tool_call",
+		State:        fingerprint.CapProbeYes,
+		ModelDigest:  "d",
+		ProbeVersion: fingerprint.CurrentToolProbeVersion,
+		TestedAt:     time.Now(),
+	}
+	if err := h.store.SaveCapProbe(ctx, row); err != nil {
+		t.Fatalf("SaveCapProbe on fallback store: %v", err)
+	}
+	got, err := h.store.GetCapProbe(ctx, "lc", "m", "tool_call")
+	if err != nil {
+		t.Fatalf("GetCapProbe on fallback store: %v", err)
+	}
+	if got == nil || got.State != fingerprint.CapProbeYes {
+		t.Fatalf("GetCapProbe = %#v, want yes row", got)
+	}
+}

--- a/cmd/golem/main.go
+++ b/cmd/golem/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kstruzzieri/go-llm/agent"
 	agenttools "github.com/kstruzzieri/go-llm/agent/tools"
 	"github.com/kstruzzieri/go-llm/conversation"
+	"github.com/kstruzzieri/go-llm/fingerprint"
 	"github.com/kstruzzieri/go-llm/internal/providerbootstrap"
 	"github.com/kstruzzieri/go-llm/mcpclient"
 	"github.com/kstruzzieri/go-llm/provider/openaicompat"
@@ -28,6 +29,7 @@ type flags struct {
 	baseURL          string
 	baseURLSet       bool // -base-url was passed (distinguishes an explicit empty value)
 	noProbe          bool
+	noCapProbe       bool
 	ragDB            string
 	maxSteps         int
 	inputCeiling     int
@@ -60,6 +62,7 @@ func parseFlags(args []string) (flags, error) {
 	fs.StringVar(&f.ollamaURL, "ollama-url", "", "override Ollama base URL")
 	fs.StringVar(&f.baseURL, "base-url", "", "override the openai-compat backend base URL for the primary agent model (server root, without /v1); used exactly as given, disables discovery")
 	fs.BoolVar(&f.noProbe, "no-probe", false, "disable openai-compat backend port discovery; explicit and configured URLs are still used as resolved")
+	fs.BoolVar(&f.noCapProbe, "no-cap-probe", false, "disable the active tool-capability probe for undeclared models (catalog and explicit capabilities still apply)")
 	fs.StringVar(&f.prompt, "p", "", "one-shot mode: run a single agent turn with this prompt and exit; only the final answer goes to stdout (implies -no-session -no-compress -no-memory; approval-gated tools are unavailable, so -allow-write/-allow-exec are ignored)")
 	fs.StringVar(&f.ragDB, "rag-db", "", "path to a prebuilt RAG SQLite DB to enable the retrieve tool")
 	fs.IntVar(&f.maxSteps, "max-steps", 0, "max agent steps per prompt (0 => default 16)")
@@ -263,11 +266,23 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 		return err // explicit-override validation error: fatal, matches validateFlags semantics
 	}
 
+	var capStore fingerprint.CapProbeStore
+	capStoreWarn := ""
+	if !f.noCapProbe {
+		var capHandle *capProbeHandle
+		capHandle, capStoreWarn = openCapProbeStore(ctx, os.Getenv, root)
+		if capHandle != nil {
+			capStore = capHandle.store
+			defer func() { _ = capHandle.db.Close() }()
+		}
+	}
+
 	bundle, err := providerbootstrap.New(ctx, providerbootstrap.Options{
 		Config:                          cfg, // nil => default Ollama provider
 		OllamaURLOverride:               f.ollamaURL,
 		OpenAICompatURLOverrideProvider: backendRes.providerKey,
 		OpenAICompatURLOverride:         backendRes.baseURL,
+		CapabilityProbeStore:            capStore, // nil when -no-cap-probe or open fully failed
 	})
 	if err != nil {
 		return fmt.Errorf("bootstrap providers: %w", err)
@@ -289,6 +304,9 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 		return err
 	}
 	warns = append(warns, oneShotWarns...)
+	if capStoreWarn != "" {
+		warns = append(warns, capStoreWarn)
+	}
 
 	autoDBPath, autoWorkspaceID, autoErr := indexDBPathForWorkspace(os.Getenv, root)
 	autoSidecar := ""

--- a/cmd/golem/main.go
+++ b/cmd/golem/main.go
@@ -226,8 +226,10 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 		switch args[0] {
 		case "index":
 			return runIndex(context.Background(), args[1:], stdout, stderr)
+		case "models":
+			return runModels(context.Background(), args[1:], stdout, stderr)
 		default:
-			return fmt.Errorf("unknown command %q (did you mean \"index\"?)", args[0])
+			return fmt.Errorf("unknown command %q (did you mean \"index\" or \"models\"?)", args[0])
 		}
 	}
 

--- a/cmd/golem/main.go
+++ b/cmd/golem/main.go
@@ -295,7 +295,11 @@ func run(args []string, stdin *os.File, stdout, stderr *os.File) error {
 	}
 
 	resolveEndpoint := newPreflightEndpointResolver(bundle.Config, f.ollamaURL, backendRes.providerKey, backendRes.diagSource())
-	warns, err := preflightToolCapable(ctx, bundle.Models, plan.chain, resolveEndpoint)
+	var resolver toolCallResolver
+	if !f.noCapProbe && capStore != nil {
+		resolver = bundle.Models // concrete *provider.ModelRegistry; always non-nil after bootstrap
+	}
+	warns, err := preflightToolCapable(ctx, bundle.Models, plan.chain, resolveEndpoint, resolver)
 	warns = append(backendRes.warns, warns...)
 	if err != nil {
 		if len(backendRes.warns) > 0 {

--- a/cmd/golem/modelcaller.go
+++ b/cmd/golem/modelcaller.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/kstruzzieri/go-llm/agent"
 	"github.com/kstruzzieri/go-llm/config"
+	"github.com/kstruzzieri/go-llm/fingerprint"
 	"github.com/kstruzzieri/go-llm/provider"
 )
 
@@ -93,6 +94,33 @@ type capChecker interface {
 }
 
 const toolRouteCaps = provider.CapChat | provider.CapStream | provider.CapToolCall
+
+// toolCallResolver is the narrow slice of *provider.ModelRegistry the preflight
+// needs for active capability resolution. A nil resolver disables probing
+// (-no-cap-probe or no store), in which case the preflight relies solely on the
+// merged (catalog+floor+declared) profile capabilities.
+type toolCallResolver interface {
+	ResolveToolCall(ctx context.Context, key provider.ModelKey) (fingerprint.CapProbeState, error)
+}
+
+// remediationCaps is the exact models.json fix fragment surfaced in remediation
+// hints: the capability list a tool-capable model entry must declare.
+const remediationCaps = `"capabilities": ["chat","generate","stream","tool_call"]`
+
+// remediationHint renders the models.json fix line for a chain entry that
+// resolved without tool_call, naming the selector and the exact capabilities
+// fragment the user should add.
+func remediationHint(sel string) string {
+	return fmt.Sprintf("if it supports function calling, add %s to the model entry for %q in models.json", remediationCaps, sel)
+}
+
+// notToolCapableWarn is the bare capability-gap warning for a selector that
+// resolved (or matched no provider) without tool_call, with its remediation
+// hint. Used wherever a probe cannot or need not run: nil resolver, unknown
+// verdict (probing disabled for the provider), and bare-selector no-match.
+func notToolCapableWarn(sel string) string {
+	return fmt.Sprintf("agent fallback %q is not tool-capable (chat|stream|tool_call); %s", sel, remediationHint(sel))
+}
 
 // preflightEndpoint is the discovery endpoint a provider exposes. It is used
 // only to build a human-facing connectivity diagnostic, never to make a call.
@@ -264,25 +292,27 @@ func parseSelector(sel string) (provider.ModelKey, bool) {
 // non-capable entry, and an error only when NO entry — or, for an empty chain,
 // the recommend set — can satisfy chat|stream|tool_call. On that failure the
 // error INLINES every per-entry diagnostic, because the caller returns on the
-// error and would otherwise drop the warnings. Pure registry lookup; never
-// makes a live model call. resolveEndpoint supplies provider base_url +
-// discovery path for connectivity diagnostics; a nil resolver yields
-// base_url-free messages.
-func preflightToolCapable(ctx context.Context, reg capChecker, chain []string, resolveEndpoint endpointResolver) (warnings []string, err error) {
+// error and would otherwise drop the warnings. Pure registry lookup unless a
+// resolver is supplied; never makes a live chat call. resolveEndpoint supplies
+// provider base_url + discovery path for connectivity diagnostics; a nil
+// resolver disables active capability probing (a nil endpointResolver yields
+// base_url-free messages).
+//
+// Bounded-eager: active probing runs only until the FIRST capable entry. Startup
+// proves ONE usable model then stops loading fallbacks (llama-swap load cost);
+// unknown entries reached after that resolve lazily at route time, reported here
+// as a non-fatal "probed on first use" line.
+func preflightToolCapable(ctx context.Context, reg capChecker, chain []string, resolveEndpoint endpointResolver, resolver toolCallResolver) (warnings []string, err error) {
 	if len(chain) == 0 {
-		profs, rerr := reg.Recommend(ctx, provider.RecommendOpts{RequiredCaps: toolRouteCaps})
-		if rerr != nil {
-			return nil, fmt.Errorf("golem: tool-capability preflight (recommend): %w", rerr)
-		}
-		if len(profs) == 0 {
-			return nil, fmt.Errorf("golem: no tool-capable model available (require chat|stream|tool_call)")
-		}
-		return nil, nil
+		return preflightRecommendToolCapable(ctx, reg, resolver)
 	}
 
 	capable := 0
 	for _, sel := range chain {
-		ok, warn := evalChainEntry(ctx, reg, sel, resolveEndpoint)
+		// Probe only until the first capable entry is proven; later unknowns
+		// are deferred to route time.
+		allowProbe := capable == 0
+		ok, warn := evalChainEntry(ctx, reg, sel, resolveEndpoint, resolver, allowProbe)
 		if ok {
 			capable++
 			continue
@@ -295,13 +325,51 @@ func preflightToolCapable(ctx context.Context, reg capChecker, chain []string, r
 	return warnings, nil
 }
 
+// preflightRecommendToolCapable handles the empty-chain case: no explicit
+// fallback chain, so the gate asks the registry to recommend a tool-capable
+// model. With no resolver it requires the declared tool_call capability up
+// front. With a resolver it relaxes the recommend query (drops CapToolCall so
+// undeclared-but-probeable models are considered) and probes candidates,
+// passing on the first that already declares tool_call or probes yes.
+func preflightRecommendToolCapable(ctx context.Context, reg capChecker, resolver toolCallResolver) ([]string, error) {
+	if resolver == nil {
+		profs, rerr := reg.Recommend(ctx, provider.RecommendOpts{RequiredCaps: toolRouteCaps})
+		if rerr != nil {
+			return nil, fmt.Errorf("golem: tool-capability preflight (recommend): %w", rerr)
+		}
+		if len(profs) == 0 {
+			return nil, fmt.Errorf("golem: no tool-capable model available (require chat|stream|tool_call)")
+		}
+		return nil, nil
+	}
+
+	profs, rerr := reg.Recommend(ctx, provider.RecommendOpts{RequiredCaps: toolRouteCaps &^ provider.CapToolCall})
+	if rerr != nil {
+		return nil, fmt.Errorf("golem: tool-capability preflight (recommend): %w", rerr)
+	}
+	// Two passes, deliberately not fused: exhaust the cheap declared-capability
+	// check across ALL candidates before doing any probe I/O, so a later
+	// already-capable model is preferred over probing an earlier one.
+	for _, p := range profs {
+		if p.Caps.Has(provider.CapToolCall) {
+			return nil, nil
+		}
+	}
+	for _, p := range profs {
+		if state, err := resolver.ResolveToolCall(ctx, p.Key); err == nil && state == fingerprint.CapProbeYes {
+			return nil, nil
+		}
+	}
+	return nil, fmt.Errorf("golem: no tool-capable model available (require chat|stream|tool_call)")
+}
+
 // evalChainEntry classifies one agent-chain selector. It returns capable=true
 // when the selector resolves to a tool-capable model; otherwise it returns a
 // bare warning string: a connectivity diagnostic when the registry lookup
-// errored, or the capability message when the model resolved without tool_call.
-func evalChainEntry(ctx context.Context, reg capChecker, sel string, resolveEndpoint endpointResolver) (capable bool, warning string) {
-	notCapable := fmt.Sprintf("agent fallback %q is not tool-capable (chat|stream|tool_call)", sel)
-
+// errored, or a capability message (possibly a probe outcome) when the model
+// resolved without a declared tool_call. allowProbe gates active probing per the
+// bounded-eager policy.
+func evalChainEntry(ctx context.Context, reg capChecker, sel string, resolveEndpoint endpointResolver, resolver toolCallResolver, allowProbe bool) (capable bool, warning string) {
 	if key, parsed := parseSelector(sel); parsed {
 		p, lerr := reg.Lookup(ctx, key)
 		if lerr != nil {
@@ -311,7 +379,7 @@ func evalChainEntry(ctx context.Context, reg capChecker, sel string, resolveEndp
 		if profileToolCapable(p) {
 			return true, ""
 		}
-		return false, notCapable
+		return classifyToolCapability(ctx, sel, key, resolver, allowProbe)
 	}
 
 	// Bare model name: resolve across providers. A bare selector names no single
@@ -326,5 +394,38 @@ func evalChainEntry(ctx context.Context, reg capChecker, sel string, resolveEndp
 			return true, ""
 		}
 	}
-	return false, notCapable
+	if len(profs) == 0 {
+		// No matching provider: nothing to probe, and no single provider to name.
+		return false, notToolCapableWarn(sel)
+	}
+	// A bare selector may match several providers; probing the first match is a
+	// pragmatic choice (the resolver's own singleflight keys per provider/model).
+	return classifyToolCapability(ctx, sel, profs[0].Key, resolver, allowProbe)
+}
+
+// classifyToolCapability resolves a chain entry that looked up cleanly but does
+// not declare tool_call. With no resolver, or when probing is not allowed for
+// this entry (bounded-eager: a capable entry already found), it reports a
+// non-fatal / capability-gap message rather than making a call. Otherwise it
+// probes and maps the tri-state verdict to a capable flag + diagnostic.
+func classifyToolCapability(ctx context.Context, sel string, key provider.ModelKey, resolver toolCallResolver, allowProbe bool) (bool, string) {
+	if resolver == nil {
+		return false, notToolCapableWarn(sel)
+	}
+	if !allowProbe {
+		return false, fmt.Sprintf("agent fallback %q: tool capability unknown; probed on first use", sel)
+	}
+	state, err := resolver.ResolveToolCall(ctx, key)
+	switch {
+	case err != nil:
+		return false, fmt.Sprintf("agent fallback %q: tool-capability probe failed: %v; %s", sel, err, remediationHint(sel))
+	case state == fingerprint.CapProbeYes:
+		return true, ""
+	case state == fingerprint.CapProbeNo:
+		return false, fmt.Sprintf("agent fallback %q: model did not produce a tool call when probed; %s", sel, remediationHint(sel))
+	case state == fingerprint.CapProbeInconclusive:
+		return false, fmt.Sprintf("agent fallback %q: tool-capability probe was inconclusive; declare capabilities to override: %s", sel, remediationHint(sel))
+	default: // "" unknown: resolution disabled for this provider (no prober/store)
+		return false, notToolCapableWarn(sel)
+	}
 }

--- a/cmd/golem/modelcaller.go
+++ b/cmd/golem/modelcaller.go
@@ -398,9 +398,20 @@ func evalChainEntry(ctx context.Context, reg capChecker, sel string, resolveEndp
 		// No matching provider: nothing to probe, and no single provider to name.
 		return false, notToolCapableWarn(sel)
 	}
-	// A bare selector may match several providers; probing the first match is a
-	// pragmatic choice (the resolver's own singleflight keys per provider/model).
-	return classifyToolCapability(ctx, sel, profs[0].Key, resolver, allowProbe)
+	warning = notToolCapableWarn(sel)
+	for _, p := range profs {
+		if p == nil {
+			continue
+		}
+		capable, w := classifyToolCapability(ctx, sel, p.Key, resolver, allowProbe)
+		if capable {
+			return true, ""
+		}
+		if w != "" {
+			warning = w
+		}
+	}
+	return false, warning
 }
 
 // classifyToolCapability resolves a chain entry that looked up cleanly but does

--- a/cmd/golem/models.go
+++ b/cmd/golem/models.go
@@ -1,0 +1,274 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/config"
+	"github.com/kstruzzieri/go-llm/fingerprint"
+	"github.com/kstruzzieri/go-llm/internal/providerbootstrap"
+	"github.com/kstruzzieri/go-llm/provider"
+	"github.com/kstruzzieri/go-llm/provider/openaicompat"
+)
+
+// modelsRegistry is the narrow slice of *provider.ModelRegistry that runModels
+// needs: profile lookup, tool_call provenance, and (for -probe-all/-reprobe)
+// active resolution. The concrete registry satisfies all three.
+type modelsRegistry interface {
+	Lookup(ctx context.Context, key provider.ModelKey) (*provider.ModelProfile, error)
+	ExplainToolCall(ctx context.Context, key provider.ModelKey) (provider.ToolCallExplanation, error)
+	ResolveToolCall(ctx context.Context, key provider.ModelKey) (fingerprint.CapProbeState, error)
+}
+
+// modelsOpts carries the two active-probe switches for `golem models`.
+type modelsOpts struct {
+	probeAll bool // probe EVERY non-explicit entry (no bounded-eager stop)
+	reprobe  bool // delete cached rows, then re-resolve every non-explicit entry
+}
+
+// runModels is the `golem models` entry point: resolve the agent chain and
+// print each entry's capabilities + tool_call provenance, and optionally probe
+// (-probe-all) or re-probe (-reprobe) non-explicit entries. It builds the real
+// providerbootstrap deps then delegates rendering to runModelsWith.
+func runModels(ctx context.Context, args []string, out, errOut io.Writer) error {
+	var (
+		configPath string
+		rootFlag   string
+		baseURL    string
+		baseURLSet bool
+		ollamaURL  string
+		noProbe    bool
+		probeAll   bool
+		reprobe    bool
+	)
+	fs := flag.NewFlagSet("golem models", flag.ContinueOnError)
+	fs.SetOutput(errOut)
+	fs.StringVar(&configPath, "config", "", "path to models.json (default: auto-discover)")
+	fs.StringVar(&rootFlag, "root", ".", "workspace root (scopes the cap-probe cache path guard)")
+	fs.StringVar(&baseURL, "base-url", "", "override the openai-compat backend base URL (server root, without /v1); used as given, disables discovery")
+	fs.BoolVar(&noProbe, "no-probe", false, "disable openai-compat backend port discovery; explicit and configured URLs are still used as resolved")
+	fs.StringVar(&ollamaURL, "ollama-url", "", "override Ollama base URL")
+	fs.BoolVar(&probeAll, "probe-all", false, "actively probe every non-explicit entry (no bounded-eager stop)")
+	fs.BoolVar(&reprobe, "reprobe", false, "delete cached probe verdicts for non-explicit entries then re-probe")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	fs.Visit(func(fl *flag.Flag) {
+		if fl.Name == "base-url" {
+			baseURLSet = true
+		}
+	})
+
+	root, err := filepath.Abs(rootFlag)
+	if err != nil {
+		return fmt.Errorf("resolve root: %w", err)
+	}
+	if root, err = filepath.EvalSymlinks(root); err != nil {
+		return fmt.Errorf("resolve root: %w", err)
+	}
+
+	cfg, err := loadConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	backendRes, err := resolveBackend(ctx, cfg, backendResolveOpts{
+		flagBaseURL: baseURL,
+		flagSet:     baseURLSet,
+		noProbe:     noProbe,
+		lookupEnv:   os.LookupEnv,
+		prober:      openaicompat.DiscoverBaseURL,
+	})
+	if err != nil {
+		return err
+	}
+
+	// The cap-probe store is required to probe/reprobe. Open it whenever
+	// probing might run (either switch), mirroring run()'s handle lifecycle.
+	var capStore fingerprint.CapProbeStore
+	if probeAll || reprobe {
+		capHandle, capStoreWarn := openCapProbeStore(ctx, os.Getenv, root)
+		if capHandle != nil {
+			capStore = capHandle.store
+			defer func() { _ = capHandle.db.Close() }()
+		}
+		if capStoreWarn != "" {
+			_, _ = fmt.Fprintln(errOut, "warning: "+capStoreWarn)
+		}
+		// Store fully unavailable (not even the in-memory fallback): a probe run
+		// would silently no-op. Tell the operator why nothing gets probed, then
+		// drop the switches so runModelsWith renders cached provenance only.
+		if capStore == nil {
+			reason := capStoreWarn
+			if reason == "" {
+				reason = "no capability-probe store"
+			}
+			_, _ = fmt.Fprintf(errOut, "cannot probe: capability-probe store unavailable (%s); showing cached provenance only\n", reason)
+			probeAll = false
+			reprobe = false
+		}
+	}
+
+	bundle, err := providerbootstrap.New(ctx, providerbootstrap.Options{
+		Config:                          cfg,
+		OllamaURLOverride:               ollamaURL,
+		OpenAICompatURLOverrideProvider: backendRes.providerKey,
+		OpenAICompatURLOverride:         backendRes.baseURL,
+		CapabilityProbeStore:            capStore,
+	})
+	if err != nil {
+		return fmt.Errorf("bootstrap providers: %w", err)
+	}
+	defer func() { _ = bundle.Close() }()
+
+	plan, err := resolveAgentChain(bundle.Config)
+	if err != nil {
+		return err
+	}
+	for _, w := range backendRes.warns {
+		_, _ = fmt.Fprintln(errOut, "warning: "+w)
+	}
+
+	resolveEndpoint := newPreflightEndpointResolver(bundle.Config, ollamaURL, backendRes.providerKey, backendRes.diagSource())
+	return runModelsWith(ctx, bundle.Models, plan.chain, bundle.Config, capStore, resolveEndpoint,
+		modelsOpts{probeAll: probeAll, reprobe: reprobe}, out, errOut)
+}
+
+// runModelsWith renders the models listing against injectable deps so the
+// output/probe/reprobe logic is unit-testable without standing up
+// providerbootstrap. reg supplies lookup + provenance (+ probing); store is used
+// only for -reprobe's DeleteCapProbes; resolveEndpoint feeds the same
+// connectivity diagnostics the run() preflight uses on a lookup error.
+func runModelsWith(
+	ctx context.Context,
+	reg modelsRegistry,
+	chain []string,
+	cfg *config.Config,
+	store fingerprint.CapProbeStore,
+	resolveEndpoint endpointResolver,
+	opts modelsOpts,
+	out, errOut io.Writer,
+) error {
+	if len(chain) == 0 {
+		_, _ = fmt.Fprintln(out, "no defaults.agent configured; the run will route to the model recommendation.")
+		_, _ = fmt.Fprintln(out, "configure a defaults.agent chain in models.json to list per-entry capabilities.")
+		return nil
+	}
+
+	now := time.Now()
+	for _, sel := range chain {
+		key, parsed := parseSelector(sel)
+		if !parsed {
+			// Bare selector: no single provider/model to explain per-entry.
+			_, _ = fmt.Fprintf(out, "%s\t(bare selector; resolved across providers at route time)\n", sel)
+			continue
+		}
+
+		// Lookup first so a connectivity/config failure renders the same
+		// diagnostic the startup preflight uses, rather than a bare zero row.
+		if _, lerr := reg.Lookup(ctx, key); lerr != nil {
+			ep, epOK := resolvePreflightEndpoint(resolveEndpoint, key.Provider)
+			_, _ = fmt.Fprintf(out, "%s\t%s\n", sel, preflightConnectivityWarn(sel, key.Provider, ep, epOK, lerr))
+			continue
+		}
+
+		exp, err := reg.ExplainToolCall(ctx, key)
+		if err != nil {
+			ep, epOK := resolvePreflightEndpoint(resolveEndpoint, key.Provider)
+			_, _ = fmt.Fprintf(out, "%s\t%s\n", sel, preflightConnectivityWarn(sel, key.Provider, ep, epOK, err))
+			continue
+		}
+		explicit := exp.Source == "explicit"
+
+		// -reprobe deletes the cached verdict BEFORE resolving so the probe is
+		// forced fresh. -probe-all / -reprobe then resolve every non-explicit
+		// entry (no bounded-eager stop) and re-read provenance.
+		if !explicit && (opts.probeAll || opts.reprobe) {
+			if opts.reprobe && store != nil {
+				_ = store.DeleteCapProbes(ctx, key.Provider, key.Model)
+			}
+			if _, rerr := reg.ResolveToolCall(ctx, key); rerr == nil {
+				if re, eerr := reg.ExplainToolCall(ctx, key); eerr == nil {
+					exp = re
+				}
+			}
+		}
+
+		_, _ = fmt.Fprintln(out, renderModelLine(sel, key, exp, cfg, now))
+	}
+	return nil
+}
+
+// renderModelLine formats one chain entry: selector, capabilities, and
+// tool_call provenance. A MISSING entry appends the shared-key annotation (when
+// another role declares caps for the same key) and a remediation hint line.
+func renderModelLine(sel string, key provider.ModelKey, exp provider.ToolCallExplanation, cfg *config.Config, now time.Time) string {
+	line := fmt.Sprintf("%s\tcaps=%s\t%s", sel, exp.Caps.String(), toolCallField(exp, now))
+
+	if role, ok := declaringRole(cfg, key); ok {
+		line += fmt.Sprintf(" (declared by model entry %q)", role)
+	}
+	if !exp.Has {
+		line += "\n  " + remediationHint(sel)
+	}
+	return line
+}
+
+// toolCallField renders the tool_call verdict + its provenance source. A
+// present bit reads "tool_call=yes (<source>)"; an absent bit reads
+// "tool_call=MISSING" plus the last probe verdict + relative age when known.
+func toolCallField(exp provider.ToolCallExplanation, now time.Time) string {
+	if exp.Has {
+		return fmt.Sprintf("tool_call=yes (%s)", exp.Source)
+	}
+	if exp.State != "" {
+		return fmt.Sprintf("tool_call=MISSING (probe: %s, %s)", exp.State, relAge(exp.TestedAt, now))
+	}
+	return "tool_call=MISSING (" + exp.Source + ")"
+}
+
+// relAge renders a coarse "Nh ago" / "Nm ago" / "Ns ago" age for a probe
+// timestamp. Zero time yields "unknown time".
+func relAge(t, now time.Time) string {
+	if t.IsZero() {
+		return "unknown time"
+	}
+	d := now.Sub(t)
+	if d < 0 {
+		d = 0
+	}
+	switch {
+	case d >= time.Hour:
+		return fmt.Sprintf("%dh ago", int(d/time.Hour))
+	case d >= time.Minute:
+		return fmt.Sprintf("%dm ago", int(d/time.Minute))
+	default:
+		return fmt.Sprintf("%ds ago", int(d/time.Second))
+	}
+}
+
+// declaringRole walks cfg.Models for a config entry whose explicit
+// Capabilities declare this key (same provider+name). It names the entry that
+// declared the caps, which may be the chain entry itself (self-declaration) --
+// still useful, since it tells the operator the caps are config-declared rather
+// than catalog/probe-derived. Returns the first such role name found, or
+// ok=false when no entry declares explicit caps for the key.
+func declaringRole(cfg *config.Config, key provider.ModelKey) (string, bool) {
+	if cfg == nil {
+		return "", false
+	}
+	for role, m := range cfg.Models {
+		if len(m.Capabilities) == 0 {
+			continue
+		}
+		if m.Provider == key.Provider && m.Name == key.Model {
+			return role, true
+		}
+	}
+	return "", false
+}

--- a/cmd/golem/models.go
+++ b/cmd/golem/models.go
@@ -21,6 +21,7 @@ import (
 // active resolution. The concrete registry satisfies all three.
 type modelsRegistry interface {
 	Lookup(ctx context.Context, key provider.ModelKey) (*provider.ModelProfile, error)
+	Refresh(ctx context.Context, key provider.ModelKey) (*provider.ModelProfile, error)
 	ExplainToolCall(ctx context.Context, key provider.ModelKey) (provider.ToolCallExplanation, error)
 	ResolveToolCall(ctx context.Context, key provider.ModelKey) (fingerprint.CapProbeState, error)
 }
@@ -88,22 +89,22 @@ func runModels(ctx context.Context, args []string, out, errOut io.Writer) error 
 		return err
 	}
 
-	// The cap-probe store is required to probe/reprobe. Open it whenever
-	// probing might run (either switch), mirroring run()'s handle lifecycle.
+	// The cap-probe store is required for cached provenance in normal listings
+	// and for probe/reprobe writes, mirroring run()'s handle lifecycle.
 	var capStore fingerprint.CapProbeStore
-	if probeAll || reprobe {
-		capHandle, capStoreWarn := openCapProbeStore(ctx, os.Getenv, root)
-		if capHandle != nil {
-			capStore = capHandle.store
-			defer func() { _ = capHandle.db.Close() }()
-		}
-		if capStoreWarn != "" {
-			_, _ = fmt.Fprintln(errOut, "warning: "+capStoreWarn)
-		}
-		// Store fully unavailable (not even the in-memory fallback): a probe run
-		// would silently no-op. Tell the operator why nothing gets probed, then
-		// drop the switches so runModelsWith renders cached provenance only.
-		if capStore == nil {
+	capHandle, capStoreWarn := openCapProbeStore(ctx, os.Getenv, root)
+	if capHandle != nil {
+		capStore = capHandle.store
+		defer func() { _ = capHandle.db.Close() }()
+	}
+	if capStoreWarn != "" {
+		_, _ = fmt.Fprintln(errOut, "warning: "+capStoreWarn)
+	}
+	// Store fully unavailable (not even the in-memory fallback): a probe run
+	// would silently no-op. Tell the operator why nothing gets probed, then
+	// drop the switches so runModelsWith renders cached provenance only.
+	if capStore == nil {
+		if probeAll || reprobe {
 			reason := capStoreWarn
 			if reason == "" {
 				reason = "no capability-probe store"
@@ -191,6 +192,7 @@ func runModelsWith(
 		if !explicit && (opts.probeAll || opts.reprobe) {
 			if opts.reprobe && store != nil {
 				_ = store.DeleteCapProbes(ctx, key.Provider, key.Model)
+				_, _ = reg.Refresh(ctx, key)
 			}
 			if _, rerr := reg.ResolveToolCall(ctx, key); rerr == nil {
 				if re, eerr := reg.ExplainToolCall(ctx, key); eerr == nil {

--- a/cmd/golem/models_test.go
+++ b/cmd/golem/models_test.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/config"
+	"github.com/kstruzzieri/go-llm/fingerprint"
+	"github.com/kstruzzieri/go-llm/provider"
+)
+
+// fakeModelsReg is a fake modelsRegistry: canned Lookup profiles, canned
+// ExplainToolCall provenance, and a ResolveToolCall that records calls (so the
+// -probe-all / -reprobe tests can assert per-entry probing). When events is
+// non-nil, each ResolveToolCall appends "resolve:<key>" to the shared ordered
+// log so a test can assert delete-before-resolve ordering across both fakes.
+type fakeModelsReg struct {
+	profiles map[provider.ModelKey]*provider.ModelProfile
+	explain  map[provider.ModelKey]provider.ToolCallExplanation
+	states   map[provider.ModelKey]fingerprint.CapProbeState
+	calls    []provider.ModelKey
+	events   *[]string
+}
+
+func (f *fakeModelsReg) Lookup(_ context.Context, key provider.ModelKey) (*provider.ModelProfile, error) {
+	if p, ok := f.profiles[key]; ok {
+		return p, nil
+	}
+	return nil, context.Canceled // any non-nil error stands in for not-found
+}
+
+func (f *fakeModelsReg) ExplainToolCall(_ context.Context, key provider.ModelKey) (provider.ToolCallExplanation, error) {
+	return f.explain[key], nil
+}
+
+func (f *fakeModelsReg) ResolveToolCall(_ context.Context, key provider.ModelKey) (fingerprint.CapProbeState, error) {
+	f.calls = append(f.calls, key)
+	if f.events != nil {
+		*f.events = append(*f.events, "resolve:"+key.String())
+	}
+	return f.states[key], nil
+}
+
+// fakeDeleteStore records DeleteCapProbes calls for the -reprobe test. Only the
+// delete path is exercised here; Get/Save satisfy the interface. When events is
+// non-nil, each delete appends "delete:<provider/model>" to the shared ordered
+// log so a test can pin delete-before-resolve ordering.
+type fakeDeleteStore struct {
+	deleted []string
+	events  *[]string
+}
+
+func (s *fakeDeleteStore) GetCapProbe(context.Context, string, string, string) (*fingerprint.CapProbe, error) {
+	return nil, fingerprint.ErrNotFound
+}
+func (s *fakeDeleteStore) SaveCapProbe(context.Context, fingerprint.CapProbe) error { return nil }
+func (s *fakeDeleteStore) DeleteCapProbes(_ context.Context, backendID, modelName string) error {
+	s.deleted = append(s.deleted, backendID+"/"+modelName)
+	if s.events != nil {
+		*s.events = append(*s.events, "delete:"+backendID+"/"+modelName)
+	}
+	return nil
+}
+
+func keyOf(sel string) provider.ModelKey {
+	p, m, _ := strings.Cut(sel, "/")
+	return provider.ModelKey{Provider: p, Model: m}
+}
+
+func TestRunModels_ListsChainWithProvenance(t *testing.T) {
+	ctx := context.Background()
+	aKey := keyOf("llamacpp/gemma4:31b")
+	bKey := keyOf("llamacpp/byo-model")
+	reg := &fakeModelsReg{
+		profiles: map[provider.ModelKey]*provider.ModelProfile{
+			aKey: {Key: aKey, Caps: provider.CapChat | provider.CapGenerate | provider.CapStream | provider.CapToolCall},
+			bKey: {Key: bKey, Caps: provider.CapChat | provider.CapGenerate | provider.CapStream},
+		},
+		explain: map[provider.ModelKey]provider.ToolCallExplanation{
+			aKey: {Caps: provider.CapChat | provider.CapGenerate | provider.CapStream | provider.CapToolCall, Has: true, Source: "explicit"},
+			bKey: {Caps: provider.CapChat | provider.CapGenerate | provider.CapStream, Has: false, Source: "probe", State: fingerprint.CapProbeNo, TestedAt: time.Now().Add(-2 * time.Hour)},
+		},
+	}
+	var out, errOut bytes.Buffer
+	chain := []string{"llamacpp/gemma4:31b", "llamacpp/byo-model"}
+	if err := runModelsWith(ctx, reg, chain, nil, nil, nil, modelsOpts{}, &out, &errOut); err != nil {
+		t.Fatalf("runModelsWith() error: %v", err)
+	}
+	got := out.String()
+	// One line per entry, with caps rendered.
+	if !strings.Contains(got, "llamacpp/gemma4:31b") || !strings.Contains(got, "llamacpp/byo-model") {
+		t.Fatalf("output missing chain entries:\n%s", got)
+	}
+	// A carries tool_call with its provenance.
+	if !strings.Contains(got, "tool_call=yes") || !strings.Contains(got, "explicit") {
+		t.Fatalf("output missing A tool_call provenance:\n%s", got)
+	}
+	// B is flagged MISSING with the probe verdict.
+	if !strings.Contains(got, "MISSING") {
+		t.Fatalf("output missing MISSING flag for B:\n%s", got)
+	}
+	// The remediation hint appears under the MISSING entry.
+	if !strings.Contains(got, remediationHint("llamacpp/byo-model")) {
+		t.Fatalf("output missing remediation hint for B:\n%s", got)
+	}
+}
+
+func TestRunModels_SharedKeyNamesDeclaringRole(t *testing.T) {
+	ctx := context.Background()
+	// The agent chain uses key llamacpp/shared with NO explicit caps of its
+	// own; role "chat" in cfg declares tool_call for the SAME key.
+	key := keyOf("llamacpp/shared")
+	reg := &fakeModelsReg{
+		profiles: map[provider.ModelKey]*provider.ModelProfile{
+			key: {Key: key, Caps: provider.CapChat | provider.CapStream | provider.CapToolCall},
+		},
+		explain: map[provider.ModelKey]provider.ToolCallExplanation{
+			key: {Caps: provider.CapChat | provider.CapStream | provider.CapToolCall, Has: true, Source: "explicit"},
+		},
+	}
+	cfg := &config.Config{
+		Models: map[string]config.ModelConfig{
+			"chat":  {Name: "shared", Provider: "llamacpp", Type: "dense", Capabilities: []string{"chat", "stream", "tool_call"}},
+			"agent": {Name: "shared", Provider: "llamacpp", Type: "dense"},
+		},
+	}
+	var out, errOut bytes.Buffer
+	if err := runModelsWith(ctx, reg, []string{"llamacpp/shared"}, cfg, nil, nil, modelsOpts{}, &out, &errOut); err != nil {
+		t.Fatalf("runModelsWith() error: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, `declared by model entry "chat"`) {
+		t.Fatalf("output missing shared-key declaring-role annotation:\n%s", got)
+	}
+}
+
+func TestRunModels_ProbeAllProbesEveryEntry(t *testing.T) {
+	ctx := context.Background()
+	sels := []string{"llamacpp/m1", "llamacpp/m2", "llamacpp/m3"}
+	reg := &fakeModelsReg{
+		profiles: map[provider.ModelKey]*provider.ModelProfile{},
+		explain:  map[provider.ModelKey]provider.ToolCallExplanation{},
+		states:   map[provider.ModelKey]fingerprint.CapProbeState{},
+	}
+	for _, s := range sels {
+		k := keyOf(s)
+		// Non-explicit, tool_call absent => all three are probe candidates.
+		reg.profiles[k] = &provider.ModelProfile{Key: k, Caps: provider.CapChat | provider.CapStream}
+		reg.explain[k] = provider.ToolCallExplanation{Caps: provider.CapChat | provider.CapStream, Has: false, Source: "unknown"}
+		reg.states[k] = fingerprint.CapProbeNo
+	}
+	var out, errOut bytes.Buffer
+	if err := runModelsWith(ctx, reg, sels, nil, nil, nil, modelsOpts{probeAll: true}, &out, &errOut); err != nil {
+		t.Fatalf("runModelsWith() error: %v", err)
+	}
+	if len(reg.calls) != 3 {
+		t.Fatalf("ResolveToolCall calls = %d, want 3 (probe every non-explicit entry, no bounded-eager stop)", len(reg.calls))
+	}
+}
+
+func TestRunModels_ReprobeDeletesRowsFirst(t *testing.T) {
+	ctx := context.Background()
+	sels := []string{"llamacpp/m1", "llamacpp/m2"}
+	// Shared ordered log so the two fakes agree on a single timeline; this is
+	// how delete-BEFORE-resolve is pinned (each fake alone has no ordering).
+	var events []string
+	reg := &fakeModelsReg{
+		profiles: map[provider.ModelKey]*provider.ModelProfile{},
+		explain:  map[provider.ModelKey]provider.ToolCallExplanation{},
+		states:   map[provider.ModelKey]fingerprint.CapProbeState{},
+		events:   &events,
+	}
+	for _, s := range sels {
+		k := keyOf(s)
+		reg.profiles[k] = &provider.ModelProfile{Key: k, Caps: provider.CapChat | provider.CapStream}
+		reg.explain[k] = provider.ToolCallExplanation{Caps: provider.CapChat | provider.CapStream, Has: false, Source: "unknown"}
+		reg.states[k] = fingerprint.CapProbeYes
+	}
+	store := &fakeDeleteStore{events: &events}
+	var out, errOut bytes.Buffer
+	if err := runModelsWith(ctx, reg, sels, nil, store, nil, modelsOpts{reprobe: true}, &out, &errOut); err != nil {
+		t.Fatalf("runModelsWith() error: %v", err)
+	}
+	if len(store.deleted) != 2 {
+		t.Fatalf("DeleteCapProbes calls = %d (%v), want 2 (per non-explicit entry)", len(store.deleted), store.deleted)
+	}
+	if len(reg.calls) != 2 {
+		t.Fatalf("ResolveToolCall calls = %d, want 2 (resolve after delete)", len(reg.calls))
+	}
+	// Every delete for a key must precede that key's resolve on the shared
+	// timeline. Locate each event's index and compare per key.
+	idx := func(want string) int {
+		for i, e := range events {
+			if e == want {
+				return i
+			}
+		}
+		return -1
+	}
+	for _, s := range sels {
+		k := keyOf(s)
+		di := idx("delete:" + k.String())
+		ri := idx("resolve:" + k.String())
+		if di < 0 || ri < 0 {
+			t.Fatalf("missing events for %s: got %v", s, events)
+		}
+		if di >= ri {
+			t.Fatalf("%s: delete (idx %d) must precede resolve (idx %d); timeline=%v", s, di, ri, events)
+		}
+	}
+}

--- a/cmd/golem/models_test.go
+++ b/cmd/golem/models_test.go
@@ -3,6 +3,10 @@ package main
 import (
 	"bytes"
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -16,12 +20,13 @@ import (
 // ExplainToolCall provenance, and a ResolveToolCall that records calls (so the
 // -probe-all / -reprobe tests can assert per-entry probing). When events is
 // non-nil, each ResolveToolCall appends "resolve:<key>" to the shared ordered
-// log so a test can assert delete-before-resolve ordering across both fakes.
+// log so a test can assert delete-refresh-resolve ordering across both fakes.
 type fakeModelsReg struct {
 	profiles map[provider.ModelKey]*provider.ModelProfile
 	explain  map[provider.ModelKey]provider.ToolCallExplanation
 	states   map[provider.ModelKey]fingerprint.CapProbeState
 	calls    []provider.ModelKey
+	refresh  []provider.ModelKey
 	events   *[]string
 }
 
@@ -30,6 +35,14 @@ func (f *fakeModelsReg) Lookup(_ context.Context, key provider.ModelKey) (*provi
 		return p, nil
 	}
 	return nil, context.Canceled // any non-nil error stands in for not-found
+}
+
+func (f *fakeModelsReg) Refresh(_ context.Context, key provider.ModelKey) (*provider.ModelProfile, error) {
+	f.refresh = append(f.refresh, key)
+	if f.events != nil {
+		*f.events = append(*f.events, "refresh:"+key.String())
+	}
+	return f.Lookup(context.Background(), key)
 }
 
 func (f *fakeModelsReg) ExplainToolCall(_ context.Context, key provider.ModelKey) (provider.ToolCallExplanation, error) {
@@ -105,6 +118,66 @@ func TestRunModels_ListsChainWithProvenance(t *testing.T) {
 	// The remediation hint appears under the MISSING entry.
 	if !strings.Contains(got, remediationHint("llamacpp/byo-model")) {
 		t.Fatalf("output missing remediation hint for B:\n%s", got)
+	}
+}
+
+func TestRunModels_ReadsCachedProbeOnPlainListing(t *testing.T) {
+	ctx := context.Background()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/models" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected request", http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":[{"id":"mystery"}]}`))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", filepath.Join(dir, "data"))
+	root := filepath.Join(dir, "workspace")
+	if err := os.Mkdir(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	h, warn := openCapProbeStore(ctx, os.Getenv, root)
+	if warn != "" {
+		t.Fatalf("openCapProbeStore warning = %q", warn)
+	}
+	if h == nil || h.store == nil {
+		t.Fatal("openCapProbeStore returned nil store")
+	}
+	key := provider.ModelKey{Provider: "llamacpp", Model: "mystery"}
+	if err := h.store.SaveCapProbe(ctx, fingerprint.CapProbe{
+		BackendID:    key.Provider,
+		ModelName:    key.Model,
+		Capability:   "tool_call",
+		State:        fingerprint.CapProbeYes,
+		ModelDigest:  key.String(),
+		ProbeVersion: fingerprint.CurrentToolProbeVersion,
+		TestedAt:     time.Now(),
+	}); err != nil {
+		t.Fatalf("seed SaveCapProbe: %v", err)
+	}
+	if err := h.db.Close(); err != nil {
+		t.Fatalf("close seed store: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "models.json")
+	if err := os.WriteFile(cfgPath, []byte(`{
+		"providers": {"llamacpp": {"base_url": "`+srv.URL+`", "api_format": "openai-compat"}},
+		"models": {"agent": {"name": "mystery", "provider": "llamacpp", "type": "dense"}},
+		"defaults": {"agent": "agent"}
+	}`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var out, errOut bytes.Buffer
+	if err := runModels(ctx, []string{"-config", cfgPath, "-root", root, "-no-probe"}, &out, &errOut); err != nil {
+		t.Fatalf("runModels() error: %v\nstderr:\n%s", err, errOut.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "tool_call=yes (probe)") {
+		t.Fatalf("output = %q, want cached probe provenance", got)
 	}
 }
 
@@ -190,8 +263,10 @@ func TestRunModels_ReprobeDeletesRowsFirst(t *testing.T) {
 	if len(reg.calls) != 2 {
 		t.Fatalf("ResolveToolCall calls = %d, want 2 (resolve after delete)", len(reg.calls))
 	}
-	// Every delete for a key must precede that key's resolve on the shared
-	// timeline. Locate each event's index and compare per key.
+	if len(reg.refresh) != 2 {
+		t.Fatalf("Refresh calls = %d, want 2 (invalidate stale profile after delete)", len(reg.refresh))
+	}
+	// Every delete for a key must precede refresh, which must precede resolve.
 	idx := func(want string) int {
 		for i, e := range events {
 			if e == want {
@@ -203,12 +278,13 @@ func TestRunModels_ReprobeDeletesRowsFirst(t *testing.T) {
 	for _, s := range sels {
 		k := keyOf(s)
 		di := idx("delete:" + k.String())
+		fi := idx("refresh:" + k.String())
 		ri := idx("resolve:" + k.String())
-		if di < 0 || ri < 0 {
+		if di < 0 || fi < 0 || ri < 0 {
 			t.Fatalf("missing events for %s: got %v", s, events)
 		}
-		if di >= ri {
-			t.Fatalf("%s: delete (idx %d) must precede resolve (idx %d); timeline=%v", s, di, ri, events)
+		if di >= fi || fi >= ri {
+			t.Fatalf("%s: delete (idx %d) must precede refresh (idx %d) then resolve (idx %d); timeline=%v", s, di, fi, ri, events)
 		}
 	}
 }

--- a/cmd/golem/preflight_test.go
+++ b/cmd/golem/preflight_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sort"
 	"strings"
 	"testing"
 
@@ -50,11 +51,16 @@ func (f fakeReg) LookupAny(ctx context.Context, model string) ([]*provider.Model
 	if e, ok := f.errByModel[model]; ok {
 		return nil, e
 	}
-	var out []*provider.ModelProfile
-	for k, c := range f.byKey {
+	var keys []provider.ModelKey
+	for k := range f.byKey {
 		if k.Model == model {
-			out = append(out, &provider.ModelProfile{Caps: c})
+			keys = append(keys, k)
 		}
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i].String() < keys[j].String() })
+	var out []*provider.ModelProfile
+	for _, k := range keys {
+		out = append(out, &provider.ModelProfile{Key: k, Caps: f.byKey[k]})
 	}
 	return out, nil
 }
@@ -148,6 +154,29 @@ func TestPreflight_BareModelNotFound(t *testing.T) {
 	}
 	if len(warns) != 1 || !strings.Contains(warns[0], "ghost") {
 		t.Errorf("warnings = %v, want one naming ghost", warns)
+	}
+}
+
+func TestPreflight_BareSelectorProbesUntilProviderCapable(t *testing.T) {
+	a := provider.ModelKey{Provider: "a", Model: "shared"}
+	b := provider.ModelKey{Provider: "b", Model: "shared"}
+	reg := fakeReg{byKey: map[provider.ModelKey]provider.Capability{
+		a: provider.CapChat | provider.CapStream,
+		b: provider.CapChat | provider.CapStream,
+	}}
+	res := &fakeToolResolver{states: map[provider.ModelKey]fingerprint.CapProbeState{
+		a: fingerprint.CapProbeNo,
+		b: fingerprint.CapProbeYes,
+	}}
+	warns, err := preflightToolCapable(context.Background(), reg, []string{"shared"}, noEndpoints, res)
+	if err != nil {
+		t.Fatalf("err = %v, want nil (second provider probes capable)", err)
+	}
+	if len(warns) != 0 {
+		t.Fatalf("warnings = %v, want none", warns)
+	}
+	if len(res.calls) != 2 || res.calls[0] != a || res.calls[1] != b {
+		t.Fatalf("resolver calls = %v, want [%s %s]", res.calls, a, b)
 	}
 }
 

--- a/cmd/golem/preflight_test.go
+++ b/cmd/golem/preflight_test.go
@@ -7,8 +7,26 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kstruzzieri/go-llm/fingerprint"
 	"github.com/kstruzzieri/go-llm/provider"
 )
+
+// fakeToolResolver is a fake toolCallResolver: it returns canned probe states
+// (or errors) per key and records the order of ResolveToolCall calls so tests
+// can assert bounded-eager probing (probe only until the first capable entry).
+type fakeToolResolver struct {
+	states map[provider.ModelKey]fingerprint.CapProbeState
+	errs   map[provider.ModelKey]error
+	calls  []provider.ModelKey
+}
+
+func (f *fakeToolResolver) ResolveToolCall(ctx context.Context, key provider.ModelKey) (fingerprint.CapProbeState, error) {
+	f.calls = append(f.calls, key)
+	if err := f.errs[key]; err != nil {
+		return "", err
+	}
+	return f.states[key], nil
+}
 
 type fakeReg struct {
 	byKey      map[provider.ModelKey]provider.Capability
@@ -73,7 +91,7 @@ func TestPreflight_HeadCapable(t *testing.T) {
 	reg := fakeReg{byKey: map[provider.ModelKey]provider.Capability{
 		{Provider: "ollama", Model: "m1"}: fullCaps,
 	}}
-	warns, err := preflightToolCapable(context.Background(), reg, []string{"ollama/m1"}, noEndpoints)
+	warns, err := preflightToolCapable(context.Background(), reg, []string{"ollama/m1"}, noEndpoints, nil)
 	if err != nil {
 		t.Fatalf("err = %v, want nil", err)
 	}
@@ -87,7 +105,7 @@ func TestPreflight_PrimaryIncapableFallbackCapable(t *testing.T) {
 		{Provider: "ollama", Model: "m1"}: provider.CapChat | provider.CapStream, // no tool_call
 		{Provider: "ollama", Model: "m2"}: fullCaps,
 	}}
-	warns, err := preflightToolCapable(context.Background(), reg, []string{"ollama/m1", "ollama/m2"}, noEndpoints)
+	warns, err := preflightToolCapable(context.Background(), reg, []string{"ollama/m1", "ollama/m2"}, noEndpoints, nil)
 	if err != nil {
 		t.Fatalf("err = %v, want nil", err)
 	}
@@ -100,7 +118,7 @@ func TestPreflight_NoneCapable(t *testing.T) {
 	reg := fakeReg{byKey: map[provider.ModelKey]provider.Capability{
 		{Provider: "ollama", Model: "m1"}: provider.CapChat | provider.CapStream,
 	}}
-	_, err := preflightToolCapable(context.Background(), reg, []string{"ollama/m1"}, noEndpoints)
+	_, err := preflightToolCapable(context.Background(), reg, []string{"ollama/m1"}, noEndpoints, nil)
 	if err == nil {
 		t.Fatal("err = nil, want failure (no tool-capable entry)")
 	}
@@ -108,11 +126,11 @@ func TestPreflight_NoneCapable(t *testing.T) {
 
 func TestPreflight_EmptyChain_UsesRecommend(t *testing.T) {
 	ok := fakeReg{recommend: []provider.Capability{fullCaps}}
-	if _, err := preflightToolCapable(context.Background(), ok, nil, noEndpoints); err != nil {
+	if _, err := preflightToolCapable(context.Background(), ok, nil, noEndpoints, nil); err != nil {
 		t.Fatalf("recommend-capable err = %v, want nil", err)
 	}
 	empty := fakeReg{recommend: nil}
-	if _, err := preflightToolCapable(context.Background(), empty, nil, noEndpoints); err == nil {
+	if _, err := preflightToolCapable(context.Background(), empty, nil, noEndpoints, nil); err == nil {
 		t.Fatal("empty recommend err = nil, want failure")
 	}
 }
@@ -124,7 +142,7 @@ func TestPreflight_BareModelNotFound(t *testing.T) {
 	reg := fakeReg{byKey: map[provider.ModelKey]provider.Capability{
 		{Provider: "ollama", Model: "other"}: fullCaps,
 	}}
-	warns, err := preflightToolCapable(context.Background(), reg, []string{"ghost"}, noEndpoints)
+	warns, err := preflightToolCapable(context.Background(), reg, []string{"ghost"}, noEndpoints, nil)
 	if err == nil {
 		t.Fatal("err = nil for bare model with no capable match, want failure")
 	}
@@ -144,7 +162,7 @@ func TestPreflight_LookupErrorIsConnectivity(t *testing.T) {
 	resolve := fixedEndpoints(map[string]preflightEndpoint{
 		"llamacpp": {BaseURL: "http://127.0.0.1:8080", ModelsPath: "/v1/models"},
 	})
-	warns, err := preflightToolCapable(context.Background(), reg, []string{"llamacpp/gemma4:31b"}, resolve)
+	warns, err := preflightToolCapable(context.Background(), reg, []string{"llamacpp/gemma4:31b"}, resolve, nil)
 	if err == nil {
 		t.Fatal("err = nil, want failure")
 	}
@@ -172,7 +190,7 @@ func TestPreflight_LookupErrorResolverMiss(t *testing.T) {
 	reg := fakeReg{errByKey: map[provider.ModelKey]error{
 		key: fmt.Errorf("boom: %w", connStatusErr{404}),
 	}}
-	warns, err := preflightToolCapable(context.Background(), reg, []string{"llamacpp/gemma4:31b"}, noEndpoints)
+	warns, err := preflightToolCapable(context.Background(), reg, []string{"llamacpp/gemma4:31b"}, noEndpoints, nil)
 	if err == nil {
 		t.Fatal("err = nil, want failure")
 	}
@@ -193,7 +211,7 @@ func TestPreflight_LookupErrorNonStatus(t *testing.T) {
 	resolve := fixedEndpoints(map[string]preflightEndpoint{
 		"llamacpp": {BaseURL: "http://127.0.0.1:8080", ModelsPath: "/v1/models"},
 	})
-	warns, err := preflightToolCapable(context.Background(), reg, []string{"llamacpp/gemma4:31b"}, resolve)
+	warns, err := preflightToolCapable(context.Background(), reg, []string{"llamacpp/gemma4:31b"}, resolve, nil)
 	if err == nil {
 		t.Fatal("err = nil, want failure")
 	}
@@ -219,7 +237,7 @@ func TestPreflight_QualifiedModelNotFoundIsLookupFailure(t *testing.T) {
 	resolve := fixedEndpoints(map[string]preflightEndpoint{
 		"ollama": {BaseURL: "http://localhost:11434", ModelsPath: "/api/tags"},
 	})
-	warns, err := preflightToolCapable(context.Background(), reg, []string{"ollama/missing"}, resolve)
+	warns, err := preflightToolCapable(context.Background(), reg, []string{"ollama/missing"}, resolve, nil)
 	if err == nil {
 		t.Fatal("err = nil, want failure")
 	}
@@ -248,7 +266,7 @@ func TestPreflight_MixedCapableAndErrored(t *testing.T) {
 		"llamacpp": {BaseURL: "http://127.0.0.1:8080", ModelsPath: "/v1/models"},
 	})
 	warns, err := preflightToolCapable(context.Background(), reg,
-		[]string{"ollama/m1", "llamacpp/down"}, resolve)
+		[]string{"ollama/m1", "llamacpp/down"}, resolve, nil)
 	if err != nil {
 		t.Fatalf("err = %v, want nil (one entry capable)", err)
 	}
@@ -270,7 +288,7 @@ func TestPreflight_MixedErroredAndNonCapable(t *testing.T) {
 		"llamacpp": {BaseURL: "http://127.0.0.1:8080", ModelsPath: "/v1/models"},
 	})
 	_, err := preflightToolCapable(context.Background(), reg,
-		[]string{"llamacpp/down", "ollama/m1"}, resolve)
+		[]string{"llamacpp/down", "ollama/m1"}, resolve, nil)
 	if err == nil {
 		t.Fatal("err = nil, want failure")
 	}
@@ -290,12 +308,247 @@ func TestPreflight_BareLookupAnyError(t *testing.T) {
 	reg := fakeReg{errByModel: map[string]error{
 		"gemma4:31b": fmt.Errorf("provider: lookup any %q: all providers failed: %w", "gemma4:31b", connStatusErr{404}),
 	}}
-	warns, err := preflightToolCapable(context.Background(), reg, []string{"gemma4:31b"}, noEndpoints)
+	warns, err := preflightToolCapable(context.Background(), reg, []string{"gemma4:31b"}, noEndpoints, nil)
 	if err == nil {
 		t.Fatal("err = nil, want failure")
 	}
 	if len(warns) != 1 || !strings.Contains(warns[0], "provider lookup failed:") ||
 		!strings.Contains(warns[0], "all providers failed") {
 		t.Errorf("warning = %v, want verbatim LookupAny error", warns)
+	}
+}
+
+// TestPreflight_BoundedEager_StopsAfterFirstCapable: chain [A unknown->probe yes,
+// B unknown, C unknown]. Probing is allowed only until the first capable entry,
+// so the resolver is called ONLY for A. Both B and C are reached after capability
+// is proven, so neither is probed at startup — each reports the non-fatal
+// "probed on first use" line (deferred to route time), NOT a probe verdict.
+func TestPreflight_BoundedEager_StopsAfterFirstCapable(t *testing.T) {
+	a := provider.ModelKey{Provider: "ollama", Model: "a"}
+	reg := fakeReg{byKey: map[provider.ModelKey]provider.Capability{
+		a:                                provider.CapChat | provider.CapStream, // resolved but no tool_call: eligible to probe
+		{Provider: "ollama", Model: "b"}: provider.CapChat | provider.CapStream, // unknown, reached after capable
+		{Provider: "ollama", Model: "c"}: provider.CapChat | provider.CapStream, // unknown, reached after capable
+	}}
+	res := &fakeToolResolver{states: map[provider.ModelKey]fingerprint.CapProbeState{
+		a: fingerprint.CapProbeYes,
+	}}
+	warns, err := preflightToolCapable(context.Background(), reg,
+		[]string{"ollama/a", "ollama/b", "ollama/c"}, noEndpoints, res)
+	if err != nil {
+		t.Fatalf("err = %v, want nil (A probes capable)", err)
+	}
+	if len(res.calls) != 1 || res.calls[0] != a {
+		t.Fatalf("resolver calls = %v, want only A (bounded-eager)", res.calls)
+	}
+	if len(warns) != 2 {
+		t.Fatalf("warnings = %v, want 2 (B and C probed-on-first-use)", warns)
+	}
+	if !strings.Contains(warns[0], "ollama/b") || !strings.Contains(warns[0], "probed on first use") {
+		t.Errorf("warn[0] = %q, want B probed-on-first-use", warns[0])
+	}
+	if !strings.Contains(warns[1], "ollama/c") || !strings.Contains(warns[1], "probed on first use") {
+		t.Errorf("warn[1] = %q, want C probed-on-first-use", warns[1])
+	}
+}
+
+// TestPreflight_ProbeNoContinuesToNextEntry: chain [A probe->no, B registry-capable].
+// A's probe returns no, so preflight continues to B (capable) => nil error. The
+// resolver is called for A only (B is capable from the registry). A's warning
+// names "did not produce a tool call" and carries the remediation hint with the
+// exact capabilities fragment.
+func TestPreflight_ProbeNoContinuesToNextEntry(t *testing.T) {
+	a := provider.ModelKey{Provider: "ollama", Model: "a"}
+	b := provider.ModelKey{Provider: "ollama", Model: "b"}
+	reg := fakeReg{byKey: map[provider.ModelKey]provider.Capability{
+		a: provider.CapChat | provider.CapStream,
+		b: fullCaps,
+	}}
+	res := &fakeToolResolver{states: map[provider.ModelKey]fingerprint.CapProbeState{
+		a: fingerprint.CapProbeNo,
+	}}
+	warns, err := preflightToolCapable(context.Background(), reg,
+		[]string{"ollama/a", "ollama/b"}, noEndpoints, res)
+	if err != nil {
+		t.Fatalf("err = %v, want nil (B capable)", err)
+	}
+	if len(res.calls) != 1 || res.calls[0] != a {
+		t.Fatalf("resolver calls = %v, want only A", res.calls)
+	}
+	if len(warns) != 1 {
+		t.Fatalf("warnings = %v, want 1 (A probed-no)", warns)
+	}
+	if !strings.Contains(warns[0], "ollama/a") || !strings.Contains(warns[0], "did not produce a tool call") ||
+		!strings.Contains(warns[0], remediationCaps) {
+		t.Errorf("warn = %q, want A probed-no + remediation with caps fragment", warns[0])
+	}
+}
+
+// TestPreflight_AllExhaustedFatalIncludesProbeOutcomes: chain [A probe->no,
+// B probe->inconclusive, C lookup error]. No entry is capable, so preflight
+// fails and the terminal error inlines all three per-entry diagnostics: A's
+// probed-no line, B's inconclusive line, and C's #217 connectivity diagnostic
+// (preserved verbatim).
+func TestPreflight_AllExhaustedFatalIncludesProbeOutcomes(t *testing.T) {
+	a := provider.ModelKey{Provider: "ollama", Model: "a"}
+	b := provider.ModelKey{Provider: "ollama", Model: "b"}
+	c := provider.ModelKey{Provider: "llamacpp", Model: "down"}
+	reg := fakeReg{
+		byKey: map[provider.ModelKey]provider.Capability{
+			a: provider.CapChat | provider.CapStream,
+			b: provider.CapChat | provider.CapStream,
+		},
+		errByKey: map[provider.ModelKey]error{c: connStatusErr{404}},
+	}
+	res := &fakeToolResolver{states: map[provider.ModelKey]fingerprint.CapProbeState{
+		a: fingerprint.CapProbeNo,
+		b: fingerprint.CapProbeInconclusive,
+	}}
+	resolve := fixedEndpoints(map[string]preflightEndpoint{
+		"llamacpp": {BaseURL: "http://127.0.0.1:8080", ModelsPath: "/v1/models"},
+	})
+	_, err := preflightToolCapable(context.Background(), reg,
+		[]string{"ollama/a", "ollama/b", "llamacpp/down"}, resolve, res)
+	if err == nil {
+		t.Fatal("err = nil, want failure (none capable)")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "ollama/a") || !strings.Contains(msg, "did not produce a tool call") {
+		t.Errorf("err = %q, missing A probed-no line", msg)
+	}
+	if !strings.Contains(msg, "ollama/b") || !strings.Contains(msg, "probe was inconclusive") ||
+		!strings.Contains(msg, "declare capabilities to override") {
+		t.Errorf("err = %q, missing B inconclusive line", msg)
+	}
+	if !strings.Contains(msg, "cannot reach provider") || !strings.Contains(msg, "GET /v1/models -> 404 Not Found") {
+		t.Errorf("err = %q, missing C connectivity diagnostic", msg)
+	}
+}
+
+// TestPreflight_NoCapProbe_NeverResolves: with a nil resolver, active probing
+// never runs. The existing #217 lookup/connectivity table runs through the new
+// signature to prove those diagnostics are unchanged; a catalog/floor-capable
+// entry still passes (merge is upstream, not disabled by -no-cap-probe).
+func TestPreflight_NoCapProbe_NeverResolves(t *testing.T) {
+	// Capable catalog/floor entry passes with a nil resolver, no warnings.
+	regCapable := fakeReg{byKey: map[provider.ModelKey]provider.Capability{
+		{Provider: "ollama", Model: "m1"}: fullCaps,
+	}}
+	warns, err := preflightToolCapable(context.Background(), regCapable, []string{"ollama/m1"}, noEndpoints, nil)
+	if err != nil || len(warns) != 0 {
+		t.Fatalf("capable-with-nil-resolver: warns=%v err=%v, want none/nil", warns, err)
+	}
+
+	// #217 connectivity diagnostic preserved byte-identically with a nil resolver.
+	key := provider.ModelKey{Provider: "llamacpp", Model: "gemma4:31b"}
+	regDown := fakeReg{errByKey: map[provider.ModelKey]error{
+		key: fmt.Errorf("provider: lookup %v: %w", key, connStatusErr{404}),
+	}}
+	resolve := fixedEndpoints(map[string]preflightEndpoint{
+		"llamacpp": {BaseURL: "http://127.0.0.1:8080", ModelsPath: "/v1/models"},
+	})
+	warns, err = preflightToolCapable(context.Background(), regDown, []string{"llamacpp/gemma4:31b"}, resolve, nil)
+	if err == nil {
+		t.Fatal("err = nil, want connectivity failure")
+	}
+	if len(warns) != 1 || !strings.Contains(warns[0], "cannot reach provider") ||
+		!strings.Contains(warns[0], "GET /v1/models -> 404 Not Found") {
+		t.Errorf("warnings = %v, want unchanged #217 connectivity diagnostic", warns)
+	}
+}
+
+// TestPreflight_NoCapProbe_CatalogKnownStillCapable: nil resolver; a chain with a
+// floor+catalog-merged capable entry passes with zero warnings, while an
+// undeclared catalog-miss entry in the same chain stays not-capable and carries
+// the remediation hint.
+func TestPreflight_NoCapProbe_CatalogKnownStillCapable(t *testing.T) {
+	reg := fakeReg{byKey: map[provider.ModelKey]provider.Capability{
+		{Provider: "ollama", Model: "known"}: fullCaps,                              // merged upstream
+		{Provider: "ollama", Model: "miss"}:  provider.CapChat | provider.CapStream, // undeclared
+	}}
+	warns, err := preflightToolCapable(context.Background(), reg,
+		[]string{"ollama/known", "ollama/miss"}, noEndpoints, nil)
+	if err != nil {
+		t.Fatalf("err = %v, want nil (known entry capable)", err)
+	}
+	if len(warns) != 1 {
+		t.Fatalf("warnings = %v, want 1 (miss not-capable)", warns)
+	}
+	if !strings.Contains(warns[0], "ollama/miss") || !strings.Contains(warns[0], "not tool-capable") ||
+		!strings.Contains(warns[0], remediationCaps) {
+		t.Errorf("warn = %q, want catalog-miss capability warning with remediation hint", warns[0])
+	}
+}
+
+// recordingReg wraps Recommend to capture the RequiredCaps it was called with,
+// so the empty-chain test can assert the recommend query dropped CapToolCall
+// when a resolver is present (probe fills the gap).
+type recordingReg struct {
+	fakeReg
+	recProfiles  []*provider.ModelProfile
+	gotRequired  provider.Capability
+	recommendHit bool
+}
+
+func (r *recordingReg) Recommend(ctx context.Context, opts provider.RecommendOpts) ([]*provider.ModelProfile, error) {
+	r.recommendHit = true
+	r.gotRequired = opts.RequiredCaps
+	return r.recProfiles, nil
+}
+
+// TestPreflight_EmptyChainRecommendResolves: empty chain with a resolver. The
+// recommend query must NOT include CapToolCall (the probe fills that gap);
+// Recommend returns one model lacking tool_call, the resolver probes it yes, and
+// preflight passes.
+func TestPreflight_EmptyChainRecommendResolves(t *testing.T) {
+	key := provider.ModelKey{Provider: "ollama", Model: "m1"}
+	reg := &recordingReg{
+		recProfiles: []*provider.ModelProfile{
+			{Key: key, Caps: provider.CapChat | provider.CapStream},
+		},
+	}
+	res := &fakeToolResolver{states: map[provider.ModelKey]fingerprint.CapProbeState{
+		key: fingerprint.CapProbeYes,
+	}}
+	if _, err := preflightToolCapable(context.Background(), reg, nil, noEndpoints, res); err != nil {
+		t.Fatalf("err = %v, want nil (recommend model probes capable)", err)
+	}
+	if !reg.recommendHit {
+		t.Fatal("Recommend was not called")
+	}
+	if reg.gotRequired.Has(provider.CapToolCall) {
+		t.Errorf("RequiredCaps = %v, must NOT include CapToolCall when resolving", reg.gotRequired)
+	}
+	if len(res.calls) != 1 || res.calls[0] != key {
+		t.Errorf("resolver calls = %v, want probe of recommended model", res.calls)
+	}
+}
+
+// TestPreflight_ProbeErrorNonFatalButNotCapable: the first (allowProbe) entry's
+// probe returns a transient error. The entry is non-fatal-but-not-capable
+// (falls through, not treated as capable); being the only entry, preflight fails
+// and the terminal error includes the "tool-capability probe failed:" warning
+// plus the remediation hint.
+func TestPreflight_ProbeErrorNonFatalButNotCapable(t *testing.T) {
+	a := provider.ModelKey{Provider: "ollama", Model: "a"}
+	reg := fakeReg{byKey: map[provider.ModelKey]provider.Capability{
+		a: provider.CapChat | provider.CapStream, // resolved, no tool_call: eligible to probe
+	}}
+	res := &fakeToolResolver{errs: map[provider.ModelKey]error{
+		a: fmt.Errorf("dial tcp: connection refused"),
+	}}
+	warns, err := preflightToolCapable(context.Background(), reg, []string{"ollama/a"}, noEndpoints, res)
+	if err == nil {
+		t.Fatal("err = nil, want failure (only entry probed with error, not capable)")
+	}
+	if len(res.calls) != 1 || res.calls[0] != a {
+		t.Fatalf("resolver calls = %v, want probe of A", res.calls)
+	}
+	if len(warns) != 1 || !strings.Contains(warns[0], "tool-capability probe failed:") ||
+		!strings.Contains(warns[0], "connection refused") || !strings.Contains(warns[0], remediationCaps) {
+		t.Errorf("warnings = %v, want probe-failed warning with underlying error + remediation hint", warns)
+	}
+	if !strings.Contains(err.Error(), "tool-capability probe failed:") {
+		t.Errorf("err = %q, want inlined probe-failed diagnostic", err)
 	}
 }

--- a/docs/llm/recommendation.md
+++ b/docs/llm/recommendation.md
@@ -91,8 +91,40 @@ endpoint and cached in the fingerprint store (SQLite).
 | `type` | yes | `"dense"`, `"moe"`, or `"embedding"` (validates fallback compatibility) |
 | `context_window` | no | Observed/overridden at runtime by fingerprint if wrong |
 | `dimensions` | no | For embedding models |
+| `capabilities` | no | Explicit capability list; **replaces** the type-derived default. See below. |
 | `fallbacks` | no | Role names to degrade to when the primary is unavailable |
 | `description`, `parameters` | no | Human-readable only |
+
+### The `capabilities` field
+
+`capabilities` is an optional explicit override of the capabilities `go-llm`
+derives from `type`. Its semantics are deliberately strict:
+
+- **Explicit list REPLACES, in both directions.** When you set `capabilities`,
+  the listed tokens become the model's capabilities outright — the derived set
+  is discarded, not merged. This cuts both ways: omitting a token *denies* that
+  capability. A model declared `["chat", "stream"]` is treated as **not**
+  tool-capable even if the model can call tools, because the explicit list left
+  `tool_call` out. Use this to carve a model down for a backend that lacks an
+  endpoint (e.g. an OpenAI-compat server with no `/v1/completions`), and to
+  pin tool support on (or off) without waiting for a probe.
+- **Only canonical single-bit names.** The accepted vocabulary is the canonical
+  set (`chat`, `generate`, `stream`, `embed`, `tool_call`, `thinking`,
+  `insert`). Catalog
+  aliases that expand to several bits (`completion`, `tools`) are rejected here,
+  so an explicit list never surprises you with hidden expansion.
+- **Derived caps are a floor, not an override.** When you *omit* `capabilities`
+  on an undeclared OpenAI-compat model, the type-derived set is applied as a
+  **floor** (OR-merged at lowest precedence). A floor can only add routability;
+  it never erases catalog, fingerprint, or runtime capabilities. So a catalog
+  entry that adds `tool_call` survives — the floor won't strip it. (This is the
+  fix for the issue where a derived REPLACE override silently erased catalog
+  tools.)
+- **Cross-role consistency.** The same provider/model can back more than one
+  role. If two roles declare an *explicit* `capabilities` list for the same
+  provider/model key, the lists must agree; a conflict is a hard startup error
+  (`conflicting capability overrides for <provider>/<model>`). Floors (omitted
+  lists) never conflict — they union.
 
 ### Adding a new provider
 
@@ -129,10 +161,70 @@ model metadata and records:
 
 The catalog (`provider/catalog.json`) matches model **families** (e.g.
 `qwen3`, `gemma4`, `codellama`, `deepseek`) by name prefix and supplies
-FIM-policy and thinking-mode defaults. If a model's family isn't in the
-catalog, the system falls back to runtime-detected capabilities and a
+FIM-policy, thinking-mode, and capability defaults. If a model's family isn't
+in the catalog, the system falls back to runtime-detected capabilities and a
 neutral default policy — it still works; it just won't get family-specific
 tuning until you add a catalog entry.
+
+#### Tool-capable bundled families
+
+The catalog records which families support tool / function calling. This is the
+static ground truth the router trusts before any probe runs:
+
+| Family | Tool calls | Notes |
+|---|---|---|
+| `qwen2.5`, `qwen3`, `qwen3.5`, `qwen3.6`, `qwen3-coder-next` | yes | Native function calling |
+| `llama3`, `llama3.1`, `llama3.2`, `llama3.3` | yes | Native function calling |
+| `gemma3`, `gemma4` | yes | Function calling (Gemma 3+) |
+| `phi3`, `phi4` | yes | |
+| `mistral`, `mixtral` | yes | |
+| `deepseek-coder-v2` | yes | |
+| `deepseek-r1` | no | Reasoning model; no function-calling surface |
+| `gemma2` | no | No native tool support |
+| `codellama` | no | Base code-completion model |
+| `starcoder`, `starcoder2` | no | Code-completion, no tool interface |
+| `nomic-embed-text`, `mxbai-embed-large` | no | Embedding only |
+
+A family absent from the catalog gets no tool claim until a probe (below) or an
+explicit `capabilities` entry supplies one.
+
+### Tool-capability probe
+
+Catalog and explicit `capabilities` cover the bundled lineup. For a model the
+router has **no** static tool-call answer for — an undeclared model on an
+OpenAI-compat backend — `go-llm` actively probes tool support rather than
+guessing.
+
+- **When it runs.** At agent startup the router bounded-eagerly probes the
+  models it is about to route, and route-time it probes on a cache miss. Models
+  with a catalog or explicit answer are never probed.
+- **What it sends (OpenAI-compat only).** A minimal `get_time` tool with up to
+  two chat-completions requests: attempt 1 forces `tool_choice: "required"`;
+  only if the server rejects that (400/422) does attempt 2 retry with `tools`
+  but no `tool_choice`. A tool call in the response means **yes**; a plain
+  answer is **inconclusive** (short TTL); a rejected `tools` array on both
+  attempts is **no**. Auth / rate-limit / transport failures are diagnostic and
+  never cached.
+- **Ollama is passive.** The Ollama path reads tool support from `/api/show`
+  template metadata — it sends no `get_time` request. The two-attempt live
+  probe is OpenAI-compat only.
+- **Cache.** Verdicts persist to `$XDG_DATA_HOME/golem/fingerprints.db` (else
+  `~/.local/share/golem/fingerprints.db`), keyed by backend + model, so a
+  probe runs at most once per model per version.
+- **Disabling.** Pass `-no-cap-probe` to Golem to skip the active probe
+  entirely; catalog and explicit `capabilities` still apply.
+
+Inspect and refresh verdicts with the `golem models` subcommand:
+
+```bash
+golem models              # list models, capabilities, and tool-call provenance
+golem models -probe-all   # actively probe every non-explicit entry
+golem models -reprobe     # drop cached verdicts for non-explicit entries, re-probe
+```
+
+Provenance in the listing tells you *why* a model has (or lacks) tool support:
+`explicit` (config), `catalog`, `probe` (with a tested-at timestamp),
+`runtime`, or `unknown`.
 
 ### Router weight profiles
 

--- a/docs/superpowers/plans/2026-07-03-tool-capability-probe-219.md
+++ b/docs/superpowers/plans/2026-07-03-tool-capability-probe-219.md
@@ -1,0 +1,2188 @@
+# Tool-Capability Probe + Discoverability (#219) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-detect `tool_call` for undeclared models via a cached active probe, fix the derived-override ceiling that erases catalog capabilities, and make capability state discoverable (`golem models`, remediation hints).
+
+**Architecture:** Registry gains a capability *floor* seam (derived caps OR-merge instead of replacing) and a tri-state `ResolveToolCall` resolver backed by a new `capability_probes` table (fingerprint store schema v2). Probing is bounded-eager at golem preflight (stop at first capable chain entry) and lazy at route time (unknown candidates probed before the capability gate rejects). Explicit `models.json` capabilities stay authoritative in both directions.
+
+**Tech Stack:** Go stdlib, modernc.org/sqlite (existing), mock `httptest` servers for probe tests.
+
+**Spec:** `docs/superpowers/specs/2026-07-03-tool-capability-probe-219-design.md` — read it first; it is the contract.
+
+**Worktree/build notes (read before Task 1):**
+- Execute in a linked worktree: `git worktree add ../go-llm-219 -b feat/tool-cap-probe-219 develop` (base develop@9c8b77c).
+- First commit on the branch adds the spec + this plan (both currently untracked in the main checkout — copy them in).
+- Every `go` command MUST be `env -u GOROOT go ...` (split-GOROOT workaround on this machine).
+- Docker pre-push hook cannot run from a linked worktree: run the gate natively (`env -u GOROOT go test ./...` then `env -u GOROOT go vet ./...`) and push with `git push --no-verify`.
+- NO emojis anywhere in commits or the eventual PR.
+
+**Review updates folded in before implementation:**
+- Capability-probe persistence is a narrow `fingerprint.CapProbeStore`, not new methods on the full `fingerprint.Store`; this keeps Golem capability-only mode and existing test fakes small.
+- openai-compat probe snippets match current provider types: `ChatResponse.ToolCalls` is direct, and `ChatRequest.ToolChoice` needs explicit wire plumbing.
+- Ollama passive probing uses `p.client.ShowModel(ctx, model)`, matching `DetectKind`.
+- `-no-cap-probe` disables active probing only; catalog/floor capability merges still apply and are covered by tests.
+
+---
+
+### Task 1: Fingerprint store schema v2 — `capability_probes` + CapProbe API
+
+**Files:**
+- Modify: `fingerprint/fingerprint.go` (CapProbe types + constants)
+- Modify: `fingerprint/migration.go` (migration v2)
+- Modify: `fingerprint/store.go` (CapProbeStore interface + SQLiteStore methods)
+- Test: `fingerprint/capprobe_test.go` (create)
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+// fingerprint/capprobe_test.go
+package fingerprint
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func newTestStore(t *testing.T) *SQLiteStore {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+t.TempDir()+"/fp.db")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	s, err := NewStore(context.Background(), db)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	return s
+}
+
+func TestCapProbe_SaveGetRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().Truncate(time.Millisecond)
+	in := CapProbe{
+		BackendID: "http://localhost:8080", ModelName: "byo-model",
+		Capability: "tool_call", State: CapProbeYes,
+		ModelDigest: "sha256:abc", ProbeVersion: CurrentToolProbeVersion,
+		TestedAt: now,
+	}
+	if err := s.SaveCapProbe(ctx, in); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := s.GetCapProbe(ctx, in.BackendID, in.ModelName, "tool_call")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.State != CapProbeYes || got.ModelDigest != "sha256:abc" ||
+		got.ProbeVersion != CurrentToolProbeVersion || !got.TestedAt.Equal(now) {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+	if !got.ExpiresAt.IsZero() {
+		t.Fatalf("yes row must not expire, got %v", got.ExpiresAt)
+	}
+}
+
+func TestCapProbe_GetMissingReturnsErrNotFound(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.GetCapProbe(context.Background(), "b", "m", "tool_call")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+}
+
+func TestCapProbe_SaveUpsertsOnSameKey(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	base := CapProbe{
+		BackendID: "b", ModelName: "m", Capability: "tool_call",
+		State: CapProbeInconclusive, ModelDigest: "d1",
+		ProbeVersion: CurrentToolProbeVersion, TestedAt: time.Now(),
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+	if err := s.SaveCapProbe(ctx, base); err != nil {
+		t.Fatalf("save 1: %v", err)
+	}
+	base.State = CapProbeYes
+	base.ExpiresAt = time.Time{}
+	if err := s.SaveCapProbe(ctx, base); err != nil {
+		t.Fatalf("save 2 (upsert): %v", err)
+	}
+	got, err := s.GetCapProbe(ctx, "b", "m", "tool_call")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.State != CapProbeYes || !got.ExpiresAt.IsZero() {
+		t.Fatalf("upsert did not replace: %+v", got)
+	}
+}
+
+func TestCapProbe_DeleteCapProbes(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	in := CapProbe{BackendID: "b", ModelName: "m", Capability: "tool_call",
+		State: CapProbeNo, ModelDigest: "d", ProbeVersion: 1, TestedAt: time.Now()}
+	if err := s.SaveCapProbe(ctx, in); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if err := s.DeleteCapProbes(ctx, "b", "m"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := s.GetCapProbe(ctx, "b", "m", "tool_call"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("want ErrNotFound after delete, got %v", err)
+	}
+}
+
+// Valid centralizes the freshness contract: digest match, version match, expiry.
+func TestCapProbe_Valid(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name   string
+		probe  CapProbe
+		digest string
+		want   bool
+	}{
+		{"fresh yes", CapProbe{State: CapProbeYes, ModelDigest: "d", ProbeVersion: CurrentToolProbeVersion, TestedAt: now}, "d", true},
+		{"digest mismatch", CapProbe{State: CapProbeYes, ModelDigest: "old", ProbeVersion: CurrentToolProbeVersion}, "new", false},
+		{"version mismatch", CapProbe{State: CapProbeYes, ModelDigest: "d", ProbeVersion: CurrentToolProbeVersion + 1}, "d", false},
+		{"expired inconclusive", CapProbe{State: CapProbeInconclusive, ModelDigest: "d", ProbeVersion: CurrentToolProbeVersion, ExpiresAt: now.Add(-time.Minute)}, "d", false},
+		{"unexpired inconclusive", CapProbe{State: CapProbeInconclusive, ModelDigest: "d", ProbeVersion: CurrentToolProbeVersion, ExpiresAt: now.Add(time.Hour)}, "d", true},
+		{"no-expiry no", CapProbe{State: CapProbeNo, ModelDigest: "d", ProbeVersion: CurrentToolProbeVersion}, "d", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.probe.Valid(tt.digest, now); got != tt.want {
+				t.Fatalf("Valid(%q) = %v, want %v", tt.digest, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMigrationV2_UpgradesExistingV1DB(t *testing.T) {
+	// Simulate a v1 database, then re-run migrations and use the new table.
+	db, err := sql.Open("sqlite", "file:"+t.TempDir()+"/fp.db")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := NewStore(context.Background(), db); err != nil { // runs all migrations
+		t.Fatalf("initial store: %v", err)
+	}
+	// Second open must be idempotent.
+	s, err := NewStore(context.Background(), db)
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	in := CapProbe{BackendID: "b", ModelName: "m", Capability: "tool_call",
+		State: CapProbeYes, ModelDigest: "d", ProbeVersion: 1, TestedAt: time.Now()}
+	if err := s.SaveCapProbe(context.Background(), in); err != nil {
+		t.Fatalf("save after re-migrate: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `env -u GOROOT go test ./fingerprint/ -run 'CapProbe|MigrationV2' -v`
+Expected: FAIL — `undefined: CapProbe`, `undefined: CapProbeYes`, etc.
+
+- [ ] **Step 3: Implement types + migration + store methods**
+
+Append to `fingerprint/fingerprint.go`:
+
+```go
+// CapProbeState is the tri-state outcome of a capability probe.
+// The empty string means "unknown" (never probed / cache miss) and is
+// never persisted.
+type CapProbeState string
+
+const (
+	CapProbeYes          CapProbeState = "yes"
+	CapProbeNo           CapProbeState = "no"
+	CapProbeInconclusive CapProbeState = "inconclusive"
+)
+
+// CurrentToolProbeVersion identifies the tool-call probe request shape.
+// Bump when the probe protocol changes (tool definition, prompt,
+// tool_choice escalation); cached rows from other versions are ignored.
+const CurrentToolProbeVersion = 1
+
+// CapProbeInconclusiveTTL bounds how long an inconclusive verdict is
+// trusted before the next demand re-probes.
+const CapProbeInconclusiveTTL = 24 * time.Hour
+
+// CapProbeDigestlessNoTTL bounds a negative verdict for models with no
+// content digest (openai-compat fallback keying): a wedged "no" silently
+// blocks usage, so digestless negatives expire rather than sticking until
+// a manual --reprobe.
+const CapProbeDigestlessNoTTL = 7 * 24 * time.Hour
+
+// CapProbe is one persisted capability-probe verdict, keyed by
+// (backend_id, model_name, capability). Distinct from Profile so
+// capability-only resolution can never masquerade as a complete
+// fingerprint profile.
+type CapProbe struct {
+	BackendID    string
+	ModelName    string
+	Capability   string // canonical token, e.g. "tool_call"
+	State        CapProbeState
+	ModelDigest  string    // runtime digest, or key fallback when digestless
+	ProbeVersion int       // CurrentToolProbeVersion at probe time
+	TestedAt     time.Time
+	ExpiresAt    time.Time // zero = does not expire
+}
+
+// Valid reports whether the cached probe still applies for the given
+// current digest at time now: digest and probe version must match and the
+// row must not be expired.
+func (p CapProbe) Valid(currentDigest string, now time.Time) bool {
+	if p.ModelDigest != currentDigest {
+		return false
+	}
+	if p.ProbeVersion != CurrentToolProbeVersion {
+		return false
+	}
+	if !p.ExpiresAt.IsZero() && now.After(p.ExpiresAt) {
+		return false
+	}
+	return true
+}
+```
+
+Append migration in `fingerprint/migration.go` (add to the `migrations` slice and define the function):
+
+```go
+	{
+		version:     2,
+		description: "capability_probes table for tri-state capability verdicts",
+		fn:          migrateV2,
+	},
+```
+
+```go
+func migrateV2(tx *sql.Tx) error {
+	const stmt = `CREATE TABLE IF NOT EXISTS capability_probes (
+		backend_id    TEXT NOT NULL,
+		model_name    TEXT NOT NULL,
+		capability    TEXT NOT NULL,
+		state         TEXT NOT NULL,
+		model_digest  TEXT NOT NULL,
+		probe_version INTEGER NOT NULL,
+		tested_at     INTEGER NOT NULL,
+		expires_at    INTEGER,
+		PRIMARY KEY (backend_id, model_name, capability)
+	)`
+	if _, err := tx.Exec(stmt); err != nil {
+		return fmt.Errorf("fingerprint: migrate v2: %w", err)
+	}
+	return nil
+}
+```
+
+Add a narrow `CapProbeStore` interface and `SQLiteStore` methods in
+`fingerprint/store.go`. Do NOT add these methods to `Store`: capability-only
+Golem wiring should not force every full fingerprint-profile fake to implement
+capability-probe persistence.
+
+```go
+// Store defines fingerprint persistence operations.
+type Store interface {
+	Get(ctx context.Context, backendID, modelName string) (*Profile, error)
+	GetFailure(ctx context.Context, backendID, modelName string) (*FailureInfo, error)
+	Save(ctx context.Context, profile Profile) error
+	NeedsFingerprint(ctx context.Context, backendID, modelName, currentDigest string) (bool, error)
+	SaveFailure(ctx context.Context, backendID, modelName, modelDigest, errMsg string) error
+}
+
+// CapProbeStore defines capability-probe persistence operations.
+// It is intentionally separate from Store so capability-only resolution
+// never affects NeedsFingerprint / IncompleteCapabilities semantics and
+// test fakes for full fingerprint profiles do not need cap-probe methods.
+type CapProbeStore interface {
+	GetCapProbe(ctx context.Context, backendID, modelName, capability string) (*CapProbe, error)
+	SaveCapProbe(ctx context.Context, probe CapProbe) error
+	DeleteCapProbes(ctx context.Context, backendID, modelName string) error
+}
+
+var _ CapProbeStore = (*SQLiteStore)(nil)
+```
+
+```go
+// GetCapProbe retrieves a capability-probe row. Returns ErrNotFound when
+// no row exists for the key.
+func (s *SQLiteStore) GetCapProbe(ctx context.Context, backendID, modelName, capability string) (*CapProbe, error) {
+	var p CapProbe
+	var testedAtMs int64
+	var expiresAtMs sql.NullInt64
+	err := s.db.QueryRowContext(ctx,
+		`SELECT backend_id, model_name, capability, state, model_digest,
+			probe_version, tested_at, expires_at
+		FROM capability_probes
+		WHERE backend_id = ? AND model_name = ? AND capability = ?`,
+		backendID, modelName, capability,
+	).Scan(&p.BackendID, &p.ModelName, &p.Capability, &p.State, &p.ModelDigest,
+		&p.ProbeVersion, &testedAtMs, &expiresAtMs)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("fingerprint: get cap probe %q/%q/%q: %w", backendID, modelName, capability, err)
+	}
+	p.TestedAt = time.UnixMilli(testedAtMs)
+	if expiresAtMs.Valid {
+		p.ExpiresAt = time.UnixMilli(expiresAtMs.Int64)
+	}
+	return &p, nil
+}
+
+// SaveCapProbe inserts or replaces the probe row for its key.
+func (s *SQLiteStore) SaveCapProbe(ctx context.Context, probe CapProbe) error {
+	var expiresAt any // nil => NULL (no expiry)
+	if !probe.ExpiresAt.IsZero() {
+		expiresAt = probe.ExpiresAt.UnixMilli()
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT OR REPLACE INTO capability_probes
+			(backend_id, model_name, capability, state, model_digest,
+			 probe_version, tested_at, expires_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		probe.BackendID, probe.ModelName, probe.Capability, string(probe.State),
+		probe.ModelDigest, probe.ProbeVersion, probe.TestedAt.UnixMilli(), expiresAt)
+	if err != nil {
+		return fmt.Errorf("fingerprint: save cap probe %q/%q/%q: %w",
+			probe.BackendID, probe.ModelName, probe.Capability, err)
+	}
+	return nil
+}
+
+// DeleteCapProbes removes all capability rows for a model (used by
+// `golem models --reprobe`).
+func (s *SQLiteStore) DeleteCapProbes(ctx context.Context, backendID, modelName string) error {
+	_, err := s.db.ExecContext(ctx,
+		`DELETE FROM capability_probes WHERE backend_id = ? AND model_name = ?`,
+		backendID, modelName)
+	if err != nil {
+		return fmt.Errorf("fingerprint: delete cap probes %q/%q: %w", backendID, modelName, err)
+	}
+	return nil
+}
+```
+
+Run a full build. No existing `fingerprint.Store` fake should need cap-probe
+methods unless that test opts into capability resolution; tests that do opt in
+should fake only `fingerprint.CapProbeStore`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `env -u GOROOT go test ./fingerprint/... -v` then `env -u GOROOT go build ./...`
+Expected: PASS; no unrelated full-profile Store fake churn.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add fingerprint/
+git commit -m "feat(fingerprint): capability_probes table + tri-state CapProbe API (schema v2)"
+```
+
+---
+
+### Task 2: Registry capability floor (`SetCapabilityFloor`)
+
+**Files:**
+- Modify: `provider/model_registry.go`
+- Test: `provider/model_registry_test.go` (append)
+
+- [ ] **Step 1: Write failing tests**
+
+Follow the existing test-harness patterns in `provider/model_registry_test.go`
+(fake ProviderResolver returning canned ModelInfo). Cases:
+
+```go
+func TestSetCapabilityFloor_ORsBelowCatalogAndOverride(t *testing.T) {
+	// Model with a catalog family hit that carries "tools" (e.g. "qwen3:8b").
+	// Floor supplies chat|generate|stream. Expect final caps to contain
+	// CapToolCall (catalog survives) AND the floor bits.
+	reg := newTestRegistryWithModel(t, "llamacpp", "qwen3:8b") // helper mirrors existing tests
+	reg.SetCapabilityFloor(func(key ModelKey) []string {
+		return []string{"chat", "generate", "stream"}
+	})
+	p, err := reg.Lookup(context.Background(), ModelKey{Provider: "llamacpp", Model: "qwen3:8b"})
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	want := CapChat | CapGenerate | CapStream | CapToolCall
+	if !p.Caps.Has(want) {
+		t.Fatalf("caps = %v, want superset of %v", p.Caps, want)
+	}
+}
+
+func TestSetCapabilityFloor_ExplicitOverrideStillReplaces(t *testing.T) {
+	// Floor + catalog give tool_call; explicit override without tool_call
+	// must win (declared set is authoritative both directions).
+	reg := newTestRegistryWithModel(t, "llamacpp", "qwen3:8b")
+	reg.SetCapabilityFloor(func(ModelKey) []string { return []string{"chat", "generate", "stream"} })
+	reg.SetCapabilityOverride(func(ModelKey) []string { return []string{"chat", "stream"} })
+	p, err := reg.Lookup(context.Background(), ModelKey{Provider: "llamacpp", Model: "qwen3:8b"})
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if p.Caps != (CapChat | CapStream) {
+		t.Fatalf("caps = %v, want exactly chat|stream", p.Caps)
+	}
+}
+
+func TestSetCapabilityFloor_InvalidTokensDroppedWithHook(t *testing.T) {
+	// Non-canonical floor tokens: rejection hook fires, caps unchanged
+	// (mirror override corner-case handling; never zero or partially apply).
+	reg := newTestRegistryWithModel(t, "llamacpp", "unknown-model")
+	var hookKey ModelKey
+	reg.SetOverrideRejectionHook(func(key ModelKey, tokens []string, err error) { hookKey = key })
+	reg.SetCapabilityFloor(func(ModelKey) []string { return []string{"completion"} }) // alias => strict-reject
+	p, err := reg.Lookup(context.Background(), ModelKey{Provider: "llamacpp", Model: "unknown-model"})
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	_ = p
+	if hookKey.Model != "unknown-model" {
+		t.Fatalf("rejection hook not fired for floor tokens")
+	}
+}
+
+func TestSetCapabilityFloor_InvalidatesCacheAndGuardsVersion(t *testing.T) {
+	// Same shape as the existing SetCapabilityOverride TOCTOU/invalidations
+	// tests: Lookup once (cache warm), SetCapabilityFloor, Lookup again and
+	// expect the floor applied (cache flushed).
+	reg := newTestRegistryWithModel(t, "llamacpp", "unknown-model")
+	if _, err := reg.Lookup(context.Background(), ModelKey{Provider: "llamacpp", Model: "unknown-model"}); err != nil {
+		t.Fatalf("warm lookup: %v", err)
+	}
+	reg.SetCapabilityFloor(func(ModelKey) []string { return []string{"chat", "stream"} })
+	p, err := reg.Lookup(context.Background(), ModelKey{Provider: "llamacpp", Model: "unknown-model"})
+	if err != nil {
+		t.Fatalf("lookup after floor: %v", err)
+	}
+	if !p.Caps.Has(CapChat | CapStream) {
+		t.Fatalf("floor not applied after cache flush: %v", p.Caps)
+	}
+}
+```
+
+If `newTestRegistryWithModel` doesn't exist, build it on the existing fake
+resolver used by other registry tests in that file (do not invent a new fake).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `env -u GOROOT go test ./provider/ -run SetCapabilityFloor -v`
+Expected: FAIL — `undefined: reg.SetCapabilityFloor`.
+
+- [ ] **Step 3: Implement the floor**
+
+In `provider/model_registry.go`:
+
+1. Add field + type + setter (mirror `SetCapabilityOverride` exactly, sharing
+   `overrideVersion` as the single policy version counter so a floor change
+   also invalidates in-flight buildProfile writes):
+
+```go
+// CapabilityFloor returns baseline canonical capability tokens for a model
+// key, or nil when none. Floor caps are OR-merged into the profile at the
+// LOWEST precedence (with the static catalog layer): they guarantee a
+// minimum capability set for models whose provider exposes no capability
+// metadata (openai-compat), WITHOUT erasing catalog/fingerprint/runtime
+// additions the way the REPLACE override does. Tokens must be canonical
+// (ParseCapsStrict); invalid slices are dropped with the rejection hook
+// fired and never zero or shrink the profile.
+type CapabilityFloor func(key ModelKey) []string
+```
+
+```go
+	capFloor        CapabilityFloor // field beside capOverride
+```
+
+```go
+// SetCapabilityFloor installs (or clears) the capability floor hook.
+// Shares SetCapabilityOverride's invalidation + version-guard semantics:
+// the profile cache is flushed and the policy version bumped so in-flight
+// merges under the old floor cannot repopulate the cache.
+func (r *ModelRegistry) SetCapabilityFloor(fn CapabilityFloor) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.capFloor = fn
+	r.overrideVersion++
+	clear(r.profiles)
+}
+```
+
+2. `buildProfile`: snapshot the floor alongside the override:
+
+```go
+	r.mu.RLock()
+	override := r.capOverride
+	floor := r.capFloor
+	overrideVer := r.overrideVersion
+	rejectionHook := r.rejectionHook
+	r.mu.RUnlock()
+```
+
+Pass `floor` through to `merge` (add a parameter).
+
+3. In `merge`, apply the floor right after the static-catalog block (lowest
+   precedence, pure OR):
+
+```go
+	// Capability floor (lowest precedence, OR-merge). Guarantees baseline
+	// caps for providers that expose no capability metadata without the
+	// REPLACE override's erasure semantics. Invalid tokens are dropped with
+	// the rejection hook fired — a floor must never zero or shrink caps.
+	if floor != nil {
+		if floorTokens := floor(key); len(floorTokens) > 0 {
+			floorCaps, err := ParseCapsStrict(floorTokens)
+			switch {
+			case err != nil:
+				if rejectionHook != nil {
+					rejectionHook(key, floorTokens, err)
+				}
+			case floorCaps != 0:
+				profile.Caps |= floorCaps
+			}
+		}
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `env -u GOROOT go test ./provider/ -v`
+Expected: PASS (all existing registry tests too — floor is additive).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add provider/model_registry.go provider/model_registry_test.go
+git commit -m "feat(provider): capability floor seam - OR-merge baseline caps below catalog/override"
+```
+
+---
+
+### Task 3: providerbootstrap floor/override split
+
+**Files:**
+- Modify: `internal/providerbootstrap/capabilities.go`
+- Modify: `internal/providerbootstrap/bootstrap.go` (install call)
+- Test: `internal/providerbootstrap/capabilities_test.go` (append)
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+func TestBuildCapabilityFloors_DerivedOpenAICompatOnly(t *testing.T) {
+	cfg := &config.Config{
+		Providers: map[string]config.ProviderConfig{
+			"llamacpp": {APIFormat: "openai-compat", BaseURL: "http://127.0.0.1:8080"},
+			"ollama":   {BaseURL: "http://localhost:11434"},
+		},
+		Models: map[string]config.ModelConfig{
+			"agent":   {Provider: "llamacpp", Name: "byo-model", Type: "dense"}, // undeclared => floor
+			"chat":    {Provider: "llamacpp", Name: "declared", Type: "dense", Capabilities: []string{"chat", "stream", "tool_call"}}, // explicit => override, NOT floor
+			"embed":   {Provider: "ollama", Name: "qwen3-embedding:8b", Type: "embedding"}, // ollama undeclared => neither
+	},
+	}
+	floors, err := buildCapabilityFloors(cfg)
+	if err != nil {
+		t.Fatalf("floors: %v", err)
+	}
+	if got := floors[provider.ModelKey{Provider: "llamacpp", Model: "byo-model"}]; len(got) == 0 {
+		t.Fatalf("undeclared openai-compat model missing floor")
+	}
+	if _, ok := floors[provider.ModelKey{Provider: "llamacpp", Model: "declared"}]; ok {
+		t.Fatalf("explicitly declared model must not get a floor")
+	}
+	if _, ok := floors[provider.ModelKey{Provider: "ollama", Model: "qwen3-embedding:8b"}]; ok {
+		t.Fatalf("ollama model must not get a floor")
+	}
+
+	overrides, err := buildCapabilityOverrides(cfg)
+	if err != nil {
+		t.Fatalf("overrides: %v", err)
+	}
+	if _, ok := overrides[provider.ModelKey{Provider: "llamacpp", Model: "byo-model"}]; ok {
+		t.Fatalf("undeclared openai-compat model must no longer get a REPLACE override")
+	}
+	if _, ok := overrides[provider.ModelKey{Provider: "llamacpp", Model: "declared"}]; !ok {
+		t.Fatalf("explicit declaration must remain an override")
+	}
+}
+
+func TestBuildCapabilityFloors_SharedKeyUnionsDerived(t *testing.T) {
+	// Two roles, same key, different types => floors union (OR semantics
+	// make conflicts impossible; no error path for floors).
+	cfg := &config.Config{
+		Providers: map[string]config.ProviderConfig{
+			"llamacpp": {APIFormat: "openai-compat"},
+		},
+		Models: map[string]config.ModelConfig{
+			"agent": {Provider: "llamacpp", Name: "m", Type: "dense"},
+			"embed": {Provider: "llamacpp", Name: "m", Type: "embedding"},
+		},
+	}
+	floors, err := buildCapabilityFloors(cfg)
+	if err != nil {
+		t.Fatalf("floors: %v", err)
+	}
+	got := floors[provider.ModelKey{Provider: "llamacpp", Model: "m"}]
+	// dense derives chat,generate,stream; embedding derives embed => union of all four.
+	want := map[string]bool{"chat": true, "generate": true, "stream": true, "embed": true}
+	if len(got) != len(want) {
+		t.Fatalf("floor union = %v, want keys %v", got, want)
+	}
+	for _, tok := range got {
+		if !want[tok] {
+			t.Fatalf("unexpected floor token %q in %v", tok, got)
+		}
+	}
+}
+```
+
+Also UPDATE existing tests that assert derived openai-compat caps arrive as
+overrides (they now arrive as floors) — run the package tests and adjust
+assertions that break, preserving their intent.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `env -u GOROOT go test ./internal/providerbootstrap/ -run CapabilityFloors -v`
+Expected: FAIL — `undefined: buildCapabilityFloors`.
+
+- [ ] **Step 3: Implement the split**
+
+In `internal/providerbootstrap/capabilities.go`:
+
+1. `buildCapabilityOverrides`: DELETE the derived-caps branch (the
+   `if len(caps) == 0 { ... apiFormat != "openai-compat" ... caps = m.ResolvedCapabilities() }`
+   block, lines 68-81). Overrides are now explicit-only:
+
+```go
+	for _, role := range roles {
+		m := cfg.Models[role]
+		if m.Provider == "" || m.Name == "" {
+			continue
+		}
+		caps := m.Capabilities
+		if len(caps) == 0 {
+			continue // derived caps are floors now, not overrides
+		}
+		// ... (ParseCapsStrict + conflict detection unchanged)
+```
+
+2. New `buildCapabilityFloors` (derived, openai-compat, undeclared only;
+   union across roles for a shared key):
+
+```go
+// buildCapabilityFloors computes baseline capability floors for undeclared
+// openai-compat models: their provider exposes no capability metadata, so
+// the type-derived set guarantees routability. Floors OR-merge in the
+// registry (lowest precedence), so unlike the old REPLACE override they
+// cannot erase catalog/fingerprint/runtime capabilities (issue #219 root
+// cause). Shared keys across roles union their derived sets — OR semantics
+// make conflicts impossible.
+func buildCapabilityFloors(cfg *config.Config) (map[provider.ModelKey][]string, error) {
+	out := make(map[provider.ModelKey][]string)
+	if cfg == nil {
+		return out, nil
+	}
+	union := make(map[provider.ModelKey]map[string]bool)
+	roles := make([]string, 0, len(cfg.Models))
+	for role := range cfg.Models {
+		roles = append(roles, role)
+	}
+	sort.Strings(roles)
+	for _, role := range roles {
+		m := cfg.Models[role]
+		if m.Provider == "" || m.Name == "" || len(m.Capabilities) > 0 {
+			continue // explicit declarations are overrides, not floors
+		}
+		pCfg, ok := cfg.Providers[m.Provider]
+		if !ok {
+			continue
+		}
+		apiFormat := pCfg.APIFormat
+		if apiFormat == "" {
+			apiFormat = "ollama"
+		}
+		if apiFormat != "openai-compat" {
+			continue
+		}
+		derived := m.ResolvedCapabilities()
+		if len(derived) == 0 {
+			continue
+		}
+		if _, err := provider.ParseCapsStrict(derived); err != nil {
+			return nil, fmt.Errorf("providerbootstrap: model %q derived floor for %s/%s: %w", role, m.Provider, m.Name, err)
+		}
+		key := provider.ModelKey{Provider: m.Provider, Model: m.Name}
+		if union[key] == nil {
+			union[key] = make(map[string]bool)
+		}
+		for _, tok := range derived {
+			union[key][tok] = true
+		}
+	}
+	for key, set := range union {
+		toks := make([]string, 0, len(set))
+		for tok := range set {
+			toks = append(toks, tok)
+		}
+		sort.Strings(toks)
+		out[key] = toks
+	}
+	return out, nil
+}
+
+// installCapabilityFloors installs the computed floors onto the registry.
+func installCapabilityFloors(mr *provider.ModelRegistry, cfg *config.Config) error {
+	if mr == nil || cfg == nil {
+		return nil
+	}
+	floors, err := buildCapabilityFloors(cfg)
+	if err != nil {
+		return err
+	}
+	if len(floors) == 0 {
+		return nil
+	}
+	mr.SetCapabilityFloor(func(key provider.ModelKey) []string {
+		caps, ok := floors[key]
+		if !ok {
+			return nil
+		}
+		out := make([]string, len(caps))
+		copy(out, caps)
+		return out
+	})
+	return nil
+}
+```
+
+3. `bootstrap.go` `New()`: install floors right after overrides:
+
+```go
+	if err := installCapabilityOverrides(mr, effCfg); err != nil {
+		return nil, err
+	}
+	if err := installCapabilityFloors(mr, effCfg); err != nil {
+		return nil, err
+	}
+```
+
+IMPORTANT side effect to preserve: `capabilitiesForKey` (used by the prober
+factory as a capability HINT) intentionally still returns explicit-or-derived
+caps — do not change it.
+
+- [ ] **Step 4: Run tests + full build**
+
+Run: `env -u GOROOT go test ./internal/providerbootstrap/ ./provider/ -v`
+Then run: `env -u GOROOT go build ./...`
+Expected: PASS after updating any existing derived-override assertions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/providerbootstrap/
+git commit -m "fix(providerbootstrap): derived openai-compat caps become floors, not REPLACE overrides (#219 root cause)"
+```
+
+---
+
+### Task 4: openai-compat tool-call probe (two-attempt protocol)
+
+**Files:**
+- Modify: `fingerprint/fingerprint.go` (CapProbeOutcome + ToolCallProber)
+- Modify: `fingerprint/probers/openaicompat.go` (ProbeToolCall)
+- Modify: `provider/types.go` (`ChatRequest.ToolChoice`)
+- Modify: `provider/openaicompat/types.go` (`chatRequest.ToolChoice`)
+- Modify: `provider/openaicompat/openaicompat.go` (copy ToolChoice to wire request)
+- Test: `fingerprint/probers/openaicompat_toolprobe_test.go` (create)
+
+- [ ] **Step 1: Define the shared probe-outcome contract (small, no test yet)**
+
+Append to `fingerprint/fingerprint.go`:
+
+```go
+// CapProbeOutcome is a classified probe verdict ready to persist.
+// TTL zero means the row does not expire.
+type CapProbeOutcome struct {
+	State  CapProbeState
+	TTL    time.Duration
+	Detail string // short human-readable classification, for diagnostics
+}
+
+// ToolCallProber is an optional interface a ModelProber may implement to
+// actively determine tool-call support. A non-nil error means the probe
+// was transient/diagnostic (network failure, auth, rate limit) and MUST
+// NOT be persisted; the outcome is only meaningful when err is nil.
+type ToolCallProber interface {
+	ProbeToolCall(ctx context.Context, model string) (CapProbeOutcome, error)
+}
+```
+
+(`fingerprint.go` needs `"context"` added to its imports.)
+
+- [ ] **Step 2: Write failing tests for the probe matrix**
+
+Use `httptest.NewServer` with a scripted handler; construct the prober via
+`openaicompat.New(...)` pointed at the test server (mirror the construction
+already used in `fingerprint/probers/openaicompat_test.go`).
+
+```go
+// fingerprint/probers/openaicompat_toolprobe_test.go
+package probers
+
+// Test matrix (table-driven, one scripted handler per case).
+// Each case scripts attempt-1 (and attempt-2 when reached) responses and
+// asserts: outcome.State, outcome.TTL, err != nil (transient), and the
+// number of HTTP requests received.
+//
+//  name                          attempt1                attempt2      wantState        wantTTL                        wantErr  wantReqs
+//  yes_on_required               200 tool_calls          -             CapProbeYes      0                              false    1
+//  inconclusive_on_required      200 no tool_calls       -             CapProbeInconclusive CapProbeInconclusiveTTL    false    1
+//  escalate_then_yes             400                     200 calls     CapProbeYes      0                              false    2
+//  escalate_then_inconclusive    422                     200 no calls  CapProbeInconclusive CapProbeInconclusiveTTL    false    2
+//  no_when_tools_rejected        400                     400           CapProbeNo       0                              false    2
+//  auth_diagnostic_not_persisted 401                     -             -                -                              true     1
+//  not_found_diagnostic          404                     -             -                -                              true     1
+//  rate_limited_diagnostic       429                     -             -                -                              true     1
+//  server_error_transient        500                     -             -                -                              true     1
+//  escalated_then_500            400                     500           -                -                              true     2
+//  network_error_transient       (server closed)         -             -                -                              true     0
+//
+// Also assert on the recorded attempt-1 request body:
+//   - tools[0].function.name == "get_time"
+//   - tool_choice == "required"
+//   - stream absent/false, max_tokens == 128, temperature == 0
+// and that attempt-2's body has NO tool_choice field but still has tools.
+```
+
+Write the full table + handler; keep each scripted response a plain
+`chat.completions` JSON body (copy the response shape from
+`fingerprint/probers/openaicompat_test.go`'s existing chat fixtures, adding
+`"tool_calls": [{"id":"1","type":"function","function":{"name":"get_time","arguments":"{}"}}]`
+for the tool-call cases).
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `env -u GOROOT go test ./fingerprint/probers/ -run ToolProbe -v`
+Expected: FAIL — `ProbeToolCall` undefined.
+
+- [ ] **Step 4: Implement ProbeToolCall**
+
+Append to `fingerprint/probers/openaicompat.go`:
+
+```go
+// toolProbeTimeout bounds one tool-call probe request. It must absorb a
+// llama-swap model load (seconds to tens of seconds for large models),
+// unlike the #218 port-scan probe's 800ms budget.
+const toolProbeTimeout = 30 * time.Second
+
+// probeToolSchema is the minimal no-arg function used to elicit a call.
+var probeToolSchema = provider.Tool{
+	Type: "function",
+	Function: provider.ToolFunction{
+		Name:        "get_time",
+		Description: "Get the current time.",
+		Parameters:  json.RawMessage(`{"type":"object","properties":{}}`),
+	},
+}
+
+// ProbeToolCall actively determines tool-call support with at most two
+// chat-completions requests (spec section 3):
+//
+//	attempt 1: tools + tool_choice "required" (deterministic elicitation)
+//	attempt 2 (only after attempt-1 400/422): tools without tool_choice,
+//	           prompt-engineered — some servers reject tool_choice but
+//	           accept tools.
+//
+// Verdicts: 200 with tool_calls => yes; 200 without => inconclusive
+// (short TTL: the model ignored the request, which varies by template);
+// 400/422 on attempt 2 => no (the tools array itself is rejected).
+// Auth/endpoint/rate-limit statuses and transport failures return a
+// non-nil error — diagnostic only, never persisted.
+func (p *OpenAICompatProber) ProbeToolCall(ctx context.Context, model string) (fingerprint.CapProbeOutcome, error) {
+	if p == nil || p.prov == nil {
+		return fingerprint.CapProbeOutcome{}, fmt.Errorf("fingerprint: openaicompat tool probe %q: provider is required", model)
+	}
+	ctx, cancel := context.WithTimeout(ctx, toolProbeTimeout)
+	defer cancel()
+
+	outcome, retry, err := p.toolProbeAttempt(ctx, model, true)
+	if err != nil || !retry {
+		return outcome, err
+	}
+	// Attempt 1 was rejected with 400/422: the server may object to
+	// tool_choice rather than tools. Re-try without tool_choice; a second
+	// 400/422 means the tools array itself is unsupported => hard no.
+	outcome, retry, err = p.toolProbeAttempt(ctx, model, false)
+	if err != nil {
+		return outcome, err
+	}
+	if retry {
+		return fingerprint.CapProbeOutcome{
+			State:  fingerprint.CapProbeNo,
+			Detail: "server rejected tools request (400/422 on both attempts)",
+		}, nil
+	}
+	return outcome, nil
+}
+
+// toolProbeAttempt runs one probe request. retry=true signals a 400/422
+// rejection that the caller may escalate past (attempt 1) or convert to a
+// hard no (attempt 2).
+func (p *OpenAICompatProber) toolProbeAttempt(ctx context.Context, model string, forceToolChoice bool) (fingerprint.CapProbeOutcome, bool, error) {
+	temp := 0.0
+	req := provider.ChatRequest{
+		Model: model,
+		Messages: []provider.ChatMessage{
+			{Role: "user", Content: "Call the get_time tool to get the current time."},
+		},
+		Tools: []provider.Tool{probeToolSchema},
+		Options: provider.ModelOptions{
+			NumPredict:  128, // tool-call JSON needs room; truncation reads as a false negative
+			Temperature: &temp,
+		},
+	}
+	if forceToolChoice {
+		req.ToolChoice = "required"
+	}
+
+	resp, err := p.prov.Chat(ctx, req)
+	if err != nil {
+		var hs interface{ HTTPStatusCode() int }
+		if errors.As(err, &hs) {
+			switch code := hs.HTTPStatusCode(); {
+			case code == 400 || code == 422:
+				return fingerprint.CapProbeOutcome{}, true, nil
+			default:
+				// 401/403/404/405/429, 5xx, anything else with a status:
+				// says nothing about the model. Diagnostic, not persisted.
+				return fingerprint.CapProbeOutcome{}, false, fmt.Errorf("fingerprint: openaicompat tool probe %q: %w", model, err)
+			}
+		}
+		// Transport-level failure (network, timeout, cancel): transient.
+		return fingerprint.CapProbeOutcome{}, false, fmt.Errorf("fingerprint: openaicompat tool probe %q: %w", model, err)
+	}
+	if len(resp.ToolCalls) > 0 {
+		return fingerprint.CapProbeOutcome{State: fingerprint.CapProbeYes, Detail: "model produced a tool call"}, false, nil
+	}
+	return fingerprint.CapProbeOutcome{
+		State:  fingerprint.CapProbeInconclusive,
+		TTL:    fingerprint.CapProbeInconclusiveTTL,
+		Detail: "200 response without tool_calls",
+	}, false, nil
+}
+```
+
+Add the required request plumbing before running the probe tests:
+
+```go
+// provider/types.go, ChatRequest
+ToolChoice string `json:"tool_choice,omitempty"` // currently honored by openai-compat
+```
+
+```go
+// provider/openaicompat/types.go, chatRequest
+ToolChoice string `json:"tool_choice,omitempty"`
+```
+
+```go
+// provider/openaicompat/openaicompat.go, toChatRequest
+r := chatRequest{
+	Model:      req.Model,
+	Messages:   msgs,
+	Stream:     stream,
+	Tools:      toWireTools(req.Tools),
+	ToolChoice: req.ToolChoice,
+}
+```
+
+Add a focused openai-compat request-conversion test (or extend an existing one)
+that `provider.ChatRequest{ToolChoice: "required"}` serializes
+`"tool_choice":"required"` and that the zero value omits the field.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `env -u GOROOT go test ./fingerprint/... ./provider/... -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add fingerprint/ provider/
+git commit -m "feat(fingerprint): active openai-compat tool-call probe with two-attempt classification"
+```
+
+---
+
+### Task 5: Ollama passive tool-call probe
+
+**Files:**
+- Modify: `fingerprint/probe.go` (OllamaProber.ProbeToolCall)
+- Test: `fingerprint/probe_test.go` (append)
+
+- [ ] **Step 1: Write failing tests**
+
+`OllamaProber` already talks to a client interface with `ShowModel`
+(inspect `fingerprint/probe.go` — `DetectKind` reads `/api/show` capabilities
+through `p.client.ShowModel(ctx, model)`; reuse exactly that call path and its
+existing test fake). Cases:
+
+```go
+func TestOllamaProbeToolCall_CapabilitiesWithTools(t *testing.T) {
+	// fake /api/show returns Capabilities: ["completion","tools"]
+	// => CapProbeYes, TTL 0, err nil
+}
+
+func TestOllamaProbeToolCall_CapabilitiesWithoutTools(t *testing.T) {
+	// fake /api/show returns Capabilities: ["completion"]
+	// => CapProbeNo, TTL 0, err nil (array present and lacks tools: curated no)
+}
+
+func TestOllamaProbeToolCall_MissingCapabilitiesArray(t *testing.T) {
+	// fake /api/show returns Capabilities: nil (older Ollama)
+	// => CapProbeInconclusive, TTL CapProbeInconclusiveTTL, err nil
+	// (never persist a hard no on missing data)
+}
+
+func TestOllamaProbeToolCall_ShowError(t *testing.T) {
+	// fake /api/show errors => err non-nil (transient, not persisted)
+}
+```
+
+Write them against the same fake client type the existing OllamaProber tests
+use, asserting `fingerprint.CapProbeOutcome` fields.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `env -u GOROOT go test ./fingerprint/ -run OllamaProbeToolCall -v`
+Expected: FAIL — method undefined.
+
+- [ ] **Step 3: Implement**
+
+```go
+// ProbeToolCall determines tool support passively from /api/show model
+// metadata — no generation request, no model load. A present capabilities
+// array is authoritative in both directions; a missing array (older
+// Ollama) is inconclusive, never a hard no.
+func (p *OllamaProber) ProbeToolCall(ctx context.Context, model string) (CapProbeOutcome, error) {
+	info, err := p.client.ShowModel(ctx, model) // match the exact call DetectKind uses
+	if err != nil {
+		return CapProbeOutcome{}, fmt.Errorf("fingerprint: ollama tool probe %q: %w", model, err)
+	}
+	if info.Capabilities == nil {
+		return CapProbeOutcome{
+			State:  CapProbeInconclusive,
+			TTL:    CapProbeInconclusiveTTL,
+			Detail: "ollama /api/show has no capabilities array",
+		}, nil
+	}
+	for _, c := range info.Capabilities {
+		if c == "tools" {
+			return CapProbeOutcome{State: CapProbeYes, Detail: "ollama capabilities lists tools"}, nil
+		}
+	}
+	return CapProbeOutcome{State: CapProbeNo, Detail: "ollama capabilities array lacks tools"}, nil
+}
+```
+
+Match receiver/client names to the real `OllamaProber` (read `fingerprint/probe.go` first).
+
+- [ ] **Step 4: Run tests, then commit**
+
+Run: `env -u GOROOT go test ./fingerprint/... -v` — Expected: PASS.
+
+```bash
+git add fingerprint/
+git commit -m "feat(fingerprint): passive ollama tool-call probe via /api/show capabilities"
+```
+
+---
+
+### Task 6: Registry resolver — `ResolveToolCall` + merge integration + `EnsureToolCallResolved`
+
+**Files:**
+- Modify: `provider/model_registry.go`
+- Test: `provider/capresolve_test.go` (create)
+
+- [ ] **Step 1: Write failing tests**
+
+Fake `fingerprint.CapProbeStore` (in-memory map implementing only the three
+cap-probe methods) and a fake prober factory whose prober implements
+`fingerprint.ToolCallProber` with scripted outcomes + a call counter. Cases:
+
+```go
+// All tests construct: NewModelRegistry(fakeResolver, nil,
+//   WithCapabilityProbeStore(fakeStore),
+//   WithCapabilityProber(fakeFactory)) — the new options.
+
+func TestResolveToolCall_ExplicitDeclarationSkipsProbe(t *testing.T) {
+	// SetCapabilityOverride includes tool_call for the key =>
+	// ResolveToolCall returns CapProbeYes, prober call count == 0.
+	// Override WITHOUT tool_call => CapProbeNo, count == 0.
+}
+
+func TestResolveToolCall_MergedCapsShortCircuit(t *testing.T) {
+	// Catalog-hit model (qwen3:8b => catalog tools) => CapProbeYes, count == 0.
+}
+
+func TestResolveToolCall_CacheHitSkipsProbe(t *testing.T) {
+	// Pre-seed store with a valid yes row (digest = key fallback,
+	// ProbeVersion current) => CapProbeYes, count == 0.
+}
+
+func TestResolveToolCall_StaleCacheReprobes(t *testing.T) {
+	// Pre-seed with ProbeVersion-1 row => probe runs (count == 1),
+	// new row persisted with current version.
+}
+
+func TestResolveToolCall_ProbePersistsAndInvalidatesProfile(t *testing.T) {
+	// Unknown model, prober scripted yes:
+	//  1. Lookup => profile lacks CapToolCall.
+	//  2. ResolveToolCall => CapProbeYes, store row saved with
+	//     Capability "tool_call", TTL zero.
+	//  3. Lookup again => profile NOW has CapToolCall (cache invalidated,
+	//     merge read the yes row).
+}
+
+func TestResolveToolCall_TransientErrorNotPersisted(t *testing.T) {
+	// Prober scripted to return error => state "", err non-nil,
+	// store has no row, count == 1; second call probes again (count == 2).
+}
+
+func TestResolveToolCall_SingleflightDedup(t *testing.T) {
+	// Prober blocks on a channel; launch 8 concurrent ResolveToolCall for
+	// the same key; release; assert count == 1 and all callers got yes.
+}
+
+func TestResolveToolCall_DisabledReturnsUnknown(t *testing.T) {
+	// Registry WITHOUT WithCapabilityProber => state "", nil error, no probe.
+}
+
+func TestEnsureToolCallResolved_FiltersAndRefreshes(t *testing.T) {
+	// Three profiles: one with CapToolCall, one probe-yes, one probe-no.
+	// required = CapChat|CapStream|CapToolCall.
+	// EnsureToolCallResolved returns refreshed profiles where the probe-yes
+	// model now carries CapToolCall; the probe-no model is returned
+	// unchanged (caller's gate drops it); the capable one untouched
+	// (count for it == 0).
+}
+
+func TestLookupAndRecommendStayPure(t *testing.T) {
+	// With WithCapabilityProber installed: plain Lookup and Recommend on an
+	// unknown model never invoke the prober (count == 0).
+}
+```
+
+Write them fully (the fake cap-probe store is ~40 lines; put it in this test
+file). Do not fake the full `fingerprint.Store` unless a test specifically
+needs full profiling behavior.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `env -u GOROOT go test ./provider/ -run 'ResolveToolCall|EnsureToolCall|StayPure' -v`
+Expected: FAIL — `WithCapabilityProbeStore` / `WithCapabilityProber` undefined.
+
+- [ ] **Step 3: Implement**
+
+In `provider/model_registry.go`:
+
+```go
+// WithCapabilityProbeStore installs the narrow cache used by ResolveToolCall
+// and the read-only cap-probe merge layer. It is intentionally separate from
+// the full fingerprint Store so Golem can persist capability verdicts without
+// enabling full latency/embedding/chat profiling.
+func WithCapabilityProbeStore(store fingerprint.CapProbeStore) ModelRegistryOption {
+	return func(r *ModelRegistry) {
+		r.capProbeStore = store
+	}
+}
+
+// WithCapabilityProber installs provider-aware prober selection used ONLY
+// for on-demand capability resolution (ResolveToolCall). Unlike
+// WithFingerprintProberFactory it never triggers full profiling from
+// Lookup: Lookup/Recommend stay pure, and active probes run only at the
+// two named call sites (golem preflight, router candidate resolution).
+func WithCapabilityProber(fn FingerprintProberFactory) ModelRegistryOption {
+	return func(r *ModelRegistry) {
+		r.capProber = fn
+	}
+}
+```
+
+Fields: `capProbeStore fingerprint.CapProbeStore`,
+`capProber FingerprintProberFactory`, and `capResolveGroup singleflight.Group`.
+Import `golang.org/x/sync/singleflight`; the module already uses it in
+`fingerprint/profiler.go` and provider packages, so this is not a new
+dependency.
+
+```go
+// ResolveToolCall resolves the tri-state tool_call capability for a model:
+// explicit declaration > merged caps > valid cache row > active probe.
+// Returns "" (unknown) without probing when no capability prober is
+// installed or the provider has none. A non-nil error is transient
+// (probe/transport failure) and nothing was persisted.
+func (r *ModelRegistry) ResolveToolCall(ctx context.Context, key ModelKey) (fingerprint.CapProbeState, error) {
+	// 1. Explicit declaration is authoritative in both directions.
+	r.mu.RLock()
+	override := r.capOverride
+	r.mu.RUnlock()
+	if override != nil {
+		if toks := override(key); len(toks) > 0 {
+			if caps, err := ParseCapsStrict(toks); err == nil && caps != 0 {
+				if caps.Has(CapToolCall) {
+					return fingerprint.CapProbeYes, nil
+				}
+				return fingerprint.CapProbeNo, nil
+			}
+		}
+	}
+
+	// 2. Merged profile already carries the bit (catalog/floor/runtime/probe row).
+	profile, err := r.Lookup(ctx, key)
+	if err != nil {
+		return "", err
+	}
+	if profile.Caps.Has(CapToolCall) {
+		return fingerprint.CapProbeYes, nil
+	}
+
+	if r.capProber == nil || r.capProbeStore == nil {
+		return "", nil // resolution disabled: unknown, never a claim
+	}
+
+	v, err, _ := r.capResolveGroup.Do(key.String(), func() (any, error) {
+		return r.resolveToolCallSlow(ctx, key)
+	})
+	if err != nil {
+		return "", err
+	}
+	state, _ := v.(fingerprint.CapProbeState)
+	return state, nil
+}
+```
+
+`resolveToolCallSlow` (called inside the singleflight body):
+
+```go
+func (r *ModelRegistry) resolveToolCallSlow(ctx context.Context, key ModelKey) (fingerprint.CapProbeState, error) {
+	p, err := r.providers.Resolve(key)
+	if err != nil {
+		return "", err
+	}
+	runtimeInfo, err := r.queryRuntime(ctx, key)
+	if err != nil {
+		return "", err
+	}
+	spec, err := r.capProber(ctx, key, runtimeInfo, p)
+	if err != nil || spec == nil || spec.Prober == nil {
+		return "", err
+	}
+	tcp, ok := spec.Prober.(fingerprint.ToolCallProber)
+	if !ok {
+		return "", nil // provider has no tool-call probe: unknown
+	}
+
+	digest := spec.ModelDigest
+	if digest == "" {
+		digest = key.String()
+	}
+	backendID := key.Provider // match EnsureProfile's existing backend_id convention
+
+	// 3. Valid cache row.
+	now := time.Now()
+	if row, gerr := r.capProbeStore.GetCapProbe(ctx, backendID, key.Model, "tool_call"); gerr == nil {
+		if row.Valid(digest, now) {
+			return row.State, nil
+		}
+	}
+
+	// 4. Active probe.
+	outcome, perr := tcp.ProbeToolCall(ctx, key.Model)
+	if perr != nil {
+		return "", perr // transient/diagnostic: never persisted
+	}
+	row := fingerprint.CapProbe{
+		BackendID: backendID, ModelName: key.Model, Capability: "tool_call",
+		State: outcome.State, ModelDigest: digest,
+		ProbeVersion: fingerprint.CurrentToolProbeVersion, TestedAt: now,
+	}
+	if outcome.TTL > 0 {
+		row.ExpiresAt = now.Add(outcome.TTL)
+	}
+	// Digestless negatives expire (spec: a wedged no silently blocks usage).
+	if outcome.State == fingerprint.CapProbeNo && digest == key.String() {
+		row.ExpiresAt = now.Add(fingerprint.CapProbeDigestlessNoTTL)
+	}
+	if serr := r.capProbeStore.SaveCapProbe(ctx, row); serr != nil {
+		// Persistence failure degrades to per-run behavior; the verdict
+		// still stands for this caller.
+		_ = serr
+	}
+	if outcome.State == fingerprint.CapProbeYes {
+		r.invalidateProfile(key) // next Lookup re-merges with the yes row
+	}
+	return outcome.State, nil
+}
+```
+
+Storage key convention: use `key.Provider` as `backend_id`, matching the
+existing `EnsureProfile(ctx, key.Provider, key.Model, ...)` call in
+`model_registry.go`. Do not derive a backend ID from base URL here.
+
+Merge integration — in `buildProfile` after the fingerprint layer (only a
+READ, no probe):
+
+```go
+	// Layer 3.5: capability-probe verdicts (yes rows only add bits).
+	if r.capProbeStore != nil {
+		digest := runtimeInfo.Digest
+		if digest == "" {
+			digest = key.String()
+		}
+		if row, err := r.capProbeStore.GetCapProbe(ctx, key.Provider, key.Model, "tool_call"); err == nil {
+			if row.State == fingerprint.CapProbeYes && row.Valid(digest, time.Now()) {
+				capProbeCaps = CapToolCall
+			}
+		}
+	}
+```
+
+Thread `capProbeCaps` into `merge` as a new parameter and OR it in right after
+the fingerprint block (`profile.Caps |= capProbeCaps`).
+
+`invalidateProfile`:
+
+```go
+// invalidateProfile drops one cached profile so the next Lookup re-merges.
+func (r *ModelRegistry) invalidateProfile(key ModelKey) {
+	r.mu.Lock()
+	delete(r.profiles, key)
+	r.mu.Unlock()
+}
+```
+
+`EnsureToolCallResolved` (router-facing helper):
+
+```go
+// EnsureToolCallResolved resolves tool_call for each profile that lacks it
+// when required demands it, refreshing resolved-yes profiles in place.
+// It never removes candidates — the caller's capability gate stays the
+// single point of rejection. No-op when resolution is disabled or the
+// required mask does not include CapToolCall. Errors are per-candidate and
+// non-fatal (transient probe failures leave the profile unchanged).
+func (r *ModelRegistry) EnsureToolCallResolved(ctx context.Context, profiles []*ModelProfile, required Capability) []*ModelProfile {
+	if !r.canResolveToolCall() || !required.Has(CapToolCall) {
+		return profiles
+	}
+	out := make([]*ModelProfile, len(profiles))
+	copy(out, profiles)
+	for i, p := range out {
+		if p == nil || p.Caps.Has(CapToolCall) {
+			continue
+		}
+		state, err := r.ResolveToolCall(ctx, p.Key)
+		if err != nil || state != fingerprint.CapProbeYes {
+			continue
+		}
+		if fresh, lerr := r.Lookup(ctx, p.Key); lerr == nil {
+			out[i] = fresh
+		}
+	}
+	return out
+}
+
+func (r *ModelRegistry) canResolveToolCall() bool {
+	return r != nil && r.capProber != nil && r.capProbeStore != nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `env -u GOROOT go test ./provider/... -v`
+Expected: PASS (including existing registry tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add provider/
+git commit -m "feat(provider): ResolveToolCall tri-state resolver + capability-probe merge layer"
+```
+
+---
+
+### Task 7: Router integration (chain, recommend, tail)
+
+**Files:**
+- Modify: `provider/router.go` (`resolveCandidates`)
+- Modify: `provider/router_chain.go` (`routeChain`, `recommendTailProfiles`)
+- Test: `provider/router_capresolve_test.go` (create)
+
+- [ ] **Step 1: Write failing tests**
+
+Build on the existing router test harness (fake registry/providers used by
+`router_test.go`). Cases:
+
+```go
+func TestRouteChain_UnknownCandidateProbedBeforeGate(t *testing.T) {
+	// Chain ["llamacpp/byo"], RequiredCaps chat|stream|tool_call, model
+	// lacks tool_call but prober scripted yes => Route succeeds and the
+	// prober ran exactly once, BEFORE any feedback-snapshot read (assert
+	// via ordering hooks if the harness records reads; otherwise assert
+	// success + probe count == 1).
+}
+
+func TestRouteChain_ConfirmedNoSkippedWithoutProbe(t *testing.T) {
+	// Store pre-seeded no-row => Route fails ErrNoViableCandidate (strict
+	// chain), probe count == 0.
+}
+
+func TestResolveCandidates_RecommendStripsThenFilters(t *testing.T) {
+	// Empty Model, RequiredCaps includes tool_call. Two models: A merged
+	// without tool_call + prober yes; B without + prober no.
+	// resolveCandidates returns A only; Recommend was called with
+	// RequiredCaps &^ CapToolCall (assert A appeared as a candidate at all —
+	// under the old code Recommend would have filtered it out first).
+}
+
+func TestRecommendTail_AppliesSameResolution(t *testing.T) {
+	// Non-strict chain with a recommend tail: tail candidates get the same
+	// strip-resolve-filter treatment.
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `env -u GOROOT go test ./provider/ -run 'RouteChain_Unknown|ConfirmedNo|RecommendStrips|RecommendTail_Applies' -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+`provider/router.go resolveCandidates` — empty-Model branch becomes:
+
+```go
+	if req.Model == "" {
+		reqCaps := req.RequiredCaps
+		if r.registry.canResolveToolCall() && reqCaps.Has(CapToolCall) {
+			// Recommend filters by caps BEFORE the router sees candidates,
+			// which would silently drop probe-resolvable models. Recommend
+			// without the tool_call bit, resolve it lazily, then re-filter.
+			candidates, err := r.registry.Recommend(ctx, RecommendOpts{
+				RequiredCaps:       reqCaps &^ CapToolCall,
+				AvailableRAM:       r.availableRAM,
+				PreferWarm:         req.PreferWarm,
+				RestrictToProvider: req.Provider,
+			})
+			if err != nil {
+				return nil, err
+			}
+			candidates = r.registry.EnsureToolCallResolved(ctx, candidates, reqCaps)
+			filtered := candidates[:0]
+			for _, p := range candidates {
+				if p.Caps.Has(CapToolCall) {
+					filtered = append(filtered, p)
+				}
+			}
+			return filtered, nil
+		}
+		return r.registry.Recommend(ctx, RecommendOpts{ /* unchanged */ })
+	}
+```
+
+`provider/router_chain.go routeChain` — inside the chain loop, after
+`resolveChainEntry` and BEFORE `snap.readCandidates` (spec: probe I/O before
+feedback reads and scoring; scorers stay pure):
+
+```go
+		profiles = r.registry.EnsureToolCallResolved(ctx, profiles, req.RequiredCaps)
+```
+
+`recommendTailProfiles` — same strip-resolve-filter dance as
+`resolveCandidates` (it calls `Recommend` at router_chain.go:268 with
+`req.RequiredCaps`; restructure identically, sharing a small unexported helper
+`r.recommendWithToolCallResolution(ctx, opts, reqCaps)` so the logic exists
+once — put the helper in router.go and use it from both call sites).
+
+Note: `resolveCandidates`'s qualified/LookupAny branches need no change —
+chain and single-key routes hit the gate with profiles the chain loop already
+resolved, and single-model routes fail the gate visibly (the caller named one
+model; per spec the gate is the single rejection point — `EnsureToolCallResolved`
+on those branches too keeps unknown-never-skipped for direct routes; ADD it):
+
+```go
+	if key, ok := parseModelSelector(req.Model); ok {
+		profile, err := r.registry.Lookup(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+		return r.registry.EnsureToolCallResolved(ctx, []*ModelProfile{profile}, req.RequiredCaps), nil
+	}
+```
+
+(and the `req.Provider != ""` + `LookupAny` branches likewise).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `env -u GOROOT go test ./provider/... -race -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add provider/
+git commit -m "feat(provider): route-time lazy tool_call resolution in chain, recommend, and direct routes"
+```
+
+---
+
+### Task 8: Golem wiring — capability-probe store, bootstrap option, `-no-cap-probe`
+
+**Files:**
+- Modify: `internal/providerbootstrap/bootstrap.go` (Options + wiring)
+- Create: `cmd/golem/capprobe.go` (store open helper)
+- Modify: `cmd/golem/main.go` (flag + wiring)
+- Test: `internal/providerbootstrap/bootstrap_test.go` (append), `cmd/golem/capprobe_test.go` (create)
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+// internal/providerbootstrap/bootstrap_test.go (append)
+func TestNew_CapabilityProbeStoreInstallsCapProberNotFullFactory(t *testing.T) {
+	// Options{CapabilityProbeStore: store}
+	// => registry has capProber installed, fpProberFactory NOT installed.
+	// Assert behaviorally: Lookup on an openai-compat model performs no
+	// probe HTTP calls (scripted test server records requests), while
+	// ResolveToolCall does.
+}
+```
+
+```go
+// cmd/golem/capprobe_test.go
+func TestCapProbeStorePath_UsesDataDir(t *testing.T) {
+	// with XDG_DATA_HOME=/tmp/x => /tmp/x/golem/fingerprints.db
+	// (reuse the dataDirBase seam/pattern from session.go tests)
+}
+
+func TestOpenCapProbeStore_FallsBackToMemoryOnFailure(t *testing.T) {
+	// Point the path at an unwritable location; expect a non-nil store
+	// (in-memory) plus a warning string, not an error.
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `env -u GOROOT go test ./internal/providerbootstrap/ ./cmd/golem/ -run 'CapabilityProbeStore|CapProbeStore' -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+`internal/providerbootstrap/bootstrap.go` Options:
+
+```go
+	// CapabilityProbeStore wires capability-probe rows and on-demand
+	// ResolveToolCall without enabling full fingerprint profiling. Golem
+	// sets this and leaves FingerprintStore nil; MCP/full-profiler callers
+	// can rely on FingerprintStore's SQLiteStore also satisfying
+	// fingerprint.CapProbeStore.
+	CapabilityProbeStore fingerprint.CapProbeStore
+```
+
+Wiring in `New()`:
+
+```go
+	mrOpts := []provider.ModelRegistryOption{}
+	factory := proberFactory(effCfg, ollamaClients)
+	if opts.FingerprintStore != nil {
+		mrOpts = append(mrOpts, provider.WithFingerprintProberFactory(factory))
+	}
+	capProbeStore := opts.CapabilityProbeStore
+	if capProbeStore == nil {
+		if s, ok := opts.FingerprintStore.(fingerprint.CapProbeStore); ok {
+			capProbeStore = s
+		}
+	}
+	if capProbeStore != nil {
+		mrOpts = append(mrOpts,
+			provider.WithCapabilityProbeStore(capProbeStore),
+			provider.WithCapabilityProber(factory),
+		)
+	}
+```
+
+Full-profiling consumers get the capability resolver too when their
+`FingerprintStore` is the SQLite store — same factory, no extra eager cost;
+route-time resolution simply also works under MCP.
+
+`cmd/golem/capprobe.go`:
+
+```go
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/kstruzzieri/go-llm/fingerprint"
+	_ "modernc.org/sqlite"
+)
+
+// capProbeStorePath resolves the shared capability-probe DB path:
+// $XDG_DATA_HOME/golem/fingerprints.db (else ~/.local/share/golem/...).
+// Mirrors memoryDBPath's use of dataDirBase.
+func capProbeStorePath(getenv func(string) string) (string, error) {
+	base, err := dataDirBase(getenv) // existing helper in session.go
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "golem", "fingerprints.db"), nil
+}
+
+// openCapProbeStore opens (creating if needed) the capability-probe store.
+// On any failure it degrades to an in-memory store for this run and
+// returns a warning — probe results still apply, persistence is lost.
+func openCapProbeStore(ctx context.Context, getenv func(string) string) (fingerprint.CapProbeStore, string) {
+	path, err := capProbeStorePath(getenv)
+	if err == nil {
+		if err = os.MkdirAll(filepath.Dir(path), 0o700); err == nil {
+			var db *sql.DB
+			if db, err = sql.Open("sqlite", "file:"+path); err == nil {
+				var s fingerprint.CapProbeStore
+				if s, err = fingerprint.NewStore(ctx, db); err == nil {
+					return s, ""
+				}
+				_ = db.Close()
+			}
+		}
+	}
+	db, merr := sql.Open("sqlite", "file::memory:")
+	if merr != nil {
+		return nil, fmt.Sprintf("capability probe cache disabled: %v (memory fallback failed: %v)", err, merr)
+	}
+	s, serr := fingerprint.NewStore(ctx, db)
+	if serr != nil {
+		return nil, fmt.Sprintf("capability probe cache disabled: %v (memory fallback failed: %v)", err, serr)
+	}
+	return s, fmt.Sprintf("capability probe cache degraded to in-memory: %v", err)
+}
+```
+
+(Check how `memory.go`/`session.go` create parent dirs and open modernc sqlite;
+if this helper needs WAL/busy-timeout pragmas for durability, copy the existing
+session pattern instead of inventing a new one.)
+
+`cmd/golem/main.go`:
+
+- flags struct: `noCapProbe bool`; parseFlags:
+
+```go
+	fs.BoolVar(&f.noCapProbe, "no-cap-probe", false, "disable the active tool-capability probe for undeclared models (catalog and explicit capabilities still apply)")
+```
+
+- in `run()`, before `providerbootstrap.New`:
+
+```go
+	var capStore fingerprint.CapProbeStore
+	var capStoreWarn string
+	if !f.noCapProbe {
+		capStore, capStoreWarn = openCapProbeStore(ctx, os.Getenv)
+	}
+```
+
+- pass into the bundle:
+
+```go
+	bundle, err := providerbootstrap.New(ctx, providerbootstrap.Options{
+		Config:                          cfg,
+		OllamaURLOverride:               f.ollamaURL,
+		OpenAICompatURLOverrideProvider: backendRes.providerKey,
+		OpenAICompatURLOverride:         backendRes.baseURL,
+		CapabilityProbeStore:            capStore, // nil when -no-cap-probe
+	})
+```
+
+- append `capStoreWarn` (when non-empty) to `warns`.
+
+- [ ] **Step 4: Run tests + full build**
+
+Run: `env -u GOROOT go test ./internal/providerbootstrap/ ./cmd/golem/ -v`
+Then run: `env -u GOROOT go build ./...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/providerbootstrap/ cmd/golem/
+git commit -m "feat(golem): wire capability-probe store + -no-cap-probe flag (capability-only mode)"
+```
+
+---
+
+### Task 9: Preflight restructure — bounded eager + remediation hints
+
+**Files:**
+- Modify: `cmd/golem/modelcaller.go`
+- Modify: `cmd/golem/main.go` (call site)
+- Test: `cmd/golem/preflight_test.go` (append)
+
+- [ ] **Step 1: Write failing tests**
+
+Existing preflight tests use a fake `capChecker`; extend the harness with a
+fake resolver:
+
+```go
+type fakeToolResolver struct {
+	states map[provider.ModelKey]fingerprint.CapProbeState
+	errs   map[provider.ModelKey]error
+	calls  []provider.ModelKey
+}
+
+func (f *fakeToolResolver) ResolveToolCall(ctx context.Context, key provider.ModelKey) (fingerprint.CapProbeState, error) {
+	f.calls = append(f.calls, key)
+	if err := f.errs[key]; err != nil {
+		return "", err
+	}
+	return f.states[key], nil
+}
+```
+
+Cases:
+
+```go
+func TestPreflight_BoundedEager_StopsAfterFirstCapable(t *testing.T) {
+	// chain: [A (unknown, probe=>yes), B (unknown), C (declared no)]
+	// => nil error; resolver called ONLY for A; B reported as
+	// "capability unknown; probed on first use" non-fatal line; C keeps
+	// its capability warning with remediation hint.
+}
+
+func TestPreflight_ProbeNoContinuesToNextEntry(t *testing.T) {
+	// chain: [A (probe=>no), B (registry-capable)]
+	// => nil error; resolver called for A only; warning for A mentions
+	// "did not produce a tool call" + the remediation line with
+	// `"capabilities": ["chat","generate","stream","tool_call"]`.
+}
+
+func TestPreflight_AllExhaustedFatalIncludesProbeOutcomes(t *testing.T) {
+	// chain: [A (probe=>no), B (probe=>inconclusive), C (lookup error)]
+	// => error; message contains A's probed-no line, B's inconclusive line
+	// ("probe was inconclusive; declare capabilities to override"),
+	// C's connectivity diagnostic (existing #217 text preserved).
+}
+
+func TestPreflight_NoCapProbe_NeverResolves(t *testing.T) {
+	// nil resolver (or resolver disabled): active probing never runs.
+	// Run the EXISTING #217 lookup/connectivity table through the new
+	// signature to prove those diagnostics are unchanged; resolver call
+	// count == 0. Catalog/floor-capable profiles still pass because that
+	// merge happens upstream and is not disabled by -no-cap-probe.
+}
+
+func TestPreflight_NoCapProbe_CatalogKnownStillCapable(t *testing.T) {
+	// Spec section 8 "no-probe flag regression": nil resolver, chain entry
+	// whose fake profile carries CapToolCall (floor+catalog merged upstream)
+	// => capable with zero warnings; an undeclared catalog-miss entry in the
+	// same chain stays not-capable with the remediation hint.
+}
+
+func TestPreflight_EmptyChainRecommendResolves(t *testing.T) {
+	// Empty chain: registry Recommend(without tool_call bit) returns one
+	// model lacking tool_call; resolver says yes => preflight passes.
+	// (Fake capChecker.Recommend must record the RequiredCaps it was
+	// called with: assert it did NOT include CapToolCall.)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `env -u GOROOT go test ./cmd/golem/ -run Preflight -v`
+Expected: FAIL (signature/behavior missing).
+
+- [ ] **Step 3: Implement**
+
+`cmd/golem/modelcaller.go`:
+
+```go
+// toolCallResolver is the narrow slice of *provider.ModelRegistry the
+// preflight needs for active capability resolution. nil disables probing
+// (-no-cap-probe or no store).
+type toolCallResolver interface {
+	ResolveToolCall(ctx context.Context, key provider.ModelKey) (fingerprint.CapProbeState, error)
+}
+```
+
+Remediation constants:
+
+```go
+const remediationCaps = `"capabilities": ["chat","generate","stream","tool_call"]`
+
+// remediationHint renders the exact models.json fix line for a chain entry.
+func remediationHint(sel string) string {
+	return fmt.Sprintf("if it supports function calling, add %s to the model entry for %q in models.json", remediationCaps, sel)
+}
+```
+
+`preflightToolCapable` gains the resolver and applies bounded-eager:
+
+```go
+func preflightToolCapable(ctx context.Context, reg capChecker, chain []string, resolveEndpoint endpointResolver, resolver toolCallResolver) (warnings []string, err error) {
+	if len(chain) == 0 {
+		return preflightRecommendToolCapable(ctx, reg, resolver)
+	}
+
+	capable := 0
+	for _, sel := range chain {
+		// Active probing is allowed only until the first capable entry:
+		// startup proves ONE usable model then stops loading fallbacks
+		// (llama-swap cost); later unknowns resolve at route time.
+		allowProbe := capable == 0
+		ok, warn := evalChainEntry(ctx, reg, sel, resolveEndpoint, resolver, allowProbe)
+		if ok {
+			capable++
+			continue
+		}
+		warnings = append(warnings, warn)
+	}
+	if capable == 0 {
+		return warnings, fmt.Errorf("golem: tool-capability preflight failed:\n%s", strings.Join(warnings, "\n"))
+	}
+	return warnings, nil
+}
+```
+
+`evalChainEntry` extension (keep the #217 connectivity path byte-identical):
+
+```go
+func evalChainEntry(ctx context.Context, reg capChecker, sel string, resolveEndpoint endpointResolver, resolver toolCallResolver, allowProbe bool) (capable bool, warning string) {
+	// ... existing Lookup/LookupAny + connectivity classification UNCHANGED ...
+	// On the resolved-but-not-capable path (both branches), replace the
+	// bare notCapable return with classifyToolCapability:
+	return classifyToolCapability(ctx, sel, key, resolver, allowProbe)
+}
+
+// classifyToolCapability turns an entry that resolved without tool_call
+// into (capable, warning) using the resolver when probing is allowed.
+func classifyToolCapability(ctx context.Context, sel string, key provider.ModelKey, resolver toolCallResolver, allowProbe bool) (bool, string) {
+	if resolver == nil {
+		return false, fmt.Sprintf("agent fallback %q is not tool-capable (chat|stream|tool_call); %s", sel, remediationHint(sel))
+	}
+	if !allowProbe {
+		return false, fmt.Sprintf("agent fallback %q: tool capability unknown; probed on first use", sel)
+	}
+	state, err := resolver.ResolveToolCall(ctx, key)
+	switch {
+	case err != nil:
+		return false, fmt.Sprintf("agent fallback %q: tool-capability probe failed: %v; %s", sel, err, remediationHint(sel))
+	case state == fingerprint.CapProbeYes:
+		return true, ""
+	case state == fingerprint.CapProbeNo:
+		return false, fmt.Sprintf("agent fallback %q: model did not produce a tool call when probed; %s", sel, remediationHint(sel))
+	case state == fingerprint.CapProbeInconclusive:
+		return false, fmt.Sprintf("agent fallback %q: tool-capability probe was inconclusive; declare capabilities to override: %s", sel, remediationHint(sel))
+	default: // unknown (resolution disabled for this provider)
+		return false, fmt.Sprintf("agent fallback %q is not tool-capable (chat|stream|tool_call); %s", sel, remediationHint(sel))
+	}
+}
+```
+
+Bare-selector branch: `LookupAny` succeeded but none capable — call
+`classifyToolCapability` with the FIRST profile's key (a bare selector may
+match several providers; probing the first match is the pragmatic choice —
+document it in a comment).
+
+Empty-chain branch:
+
+```go
+func preflightRecommendToolCapable(ctx context.Context, reg capChecker, resolver toolCallResolver) ([]string, error) {
+	if resolver == nil {
+		// No resolution available: original behavior.
+		profs, rerr := reg.Recommend(ctx, provider.RecommendOpts{RequiredCaps: toolRouteCaps})
+		if rerr != nil {
+			return nil, fmt.Errorf("golem: tool-capability preflight (recommend): %w", rerr)
+		}
+		if len(profs) == 0 {
+			return nil, fmt.Errorf("golem: no tool-capable model available (require chat|stream|tool_call)")
+		}
+		return nil, nil
+	}
+	// Recommend WITHOUT the tool_call bit, then resolve lazily until one
+	// candidate confirms (bounded eager, same policy as the chain path).
+	profs, rerr := reg.Recommend(ctx, provider.RecommendOpts{RequiredCaps: toolRouteCaps &^ provider.CapToolCall})
+	if rerr != nil {
+		return nil, fmt.Errorf("golem: tool-capability preflight (recommend): %w", rerr)
+	}
+	for _, p := range profs {
+		if p.Caps.Has(provider.CapToolCall) {
+			return nil, nil
+		}
+	}
+	for _, p := range profs {
+		if state, err := resolver.ResolveToolCall(ctx, p.Key); err == nil && state == fingerprint.CapProbeYes {
+			return nil, nil
+		}
+	}
+	return nil, fmt.Errorf("golem: no tool-capable model available (require chat|stream|tool_call)")
+}
+```
+
+`cmd/golem/main.go` call site:
+
+```go
+	var resolver toolCallResolver
+	if !f.noCapProbe && capStore != nil {
+		resolver = bundle.Models
+	}
+	warns, err := preflightToolCapable(ctx, bundle.Models, plan.chain, resolveEndpoint, resolver)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `env -u GOROOT go test ./cmd/golem/ -v`
+Expected: PASS including ALL pre-existing preflight tests (adapted to the new
+signature with a nil resolver — their behavior must not change).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/golem/
+git commit -m "feat(golem): bounded-eager preflight probing with remediation hints"
+```
+
+---
+
+### Task 10: `golem models` subcommand
+
+**Files:**
+- Modify: `provider/model_registry.go` (narrow explain export)
+- Create: `cmd/golem/models.go`
+- Modify: `cmd/golem/main.go` (dispatch)
+- Test: `cmd/golem/models_test.go`, `provider/capresolve_test.go` (append explain tests)
+
+- [ ] **Step 1: Write failing tests**
+
+Registry explain (append to `provider/capresolve_test.go`):
+
+```go
+func TestExplainToolCall_Provenance(t *testing.T) {
+	// Cases: explicit-override key => Source "explicit";
+	// catalog-tools key => Source "catalog"; probe-yes row => Source
+	// "probe" with TestedAt set; nothing => Source "unknown".
+}
+```
+
+`cmd/golem/models_test.go` (render tests against fakes; follow the
+`runIndex` test style):
+
+```go
+func TestRunModels_ListsChainWithProvenance(t *testing.T) {
+	// Two chain entries; fake registry: A explicit incl tool_call, B probe-no.
+	// Output contains one line per entry with caps + provenance + a
+	// MISSING tool_call flag for B, plus the remediation hint.
+}
+
+func TestRunModels_SharedKeyNamesDeclaringRole(t *testing.T) {
+	// cfg has role "chat" declaring caps for the same key the agent chain
+	// uses undeclared => output marks the entry "explicit (declared by
+	// model entry \"chat\")".
+}
+
+func TestRunModels_ProbeAllProbesEveryEntry(t *testing.T) {
+	// --probe-all with 3 non-explicit entries => resolver called 3 times
+	// (no bounded-eager stop).
+}
+
+func TestRunModels_ReprobeDeletesRowsFirst(t *testing.T) {
+	// --reprobe => DeleteCapProbes called per non-explicit entry before
+	// resolver runs.
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `env -u GOROOT go test ./cmd/golem/ -run RunModels -v`
+Then run: `env -u GOROOT go test ./provider/ -run ExplainToolCall -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Registry export (narrow, tool_call-scoped — deliberately NOT a general
+provenance API):
+
+```go
+// ToolCallExplanation is diagnostic provenance for one model's tool_call
+// capability, consumed by `golem models`. Deliberately narrow.
+type ToolCallExplanation struct {
+	Caps     Capability
+	Has      bool
+	Source   string    // "explicit" | "catalog" | "runtime" | "probe" | "unknown"
+	State    fingerprint.CapProbeState // cached probe state, "" if none
+	TestedAt time.Time // zero when no probe row
+}
+
+// ExplainToolCall reports where a model's tool_call bit comes from (or why
+// it is absent).
+func (r *ModelRegistry) ExplainToolCall(ctx context.Context, key ModelKey) (ToolCallExplanation, error) {
+	// Order mirrors ResolveToolCall's precedence:
+	// 1. explicit override (parse; contains/lacks tool_call => "explicit")
+	// 2. merged profile caps: if profile.Caps.Has(CapToolCall), distinguish
+	//    catalog vs probe vs runtime. Check catalog first; then valid
+	//    probe-yes row; otherwise runtime/floor.
+	// 3. when profile lacks tool_call, valid probe no/inconclusive rows
+	//    explain the absence as "probe".
+	// 4. otherwise "unknown".
+	//
+	// To distinguish catalog vs runtime/floor/probe, re-run the catalog lookup
+	// (r.catalog.lookup with ParseModelName like buildProfile) and check its
+	// Caps for CapToolCall => "catalog". If not catalog but a valid probe-yes
+	// row exists, source is "probe"; otherwise source is "runtime" (the floor
+	// is treated as registry/provider-layer runtime knowledge for operator
+	// diagnostics).
+}
+```
+
+(Write the body following that comment; ~40 lines, all pieces exist.)
+
+`cmd/golem/models.go` — subcommand skeleton mirroring `runIndex`
+(flag set: `-config`, `-base-url`, `-no-probe`, `-ollama-url`, `--probe-all`
+as `-probe-all`, `--reprobe` as `-reprobe`; Go flags use single dash):
+
+```go
+// runModels is the `golem models` entry point: resolve the agent chain,
+// print each entry's capabilities + tool_call provenance, and optionally
+// probe (-probe-all) or re-probe (-reprobe) non-explicit entries.
+func runModels(ctx context.Context, args []string, out, errOut io.Writer) error
+```
+
+Flow (write it fully):
+1. parse flags; load config; `resolveBackend` (same as run(), reusing
+   backendResolveOpts); `providerbootstrap.New` with capability-probe store
+   (open via `openCapProbeStore`; `-probe-all`/`-reprobe` require it — if the
+   store warning is non-empty print it to errOut).
+2. `resolveAgentChain`; for empty chain print the recommend-mode note and the
+   recommend set with explanations.
+3. Per entry: parse selector; `reg.Lookup`; `reg.ExplainToolCall`; assemble a
+   line:
+
+```
+llamacpp/gemma4:31b   caps=chat|generate|stream|tool_call   tool_call=yes (catalog)
+llamacpp/byo-model    caps=chat|generate|stream              tool_call=MISSING (probe: no, 2h ago)
+    fix: if it supports function calling, add "capabilities": [...] to the model entry ...
+```
+
+4. Shared-key annotation: walk `cfg.Models` for another role declaring
+   explicit caps on the same key; if found append `(declared by model entry "<role>")`.
+5. `-reprobe`: for each non-explicit entry `store.DeleteCapProbes` +
+   `reg.Refresh(key)` if a Refresh exists (else the resolver's invalidate
+   covers it), then resolve.
+6. `-probe-all`: `reg.ResolveToolCall` per non-explicit entry (no stop), print
+   updated states.
+7. Lookup errors render the same connectivity diagnostics preflight uses
+   (reuse `preflightConnectivityWarn` via the endpoint resolver).
+
+`cmd/golem/main.go` dispatch:
+
+```go
+	switch args[0] {
+	case "index":
+		return runIndex(context.Background(), args[1:], stdout, stderr)
+	case "models":
+		return runModels(context.Background(), args[1:], stdout, stderr)
+	default:
+		return fmt.Errorf("unknown command %q (did you mean \"index\" or \"models\"?)", args[0])
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `env -u GOROOT go test ./cmd/golem/ ./provider/ -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/golem/ provider/
+git commit -m "feat(golem): models subcommand - capability listing, provenance, -probe-all/-reprobe"
+```
+
+---
+
+### Task 11: Catalog audit + docs + integration test
+
+**Files:**
+- Modify: `provider/catalog.json` (only if the audit finds gaps)
+- Modify: `docs/llm/` BYO/models doc (locate: `ls docs/llm/`)
+- Create: `cmd/golem/capprobe_integration_test.go` (build-tagged)
+
+- [ ] **Step 1: Catalog audit**
+
+Compare `provider/catalog.json` family `caps` against upstream tool-support
+reality for the bundled lineup (qwen2.5/3/3.5/3.6, qwen3-coder-next, gemma2/3/4,
+llama3.x, phi3/4, mistral, mixtral, deepseek-*, codellama, starcoder*,
+embeddings). Current state (verified 2026-07-03): `tools` present on all
+majors; absent on deepseek-r1, codellama, starcoder, starcoder2, gemma2 —
+all correct denials. Expected outcome: NO changes; document the audit result
+in the commit message if so. If a gap IS found, add the `tools` alias to that
+family's caps.
+
+- [ ] **Step 2: Docs**
+
+Update the BYO models doc (find the exact file with
+`grep -rln "capabilities" docs/llm/`):
+
+- `capabilities` field semantics: explicit list REPLACES (both directions —
+  omitting `tool_call` denies it); derived caps are a FLOOR for undeclared
+  openai-compat models (catalog additions survive); cross-role consistency
+  rule for explicit declarations.
+- Tool-capable bundled models table (from the catalog audit).
+- The probe: when it runs (undeclared openai-compat models at agent startup /
+  route time), what it sends (get_time tool, two attempts), cache location
+  (`$XDG_DATA_HOME/golem/fingerprints.db`), `-no-cap-probe`, and
+  `golem models` / `-probe-all` / `-reprobe`.
+
+- [ ] **Step 3: Integration test (build tag `integration`)**
+
+```go
+//go:build integration
+
+// cmd/golem/capprobe_integration_test.go
+// Requires a running llama.cpp llama-server (env GO_LLM_TEST_OPENAI_BASE
+// + GO_LLM_TEST_TOOL_MODEL [+ optional GO_LLM_TEST_NOTOOL_MODEL]).
+// Asserts: ProbeToolCall => yes on the tool-capable model; => no/inconclusive
+// on the non-tool model when provided; probe result lands in a temp store
+// and a second resolve is a cache hit (no second HTTP request — count via
+// a recording proxy httputil.ReverseProxy).
+```
+
+- [ ] **Step 4: Full gate + commit**
+
+Run: `env -u GOROOT go test ./...`
+Then run: `env -u GOROOT go vet ./...`
+Expected: PASS.
+
+```bash
+git add provider/catalog.json docs/ cmd/golem/
+git commit -m "docs: capabilities semantics, tool-capable model table, probe + golem models reference"
+```
+
+---
+
+### Final verification (before PR)
+
+- [ ] `env -u GOROOT go test ./... -race` — PASS
+- [ ] `env -u GOROOT go vet ./...` — clean
+- [ ] `env -u GOROOT gofmt -l .` — empty
+- [ ] Manual smoke: `golem models` against a live llama.cpp with an undeclared
+      model; first run probes (visible latency), second run cache-hits.
+- [ ] /code-review cycles until clean + /criticize-review (user's standing rule).
+- [ ] PR into develop titled `feat(provider/golem): auto-detect tool_call via active probe + capability discoverability`, body `Closes #219`, no emojis.

--- a/docs/superpowers/specs/2026-07-03-tool-capability-probe-219-design.md
+++ b/docs/superpowers/specs/2026-07-03-tool-capability-probe-219-design.md
@@ -1,0 +1,352 @@
+# Tool-Capability Probe + Capability Discoverability (#219)
+
+**Date:** 2026-07-03
+**Issue:** [#219](https://github.com/kstruzzieri/go-llm/issues/219)
+**Base:** develop@9c8b77c (post PR #265 / #218 merge)
+**Status:** Reviewed design (findings folded; ready for implementation plan)
+
+## Problem
+
+`tool_call` is deliberately never derived from model `type`, so undeclared
+openai-compat models cannot route as agent models even when they genuinely
+support function calling. The issue text predates two fixes (#217 preflight
+connectivity split, #184 openai-compat prober), so the remaining work was
+re-scoped against the current tree.
+
+### Root cause (differs from the issue's framing)
+
+`internal/providerbootstrap/capabilities.go:67-81`: for openai-compat models
+with **no explicit `capabilities`** in models.json, bootstrap installs the
+type-DERIVED caps (`chat,generate,stream`) as the **highest-precedence
+REPLACE capability override**. The registry merge (`provider/model_registry.go
+merge()`) assembles caps as `catalog | fingerprint | runtime`, then the
+override replaces the result wholesale. Consequences:
+
+- The static catalog already stamps `tools` on qwen2.5/3/3.5/3.6,
+  qwen3-coder-next, gemma3/4, llama3.x, phi3/4, mistral, mixtral,
+  deepseek-coder-v2 — but the derived override **erases it** for every
+  undeclared openai-compat model.
+- Any probe result written into the fingerprint merge layer would be erased
+  by the same override. The probe is dead on arrival unless this changes.
+
+The derived override exists because openai-compat `/v1/models` carries no
+capability data: without it, a catalog-miss model merges to zero caps and is
+unroutable. It is a floor implemented as a ceiling.
+
+## Design overview
+
+Five parts, one PR:
+
+1. **Floor/ceiling split** — registry gains a capability *floor* seam;
+   derived caps stop erasing catalog/probe data.
+2. **Tri-state capability probe cache** — fingerprint store schema v2,
+   `capability_probes` table, separate from `fingerprint_profiles`.
+3. **Active tool-call probe** — openaicompat prober extension (two-attempt
+   protocol), passive ollama branch.
+4. **Bounded-eager preflight + route-time lazy resolution** — probe only
+   until one chain entry is proven capable; unknown fallbacks probed at
+   route time, never silently skipped.
+5. **Discoverability** — remediation hints in preflight warnings,
+   `golem models` subcommand, catalog audit, docs.
+
+Explicit `models.json` capabilities remain authoritative in BOTH directions:
+a declared set without `tool_call` is a hard no; the probe never runs for
+explicitly declared models.
+
+## 1. Capability floor (registry seam)
+
+- `ModelRegistry.SetCapabilityFloor(fn func(key ModelKey) []string)` —
+  parallel to `SetCapabilityOverride`. Floor caps are parsed with
+  `ParseCapsStrict` and OR-merged into the profile at the **lowest**
+  precedence (alongside the static catalog layer), before fingerprint,
+  runtime, and the explicit override.
+- `providerbootstrap.buildCapabilityOverrides` splits:
+  - explicit `capabilities` → REPLACE override (unchanged, cross-role
+    conflict check unchanged, explicit-only);
+  - derived caps for undeclared openai-compat models → **floor** (new
+    `buildCapabilityFloors`), installed via `SetCapabilityFloor`.
+- Same cache-invalidation/versioning treatment as `SetCapabilityOverride`
+  (mirror ALL invariants: cache invalidation, override-version TOCTOU guard,
+  zero/invalid-token rejection semantics — floors that fail strict parsing
+  are dropped with the rejection hook fired, never zero the profile).
+- Effect: undeclared `llamacpp/gemma4:31b` gets catalog `tools` → tool-capable
+  with zero config and zero probe. The probe only matters for BYO aliases the
+  catalog misses.
+
+## 2. Tri-state probe cache (fingerprint store schema v2)
+
+New table:
+
+```sql
+CREATE TABLE capability_probes (
+  backend_id    TEXT NOT NULL,   -- fingerprint.NormalizeBackendID
+  model_name    TEXT NOT NULL,
+  capability    TEXT NOT NULL,   -- "tool_call" (schema supports future caps)
+  state         TEXT NOT NULL,   -- "yes" | "no" | "inconclusive"
+  model_digest  TEXT NOT NULL,   -- runtime digest, or key fallback (digestless)
+  probe_version INTEGER NOT NULL,-- request-shape identity; bump => re-probe
+  tested_at     INTEGER NOT NULL,
+  expires_at    INTEGER,         -- NULL = does not expire
+  PRIMARY KEY (backend_id, model_name, capability)
+);
+```
+
+- **Separate from `fingerprint_profiles`**: capability-only results never
+  masquerade as complete profiles; MCP's full profiler and its
+  `NeedsFingerprint`/`IncompleteCapabilities` logic are untouched.
+- `fingerprint.Store` interface gains `GetCapProbe`/`SaveCapProbe`/
+  `DeleteCapProbes` (in-repo implementors only; noted as an interface
+  extension). Migration v2 via the existing `fingerprint_schema_version`
+  mechanism.
+- Expiry policy:
+  - `yes`: no expiry; invalidated by digest change, `probe_version` bump, or
+    `golem models --reprobe`. A stale yes fails loudly at call time (agent
+    tool call errors surface), so it is the safe sticky direction.
+  - `no`: no expiry when digest-keyed; **7-day expiry when digestless**
+    (openai-compat fallback keying) so a fixed server/template does not stay
+    wedged until manual `--reprobe`. A wedged no silently blocks usage —
+    the damaging direction — hence the TTL.
+  - `inconclusive`: 24-hour expiry, then re-probe on next demand.
+  - Rows whose `model_digest` mismatches the current runtime digest, or whose
+    `probe_version` differs from the binary's, are treated as absent.
+- Transient probe failures (network, timeout, 5xx, context cancel) are
+  **never persisted** — no claim is recorded; the next demand re-probes.
+- Merge integration: `buildProfile` gains a capability-probe input beside the
+  fingerprint layer — a valid `yes` row ORs `CapToolCall` into the profile
+  (below runtime, below explicit override). `no`/`inconclusive` rows add
+  nothing to caps but are exposed to the resolver/preflight for state
+  classification.
+
+## 3. Probe mechanics
+
+### openai-compat (active; the primary case)
+
+At most two requests, non-streaming, `temperature 0`, `max_tokens 128`
+(tool-call JSON needs room; a small cap truncates mid-call and produces a
+false negative). Tool: no-arg `get_time` function; user prompt:
+"Call the get_time tool to get the current time."
+
+Attempt 1 — `tools` + `tool_choice: "required"`:
+
+| Response | Verdict |
+| --- | --- |
+| 200, non-empty `tool_calls` | `yes` (persist) |
+| 200, no `tool_calls` | `inconclusive` (persist, 24h TTL) — model ignored a forced tool choice |
+| 400 / 422 | escalate to attempt 2 (server may reject `tool_choice`, not `tools`) |
+| 401 / 403 / 404 / 405 / 429 | diagnostic, **not persisted** (auth/endpoint/rate problems say nothing about the model) |
+| other 4xx/5xx / network / timeout | transient, not persisted |
+
+Attempt 2 — `tools` only, no `tool_choice` (prompt-engineered elicitation):
+
+| Response | Verdict |
+| --- | --- |
+| 200, non-empty `tool_calls` | `yes` (persist) |
+| 200, no `tool_calls` | `inconclusive` (persist, 24h TTL) |
+| 400 / 422 | `no` (persist) — the `tools` array itself is rejected (e.g. llama.cpp template without tool support) |
+| other 4xx/5xx / network / timeout | transient, not persisted |
+
+Probe context timeout ~30s (must absorb a llama-swap model load; distinct
+from #218's 800ms port-scan probe). Implemented as a new method on
+`fingerprint/probers.OpenAICompatProber` (e.g. `ProbeToolCall`), exposed via
+an optional interface so `fingerprint.ModelProber` itself is unchanged.
+
+### ollama (passive; cheap parity)
+
+Query `/api/show` (no model load):
+
+- response has a `capabilities` array containing `tools` → `yes`;
+- response has a `capabilities` array WITHOUT `tools` → `no`;
+- response has **no capabilities array** (older Ollama) → `inconclusive`
+  (never persist `no` on missing data).
+
+## 4. Resolution policy
+
+New registry method (name indicative):
+
+```go
+func (r *ModelRegistry) ResolveToolCall(ctx context.Context, key ModelKey) (CapProbeState, error)
+```
+
+Singleflight-deduplicated. Order:
+
+1. Explicit declaration exists for key → authoritative (`yes`/`no` per the
+   declared set), no probe.
+2. Merged profile already has `CapToolCall` (catalog/floor/runtime) → `yes`,
+   no probe.
+3. Valid cache row (digest + probe_version match, not expired) → its state.
+4. Active probe (per §3) → persist per policy → invalidate the profile cache
+   entry so the next `Lookup` re-merges with the new row.
+5. Probing disabled (`-no-cap-probe`, or no prober available for the
+   provider) → `unknown` without probing.
+
+`Lookup` itself **never probes**. Active resolution happens only at the named
+call sites below. Golem never wires the full fingerprint profiler.
+
+### Preflight (bounded eager)
+
+Restructure `preflightToolCapable` / `evalChainEntry` (cmd/golem):
+
+- Walk the chain in order. Per entry: registry lookup (connectivity
+  classification from #217 unchanged); if tool-capable → capable, **stop
+  probing** further entries.
+- Entry resolved but lacking `tool_call`: call `ResolveToolCall` — but only
+  while no capable entry has been found yet. `yes` → capable, stop. `no` /
+  `inconclusive` → warning with remediation hint, continue.
+- After the first capable entry: remaining entries are classified passively
+  (declared/cached state only, no live probes); unknowns are reported as
+  "capability unknown; probed on first use" info lines, confirmed-no entries
+  as warnings.
+- Zero capable entries after exhaustion → fatal, inlining per-entry
+  diagnostics (connectivity, probe outcomes, remediation lines).
+- Empty chain (recommend mode): see Recommend integration below.
+
+### Route-time (lazy; unknown never silently skipped)
+
+- Chain candidates: in the Router's candidate-resolution path, before
+  feedback-snapshot reads and before scoring, a candidate that would fail the
+  `RequiredCaps` gate only because `CapToolCall` is missing and whose probe
+  state is unknown → `ResolveToolCall(ctx, key)` first, then re-lookup or
+  refresh that candidate and re-evaluate the gate. Only when a resolver is
+  enabled. Do not put active probe I/O in `scoreCandidate`/`scoreAll`; those
+  stay pure scoring functions.
+- **Recommend paths** (`provider/model_registry.go` Recommend;
+  consumed by `router.go` empty-model routing and `router_chain.go` chain
+  tail; also the preflight empty-chain branch): `Recommend` filters by
+  `RequiredCaps` before the router sees candidates, so lazy probing must be
+  applied around it. When the resolver is enabled and `RequiredCaps` includes
+  `CapToolCall`: recommend with `RequiredCaps &^ CapToolCall`, resolve
+  `tool_call` for candidates missing it, then filter to the full mask.
+  `Lookup`/`Recommend` themselves stay pure.
+
+## 5. Golem wiring
+
+- Fingerprint store: `$XDG_DATA_HOME/golem/fingerprints.db` (via the
+  existing `dataDirBase`, beside memories.db). Open failure → warning +
+  per-run in-memory cap-probe cache (probing still works; persistence
+  degrades). Contents are non-sensitive (model names, normalized backend
+  hosts — userinfo already stripped by `NormalizeBackendID`); no
+  hardened-open treatment.
+- `providerbootstrap.Options` gains capability-probe wiring (store handle +
+  tool-prober factory reusing the existing `proberFactory` provider
+  plumbing), distinct from the full-profiling `FingerprintStore` path used
+  by MCP. Bootstrap installs the resolver on the registry when configured.
+- New flag `-no-cap-probe`: disables active probing at preflight AND route
+  time (resolver returns unknown). The floor fix still applies, so catalog
+  `tool_call` for undeclared openai-compat models survives even with this flag;
+  `-no-cap-probe` disables only active live probes, not the floor/ceiling bug
+  fix. Unknown catalog-miss models behave as not-capable with a remediation
+  hint. The explicit-config path is unchanged. Named distinctly from #218's
+  `-no-probe` (port scan).
+- `-p` one-shot mode: probing stays enabled (an undeclared model must work in
+  one-shot too); result is cached like any other run.
+
+## 6. Discoverability (secondary items, all in-slice)
+
+- **Remediation hint**: capability warnings gain the exact fix line —
+  `add "capabilities": ["chat","generate","stream","tool_call"] to the
+  <role> model entry in models.json` — with a tail that varies by state:
+  declared-without-tool_call ("declared capabilities lack tool_call"),
+  probed-no ("model did not produce a tool call when probed"), inconclusive
+  ("probe was inconclusive; declare capabilities to override").
+- **`golem models` subcommand** (pattern: `golem index`): lists each
+  agent-chain entry with resolved capabilities, per-cap provenance
+  (explicit / catalog / floor / probed(+age) / runtime), probe state for
+  `tool_call`, and flags entries missing it. Flags:
+  - `--probe-all`: actively probe every chain entry now (full-chain
+    certification; ignores bounded-eager stopping; still respects explicit
+    declarations).
+  - `--reprobe`: delete cached probe rows for chain models, then probe
+    non-explicit entries.
+  - Shared-key visibility: when one role declares explicit caps and another
+    role references the same provider/model undeclared, the key-wide explicit
+    override wins over floor/catalog/probe — the listing must surface this
+    ("explicit, declared by role <X>").
+  - Provenance comes from a **narrow exported explain helper** on
+    `ModelRegistry` scoped to what `golem models` needs (tool_call-focused;
+    no general public CapProvenance API).
+- **Catalog**: audit pass only — `tools` is already stamped on all major
+  families; gap-fill any misses found (e.g. verify qwen3-coder-next
+  variants).
+- **Docs**: BYO/models doc — `capabilities` semantics (explicit = replace,
+  derived = floor, cross-role consistency rule), tool-capable bundled-model
+  table, probe behavior, cache location, `-no-cap-probe`, `golem models`.
+
+## 7. Error handling / degradation summary
+
+- Probe failure/timeout: never fatal, never persisted; preflight warns,
+  routing proceeds with remaining candidates.
+- Store open/migration failure: warn, degrade to in-memory cache for the run.
+- Floor parse failure (non-canonical tokens): dropped + rejection hook, never
+  zeroes caps (mirrors override corner-case handling).
+- `-no-cap-probe`: disables active probes only; floor/catalog capability
+  merging still fixes undeclared openai-compat catalog hits.
+- Preflight remains non-fatal when ≥1 chain entry is capable (warnings only),
+  fatal with full inlined diagnostics when none is.
+
+## 8. Testing
+
+Table-driven throughout; mock HTTP servers; no live backend in unit tests.
+
+- Merge precedence: floor OR-merges below catalog/fingerprint/runtime;
+  explicit override still replaces (probe-yes + explicit-no → no wins;
+  floor + catalog tools survive for undeclared openai-compat).
+- Floor invariants mirror override: cache invalidation on SetCapabilityFloor,
+  version guard, invalid-token rejection (hook fired, caps preserved).
+- Probe classification matrix: both attempts × (200+calls, 200-empty,
+  400/422, 401/403/404/405/429, 5xx, timeout) — verdict + persistence
+  asserted for each cell.
+- Ollama passive branch: capabilities-with-tools / capabilities-without /
+  missing-array → yes / no / inconclusive.
+- Store v2: migration from v1, TTL expiry (inconclusive 24h, digestless-no
+  7d), digest mismatch → treated absent, probe_version bump → treated
+  absent, delete-for-reprobe.
+- Resolver: order-of-precedence (explicit beats cache beats probe),
+  singleflight dedup, profile-cache invalidation after persist.
+- Preflight bounded-eager: stop-after-first-capable (probe count asserted via
+  fake resolver), passive classification after stop, fatal path inlines
+  probe outcomes + remediation lines, `-no-cap-probe` performs no active
+  probes while still preserving floor/catalog `tool_call` (#217 tests keep
+  passing).
+- Recommend integration: RequiredCaps-with-tool_call recommend path resolves
+  then filters; empty-chain preflight benefits; Lookup/Recommend purity
+  (no probe side effects) asserted.
+- Route-time: unknown candidate probed before gate rejection and before
+  scoring/feedback reads; confirmed-no candidate skipped without probe.
+- No-probe flag regression: undeclared catalog-known openai-compat model keeps
+  `tool_call` through floor/catalog even with `-no-cap-probe`; undeclared
+  catalog-miss model remains not-capable without active probing.
+- Shared model key: role A explicit + role B undeclared same key → explicit
+  wins; `golem models` output surfaces the declaring role.
+- `golem models`: provenance rendering, --probe-all probes all entries,
+  --reprobe busts rows first.
+- Integration (build tag, live llama.cpp): probe yes on a tool-capable
+  model; probe no on a non-tool template.
+
+## 9. Out of scope
+
+- Full profiling in golem (future `golem models --profile` when routing
+  consumes latency metrics).
+- `thinking` / `insert` probes (same seam; separate issues).
+- Launcher port-handoff (#218 slice B), GO_LLM_SCAN_PORTS.
+- Probe-result sharing between MCP and golem beyond the common store schema.
+- Public general-purpose CapProvenance API.
+
+## Design decisions log
+
+1. **Floor seam over alternatives** (derived caps via prober hint →
+   fingerprint layer: fails storeless, MCP regression; dynamic override
+   closure consulting probe cache: duplicates merge logic). Floor fixes
+   catalog-for-openai-compat as a side effect; invariant lives at the
+   provider layer. (User-approved.)
+2. **Two-attempt probe protocol** — user finding on 4xx→no being too broad:
+   `tool_choice: required` first, escalate on 400/422, persist `no` only when
+   the `tools` array itself is rejected; auth/endpoint/rate 4xx never
+   persisted.
+3. **Bounded-eager + route-lazy** (user policy): startup proves one capable
+   entry then stops; unknown must never mean silently skip.
+4. **Capability resolver, not profiler-with-benchmarks-off** (user): separate
+   cache table + completeness isolation from MCP's full profiles.
+5. **Sticky-yes / expiring-no asymmetry**: stale yes fails loudly, wedged no
+   blocks silently → digestless no gets 7d TTL.
+6. **`golem models` name** (over `doctor`): matches scope selection; `doctor`
+   reserved for future broader diagnostics.

--- a/fingerprint/capprobe_test.go
+++ b/fingerprint/capprobe_test.go
@@ -1,0 +1,193 @@
+package fingerprint
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestCapProbe_SaveGetRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().Truncate(time.Millisecond)
+	in := CapProbe{
+		BackendID: "http://localhost:8080", ModelName: "byo-model",
+		Capability: "tool_call", State: CapProbeYes,
+		ModelDigest: "sha256:abc", ProbeVersion: CurrentToolProbeVersion,
+		TestedAt: now,
+	}
+	if err := s.SaveCapProbe(ctx, in); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := s.GetCapProbe(ctx, in.BackendID, in.ModelName, "tool_call")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.State != CapProbeYes || got.ModelDigest != "sha256:abc" ||
+		got.ProbeVersion != CurrentToolProbeVersion || !got.TestedAt.Equal(now) {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+	if !got.ExpiresAt.IsZero() {
+		t.Fatalf("yes row must not expire, got %v", got.ExpiresAt)
+	}
+}
+
+func TestCapProbe_GetMissingReturnsErrNotFound(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.GetCapProbe(context.Background(), "b", "m", "tool_call")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+}
+
+func TestCapProbe_SaveUpsertsOnSameKey(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	base := CapProbe{
+		BackendID: "b", ModelName: "m", Capability: "tool_call",
+		State: CapProbeInconclusive, ModelDigest: "d1",
+		ProbeVersion: CurrentToolProbeVersion, TestedAt: time.Now(),
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+	if err := s.SaveCapProbe(ctx, base); err != nil {
+		t.Fatalf("save 1: %v", err)
+	}
+	base.State = CapProbeYes
+	base.ExpiresAt = time.Time{}
+	if err := s.SaveCapProbe(ctx, base); err != nil {
+		t.Fatalf("save 2 (upsert): %v", err)
+	}
+	got, err := s.GetCapProbe(ctx, "b", "m", "tool_call")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.State != CapProbeYes || !got.ExpiresAt.IsZero() {
+		t.Fatalf("upsert did not replace: %+v", got)
+	}
+}
+
+func TestCapProbe_SaveStaleWriteGuard(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().Truncate(time.Millisecond)
+	newer := CapProbe{
+		BackendID: "b", ModelName: "m", Capability: "tool_call",
+		State: CapProbeYes, ModelDigest: "new",
+		ProbeVersion: CurrentToolProbeVersion, TestedAt: now,
+	}
+	if err := s.SaveCapProbe(ctx, newer); err != nil {
+		t.Fatalf("save newer: %v", err)
+	}
+	stale := newer
+	stale.State = CapProbeNo
+	stale.ModelDigest = "old"
+	stale.TestedAt = now.Add(-time.Hour)
+	if err := s.SaveCapProbe(ctx, stale); err != nil {
+		t.Fatalf("save stale: %v", err)
+	}
+	got, err := s.GetCapProbe(ctx, "b", "m", "tool_call")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.State != CapProbeYes || got.ModelDigest != "new" || !got.TestedAt.Equal(now) {
+		t.Fatalf("stale probe overwrote newer row: %+v", got)
+	}
+}
+
+func TestCapProbe_DeleteCapProbes(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	in := CapProbe{BackendID: "b", ModelName: "m", Capability: "tool_call",
+		State: CapProbeNo, ModelDigest: "d", ProbeVersion: 1, TestedAt: time.Now()}
+	if err := s.SaveCapProbe(ctx, in); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if err := s.DeleteCapProbes(ctx, "b", "m"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := s.GetCapProbe(ctx, "b", "m", "tool_call"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("want ErrNotFound after delete, got %v", err)
+	}
+}
+
+// Valid centralizes the freshness contract: digest match, version match, expiry.
+func TestCapProbe_Valid(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name   string
+		probe  CapProbe
+		digest string
+		want   bool
+	}{
+		{"fresh yes", CapProbe{State: CapProbeYes, ModelDigest: "d", ProbeVersion: CurrentToolProbeVersion, TestedAt: now}, "d", true},
+		{"digest mismatch", CapProbe{State: CapProbeYes, ModelDigest: "old", ProbeVersion: CurrentToolProbeVersion}, "new", false},
+		{"version mismatch", CapProbe{State: CapProbeYes, ModelDigest: "d", ProbeVersion: CurrentToolProbeVersion + 1}, "d", false},
+		{"expired inconclusive", CapProbe{State: CapProbeInconclusive, ModelDigest: "d", ProbeVersion: CurrentToolProbeVersion, ExpiresAt: now.Add(-time.Minute)}, "d", false},
+		{"unexpired inconclusive", CapProbe{State: CapProbeInconclusive, ModelDigest: "d", ProbeVersion: CurrentToolProbeVersion, ExpiresAt: now.Add(time.Hour)}, "d", true},
+		{"no-expiry no", CapProbe{State: CapProbeNo, ModelDigest: "d", ProbeVersion: CurrentToolProbeVersion}, "d", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.probe.Valid(tt.digest, now); got != tt.want {
+				t.Fatalf("Valid(%q) = %v, want %v", tt.digest, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMigrationV2_UpgradesExistingV1DB(t *testing.T) {
+	// Build a genuine v1-only database: v1 tables plus schema version 1
+	// recorded exactly as runMigrations records it, and no v2 table.
+	db := openTestDB(t)
+	if _, err := db.Exec(`CREATE TABLE fingerprint_schema_version (
+		version     INTEGER PRIMARY KEY,
+		description TEXT NOT NULL,
+		applied_at  INTEGER NOT NULL
+	)`); err != nil {
+		t.Fatalf("create version table: %v", err)
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin v1 tx: %v", err)
+	}
+	if err := migrateV1(tx); err != nil {
+		t.Fatalf("apply v1: %v", err)
+	}
+	if _, err := tx.Exec(
+		`INSERT INTO fingerprint_schema_version (version, description, applied_at) VALUES (?, ?, ?)`,
+		migrations[0].version, migrations[0].description, time.Now().UnixMilli(),
+	); err != nil {
+		t.Fatalf("record v1: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit v1: %v", err)
+	}
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'capability_probes'`).Scan(&n); err != nil {
+		t.Fatalf("check pre-upgrade schema: %v", err)
+	}
+	if n != 0 {
+		t.Fatal("capability_probes must not exist in v1 DB")
+	}
+
+	// Opening the store must apply v2 on top of the existing v1 DB.
+	s, err := NewStore(context.Background(), db)
+	if err != nil {
+		t.Fatalf("upgrade store: %v", err)
+	}
+	want := migrations[len(migrations)-1].version
+	if v, err := currentSchemaVersion(db); err != nil || v != want {
+		t.Fatalf("want schema version %d, got %d (err %v)", want, v, err)
+	}
+	in := CapProbe{BackendID: "b", ModelName: "m", Capability: "tool_call",
+		State: CapProbeYes, ModelDigest: "d", ProbeVersion: 1, TestedAt: time.Now()}
+	if err := s.SaveCapProbe(context.Background(), in); err != nil {
+		t.Fatalf("save after upgrade: %v", err)
+	}
+
+	// Reopen must be idempotent.
+	if _, err := NewStore(context.Background(), db); err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+}

--- a/fingerprint/fingerprint.go
+++ b/fingerprint/fingerprint.go
@@ -4,6 +4,7 @@
 package fingerprint
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -166,4 +167,20 @@ func (p CapProbe) Valid(currentDigest string, now time.Time) bool {
 		return false
 	}
 	return true
+}
+
+// CapProbeOutcome is a classified probe verdict ready to persist.
+// TTL zero means the row does not expire.
+type CapProbeOutcome struct {
+	State  CapProbeState
+	TTL    time.Duration
+	Detail string // short human-readable classification, for diagnostics
+}
+
+// ToolCallProber is an optional interface a ModelProber may implement to
+// actively determine tool-call support. A non-nil error means the probe
+// was transient/diagnostic (network failure, auth, rate limit) and MUST
+// NOT be persisted; the outcome is only meaningful when err is nil.
+type ToolCallProber interface {
+	ProbeToolCall(ctx context.Context, model string) (CapProbeOutcome, error)
 }

--- a/fingerprint/fingerprint.go
+++ b/fingerprint/fingerprint.go
@@ -106,3 +106,64 @@ type BackoffError struct {
 func (e *BackoffError) Error() string {
 	return fmt.Sprintf("fingerprint: in backoff until %s: %s", e.RetryAfter.Format(time.RFC3339), e.LastError)
 }
+
+// CapProbeState is the tri-state outcome of a capability probe.
+// The empty string means "unknown" (never probed / cache miss) and is
+// never persisted.
+type CapProbeState string
+
+const (
+	CapProbeYes          CapProbeState = "yes"
+	CapProbeNo           CapProbeState = "no"
+	CapProbeInconclusive CapProbeState = "inconclusive"
+)
+
+// CurrentToolProbeVersion identifies the tool-call probe request shape.
+// Bump when the probe protocol changes (tool definition, prompt,
+// tool_choice escalation); cached rows from other versions are ignored.
+const CurrentToolProbeVersion = 1
+
+// CapProbeInconclusiveTTL bounds how long an inconclusive verdict is
+// trusted before the next demand re-probes.
+const CapProbeInconclusiveTTL = 24 * time.Hour
+
+// CapProbeDigestlessNoTTL bounds a negative verdict for models with no
+// content digest (openai-compat fallback keying): a wedged "no" silently
+// blocks usage, so digestless negatives expire rather than sticking until
+// a manual --reprobe.
+const CapProbeDigestlessNoTTL = 7 * 24 * time.Hour
+
+// CapProbe is one persisted capability-probe verdict, keyed by
+// (backend_id, model_name, capability). Distinct from Profile so
+// capability-only resolution can never masquerade as a complete
+// fingerprint profile.
+type CapProbe struct {
+	BackendID    string
+	ModelName    string
+	Capability   string // canonical token, e.g. "tool_call"
+	State        CapProbeState
+	ModelDigest  string // runtime digest, or key fallback when digestless
+	ProbeVersion int    // CurrentToolProbeVersion at probe time
+	TestedAt     time.Time
+	ExpiresAt    time.Time // zero = does not expire
+}
+
+// Valid reports whether the cached probe still applies for the given
+// current digest at time now: digest and probe version must match and the
+// row must not be expired.
+//
+// The version check is coupled to the tool_call probe protocol
+// (CurrentToolProbeVersion); a second capability would need its own
+// probe-version parameter here.
+func (p CapProbe) Valid(currentDigest string, now time.Time) bool {
+	if p.ModelDigest != currentDigest {
+		return false
+	}
+	if p.ProbeVersion != CurrentToolProbeVersion {
+		return false
+	}
+	if !p.ExpiresAt.IsZero() && now.After(p.ExpiresAt) {
+		return false
+	}
+	return true
+}

--- a/fingerprint/migration.go
+++ b/fingerprint/migration.go
@@ -18,6 +18,11 @@ var migrations = []migration{
 		description: "baseline fingerprint profiles and failures tables",
 		fn:          migrateV1,
 	},
+	{
+		version:     2,
+		description: "capability_probes table for tri-state capability verdicts",
+		fn:          migrateV2,
+	},
 }
 
 func migrateV1(tx *sql.Tx) error {
@@ -59,6 +64,24 @@ func migrateV1(tx *sql.Tx) error {
 		if _, err := tx.Exec(stmt); err != nil {
 			return fmt.Errorf("fingerprint: migrate v1: %w", err)
 		}
+	}
+	return nil
+}
+
+func migrateV2(tx *sql.Tx) error {
+	const stmt = `CREATE TABLE IF NOT EXISTS capability_probes (
+		backend_id    TEXT NOT NULL,
+		model_name    TEXT NOT NULL,
+		capability    TEXT NOT NULL,
+		state         TEXT NOT NULL,
+		model_digest  TEXT NOT NULL,
+		probe_version INTEGER NOT NULL,
+		tested_at     INTEGER NOT NULL,
+		expires_at    INTEGER,
+		PRIMARY KEY (backend_id, model_name, capability)
+	)`
+	if _, err := tx.Exec(stmt); err != nil {
+		return fmt.Errorf("fingerprint: migrate v2: %w", err)
 	}
 	return nil
 }

--- a/fingerprint/probe.go
+++ b/fingerprint/probe.go
@@ -102,8 +102,35 @@ func (p *OllamaProber) probeKind(ctx context.Context, model string, info *ollama
 	}, nil
 }
 
-// Compile-time interface check.
-var _ ModelProber = (*OllamaProber)(nil)
+// Compile-time interface checks.
+var (
+	_ ModelProber    = (*OllamaProber)(nil)
+	_ ToolCallProber = (*OllamaProber)(nil)
+)
+
+// ProbeToolCall determines tool support passively from /api/show model
+// metadata — no generation request, no model load. A present capabilities
+// array is authoritative in both directions; a missing array (older
+// Ollama) is inconclusive, never a hard no.
+func (p *OllamaProber) ProbeToolCall(ctx context.Context, model string) (CapProbeOutcome, error) {
+	info, err := p.client.ShowModel(ctx, model)
+	if err != nil {
+		return CapProbeOutcome{}, fmt.Errorf("fingerprint: ollama tool probe %q: %w", model, err)
+	}
+	if info.Capabilities == nil {
+		return CapProbeOutcome{
+			State:  CapProbeInconclusive,
+			TTL:    CapProbeInconclusiveTTL,
+			Detail: "ollama /api/show has no capabilities array",
+		}, nil
+	}
+	for _, c := range info.Capabilities {
+		if c == "tools" {
+			return CapProbeOutcome{State: CapProbeYes, Detail: "ollama capabilities lists tools"}, nil
+		}
+	}
+	return CapProbeOutcome{State: CapProbeNo, Detail: "ollama capabilities array lacks tools"}, nil
+}
 
 // ProbeChat sends a minimal chat request and extracts performance metrics
 // from Ollama's timing fields. The opts parameter accepts *ollama.ModelOptions

--- a/fingerprint/probe_test.go
+++ b/fingerprint/probe_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/kstruzzieri/go-llm/ollama"
@@ -328,5 +329,114 @@ func TestProbeEmbedding_Error(t *testing.T) {
 	_, err := prober.ProbeEmbedding(context.Background(), "chat-only-model")
 	if err == nil {
 		t.Fatal("expected error from embedding failure")
+	}
+}
+
+// TestOllamaProbeToolCall_CapabilitiesWithTools verifies a curated yes when
+// /api/show lists "tools".
+func TestOllamaProbeToolCall_CapabilitiesWithTools(t *testing.T) {
+	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"capabilities": []string{"completion", "tools"},
+		})
+	}))
+	defer srv.Close()
+
+	out, err := prober.ProbeToolCall(context.Background(), "qwen2.5:72b")
+	if err != nil {
+		t.Fatalf("ProbeToolCall() error: %v", err)
+	}
+	if out.State != CapProbeYes {
+		t.Errorf("State = %q, want %q", out.State, CapProbeYes)
+	}
+	if out.TTL != 0 {
+		t.Errorf("TTL = %v, want 0", out.TTL)
+	}
+}
+
+// TestOllamaProbeToolCall_CapabilitiesWithoutTools verifies a curated no when
+// the capabilities array is present but lacks "tools".
+func TestOllamaProbeToolCall_CapabilitiesWithoutTools(t *testing.T) {
+	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"capabilities": []string{"completion"},
+		})
+	}))
+	defer srv.Close()
+
+	out, err := prober.ProbeToolCall(context.Background(), "gemma3:27b")
+	if err != nil {
+		t.Fatalf("ProbeToolCall() error: %v", err)
+	}
+	if out.State != CapProbeNo {
+		t.Errorf("State = %q, want %q", out.State, CapProbeNo)
+	}
+	if out.TTL != 0 {
+		t.Errorf("TTL = %v, want 0", out.TTL)
+	}
+}
+
+// TestOllamaProbeToolCall_EmptyCapabilitiesArray verifies an empty-but-present
+// array is still a curated no, not inconclusive.
+func TestOllamaProbeToolCall_EmptyCapabilitiesArray(t *testing.T) {
+	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"capabilities": []string{},
+		})
+	}))
+	defer srv.Close()
+
+	out, err := prober.ProbeToolCall(context.Background(), "gemma3:27b")
+	if err != nil {
+		t.Fatalf("ProbeToolCall() error: %v", err)
+	}
+	if out.State != CapProbeNo {
+		t.Errorf("State = %q, want %q", out.State, CapProbeNo)
+	}
+	if out.TTL != 0 {
+		t.Errorf("TTL = %v, want 0", out.TTL)
+	}
+}
+
+// TestOllamaProbeToolCall_MissingCapabilitiesArray verifies older Ollama
+// (no capabilities field) yields inconclusive with a bounded TTL, never a
+// hard no.
+func TestOllamaProbeToolCall_MissingCapabilitiesArray(t *testing.T) {
+	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"details": map[string]any{"family": "llama"},
+		})
+	}))
+	defer srv.Close()
+
+	out, err := prober.ProbeToolCall(context.Background(), "llama2:7b")
+	if err != nil {
+		t.Fatalf("ProbeToolCall() error: %v", err)
+	}
+	if out.State != CapProbeInconclusive {
+		t.Errorf("State = %q, want %q", out.State, CapProbeInconclusive)
+	}
+	if out.TTL != CapProbeInconclusiveTTL {
+		t.Errorf("TTL = %v, want %v", out.TTL, CapProbeInconclusiveTTL)
+	}
+}
+
+// TestOllamaProbeToolCall_ShowError verifies a transport/API failure is
+// surfaced as an error, not persisted as a verdict.
+func TestOllamaProbeToolCall_ShowError(t *testing.T) {
+	prober, srv := newTestProber(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"model not found"}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	out, err := prober.ProbeToolCall(context.Background(), "missing:latest")
+	if err == nil {
+		t.Fatal("ProbeToolCall() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "fingerprint: ollama tool probe") {
+		t.Errorf("error = %q, want wrap prefix %q", err, "fingerprint: ollama tool probe")
+	}
+	if out != (CapProbeOutcome{}) {
+		t.Errorf("outcome = %+v, want zero value", out)
 	}
 }

--- a/fingerprint/probers/openaicompat.go
+++ b/fingerprint/probers/openaicompat.go
@@ -12,6 +12,8 @@ package probers
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -147,4 +149,106 @@ func (p *OpenAICompatProber) ProbeEmbedding(ctx context.Context, model string) (
 		return nil, fmt.Errorf("fingerprint: openaicompat probe embedding %q: backend returned no embedding vector", model)
 	}
 	return &fingerprint.EmbeddingMetrics{Latency: time.Since(start), Dim: len(resp.Embeddings[0])}, nil
+}
+
+// Compile-time check: the prober actively probes tool-call support.
+var _ fingerprint.ToolCallProber = (*OpenAICompatProber)(nil)
+
+// toolProbeTimeout bounds one tool-call probe request. It must absorb a
+// llama-swap model load (seconds to tens of seconds for large models),
+// unlike the #218 port-scan probe's 800ms budget.
+const toolProbeTimeout = 30 * time.Second
+
+// probeToolSchema is the minimal no-arg function used to elicit a call.
+var probeToolSchema = provider.Tool{
+	Type: "function",
+	Function: provider.ToolFunction{
+		Name:        "get_time",
+		Description: "Get the current time.",
+		Parameters:  json.RawMessage(`{"type":"object","properties":{}}`),
+	},
+}
+
+// ProbeToolCall actively determines tool-call support with at most two
+// chat-completions requests (spec section 3):
+//
+//	attempt 1: tools + tool_choice "required" (deterministic elicitation)
+//	attempt 2 (only after attempt-1 400/422): tools without tool_choice,
+//	           prompt-engineered — some servers reject tool_choice but
+//	           accept tools.
+//
+// Verdicts: 200 with tool_calls => yes; 200 without => inconclusive
+// (short TTL: the model ignored the request, which varies by template);
+// 400/422 on attempt 2 => no (the tools array itself is rejected).
+// Auth/endpoint/rate-limit statuses and transport failures return a
+// non-nil error — diagnostic only, never persisted.
+func (p *OpenAICompatProber) ProbeToolCall(ctx context.Context, model string) (fingerprint.CapProbeOutcome, error) {
+	if p == nil || p.prov == nil {
+		return fingerprint.CapProbeOutcome{}, fmt.Errorf("fingerprint: openaicompat tool probe %q: provider is required", model)
+	}
+	ctx, cancel := context.WithTimeout(ctx, toolProbeTimeout)
+	defer cancel()
+
+	outcome, retry, err := p.toolProbeAttempt(ctx, model, true)
+	if err != nil || !retry {
+		return outcome, err
+	}
+	// Attempt 1 was rejected with 400/422: the server may object to
+	// tool_choice rather than tools. Re-try without tool_choice; a second
+	// 400/422 means the tools array itself is unsupported => hard no.
+	outcome, retry, err = p.toolProbeAttempt(ctx, model, false)
+	if err != nil {
+		return outcome, err
+	}
+	if retry {
+		return fingerprint.CapProbeOutcome{
+			State:  fingerprint.CapProbeNo,
+			Detail: "server rejected tools request (400/422 on both attempts)",
+		}, nil
+	}
+	return outcome, nil
+}
+
+// toolProbeAttempt runs one probe request. retry=true signals a 400/422
+// rejection that the caller may escalate past (attempt 1) or convert to a
+// hard no (attempt 2).
+func (p *OpenAICompatProber) toolProbeAttempt(ctx context.Context, model string, forceToolChoice bool) (fingerprint.CapProbeOutcome, bool, error) {
+	temp := 0.0
+	req := provider.ChatRequest{
+		Model: model,
+		Messages: []provider.ChatMessage{
+			{Role: "user", Content: "Call the get_time tool to get the current time."},
+		},
+		Tools: []provider.Tool{probeToolSchema},
+		Options: provider.ModelOptions{
+			NumPredict:  128, // tool-call JSON needs room; truncation reads as a false negative
+			Temperature: &temp,
+		},
+	}
+	if forceToolChoice {
+		req.ToolChoice = "required"
+	}
+
+	resp, err := p.prov.Chat(ctx, req)
+	if err != nil {
+		var hs interface{ HTTPStatusCode() int }
+		if errors.As(err, &hs) {
+			if code := hs.HTTPStatusCode(); code == 400 || code == 422 {
+				return fingerprint.CapProbeOutcome{}, true, nil
+			}
+			// 401/403/404/405/429, 5xx, anything else with a status:
+			// says nothing about the model. Diagnostic, not persisted.
+			return fingerprint.CapProbeOutcome{}, false, fmt.Errorf("fingerprint: openaicompat tool probe %q: %w", model, err)
+		}
+		// Transport-level failure (network, timeout, cancel): transient.
+		return fingerprint.CapProbeOutcome{}, false, fmt.Errorf("fingerprint: openaicompat tool probe %q: %w", model, err)
+	}
+	if len(resp.ToolCalls) > 0 {
+		return fingerprint.CapProbeOutcome{State: fingerprint.CapProbeYes, Detail: "model produced a tool call"}, false, nil
+	}
+	return fingerprint.CapProbeOutcome{
+		State:  fingerprint.CapProbeInconclusive,
+		TTL:    fingerprint.CapProbeInconclusiveTTL,
+		Detail: "200 response without tool_calls",
+	}, false, nil
 }

--- a/fingerprint/probers/openaicompat_toolprobe_test.go
+++ b/fingerprint/probers/openaicompat_toolprobe_test.go
@@ -1,0 +1,286 @@
+package probers
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/fingerprint"
+	"github.com/kstruzzieri/go-llm/provider/openaicompat"
+)
+
+// toolProbeChatOK is a chat.completions body whose message carries a tool
+// call — the shape a tool-capable model returns for tool_choice "required".
+const toolProbeChatOK = `{
+	"choices": [{"message": {
+		"role": "assistant",
+		"content": "",
+		"tool_calls": [{"id":"1","type":"function","function":{"name":"get_time","arguments":"{}"}}]
+	}}],
+	"usage": {"completion_tokens": 4}
+}`
+
+// toolProbeChatNoCalls is a 200 body where the model answered in prose
+// instead of calling the tool.
+const toolProbeChatNoCalls = `{
+	"choices": [{"message": {"role": "assistant", "content": "It is noon."}}],
+	"usage": {"completion_tokens": 4}
+}`
+
+// scriptedToolProbeServer serves the nth request with responses[n]
+// (status + body) and records every request body for later assertions.
+type scriptedToolProbeServer struct {
+	mu     sync.Mutex
+	bodies [][]byte
+
+	srv *httptest.Server
+}
+
+type scriptedResponse struct {
+	status int
+	body   string
+}
+
+func newScriptedToolProbeServer(t *testing.T, responses []scriptedResponse) *scriptedToolProbeServer {
+	t.Helper()
+	s := &scriptedToolProbeServer{}
+	s.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			http.NotFound(w, r)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+		}
+		s.mu.Lock()
+		idx := len(s.bodies)
+		s.bodies = append(s.bodies, body)
+		s.mu.Unlock()
+		if idx >= len(responses) {
+			t.Errorf("unexpected request %d, only %d scripted", idx+1, len(responses))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		resp := responses[idx]
+		if resp.status != http.StatusOK {
+			w.WriteHeader(resp.status)
+			_, _ = w.Write([]byte(`{"error":{"message":"scripted error"}}`))
+			return
+		}
+		_, _ = w.Write([]byte(resp.body))
+	}))
+	return s
+}
+
+func (s *scriptedToolProbeServer) requests() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.bodies)
+}
+
+func (s *scriptedToolProbeServer) body(i int) []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.bodies[i]
+}
+
+func TestOpenAICompatProber_ProbeToolCall_Matrix(t *testing.T) {
+	tests := []struct {
+		name       string
+		responses  []scriptedResponse
+		closed     bool // close the server before probing (network error)
+		precancel  bool // cancel the context before ProbeToolCall
+		wantState  fingerprint.CapProbeState
+		wantTTL    time.Duration
+		wantDetail string // exact Detail match when non-empty
+		wantErr    bool
+		wantReqs   int
+	}{
+		{
+			name:      "yes_on_required",
+			responses: []scriptedResponse{{200, toolProbeChatOK}},
+			wantState: fingerprint.CapProbeYes,
+			wantReqs:  1,
+		},
+		{
+			name:      "inconclusive_on_required",
+			responses: []scriptedResponse{{200, toolProbeChatNoCalls}},
+			wantState: fingerprint.CapProbeInconclusive,
+			wantTTL:   fingerprint.CapProbeInconclusiveTTL,
+			wantReqs:  1,
+		},
+		{
+			name:      "escalate_then_yes",
+			responses: []scriptedResponse{{400, ""}, {200, toolProbeChatOK}},
+			wantState: fingerprint.CapProbeYes,
+			wantReqs:  2,
+		},
+		{
+			name:      "escalate_then_inconclusive",
+			responses: []scriptedResponse{{422, ""}, {200, toolProbeChatNoCalls}},
+			wantState: fingerprint.CapProbeInconclusive,
+			wantTTL:   fingerprint.CapProbeInconclusiveTTL,
+			wantReqs:  2,
+		},
+		{
+			name:       "no_when_tools_rejected",
+			responses:  []scriptedResponse{{400, ""}, {400, ""}},
+			wantState:  fingerprint.CapProbeNo,
+			wantDetail: "server rejected tools request (400/422 on both attempts)",
+			wantReqs:   2,
+		},
+		{
+			name:      "auth_diagnostic_not_persisted",
+			responses: []scriptedResponse{{401, ""}},
+			wantErr:   true,
+			wantReqs:  1,
+		},
+		{
+			name:      "not_found_diagnostic",
+			responses: []scriptedResponse{{404, ""}},
+			wantErr:   true,
+			wantReqs:  1,
+		},
+		{
+			name:      "rate_limited_diagnostic",
+			responses: []scriptedResponse{{429, ""}},
+			wantErr:   true,
+			wantReqs:  1,
+		},
+		{
+			name:      "server_error_transient",
+			responses: []scriptedResponse{{500, ""}},
+			wantErr:   true,
+			wantReqs:  1,
+		},
+		{
+			name:      "escalated_then_500",
+			responses: []scriptedResponse{{400, ""}, {500, ""}},
+			wantErr:   true,
+			wantReqs:  2,
+		},
+		{
+			name:     "network_error_transient",
+			closed:   true,
+			wantErr:  true,
+			wantReqs: 0,
+		},
+		{
+			// A verdict from a cancelled probe must never be persisted:
+			// the transport fails before dialing, so no request is sent.
+			name:      "precancelled_context_transient",
+			precancel: true,
+			wantErr:   true,
+			wantReqs:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newScriptedToolProbeServer(t, tt.responses)
+			prober := NewOpenAICompatProber(openaicompat.NewProvider(openaicompat.NewClient(s.srv.URL)))
+			if tt.closed {
+				s.srv.Close()
+			} else {
+				defer s.srv.Close()
+			}
+
+			ctx := context.Background()
+			if tt.precancel {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+
+			outcome, err := prober.ProbeToolCall(ctx, "llama-3")
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ProbeToolCall() error = nil, want transient/diagnostic error (outcome=%+v)", outcome)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("ProbeToolCall() error = %v", err)
+				}
+				if outcome.State != tt.wantState {
+					t.Errorf("State = %q, want %q", outcome.State, tt.wantState)
+				}
+				if outcome.TTL != tt.wantTTL {
+					t.Errorf("TTL = %v, want %v", outcome.TTL, tt.wantTTL)
+				}
+				if tt.wantDetail != "" && outcome.Detail != tt.wantDetail {
+					t.Errorf("Detail = %q, want %q", outcome.Detail, tt.wantDetail)
+				}
+			}
+			if got := s.requests(); got != tt.wantReqs {
+				t.Errorf("requests received = %d, want %d", got, tt.wantReqs)
+			}
+		})
+	}
+}
+
+// TestOpenAICompatProber_ProbeToolCall_RequestBodies pins the wire contract:
+// attempt 1 forces tool_choice "required" with the minimal get_time tool and
+// deterministic options; attempt 2 drops tool_choice but keeps tools.
+func TestOpenAICompatProber_ProbeToolCall_RequestBodies(t *testing.T) {
+	// escalate_then_yes exercises both attempts in one probe.
+	s := newScriptedToolProbeServer(t, []scriptedResponse{{400, ""}, {200, toolProbeChatOK}})
+	defer s.srv.Close()
+	prober := NewOpenAICompatProber(openaicompat.NewProvider(openaicompat.NewClient(s.srv.URL)))
+
+	if _, err := prober.ProbeToolCall(context.Background(), "llama-3"); err != nil {
+		t.Fatalf("ProbeToolCall() error = %v", err)
+	}
+	if got := s.requests(); got != 2 {
+		t.Fatalf("requests received = %d, want 2", got)
+	}
+
+	type wireBody struct {
+		Stream      bool            `json:"stream"`
+		MaxTokens   int             `json:"max_tokens"`
+		Temperature *float64        `json:"temperature"`
+		ToolChoice  json.RawMessage `json:"tool_choice"`
+		Tools       []struct {
+			Function struct {
+				Name string `json:"name"`
+			} `json:"function"`
+		} `json:"tools"`
+	}
+
+	var first wireBody
+	if err := json.Unmarshal(s.body(0), &first); err != nil {
+		t.Fatalf("decode attempt-1 body: %v (body=%s)", err, s.body(0))
+	}
+	if len(first.Tools) != 1 || first.Tools[0].Function.Name != "get_time" {
+		t.Errorf("attempt-1 tools = %+v, want single get_time", first.Tools)
+	}
+	if string(first.ToolChoice) != `"required"` {
+		t.Errorf("attempt-1 tool_choice = %s, want \"required\"", first.ToolChoice)
+	}
+	if first.Stream {
+		t.Error("attempt-1 stream = true, want absent/false")
+	}
+	if first.MaxTokens != 128 {
+		t.Errorf("attempt-1 max_tokens = %d, want 128", first.MaxTokens)
+	}
+	if first.Temperature == nil || *first.Temperature != 0 {
+		t.Errorf("attempt-1 temperature = %v, want 0", first.Temperature)
+	}
+
+	var second wireBody
+	if err := json.Unmarshal(s.body(1), &second); err != nil {
+		t.Fatalf("decode attempt-2 body: %v (body=%s)", err, s.body(1))
+	}
+	if second.ToolChoice != nil {
+		t.Errorf("attempt-2 tool_choice = %s, want field absent", second.ToolChoice)
+	}
+	if len(second.Tools) != 1 || second.Tools[0].Function.Name != "get_time" {
+		t.Errorf("attempt-2 tools = %+v, want single get_time", second.Tools)
+	}
+}

--- a/fingerprint/store.go
+++ b/fingerprint/store.go
@@ -23,6 +23,18 @@ type Store interface {
 	SaveFailure(ctx context.Context, backendID, modelName, modelDigest, errMsg string) error
 }
 
+// CapProbeStore defines capability-probe persistence operations.
+// It is intentionally separate from Store so capability-only resolution
+// never affects NeedsFingerprint / IncompleteCapabilities semantics and
+// test fakes for full fingerprint profiles do not need cap-probe methods.
+type CapProbeStore interface {
+	GetCapProbe(ctx context.Context, backendID, modelName, capability string) (*CapProbe, error)
+	SaveCapProbe(ctx context.Context, probe CapProbe) error
+	DeleteCapProbes(ctx context.Context, backendID, modelName string) error
+}
+
+var _ CapProbeStore = (*SQLiteStore)(nil)
+
 // SQLiteStore is a fingerprint Store backed by SQLite.
 type SQLiteStore struct {
 	db *sql.DB
@@ -319,6 +331,77 @@ func (s *SQLiteStore) SaveFailure(ctx context.Context, backendID, modelName, mod
 	)
 	if err != nil {
 		return fmt.Errorf("fingerprint: save failure %q/%q: %w", backendID, modelName, err)
+	}
+	return nil
+}
+
+// GetCapProbe retrieves a capability-probe row. Returns ErrNotFound when
+// no row exists for the key.
+func (s *SQLiteStore) GetCapProbe(ctx context.Context, backendID, modelName, capability string) (*CapProbe, error) {
+	var p CapProbe
+	var testedAtMs int64
+	var expiresAtMs sql.NullInt64
+	err := s.db.QueryRowContext(ctx,
+		`SELECT backend_id, model_name, capability, state, model_digest,
+			probe_version, tested_at, expires_at
+		FROM capability_probes
+		WHERE backend_id = ? AND model_name = ? AND capability = ?`,
+		backendID, modelName, capability,
+	).Scan(&p.BackendID, &p.ModelName, &p.Capability, &p.State, &p.ModelDigest,
+		&p.ProbeVersion, &testedAtMs, &expiresAtMs)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("fingerprint: get cap probe %q/%q/%q: %w", backendID, modelName, capability, err)
+	}
+	p.TestedAt = time.UnixMilli(testedAtMs)
+	if expiresAtMs.Valid {
+		p.ExpiresAt = time.UnixMilli(expiresAtMs.Int64)
+	}
+	return &p, nil
+}
+
+// SaveCapProbe persists a probe verdict using upsert semantics.
+//
+// The upsert only overwrites an existing row when the incoming probe is
+// at least as recent (by tested_at). This prevents a slow-finishing probe
+// for an old digest from overwriting a newer verdict during concurrent
+// probing, mirroring the guard on Save.
+func (s *SQLiteStore) SaveCapProbe(ctx context.Context, probe CapProbe) error {
+	var expiresAt any // nil => NULL (no expiry)
+	if !probe.ExpiresAt.IsZero() {
+		expiresAt = probe.ExpiresAt.UnixMilli()
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO capability_probes
+			(backend_id, model_name, capability, state, model_digest,
+			 probe_version, tested_at, expires_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(backend_id, model_name, capability) DO UPDATE SET
+			state         = excluded.state,
+			model_digest  = excluded.model_digest,
+			probe_version = excluded.probe_version,
+			tested_at     = excluded.tested_at,
+			expires_at    = excluded.expires_at
+		WHERE excluded.tested_at >= capability_probes.tested_at`,
+		probe.BackendID, probe.ModelName, probe.Capability, string(probe.State),
+		probe.ModelDigest, probe.ProbeVersion, probe.TestedAt.UnixMilli(), expiresAt)
+	if err != nil {
+		return fmt.Errorf("fingerprint: save cap probe %q/%q/%q: %w",
+			probe.BackendID, probe.ModelName, probe.Capability, err)
+	}
+	return nil
+}
+
+// DeleteCapProbes removes all capability rows for a model (used by
+// `golem models --reprobe`).
+func (s *SQLiteStore) DeleteCapProbes(ctx context.Context, backendID, modelName string) error {
+	_, err := s.db.ExecContext(ctx,
+		`DELETE FROM capability_probes WHERE backend_id = ? AND model_name = ?`,
+		backendID, modelName)
+	if err != nil {
+		return fmt.Errorf("fingerprint: delete cap probes %q/%q: %w", backendID, modelName, err)
 	}
 	return nil
 }

--- a/internal/providerbootstrap/bootstrap.go
+++ b/internal/providerbootstrap/bootstrap.go
@@ -86,6 +86,9 @@ func New(ctx context.Context, opts Options) (*Bundle, error) {
 	if err := installCapabilityOverrides(mr, effCfg); err != nil {
 		return nil, err
 	}
+	if err := installCapabilityFloors(mr, effCfg); err != nil {
+		return nil, err
+	}
 
 	router := provider.NewRouter(mr, pReg, opts.RouterOptions...)
 

--- a/internal/providerbootstrap/bootstrap.go
+++ b/internal/providerbootstrap/bootstrap.go
@@ -31,6 +31,13 @@ type Options struct {
 	// live client uses.
 	OpenAICompatURLOverrideProvider string
 	OpenAICompatURLOverride         string
+
+	// CapabilityProbeStore wires capability-probe rows and on-demand
+	// ResolveToolCall without enabling full fingerprint profiling. Golem
+	// sets this and leaves FingerprintStore nil; MCP/full-profiler callers
+	// can rely on FingerprintStore's SQLiteStore also satisfying
+	// fingerprint.CapProbeStore (interface-assert fallback below).
+	CapabilityProbeStore fingerprint.CapProbeStore
 }
 
 // Bundle is the assembled provider stack. Warnings collects non-fatal,
@@ -76,8 +83,25 @@ func New(ctx context.Context, opts Options) (*Bundle, error) {
 	}
 
 	mrOpts := []provider.ModelRegistryOption{}
+	factory := proberFactory(effCfg, ollamaClients)
 	if opts.FingerprintStore != nil {
-		mrOpts = append(mrOpts, provider.WithFingerprintProberFactory(proberFactory(effCfg, ollamaClients)))
+		mrOpts = append(mrOpts, provider.WithFingerprintProberFactory(factory))
+	}
+	// Capability-only resolution (ResolveToolCall): explicit store wins;
+	// otherwise a FingerprintStore that also satisfies CapProbeStore (the
+	// SQLite store does) provides it for free. The prober factory is shared —
+	// WithCapabilityProber never triggers full profiling from Lookup.
+	capProbeStore := opts.CapabilityProbeStore
+	if capProbeStore == nil {
+		if s, ok := opts.FingerprintStore.(fingerprint.CapProbeStore); ok {
+			capProbeStore = s
+		}
+	}
+	if capProbeStore != nil {
+		mrOpts = append(mrOpts,
+			provider.WithCapabilityProbeStore(capProbeStore),
+			provider.WithCapabilityProber(factory),
+		)
 	}
 	mr, err := provider.NewModelRegistry(pReg, opts.FingerprintStore, mrOpts...)
 	if err != nil {

--- a/internal/providerbootstrap/bootstrap_test.go
+++ b/internal/providerbootstrap/bootstrap_test.go
@@ -27,8 +27,9 @@ func TestBundleCloseNilSafe(t *testing.T) {
 }
 
 // newTestFingerprintStore creates an in-memory SQLite-backed fingerprint store
-// for testing. It registers a t.Cleanup to close the underlying DB.
-func newTestFingerprintStore(t *testing.T) fingerprint.Store {
+// for testing. The concrete *SQLiteStore satisfies both fingerprint.Store and
+// fingerprint.CapProbeStore. It registers a t.Cleanup to close the underlying DB.
+func newTestFingerprintStore(t *testing.T) *fingerprint.SQLiteStore {
 	t.Helper()
 	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
@@ -153,6 +154,115 @@ func TestNew_FingerprintStoreUsesProviderSpecificOllamaClient(t *testing.T) {
 	}
 	if got := providerBShowCalls.Load(); got < 3 {
 		t.Fatalf("provider B /api/show calls = %d, want startup, runtime lookup, and fingerprint probe", got)
+	}
+}
+
+func TestNew_CapabilityProbeStoreInstallsCapProberNotFullFactory(t *testing.T) {
+	// Golem's capability-only mode: Options{CapabilityProbeStore: store} with
+	// FingerprintStore nil must wire the on-demand capability prober WITHOUT
+	// full fingerprint profiling. Behaviorally: Lookup performs no probe
+	// chat-completions calls; ResolveToolCall does.
+	ctx := context.Background()
+	var chatCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/models":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":[{"id":"mystery-model-x"}]}`))
+		case "/v1/chat/completions":
+			chatCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"","tool_calls":[{"id":"1","type":"function","function":{"name":"get_time","arguments":"{}"}}]}}],"usage":{"completion_tokens":4}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{
+		Providers: map[string]config.ProviderConfig{
+			"lc": {APIFormat: "openai-compat", BaseURL: srv.URL},
+		},
+		Models: map[string]config.ModelConfig{
+			// No explicit Capabilities: derived dense caps become a floor
+			// (chat/generate/stream) without tool_call, so resolution must probe.
+			"chat": {Provider: "lc", Name: "mystery-model-x", Type: "dense"},
+		},
+	}
+	b, err := New(ctx, Options{Config: cfg, CapabilityProbeStore: newTestFingerprintStore(t)})
+	if err != nil {
+		t.Fatalf("New(capability-probe store) error: %v", err)
+	}
+	defer func() { _ = b.Close() }()
+
+	key := provider.ModelKey{Provider: "lc", Model: "mystery-model-x"}
+	profile, err := b.Models.Lookup(ctx, key)
+	if err != nil {
+		t.Fatalf("Lookup error: %v", err)
+	}
+	if profile.Caps.Has(provider.CapToolCall) {
+		t.Fatalf("precondition: undeclared model must not already claim tool_call, caps = %v", profile.Caps)
+	}
+	if got := chatCalls.Load(); got != 0 {
+		t.Fatalf("Lookup made %d chat-completions probe call(s), want 0 (Lookup must never probe in capability-only mode)", got)
+	}
+
+	state, err := b.Models.ResolveToolCall(ctx, key)
+	if err != nil {
+		t.Fatalf("ResolveToolCall error: %v", err)
+	}
+	if state != fingerprint.CapProbeYes {
+		t.Fatalf("ResolveToolCall state = %q, want %q", state, fingerprint.CapProbeYes)
+	}
+	if got := chatCalls.Load(); got < 1 {
+		t.Fatalf("ResolveToolCall made %d probe call(s), want >= 1", got)
+	}
+}
+
+func TestNew_FingerprintStoreSatisfiesCapProbeStoreFallback(t *testing.T) {
+	// MCP path: with a FingerprintStore (whose SQLiteStore also satisfies
+	// fingerprint.CapProbeStore) and NO explicit CapabilityProbeStore, the
+	// interface-assert fallback must still enable ResolveToolCall. This proves
+	// the fallback branch wires the resolver, not just compiles.
+	//
+	// Unlike the capability-only test, a FingerprintStore is wired here, so
+	// Lookup MAY trigger full profiling — do not assert zero probe calls.
+	ctx := context.Background()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/models":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":[{"id":"mystery-model-x"}]}`))
+		case "/v1/chat/completions":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"","tool_calls":[{"id":"1","type":"function","function":{"name":"get_time","arguments":"{}"}}]}}],"usage":{"completion_tokens":4}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{
+		Providers: map[string]config.ProviderConfig{
+			"lc": {APIFormat: "openai-compat", BaseURL: srv.URL},
+		},
+		Models: map[string]config.ModelConfig{
+			"chat": {Provider: "lc", Name: "mystery-model-x", Type: "dense"},
+		},
+	}
+	b, err := New(ctx, Options{Config: cfg, FingerprintStore: newTestFingerprintStore(t)})
+	if err != nil {
+		t.Fatalf("New(fingerprint store, no explicit cap store) error: %v", err)
+	}
+	defer func() { _ = b.Close() }()
+
+	key := provider.ModelKey{Provider: "lc", Model: "mystery-model-x"}
+	state, err := b.Models.ResolveToolCall(ctx, key)
+	if err != nil {
+		t.Fatalf("ResolveToolCall error: %v", err)
+	}
+	if state != fingerprint.CapProbeYes {
+		t.Fatalf("ResolveToolCall state = %q, want %q (fallback resolver must be enabled)", state, fingerprint.CapProbeYes)
 	}
 }
 

--- a/internal/providerbootstrap/capabilities.go
+++ b/internal/providerbootstrap/capabilities.go
@@ -66,21 +66,7 @@ func buildCapabilityOverrides(cfg *config.Config) (map[provider.ModelKey][]strin
 		}
 		caps := m.Capabilities
 		if len(caps) == 0 {
-			pCfg, ok := cfg.Providers[m.Provider]
-			if !ok {
-				continue
-			}
-			apiFormat := pCfg.APIFormat
-			if apiFormat == "" {
-				apiFormat = "ollama"
-			}
-			if apiFormat != "openai-compat" {
-				continue
-			}
-			caps = m.ResolvedCapabilities()
-		}
-		if len(caps) == 0 {
-			continue
+			continue // derived caps are floors now (buildCapabilityFloors), not overrides
 		}
 		parsedCaps, err := provider.ParseCapsStrict(caps)
 		if err != nil {
@@ -116,6 +102,91 @@ func buildCapabilityOverrides(cfg *config.Config) (map[provider.ModelKey][]strin
 		out[key] = entry.caps
 	}
 	return out, nil
+}
+
+// buildCapabilityFloors computes baseline capability floors for undeclared
+// openai-compat models: their provider exposes no capability metadata, so
+// the type-derived set guarantees routability. Floors OR-merge in the
+// registry (lowest precedence), so unlike the old REPLACE override they
+// cannot erase catalog/fingerprint/runtime capabilities (issue #219 root
+// cause). Shared keys across roles union their derived sets — OR semantics
+// make conflicts impossible.
+func buildCapabilityFloors(cfg *config.Config) (map[provider.ModelKey][]string, error) {
+	out := make(map[provider.ModelKey][]string)
+	if cfg == nil {
+		return out, nil
+	}
+	union := make(map[provider.ModelKey]map[string]bool)
+	roles := make([]string, 0, len(cfg.Models))
+	for role := range cfg.Models {
+		roles = append(roles, role)
+	}
+	sort.Strings(roles)
+	for _, role := range roles {
+		m := cfg.Models[role]
+		if m.Provider == "" || m.Name == "" || len(m.Capabilities) > 0 {
+			continue // explicit declarations are overrides, not floors
+		}
+		pCfg, ok := cfg.Providers[m.Provider]
+		if !ok {
+			continue
+		}
+		apiFormat := pCfg.APIFormat
+		if apiFormat == "" {
+			apiFormat = "ollama"
+		}
+		if apiFormat != "openai-compat" {
+			continue
+		}
+		derived := m.ResolvedCapabilities()
+		if len(derived) == 0 {
+			continue
+		}
+		if _, err := provider.ParseCapsStrict(derived); err != nil {
+			return nil, fmt.Errorf("providerbootstrap: model %q derived floor for %s/%s: %w", role, m.Provider, m.Name, err)
+		}
+		key := provider.ModelKey{Provider: m.Provider, Model: m.Name}
+		if union[key] == nil {
+			union[key] = make(map[string]bool)
+		}
+		for _, tok := range derived {
+			union[key][tok] = true
+		}
+	}
+	for key, set := range union {
+		toks := make([]string, 0, len(set))
+		for tok := range set {
+			toks = append(toks, tok)
+		}
+		sort.Strings(toks)
+		out[key] = toks
+	}
+	return out, nil
+}
+
+// installCapabilityFloors installs the computed floors onto the registry.
+// No-op when mr/cfg is nil or there are no floors.
+func installCapabilityFloors(mr *provider.ModelRegistry, cfg *config.Config) error {
+	if mr == nil || cfg == nil {
+		return nil
+	}
+	floors, err := buildCapabilityFloors(cfg)
+	if err != nil {
+		return err
+	}
+	if len(floors) == 0 {
+		return nil
+	}
+	mr.SetCapabilityFloor(func(key provider.ModelKey) []string {
+		caps, ok := floors[key]
+		if !ok {
+			return nil
+		}
+		out := make([]string, len(caps))
+		copy(out, caps)
+		return out
+	})
+	return nil
 }
 
 // installCapabilityOverrides installs the computed overrides onto the registry.

--- a/internal/providerbootstrap/capabilities_test.go
+++ b/internal/providerbootstrap/capabilities_test.go
@@ -55,6 +55,92 @@ func TestBuildCapabilityOverrides_ConflictErrors(t *testing.T) {
 	}
 }
 
+func TestBuildCapabilityFloors_DerivedOpenAICompatOnly(t *testing.T) {
+	cfg := &config.Config{
+		Providers: map[string]config.ProviderConfig{
+			"llamacpp": {APIFormat: "openai-compat", BaseURL: "http://127.0.0.1:8080"},
+			"ollama":   {BaseURL: "http://localhost:11434"},
+			"ollama2":  {APIFormat: "ollama"},
+		},
+		Models: map[string]config.ModelConfig{
+			"agent":     {Provider: "llamacpp", Name: "byo-model", Type: "dense"},                                                       // undeclared => floor
+			"chat":      {Provider: "llamacpp", Name: "declared", Type: "dense", Capabilities: []string{"chat", "stream", "tool_call"}}, // explicit => override, NOT floor
+			"embed":     {Provider: "ollama", Name: "qwen3-embedding:8b", Type: "embedding"},                                            // default-empty format => ollama => neither
+			"summarize": {Provider: "ollama2", Name: "small", Type: "dense"},                                                            // explicit ollama format => no floor
+			"orphan":    {Provider: "ghost", Name: "m", Type: "dense"},                                                                  // provider missing from cfg.Providers => no floor
+			"notype":    {Provider: "llamacpp", Name: "untyped", Type: ""},                                                              // empty derived set => no floor
+		},
+	}
+	floors, err := buildCapabilityFloors(cfg)
+	if err != nil {
+		t.Fatalf("floors: %v", err)
+	}
+	if got := floors[provider.ModelKey{Provider: "llamacpp", Model: "byo-model"}]; len(got) == 0 {
+		t.Fatalf("undeclared openai-compat model missing floor")
+	}
+	if _, ok := floors[provider.ModelKey{Provider: "llamacpp", Model: "declared"}]; ok {
+		t.Fatalf("explicitly declared model must not get a floor")
+	}
+	if _, ok := floors[provider.ModelKey{Provider: "ollama", Model: "qwen3-embedding:8b"}]; ok {
+		t.Fatalf("ollama model must not get a floor")
+	}
+	if _, ok := floors[provider.ModelKey{Provider: "ollama2", Model: "small"}]; ok {
+		t.Fatalf("explicit ollama-format model must not get a floor")
+	}
+	if _, ok := floors[provider.ModelKey{Provider: "ghost", Model: "m"}]; ok {
+		t.Fatalf("model on a provider missing from cfg.Providers must not get a floor")
+	}
+	if _, ok := floors[provider.ModelKey{Provider: "llamacpp", Model: "untyped"}]; ok {
+		t.Fatalf("openai-compat model with empty derived set must not get a floor")
+	}
+
+	overrides, err := buildCapabilityOverrides(cfg)
+	if err != nil {
+		t.Fatalf("overrides: %v", err)
+	}
+	if _, ok := overrides[provider.ModelKey{Provider: "llamacpp", Model: "byo-model"}]; ok {
+		t.Fatalf("undeclared openai-compat model must no longer get a REPLACE override")
+	}
+	if _, ok := overrides[provider.ModelKey{Provider: "llamacpp", Model: "declared"}]; !ok {
+		t.Fatalf("explicit declaration must remain an override")
+	}
+}
+
+func TestBuildCapabilityFloors_SharedKeyUnionsDerived(t *testing.T) {
+	// Two roles, same key, different types => floors union (OR semantics
+	// make conflicts impossible; no error path for floors).
+	cfg := &config.Config{
+		Providers: map[string]config.ProviderConfig{
+			"llamacpp": {APIFormat: "openai-compat"},
+		},
+		Models: map[string]config.ModelConfig{
+			"agent": {Provider: "llamacpp", Name: "m", Type: "dense"},
+			"embed": {Provider: "llamacpp", Name: "m", Type: "embedding"},
+		},
+	}
+	floors, err := buildCapabilityFloors(cfg)
+	if err != nil {
+		t.Fatalf("floors: %v", err)
+	}
+	got := floors[provider.ModelKey{Provider: "llamacpp", Model: "m"}]
+	// dense derives chat,generate,stream; embedding derives embed => union of all four.
+	want := map[string]bool{"chat": true, "generate": true, "stream": true, "embed": true}
+	if len(got) != len(want) {
+		t.Fatalf("floor union = %v, want keys %v", got, want)
+	}
+	for _, tok := range got {
+		if !want[tok] {
+			t.Fatalf("unexpected floor token %q in %v", tok, got)
+		}
+	}
+}
+
+func TestInstallCapabilityFloors_NilSafe(t *testing.T) {
+	if err := installCapabilityFloors(nil, nil); err != nil {
+		t.Fatalf("installCapabilityFloors(nil,nil) = %v, want nil", err)
+	}
+}
+
 func TestInstallCapabilityOverrides_NilSafe(t *testing.T) {
 	if err := installCapabilityOverrides(nil, nil); err != nil {
 		t.Fatalf("installCapabilityOverrides(nil,nil) = %v, want nil", err)

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -407,7 +407,7 @@ func TestNewServerRegistersConfiguredProvidersAndOverridesCapabilities(t *testin
 		t.Fatalf("Lookup(vllm-local/local-chat) error = %v", err)
 	}
 	if !profile.Caps.Has(provider.CapChat | provider.CapGenerate | provider.CapStream) {
-		t.Fatalf("local-chat caps = %v, want openai-compatible type-derived chat+generate+stream override", profile.Caps)
+		t.Fatalf("local-chat caps = %v, want openai-compatible type-derived chat+generate+stream floor", profile.Caps)
 	}
 
 	profile, err = s.modelRegistry.Lookup(context.Background(), provider.ModelKey{Provider: "vllm-local", Model: "local-carved"})

--- a/provider/capresolve_test.go
+++ b/provider/capresolve_test.go
@@ -1,0 +1,744 @@
+// provider/capresolve_test.go
+//
+// Tests for ResolveToolCall (tri-state on-demand capability resolution),
+// the read-only cap-probe merge layer, and EnsureToolCallResolved.
+package provider
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/fingerprint"
+)
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+// fakeCapProbeStore is an in-memory fingerprint.CapProbeStore.
+type fakeCapProbeStore struct {
+	mu      sync.Mutex
+	rows    map[string]fingerprint.CapProbe
+	saveErr error // when non-nil, SaveCapProbe fails with it
+}
+
+func newFakeCapProbeStore() *fakeCapProbeStore {
+	return &fakeCapProbeStore{rows: make(map[string]fingerprint.CapProbe)}
+}
+
+func capRowKey(backendID, modelName, capability string) string {
+	return backendID + "\x00" + modelName + "\x00" + capability
+}
+
+func (s *fakeCapProbeStore) GetCapProbe(_ context.Context, backendID, modelName, capability string) (*fingerprint.CapProbe, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	row, ok := s.rows[capRowKey(backendID, modelName, capability)]
+	if !ok {
+		return nil, fingerprint.ErrNotFound
+	}
+	cp := row
+	return &cp, nil
+}
+
+func (s *fakeCapProbeStore) SaveCapProbe(_ context.Context, probe fingerprint.CapProbe) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.saveErr != nil {
+		return s.saveErr
+	}
+	s.rows[capRowKey(probe.BackendID, probe.ModelName, probe.Capability)] = probe
+	return nil
+}
+
+func (s *fakeCapProbeStore) DeleteCapProbes(_ context.Context, backendID, modelName string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	prefix := backendID + "\x00" + modelName + "\x00"
+	for k := range s.rows {
+		if strings.HasPrefix(k, prefix) {
+			delete(s.rows, k)
+		}
+	}
+	return nil
+}
+
+func (s *fakeCapProbeStore) row(backendID, modelName, capability string) (fingerprint.CapProbe, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	row, ok := s.rows[capRowKey(backendID, modelName, capability)]
+	return row, ok
+}
+
+func (s *fakeCapProbeStore) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.rows)
+}
+
+// fakeToolCallProber implements fingerprint.ModelProber (stubs) plus
+// fingerprint.ToolCallProber with scripted per-model outcomes and a call
+// counter. If block is non-nil, ProbeToolCall waits until it is closed.
+type fakeToolCallProber struct {
+	mu       sync.Mutex
+	outcomes map[string]fingerprint.CapProbeOutcome
+	errs     map[string]error
+	calls    map[string]int
+	block    chan struct{}
+}
+
+func newFakeToolCallProber() *fakeToolCallProber {
+	return &fakeToolCallProber{
+		outcomes: make(map[string]fingerprint.CapProbeOutcome),
+		errs:     make(map[string]error),
+		calls:    make(map[string]int),
+	}
+}
+
+func (p *fakeToolCallProber) DetectKind(context.Context, string) (*fingerprint.KindDetection, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p *fakeToolCallProber) ProbeChat(context.Context, string, interface{}) (*fingerprint.ChatMetrics, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p *fakeToolCallProber) ProbeEmbedding(context.Context, string) (*fingerprint.EmbeddingMetrics, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p *fakeToolCallProber) ProbeToolCall(_ context.Context, model string) (fingerprint.CapProbeOutcome, error) {
+	p.mu.Lock()
+	p.calls[model]++
+	block := p.block
+	p.mu.Unlock()
+	if block != nil {
+		<-block
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err := p.errs[model]; err != nil {
+		return fingerprint.CapProbeOutcome{}, err
+	}
+	return p.outcomes[model], nil
+}
+
+func (p *fakeToolCallProber) callCount(model string) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls[model]
+}
+
+func (p *fakeToolCallProber) totalCalls() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	total := 0
+	for _, n := range p.calls {
+		total += n
+	}
+	return total
+}
+
+func capProberFactory(prober fingerprint.ModelProber) FingerprintProberFactory {
+	return func(_ context.Context, _ ModelKey, _ *ModelInfo, _ Provider) (*FingerprintProberSpec, error) {
+		return &FingerprintProberSpec{Prober: prober}, nil
+	}
+}
+
+// newCapResolveRegistry builds a registry over a single mock provider that
+// advertises the given models, with the cap-probe store and prober wired.
+func newCapResolveRegistry(t *testing.T, providerName string, models []string, store fingerprint.CapProbeStore, prober fingerprint.ModelProber) *ModelRegistry {
+	t.Helper()
+	infos := make([]ModelInfo, 0, len(models))
+	for _, m := range models {
+		infos = append(infos, ModelInfo{Name: m})
+	}
+	reg := &mrMockProviderRegistry{
+		providers: map[string]Provider{
+			providerName: &mrMockProvider{name: providerName, models: infos},
+		},
+	}
+	opts := []ModelRegistryOption{}
+	if store != nil {
+		opts = append(opts, WithCapabilityProbeStore(store))
+	}
+	if prober != nil {
+		opts = append(opts, WithCapabilityProber(capProberFactory(prober)))
+	}
+	mr, err := NewModelRegistry(reg, nil, opts...)
+	if err != nil {
+		t.Fatalf("NewModelRegistry() error: %v", err)
+	}
+	return mr
+}
+
+// ---------------------------------------------------------------------------
+// ResolveToolCall
+// ---------------------------------------------------------------------------
+
+func TestResolveToolCall_ExplicitDeclarationSkipsProbe(t *testing.T) {
+	ctx := context.Background()
+	store := newFakeCapProbeStore()
+	prober := newFakeToolCallProber()
+	mr := newCapResolveRegistry(t, "probe-prov", []string{"mystery-model"}, store, prober)
+	key := ModelKey{Provider: "probe-prov", Model: "mystery-model"}
+
+	mr.SetCapabilityOverride(func(k ModelKey) []string {
+		if k == key {
+			return []string{"chat", "tool_call"}
+		}
+		return nil
+	})
+	state, err := mr.ResolveToolCall(ctx, key)
+	if err != nil {
+		t.Fatalf("ResolveToolCall() error: %v", err)
+	}
+	if state != fingerprint.CapProbeYes {
+		t.Fatalf("state = %q, want yes", state)
+	}
+	if got := prober.callCount("mystery-model"); got != 0 {
+		t.Fatalf("prober calls = %d, want 0", got)
+	}
+
+	mr.SetCapabilityOverride(func(k ModelKey) []string {
+		if k == key {
+			return []string{"chat"}
+		}
+		return nil
+	})
+	state, err = mr.ResolveToolCall(ctx, key)
+	if err != nil {
+		t.Fatalf("ResolveToolCall() error: %v", err)
+	}
+	if state != fingerprint.CapProbeNo {
+		t.Fatalf("state = %q, want no", state)
+	}
+	if got := prober.callCount("mystery-model"); got != 0 {
+		t.Fatalf("prober calls = %d, want 0", got)
+	}
+}
+
+func TestResolveToolCall_MergedCapsShortCircuit(t *testing.T) {
+	ctx := context.Background()
+	store := newFakeCapProbeStore()
+	prober := newFakeToolCallProber()
+	mr := newCapResolveRegistry(t, "ollama-local", []string{"qwen3:8b"}, store, prober)
+	key := ModelKey{Provider: "ollama-local", Model: "qwen3:8b"}
+
+	state, err := mr.ResolveToolCall(ctx, key)
+	if err != nil {
+		t.Fatalf("ResolveToolCall() error: %v", err)
+	}
+	if state != fingerprint.CapProbeYes {
+		t.Fatalf("state = %q, want yes (catalog declares tools)", state)
+	}
+	if got := prober.callCount("qwen3:8b"); got != 0 {
+		t.Fatalf("prober calls = %d, want 0", got)
+	}
+}
+
+func TestResolveToolCall_CacheHitSkipsProbe(t *testing.T) {
+	ctx := context.Background()
+	store := newFakeCapProbeStore()
+	prober := newFakeToolCallProber()
+	mr := newCapResolveRegistry(t, "probe-prov", []string{"mystery-model"}, store, prober)
+	key := ModelKey{Provider: "probe-prov", Model: "mystery-model"}
+
+	if err := store.SaveCapProbe(ctx, fingerprint.CapProbe{
+		BackendID:    "probe-prov",
+		ModelName:    "mystery-model",
+		Capability:   "tool_call",
+		State:        fingerprint.CapProbeYes,
+		ModelDigest:  key.String(),
+		ProbeVersion: fingerprint.CurrentToolProbeVersion,
+		TestedAt:     time.Now(),
+	}); err != nil {
+		t.Fatalf("seed SaveCapProbe() error: %v", err)
+	}
+
+	state, err := mr.ResolveToolCall(ctx, key)
+	if err != nil {
+		t.Fatalf("ResolveToolCall() error: %v", err)
+	}
+	if state != fingerprint.CapProbeYes {
+		t.Fatalf("state = %q, want yes", state)
+	}
+	if got := prober.callCount("mystery-model"); got != 0 {
+		t.Fatalf("prober calls = %d, want 0", got)
+	}
+}
+
+func TestResolveToolCall_StaleCacheReprobes(t *testing.T) {
+	ctx := context.Background()
+	store := newFakeCapProbeStore()
+	prober := newFakeToolCallProber()
+	prober.outcomes["mystery-model"] = fingerprint.CapProbeOutcome{State: fingerprint.CapProbeYes}
+	mr := newCapResolveRegistry(t, "probe-prov", []string{"mystery-model"}, store, prober)
+	key := ModelKey{Provider: "probe-prov", Model: "mystery-model"}
+
+	if err := store.SaveCapProbe(ctx, fingerprint.CapProbe{
+		BackendID:    "probe-prov",
+		ModelName:    "mystery-model",
+		Capability:   "tool_call",
+		State:        fingerprint.CapProbeYes,
+		ModelDigest:  key.String(),
+		ProbeVersion: fingerprint.CurrentToolProbeVersion - 1,
+		TestedAt:     time.Now().Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("seed SaveCapProbe() error: %v", err)
+	}
+
+	state, err := mr.ResolveToolCall(ctx, key)
+	if err != nil {
+		t.Fatalf("ResolveToolCall() error: %v", err)
+	}
+	if state != fingerprint.CapProbeYes {
+		t.Fatalf("state = %q, want yes", state)
+	}
+	if got := prober.callCount("mystery-model"); got != 1 {
+		t.Fatalf("prober calls = %d, want 1", got)
+	}
+	row, ok := store.row("probe-prov", "mystery-model", "tool_call")
+	if !ok {
+		t.Fatal("expected persisted row")
+	}
+	if row.ProbeVersion != fingerprint.CurrentToolProbeVersion {
+		t.Fatalf("persisted ProbeVersion = %d, want %d", row.ProbeVersion, fingerprint.CurrentToolProbeVersion)
+	}
+}
+
+func TestResolveToolCall_ProbePersistsAndInvalidatesProfile(t *testing.T) {
+	ctx := context.Background()
+	store := newFakeCapProbeStore()
+	prober := newFakeToolCallProber()
+	prober.outcomes["mystery-model"] = fingerprint.CapProbeOutcome{State: fingerprint.CapProbeYes}
+	mr := newCapResolveRegistry(t, "probe-prov", []string{"mystery-model"}, store, prober)
+	key := ModelKey{Provider: "probe-prov", Model: "mystery-model"}
+
+	// 1. Initial lookup: profile lacks CapToolCall.
+	profile, err := mr.Lookup(ctx, key)
+	if err != nil {
+		t.Fatalf("Lookup() error: %v", err)
+	}
+	if profile.Caps.Has(CapToolCall) {
+		t.Fatalf("initial profile Caps = %v, want no tool_call", profile.Caps)
+	}
+
+	// 2. Resolve: probe runs, verdict persisted.
+	state, err := mr.ResolveToolCall(ctx, key)
+	if err != nil {
+		t.Fatalf("ResolveToolCall() error: %v", err)
+	}
+	if state != fingerprint.CapProbeYes {
+		t.Fatalf("state = %q, want yes", state)
+	}
+	row, ok := store.row("probe-prov", "mystery-model", "tool_call")
+	if !ok {
+		t.Fatal("expected persisted row")
+	}
+	if row.Capability != "tool_call" {
+		t.Fatalf("row Capability = %q, want tool_call", row.Capability)
+	}
+	if row.State != fingerprint.CapProbeYes {
+		t.Fatalf("row State = %q, want yes", row.State)
+	}
+	if !row.ExpiresAt.IsZero() {
+		t.Fatalf("row ExpiresAt = %v, want zero (yes verdicts do not expire)", row.ExpiresAt)
+	}
+
+	// 3. Re-lookup: profile cache was invalidated and the merge layer read
+	// the yes row.
+	profile, err = mr.Lookup(ctx, key)
+	if err != nil {
+		t.Fatalf("Lookup() after resolve error: %v", err)
+	}
+	if !profile.Caps.Has(CapToolCall) {
+		t.Fatalf("refreshed profile Caps = %v, want tool_call", profile.Caps)
+	}
+}
+
+func TestResolveToolCall_TransientErrorNotPersisted(t *testing.T) {
+	ctx := context.Background()
+	store := newFakeCapProbeStore()
+	prober := newFakeToolCallProber()
+	prober.errs["mystery-model"] = errors.New("connection refused")
+	mr := newCapResolveRegistry(t, "probe-prov", []string{"mystery-model"}, store, prober)
+	key := ModelKey{Provider: "probe-prov", Model: "mystery-model"}
+
+	state, err := mr.ResolveToolCall(ctx, key)
+	if err == nil {
+		t.Fatal("expected error from transient probe failure")
+	}
+	if state != "" {
+		t.Fatalf("state = %q, want empty (unknown)", state)
+	}
+	if store.count() != 0 {
+		t.Fatalf("store rows = %d, want 0 (transient errors never persisted)", store.count())
+	}
+	if got := prober.callCount("mystery-model"); got != 1 {
+		t.Fatalf("prober calls = %d, want 1", got)
+	}
+
+	// Second call probes again -- nothing cached the failure.
+	if _, err := mr.ResolveToolCall(ctx, key); err == nil {
+		t.Fatal("expected error on second resolve")
+	}
+	if got := prober.callCount("mystery-model"); got != 2 {
+		t.Fatalf("prober calls = %d, want 2", got)
+	}
+}
+
+func TestResolveToolCall_SingleflightDedup(t *testing.T) {
+	ctx := context.Background()
+	store := newFakeCapProbeStore()
+	prober := newFakeToolCallProber()
+	prober.outcomes["mystery-model"] = fingerprint.CapProbeOutcome{State: fingerprint.CapProbeYes}
+	prober.block = make(chan struct{})
+	mr := newCapResolveRegistry(t, "probe-prov", []string{"mystery-model"}, store, prober)
+	key := ModelKey{Provider: "probe-prov", Model: "mystery-model"}
+
+	const callers = 8
+	var wg sync.WaitGroup
+	var launched sync.WaitGroup
+	states := make([]fingerprint.CapProbeState, callers)
+	errs := make([]error, callers)
+	launched.Add(callers)
+	wg.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func(i int) {
+			defer wg.Done()
+			launched.Done()
+			states[i], errs[i] = mr.ResolveToolCall(ctx, key)
+		}(i)
+	}
+	launched.Wait()
+	close(prober.block)
+	wg.Wait()
+
+	for i := 0; i < callers; i++ {
+		if errs[i] != nil {
+			t.Fatalf("caller %d error: %v", i, errs[i])
+		}
+		if states[i] != fingerprint.CapProbeYes {
+			t.Fatalf("caller %d state = %q, want yes", i, states[i])
+		}
+	}
+	// Stragglers that miss the shared flight hit the persisted row instead
+	// of re-probing, so exactly one probe runs either way.
+	if got := prober.callCount("mystery-model"); got != 1 {
+		t.Fatalf("prober calls = %d, want 1", got)
+	}
+}
+
+func TestResolveToolCall_DisabledReturnsUnknown(t *testing.T) {
+	ctx := context.Background()
+	store := newFakeCapProbeStore()
+	prober := newFakeToolCallProber()
+	// Store installed but NO prober: resolution is disabled.
+	mr := newCapResolveRegistry(t, "probe-prov", []string{"mystery-model"}, store, nil)
+	key := ModelKey{Provider: "probe-prov", Model: "mystery-model"}
+
+	state, err := mr.ResolveToolCall(ctx, key)
+	if err != nil {
+		t.Fatalf("ResolveToolCall() error: %v", err)
+	}
+	if state != "" {
+		t.Fatalf("state = %q, want empty (unknown, never a claim)", state)
+	}
+	if got := prober.totalCalls(); got != 0 {
+		t.Fatalf("prober calls = %d, want 0", got)
+	}
+}
+
+// TestResolveToolCall_SyntheticFactoryDigestIgnored pins the real-world
+// factory shape: providerbootstrap's fingerprintDigestForModel returns a
+// synthetic "config-caps:<caps>" digest for openai-compat models (no
+// runtime digest). Cap-probe rows must be keyed by the read-side digest
+// (runtimeInfo.Digest -> key.String()), NOT the synthetic spec digest --
+// otherwise probe verdicts never merge into profiles and negatives dodge
+// the digestless TTL cap.
+func TestResolveToolCall_SyntheticFactoryDigestIgnored(t *testing.T) {
+	ctx := context.Background()
+
+	syntheticFactory := func(prober fingerprint.ModelProber) FingerprintProberFactory {
+		return func(_ context.Context, _ ModelKey, _ *ModelInfo, _ Provider) (*FingerprintProberSpec, error) {
+			return &FingerprintProberSpec{Prober: prober, ModelDigest: "config-caps:chat,stream"}, nil
+		}
+	}
+	newRegistry := func(t *testing.T, store *fakeCapProbeStore, prober *fakeToolCallProber) *ModelRegistry {
+		t.Helper()
+		reg := &mrMockProviderRegistry{
+			providers: map[string]Provider{
+				"openai-local": &mrMockProvider{name: "openai-local", models: []ModelInfo{{Name: "mystery-model"}}},
+			},
+		}
+		mr, err := NewModelRegistry(reg, nil,
+			WithCapabilityProbeStore(store), WithCapabilityProber(syntheticFactory(prober)))
+		if err != nil {
+			t.Fatalf("NewModelRegistry() error: %v", err)
+		}
+		return mr
+	}
+	key := ModelKey{Provider: "openai-local", Model: "mystery-model"}
+
+	t.Run("yes row keyed by fallback and merges", func(t *testing.T) {
+		store := newFakeCapProbeStore()
+		prober := newFakeToolCallProber()
+		prober.outcomes["mystery-model"] = fingerprint.CapProbeOutcome{State: fingerprint.CapProbeYes}
+		mr := newRegistry(t, store, prober)
+
+		state, err := mr.ResolveToolCall(ctx, key)
+		if err != nil {
+			t.Fatalf("ResolveToolCall() error: %v", err)
+		}
+		if state != fingerprint.CapProbeYes {
+			t.Fatalf("state = %q, want yes", state)
+		}
+		row, ok := store.row("openai-local", "mystery-model", "tool_call")
+		if !ok {
+			t.Fatal("expected persisted row")
+		}
+		if row.ModelDigest != key.String() {
+			t.Fatalf("row ModelDigest = %q, want key fallback %q (synthetic factory digest must be ignored)", row.ModelDigest, key.String())
+		}
+		profile, err := mr.Lookup(ctx, key)
+		if err != nil {
+			t.Fatalf("Lookup() error: %v", err)
+		}
+		if !profile.Caps.Has(CapToolCall) {
+			t.Fatalf("profile Caps = %v, want tool_call merged from probe row", profile.Caps)
+		}
+	})
+
+	t.Run("no row gets digestless TTL cap", func(t *testing.T) {
+		store := newFakeCapProbeStore()
+		prober := newFakeToolCallProber()
+		prober.outcomes["mystery-model"] = fingerprint.CapProbeOutcome{State: fingerprint.CapProbeNo}
+		mr := newRegistry(t, store, prober)
+
+		before := time.Now()
+		state, err := mr.ResolveToolCall(ctx, key)
+		if err != nil {
+			t.Fatalf("ResolveToolCall() error: %v", err)
+		}
+		if state != fingerprint.CapProbeNo {
+			t.Fatalf("state = %q, want no", state)
+		}
+		row, ok := store.row("openai-local", "mystery-model", "tool_call")
+		if !ok {
+			t.Fatal("expected persisted row")
+		}
+		if row.ExpiresAt.IsZero() {
+			t.Fatal("digestless no must expire, got zero ExpiresAt")
+		}
+		if max := before.Add(fingerprint.CapProbeDigestlessNoTTL + time.Minute); row.ExpiresAt.After(max) {
+			t.Fatalf("ExpiresAt = %v, want within ~%v", row.ExpiresAt, fingerprint.CapProbeDigestlessNoTTL)
+		}
+		if min := before.Add(fingerprint.CapProbeDigestlessNoTTL - time.Minute); row.ExpiresAt.Before(min) {
+			t.Fatalf("ExpiresAt = %v, want at least ~%v out", row.ExpiresAt, fingerprint.CapProbeDigestlessNoTTL)
+		}
+	})
+}
+
+func TestResolveToolCall_RejectedOverrideFallsThrough(t *testing.T) {
+	ctx := context.Background()
+	store := newFakeCapProbeStore()
+	prober := newFakeToolCallProber()
+	prober.outcomes["mystery-model"] = fingerprint.CapProbeOutcome{State: fingerprint.CapProbeYes}
+	mr := newCapResolveRegistry(t, "probe-prov", []string{"mystery-model"}, store, prober)
+	key := ModelKey{Provider: "probe-prov", Model: "mystery-model"}
+
+	// "completion" is a multi-bit catalog alias: ParseCapsStrict rejects it,
+	// so the override must be a no-op here (no fabricated No claim) and
+	// resolution falls through to the probe path.
+	mr.SetCapabilityOverride(func(k ModelKey) []string {
+		if k == key {
+			return []string{"completion"}
+		}
+		return nil
+	})
+
+	state, err := mr.ResolveToolCall(ctx, key)
+	if err != nil {
+		t.Fatalf("ResolveToolCall() error: %v", err)
+	}
+	if state != fingerprint.CapProbeYes {
+		t.Fatalf("state = %q, want yes from probe fallthrough", state)
+	}
+	if got := prober.callCount("mystery-model"); got != 1 {
+		t.Fatalf("prober calls = %d, want 1 (rejected override must not short-circuit)", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EnsureToolCallResolved
+// ---------------------------------------------------------------------------
+
+func TestEnsureToolCallResolved_FiltersAndRefreshes(t *testing.T) {
+	ctx := context.Background()
+	store := newFakeCapProbeStore()
+	prober := newFakeToolCallProber()
+	prober.outcomes["mystery-yes"] = fingerprint.CapProbeOutcome{State: fingerprint.CapProbeYes}
+	prober.outcomes["mystery-no"] = fingerprint.CapProbeOutcome{State: fingerprint.CapProbeNo}
+	mr := newCapResolveRegistry(t, "multi", []string{"qwen3:8b", "mystery-yes", "mystery-no"}, store, prober)
+
+	var profiles []*ModelProfile
+	for _, m := range []string{"qwen3:8b", "mystery-yes", "mystery-no"} {
+		p, err := mr.Lookup(ctx, ModelKey{Provider: "multi", Model: m})
+		if err != nil {
+			t.Fatalf("Lookup(%s) error: %v", m, err)
+		}
+		profiles = append(profiles, p)
+	}
+	if !profiles[0].Caps.Has(CapToolCall) {
+		t.Fatalf("qwen3:8b should carry catalog tool_call, got %v", profiles[0].Caps)
+	}
+
+	required := CapChat | CapStream | CapToolCall
+	out := mr.EnsureToolCallResolved(ctx, profiles, required)
+	if len(out) != len(profiles) {
+		t.Fatalf("len(out) = %d, want %d (never removes candidates)", len(out), len(profiles))
+	}
+
+	// Capable profile untouched, never probed.
+	if out[0] != profiles[0] {
+		t.Fatal("capable profile should be returned unchanged")
+	}
+	if got := prober.callCount("qwen3:8b"); got != 0 {
+		t.Fatalf("qwen3:8b prober calls = %d, want 0", got)
+	}
+
+	// Probe-yes model refreshed with CapToolCall.
+	if !out[1].Caps.Has(CapToolCall) {
+		t.Fatalf("mystery-yes Caps = %v, want tool_call after refresh", out[1].Caps)
+	}
+
+	// Probe-no model returned unchanged; the caller's gate is the single
+	// rejection point.
+	if out[2] != profiles[2] {
+		t.Fatal("probe-no profile should be returned unchanged")
+	}
+	if out[2].Caps.Has(CapToolCall) {
+		t.Fatalf("mystery-no Caps = %v, want no tool_call", out[2].Caps)
+	}
+
+	// Input slice must not be mutated.
+	if profiles[1].Caps.Has(CapToolCall) && out[1] == profiles[1] {
+		t.Fatal("input slice entry was mutated in place")
+	}
+}
+
+func TestEnsureToolCallResolved_NoOpWhenDisabledOrNotRequired(t *testing.T) {
+	ctx := context.Background()
+	store := newFakeCapProbeStore()
+	prober := newFakeToolCallProber()
+	mr := newCapResolveRegistry(t, "multi", []string{"mystery-model"}, store, prober)
+
+	p, err := mr.Lookup(ctx, ModelKey{Provider: "multi", Model: "mystery-model"})
+	if err != nil {
+		t.Fatalf("Lookup() error: %v", err)
+	}
+	in := []*ModelProfile{p}
+
+	// required lacks CapToolCall: input returned as-is, no probes.
+	out := mr.EnsureToolCallResolved(ctx, in, CapChat|CapStream)
+	if len(out) != 1 || out[0] != p {
+		t.Fatal("expected input passthrough when tool_call not required")
+	}
+	if got := prober.totalCalls(); got != 0 {
+		t.Fatalf("prober calls = %d, want 0", got)
+	}
+
+	// Resolution disabled (no prober): passthrough too.
+	mrDisabled := newCapResolveRegistry(t, "multi", []string{"mystery-model"}, store, nil)
+	out = mrDisabled.EnsureToolCallResolved(ctx, in, CapChat|CapStream|CapToolCall)
+	if len(out) != 1 || out[0] != p {
+		t.Fatal("expected input passthrough when resolution disabled")
+	}
+}
+
+// TestInvalidateProfileBumpsPolicyVersion pins the guard against the
+// invalidation/build race: a buildProfile in flight when a probe lands
+// snapshots the policy version at entry, so invalidateProfile must bump
+// that shared counter -- otherwise the in-flight build's cache write
+// passes the version check and permanently re-caches a stale profile
+// (the row-hit fast path never invalidates, so it would never self-heal).
+func TestInvalidateProfileBumpsPolicyVersion(t *testing.T) {
+	store := newFakeCapProbeStore()
+	prober := newFakeToolCallProber()
+	mr := newCapResolveRegistry(t, "probe-prov", []string{"mystery-model"}, store, prober)
+	key := ModelKey{Provider: "probe-prov", Model: "mystery-model"}
+
+	mr.mu.RLock()
+	before := mr.overrideVersion
+	mr.mu.RUnlock()
+
+	mr.invalidateProfile(key)
+
+	mr.mu.RLock()
+	after := mr.overrideVersion
+	mr.mu.RUnlock()
+	if after != before+1 {
+		t.Fatalf("overrideVersion = %d after invalidateProfile, want %d (must bump to fence in-flight buildProfile cache writes)", after, before+1)
+	}
+}
+
+// TestEnsureToolCallResolved_SaveFailureKeepsVerdict pins the "verdict
+// stands for this caller" contract: when SaveCapProbe fails (swallowed as
+// non-fatal), the refreshed Lookup cannot see a probe row and still lacks
+// CapToolCall -- but the probe DID answer yes, so the returned profile
+// must carry the bit rather than letting the caller's gate reject a
+// confirmed-capable candidate.
+func TestEnsureToolCallResolved_SaveFailureKeepsVerdict(t *testing.T) {
+	ctx := context.Background()
+	store := newFakeCapProbeStore()
+	store.saveErr = errors.New("disk full")
+	prober := newFakeToolCallProber()
+	prober.outcomes["mystery-model"] = fingerprint.CapProbeOutcome{State: fingerprint.CapProbeYes}
+	mr := newCapResolveRegistry(t, "probe-prov", []string{"mystery-model"}, store, prober)
+	key := ModelKey{Provider: "probe-prov", Model: "mystery-model"}
+
+	p, err := mr.Lookup(ctx, key)
+	if err != nil {
+		t.Fatalf("Lookup() error: %v", err)
+	}
+	in := []*ModelProfile{p}
+
+	out := mr.EnsureToolCallResolved(ctx, in, CapChat|CapStream|CapToolCall)
+	if len(out) != 1 {
+		t.Fatalf("len(out) = %d, want 1", len(out))
+	}
+	if !out[0].Caps.Has(CapToolCall) {
+		t.Fatalf("out[0].Caps = %v, want tool_call despite lost store write", out[0].Caps)
+	}
+	// Input profile must not be mutated in place.
+	if p.Caps.Has(CapToolCall) {
+		t.Fatalf("input profile mutated: Caps = %v", p.Caps)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Purity of Lookup / Recommend
+// ---------------------------------------------------------------------------
+
+func TestLookupAndRecommendStayPure(t *testing.T) {
+	ctx := context.Background()
+	store := newFakeCapProbeStore()
+	prober := newFakeToolCallProber()
+	prober.outcomes["mystery-model"] = fingerprint.CapProbeOutcome{State: fingerprint.CapProbeYes}
+	mr := newCapResolveRegistry(t, "probe-prov", []string{"mystery-model"}, store, prober)
+
+	if _, err := mr.Lookup(ctx, ModelKey{Provider: "probe-prov", Model: "mystery-model"}); err != nil {
+		t.Fatalf("Lookup() error: %v", err)
+	}
+	if _, err := mr.Recommend(ctx, RecommendOpts{}); err != nil {
+		t.Fatalf("Recommend() error: %v", err)
+	}
+	if got := prober.totalCalls(); got != 0 {
+		t.Fatalf("prober calls = %d, want 0 (Lookup/Recommend never probe)", got)
+	}
+}

--- a/provider/capresolve_test.go
+++ b/provider/capresolve_test.go
@@ -599,7 +599,7 @@ func TestEnsureToolCallResolved_FiltersAndRefreshes(t *testing.T) {
 	}
 
 	required := CapChat | CapStream | CapToolCall
-	out := mr.EnsureToolCallResolved(ctx, profiles, required)
+	out, _ := mr.EnsureToolCallResolved(ctx, profiles, required)
 	if len(out) != len(profiles) {
 		t.Fatalf("len(out) = %d, want %d (never removes candidates)", len(out), len(profiles))
 	}
@@ -645,7 +645,7 @@ func TestEnsureToolCallResolved_NoOpWhenDisabledOrNotRequired(t *testing.T) {
 	in := []*ModelProfile{p}
 
 	// required lacks CapToolCall: input returned as-is, no probes.
-	out := mr.EnsureToolCallResolved(ctx, in, CapChat|CapStream)
+	out, _ := mr.EnsureToolCallResolved(ctx, in, CapChat|CapStream)
 	if len(out) != 1 || out[0] != p {
 		t.Fatal("expected input passthrough when tool_call not required")
 	}
@@ -655,7 +655,7 @@ func TestEnsureToolCallResolved_NoOpWhenDisabledOrNotRequired(t *testing.T) {
 
 	// Resolution disabled (no prober): passthrough too.
 	mrDisabled := newCapResolveRegistry(t, "multi", []string{"mystery-model"}, store, nil)
-	out = mrDisabled.EnsureToolCallResolved(ctx, in, CapChat|CapStream|CapToolCall)
+	out, _ = mrDisabled.EnsureToolCallResolved(ctx, in, CapChat|CapStream|CapToolCall)
 	if len(out) != 1 || out[0] != p {
 		t.Fatal("expected input passthrough when resolution disabled")
 	}
@@ -708,7 +708,7 @@ func TestEnsureToolCallResolved_SaveFailureKeepsVerdict(t *testing.T) {
 	}
 	in := []*ModelProfile{p}
 
-	out := mr.EnsureToolCallResolved(ctx, in, CapChat|CapStream|CapToolCall)
+	out, _ := mr.EnsureToolCallResolved(ctx, in, CapChat|CapStream|CapToolCall)
 	if len(out) != 1 {
 		t.Fatalf("len(out) = %d, want 1", len(out))
 	}

--- a/provider/capresolve_test.go
+++ b/provider/capresolve_test.go
@@ -742,3 +742,199 @@ func TestLookupAndRecommendStayPure(t *testing.T) {
 		t.Fatalf("prober calls = %d, want 0 (Lookup/Recommend never probe)", got)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// ExplainToolCall (diagnostic provenance for `golem models`)
+// ---------------------------------------------------------------------------
+
+func TestExplainToolCall_Provenance(t *testing.T) {
+	ctx := context.Background()
+
+	// Explicit override key => Source "explicit".
+	t.Run("explicit", func(t *testing.T) {
+		store := newFakeCapProbeStore()
+		prober := newFakeToolCallProber()
+		mr := newCapResolveRegistry(t, "probe-prov", []string{"mystery-model"}, store, prober)
+		key := ModelKey{Provider: "probe-prov", Model: "mystery-model"}
+		mr.SetCapabilityOverride(func(k ModelKey) []string {
+			if k == key {
+				return []string{"chat", "tool_call"}
+			}
+			return nil
+		})
+		exp, err := mr.ExplainToolCall(ctx, key)
+		if err != nil {
+			t.Fatalf("ExplainToolCall() error: %v", err)
+		}
+		if exp.Source != "explicit" {
+			t.Fatalf("Source = %q, want explicit", exp.Source)
+		}
+		if !exp.Has {
+			t.Fatalf("Has = false, want true (override declares tool_call)")
+		}
+		if got := prober.totalCalls(); got != 0 {
+			t.Fatalf("prober calls = %d, want 0 (Explain never probes)", got)
+		}
+	})
+
+	// Catalog-tools key => Source "catalog". qwen3:8b declares tool_call in the
+	// static catalog, so the merged profile carries the bit without any probe.
+	t.Run("catalog", func(t *testing.T) {
+		store := newFakeCapProbeStore()
+		prober := newFakeToolCallProber()
+		mr := newCapResolveRegistry(t, "ollama-local", []string{"qwen3:8b"}, store, prober)
+		key := ModelKey{Provider: "ollama-local", Model: "qwen3:8b"}
+		exp, err := mr.ExplainToolCall(ctx, key)
+		if err != nil {
+			t.Fatalf("ExplainToolCall() error: %v", err)
+		}
+		if exp.Source != "catalog" {
+			t.Fatalf("Source = %q, want catalog", exp.Source)
+		}
+		if !exp.Has {
+			t.Fatalf("Has = false, want true")
+		}
+	})
+
+	// Probe-yes row => Source "probe" with TestedAt set. mystery-model has no
+	// catalog tool_call, so a valid cached "yes" row is the only source.
+	t.Run("probe", func(t *testing.T) {
+		store := newFakeCapProbeStore()
+		prober := newFakeToolCallProber()
+		mr := newCapResolveRegistry(t, "probe-prov", []string{"mystery-model"}, store, prober)
+		key := ModelKey{Provider: "probe-prov", Model: "mystery-model"}
+		tested := time.Now().Add(-2 * time.Hour)
+		if err := store.SaveCapProbe(ctx, fingerprint.CapProbe{
+			BackendID:    "probe-prov",
+			ModelName:    "mystery-model",
+			Capability:   "tool_call",
+			State:        fingerprint.CapProbeYes,
+			ModelDigest:  key.String(),
+			ProbeVersion: fingerprint.CurrentToolProbeVersion,
+			TestedAt:     tested,
+		}); err != nil {
+			t.Fatalf("seed SaveCapProbe() error: %v", err)
+		}
+		exp, err := mr.ExplainToolCall(ctx, key)
+		if err != nil {
+			t.Fatalf("ExplainToolCall() error: %v", err)
+		}
+		if exp.Source != "probe" {
+			t.Fatalf("Source = %q, want probe", exp.Source)
+		}
+		if !exp.Has {
+			t.Fatalf("Has = false, want true")
+		}
+		if exp.State != fingerprint.CapProbeYes {
+			t.Fatalf("State = %q, want yes", exp.State)
+		}
+		if exp.TestedAt.IsZero() {
+			t.Fatalf("TestedAt is zero, want the probe row timestamp")
+		}
+		if got := prober.totalCalls(); got != 0 {
+			t.Fatalf("prober calls = %d, want 0 (Explain never probes)", got)
+		}
+	})
+
+	// Nothing known => Source "unknown". A probe-no row is still surfaced in
+	// State/TestedAt even though Has is false.
+	t.Run("unknown_with_no_row", func(t *testing.T) {
+		store := newFakeCapProbeStore()
+		prober := newFakeToolCallProber()
+		mr := newCapResolveRegistry(t, "probe-prov", []string{"mystery-model"}, store, prober)
+		key := ModelKey{Provider: "probe-prov", Model: "mystery-model"}
+		tested := time.Now().Add(-time.Hour)
+		if err := store.SaveCapProbe(ctx, fingerprint.CapProbe{
+			BackendID:    "probe-prov",
+			ModelName:    "mystery-model",
+			Capability:   "tool_call",
+			State:        fingerprint.CapProbeNo,
+			ModelDigest:  key.String(),
+			ProbeVersion: fingerprint.CurrentToolProbeVersion,
+			TestedAt:     tested,
+		}); err != nil {
+			t.Fatalf("seed SaveCapProbe() error: %v", err)
+		}
+		exp, err := mr.ExplainToolCall(ctx, key)
+		if err != nil {
+			t.Fatalf("ExplainToolCall() error: %v", err)
+		}
+		if exp.Source != "probe" {
+			t.Fatalf("Source = %q, want probe (a no row is still a probe source)", exp.Source)
+		}
+		if exp.Has {
+			t.Fatalf("Has = true, want false (probe said no)")
+		}
+		if exp.State != fingerprint.CapProbeNo {
+			t.Fatalf("State = %q, want no", exp.State)
+		}
+	})
+
+	// Stale probe-yes row (wrong digest) + floor-supplied tool_call => the live
+	// bit is NOT the probe's (the merge layer would reject the stale row), so
+	// Source must be "runtime", not "probe". State/TestedAt still surface the
+	// stale row for operator visibility.
+	t.Run("stale_probe_with_floor_bit_is_runtime", func(t *testing.T) {
+		store := newFakeCapProbeStore()
+		prober := newFakeToolCallProber()
+		mr := newCapResolveRegistry(t, "probe-prov", []string{"mystery-model"}, store, prober)
+		key := ModelKey{Provider: "probe-prov", Model: "mystery-model"}
+		// Floor supplies tool_call (registry/provider-layer knowledge).
+		mr.SetCapabilityFloor(func(k ModelKey) []string {
+			if k == key {
+				return []string{"tool_call"}
+			}
+			return nil
+		})
+		// A stale yes row: wrong digest, so Valid() is false at read time.
+		tested := time.Now().Add(-3 * time.Hour)
+		if err := store.SaveCapProbe(ctx, fingerprint.CapProbe{
+			BackendID:    "probe-prov",
+			ModelName:    "mystery-model",
+			Capability:   "tool_call",
+			State:        fingerprint.CapProbeYes,
+			ModelDigest:  "stale-digest-does-not-match",
+			ProbeVersion: fingerprint.CurrentToolProbeVersion,
+			TestedAt:     tested,
+		}); err != nil {
+			t.Fatalf("seed SaveCapProbe() error: %v", err)
+		}
+		exp, err := mr.ExplainToolCall(ctx, key)
+		if err != nil {
+			t.Fatalf("ExplainToolCall() error: %v", err)
+		}
+		if !exp.Has {
+			t.Fatalf("Has = false, want true (floor supplies tool_call)")
+		}
+		if exp.Source != "runtime" {
+			t.Fatalf("Source = %q, want runtime (stale probe row must NOT be the source)", exp.Source)
+		}
+		if exp.State != fingerprint.CapProbeYes || exp.TestedAt.IsZero() {
+			t.Fatalf("State/TestedAt = %q/%v, want the stale row still surfaced", exp.State, exp.TestedAt)
+		}
+	})
+
+	// Truly nothing: no override, no catalog tool_call, no probe row => unknown.
+	t.Run("unknown", func(t *testing.T) {
+		store := newFakeCapProbeStore()
+		prober := newFakeToolCallProber()
+		mr := newCapResolveRegistry(t, "probe-prov", []string{"mystery-model"}, store, prober)
+		key := ModelKey{Provider: "probe-prov", Model: "mystery-model"}
+		exp, err := mr.ExplainToolCall(ctx, key)
+		if err != nil {
+			t.Fatalf("ExplainToolCall() error: %v", err)
+		}
+		if exp.Source != "unknown" {
+			t.Fatalf("Source = %q, want unknown", exp.Source)
+		}
+		if exp.Has {
+			t.Fatalf("Has = true, want false")
+		}
+		if exp.State != "" {
+			t.Fatalf("State = %q, want empty", exp.State)
+		}
+		if !exp.TestedAt.IsZero() {
+			t.Fatalf("TestedAt = %v, want zero (no row)", exp.TestedAt)
+		}
+	})
+}

--- a/provider/model_registry.go
+++ b/provider/model_registry.go
@@ -43,7 +43,8 @@ type ModelRegistry struct {
 	fpProberFactory FingerprintProberFactory
 	providers       ProviderResolver
 	capOverride     CapabilityOverride
-	overrideVersion uint64
+	capFloor        CapabilityFloor
+	overrideVersion uint64 // bumped by SetCapabilityOverride AND SetCapabilityFloor; guards stale cache writes in buildProfile
 	rejectionHook   OverrideRejectionHook
 }
 
@@ -100,6 +101,21 @@ func WithFingerprintProberFactory(fn FingerprintProberFactory) ModelRegistryOpti
 //   - parses to zero caps: ignored (same crippling hazard)
 type CapabilityOverride func(key ModelKey) []string
 
+// CapabilityFloor returns baseline canonical capability tokens for a model
+// key, or nil when none. Floor caps are OR-merged into the profile at the
+// LOWEST precedence (with the static catalog layer): they guarantee a
+// minimum capability set for models whose provider exposes no capability
+// metadata (openai-compat), WITHOUT erasing catalog/fingerprint/runtime
+// additions the way the REPLACE override does. Tokens must be canonical
+// (ParseCapsStrict); invalid slices are dropped with the rejection hook
+// fired and never zero or shrink the profile.
+//
+// CapInsert exception: the runtime layer sits ABOVE the floor and clears
+// CapInsert (`&^= CapInsert`) when the model's template lacks suffix
+// markers, so a floor-supplied "insert" bit may still be removed by
+// runtime template detection. Every other floor bit is OR-only.
+type CapabilityFloor func(key ModelKey) []string
+
 // OverrideRejectionHook is called when a capability override returned a
 // non-empty token slice that failed strict canonical-only parsing — i.e.
 // the override was applied at the registry but had to be DROPPED because
@@ -110,6 +126,10 @@ type CapabilityOverride func(key ModelKey) []string
 // safe), so the hook is the only signal the misconfiguration ever happened.
 // Without it the override is silently swallowed and the operator sees
 // router decisions that don't match the config they wrote.
+//
+// The hook also fires for rejected capability-floor slices: a floor whose
+// tokens fail strict parsing is dropped wholesale (caps unchanged) with
+// the same observability contract.
 //
 // Typical implementations log the rejection or emit a metric. Hooks MUST
 // be cheap and non-blocking — they run inside merge() on every cache miss
@@ -158,6 +178,21 @@ func (r *ModelRegistry) SetCapabilityOverride(fn CapabilityOverride) {
 	// override in effect. Skipping this flush is the bug class where a
 	// warm cache silently shadows config changes — see feedback memory
 	// on rebuilding downstream state when a cache source changes.
+	clear(r.profiles)
+}
+
+// SetCapabilityFloor installs (or clears) the capability floor hook.
+// Pass nil to disable. Safe for concurrent use.
+//
+// Shares SetCapabilityOverride's invalidation + version-guard semantics:
+// the profile cache is flushed and the single policy version counter is
+// bumped so an in-flight buildProfile that snapshotted the OLD floor
+// cannot repopulate the cache with a stale-policy profile.
+func (r *ModelRegistry) SetCapabilityFloor(fn CapabilityFloor) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.capFloor = fn
+	r.overrideVersion++
 	clear(r.profiles)
 }
 
@@ -380,15 +415,18 @@ func (r *ModelRegistry) FIMConfigFor(ctx context.Context, key ModelKey) (*FIMCon
 //  2. Fingerprint: capability probing data, benchmarked resource observations
 //  3. Runtime: context_window, parameter_size, quant_level, digest (freshest)
 func (r *ModelRegistry) buildProfile(ctx context.Context, key ModelKey) (*ModelProfile, error) {
-	// Snapshot (override, version, rejectionHook) FIRST so the policy a
-	// single buildProfile applies is fixed at start, and the cache write
-	// at the end can detect any concurrent SetCapabilityOverride. Reading
+	// Snapshot (override, floor, version, rejectionHook) FIRST so the
+	// policy a single buildProfile applies is fixed at start, and the
+	// cache write at the end can detect any concurrent
+	// SetCapabilityOverride or SetCapabilityFloor (both bump the shared
+	// version counter). Reading
 	// later (after slow IO like queryRuntime) would shrink the visible
 	// TOCTOU window but also leave the same race against the cache write
 	// itself; reading first keeps the contract simple: one buildProfile ->
 	// one policy version.
 	r.mu.RLock()
 	override := r.capOverride
+	floor := r.capFloor
 	overrideVer := r.overrideVersion
 	rejectionHook := r.rejectionHook
 	r.mu.RUnlock()
@@ -419,9 +457,9 @@ func (r *ModelRegistry) buildProfile(ctx context.Context, key ModelKey) (*ModelP
 	// Layer 3: Fingerprint enrichment.
 	fpProfile := r.fingerprintProfile(ctx, key, runtimeInfo)
 
-	// Merge layers using the (override, rejectionHook) snapshot taken at
-	// function entry.
-	profile := r.merge(key, runtimeInfo, staticProfile, fpProfile, parsed, override, rejectionHook)
+	// Merge layers using the (override, floor, rejectionHook) snapshot
+	// taken at function entry.
+	profile := r.merge(key, runtimeInfo, staticProfile, fpProfile, parsed, override, floor, rejectionHook)
 
 	// Cache the result iff the override snapshot is still current.
 	r.mu.Lock()
@@ -507,6 +545,7 @@ func (r *ModelRegistry) merge(
 	fp *fingerprint.Profile,
 	parsed ParsedModel,
 	override CapabilityOverride,
+	floor CapabilityFloor,
 	rejectionHook OverrideRejectionHook,
 ) *ModelProfile {
 	profile := &ModelProfile{
@@ -531,6 +570,26 @@ func (r *ModelRegistry) merge(
 
 		if static.ContextWindow > 0 {
 			profile.ContextWindow = static.ContextWindow
+		}
+	}
+
+	// Capability floor (lowest precedence, OR-merge). Guarantees baseline
+	// caps for providers that expose no capability metadata without the
+	// REPLACE override's erasure semantics. Invalid tokens are dropped
+	// wholesale with the rejection hook fired — a floor must never zero,
+	// shrink, or partially apply to the profile. Passed in by buildProfile
+	// (not read from r) for the same TOCTOU reason as the override.
+	if floor != nil {
+		if floorTokens := floor(key); len(floorTokens) > 0 {
+			floorCaps, err := ParseCapsStrict(floorTokens)
+			switch {
+			case err != nil:
+				if rejectionHook != nil {
+					rejectionHook(key, floorTokens, err)
+				}
+			case floorCaps != 0:
+				profile.Caps |= floorCaps
+			}
 		}
 	}
 

--- a/provider/model_registry.go
+++ b/provider/model_registry.go
@@ -383,13 +383,7 @@ func (r *ModelRegistry) resolveToolCallSlow(ctx context.Context, key ModelKey) (
 	// synthetic-digest negatives would dodge the digestless TTL cap below.
 	// Using runtimeInfo.Digest with the key fallback keeps the write and
 	// read digests byte-symmetric by construction.
-	digest := ""
-	if runtimeInfo != nil {
-		digest = runtimeInfo.Digest
-	}
-	if digest == "" {
-		digest = key.String()
-	}
+	digest := capProbeDigest(key, runtimeInfo)
 	backendID := key.Provider // EnsureProfile's existing backend_id convention
 
 	now := time.Now()
@@ -688,20 +682,7 @@ func (r *ModelRegistry) buildProfile(ctx context.Context, key ModelKey) (*ModelP
 
 	// Layer 2: Static catalog match.
 	parsed := ParseModelName(key.Model)
-	staticProfile := r.catalog.lookup(parsed.NormalizedFamily(), parsed.ParamSize)
-	if staticProfile == nil && parsed.ParamSize == "" && parsed.Tag != "" {
-		// Some catalog-only variants are keyed by tag (for example ":latest")
-		// rather than by parsed parameter size.
-		staticProfile = r.catalog.lookup(parsed.NormalizedFamily(), parsed.Tag)
-	}
-	if staticProfile == nil {
-		// Try family-only lookup for family-level metadata (FIM, think mode).
-		staticProfile = r.catalog.lookupFamily(parsed.NormalizedFamily())
-	}
-	if staticProfile == nil && runtimeInfo.Family != "" {
-		// Fall back to runtime-reported family.
-		staticProfile = r.catalog.lookupFamily(strings.ToLower(runtimeInfo.Family))
-	}
+	staticProfile := r.catalogProfileFor(parsed, runtimeInfo)
 
 	// Layer 3: Fingerprint enrichment.
 	fpProfile := r.fingerprintProfile(ctx, key, runtimeInfo)
@@ -724,6 +705,150 @@ func (r *ModelRegistry) buildProfile(ctx context.Context, key ModelKey) (*ModelP
 	r.mu.Unlock()
 
 	return profile, nil
+}
+
+// catalogProfileFor resolves the static-catalog profile for a parsed model
+// name, applying the same fallback ladder buildProfile uses: exact
+// family+param, family+tag, family-only, then runtime-reported family.
+// Returns nil when the catalog knows nothing about the model.
+func (r *ModelRegistry) catalogProfileFor(parsed ParsedModel, runtimeInfo *ModelInfo) *ModelProfile {
+	staticProfile := r.catalog.lookup(parsed.NormalizedFamily(), parsed.ParamSize)
+	if staticProfile == nil && parsed.ParamSize == "" && parsed.Tag != "" {
+		// Some catalog-only variants are keyed by tag (for example ":latest")
+		// rather than by parsed parameter size.
+		staticProfile = r.catalog.lookup(parsed.NormalizedFamily(), parsed.Tag)
+	}
+	if staticProfile == nil {
+		// Try family-only lookup for family-level metadata (FIM, think mode).
+		staticProfile = r.catalog.lookupFamily(parsed.NormalizedFamily())
+	}
+	if staticProfile == nil && runtimeInfo != nil && runtimeInfo.Family != "" {
+		// Fall back to runtime-reported family.
+		staticProfile = r.catalog.lookupFamily(strings.ToLower(runtimeInfo.Family))
+	}
+	return staticProfile
+}
+
+// ToolCallExplanation is diagnostic provenance for one model's tool_call
+// capability, consumed by `golem models`. Deliberately narrow -- not a general
+// provenance API.
+type ToolCallExplanation struct {
+	Caps     Capability
+	Has      bool
+	Source   string                    // "explicit" | "catalog" | "runtime" | "probe" | "unknown"
+	State    fingerprint.CapProbeState // cached probe state, "" if none
+	TestedAt time.Time                 // zero when no probe row
+}
+
+// ExplainToolCall reports where a model's tool_call bit comes from (or why it
+// is absent). READ-ONLY: it consults the explicit override, the merged profile
+// (a cache read; Lookup never probes), the static catalog, and the cap-probe
+// cache -- it never triggers an active probe. Precedence mirrors
+// ResolveToolCall / merge():
+//  1. explicit override => "explicit" (present or absent per the declared set).
+//  2. merged profile carries CapToolCall => catalog / probe / runtime,
+//     distinguished by re-running the pure catalog lookup and the cached row.
+//  3. profile lacks tool_call but a probe row (any state) exists => "probe".
+//  4. otherwise => "unknown".
+//
+// State + TestedAt are populated from the cap-probe row whenever one exists,
+// regardless of the chosen Source, so operators see the last verdict and when.
+func (r *ModelRegistry) ExplainToolCall(ctx context.Context, key ModelKey) (ToolCallExplanation, error) {
+	// 1. Explicit override is authoritative in both directions.
+	r.mu.RLock()
+	override := r.capOverride
+	r.mu.RUnlock()
+	if override != nil {
+		if tokens := override(key); len(tokens) > 0 {
+			if caps, err := ParseCapsStrict(tokens); err == nil && caps != 0 {
+				return ToolCallExplanation{
+					Caps:   caps,
+					Has:    caps.Has(CapToolCall),
+					Source: "explicit",
+				}, nil
+			}
+		}
+	}
+
+	profile, err := r.Lookup(ctx, key)
+	if err != nil {
+		return ToolCallExplanation{}, err
+	}
+
+	// Read the cap-probe row (any state) once so State/TestedAt are always
+	// populated when a row exists. Uses the write-side digest convention.
+	row := r.capProbeRow(ctx, key)
+
+	exp := ToolCallExplanation{Caps: profile.Caps, Has: profile.Caps.Has(CapToolCall)}
+	if row != nil {
+		exp.State = row.State
+		exp.TestedAt = row.TestedAt
+	}
+
+	if profile.Caps.Has(CapToolCall) {
+		// Distinguish catalog vs probe vs runtime for a present bit. The catalog
+		// lookup is a pure in-memory read (no probe); if the catalog profile
+		// carries tool_call, that is the source.
+		// This queryRuntime is deliberate: Lookup above ran its own internal
+		// queryRuntime but does not expose the digest, and the probe-row Valid
+		// check below needs it (via capProbeDigest). It is a metadata read, not
+		// a tool-call probe -- the READ-ONLY contract holds.
+		runtimeInfo, _ := r.queryRuntime(ctx, key)
+		parsed := ParseModelName(key.Model)
+		if static := r.catalogProfileFor(parsed, runtimeInfo); static != nil && static.Caps.Has(CapToolCall) {
+			exp.Source = "catalog"
+			return exp, nil
+		}
+		// "probe" only when the row is the one the merge layer would actually
+		// honor: a VALID "yes" (same digest + probe version, unexpired). A stale
+		// yes row cannot be the source of a live bit -- that came from floor /
+		// fingerprint / runtime -- so gate on Valid() exactly like capProbeCaps,
+		// using the identical digest fallback (runtimeInfo.Digest -> key.String()).
+		if row != nil && row.State == fingerprint.CapProbeYes && row.Valid(capProbeDigest(key, runtimeInfo), time.Now()) {
+			exp.Source = "probe"
+			return exp, nil
+		}
+		// Floor/fingerprint/runtime-supplied bit: registry/provider-layer
+		// knowledge, labeled "runtime" for operator diagnostics.
+		exp.Source = "runtime"
+		return exp, nil
+	}
+
+	// Bit absent: a probe row (no/inconclusive) is still a "probe" source so
+	// operators can see the verdict that blocked it.
+	if row != nil {
+		exp.Source = "probe"
+		return exp, nil
+	}
+	exp.Source = "unknown"
+	return exp, nil
+}
+
+// capProbeDigest returns the digest a cap-probe row is keyed by: the runtime
+// content digest, or key.String() when the runtime is digestless (the
+// openai-compat case). Write side (resolveToolCallSlow) and read sides
+// (capProbeCaps, ExplainToolCall) MUST agree byte-for-byte, so the convention
+// lives in one place.
+func capProbeDigest(key ModelKey, runtimeInfo *ModelInfo) string {
+	if runtimeInfo != nil && runtimeInfo.Digest != "" {
+		return runtimeInfo.Digest
+	}
+	return key.String()
+}
+
+// capProbeRow reads the persisted tool-call probe row for a key (any state),
+// or nil when the store is absent or has no row. Uses the same digest-agnostic
+// read the merge layer uses: the row is returned even when stale so callers can
+// surface State/TestedAt; validity is the caller's concern. Pure cache read.
+func (r *ModelRegistry) capProbeRow(ctx context.Context, key ModelKey) *fingerprint.CapProbe {
+	if r.capProbeStore == nil {
+		return nil
+	}
+	row, err := r.capProbeStore.GetCapProbe(ctx, key.Provider, key.Model, capabilityToolCall)
+	if err != nil || row == nil {
+		return nil
+	}
+	return row
 }
 
 func (r *ModelRegistry) fingerprintProfile(ctx context.Context, key ModelKey, runtimeInfo *ModelInfo) *fingerprint.Profile {
@@ -762,13 +887,7 @@ func (r *ModelRegistry) capProbeCaps(ctx context.Context, key ModelKey, runtimeI
 	if r.capProbeStore == nil {
 		return 0
 	}
-	digest := ""
-	if runtimeInfo != nil {
-		digest = runtimeInfo.Digest
-	}
-	if digest == "" {
-		digest = key.String()
-	}
+	digest := capProbeDigest(key, runtimeInfo)
 	row, err := r.capProbeStore.GetCapProbe(ctx, key.Provider, key.Model, capabilityToolCall)
 	if err != nil {
 		if errors.Is(err, fingerprint.ErrNotFound) {

--- a/provider/model_registry.go
+++ b/provider/model_registry.go
@@ -3,6 +3,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -11,8 +12,14 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/singleflight"
+
 	"github.com/kstruzzieri/go-llm/fingerprint"
 )
+
+// capabilityToolCall is the canonical capability token persisted in
+// capability_probes rows and resolved by ResolveToolCall.
+const capabilityToolCall = "tool_call"
 
 // ProviderResolver provides the subset of Registry methods needed by
 // ModelRegistry to query providers and resolve model keys. This interface
@@ -46,6 +53,13 @@ type ModelRegistry struct {
 	capFloor        CapabilityFloor
 	overrideVersion uint64 // bumped by SetCapabilityOverride AND SetCapabilityFloor; guards stale cache writes in buildProfile
 	rejectionHook   OverrideRejectionHook
+
+	// Capability-probe resolution (ResolveToolCall). Both fields are set
+	// only at construction via options and never mutated afterward, so
+	// they are read without holding mu.
+	capProbeStore   fingerprint.CapProbeStore
+	capProber       FingerprintProberFactory
+	capResolveGroup singleflight.Group
 }
 
 // FingerprintProberSpec contains the model prober and digest identity the
@@ -68,6 +82,27 @@ type ModelRegistryOption func(*ModelRegistry)
 func WithFingerprintProberFactory(fn FingerprintProberFactory) ModelRegistryOption {
 	return func(r *ModelRegistry) {
 		r.fpProberFactory = fn
+	}
+}
+
+// WithCapabilityProbeStore installs the narrow cache used by ResolveToolCall
+// and the read-only cap-probe merge layer. It is intentionally separate from
+// the full fingerprint Store so Golem can persist capability verdicts without
+// enabling full latency/embedding/chat profiling.
+func WithCapabilityProbeStore(store fingerprint.CapProbeStore) ModelRegistryOption {
+	return func(r *ModelRegistry) {
+		r.capProbeStore = store
+	}
+}
+
+// WithCapabilityProber installs provider-aware prober selection used ONLY
+// for on-demand capability resolution (ResolveToolCall). Unlike
+// WithFingerprintProberFactory it never triggers full profiling from
+// Lookup: Lookup/Recommend stay pure, and active probes run only at the
+// named call sites (golem preflight, router candidate resolution).
+func WithCapabilityProber(fn FingerprintProberFactory) ModelRegistryOption {
+	return func(r *ModelRegistry) {
+		r.capProber = fn
 	}
 }
 
@@ -250,6 +285,208 @@ func (r *ModelRegistry) Refresh(ctx context.Context, key ModelKey) (*ModelProfil
 	r.mu.Unlock()
 
 	return r.buildProfile(ctx, key)
+}
+
+// ResolveToolCall resolves the tri-state tool-call capability for a model
+// key on demand. Precedence:
+//  1. Explicit capability override -- authoritative in both directions
+//     (declared set contains tool_call => yes, otherwise no), no probe.
+//  2. Merged profile already carries CapToolCall (catalog/floor/runtime/
+//     cached probe row) => yes, no probe.
+//  3. Resolution disabled (no prober or no store) => "" (unknown) -- the
+//     empty state is never a claim.
+//  4. Active probe, singleflight-deduplicated per key: valid cached row
+//     wins, otherwise probe, persist the verdict, and invalidate the
+//     cached profile so the next Lookup re-merges.
+//
+// A non-nil error means the probe was transient (network/auth); nothing
+// is persisted and the state is "".
+func (r *ModelRegistry) ResolveToolCall(ctx context.Context, key ModelKey) (fingerprint.CapProbeState, error) {
+	// 1. Explicit declaration is authoritative both directions. A rejected
+	// override (non-canonical tokens / zero caps) is a no-op here exactly
+	// as it is in merge(): fall through rather than fabricate a verdict.
+	r.mu.RLock()
+	override := r.capOverride
+	r.mu.RUnlock()
+	if override != nil {
+		if tokens := override(key); len(tokens) > 0 {
+			if caps, err := ParseCapsStrict(tokens); err == nil && caps != 0 {
+				if caps.Has(CapToolCall) {
+					return fingerprint.CapProbeYes, nil
+				}
+				return fingerprint.CapProbeNo, nil
+			}
+		}
+	}
+
+	// 2. Merged profile short-circuit (cache READ only; Lookup never probes).
+	profile, err := r.Lookup(ctx, key)
+	if err != nil {
+		return "", err
+	}
+	if profile.Caps.Has(CapToolCall) {
+		return fingerprint.CapProbeYes, nil
+	}
+
+	// 3. Resolution disabled: unknown is never a claim.
+	if r.capProber == nil || r.capProbeStore == nil {
+		return "", nil
+	}
+
+	// 4. Deduplicated slow path. The singleflight fn holds no registry
+	// locks; invalidateProfile takes mu only briefly after probe IO.
+	// Flight key uses an explicit NUL separator (not key.String(), whose
+	// "provider/model" join could collide across keys containing slashes).
+	// Follower semantics: the leader's ctx governs the probe; followers
+	// block until the shared flight completes and receive its result even
+	// if their own ctx was canceled meanwhile.
+	flightKey := key.Provider + "\x00" + key.Model
+	v, err, _ := r.capResolveGroup.Do(flightKey, func() (interface{}, error) {
+		return r.resolveToolCallSlow(ctx, key)
+	})
+	if err != nil {
+		return "", err
+	}
+	return v.(fingerprint.CapProbeState), nil
+}
+
+// resolveToolCallSlow is the probe path behind ResolveToolCall's
+// singleflight: cache check, active probe, persistence, and profile-cache
+// invalidation. Must not be called while holding r.mu.
+func (r *ModelRegistry) resolveToolCallSlow(ctx context.Context, key ModelKey) (fingerprint.CapProbeState, error) {
+	p, err := r.providers.Resolve(key)
+	if err != nil {
+		return "", err
+	}
+	runtimeInfo, err := r.queryRuntime(ctx, key)
+	if err != nil {
+		return "", err
+	}
+	spec, err := r.capProber(ctx, key, runtimeInfo, p)
+	if err != nil {
+		return "", err
+	}
+	if spec == nil || spec.Prober == nil {
+		return "", nil
+	}
+	prober, ok := spec.Prober.(fingerprint.ToolCallProber)
+	if !ok {
+		return "", nil
+	}
+
+	// Cap-probe rows deliberately IGNORE spec.ModelDigest: the real factory
+	// (providerbootstrap's fingerprintDigestForModel) synthesizes
+	// "config-caps:<caps>" digests when the runtime digest is empty --
+	// exactly the openai-compat case -- and the read side (capProbeCaps:
+	// runtimeInfo.Digest fallback key.String()) can never reproduce that
+	// value. Rows keyed by it would never merge into profiles, and
+	// synthetic-digest negatives would dodge the digestless TTL cap below.
+	// Using runtimeInfo.Digest with the key fallback keeps the write and
+	// read digests byte-symmetric by construction.
+	digest := ""
+	if runtimeInfo != nil {
+		digest = runtimeInfo.Digest
+	}
+	if digest == "" {
+		digest = key.String()
+	}
+	backendID := key.Provider // EnsureProfile's existing backend_id convention
+
+	now := time.Now()
+	if row, gErr := r.capProbeStore.GetCapProbe(ctx, backendID, key.Model, capabilityToolCall); gErr == nil && row != nil && row.Valid(digest, now) {
+		return row.State, nil
+	}
+
+	outcome, err := prober.ProbeToolCall(ctx, key.Model)
+	if err != nil {
+		// Transient/diagnostic: never persisted, never a claim.
+		return "", err
+	}
+
+	row := fingerprint.CapProbe{
+		BackendID:    backendID,
+		ModelName:    key.Model,
+		Capability:   capabilityToolCall,
+		State:        outcome.State,
+		ModelDigest:  digest,
+		ProbeVersion: fingerprint.CurrentToolProbeVersion,
+		TestedAt:     now,
+	}
+	if outcome.TTL > 0 {
+		row.ExpiresAt = now.Add(outcome.TTL)
+	}
+	// Digestless negatives expire: a wedged "no" keyed only by name would
+	// silently block usage until a manual reprobe. A real digest keeps the
+	// prober-chosen TTL (ollama's curated "no" stays unbounded).
+	if outcome.State == fingerprint.CapProbeNo && digest == key.String() {
+		row.ExpiresAt = now.Add(fingerprint.CapProbeDigestlessNoTTL)
+	}
+	// Persistence failure is non-fatal: the verdict stands for this caller.
+	_ = r.capProbeStore.SaveCapProbe(ctx, row)
+
+	if outcome.State == fingerprint.CapProbeYes {
+		r.invalidateProfile(key)
+	}
+	return outcome.State, nil
+}
+
+// invalidateProfile drops one cached profile so the next Lookup re-merges.
+//
+// It also bumps the shared policy version counter: a buildProfile in
+// flight for this key may have read the store BEFORE the probe row was
+// saved; without the bump its cache write would pass the version guard
+// and re-cache the stale no-toolcall profile permanently (ResolveToolCall's
+// row-hit fast path never invalidates, so it would never self-heal).
+// Bumping fences those in-flight writes exactly like
+// SetCapabilityOverride/SetCapabilityFloor do.
+func (r *ModelRegistry) invalidateProfile(key ModelKey) {
+	r.mu.Lock()
+	delete(r.profiles, key)
+	r.overrideVersion++
+	r.mu.Unlock()
+}
+
+// canResolveToolCall reports whether on-demand tool-call resolution is
+// fully wired (prober factory AND probe store).
+func (r *ModelRegistry) canResolveToolCall() bool {
+	return r != nil && r.capProber != nil && r.capProbeStore != nil
+}
+
+// EnsureToolCallResolved resolves tool_call for candidate profiles that
+// lack CapToolCall, returning a slice where probe-yes candidates are
+// replaced by their refreshed profiles. Candidates are NEVER removed --
+// probe-no/inconclusive/error entries are returned unchanged so the
+// caller's RequiredCaps gate stays the single rejection point. The input
+// slice and its profiles are never modified; replacements land in a copy.
+// No-op (input returned as-is) when resolution is disabled or required
+// does not include CapToolCall.
+func (r *ModelRegistry) EnsureToolCallResolved(ctx context.Context, profiles []*ModelProfile, required Capability) []*ModelProfile {
+	if !r.canResolveToolCall() || !required.Has(CapToolCall) {
+		return profiles
+	}
+	out := make([]*ModelProfile, len(profiles))
+	copy(out, profiles)
+	for i, p := range out {
+		if p == nil || p.Caps.Has(CapToolCall) {
+			continue
+		}
+		state, err := r.ResolveToolCall(ctx, p.Key)
+		if err != nil || state != fingerprint.CapProbeYes {
+			continue
+		}
+		if refreshed, lErr := r.Lookup(ctx, p.Key); lErr == nil && refreshed.Caps.Has(CapToolCall) {
+			out[i] = refreshed
+			continue
+		}
+		// The probe said yes but the refreshed profile lacks the bit --
+		// e.g. SaveCapProbe failed (swallowed as non-fatal) so the merge
+		// layer had no row to read. A lost store write must not erase the
+		// verdict for this caller: patch a copy, never the caller's input.
+		cp := *p
+		cp.Caps |= CapToolCall
+		out[i] = &cp
+	}
+	return out
 }
 
 // LookupAny returns merged profiles for an unqualified model name across
@@ -457,9 +694,15 @@ func (r *ModelRegistry) buildProfile(ctx context.Context, key ModelKey) (*ModelP
 	// Layer 3: Fingerprint enrichment.
 	fpProfile := r.fingerprintProfile(ctx, key, runtimeInfo)
 
+	// Cap-probe merge layer: READ ONLY -- never probes. A valid cached
+	// "yes" row ORs CapToolCall into the profile. Computed here (not in
+	// merge) so merge stays IO-free and applies exactly the bits this
+	// buildProfile snapshot observed.
+	capProbeCaps := r.capProbeCaps(ctx, key, runtimeInfo)
+
 	// Merge layers using the (override, floor, rejectionHook) snapshot
 	// taken at function entry.
-	profile := r.merge(key, runtimeInfo, staticProfile, fpProfile, parsed, override, floor, rejectionHook)
+	profile := r.merge(key, runtimeInfo, staticProfile, fpProfile, parsed, override, floor, rejectionHook, capProbeCaps)
 
 	// Cache the result iff the override snapshot is still current.
 	r.mu.Lock()
@@ -498,6 +741,38 @@ func (r *ModelRegistry) fingerprintProfile(ctx context.Context, key ModelKey, ru
 	fpProfile, _ := r.fpStore.Get(ctx, key.Provider, key.Model)
 	// Ignore errors -- fingerprint is optional enrichment.
 	return fpProfile
+}
+
+// capProbeCaps reads the persisted tool-call probe verdict for a key and
+// returns the capability bits it contributes to the merge (CapToolCall for
+// a valid "yes" row, zero otherwise). Pure cache read; never probes.
+func (r *ModelRegistry) capProbeCaps(ctx context.Context, key ModelKey, runtimeInfo *ModelInfo) Capability {
+	if r.capProbeStore == nil {
+		return 0
+	}
+	digest := ""
+	if runtimeInfo != nil {
+		digest = runtimeInfo.Digest
+	}
+	if digest == "" {
+		digest = key.String()
+	}
+	row, err := r.capProbeStore.GetCapProbe(ctx, key.Provider, key.Model, capabilityToolCall)
+	if err != nil {
+		if errors.Is(err, fingerprint.ErrNotFound) {
+			return 0 // expected miss: never probed
+		}
+		// Real store error (corruption, IO): fail closed to "no bits" --
+		// enrichment is optional and must never block a profile build.
+		return 0
+	}
+	if row == nil {
+		return 0
+	}
+	if row.State == fingerprint.CapProbeYes && row.Valid(digest, time.Now()) {
+		return CapToolCall
+	}
+	return 0
 }
 
 // queryRuntime asks the provider for model information by resolving the
@@ -547,6 +822,7 @@ func (r *ModelRegistry) merge(
 	override CapabilityOverride,
 	floor CapabilityFloor,
 	rejectionHook OverrideRejectionHook,
+	capProbeCaps Capability,
 ) *ModelProfile {
 	profile := &ModelProfile{
 		Key:       key,
@@ -607,6 +883,10 @@ func (r *ModelRegistry) merge(
 			}
 		}
 	}
+
+	// Cap-probe verdict (read-only layer, computed by buildProfile). OR-only
+	// like the floor; the REPLACE override below still wins both directions.
+	profile.Caps |= capProbeCaps
 
 	// Apply runtime data (highest precedence).
 	if runtime != nil {

--- a/provider/model_registry.go
+++ b/provider/model_registry.go
@@ -460,10 +460,18 @@ func (r *ModelRegistry) canResolveToolCall() bool {
 // slice and its profiles are never modified; replacements land in a copy.
 // No-op (input returned as-is) when resolution is disabled or required
 // does not include CapToolCall.
-func (r *ModelRegistry) EnsureToolCallResolved(ctx context.Context, profiles []*ModelProfile, required Capability) []*ModelProfile {
+//
+// The returned errors are per-candidate probe diagnostics labeled with
+// the model key (transient failures: network, auth, ...). They are
+// diagnostics ONLY -- never a rejection signal; the affected candidates
+// stay in the returned slice unchanged -- so operators can distinguish
+// "probe failed (e.g. 401)" from "genuinely not tool-capable" when a
+// route comes up empty. Callers thread them into the route-failure error.
+func (r *ModelRegistry) EnsureToolCallResolved(ctx context.Context, profiles []*ModelProfile, required Capability) ([]*ModelProfile, []error) {
 	if !r.canResolveToolCall() || !required.Has(CapToolCall) {
-		return profiles
+		return profiles, nil
 	}
+	var diags []error
 	out := make([]*ModelProfile, len(profiles))
 	copy(out, profiles)
 	for i, p := range out {
@@ -471,7 +479,11 @@ func (r *ModelRegistry) EnsureToolCallResolved(ctx context.Context, profiles []*
 			continue
 		}
 		state, err := r.ResolveToolCall(ctx, p.Key)
-		if err != nil || state != fingerprint.CapProbeYes {
+		if err != nil {
+			diags = append(diags, fmt.Errorf("resolve tool_call %s: %w", p.Key, err))
+			continue
+		}
+		if state != fingerprint.CapProbeYes {
 			continue
 		}
 		if refreshed, lErr := r.Lookup(ctx, p.Key); lErr == nil && refreshed.Caps.Has(CapToolCall) {
@@ -486,7 +498,7 @@ func (r *ModelRegistry) EnsureToolCallResolved(ctx context.Context, profiles []*
 		cp.Caps |= CapToolCall
 		out[i] = &cp
 	}
-	return out
+	return out, diags
 }
 
 // LookupAny returns merged profiles for an unqualified model name across

--- a/provider/model_registry_test.go
+++ b/provider/model_registry_test.go
@@ -2112,3 +2112,123 @@ func TestRecommend_RestrictToProvider(t *testing.T) {
 		t.Fatal("Recommend (nonexistent) returned nil error, want provider resolution error")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// SetCapabilityFloor
+// ---------------------------------------------------------------------------
+
+// newTestRegistryWithModel builds a ModelRegistry over a single mock provider
+// advertising one model with no runtime capability metadata — the
+// openai-compat shape the capability floor exists for.
+func newTestRegistryWithModel(t *testing.T, providerName, model string) *ModelRegistry {
+	t.Helper()
+	prov := &mrMockProvider{
+		name:   providerName,
+		models: []ModelInfo{{Name: model}},
+	}
+	reg := &mrMockProviderRegistry{providers: map[string]Provider{providerName: prov}}
+	mr, err := NewModelRegistry(reg, newMrMockFingerprintStore())
+	if err != nil {
+		t.Fatalf("NewModelRegistry: %v", err)
+	}
+	return mr
+}
+
+// TestSetCapabilityFloor_ORsBelowCatalogAndOverride verifies the floor
+// OR-merges with the static catalog instead of replacing it: a catalog
+// family hit carrying tool_call must survive a floor that omits it.
+func TestSetCapabilityFloor_ORsBelowCatalogAndOverride(t *testing.T) {
+	// "qwen3:8b" hits the catalog family entry whose caps include "tools".
+	reg := newTestRegistryWithModel(t, "llamacpp", "qwen3:8b")
+	reg.SetCapabilityFloor(func(key ModelKey) []string {
+		return []string{"chat", "generate", "stream"}
+	})
+	p, err := reg.Lookup(context.Background(), ModelKey{Provider: "llamacpp", Model: "qwen3:8b"})
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	want := CapChat | CapGenerate | CapStream | CapToolCall
+	if !p.Caps.Has(want) {
+		t.Fatalf("caps = %v, want superset of %v", p.Caps, want)
+	}
+}
+
+// TestSetCapabilityFloor_ExplicitOverrideStillReplaces verifies the explicit
+// override keeps its wholesale-REPLACE semantics above the floor: floor and
+// catalog both contribute tool_call, but an override without it wins.
+func TestSetCapabilityFloor_ExplicitOverrideStillReplaces(t *testing.T) {
+	reg := newTestRegistryWithModel(t, "llamacpp", "qwen3:8b")
+	reg.SetCapabilityFloor(func(ModelKey) []string { return []string{"chat", "generate", "stream"} })
+	reg.SetCapabilityOverride(func(ModelKey) []string { return []string{"chat", "stream"} })
+	p, err := reg.Lookup(context.Background(), ModelKey{Provider: "llamacpp", Model: "qwen3:8b"})
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if p.Caps != (CapChat | CapStream) {
+		t.Fatalf("caps = %v, want exactly chat|stream", p.Caps)
+	}
+}
+
+// TestSetCapabilityFloor_InvalidTokensDroppedWithHook verifies non-canonical
+// floor tokens are rejected wholesale (never partially applied) and that the
+// rejection hook fires so the misconfiguration is observable.
+func TestSetCapabilityFloor_InvalidTokensDroppedWithHook(t *testing.T) {
+	reg := newTestRegistryWithModel(t, "llamacpp", "unknown-model")
+	var hookKey ModelKey
+	reg.SetOverrideRejectionHook(func(key ModelKey, tokens []string, err error) { hookKey = key })
+	reg.SetCapabilityFloor(func(ModelKey) []string { return []string{"completion"} }) // multi-bit alias => strict-reject
+	p, err := reg.Lookup(context.Background(), ModelKey{Provider: "llamacpp", Model: "unknown-model"})
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	// "completion" would lenient-expand to chat|generate|stream; none of
+	// those bits may leak through a rejected floor.
+	if p.Caps.Has(CapChat) || p.Caps.Has(CapGenerate) || p.Caps.Has(CapStream) {
+		t.Fatalf("rejected floor partially applied: caps = %v", p.Caps)
+	}
+	if hookKey.Model != "unknown-model" {
+		t.Fatalf("rejection hook not fired for floor tokens")
+	}
+}
+
+// TestSetCapabilityFloor_InvalidatesCache verifies installing a floor
+// flushes the profile cache so already-warm keys pick up the new policy on
+// the next Lookup (same invalidation contract as the override; the TOCTOU
+// version guard is shared machinery covered by the override tests).
+func TestSetCapabilityFloor_InvalidatesCache(t *testing.T) {
+	reg := newTestRegistryWithModel(t, "llamacpp", "unknown-model")
+	if _, err := reg.Lookup(context.Background(), ModelKey{Provider: "llamacpp", Model: "unknown-model"}); err != nil {
+		t.Fatalf("warm lookup: %v", err)
+	}
+	reg.SetCapabilityFloor(func(ModelKey) []string { return []string{"chat", "stream"} })
+	p, err := reg.Lookup(context.Background(), ModelKey{Provider: "llamacpp", Model: "unknown-model"})
+	if err != nil {
+		t.Fatalf("lookup after floor: %v", err)
+	}
+	if !p.Caps.Has(CapChat | CapStream) {
+		t.Fatalf("floor not applied after cache flush: %v", p.Caps)
+	}
+}
+
+// TestSetCapabilityFloor_NilClearsFloor verifies SetCapabilityFloor(nil)
+// removes the floor: a catalog-miss model that only had floor-supplied bits
+// loses them on the next Lookup.
+func TestSetCapabilityFloor_NilClearsFloor(t *testing.T) {
+	reg := newTestRegistryWithModel(t, "llamacpp", "unknown-model")
+	reg.SetCapabilityFloor(func(ModelKey) []string { return []string{"chat", "stream"} })
+	p, err := reg.Lookup(context.Background(), ModelKey{Provider: "llamacpp", Model: "unknown-model"})
+	if err != nil {
+		t.Fatalf("lookup with floor: %v", err)
+	}
+	if !p.Caps.Has(CapChat | CapStream) {
+		t.Fatalf("floor not applied: %v", p.Caps)
+	}
+	reg.SetCapabilityFloor(nil)
+	p, err = reg.Lookup(context.Background(), ModelKey{Provider: "llamacpp", Model: "unknown-model"})
+	if err != nil {
+		t.Fatalf("lookup after clearing floor: %v", err)
+	}
+	if p.Caps.Has(CapChat) || p.Caps.Has(CapStream) {
+		t.Fatalf("floor bits survived SetCapabilityFloor(nil): %v", p.Caps)
+	}
+}

--- a/provider/openaicompat/openaicompat.go
+++ b/provider/openaicompat/openaicompat.go
@@ -691,10 +691,11 @@ func toChatRequest(req provider.ChatRequest, stream bool) chatRequest {
 		}
 	}
 	r := chatRequest{
-		Model:    req.Model,
-		Messages: msgs,
-		Stream:   stream,
-		Tools:    toWireTools(req.Tools),
+		Model:      req.Model,
+		Messages:   msgs,
+		Stream:     stream,
+		Tools:      toWireTools(req.Tools),
+		ToolChoice: req.ToolChoice,
 	}
 	if stream {
 		r.StreamOptions = &chatStreamOptions{IncludeUsage: true}

--- a/provider/openaicompat/openaicompat_test.go
+++ b/provider/openaicompat/openaicompat_test.go
@@ -623,6 +623,53 @@ func TestProvider_Chat_RequestBodyShape(t *testing.T) {
 	}
 }
 
+// TestProvider_Chat_RequestBody_ToolChoice verifies that
+// ChatRequest.ToolChoice serializes as tool_choice and that the zero value
+// omits the field entirely (some servers reject an empty tool_choice).
+func TestProvider_Chat_RequestBody_ToolChoice(t *testing.T) {
+	var rawBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		rawBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(chatResponse{
+			Choices: []chatChoice{{Message: chatMessage{Content: "ok"}}},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewProvider(NewClient(srv.URL))
+
+	if _, err := p.Chat(context.Background(), provider.ChatRequest{
+		Model:      "m",
+		Messages:   []provider.ChatMessage{{Role: "user", Content: "hi"}},
+		ToolChoice: "required",
+	}); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	var withChoice struct {
+		ToolChoice string `json:"tool_choice"`
+	}
+	if err := json.Unmarshal(rawBody, &withChoice); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if withChoice.ToolChoice != "required" {
+		t.Errorf("tool_choice = %q, want %q (body=%s)", withChoice.ToolChoice, "required", rawBody)
+	}
+
+	if _, err := p.Chat(context.Background(), provider.ChatRequest{
+		Model:    "m",
+		Messages: []provider.ChatMessage{{Role: "user", Content: "hi"}},
+	}); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if strings.Contains(string(rawBody), "tool_choice") {
+		t.Errorf("zero-value ToolChoice must omit tool_choice field, body was: %s", rawBody)
+	}
+}
+
 // TestProvider_Chat_RequestBody_OmitsToolCallIndex verifies that the
 // outbound wire does NOT carry an `index` field on tool_calls entries.
 // OpenAI treats index as response-only — strict server-side schema

--- a/provider/openaicompat/types.go
+++ b/provider/openaicompat/types.go
@@ -18,6 +18,7 @@ type chatRequest struct {
 	MaxTokens     int                `json:"max_tokens,omitempty"`
 	Stop          []string           `json:"stop,omitempty"`
 	Tools         []chatTool         `json:"tools,omitempty"`
+	ToolChoice    string             `json:"tool_choice,omitempty"`
 }
 
 type chatStreamOptions struct {

--- a/provider/router.go
+++ b/provider/router.go
@@ -15,6 +15,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -335,13 +336,15 @@ func (r *Router) Route(ctx context.Context, req RoutingRequest) (*RoutePlan, err
 	// is a valid explicit choice, so we do not override it with a default.
 	// Convenience methods set appropriate priorities (e.g., FIM -> PriorityHigh).
 
-	// 2. Resolve candidates.
-	candidates, err := r.resolveCandidates(ctx, req)
+	// 2. Resolve candidates. probeDiags are non-fatal per-candidate probe
+	//    failures (e.g. 401 from the backend) — surfaced only if the route
+	//    ultimately fails, mirroring how chain routing joins lookupErrs.
+	candidates, probeDiags, err := r.resolveCandidates(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 	if len(candidates) == 0 {
-		return nil, ErrNoViableCandidate
+		return nil, joinNoViableCandidate(probeDiags)
 	}
 
 	// 3. Hard gates + budget + score all candidates.
@@ -387,7 +390,7 @@ func (r *Router) Route(ctx context.Context, req RoutingRequest) (*RoutePlan, err
 			winner := truncatable[0]
 			plan, buildErr := r.buildPlan(winner, nil, req, false, snap)
 			if buildErr != nil {
-				return nil, ErrNoViableCandidate
+				return nil, joinNoViableCandidate(probeDiags)
 			}
 			plan.Degraded = true
 			return plan, ErrBudgetAdaptationRequired
@@ -398,7 +401,7 @@ func (r *Router) Route(ctx context.Context, req RoutingRequest) (*RoutePlan, err
 		if allBudgeted {
 			return nil, ErrBudgetExceeded
 		}
-		return nil, ErrNoViableCandidate
+		return nil, joinNoViableCandidate(probeDiags)
 	}
 
 	// 5. Sort scored candidates.
@@ -674,33 +677,95 @@ func parseModelSelector(selector string) (ModelKey, bool) {
 // in Router.Route before this is called; by the time we reach the qualified
 // branch here, either req.Provider is empty or it agrees with the qualified
 // prefix, so we do not need to re-read req.Provider in that branch.
-func (r *Router) resolveCandidates(ctx context.Context, req RoutingRequest) ([]*ModelProfile, error) {
+//
+// The second return value carries non-fatal per-candidate probe
+// diagnostics from EnsureToolCallResolved (candidates always stay);
+// Route() joins them into ErrNoViableCandidate when the route fails.
+func (r *Router) resolveCandidates(ctx context.Context, req RoutingRequest) ([]*ModelProfile, []error, error) {
 	if req.Model == "" {
-		return r.registry.Recommend(ctx, RecommendOpts{
-			RequiredCaps:       req.RequiredCaps,
+		return r.recommendWithToolCallResolution(ctx, RecommendOpts{
 			AvailableRAM:       r.availableRAM,
 			PreferWarm:         req.PreferWarm,
 			RestrictToProvider: req.Provider, // empty == unrestricted
-		})
+		}, req.RequiredCaps)
 	}
 
 	if key, ok := parseModelSelector(req.Model); ok {
 		profile, err := r.registry.Lookup(ctx, key)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return []*ModelProfile{profile}, nil
+		resolved, diags := r.registry.EnsureToolCallResolved(ctx, []*ModelProfile{profile}, req.RequiredCaps)
+		return resolved, diags, nil
 	}
 
 	if req.Provider != "" {
 		key := ModelKey{Provider: req.Provider, Model: req.Model}
 		profile, err := r.registry.Lookup(ctx, key)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return []*ModelProfile{profile}, nil
+		resolved, diags := r.registry.EnsureToolCallResolved(ctx, []*ModelProfile{profile}, req.RequiredCaps)
+		return resolved, diags, nil
 	}
-	return r.registry.LookupAny(ctx, req.Model)
+	profiles, err := r.registry.LookupAny(ctx, req.Model)
+	if err != nil {
+		return nil, nil, err
+	}
+	resolved, diags := r.registry.EnsureToolCallResolved(ctx, profiles, req.RequiredCaps)
+	return resolved, diags, nil
+}
+
+// joinNoViableCandidate wraps ErrNoViableCandidate with probe diagnostics
+// so a route that failed because a probe errored (e.g. 401) is
+// distinguishable from one whose candidates are genuinely not capable.
+// Mirrors classifyChainExhaustion's lookupErrs join.
+func joinNoViableCandidate(diags []error) error {
+	if len(diags) == 0 {
+		return ErrNoViableCandidate
+	}
+	return fmt.Errorf("%w: %s", ErrNoViableCandidate, errors.Join(diags...))
+}
+
+// recommendWithToolCallResolution runs ModelRegistry.Recommend for the
+// given required caps, lazily resolving tool_call when possible. Recommend
+// filters by caps BEFORE the router sees candidates, which would silently
+// drop probe-resolvable models — so when resolution is wired and tool_call
+// is required, Recommend runs WITHOUT the tool_call bit, the router
+// resolves it via EnsureToolCallResolved (probe I/O — callers must invoke
+// this before any feedback-snapshot reads), and then re-applies the
+// tool_call filter itself. That re-filter is the router-applied capability
+// gate for the Recommend path; EnsureToolCallResolved itself never drops
+// candidates. When resolution is disabled or tool_call is not required,
+// behavior is byte-identical to a plain Recommend call. Shared by
+// resolveCandidates and recommendTailProfiles so the dance exists once.
+// Probe diagnostics (second return) are non-fatal; callers surface them
+// only when the route fails.
+//
+// Worst case on cache miss: N unknown models x up to ~30s active probe,
+// resolved sequentially inside EnsureToolCallResolved. Persisted verdicts
+// amortize this to zero on later routes, and the bounded-eager preflight
+// (Task 9) keeps this path rare. Transient-error models re-probe on every
+// route with no backoff — deliberate; add a backoff seam here if it bites.
+func (r *Router) recommendWithToolCallResolution(ctx context.Context, opts RecommendOpts, reqCaps Capability) ([]*ModelProfile, []error, error) {
+	if !r.registry.canResolveToolCall() || !reqCaps.Has(CapToolCall) {
+		opts.RequiredCaps = reqCaps
+		profiles, err := r.registry.Recommend(ctx, opts)
+		return profiles, nil, err
+	}
+	opts.RequiredCaps = reqCaps &^ CapToolCall
+	candidates, err := r.registry.Recommend(ctx, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	candidates, diags := r.registry.EnsureToolCallResolved(ctx, candidates, reqCaps)
+	filtered := make([]*ModelProfile, 0, len(candidates))
+	for _, p := range candidates {
+		if p.Caps.Has(CapToolCall) {
+			filtered = append(filtered, p)
+		}
+	}
+	return filtered, diags, nil
 }
 
 // scoreAll evaluates all candidates against the routing request, applying

--- a/provider/router_capresolve_test.go
+++ b/provider/router_capresolve_test.go
@@ -1,0 +1,389 @@
+// provider/router_capresolve_test.go
+//
+// Task 7 (#219): route-time lazy tool_call resolution. Verifies that the
+// Router probes unknown candidates via EnsureToolCallResolved in the chain
+// path, the Recommend (empty-Model) path, and the recommend tail — with
+// probe I/O strictly BEFORE feedback-snapshot reads, and the capability
+// gate remaining the single rejection point.
+//
+// The disabled-resolver path (no prober/store wired) is covered by the
+// pre-existing router suite, which runs entirely without cap resolution.
+package provider
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kstruzzieri/go-llm/fingerprint"
+)
+
+// ---------------------------------------------------------------------------
+// Ordering fakes
+// ---------------------------------------------------------------------------
+
+// rcOrderLog records probe/feedback events so tests can assert that probe
+// I/O happens before feedback-snapshot reads.
+type rcOrderLog struct {
+	mu     sync.Mutex
+	events []string
+}
+
+func (l *rcOrderLog) add(e string) {
+	l.mu.Lock()
+	l.events = append(l.events, e)
+	l.mu.Unlock()
+}
+
+func (l *rcOrderLog) list() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]string, len(l.events))
+	copy(out, l.events)
+	return out
+}
+
+// rcLoggingProber wraps fakeToolCallProber and records each probe.
+type rcLoggingProber struct {
+	*fakeToolCallProber
+	log *rcOrderLog
+}
+
+func (p *rcLoggingProber) ProbeToolCall(ctx context.Context, model string) (fingerprint.CapProbeOutcome, error) {
+	p.log.add("probe:" + model)
+	return p.fakeToolCallProber.ProbeToolCall(ctx, model)
+}
+
+// rcLoggingFeedbackStore is a RoutingFeedbackStore that records reads.
+type rcLoggingFeedbackStore struct {
+	log *rcOrderLog
+}
+
+func (s *rcLoggingFeedbackStore) Get(_ context.Context, key FeedbackKey) (Aggregate, error) {
+	s.log.add("feedback:" + key.Model)
+	return Aggregate{}, nil
+}
+
+func (s *rcLoggingFeedbackStore) Record(context.Context, FeedbackKey, FeedbackSignal) error {
+	return nil
+}
+
+func (s *rcLoggingFeedbackStore) RecordBatch(context.Context, []FeedbackItem) error {
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+// newCapRouteRouter builds a Router over a single "llamacpp" mock provider
+// whose models advertise chat+stream but NOT tool_call, with the cap-probe
+// store and prober wired into the ModelRegistry.
+func newCapRouteRouter(t *testing.T, models []string, store fingerprint.CapProbeStore, prober fingerprint.ModelProber, ropts ...RouterOption) *Router {
+	t.Helper()
+
+	infos := make([]ModelInfo, 0, len(models))
+	for _, m := range models {
+		infos = append(infos, ModelInfo{
+			Name:          m,
+			ContextWindow: 32768,
+			Capabilities:  []string{"chat", "stream"},
+		})
+	}
+	prov := &rtMockProvider{
+		name:   "llamacpp",
+		caps:   CapChat | CapStream,
+		models: infos,
+	}
+	provReg := NewRegistry()
+	if err := provReg.Register(prov); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+	if err := provReg.RefreshModels(context.Background(), "llamacpp"); err != nil {
+		t.Fatalf("RefreshModels failed: %v", err)
+	}
+
+	var mrOpts []ModelRegistryOption
+	if store != nil {
+		mrOpts = append(mrOpts, WithCapabilityProbeStore(store))
+	}
+	if prober != nil {
+		mrOpts = append(mrOpts, WithCapabilityProber(capProberFactory(prober)))
+	}
+	modelReg, err := NewModelRegistry(provReg, nil, mrOpts...)
+	if err != nil {
+		t.Fatalf("NewModelRegistry failed: %v", err)
+	}
+
+	router := NewRouter(modelReg, provReg, ropts...)
+	t.Cleanup(func() { _ = router.Close() })
+	return router
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestRouteChain_UnknownCandidateProbedBeforeGate(t *testing.T) {
+	ctx := context.Background()
+	log := &rcOrderLog{}
+	store := newFakeCapProbeStore()
+	inner := newFakeToolCallProber()
+	inner.outcomes["mystery-byo"] = fingerprint.CapProbeOutcome{State: fingerprint.CapProbeYes}
+	prober := &rcLoggingProber{fakeToolCallProber: inner, log: log}
+
+	router := newCapRouteRouter(t, []string{"mystery-byo"}, store, prober,
+		WithRoutingFeedback(NewRoutingFeedback(&rcLoggingFeedbackStore{log: log})),
+		WithFeedbackScoringMode(FeedbackScoringShadow),
+	)
+
+	plan, err := router.Route(ctx, RoutingRequest{
+		PreferredChain: []string{"llamacpp/mystery-byo"},
+		StrictChain:    true,
+		UseCase:        "chat",
+		RequiredCaps:   CapChat | CapStream | CapToolCall,
+	})
+	if err != nil {
+		t.Fatalf("Route() error: %v (probe-resolvable candidate must not be rejected)", err)
+	}
+	if plan.Profile.Key.Model != "mystery-byo" {
+		t.Fatalf("winner = %q, want mystery-byo", plan.Profile.Key.Model)
+	}
+	if got := inner.callCount("mystery-byo"); got != 1 {
+		t.Fatalf("prober calls = %d, want 1", got)
+	}
+
+	// Design lock: probe I/O happens BEFORE any feedback-snapshot read.
+	events := log.list()
+	probeIdx, feedbackIdx := -1, -1
+	for i, e := range events {
+		if probeIdx == -1 && strings.HasPrefix(e, "probe:") {
+			probeIdx = i
+		}
+		if feedbackIdx == -1 && strings.HasPrefix(e, "feedback:") {
+			feedbackIdx = i
+		}
+	}
+	if probeIdx == -1 {
+		t.Fatalf("no probe event recorded; events = %v", events)
+	}
+	if feedbackIdx == -1 {
+		t.Fatalf("no feedback read recorded; events = %v", events)
+	}
+	if probeIdx > feedbackIdx {
+		t.Fatalf("probe at %d AFTER feedback read at %d; events = %v", probeIdx, feedbackIdx, events)
+	}
+}
+
+func TestRouteChain_ConfirmedNoSkippedWithoutProbe(t *testing.T) {
+	ctx := context.Background()
+	store := newFakeCapProbeStore()
+	prober := newFakeToolCallProber()
+
+	// Pre-seed a valid "no" row keyed by the digestless fallback digest.
+	now := time.Now()
+	if err := store.SaveCapProbe(ctx, fingerprint.CapProbe{
+		BackendID:    "llamacpp",
+		ModelName:    "mystery-byo",
+		Capability:   "tool_call",
+		State:        fingerprint.CapProbeNo,
+		ModelDigest:  "llamacpp/mystery-byo",
+		ProbeVersion: fingerprint.CurrentToolProbeVersion,
+		TestedAt:     now,
+		ExpiresAt:    now.Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("SaveCapProbe failed: %v", err)
+	}
+
+	router := newCapRouteRouter(t, []string{"mystery-byo"}, store, prober)
+
+	_, err := router.Route(ctx, RoutingRequest{
+		PreferredChain: []string{"llamacpp/mystery-byo"},
+		StrictChain:    true,
+		UseCase:        "chat",
+		RequiredCaps:   CapChat | CapStream | CapToolCall,
+	})
+	if !errors.Is(err, ErrNoViableCandidate) {
+		t.Fatalf("Route() error = %v, want ErrNoViableCandidate", err)
+	}
+	if got := prober.totalCalls(); got != 0 {
+		t.Fatalf("prober calls = %d, want 0 (confirmed-no must not re-probe)", got)
+	}
+}
+
+func TestResolveCandidates_RecommendStripsThenFilters(t *testing.T) {
+	ctx := context.Background()
+	store := newFakeCapProbeStore()
+	prober := newFakeToolCallProber()
+	prober.outcomes["mystery-a"] = fingerprint.CapProbeOutcome{State: fingerprint.CapProbeYes}
+	prober.outcomes["mystery-b"] = fingerprint.CapProbeOutcome{State: fingerprint.CapProbeNo}
+
+	router := newCapRouteRouter(t, []string{"mystery-a", "mystery-b"}, store, prober)
+
+	candidates, _, err := router.resolveCandidates(ctx, RoutingRequest{
+		Model:        "",
+		UseCase:      "chat",
+		RequiredCaps: CapChat | CapStream | CapToolCall,
+	})
+	if err != nil {
+		t.Fatalf("resolveCandidates() error: %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].Key.Model != "mystery-a" {
+		names := make([]string, 0, len(candidates))
+		for _, c := range candidates {
+			names = append(names, c.Key.Model)
+		}
+		t.Fatalf("candidates = %v, want exactly [mystery-a]", names)
+	}
+	// Both models were probed: proof that Recommend ran WITHOUT the
+	// tool_call bit (the old code would have filtered both out before the
+	// router ever saw them, and the prober would never run).
+	if got := prober.callCount("mystery-a"); got != 1 {
+		t.Fatalf("prober calls for mystery-a = %d, want 1", got)
+	}
+	if got := prober.callCount("mystery-b"); got != 1 {
+		t.Fatalf("prober calls for mystery-b = %d, want 1", got)
+	}
+}
+
+func TestRecommendTail_AppliesSameResolution(t *testing.T) {
+	ctx := context.Background()
+	store := newFakeCapProbeStore()
+	prober := newFakeToolCallProber()
+	prober.outcomes["mystery-chain"] = fingerprint.CapProbeOutcome{State: fingerprint.CapProbeNo}
+	prober.outcomes["mystery-a"] = fingerprint.CapProbeOutcome{State: fingerprint.CapProbeYes}
+
+	router := newCapRouteRouter(t, []string{"mystery-chain", "mystery-a"}, store, prober)
+
+	// Non-strict chain: the chain entry probes "no" and is gated out; the
+	// recommend tail must apply the same strip-resolve-filter treatment so
+	// mystery-a (probe-yes) can win.
+	plan, err := router.Route(ctx, RoutingRequest{
+		PreferredChain: []string{"llamacpp/mystery-chain"},
+		StrictChain:    false,
+		UseCase:        "chat",
+		RequiredCaps:   CapChat | CapStream | CapToolCall,
+	})
+	if err != nil {
+		t.Fatalf("Route() error: %v (tail must resolve probe-yes candidates)", err)
+	}
+	if plan.Profile.Key.Model != "mystery-a" {
+		t.Fatalf("winner = %q, want mystery-a", plan.Profile.Key.Model)
+	}
+	if got := prober.callCount("mystery-a"); got != 1 {
+		t.Fatalf("prober calls for mystery-a = %d, want 1", got)
+	}
+	// mystery-chain's "no" verdict was persisted by the chain-step probe;
+	// the tail resolution must reuse the cached row, not probe again.
+	if got := prober.callCount("mystery-chain"); got != 1 {
+		t.Fatalf("prober calls for mystery-chain = %d, want 1", got)
+	}
+	for _, fb := range plan.Fallbacks {
+		if fb.Profile.Key.Model == "mystery-chain" {
+			t.Fatalf("probe-no candidate mystery-chain leaked into fallbacks")
+		}
+	}
+}
+
+// TestRoute_DirectRoutesResolved pins the EnsureToolCallResolved wiring on
+// the three direct-route branches of resolveCandidates: qualified selector,
+// provider-restricted unqualified, and LookupAny. Each would fail with
+// ErrNoViableCandidate if its wiring line were reverted (the merged profile
+// lacks tool_call until the probe resolves it).
+func TestRoute_DirectRoutesResolved(t *testing.T) {
+	cases := []struct {
+		name string
+		req  RoutingRequest
+	}{
+		{
+			name: "qualified selector",
+			req: RoutingRequest{
+				Model:        "llamacpp/mystery-byo",
+				UseCase:      "chat",
+				RequiredCaps: CapChat | CapStream | CapToolCall,
+			},
+		},
+		{
+			name: "provider-restricted unqualified",
+			req: RoutingRequest{
+				Model:        "mystery-byo",
+				Provider:     "llamacpp",
+				UseCase:      "chat",
+				RequiredCaps: CapChat | CapStream | CapToolCall,
+			},
+		},
+		{
+			name: "lookup-any unqualified",
+			req: RoutingRequest{
+				Model:        "mystery-byo",
+				UseCase:      "chat",
+				RequiredCaps: CapChat | CapStream | CapToolCall,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newFakeCapProbeStore()
+			prober := newFakeToolCallProber()
+			prober.outcomes["mystery-byo"] = fingerprint.CapProbeOutcome{State: fingerprint.CapProbeYes}
+			router := newCapRouteRouter(t, []string{"mystery-byo"}, store, prober)
+
+			plan, err := router.Route(context.Background(), tc.req)
+			if err != nil {
+				t.Fatalf("Route() error: %v (direct route must resolve probe-yes candidate)", err)
+			}
+			if plan.Profile.Key.Model != "mystery-byo" {
+				t.Fatalf("winner = %q, want mystery-byo", plan.Profile.Key.Model)
+			}
+			if got := prober.callCount("mystery-byo"); got != 1 {
+				t.Fatalf("prober calls = %d, want 1", got)
+			}
+		})
+	}
+}
+
+// TestRoute_ProbeErrorSurfacedInDiagnostics pins the diagnostics surface:
+// a transient probe failure (e.g. 401) must be readable from the route
+// error so operators can distinguish it from "genuinely not tool-capable".
+func TestRoute_ProbeErrorSurfacedInDiagnostics(t *testing.T) {
+	newRouter := func(t *testing.T) (*Router, *fakeToolCallProber) {
+		store := newFakeCapProbeStore()
+		prober := newFakeToolCallProber()
+		prober.errs["mystery-byo"] = errors.New("unexpected status 401 Unauthorized")
+		return newCapRouteRouter(t, []string{"mystery-byo"}, store, prober), prober
+	}
+
+	t.Run("direct qualified route", func(t *testing.T) {
+		router, _ := newRouter(t)
+		_, err := router.Route(context.Background(), RoutingRequest{
+			Model:        "llamacpp/mystery-byo",
+			UseCase:      "chat",
+			RequiredCaps: CapChat | CapStream | CapToolCall,
+		})
+		if !errors.Is(err, ErrNoViableCandidate) {
+			t.Fatalf("Route() error = %v, want ErrNoViableCandidate", err)
+		}
+		if !strings.Contains(err.Error(), "resolve tool_call") || !strings.Contains(err.Error(), "401") {
+			t.Fatalf("error %q must contain the probe diagnostic (resolve tool_call ... 401)", err)
+		}
+	})
+
+	t.Run("strict chain", func(t *testing.T) {
+		router, _ := newRouter(t)
+		_, err := router.Route(context.Background(), RoutingRequest{
+			PreferredChain: []string{"llamacpp/mystery-byo"},
+			StrictChain:    true,
+			UseCase:        "chat",
+			RequiredCaps:   CapChat | CapStream | CapToolCall,
+		})
+		if !errors.Is(err, ErrNoViableCandidate) {
+			t.Fatalf("Route() error = %v, want ErrNoViableCandidate", err)
+		}
+		if !strings.Contains(err.Error(), "resolve tool_call") || !strings.Contains(err.Error(), "401") {
+			t.Fatalf("chain exhaustion error %q must contain the probe diagnostic (resolve tool_call ... 401)", err)
+		}
+	})
+}

--- a/provider/router_chain.go
+++ b/provider/router_chain.go
@@ -52,6 +52,20 @@ func (r *Router) routeChain(ctx context.Context, req RoutingRequest) (*RoutePlan
 			continue
 		}
 
+		// Route-time lazy tool_call resolution (probe I/O) — strictly
+		// BEFORE this step's snap.readCandidates so feedback-snapshot
+		// reads never interleave with probe I/O and scorers stay pure.
+		// EnsureToolCallResolved never drops candidates; the capability
+		// gate in scoreChainStep remains the single rejection point.
+		// Probe diagnostics join lookupErrs so an exhausted route names
+		// probe failures (401 vs genuinely-not-capable). Worst case on
+		// cache miss: N unknown models x ~30s sequential probe; persisted
+		// verdicts amortize, Task 9's bounded-eager preflight keeps this
+		// rare (see recommendWithToolCallResolution).
+		var resolveDiags []error
+		profiles, resolveDiags = r.registry.EnsureToolCallResolved(ctx, profiles, req.RequiredCaps)
+		lookupErrs = append(lookupErrs, resolveDiags...)
+
 		chainSteps = append(chainSteps, profiles)
 		r.markChainSeenForTail(chainSeenForTail, profiles, req)
 
@@ -64,9 +78,10 @@ func (r *Router) routeChain(ctx context.Context, req RoutingRequest) (*RoutePlan
 
 	var tailProfiles []*ModelProfile
 	if !req.StrictChain {
-		var terr error
-		tailProfiles, terr = r.recommendTailProfiles(ctx, req, chainSeenForTail)
+		tp, tailDiags, terr := r.recommendTailProfiles(ctx, req, chainSeenForTail)
 		if terr == nil {
+			tailProfiles = tp
+			lookupErrs = append(lookupErrs, tailDiags...)
 			snap.readCandidates(ctx, r, tailProfiles, req.UseCase)
 		}
 	}
@@ -264,14 +279,17 @@ func (r *Router) recordChainLookupFailure(selector string, err error) {
 // tail's profiles are extended into the same snapshot before any chain/tail
 // scoring happens, keeping the snapshot's fail-open latch consistent across
 // the whole route.
-func (r *Router) recommendTailProfiles(ctx context.Context, req RoutingRequest, seen map[ModelKey]bool) ([]*ModelProfile, error) {
-	all, err := r.registry.Recommend(ctx, RecommendOpts{
-		RequiredCaps: req.RequiredCaps,
+func (r *Router) recommendTailProfiles(ctx context.Context, req RoutingRequest, seen map[ModelKey]bool) ([]*ModelProfile, []error, error) {
+	// Same strip-resolve-filter dance as resolveCandidates (shared helper):
+	// probe I/O runs here, before routeChain's snap.readCandidates call on
+	// the tail profiles, preserving feedback-snapshot purity. Probe
+	// diagnostics bubble to routeChain, which joins them into lookupErrs.
+	all, diags, err := r.recommendWithToolCallResolution(ctx, RecommendOpts{
 		AvailableRAM: r.availableRAM,
 		PreferWarm:   req.PreferWarm,
-	})
+	}, req.RequiredCaps)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	// Pre-filter Recommend output against the chain's `seen` set before
 	// extending the route-level snapshot. Without this, every candidate
@@ -287,7 +305,7 @@ func (r *Router) recommendTailProfiles(ctx context.Context, req RoutingRequest, 
 		}
 		fresh = append(fresh, p)
 	}
-	return fresh, nil
+	return fresh, diags, nil
 }
 
 func (r *Router) scoreRecommendTail(

--- a/provider/types.go
+++ b/provider/types.go
@@ -194,7 +194,11 @@ type ChatRequest struct {
 	Messages []ChatMessage `json:"messages"`
 	Options  ModelOptions  `json:"options,omitempty"`
 	Tools    []Tool        `json:"tools,omitempty"`
-	Stream   bool          `json:"stream"`
+	// ToolChoice forces the model's tool-use behavior (e.g. "required").
+	// Currently honored by the openai-compat provider; empty omits the
+	// field from the wire request.
+	ToolChoice string `json:"tool_choice,omitempty"`
+	Stream     bool   `json:"stream"`
 }
 
 // ChatResponse is the provider-agnostic response from a chat completion.


### PR DESCRIPTION
Closes #219

## Problem

Undeclared openai-compat models (llama.cpp `api_format: openai-compat` with no explicit `capabilities` in models.json) were denied `tool_call` even when the static catalog knew the family supports function calling. Root cause was not the missing prober the issue text describes (that predates the #217 fix + #184 prober) but a derived-REPLACE-override in providerbootstrap: type-derived caps were installed as a REPLACE override that ERASED the catalog's `tools` bit. An undeclared `llamacpp/gemma4:31b` came out chat|generate|stream, tool_call stripped.

## What this does

Two independent fixes plus discoverability:

1. Capability floor seam (root-cause fix). Derived openai-compat caps become an OR-merged FLOOR at lowest registry precedence instead of a REPLACE override. Catalog/fingerprint/runtime/probe additions survive; explicit models.json declarations still REPLACE in both directions. Undeclared catalog-known models are tool-capable with zero config.

2. Active tool-capability probe for genuinely-unknown models. New `capability_probes` table (fingerprint schema v2) backs a tri-state `ResolveToolCall` resolver (explicit > merged caps > valid cache row > active probe). openai-compat probes actively (two attempts: `get_time` tool with `tool_choice: required`, then without on 400/422; hard "no" only when the tools array itself is rejected). Ollama probes passively via `/api/show` capabilities. Auth/rate-limit/transport failures are diagnostic-only, never persisted. Bounded-eager at golem startup (stop at first capable), lazy at router route time (before feedback-snapshot reads, so scorers stay pure).

3. Discoverability. `golem models` lists the agent chain with capabilities and tool_call provenance (explicit | catalog | probe | runtime | unknown), plus `-probe-all` / `-reprobe`. Preflight emits remediation hints naming the exact models.json fix. `-no-cap-probe` disables active probing (floors + catalog merges still apply).

## Layering

- `fingerprint`: schema v2, CapProbe types, ToolCallProber interface.
- `provider`: SetCapabilityFloor, ResolveToolCall + capProbeCaps merge layer + EnsureToolCallResolved + ExplainToolCall; single `capProbeDigest` helper keeps write/merge-read/explain digests byte-symmetric.
- `internal/providerbootstrap`: derived caps -> floors, explicit -> overrides.
- `fingerprint/probers`: openai-compat active + ollama passive probes.
- `cmd/golem`: capability-only store wiring (FingerprintStore stays nil), bounded-eager preflight, models subcommand.
- Full-profiling consumers (MCP) whose FingerprintStore is the SQLite store get the resolver for free via an interface assert.

## Testing

TDD per task, two-stage review (spec then quality) each, plus a final cross-task integration pass. `go test ./... -race` green, `go vet ./...` clean, `go vet -tags integration ./cmd/golem/` clean, gofmt clean on all touched files. Build-tagged integration test (`capprobe_integration_test.go`) exercises a live llama.cpp probe + cache-hit via a recording proxy; skips cleanly without a server.

Catalog audit found no gaps (tools correctly present on qwen/llama/gemma3+/phi/mistral families, correctly absent on deepseek-r1/codellama/starcoder/gemma2/embeddings). Docs updated in docs/llm/recommendation.md.