### PR TITLE
chore: gofmt for Go 1.26.1 comment/field alignment drift

### DIFF
--- a/analysis/metrics.go
+++ b/analysis/metrics.go
@@ -23,8 +23,8 @@ type TrainingMetrics struct {
 
 // AnomalyInfo describes a detected anomaly in training metrics.
 type AnomalyInfo struct {
-	Type        string             // e.g. "reward_hack", "kl_drift", "loss_spike"
-	Severity    string             // "warning" or "critical"
+	Type        string // e.g. "reward_hack", "kl_drift", "loss_spike"
+	Severity    string // "warning" or "critical"
 	Description string
 	Metrics     map[string]float64
 }

--- a/cmd/llm-bench/trace_test.go
+++ b/cmd/llm-bench/trace_test.go
@@ -156,4 +156,3 @@ func TestValidateTraceAllowsKnownAndEmptyDifficulty(t *testing.T) {
 		}
 	}
 }
-

--- a/cmd/llm-bench/xlam_import_test.go
+++ b/cmd/llm-bench/xlam_import_test.go
@@ -176,11 +176,11 @@ func TestXlamRecordToTraceRejectsNonEmptyAnswers(t *testing.T) {
 
 func TestXlamRecordToTraceRejectsBadInput(t *testing.T) {
 	for name, rec := range map[string]xlamRecord{
-		"empty query":  {Query: "  ", Tools: sampleXlamTools, Answers: "[]"},
-		"bad tools":    {Query: "q", Tools: "not json", Answers: "[]"},
-		"bad answers":  {Query: "q", Tools: sampleXlamTools, Answers: "not json"},
-		"null answers": {Query: "q", Tools: sampleXlamTools, Answers: "null"},
-		"null tools":   {Query: "q", Tools: "null", Answers: "[]"},
+		"empty query":          {Query: "  ", Tools: sampleXlamTools, Answers: "[]"},
+		"bad tools":            {Query: "q", Tools: "not json", Answers: "[]"},
+		"bad answers":          {Query: "q", Tools: sampleXlamTools, Answers: "not json"},
+		"null answers":         {Query: "q", Tools: sampleXlamTools, Answers: "null"},
+		"null tools":           {Query: "q", Tools: "null", Answers: "[]"},
 		"empty answers string": {Query: "q", Tools: sampleXlamTools, Answers: "  "},
 	} {
 		if _, err := xlamRecordToTrace(rec, 0); err == nil {
@@ -193,8 +193,8 @@ func TestImportXlamIrrelevanceFilterSampleDeterministic(t *testing.T) {
 	// 5 records: 2 valid (>=1 tool, empty answers), 1 zero-tool, 1 non-empty answers, 1 valid.
 	recs := []xlamRecord{
 		{Query: "a", Tools: sampleXlamTools, Answers: "[]"},
-		{Query: "b", Tools: "[]", Answers: "[]"},                                  // 0 tools -> filtered
-		{Query: "c", Tools: sampleXlamTools, Answers: `[{"name":"x"}]`},           // has answer -> filtered
+		{Query: "b", Tools: "[]", Answers: "[]"},                        // 0 tools -> filtered
+		{Query: "c", Tools: sampleXlamTools, Answers: `[{"name":"x"}]`}, // has answer -> filtered
 		{Query: "d", Tools: sampleXlamTools, Answers: "[]"},
 		{Query: "e", Tools: sampleXlamTools, Answers: "[]"},
 	}

--- a/mcp/router_seam_test.go
+++ b/mcp/router_seam_test.go
@@ -33,7 +33,7 @@ type fakeRouteProvider struct {
 	genResponse  string
 }
 
-func (f *fakeRouteProvider) Name() string             { return f.name }
+func (f *fakeRouteProvider) Name() string { return f.name }
 func (f *fakeRouteProvider) Capabilities() provider.Capability {
 	return provider.CapChat | provider.CapGenerate | provider.CapEmbed | provider.CapStream
 }

--- a/ollama/tools.go
+++ b/ollama/tools.go
@@ -18,7 +18,7 @@ const (
 // ParamDef describes a single property in a tool's parameter schema.
 type ParamDef struct {
 	Name        string
-	Type        string   // Use ParamType* constants
+	Type        string // Use ParamType* constants
 	Description string
 	Enum        []string // optional: constrained values
 }

--- a/prefetch/engine_test.go
+++ b/prefetch/engine_test.go
@@ -12,12 +12,12 @@ import (
 
 // mockRetriever implements Retriever for testing.
 type mockRetriever struct {
-	mu          sync.Mutex
-	results     *RetrieveResult
-	err         error
-	callCount   int
-	lastQuery   string
-	lastK       int
+	mu        sync.Mutex
+	results   *RetrieveResult
+	err       error
+	callCount int
+	lastQuery string
+	lastK     int
 }
 
 func (m *mockRetriever) Retrieve(_ context.Context, query string, k int,
@@ -191,11 +191,11 @@ func TestEngine_SkipCache(t *testing.T) {
 
 func TestEngine_ResourceAdaptation(t *testing.T) {
 	tests := []struct {
-		name          string
-		memory        int64
-		wantCapacity  int
-		wantPolicy    string
-		wantCacheNil  bool
+		name         string
+		memory       int64
+		wantCapacity int
+		wantPolicy   string
+		wantCacheNil bool
 	}{
 		{
 			name:         "high resources (64GB)",

--- a/provider/registry_test.go
+++ b/provider/registry_test.go
@@ -17,7 +17,7 @@ type mockProvider struct {
 }
 
 func (m *mockProvider) Name() string             { return m.name }
-func (m *mockProvider) Capabilities() Capability  { return m.caps }
+func (m *mockProvider) Capabilities() Capability { return m.caps }
 
 func (m *mockProvider) Health(_ context.Context) error {
 	if !m.healthy {

--- a/provider/router_sticky_test.go
+++ b/provider/router_sticky_test.go
@@ -259,46 +259,46 @@ func TestHysteresisCheck(t *testing.T) {
 	const margin = 0.15
 
 	tests := []struct {
-		name           string
-		incumbentScore float64
+		name            string
+		incumbentScore  float64
 		challengerScore float64
-		margin         float64
-		wantKeep       bool // true = keep incumbent
+		margin          float64
+		wantKeep        bool // true = keep incumbent
 	}{
 		{
-			name:           "challenger far better",
-			incumbentScore: 0.70,
+			name:            "challenger far better",
+			incumbentScore:  0.70,
 			challengerScore: 0.90,
-			margin:         margin,
-			wantKeep:       false, // 0.90 >= 0.70*1.15=0.805
+			margin:          margin,
+			wantKeep:        false, // 0.90 >= 0.70*1.15=0.805
 		},
 		{
-			name:           "challenger marginally better",
-			incumbentScore: 0.70,
+			name:            "challenger marginally better",
+			incumbentScore:  0.70,
 			challengerScore: 0.78,
-			margin:         margin,
-			wantKeep:       true, // 0.78 < 0.805
+			margin:          margin,
+			wantKeep:        true, // 0.78 < 0.805
 		},
 		{
-			name:           "challenger at margin boundary",
-			incumbentScore: 0.70,
+			name:            "challenger at margin boundary",
+			incumbentScore:  0.70,
 			challengerScore: 0.805,
-			margin:         margin,
-			wantKeep:       false, // 0.805 >= 0.805
+			margin:          margin,
+			wantKeep:        false, // 0.805 >= 0.805
 		},
 		{
-			name:           "challenger equal",
-			incumbentScore: 0.70,
+			name:            "challenger equal",
+			incumbentScore:  0.70,
 			challengerScore: 0.70,
-			margin:         margin,
-			wantKeep:       true, // 0.70 < 0.805
+			margin:          margin,
+			wantKeep:        true, // 0.70 < 0.805
 		},
 		{
-			name:           "challenger worse",
-			incumbentScore: 0.70,
+			name:            "challenger worse",
+			incumbentScore:  0.70,
 			challengerScore: 0.60,
-			margin:         margin,
-			wantKeep:       true, // 0.60 < 0.805
+			margin:          margin,
+			wantKeep:        true, // 0.60 < 0.805
 		},
 	}
 

--- a/provider/token_budget_test.go
+++ b/provider/token_budget_test.go
@@ -98,7 +98,7 @@ func TestTokenBudgetPerUseCaseOutput(t *testing.T) {
 	contextWindow := 32768
 
 	tests := []struct {
-		useCase       string
+		useCase        string
 		expectedBudget int
 	}{
 		{"fim", contextWindow - 200},

--- a/rag/gitignore_test.go
+++ b/rag/gitignore_test.go
@@ -132,11 +132,11 @@ func TestGlobMatch(t *testing.T) {
 		{"[Tt]mp/**", "xmp/cache.dat", false},
 
 		// Trailing /** with /**/ in the prefix
-		{"a/**/b/**", "a/b/out.go", true},         // zero dirs in /**/
-		{"a/**/b/**", "a/x/y/b/out.go", true},     // multiple dirs in /**/
-		{"a/**/b/**", "a/x/y/b/d/e/f.go", true},   // deep under b/
-		{"a/**/b/**", "a/b", false},                // b itself not matched (no trailing content)
-		{"a/**/b/**", "other/b/out.go", false},     // wrong prefix
+		{"a/**/b/**", "a/b/out.go", true},       // zero dirs in /**/
+		{"a/**/b/**", "a/x/y/b/out.go", true},   // multiple dirs in /**/
+		{"a/**/b/**", "a/x/y/b/d/e/f.go", true}, // deep under b/
+		{"a/**/b/**", "a/b", false},             // b itself not matched (no trailing content)
+		{"a/**/b/**", "other/b/out.go", false},  // wrong prefix
 
 		// Middle /**/
 		{"a/**/b", "a/b", true},       // zero dirs
@@ -193,14 +193,20 @@ func TestGitignoreMatcherIsIgnored(t *testing.T) {
 		// Basic ignore
 		{
 			name: "simple glob match",
-			rules: []struct{ baseDir string; patterns []string }{
+			rules: []struct {
+				baseDir  string
+				patterns []string
+			}{
 				{".", []string{"*.log"}},
 			},
 			path: "app.log", isDir: false, want: true,
 		},
 		{
 			name: "no match",
-			rules: []struct{ baseDir string; patterns []string }{
+			rules: []struct {
+				baseDir  string
+				patterns []string
+			}{
 				{".", []string{"*.log"}},
 			},
 			path: "app.go", isDir: false, want: false,
@@ -209,7 +215,10 @@ func TestGitignoreMatcherIsIgnored(t *testing.T) {
 		// Unanchored matches at any depth
 		{
 			name: "unanchored deep match",
-			rules: []struct{ baseDir string; patterns []string }{
+			rules: []struct {
+				baseDir  string
+				patterns []string
+			}{
 				{".", []string{"*.log"}},
 			},
 			path: "a/b/app.log", isDir: false, want: true,
@@ -218,14 +227,20 @@ func TestGitignoreMatcherIsIgnored(t *testing.T) {
 		// Anchored matches only at scope level
 		{
 			name: "anchored match",
-			rules: []struct{ baseDir string; patterns []string }{
+			rules: []struct {
+				baseDir  string
+				patterns []string
+			}{
 				{".", []string{"src/foo"}},
 			},
 			path: "src/foo", isDir: false, want: true,
 		},
 		{
 			name: "anchored no match elsewhere",
-			rules: []struct{ baseDir string; patterns []string }{
+			rules: []struct {
+				baseDir  string
+				patterns []string
+			}{
 				{".", []string{"src/foo"}},
 			},
 			path: "lib/src/foo", isDir: false, want: false,
@@ -234,14 +249,20 @@ func TestGitignoreMatcherIsIgnored(t *testing.T) {
 		// Negation
 		{
 			name: "negation un-ignores",
-			rules: []struct{ baseDir string; patterns []string }{
+			rules: []struct {
+				baseDir  string
+				patterns []string
+			}{
 				{".", []string{"*.log", "!important.log"}},
 			},
 			path: "important.log", isDir: false, want: false,
 		},
 		{
 			name: "negation does not affect others",
-			rules: []struct{ baseDir string; patterns []string }{
+			rules: []struct {
+				baseDir  string
+				patterns []string
+			}{
 				{".", []string{"*.log", "!important.log"}},
 			},
 			path: "debug.log", isDir: false, want: true,
@@ -250,14 +271,20 @@ func TestGitignoreMatcherIsIgnored(t *testing.T) {
 		// Directory-only
 		{
 			name: "dir-only matches dir",
-			rules: []struct{ baseDir string; patterns []string }{
+			rules: []struct {
+				baseDir  string
+				patterns []string
+			}{
 				{".", []string{"build/"}},
 			},
 			path: "build", isDir: true, want: true,
 		},
 		{
 			name: "dir-only skips file",
-			rules: []struct{ baseDir string; patterns []string }{
+			rules: []struct {
+				baseDir  string
+				patterns []string
+			}{
 				{".", []string{"build/"}},
 			},
 			path: "build", isDir: false, want: false,
@@ -266,14 +293,20 @@ func TestGitignoreMatcherIsIgnored(t *testing.T) {
 		// Nested .gitignore scoping
 		{
 			name: "nested rule applies within scope",
-			rules: []struct{ baseDir string; patterns []string }{
+			rules: []struct {
+				baseDir  string
+				patterns []string
+			}{
 				{"src", []string{"*.tmp"}},
 			},
 			path: "src/cache.tmp", isDir: false, want: true,
 		},
 		{
 			name: "nested rule does NOT affect sibling",
-			rules: []struct{ baseDir string; patterns []string }{
+			rules: []struct {
+				baseDir  string
+				patterns []string
+			}{
 				{"src", []string{"*.tmp"}},
 			},
 			path: "lib/cache.tmp", isDir: false, want: false,
@@ -282,14 +315,20 @@ func TestGitignoreMatcherIsIgnored(t *testing.T) {
 		// Leading **/ pattern
 		{
 			name: "leading doublestar",
-			rules: []struct{ baseDir string; patterns []string }{
+			rules: []struct {
+				baseDir  string
+				patterns []string
+			}{
 				{".", []string{"**/test"}},
 			},
 			path: "a/b/test", isDir: false, want: true,
 		},
 		{
 			name: "leading doublestar root",
-			rules: []struct{ baseDir string; patterns []string }{
+			rules: []struct {
+				baseDir  string
+				patterns []string
+			}{
 				{".", []string{"**/test"}},
 			},
 			path: "test", isDir: false, want: true,
@@ -298,7 +337,10 @@ func TestGitignoreMatcherIsIgnored(t *testing.T) {
 		// Last rule wins across files
 		{
 			name: "nested negation overrides parent",
-			rules: []struct{ baseDir string; patterns []string }{
+			rules: []struct {
+				baseDir  string
+				patterns []string
+			}{
 				{".", []string{"*.gen.go"}},
 				{"src", []string{"!important.gen.go"}},
 			},
@@ -306,7 +348,10 @@ func TestGitignoreMatcherIsIgnored(t *testing.T) {
 		},
 		{
 			name: "nested re-ignore after parent negation",
-			rules: []struct{ baseDir string; patterns []string }{
+			rules: []struct {
+				baseDir  string
+				patterns []string
+			}{
 				{".", []string{"*.log", "!*.log"}},
 				{"src", []string{"*.log"}},
 			},
@@ -316,14 +361,20 @@ func TestGitignoreMatcherIsIgnored(t *testing.T) {
 		// Leading slash anchoring
 		{
 			name: "leading slash root only",
-			rules: []struct{ baseDir string; patterns []string }{
+			rules: []struct {
+				baseDir  string
+				patterns []string
+			}{
 				{".", []string{"/build"}},
 			},
 			path: "build", isDir: false, want: true,
 		},
 		{
 			name: "leading slash no deep match",
-			rules: []struct{ baseDir string; patterns []string }{
+			rules: []struct {
+				baseDir  string
+				patterns []string
+			}{
 				{".", []string{"/build"}},
 			},
 			path: "src/build", isDir: false, want: false,

--- a/rag/migration.go
+++ b/rag/migration.go
@@ -145,7 +145,7 @@ func migrateV4(tx *sql.Tx) error {
 // migrateV5 adds the vector_space_id column and a partial index over
 // non-empty values. Legacy rows keep the empty default; the partial-index
 // predicate keeps them out of the index, so probe queries that filter on
-// vector_space_id <> '' stay cheap regardless of corpus size.
+// vector_space_id <> ” stay cheap regardless of corpus size.
 func migrateV5(tx *sql.Tx) error {
 	stmts := []string{
 		`ALTER TABLE chunks ADD COLUMN vector_space_id TEXT NOT NULL DEFAULT ''`,

--- a/rag/parquet/export_test.go
+++ b/rag/parquet/export_test.go
@@ -1,13 +1,13 @@
 package parquet
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"iter"
 	"math"
 	"os"
 	"path/filepath"
-	"bytes"
 	"strings"
 	"testing"
 
@@ -432,10 +432,10 @@ func TestQualityNaNNotCountedAsZeroVector(t *testing.T) {
 func TestQualityFloat32Float64Consistency(t *testing.T) {
 	// Same data should produce identical quality flags regardless of DType.
 	embs := [][]float64{
-		uniformEmb(3, 1.0),          // clean
-		uniformEmb(3, 0),            // zero_vector
-		{math.NaN(), 0.1, 0.2},     // nan_replaced
-		uniformEmb(3, 100.0),        // outlier_norm
+		uniformEmb(3, 1.0),     // clean
+		uniformEmb(3, 0),       // zero_vector
+		{math.NaN(), 0.1, 0.2}, // nan_replaced
+		uniformEmb(3, 100.0),   // outlier_norm
 	}
 
 	for _, dt := range []DType{Float32, Float64} {


### PR DESCRIPTION
Pure formatting cleanup. Go 1.26.1's gofmt changed comment and struct-field alignment rules; 12 files predate the toolchain bump and now report as unformatted under `gofmt -l`. This runs `gofmt -w` on them — no token or semantic changes.

Files: analysis/metrics.go, cmd/llm-bench/trace_test.go, cmd/llm-bench/xlam_import_test.go, mcp/router_seam_test.go, ollama/tools.go, prefetch/engine_test.go, provider/registry_test.go, provider/router_sticky_test.go, provider/token_budget_test.go, rag/gitignore_test.go, rag/migration.go, rag/parquet/export_test.go

`go test ./...` passes. Independent of #266.