### PR TITLE
docs(golem): hosted openai-compat provider walkthrough (#208)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ If a hosted backend lacks an endpoint (`/v1/completions`, embeddings, FIM, or
 tool calls), set that model's `capabilities` to the endpoints that actually work
 so the Router won't send unsupported requests.
 
+For the Golem-specific walkthrough (flags, capability probing costs, verification
+runbook), see [Running Golem against a hosted API](docs/GETTING_STARTED.md#running-golem-against-a-hosted-api).
+
 ## Terminal Quick Start
 
 Start your configured model backend first. The checked-in `models.json` defaults to a llama.cpp-compatible server at `http://127.0.0.1:8080`; see [Local model backends](#local-model-backends) for the llama-swap and Ollama setup options.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -9,9 +9,11 @@ reference.
 ## Prerequisites
 
 1. **Go 1.25+** installed
-2. A local model backend:
+2. A model backend — one of:
    - **llama.cpp** (recommended) — `llama-server` per model, exposing the OpenAI-compatible API
    - **Ollama** (alternative) — running locally ([install](https://ollama.com/download))
+   - **A hosted OpenAI-compatible API** — no local model needed; see
+     [Running Golem against a hosted API](#running-golem-against-a-hosted-api)
 3. Models available to your backend (see [Model Configuration](#model-configuration))
 
 ## Install
@@ -147,6 +149,118 @@ To use different models, edit `models.json`:
 ```
 
 Pull the new model (`ollama pull llama3.3:70b`) and restart your application.
+
+## Running Golem against a hosted API
+
+Golem does not require a local LLM. Any hosted OpenAI-compatible endpoint works:
+declare a provider with `api_format: "openai-compat"` and an `api_key`, point the
+`agent` role at it, and run `golem` as usual. For the general (non-Golem)
+hosted-provider reference — compatibility table, mixing providers, fallbacks —
+see [Use a hosted API](../README.md#use-a-hosted-api-bring-your-own-key) in the
+README; this section is the Golem-specific path.
+
+A minimal hosted `models.json` (this exact config is load-verified against
+`config.Load`):
+
+```json
+{
+  "providers": {
+    "hosted": {
+      "base_url": "https://api.openai.com",
+      "api_format": "openai-compat",
+      "api_key": "${HOSTED_API_KEY}"
+    }
+  },
+  "models": {
+    "agent": {
+      "name": "gpt-4o",
+      "provider": "hosted",
+      "type": "dense",
+      "context_window": 128000,
+      "capabilities": ["chat", "stream", "tool_call"]
+    }
+  },
+  "defaults": {
+    "agent": "agent"
+  }
+}
+```
+
+Three things in this config are easy to get wrong:
+
+- `base_url` is the server **root** — do not include `/v1`; the client appends
+  the `/v1/...` endpoint paths itself.
+- `api_format` must be set explicitly. When omitted it defaults to `ollama`,
+  and a hosted endpoint will not speak that protocol.
+- `capabilities` must declare `tool_call` explicitly, alongside `chat` and
+  `stream`. `tool_call` is never derived from the model `type`; without it the
+  agent loop rejects the model.
+
+### Secrets
+
+Set `api_key` to a `${ENV_VAR}` reference and export the variable before
+running golem:
+
+```bash
+export HOSTED_API_KEY=sk-...
+golem -config models.json
+```
+
+Expansion happens when the config file loads and fails fast if the variable is
+unset or empty — it never falls back to the literal `${...}` string, and the
+error names the provider and variable, never the secret value. Never commit a
+literal key to a config file. Expansion applies only to file-loaded configs;
+a `config.Config` built programmatically keeps `api_key` as written.
+
+### Remote-relevant flags
+
+- `-no-probe` — skips the openai-compat port discovery scan. The scan is
+  loopback-only (localhost ports 8080-8090); a remote `base_url` is never
+  scanned regardless, so this flag just silences local discovery when you are
+  not running a local backend.
+- `-no-cap-probe` — disables the active tool-capability probe. For a model
+  with no declared or catalog-known `tool_call` capability, golem sends up to
+  two real chat-completion requests to the endpoint to test tool support —
+  against a hosted API those are billable calls. Verdicts are cached in
+  `fingerprints.db` under the golem data directory, so a positive verdict is
+  probed once per backend/model rather than per session (negative and
+  inconclusive verdicts can expire and re-probe). Declaring `capabilities` explicitly (as in
+  the example above) makes the probe unnecessary: an explicit declaration is
+  authoritative and no probe is sent.
+- `-base-url` — overrides the primary openai-compat agent provider's base URL.
+  Server root, without `/v1`, used exactly as given; also disables discovery.
+- `golem models -probe-all` / `golem models -reprobe` — subcommand flags for
+  explicit capability-probe refresh: `-probe-all` actively probes every
+  non-explicit entry, `-reprobe` deletes the cached verdicts first and probes
+  fresh. Use these when checking provenance with `golem models`; they are not
+  top-level `golem` flags.
+
+### Capabilities the agent loop needs
+
+Golem's agent loop requires `chat`, `stream`, and `tool_call` on the agent
+model (and on any fallback it may route to). Explicit `capabilities` REPLACE
+the type-derived defaults, which also makes them the carve-down mechanism: the
+example's `["chat", "stream", "tool_call"]` omits `generate`, so a hosted
+server without `/v1/completions` is fine — the Router never sends it
+unsupported requests.
+
+RAG is optional. To index and use `retrieve`, add a hosted embedding model
+(`"type": "embedding"`) and set `defaults.embedding` to it. Without one, golem
+runs with file tools only.
+
+### Verify the setup
+
+```bash
+golem models                 # confirm resolution and tool_call provenance
+golem -p "say hi"            # one-shot smoke against the hosted endpoint
+```
+
+`golem models` shows which model each role resolves to and where its
+`tool_call` verdict came from (`explicit`, `catalog`, `runtime`, or `probe`).
+If it looks right, the one-shot run is the end-to-end proof.
+
+Provider `timeout` defaults to `5m` when omitted. Set `"timeout"` on the
+provider entry if a hosted model needs longer.
 
 ## Quick Start
 

--- a/docs/superpowers/plans/2026-07-04-golem-remote-providers-docs-208.md
+++ b/docs/superpowers/plans/2026-07-04-golem-remote-providers-docs-208.md
@@ -1,0 +1,152 @@
+# Document API-Key-Backed OpenAI-Compatible Providers (#208) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Golem-focused documentation for running against a hosted OpenAI-compatible endpoint with an API key: copy-pasteable config, secret handling, remote-relevant flags, required capability declarations.
+
+**Architecture:** Docs-only PR. Extend `docs/GETTING_STARTED.md` with a "Running Golem against a hosted API" section; one cross-link line in README. README already has the general hosted-provider walkthrough, so do not duplicate it. Every claim verified against source before it is written; the example JSON is proven loadable by a throwaway `config.Load` check during development.
+
+**Tech Stack:** Markdown. Spec: `docs/superpowers/specs/2026-07-04-golem-remote-providers-docs-208-design.md`.
+
+**Session rules:**
+- Branch AFTER #220 ships (sequential): `git worktree add ../go-llm-208 -b docs/golem-remote-providers-208 develop` (or reuse an in-place feature branch off fresh develop — docs-only, no hook problem either way; if a linked worktree is used, native gate + `git push --no-verify`).
+- `env -u GOROOT go ...` for every go command.
+- No emojis in commits or the PR.
+- First commit: `git add -f docs/superpowers/specs/2026-07-04-golem-remote-providers-docs-208-design.md docs/superpowers/plans/2026-07-04-golem-remote-providers-docs-208.md`, message `docs(spec): remote-provider docs design and plan (#208)`.
+
+---
+
+### Task 1: Claim verification checklist
+
+**Files:** none modified — this task produces verified facts for Task 2.
+
+- [ ] **Step 1: Verify each claim against source, recording file:line**
+
+| Claim to document | Verify at |
+| --- | --- |
+| `docs/GETTING_STARTED.md` still frames setup as local-only and needs the Golem-specific remote path | `docs/GETTING_STARTED.md:3-15, 68-117` |
+| README already has the general hosted-provider section; only add a cross-link, no duplicate walkthrough | `README.md:137-205` |
+| `base_url` is server root; client appends `/v1/...` | `provider/openaicompat/client.go:51-75`, endpoint callers in `provider/openaicompat/openaicompat.go` |
+| Bearer header sent only when api_key non-empty | `provider/openaicompat/client.go:42-48, 143-149` |
+| `${ENV}` expansion: fails fast on unset/empty, never falls back to literal, errors never echo the secret | `config/config.go:311-335, 343-376, 407-426` |
+| Expansion happens only on file-backed `Load`, not programmatic Config | `config/config.go:311-335` call site |
+| Timeout default 5m when omitted | `config/config.go:429-449` |
+| `api_format` defaults to `"ollama"` when omitted (so remote configs MUST set `openai-compat`) | `config/config.go:429-449` |
+| Config schema uses `models` as a role-keyed map, not an array | `config/config.go:79-84`; compare existing `models.json` |
+| Agent model needs explicit `capabilities: ["chat","stream","tool_call"]`; `tool_call` never derived | `config/config.go:139-147`, `provider/catalog.go:187-203`, `cmd/golem/modelcaller.go:305-363` |
+| `-no-probe` skips loopback port discovery only; remote/non-loopback URLs are never scanned | `cmd/golem/main.go:62-67`, `cmd/golem/backend_resolve.go:102-140` |
+| `-base-url` overrides the primary openai-compat agent provider and must be server root without `/v1` | `cmd/golem/main.go:62-67`, `cmd/golem/backend_resolve.go:36-43, 102-132` |
+| Cap probe can hit the endpoint for undeclared models; cached in fingerprints.db; `-no-cap-probe` disables top-level probing | `cmd/golem/main.go:288-321`, `provider/model_registry.go:290-425`, `fingerprint/probers/openaicompat.go:172-254`, `cmd/golem/capprobe.go:48-57`, `fingerprint/store.go:340-407` |
+| `golem models -probe-all` and `golem models -reprobe` are subcommand flags for explicit probe/provenance refresh; `-reprobe` is not top-level `golem` | `cmd/golem/models.go:50-58, 189-198` |
+| Bearer integration already tested | `internal/providerbootstrap/apikey_integration_test.go` |
+
+Expected: every row confirmed or corrected. A WRONG claim here becomes a doc correction, not silent drift; a MISSING behavior becomes a new issue, not scope creep.
+
+- [ ] **Step 2: Prove the example config loads**
+
+Write the Task 2 example JSON to a scratch file:
+
+```json
+{
+  "providers": {
+    "hosted": {
+      "base_url": "https://api.openai.com",
+      "api_format": "openai-compat",
+      "api_key": "${HOSTED_API_KEY}"
+    }
+  },
+  "models": {
+    "agent": {
+      "name": "gpt-4o",
+      "provider": "hosted",
+      "type": "dense",
+      "context_window": 128000,
+      "capabilities": ["chat", "stream", "tool_call"]
+    }
+  },
+  "defaults": {
+    "agent": "agent"
+  }
+}
+```
+
+Prove loadability with a throwaway test (never run golem against a real endpoint for this):
+
+```go
+// temporary, NOT committed: place in config/ as loadcheck_x_test.go,
+// run once, delete.
+package config_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kstruzzieri/go-llm/config"
+)
+
+func TestRemoteExampleLoads(t *testing.T) {
+	os.Setenv("HOSTED_API_KEY", "dummy")
+	defer os.Unsetenv("HOSTED_API_KEY")
+	cfg, err := config.Load("/tmp/golem-remote-example.json")
+	if err != nil {
+		t.Fatalf("example from docs does not load: %v", err)
+	}
+	if cfg.Providers["hosted"].APIKey != "dummy" {
+		t.Fatalf("api_key not expanded")
+	}
+	if cfg.Defaults["agent"] != "agent" || cfg.Models["agent"].Name != "gpt-4o" {
+		t.Fatalf("agent default/model wiring mismatch")
+	}
+}
+```
+
+Run: `HOSTED_API_KEY=dummy env -u GOROOT go test ./config/ -run TestRemoteExampleLoads -v` — confirm PASS, then delete the temp test file. IMPORTANT: first diff the example's field names against `config/config.go` structs and the real `models.json` — in particular whether the top level uses `"providers"` as a map and what the defaults section is actually called (`defaults.agent` vs another key). Fix the example to match reality, not the other way around.
+
+---
+
+### Task 2: Write the GETTING_STARTED section
+
+**Files:**
+- Modify: `docs/GETTING_STARTED.md` (new section after the model-config material around lines 68-115)
+- Modify: `README.md` (one cross-link line in the existing "Use a hosted API" section, :137-150)
+
+- [ ] **Step 1: Write "Running Golem against a hosted API"**
+
+Content order (prose per house style — plain, terse, no emojis):
+
+1. Direct answer up front: Golem does not require a local LLM; any OpenAI-compatible endpoint works via `api_format: "openai-compat"` + `api_key`.
+2. The verified example config from Task 1, verbatim, with the three inline caveats: `base_url` is the server root (client appends `/v1`); `api_format` must be set explicitly (default is `ollama`); `capabilities` must declare `tool_call` explicitly (never derived) plus `chat` and `stream` for the agent loop.
+3. Secret handling: `${ENV_VAR}` expansion semantics (fails fast when unset/empty, no literal fallback, errors never contain the secret); never commit a literal key; expansion applies only to file-loaded configs.
+4. Remote-relevant flags: `-no-probe` (loopback port scan is pointless against remote and remote/non-loopback URLs are never scanned), `-no-cap-probe` (active tool-capability probe sends real requests to the paid endpoint; verdicts cached in fingerprints.db), `golem models -probe-all` / `golem models -reprobe` (explicit probe/provenance refresh), `-base-url` (overrides the primary openai-compat agent provider's base URL; server root, no `/v1`).
+5. Optional RAG note: `defaults.embedding` + a hosted embedding model with `"embed"`; otherwise golem runs with file tools only.
+6. Verification runbook: `golem models` to confirm resolution and capability provenance, then `HOSTED_API_KEY=... golem -p "say hi"` smoke.
+7. Timeout note: provider timeout defaults to 5m; set `"timeout"` for slower hosted models if needed.
+8. Update the top prerequisites/opening language so GETTING_STARTED no longer implies a local model backend is mandatory.
+
+- [ ] **Step 2: README cross-link**
+
+One line at the end of the existing hosted-API section: see docs/GETTING_STARTED.md "Running Golem against a hosted API" for the Golem-specific walkthrough. No content duplication.
+
+- [ ] **Step 3: Full gate + commit**
+
+```bash
+env -u GOROOT go test ./...
+git add docs/GETTING_STARTED.md README.md
+git commit -m "docs(golem): hosted openai-compat provider walkthrough (#208)"
+git push --no-verify -u origin docs/golem-remote-providers-208
+```
+
+Expected: tests PASS (no code changed).
+
+- [ ] **Step 4: PR**
+
+`gh pr create` targeting develop, plain-text body: what was documented, the claim-verification table from Task 1 (file:line evidence), note that the example JSON was load-verified. Mention manual live-endpoint smoke is available to Keith at review (needs a real key). No emojis.
+
+---
+
+## Plan Self-Review Notes
+
+- Spec coverage: goals 1-5 map to Task 2 items 1-7 (walkthrough), Task 1 (verification), Task 2 Step 2 (cross-link). Non-goals respected: zero code changes; gaps found in Task 1 become filed issues.
+- Review finding incorporated: the original scratch example used `"models": [...]`, but the real schema is a role-keyed map. The plan now uses `"models": {"agent": ...}` with `defaults.agent: "agent"`.
+- Review finding incorporated: cap-probe verification targets now point at the current active-probe path; `cmd/golem/capprobe.go` alone is only the store/cache path.
+- The example JSON's exact top-level schema (providers map key name, defaults section shape) is deliberately verified in Task 1 before being committed to prose.

--- a/docs/superpowers/specs/2026-07-04-golem-remote-providers-docs-208-design.md
+++ b/docs/superpowers/specs/2026-07-04-golem-remote-providers-docs-208-design.md
@@ -1,0 +1,114 @@
+# Document API-Key-Backed OpenAI-Compatible Providers (#208) Design
+
+**Date:** 2026-07-04
+**Issue:** [#208](https://github.com/kstruzzieri/go-llm/issues/208)
+**Status:** Draft; reviewed with findings incorporated; awaiting approval before
+implementation plan execution.
+
+## Problem
+
+Most of #208's original mechanics already shipped: `${ENV}` api_key expansion
+(config/config.go:343-376, 407-426; PR #223), the README "Use a hosted API"
+section (README.md:137-205), and the Bearer-header integration test
+(internal/providerbootstrap). The current README already has a hosted-provider
+example and capability guidance; the remaining gap is the **Golem-focused**
+path in `docs/GETTING_STARTED.md`, whose opening still frames setup around
+local models. A user still cannot tell there whether Golem needs a local LLM or
+can run against a hosted key, which flags matter for a remote endpoint, and
+which capability declarations the agent loop requires.
+
+## Review Findings
+
+1. Do not duplicate the README hosted-provider walkthrough. README already
+   covers server-root `base_url`, `${ENV}` secrets, `defaults.agent`,
+   `tool_call`, hosted embeddings, compatibility examples, and fallbacks. The
+   GETTING_STARTED section should be the Golem-specific path and README should
+   get only a cross-link.
+2. Example JSON must use the real config schema: `models` is a map keyed by role
+   (`config.Config.Models map[string]ModelConfig`), not an array. Any plan or
+   doc example using `"models": [...]` is invalid.
+3. `-reprobe` is not a top-level `golem` flag. It belongs to `golem models
+   -reprobe`; the top-level remote-relevant flags are `-base-url`, `-no-probe`,
+   and `-no-cap-probe`.
+4. Capability-probe source references must point at the active probe path, not
+   only `cmd/golem/capprobe.go`, which now owns the SQLite store path. Verify
+   against `cmd/golem/main.go`, `provider/model_registry.go`,
+   `fingerprint/probers/openaicompat.go`, `cmd/golem/models.go`, and
+   `fingerprint/store.go`.
+
+## Goals
+
+1. A Golem-focused walkthrough: copy-pasteable `models.json` for a hosted
+   openai-compat provider, wired to `defaults.agent`, with secret handling.
+2. Answer "does Golem require a local LLM?" explicitly in the docs.
+3. Document the remote-relevant golem flags and behaviors: `-base-url`,
+   `-no-probe` (port scan is localhost-only — irrelevant/noise for remote),
+   `-no-cap-probe`, and the cost implication of active tool-probing a paid API.
+   Mention `golem models -probe-all` / `golem models -reprobe` only in the
+   verification/provenance context.
+4. Document required capability declarations for the agent loop
+   (`chat`, `stream`, `tool_call` on the agent model; `embed` for RAG), and
+   that `tool_call`/`thinking` are never derived.
+5. Verify every documented claim against code while writing (base_url is
+   server root and `/v1` is appended — provider/openaicompat/client.go:51-75;
+   Bearer header only when key non-empty — client.go:42-48, 143-149; `${ENV}` fails
+   fast on unset/empty var; expansion only on file-backed `Load`).
+
+## Non-Goals
+
+- No new code or config fields. Docs-only PR unless verification exposes an
+  actual gap (a gap becomes its own issue, not scope creep here).
+- No provider-by-provider compatibility matrix beyond the existing README
+  table.
+- No secrets-manager integration guidance beyond "env var, never a literal in
+  a committed file".
+
+## Design
+
+### Placement
+
+Extend `docs/GETTING_STARTED.md` with a new section "Running Golem against a
+hosted API" (after the existing model-config section, lines 68–115 territory).
+README gets one cross-link line from the existing hosted-API section; no
+duplicated content. No new doc file — GETTING_STARTED is the established home
+for golem setup, and #208's audience lands there.
+
+### Walkthrough content
+
+1. Local vs remote statement: Golem defaults to local (llama.cpp/Ollama) but
+   runs fully against any OpenAI-compatible hosted endpoint via
+   `api_format: "openai-compat"` + `api_key`.
+2. Complete minimal `models.json`: one hosted provider
+   (`base_url` = server root, explicit note that the client appends `/v1`),
+   `api_key: "${PROVIDER_API_KEY}"`, timeout note (default 5m), one agent
+   model with explicit `capabilities: ["chat", "stream", "tool_call"]`, one
+   embedding model marked optional (RAG), `defaults.agent` /
+   `defaults.embedding` wiring.
+3. Secret handling: `${ENV}` expansion semantics — fails fast when unset or
+   empty, never falls back to the literal, errors never echo secrets; keep
+   keys out of committed models.json.
+4. Golem flags for remote: `-no-probe` (skip localhost port scan),
+   `-no-cap-probe` (active tool-capability probe hits the paid endpoint; cached
+   in fingerprints.db), `golem models -probe-all` / `golem models -reprobe`
+   for explicit provenance refresh, and `-base-url` interplay with the primary
+   openai-compat agent provider.
+5. Capability declarations: what the agent loop requires and why
+   `tool_call` must be explicit (never derived from `type`); carve-down note
+   for servers missing `/v1/completions`.
+6. Verification runbook: `golem models` to confirm resolution/provenance,
+   then a one-shot `golem -p "..."` smoke.
+
+### Verification step (in-PR, not doc prose)
+
+Before writing each claim, confirm against source; where a claim is testable
+and untested, prefer citing the existing test (apikey integration test) over
+adding new ones. Manual smoke against a real hosted endpoint is Keith's call
+at review time (needs a key).
+
+## Testing
+
+- Docs-only: `env -u GOROOT go test ./...` still green (no code change).
+- Example JSON in the walkthrough validated by feeding it to `config.Load` in
+  a throwaway test or `go run` snippet during development (not committed) to
+  guarantee copy-paste correctness — field names, enum values, defaults
+  section shape.


### PR DESCRIPTION
Closes #208.

## What this does

Docs-only. Adds a Golem-focused walkthrough for running against an API-key-backed OpenAI-compatible endpoint: docs/GETTING_STARTED.md gains a "Running Golem against a hosted API" section, and the README's existing hosted-API section gets a single cross-link (no duplicated content, per the review findings in the design).

The section answers the acceptance criteria directly:

- States up front that Golem does not require a local LLM; any OpenAI-compatible hosted endpoint works via api_format "openai-compat" plus api_key.
- Copy-pasteable models.json example (providers/models/defaults maps, models keyed by role, explicit capabilities ["chat", "stream", "tool_call"], ${HOSTED_API_KEY} expansion, defaults.agent wiring). The example was load-verified during development by feeding it through config.Load with a dummy env var and asserting expansion and resolved capabilities; the throwaway test was deleted before commit.
- Secret handling: ${ENV} expansion fails fast on unset or empty variables, never falls back to the literal, errors never echo the secret, and expansion applies only to file-loaded configs. Keys stay out of committed files.
- Remote-relevant flags: -no-probe (the port scan is loopback-only; remote URLs are never scanned), -no-cap-probe (the active tool-capability probe sends up to two real, billable chat requests for undeclared models; verdicts cached in fingerprints.db; explicit capability declarations skip it entirely), -base-url, and golem models -probe-all / -reprobe presented only in the provenance-refresh context (they are subcommand flags, not top-level).
- Capability declarations the agent loop requires (chat, stream, tool_call; tool_call never derived from type) plus the carve-down note for servers missing /v1/completions, and the optional hosted-embedding/RAG wiring.
- Verification runbook: golem models for resolution and tool_call provenance, then a one-shot smoke.

## Claim verification

Every factual claim in the new prose was verified against source before writing (base_url root + /v1 appending: provider/openaicompat/client.go; Bearer only when key non-empty: client.go setHeaders; ${ENV} semantics: config/config.go expandAPIKeyRefs; api_format/timeout defaults: applyDefaults; derived capabilities: config.go derivedCapabilitiesByType; agent-loop requirement: cmd/golem/modelcaller.go; probe path and caching: fingerprint/probers/openaicompat.go, fingerprint/store.go, cmd/golem/capprobe.go; loopback-only scan: cmd/golem/backend_resolve.go; Bearer integration test: internal/providerbootstrap/apikey_integration_test.go). An independent review pass re-verified each claim and the example JSON against the config schema.

go test ./... green (no code changes).

Manual smoke against a real hosted endpoint is available at review if you want to run it with a live key.
